### PR TITLE
Make Django Urls available in Javascript

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,3 +19,4 @@ Kolibri 0.0.1
   * Adds pipelining and integration for building frontend assets with webpack and dynamically serving them in Django.
   * Updates to *Users, Collections, and Roles, mostly to account for multiple facilities in one database
   * Plugin API with hooks, documented and implemented
+  * Adds Django JS Reverse and loads into kolibriGlobal object

--- a/assets/src/parse_bundle_plugin.js
+++ b/assets/src/parse_bundle_plugin.js
@@ -39,12 +39,11 @@ var parseBundlePlugin = function(data, base_dir) {
         (typeof data.static_dir !== "undefined") &&
         (typeof data.stats_file !== "undefined")) {
         bundle_data[data.name] = data.src_file;
-        if (typeof data.external !== "undefined" && data.external) {
+        if (typeof data.external !== "undefined" && data.external && data.core_name) {
             // If we want to create a plugin that can be directly referenced by other plugins, this sets it to be
-            // instantiated as a global variable. Only currently used by the Kolibri core app.
+            // instantiated as a global variable. Only to be used by the Kolibri core app.
             external = data.name;
-            // change the periods of the Python module path name to underscores, so that it is a valid JS variable name.
-            library = data.core ? 'kolibriGlobal' : data.name.replace(/\./g, "_");
+            library = data.core_name;
         }
 
         bundle.resolve.root = base_dir;
@@ -66,7 +65,7 @@ var parseBundlePlugin = function(data, base_dir) {
             })
         ]);
         _.extend(bundle, {
-            core: data.core,
+            core_name: data.core_name,
             name: data.name,
             context: base_dir,
             entry: bundle_data,

--- a/assets/src/read_bundle_plugins.js
+++ b/assets/src/read_bundle_plugins.js
@@ -45,7 +45,7 @@ var readBundlePlugin = function(base_dir, libs) {
                 // The second part of the output is any global variables that will be available to all other
                 // plugins. For the moment, this is only the Kolibri global variable.
                 var external = output[1];
-                if (typeof externals[external] === "undefined") {
+                if (external && typeof externals[external] === "undefined") {
 
                     externals[external] = external;
                 } else {

--- a/assets/src/read_bundle_plugins.js
+++ b/assets/src/read_bundle_plugins.js
@@ -36,6 +36,7 @@ var readBundlePlugin = function(base_dir, libs) {
 
         for (var i = 0; i < results.length; i++) {
             var message = results[i];
+
             var output = parseBundlePlugin(message, base_dir);
             if (typeof output !== "undefined") {
                 var webpack_configuration = output[0];
@@ -68,7 +69,7 @@ var readBundlePlugin = function(base_dir, libs) {
     }
 
     // One bundle is special - that is the one for the core bundle.
-    var core_bundle = _.find(bundles, function(bundle) {return bundle.core && bundle.core !== null;});
+    var core_bundle = _.find(bundles, function(bundle) {return bundle.core_name && bundle.core_name !== null;});
 
     // For that bundle, we replace all references to library modules (like Backbone) that we bundle into the core app
     // with references to the core app itself, so if someone does `var Backbone = require('backbone');` webpack
@@ -76,14 +77,13 @@ var readBundlePlugin = function(base_dir, libs) {
     var lib_externals = core_bundle ? libs(core_bundle.output.library) : {};
 
     bundles.forEach(function(bundle) {
-        if (bundle.core === null || typeof bundle.core === "undefined") {
+        if (bundle.core_name === null || typeof bundle.core_name === "undefined") {
             // If this is not the core bundle, then we need to add the external library mappings.
             bundle.externals = _.extend({}, externals, lib_externals);
         } else {
             bundle.externals = externals;
         }
     });
-
 
     return bundles;
 

--- a/assets/test/test_bundle_parse.js
+++ b/assets/test/test_bundle_parse.js
@@ -66,14 +66,15 @@ describe('parseBundlePlugin', function() {
             done();
         });
     });
-    describe('input is valid, has externals flag, externals output', function() {
+    describe('input is valid, has externals flag and core_name value, externals output', function() {
         it('should have one entry', function (done) {
             var data = {
                 name: "kolibri.plugin.test.test_plugin",
                 src_file: "src/file.js",
                 external: true,
                 stats_file: "output.json",
-                static_dir: "kolibri/plugin/test"
+                static_dir: "kolibri/plugin/test",
+                core_name: "test_core"
             };
             assert(typeof parseBundlePlugin(data, "/")[1] !== "undefined");
             done();
@@ -85,7 +86,7 @@ describe('parseBundlePlugin', function() {
                 name: "kolibri.plugin.test.test_plugin",
                 src_file: "src/file.js",
                 external: true,
-                core: true,
+                core_name: "kolibriGlobal",
                 stats_file: "output.json",
                 static_dir: "kolibri/plugin/test"
             };
@@ -162,15 +163,16 @@ describe('readBundlePlugins', function() {
             done();
         });
     });
-    describe('two external flags on inputs, externals output', function() {
-        it('should have two entries', function (done) {
+    describe('two external flags on inputs, one with core_name value, externals output', function() {
+        it('should have one entry', function (done) {
             data = [
                 {
                     name: "kolibri.plugin.test.test_plugin",
                     src_file: "src/file.js",
                     stats_file: "output.json",
                     external: true,
-                    static_dir: "kolibri/plugin/test"
+                    static_dir: "kolibri/plugin/test",
+                    core_name: "test_global"
                 },
                 {
                     name: "kolibri.plugin.test.test_plugin1",
@@ -180,29 +182,31 @@ describe('readBundlePlugins', function() {
                     static_dir: "kolibri/plugin/test"
                 }
             ];
-            assert(Object.keys(readBundlePlugins("", "")[0].externals).length === 2);
+            assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
             done();
         });
     });
     describe('two identically named external flags on inputs, externals output', function() {
-        it('should have two entries', function (done) {
+        it('should have one entry', function (done) {
             data = [
                 {
                     name: "kolibri.plugin.test.test_plugin",
                     src_file: "src/file.js",
                     stats_file: "output.json",
                     external: true,
-                    static_dir: "kolibri/plugin/test"
+                    static_dir: "kolibri/plugin/test",
+                    core_name: "test_global"
                 },
                 {
                     name: "kolibri.plugin.test.test_plugin",
                     src_file: "src/file1.js",
                     stats_file: "output1.json",
                     external: true,
-                    static_dir: "kolibri/plugin/test"
+                    static_dir: "kolibri/plugin/test",
+                    core_name: "test_global"
                 }
             ];
-            assert(Object.keys(readBundlePlugins("", "")[0].externals).length === 1);
+            assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
             done();
         });
     });

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,4 +1,4 @@
-{% load i18n kolibri_tags webpack_tags %}<html>
+{% load i18n kolibri_tags webpack_tags js_reverse cache %}<html>
 <head>
   <title>{% block title %}{% endblock %} - {% trans "Kolibri" %}</title>
 </head>
@@ -18,6 +18,11 @@
 <main></main>
 {% block frontend_assets %}
 {% webpack_asset 'default_frontend' %}
+<script type="text/javascript" charset="utf-8">
+  {% cache 5000 js_urls %}
+    {% js_reverse_inline %}
+  {% endcache %}
+</script>
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}
 {% endblock %}

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -17,7 +17,6 @@ from django.conf import settings as django_settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-
 from kolibri.core.webpack.utils import render_as_url
 from kolibri.plugins import hooks
 
@@ -286,7 +285,7 @@ class FrontEndCoreAssetHook(WebpackBundleHook):
     @hooks.registered_method
     def webpack_bundle_data(self):
         dct = super(FrontEndCoreAssetHook, self).webpack_bundle_data
-        dct['core'] = True
+        dct['core_name'] = django_settings.KOLIBRI_CORE_JS_NAME
         dct['external'] = True
         return dct
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -19,6 +19,8 @@ BASE_DIR = os.path.abspath(os.path.dirname(__name__))
 
 KOLIBRI_HOME = os.environ['KOLIBRI_HOME']
 
+KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
@@ -205,6 +207,6 @@ REST_FRAMEWORK = {
 # Configuration for Django JS Reverse
 JS_REVERSE_JS_VAR_NAME = 'urls'
 
-JS_REVERSE_JS_GLOBAL_OBJECT_NAME = 'kolibriGlobal'
+JS_REVERSE_JS_GLOBAL_OBJECT_NAME = KOLIBRI_CORE_JS_NAME
 
 JS_REVERSE_EXCLUDE_NAMESPACES = ['admin', ]

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'kolibri.content',
     'kolibri.core.webpack',
     'rest_framework',
+    'django_js_reverse',
 ] + conf.config['INSTALLED_APPS']
 
 MIDDLEWARE_CLASSES = (
@@ -200,3 +201,10 @@ AUTHENTICATION_BACKENDS = ['kolibri.auth.backends.DeviceOwnerBackend', 'kolibri.
 REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": "kolibri.auth.models.KolibriAnonymousUser"
 }
+
+# Configuration for Django JS Reverse
+JS_REVERSE_JS_VAR_NAME = 'urls'
+
+JS_REVERSE_JS_GLOBAL_OBJECT_NAME = 'kolibriGlobal'
+
+JS_REVERSE_EXCLUDE_NAMESPACES = ['admin', ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ django-mptt==0.8.0
 djangorestframework==3.3.3
 drf-nested-routers
 six==1.10.0
+django-js-reverse==0.7.2

--- a/webpack_config/webpack.config.js
+++ b/webpack_config/webpack.config.js
@@ -17,7 +17,7 @@ var readBundlePlugins = require('../assets/src/read_bundle_plugins');
 // * the keys are names exposed by webpack to use in `require` statements, across apps
 // * the values are references to the packages, already inserted into kolibriGlobal
 //
-// kolibri_name is always == kolibriGlobal
+// kolibri_name is always == kolibriGlobal (this is defined in the base settings - base.py)
 var libs = function(kolibri_name) {
     return {
         'loglevel': kolibri_name + '.lib.loglevel',


### PR DESCRIPTION
## Summary

* Attaches a Django JS Reverse `urls` object to `kolibriGlobal`.

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file
- [x] Add an entry to CHANGELOG.rst

## Reviewer guidance

Can access Urls from `kolibriGlobal.urls`.

## Documentation

Updated here:
https://github.com/rtibbles/kolibri/blob/c548a8c8d27b9917876068c08a0d61b741adfe3f/docs/dev/frontend.rst