### PR TITLE
Reference core app by 'kolibri'.

### DIFF
--- a/kolibri/core/assets/src/kolibri_module.js
+++ b/kolibri/core/assets/src/kolibri_module.js
@@ -4,7 +4,7 @@
  * @module kolibri_module
  */
 
-const Kolibri = require('./core_app_instance');
+const Kolibri = require('kolibri');
 
 export default class KolibriModule {
   /**


### PR DESCRIPTION
Prevent core app being bundled into any plugin modules by using its external shadowed name on import.