### PR TITLE
Fix testing issues on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,17 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.4.2
+    sha: 97b88d9610bcc03982ddac33caba98bb2b751f5f
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
-        args: [--exclude=kolibri/*/migrations/*]
+        args:
+        - --exclude=kolibri/*/migrations/*
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements
     -   id: end-of-file-fixer
-
--   repo: git://github.com/pre-commit/mirrors-jshint
-    sha: v2.8.0
+-   repo: git://github.com/FalconSocial/pre-commit-python-sorter
+    sha: d044ff27300a6dc8b1a56cd22552e3a810dc6f49
     hooks:
-    -   id: jshint
-
-- repo: git://github.com/FalconSocial/pre-commit-python-sorter
-  sha: 1.0.1
-  hooks:
-  - id: python-import-sorter
-    args: ['--silent-overwrite']
+    -   id: python-import-sorter
+        args:
+        - --silent-overwrite

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Adjust according to your operating system or personal preferences.
     $ kolibri manage runserver
 
 # Install pre-commit hooks to ensure you commit good code::
+
     $ pre-commit install
 
 

--- a/kolibri/plugins/test/test_base_plugins.py
+++ b/kolibri/plugins/test/test_base_plugins.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import os
+
 from django.test import TestCase
 
 from kolibri.plugins.base import KolibriFrontEndPluginBase
+
 
 class KolibriFrontEndPluginBaseTestCase(TestCase):
     def setUp(self):
@@ -12,7 +15,7 @@ class KolibriFrontEndPluginBaseTestCase(TestCase):
         self.plugin_base = KolibriTestFrontEnd()
 
     def test_module_file_path(self):
-        self.assertEqual(self.plugin_base._module_file_path(), "kolibri/plugins/test")
+        self.assertEqual(self.plugin_base._module_file_path(), os.path.join("kolibri", "plugins", "test"))
 
     def test_register_front_end_plugins(self):
         module_path, name, stats_file = self.plugin_base._register_front_end_plugins()


### PR DESCRIPTION
## Summary

The jshint pre-commit hook is incompatible with Windows
due to an underlying incompatibility in the nodeenv pkg.

Also use non-OS-specific path names.