### PR TITLE
Cleanup pre-commit exclude rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,6 @@
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
-        args:
-        - --exclude=kolibri/*/migrations/*
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,6 @@ bdd = pytest --addopts "-c pytest.bdd.ini"
 ignore = E226,E302,E41
 max-line-length = 160
 max-complexity = 10
-exclude = migrations
-
-[pep8]
-ignore = E226,E302,E41,E402
-max-line-length = 160
 exclude = kolibri/*/migrations/*
 
 [isort]


### PR DESCRIPTION
Have only one set of exclude rules, the other was a mess, and the pre-commit args meant that setup.cfg wasn't read