### PR TITLE
Configure travis to test with postgres too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 
 language: python
 
+services:
+  - postgresql
+
 sudo: false
 
 cache:
@@ -42,6 +45,10 @@ matrix:
       env:
         - TOX_ENV=node5.x
         - TRAVIS_NODE_VERSION="5"
+    - python: "2.7"
+      env:
+        - TOX_ENV=postgres
+        - TRAVIS_NODE_VERSION="0.12"
 
 before_install:
   - pip install codecov
@@ -52,6 +59,7 @@ before_install:
 
 before_script:
   - tox -e lint
+  - psql -c 'create database travis_ci_test;' -U postgres
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/kolibri/deployment/default/settings/postgres_test.py
+++ b/kolibri/deployment/default/settings/postgres_test.py
@@ -1,0 +1,18 @@
+"""
+A settings module for running tests using a postgres db backend.
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+from kolibri.deployment.default.settings.base import *  # noqa
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'NAME': 'foo',  # This module should never be used outside of tests -- so this name is irrelevant
+        'TEST': {
+            'NAME': 'travis_ci_test'
+        }
+    }
+}

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,8 @@
 -r base.txt
 # These are for testing
-pytest
-pytest-django
-pytest-cov
 coverage
 mock
+psycopg2==2.6.1
+pytest
+pytest-cov
+pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,pypy}, lint, docs, bdd, node
+envlist = py{2.7,3.4,3.5,pypy}, lint, docs, bdd, node, postgres
 
 [testenv]
 setenv =
@@ -16,6 +16,18 @@ basepython =
     node0.12.x: python2.7
     node4.x: python2.7
     node5.x: python2.7
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    py.test --cov=kolibri --color=no {posargs}
+
+[testenv:postgres]
+setenv =
+    PYTHONPATH = {toxinidir}
+    KOLIBRI_HOME = {toxinidir}/kolibrihome_test
+    DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.postgres_test
+basepython =
+    postgres: python2.7
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
## Summary

See #50, where I suggest the necessity of testing with postgres early and automatically. TL;DR: @jamalex has identified this as an important use-case later, and I want to get tests running on *all* target database backends to avoid any surprises down the line.

## TODO

- [X] Have tests been written for the new code?
- [X] New dependencies (if any) added to requirements file
