### PR TITLE
Conditional testing of sdist building and installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_script:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - ./testif.sh "setup_changed" || echo "[ OK ] Skipped setup.py"
+  - ./testif.sh "setup_changed"
   - tox -e $TOX_ENV
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ before_script:
 
 # command to run tests, e.g. python setup.py test
 script:
+  - ./testif.sh "setup_changed" || echo "[ OK ] Skipped setup.py"
   - tox -e $TOX_ENV
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,5 @@ release: clean
 
 sdist: clean
 	python setup.py sdist
-	python setup.py bdist_wheel upload
+	python setup.py bdist_wheel
 	ls -l dist

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,5 @@
+# Requirements for building wheels
+# This does not depend on runtime stuff so we do not
+# include base.txt
+sphinx
+sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ doclink = """
 Documentation
 -------------
 
-The full documentation is at http://kolibri_skeleton.rtfd.org."""
+The full documentation is at http://kolibri.rtfd.org."""
 history = open('CHANGELOG.rst').read().replace('.. :changelog:', '')
 
 setup(

--- a/testif.sh
+++ b/testif.sh
@@ -39,12 +39,9 @@ commit="$TRAVIS_COMMIT"
 commits="$TRAVIS_COMMIT_RANGE"
 git_changeset=`git show --name-only --no-notes --oneline $commits`
 
-echo "Testing commit $commit"
-echo "Testing commit range $commits"
 
-echo "Changeset is: \n\n $git_changeset"
-echo ""
-
+# If something changes that's related to our sdist packaging
+# or installation mechanism, then we build and install.
 if [[ "$LABEL" == "setup_changed" ]]
 then
 
@@ -53,11 +50,17 @@ then
     # Match commits changing setup.py
     if echo "$git_changeset" | grep -q "\[\s*setup\s*\]" || \
        echo "$git_changeset" | grep -q "^setup\.py" || \
-       echo "$git_changeset" | grep -q "^requirements.txt"
+       echo "$git_changeset" | grep -q "^requirements"
+       echo "$git_changeset" | grep -q "^Makefile"
+       echo "$git_changeset" | grep -q "^MANIFEST*"
     then
 
-        pip install .
+        # Install build deps
+        pip install -r requirements/build.txt
 
+        # Build .whl
+        make sdist
+        pip install dist/kolibri-*.whl
         exit 0
 
     fi

--- a/testif.sh
+++ b/testif.sh
@@ -50,8 +50,8 @@ then
     # Match commits changing setup.py
     if echo "$git_changeset" | grep -q "\[\s*setup\s*\]" || \
        echo "$git_changeset" | grep -q "^setup\.py" || \
-       echo "$git_changeset" | grep -q "^requirements"
-       echo "$git_changeset" | grep -q "^Makefile"
+       echo "$git_changeset" | grep -q "^requirements" || \
+       echo "$git_changeset" | grep -q "^Makefile" || \
        echo "$git_changeset" | grep -q "^MANIFEST*"
     then
 


### PR DESCRIPTION
## Summary

Adds automated testing of building and installing the dists only when it's necessary or manually requested.

 * If `requirements*` are in the changeset
 * If `setup.py` is in the changeset
 * If `Makefile` is in the changeset
 * If `MANIFEST.in` is in the changeset
 * if `[ setup ]` is in the commit message

## TODO

 * [x] Wrap repetitive routines in bash functions
 * [x] Always test everything when merging to master
 * [x] Use diffset between PR branch and upstream branch to merge into as diffset to fire conditions for

## Reviewer guidance

Make note that the intention of this PR is to have something tested **that would otherwise not be tested**. It is not to skip essential testing.

As a strategic means, we can perhaps use/improve this practice for other purposes if we run into similar scenarios.

## Issues addressed

#27 

## Documentation

Added as comments in testif.sh
