### PR TITLE
Adds JSDoc generated RST doc files to Sphinx docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ coverage:
 
 docs: clean-docs
 	sphinx-apidoc -d 10 -H "Python Reference" -o docs/ kolibri kolibri/test kolibri/deployment/
+	./node_modules/.bin/jsdoc -t ./node_modules/jsdoc-sphinx/template/ --recurse kolibri/ -d ./docs/js_modules -p ./package.json
 	$(MAKE) -C docs html
 
 release: clean

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,3 +28,4 @@ For Developers
    changelog
    todo
    modules
+   js_docs

--- a/docs/js_docs.rst
+++ b/docs/js_docs.rst
@@ -1,0 +1,8 @@
+Javascript Reference
+====================
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   js_modules/*

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
     "temp": "^0.8.3",
     "webpack": "^1.12.12",
     "webpack-bundle-tracker": "0.0.93"
+  },
+  "optionalDependencies": {
+    "jsdoc": "^3.4.0",
+    "jsdoc-sphinx": "0.0.4"
   }
 }


### PR DESCRIPTION
## Summary

Adds JSDoc RST file generation to add Javascript API docs to our readthedocs.

## Reviewer guidance

Run `make docs` and browse locally to see how it works.

