### PR TITLE
Destroy KOLIBRI_HOME for every test env for better isolation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
 commands =
     kolibri plugin kolibri.plugins.navigation enable
     py.test --cov=kolibri --color=no {posargs}
+    rm -r {env:KOLIBRI_HOME}
 
 [testenv:postgres]
 setenv =


### PR DESCRIPTION
## Summary

Does what the title says.