### PR TITLE
Add DJANGO_SETTINGS_MODULE to tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,10 @@
 envlist = py{2.7,3.4,3.5,pypy}, lint, docs, bdd
 
 [testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+    DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.base
+    KOLIBRI_HOME = {toxinidir}/kolibrihome_test
 basepython =
     py2.7: python2.7
     py3.4: python3.4


### PR DESCRIPTION
Tested this out, I previously was getting circular import errors before @66eli77 had the same problem, and made me realize that we hadn't set DJANGO_SETTINGS_MODULE.