### PR TITLE
Django REST framework API for auth app, including wrapper for permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,17 @@ use simply ``tox``. This simulates what our CI also does.
 To run linting tests (pep8 and static code analysis), use ``tox -e lint`` or
 ``make lint``.
 
+Note that tox, by default, reuses its environment when it is run again. If you add anything to the requirements,
+you will want to either delete the `.tox` directory, or run ``tox`` with the ``-r`` argument to recreate the environment.
+
+We strive for 100% code coverage in Kolibri. When you open a Pull Request, code coverage (and your impact on coverage)
+will be reported. To test code coverage locally, so that you can work to improve it, you can run the following::
+
+    $ tox -e py3.4
+    $ coverage html
+
+    <open the generated ./htmlcov/index.html file in your browser>
+
 Kolibri comes with a Javascript test suite based on ``mocha``. To run all tests::
 
     $ npm test

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,9 @@ Adjust according to your operating system or personal preferences.
     $ mkvirtualenv --python=python3 kolibri
     $ workon kolibri
 
+#. Ensure NodeJS is installed, using a platform-appropriate installer. We test on versions v0.12, v4, and v5.
+   On Ubuntu, you may encounter issues building if you don't use NodeJS installed via [nvm](https://github.com/creationix/nvm).
+
 #. Install all NodeJS dependency packages for building the frontend code::
 
     $ npm install

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -1,0 +1,109 @@
+from rest_framework import filters, permissions, viewsets
+
+from .models import (
+    Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership,
+    Role
+)
+from .serializers import (
+    ClassroomSerializer, DeviceOwnerSerializer, FacilitySerializer,
+    FacilityUserSerializer, LearnerGroupSerializer, MembershipSerializer,
+    RoleSerializer
+)
+
+
+class KolibriAuthPermissionsFilter(filters.BaseFilterBackend):
+    """
+    A Django REST Framework filter backend that limits results to those where the
+    requesting user has read object level permissions. This filtering is delegated
+    to the ``filter_readable`` method on ``KolibriAbstractBaseUser``.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        if request.method == "GET" and request.resolver_match.url_name.endswith("-list"):
+            # only filter down the queryset in the case of the list view being requested
+            return request.user.filter_readable(queryset)
+        else:
+            # otherwise, return the full queryset, as permission checks will happen object-by-object
+            # (and filtering here then leads to 404's instead of the more correct 403's)
+            return queryset
+
+
+class KolibriAuthPermissions(permissions.BasePermission):
+    """
+    A Django REST Framework permissions class that defers to Kolibri's permissions
+    system to determine object-level permissions.
+    """
+
+    def has_permission(self, request, view):
+
+        # as `has_object_permission` isn't called for POST/create, we need to check here
+        if request.method == "POST" and request.data:
+            model = view.serializer_class.Meta.model
+            validated_data = view.serializer_class().to_internal_value(request.data.dict())
+            return request.user.can_create(model, validated_data)
+
+        # for other methods, we return True, as their permissions get checked below
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        if request.method == "POST":
+            # this shouldn't get called under normal API use (as actual creation is checked above under
+            # ``has_permission``), but this gets called by the browsable API when generating a form
+            return request.user.can_create_instance(obj)
+        elif request.method in permissions.SAFE_METHODS:  # 'GET', 'OPTIONS' or 'HEAD'
+            return request.user.can_read(obj)
+        elif request.method == "PUT":
+            return request.user.can_update(obj)
+        elif request.method == "DELETE":
+            return request.user.can_delete(obj)
+        else:
+            return False
+
+
+class FacilityUserViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = FacilityUser.objects.all()
+    serializer_class = FacilityUserSerializer
+
+
+class DeviceOwnerViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = DeviceOwner.objects.all()
+    serializer_class = DeviceOwnerSerializer
+
+
+class MembershipViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = Membership.objects.all()
+    serializer_class = MembershipSerializer
+
+
+class RoleViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = Role.objects.all()
+    serializer_class = RoleSerializer
+
+
+class FacilityViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = Facility.objects.all()
+    serializer_class = FacilitySerializer
+
+
+class ClassroomViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = Classroom.objects.all()
+    serializer_class = ClassroomSerializer
+
+
+class LearnerGroupViewSet(viewsets.ModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = LearnerGroup.objects.all()
+    serializer_class = LearnerGroupSerializer

--- a/kolibri/auth/backends.py
+++ b/kolibri/auth/backends.py
@@ -9,7 +9,7 @@ from kolibri.auth.models import DeviceOwner, FacilityUser
 
 class FacilityUserBackend(object):
     """
-    A class that implements permissions checking for FacilityUsers.
+    A class that implements authentication for FacilityUsers.
     """
 
     def authenticate(self, username=None, password=None, facility=None):
@@ -45,7 +45,7 @@ class FacilityUserBackend(object):
 
 class DeviceOwnerBackend(object):
     """
-    A class that implements permissions checking for DeviceOwners.
+    A class that implements authentication for DeviceOwners.
     """
 
     def authenticate(self, username=None, password=None):

--- a/kolibri/auth/middleware.py
+++ b/kolibri/auth/middleware.py
@@ -1,12 +1,8 @@
-import importlib
-
-from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.utils.functional import SimpleLazyObject
 
-module, klass = settings.AUTH_ANONYMOUS_USER_MODEL.rsplit('.', 1)
-CustomAnonymousUser = getattr(importlib.import_module(module), klass)
+from .models import KolibriAnonymousUser
 
 
 def _get_user(request):
@@ -14,7 +10,7 @@ def _get_user(request):
     if not hasattr(request, '_cached_user'):
         user = get_user(request)
         if user.is_anonymous():
-            user = CustomAnonymousUser()
+            user = KolibriAnonymousUser()
         request._cached_user = user
 
     return request._cached_user

--- a/kolibri/auth/middleware.py
+++ b/kolibri/auth/middleware.py
@@ -3,9 +3,21 @@ import importlib
 from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.utils.functional import SimpleLazyObject
 
 module, klass = settings.AUTH_ANONYMOUS_USER_MODEL.rsplit('.', 1)
 CustomAnonymousUser = getattr(importlib.import_module(module), klass)
+
+
+def _get_user(request):
+
+    if not hasattr(request, '_cached_user'):
+        user = get_user(request)
+        if user.is_anonymous():
+            user = CustomAnonymousUser()
+        request._cached_user = user
+
+    return request._cached_user
 
 
 class CustomAuthenticationMiddleware(AuthenticationMiddleware):
@@ -14,16 +26,6 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
     to replace the default AnonymousUser with a custom implementation.
     """
 
-    def _get_cached_user(self, request):
-
-        if not hasattr(request, '_cached_user'):
-            user = get_user(request)
-            if user.is_anonymous():
-                user = CustomAnonymousUser()
-            request._cached_user = user
-
-        return request._cached_user
-
     def process_request(self, request):
         assert hasattr(request, 'session'), (
             "The authentication middleware requires session middleware "
@@ -31,4 +33,4 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
             "'django.contrib.sessions.middleware.SessionMiddleware' before "
             "'kolibri.auth.middleware.CustomAuthenticationMiddleware'."
         )
-        request.user = self._get_cached_user(request)
+        request.user = SimpleLazyObject(lambda: _get_user(request))

--- a/kolibri/auth/middleware.py
+++ b/kolibri/auth/middleware.py
@@ -1,0 +1,34 @@
+import importlib
+
+from django.conf import settings
+from django.contrib.auth import get_user
+from django.contrib.auth.middleware import AuthenticationMiddleware
+
+module, klass = settings.AUTH_ANONYMOUS_USER_MODEL.rsplit('.', 1)
+CustomAnonymousUser = getattr(importlib.import_module(module), klass)
+
+
+class CustomAuthenticationMiddleware(AuthenticationMiddleware):
+    """
+    Adaptation of Django's ``account.middleware.AuthenticationMiddleware``
+    to replace the default AnonymousUser with a custom implementation.
+    """
+
+    def _get_cached_user(self, request):
+
+        if not hasattr(request, '_cached_user'):
+            user = get_user(request)
+            if user.is_anonymous():
+                user = CustomAnonymousUser()
+            request._cached_user = user
+
+        return request._cached_user
+
+    def process_request(self, request):
+        assert hasattr(request, 'session'), (
+            "The authentication middleware requires session middleware "
+            "to be installed. Edit your MIDDLEWARE_CLASSES setting to insert "
+            "'django.contrib.sessions.middleware.SessionMiddleware' before "
+            "'kolibri.auth.middleware.CustomAuthenticationMiddleware'."
+        )
+        request.user = self._get_cached_user(request)

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -436,6 +436,17 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
         return '"{user}"@"{facility}"'.format(user=self.get_full_name() or self.username, facility=self.facility)
 
 
+class DeviceOwnerManager(models.Manager):
+
+    def create_superuser(self, username, password, **extra_fields):
+        if not username:
+            raise ValueError('The given username must be set')
+        user = DeviceOwner(username=username)
+        user.set_password(password)
+        user.save()
+        return user
+
+
 @python_2_unicode_compatible
 class DeviceOwner(KolibriAbstractBaseUser):
     """
@@ -449,6 +460,8 @@ class DeviceOwner(KolibriAbstractBaseUser):
 
     A ``DeviceOwner`` is a superuser, and has full access to do anything she wants with data on the device.
     """
+
+    objects = DeviceOwnerManager()
 
     # DeviceOwners can access the Django admin interface
     is_staff = True
@@ -494,6 +507,18 @@ class DeviceOwner(KolibriAbstractBaseUser):
 
     def __str__(self):
         return self.get_full_name() or self.username
+
+    def has_perm(self, perm, obj=None):
+        # ensure the DeviceOwner has full access to the Django admin
+        return True
+
+    def has_perms(self, perm_list, obj=None):
+        # ensure the DeviceOwner has full access to the Django admin
+        return True
+
+    def has_module_perms(self, app_label):
+        # ensure the DeviceOwner has full access to the Django admin
+        return True
 
 
 @python_2_unicode_compatible

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -23,7 +23,7 @@ user gains through the ``Role``.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.contrib.auth.models import AbstractBaseUser
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -51,6 +51,11 @@ from .permissions.general import (
 )
 
 
+def _has_permissions_class(obj):
+    return hasattr(obj, "permissions") and isinstance(obj.permissions, BasePermissions)
+
+
+@python_2_unicode_compatible
 class FacilityDataset(models.Model):
     """
     ``FacilityDataset`` stores high-level metadata and settings for a particular ``Facility``. It is also the
@@ -62,6 +67,9 @@ class FacilityDataset(models.Model):
     location = models.CharField(max_length=200, blank=True)
 
     allow_signups = models.BooleanField(default=True)
+
+    def __str__(self):
+        return "FacilityDataset for {}".format(str(self.facility_set.all()))
 
 
 class AbstractFacilityDataModel(models.Model):
@@ -310,6 +318,68 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
         raise NotImplementedError("Subclasses of KolibriAbstractBaseUser must override the `can_delete` method.")
 
 
+class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
+    """
+    Custom anonymous user that also exposes the same interface as KolibriAbstractBaseUser, for consistency.
+    """
+
+    class Meta:
+        abstract = True
+
+    def get_username(self):
+        return self.username
+
+    def is_member_of(self, coll):
+        return False
+
+    def get_roles_for_user(self, user):
+        return set([])
+
+    def get_roles_for_collection(self, coll):
+        return set([])
+
+    def has_role_for_user(self, kinds, user):
+        return False
+
+    def has_role_for_collection(self, kinds, coll):
+        return False
+
+    def can_create_instance(self, obj):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(obj):
+            return obj.permissions.user_can_create_object(self, obj)
+        else:
+            return False
+
+    def can_read(self, obj):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(obj):
+            return obj.permissions.user_can_read_object(self, obj)
+        else:
+            return False
+
+    def can_update(self, obj):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(obj):
+            return obj.permissions.user_can_update_object(self, obj)
+        else:
+            return False
+
+    def can_delete(self, obj):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(obj):
+            return obj.permissions.user_can_delete_object(self, obj)
+        else:
+            return False
+
+    def filter_readable(self, queryset):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(queryset.model):
+            return queryset.model.permissions.readable_by_user_filter(self, queryset).distinct()
+        else:
+            return queryset.none()
+
+
 @python_2_unicode_compatible
 class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
     """
@@ -395,39 +465,36 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
             descendant_collection=coll,
         ).filter(user=self).exists()
 
-    def _has_permissions_class(self, obj):
-        return hasattr(obj, "permissions") and isinstance(obj.permissions, BasePermissions)
-
     def can_create_instance(self, obj):
         # a FacilityUser's permissions are determined through the object's permission class
-        if self._has_permissions_class(obj):
+        if _has_permissions_class(obj):
             return obj.permissions.user_can_create_object(self, obj)
         else:
             return False
 
     def can_read(self, obj):
         # a FacilityUser's permissions are determined through the object's permission class
-        if self._has_permissions_class(obj):
+        if _has_permissions_class(obj):
             return obj.permissions.user_can_read_object(self, obj)
         else:
             return False
 
     def can_update(self, obj):
         # a FacilityUser's permissions are determined through the object's permission class
-        if self._has_permissions_class(obj):
+        if _has_permissions_class(obj):
             return obj.permissions.user_can_update_object(self, obj)
         else:
             return False
 
     def can_delete(self, obj):
         # a FacilityUser's permissions are determined through the object's permission class
-        if self._has_permissions_class(obj):
+        if _has_permissions_class(obj):
             return obj.permissions.user_can_delete_object(self, obj)
         else:
             return False
 
     def filter_readable(self, queryset):
-        if self._has_permissions_class(queryset.model):
+        if _has_permissions_class(queryset.model):
             return queryset.model.permissions.readable_by_user_filter(self, queryset).distinct()
         else:
             return queryset.none()

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -69,8 +69,11 @@ class FacilityDataset(models.Model):
     allow_signups = models.BooleanField(default=True)
 
     def __str__(self):
-        return "FacilityDataset for {}".format(str(self.facility_set.all()))
-
+        facilities = self.collection_set.filter(kind=collection_kinds.FACILITY)
+        if facilities:
+            return "FacilityDataset for {}".format(Facility.objects.get(id=facilities[0].id))
+        else:
+            return "FacilityDataset (no associated Facility)"
 
 class AbstractFacilityDataModel(models.Model):
     """
@@ -325,9 +328,6 @@ class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
 
     class Meta:
         abstract = True
-
-    def get_username(self):
-        return self.username
 
     def is_member_of(self, coll):
         return False

--- a/kolibri/auth/permissions/general.py
+++ b/kolibri/auth/permissions/general.py
@@ -72,6 +72,8 @@ class IsSelf(BasePermissions):
         return (not self.read_only) and (user == obj)
 
     def readable_by_user_filter(self, user, queryset):
+        if user.id is None:
+            return queryset.none()
         return queryset.filter(id=user.id)
 
 
@@ -129,7 +131,10 @@ class IsFromSameFacility(BasePermissions):
         return (not self.read_only) and self._facility_dataset_is_same(user, obj)
 
     def readable_by_user_filter(self, user, queryset):
-        return queryset.filter(dataset=user.dataset)
+        if hasattr(user, "dataset"):
+            return queryset.filter(dataset=user.dataset)
+        else:
+            return queryset.none()
 
 
 class IsAdminForOwnFacility(BasePermissions):
@@ -144,6 +149,9 @@ class IsAdminForOwnFacility(BasePermissions):
 
         # import here to avoid circular imports
         from ..models import Facility
+
+        if not hasattr(user, "dataset"):
+            return False
 
         # if we've been given an object, make sure it too is from the same dataset (facility)
         if obj:

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -1,0 +1,69 @@
+from rest_framework import serializers
+
+from .models import (
+    Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership,
+    Role
+)
+
+
+class FacilityUserSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = FacilityUser
+        exclude = ("dataset", "last_login")
+        extra_kwargs = {'password': {'write_only': True}}
+
+    def create(self, validated_data):
+        user = FacilityUser(**validated_data)
+        user.set_password(validated_data['password'])
+        user.save()
+        return user
+
+
+class DeviceOwnerSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DeviceOwner
+        exclude = ("last_login",)
+        extra_kwargs = {'password': {'write_only': True}}
+
+    def create(self, validated_data):
+        user = DeviceOwner(**validated_data)
+        user.set_password(validated_data['password'])
+        user.save()
+        return user
+
+
+class MembershipSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Membership
+        exclude = ("dataset",)
+
+
+class RoleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Role
+        exclude = ("dataset",)
+
+
+class FacilitySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Facility
+        exclude = ("dataset", "kind", "parent")
+
+
+class ClassroomSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Classroom
+        exclude = ("dataset", "kind")
+
+
+class LearnerGroupSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = LearnerGroup
+        exclude = ("dataset", "kind")

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import factory
+
+from django.test import TestCase, Client
+
+from .. import models
+
+
+class FacilityFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.Facility
+
+    name = "Rock N' Roll High School"
+
+
+class FacilityUserFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.FacilityUser
+
+    facility = factory.SubFactory(FacilityFactory)
+    username = factory.Sequence(lambda n: 'user%d' % n)
+
+
+class FacilityApiTestCase(TestCase):
+
+    def setUp(self):
+        self.password = "abc123"
+        self.facility = FacilityFactory.create()
+        self.user = FacilityUserFactory.create(facility=self.facility)
+        self.user.set_password(self.password)
+        self.user.save()
+        self.client = Client()
+
+    def test(self):
+        self.assertTrue(self.client.login(username=self.user.username, password=self.password, facility=self.facility))

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -4,10 +4,12 @@ import factory
 
 from django.core.urlresolvers import reverse
 
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 from .. import models
 
+DUMMY_PASSWORD = "password"
 
 class FacilityFactory(factory.DjangoModelFactory):
 
@@ -24,23 +26,32 @@ class FacilityUserFactory(factory.DjangoModelFactory):
 
     facility = factory.SubFactory(FacilityFactory)
     username = factory.Sequence(lambda n: 'user%d' % n)
-    password = factory.PostGenerationMethodCall('set_password', 'password')
+    password = factory.PostGenerationMethodCall('set_password', DUMMY_PASSWORD)
 
 
-class FacilityApiTestCase(APITestCase):
+class DeviceOwnerFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = models.DeviceOwner
+
+    username = factory.Sequence(lambda n: 'deviceowner%d' % n)
+    password = factory.PostGenerationMethodCall('set_password', DUMMY_PASSWORD)
+
+
+class FacilityAPITestCase(APITestCase):
 
     def setUp(self):
-        self.password = 'abc123'
+        self.device_owner = DeviceOwnerFactory.create()
         self.facility1 = FacilityFactory.create()
         self.facility2 = FacilityFactory.create()
         self.user1 = FacilityUserFactory.create(facility=self.facility1)
         self.user2 = FacilityUserFactory.create(facility=self.facility2)
 
     def test_sanity(self):
-        self.assertTrue(self.client.login(username=self.user1.username, password="password", facility=self.facility1))
+        self.assertTrue(self.client.login(username=self.user1.username, password=DUMMY_PASSWORD, facility=self.facility1))
 
     def test_facility_user_can_get_detail(self):
-        self.client.login(username=self.user1.username, password="password", facility=self.facility1)
+        self.client.login(username=self.user1.username, password=DUMMY_PASSWORD, facility=self.facility1)
         response = self.client.get(reverse('facility-detail', kwargs={'pk': self.facility1.pk}),
                                    format='json')
         # .assertDictContainsSubset checks that the first argument is a subset of the second argument
@@ -51,3 +62,69 @@ class FacilityApiTestCase(APITestCase):
     def test_anonymous_user_gets_empty_list(self):
         response = self.client.get(reverse('facility-list'), format='json')
         self.assertEqual(response.data, [])
+
+    def test_device_admin_can_create_facility(self):
+        new_facility_name = "New Facility"
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 0)
+        response = self.client.post(reverse('facility-list'), {"name": new_facility_name}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 1)
+
+    def test_facility_user_cannot_create_facility(self):
+        new_facility_name = "New Facility"
+        self.client.login(username=self.user1.username, password=DUMMY_PASSWORD, facility=self.facility1)
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 0)
+        response = self.client.post(reverse('facility-list'), {"name": new_facility_name}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 0)
+
+    def test_anonymous_user_cannot_create_facility(self):
+        new_facility_name = "New Facility"
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 0)
+        response = self.client.post(reverse('facility-list'), {"name": new_facility_name}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(models.Facility.objects.filter(name=new_facility_name).count(), 0)
+
+    def test_device_admin_can_update_facility(self):
+        old_facility_name = self.facility1.name
+        new_facility_name = "Renamed Facility"
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+        self.assertEqual(models.Facility.objects.get(id=self.facility1.id).name, old_facility_name)
+        response = self.client.put(reverse('facility-detail', kwargs={"pk": self.facility1.id}), {"name": new_facility_name}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(models.Facility.objects.get(id=self.facility1.id).name, new_facility_name)
+
+    def test_device_admin_can_delete_facility(self):
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+        self.assertEqual(models.Facility.objects.filter(id=self.facility1.id).count(), 1)
+        response = self.client.delete(reverse('facility-detail', kwargs={"pk": self.facility1.id}))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(models.Facility.objects.filter(id=self.facility1.id).count(), 0)
+
+
+class UserCreationTestCase(APITestCase):
+
+    def setUp(self):
+        self.device_owner = DeviceOwnerFactory.create()
+        self.facility = FacilityFactory.create()
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+
+    def test_creating_device_owner_via_api_sets_password_correctly(self):
+        new_username = "goliath"
+        new_password = "davidsucks"
+        bad_password = "ilovedavid"
+        response = self.client.post(reverse('deviceowner-list'), {"username": new_username, "password": new_password}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(models.DeviceOwner.objects.get(username=new_username).check_password(new_password))
+        self.assertFalse(models.DeviceOwner.objects.get(username=new_username).check_password(bad_password))
+
+    def test_creating_facility_user_via_api_sets_password_correctly(self):
+        new_username = "goliath"
+        new_password = "davidsucks"
+        bad_password = "ilovedavid"
+        data = {"username": new_username, "password": new_password, "facility": self.facility.id}
+        response = self.client.post(reverse('facilityuser-list'), data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(models.FacilityUser.objects.get(username=new_username).check_password(new_password))
+        self.assertFalse(models.FacilityUser.objects.get(username=new_username).check_password(bad_password))

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import factory
 
-from django.test import TestCase, Client
+from django.core.urlresolvers import reverse
+
+from rest_framework.test import APITestCase
 
 from .. import models
 
@@ -22,15 +24,28 @@ class FacilityUserFactory(factory.DjangoModelFactory):
     username = factory.Sequence(lambda n: 'user%d' % n)
 
 
-class FacilityApiTestCase(TestCase):
+class FacilityApiTestCase(APITestCase):
 
     def setUp(self):
-        self.password = "abc123"
+        self.password = 'abc123'
         self.facility = FacilityFactory.create()
         self.user = FacilityUserFactory.create(facility=self.facility)
         self.user.set_password(self.password)
         self.user.save()
-        self.client = Client()
 
-    def test(self):
+    def test_sanity(self):
         self.assertTrue(self.client.login(username=self.user.username, password=self.password, facility=self.facility))
+
+    def test_facility_user_can_get_detail(self):
+        response = self.client.get(reverse('rest_framework:facility-detail', kwargs={'pk': self.facility.pk}),
+                                   format='json')
+        # .assertDictContainsSubset checks that the first argument is a subset of the second argument
+        self.assertDictContainsSubset({
+            'name': self.facility.name,
+            'kind': self.facility.kind,
+            'parent': ''
+        }, response.data)
+
+    def test_facility_user_cant_get_list(self):
+        response = self.client.get(reverse('rest_framework:facility-list'), format='json')
+        self.assertEqual(response.status_code, 403)

--- a/kolibri/auth/test/test_datasets.py
+++ b/kolibri/auth/test/test_datasets.py
@@ -59,3 +59,8 @@ class FacilityDatasetTestCase(TestCase):
         facility.full_clean()
         facility.save()
         self.assertEqual(dataset, facility.dataset)
+
+    def test_dataset_representation(self):
+        self.assertEqual(str(self.facility.dataset), "FacilityDataset for {}".format(self.facility.name))
+        new_dataset = FacilityDataset.objects.create()
+        self.assertEqual(str(new_dataset), "FacilityDataset (no associated Facility)")

--- a/kolibri/auth/test/test_middleware.py
+++ b/kolibri/auth/test/test_middleware.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.test import TestCase
+
+from ..middleware import _get_user, CustomAuthenticationMiddleware
+from ..models import KolibriAnonymousUser
+
+class DummyRequestObject(object):
+    def __init__(self):
+        self.session = {}
+
+class AuthMiddlewareTestCase(TestCase):
+
+    def test_custom_anonymous_user(self):
+        request = DummyRequestObject()
+        mw = CustomAuthenticationMiddleware()
+        mw.process_request(request)
+        self.assertIsInstance(request.user, KolibriAnonymousUser)
+
+    def test_custom_anonymous_user_caching(self):
+        # this test specifically helps with code coverage by checking user caching
+        request = DummyRequestObject()
+        user = _get_user(request)
+        self.assertIsInstance(user, KolibriAnonymousUser)
+        user = _get_user(request)
+        self.assertIsInstance(user, KolibriAnonymousUser)

--- a/kolibri/auth/test/test_models.py
+++ b/kolibri/auth/test/test_models.py
@@ -327,6 +327,29 @@ class DeviceOwnerRoleMembershipTestCase(TestCase):
             self.classroom.remove_member(self.device_owner)
 
 
+class DeviceOwnerSuperuserTestCase(TestCase):
+
+    def test_device_owner_is_superuser(self):
+        device_owner = DeviceOwner.objects.create(username="test", password="##")
+        self.assertTrue(device_owner.is_superuser)
+
+    def test_device_owner_manager_supports_superuser_creation(self):
+        superusername = "boss"
+        DeviceOwner.objects.create_superuser(superusername, "password")
+        self.assertEqual(DeviceOwner.objects.get().username, superusername)
+
+    def test_device_owner_manager_superuser_creation_fails_with_empty_username(self):
+        superusername = ""
+        with self.assertRaises(ValueError):
+            DeviceOwner.objects.create_superuser(superusername, "password")
+        self.assertEqual(DeviceOwner.objects.count(), 0)
+
+    def test_device_owner_has_all_django_perms_for_django_admin(self):
+        device_owner = DeviceOwner.objects.create(username="test", password="##")
+        self.assertTrue(device_owner.has_perm("someperm", object()))
+        self.assertTrue(device_owner.has_perms(["someperm"], object()))
+        self.assertTrue(device_owner.has_module_perms("module.someapp"))
+
 class StringMethodTestCase(TestCase):
 
     def setUp(self):

--- a/kolibri/auth/urls.py
+++ b/kolibri/auth/urls.py
@@ -1,0 +1,18 @@
+from rest_framework_nested import routers
+
+from .api import (
+    ClassroomViewSet, DeviceOwnerViewSet, FacilityUserViewSet, FacilityViewSet,
+    LearnerGroupViewSet, MembershipViewSet, RoleViewSet
+)
+
+router = routers.SimpleRouter()
+
+router.register(r'facilityuser', FacilityUserViewSet)
+router.register(r'deviceowner', DeviceOwnerViewSet)
+router.register(r'membership', MembershipViewSet)
+router.register(r'role', RoleViewSet)
+router.register(r'facility', FacilityViewSet)
+router.register(r'classroom', ClassroomViewSet)
+router.register(r'learnergroup', LearnerGroupViewSet)
+
+urlpatterns = router.urls

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -50,7 +50,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'kolibri.auth.middleware.CustomAuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -195,5 +195,10 @@ LOGGING = {
 
 AUTH_USER_MODEL = 'kolibriauth.DeviceOwner'
 
+AUTH_ANONYMOUS_USER_MODEL = "kolibri.auth.models.KolibriAnonymousUser"
 
 AUTHENTICATION_BACKENDS = ['kolibri.auth.backends.DeviceOwnerBackend', 'kolibri.auth.backends.FacilityUserBackend']
+
+REST_FRAMEWORK = {
+    "UNAUTHENTICATED_USER": AUTH_ANONYMOUS_USER_MODEL
+}

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -195,10 +195,8 @@ LOGGING = {
 
 AUTH_USER_MODEL = 'kolibriauth.DeviceOwner'
 
-AUTH_ANONYMOUS_USER_MODEL = "kolibri.auth.models.KolibriAnonymousUser"
-
 AUTHENTICATION_BACKENDS = ['kolibri.auth.backends.DeviceOwnerBackend', 'kolibri.auth.backends.FacilityUserBackend']
 
 REST_FRAMEWORK = {
-    "UNAUTHENTICATED_USER": AUTH_ANONYMOUS_USER_MODEL
+    "UNAUTHENTICATED_USER": "kolibri.auth.models.KolibriAnonymousUser"
 }

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^$', include('kolibri.core.urls')),
     url(r'', include('kolibri.content.urls')),
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -26,5 +26,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^$', include('kolibri.core.urls')),
     url(r'', include('kolibri.content.urls')),
+    url(r'^api/', include('kolibri.auth.urls')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,6 @@ docopt==0.6.2
 colorlog==2.6.0
 django==1.9.1
 django-mptt==0.8.0
-djangorestframework==3.3.2
+djangorestframework==3.3.3
 drf-nested-routers
 six==1.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,6 +8,3 @@ pytest-cov
 coverage
 mock
 psycopg2==2.6.1
-pytest
-pytest-cov
-pytest-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 -r base.txt
 # These are for testing
-factory-boy==2.6.1
+factory-boy==2.7.0
+fake-factory==0.5.7
 pytest
 pytest-django
 pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,9 @@
 -r base.txt
 # These are for testing
+factory-boy==2.6.1
+pytest
+pytest-django
+pytest-cov
 coverage
 mock
 psycopg2==2.6.1


### PR DESCRIPTION
## Summary

- Added wrappers for the `kolibri.auth` permissions system to allow it to be easily used in Django REST Framework
- Added the main Django REST Framework API endpoints for the `auth` app models
- Added a `KolibriAnonymousUser` model that exposes our `KolibriAbstractBaseUser` interface, so we can check permissions on unauthenticated users

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

I have followed a fairly standard approach to organizing the various DRF pieces (serializer classes in `serializers.py`, viewsets in `api.py`, and routers in `urls.py`), but we should think about how we want to do that in a consistent way across apps (might be different from what I did here).

I also haven't done any customization or made any calls here about how we handle things like related models (e.g. hyperlinking foreign keys), as I think that will become clearer once we better understand how we'll be handling state in Vue.js.

## Documentation

Coming soon.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/618416/15020863/c740aee0-11d8-11e6-9b07-78158e367ae5.png)

![image](https://cloud.githubusercontent.com/assets/618416/15020987/4b165490-11d9-11e6-9f24-9e7330a5d164.png)
