### PR TITLE
Consistency 3

### DIFF
--- a/kolibri/plugins/learn/assets/src/learn-main.vue
+++ b/kolibri/plugins/learn/assets/src/learn-main.vue
@@ -12,7 +12,7 @@
 
 <script>
 
-  export default {
+  module.exports = {
     components: {
       'core-base': require('core-base'),
     },

--- a/kolibri/plugins/learn/assets/src/learn-main.vue
+++ b/kolibri/plugins/learn/assets/src/learn-main.vue
@@ -21,5 +21,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/drop-down.vue
+++ b/kolibri/plugins/management/assets/src/drop-down.vue
@@ -1,4 +1,5 @@
 <template>
+
   <select v-model="selected">
     <template v-for="option in list">
       <option :value="option">
@@ -6,18 +7,21 @@
       </option>
     </template>
   </select>
+
 </template>
 
 
 <script>
-module.exports = {
-  props: {
-    list: {
-      type: Array,
+
+  module.exports = {
+    props: {
+      list: {
+        type: Array,
+      },
+      selected: null,
     },
-    selected: null,
-  },
-};
+  };
+
 </script>
 
 

--- a/kolibri/plugins/management/assets/src/drop-down.vue
+++ b/kolibri/plugins/management/assets/src/drop-down.vue
@@ -10,7 +10,7 @@
 
 
 <script>
-export default {
+module.exports = {
   props: {
     list: {
       type: Array,

--- a/kolibri/plugins/management/assets/src/learner-roster.vue
+++ b/kolibri/plugins/management/assets/src/learner-roster.vue
@@ -27,7 +27,7 @@
 
 
 <script>
-export default {
+module.exports = {
   props: {
     learners: {
       type: Array,

--- a/kolibri/plugins/management/assets/src/learner-roster.vue
+++ b/kolibri/plugins/management/assets/src/learner-roster.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div class="roster">
     <input type="search" placeholder="Search for learner...">
     <div>
@@ -23,28 +24,33 @@
       <div>{{ learners.length }}</div>
     </div>
   </div>
+
 </template>
 
 
 <script>
-module.exports = {
-  props: {
-    learners: {
-      type: Array,
-      default: () => [{
-        last_name: 'Duck',
-        first_name: 'John',
-      }],
+
+  module.exports = {
+    props: {
+      learners: {
+        type: Array,
+        default: () => [{
+          last_name: 'Duck',
+          first_name: 'John',
+        }],
+      },
     },
-  },
-};
+  };
+
 </script>
 
 
 <style lang="stylus" scoped>
-.roster, .sidebar
-  display: inline-block
 
-.learner-count
-  border: solid, 1px, black
+  .roster, .sidebar
+    display: inline-block
+
+  .learner-count
+    border: solid, 1px, black
+
 </style>

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div>
     <drop-down v-ref:classroom-selector :list="classrooms" :selected.sync="selectedClassroom"></drop-down>
     <button v-on:click="addClassroom({name: 'foo'})">Create</button>
@@ -10,92 +11,94 @@
     <button>Delete</button>
   </div>
   <learner-roster v-ref:learner-roster :learners="filteredLearners"></learner-roster>
+
 </template>
 
 
 <script>
-const learnerRoster = require('./learner-roster.vue');
-const dropDown = require('./drop-down.vue');
 
-const actions = require('./vuex/actions.js');
-const addClassroom = actions.addClassroom;
-const setSelectedClassroomId = actions.setSelectedClassroomId;
+  const learnerRoster = require('./learner-roster.vue');
+  const dropDown = require('./drop-down.vue');
 
-const getters = require('./vuex/getters.js');
-const getClassrooms = getters.getClassrooms;
-const getSelectedClassroomId = getters.getSelectedClassroomId;
+  const actions = require('./vuex/actions.js');
+  const addClassroom = actions.addClassroom;
+  const setSelectedClassroomId = actions.setSelectedClassroomId;
 
-const store = require('./vuex/store.js');
-const constants = store.constants;
+  const getters = require('./vuex/getters.js');
+  const getClassrooms = getters.getClassrooms;
+  const getSelectedClassroomId = getters.getSelectedClassroomId;
 
-module.exports = {
-  components: {
-    'learner-roster': learnerRoster,
-    'drop-down': dropDown,
-  },
-  computed: {
-    classrooms() {
-      const _classrooms = [{
-        id: constants.ALL_CLASSROOMS_ID,
-        name: 'All classrooms',
-        learnerGroups: [],
-      }];
-      _classrooms.push(...this.getClassrooms);
-      return _classrooms;
+  const store = require('./vuex/store.js');
+  const constants = store.constants;
+
+  module.exports = {
+    components: {
+      'learner-roster': learnerRoster,
+      'drop-down': dropDown,
     },
-    selectedClassroom: {
-      get() {
-        for (const classroom of this.classrooms) {
-          if (classroom.id === this.getSelectedClassroomId) {
-            return classroom;
+    computed: {
+      classrooms() {
+        const _classrooms = [{
+          id: constants.ALL_CLASSROOMS_ID,
+          name: 'All classrooms',
+          learnerGroups: [],
+        }];
+        _classrooms.push(...this.getClassrooms);
+        return _classrooms;
+      },
+      selectedClassroom: {
+        get() {
+          for (const classroom of this.classrooms) {
+            if (classroom.id === this.getSelectedClassroomId) {
+              return classroom;
+            }
           }
-        }
-        // Default value in case getSelectedClassroom is inconsistent
-        return this.classrooms[0];
+          // Default value in case getSelectedClassroom is inconsistent
+          return this.classrooms[0];
+        },
+        set({ id }) {
+          this.setSelectedClassroomId(id);
+        },
       },
-      set({ id }) {
-        this.setSelectedClassroomId(id);
-      },
-    },
-    filteredLearners() {
-      const learners = this.$store.state.learners;
-      let _learners = learners;
-      if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
-        const learnerGroupIds = this.selectedClassroom.learnerGroups;
-        const learnerIds = new Set();
-        for (const group of this.$store.state.learnerGroups) {
-          if (learnerGroupIds.indexOf(group.id) !== -1) {
-            for (const learnerId of group.learners) {
-              if (!learnerIds.has(learnerId)) {
-                learnerIds.add(learnerId);
+      filteredLearners() {
+        const learners = this.$store.state.learners;
+        let _learners = learners;
+        if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
+          const learnerGroupIds = this.selectedClassroom.learnerGroups;
+          const learnerIds = new Set();
+          for (const group of this.$store.state.learnerGroups) {
+            if (learnerGroupIds.indexOf(group.id) !== -1) {
+              for (const learnerId of group.learners) {
+                if (!learnerIds.has(learnerId)) {
+                  learnerIds.add(learnerId);
+                }
               }
             }
           }
-        }
 
-        _learners = [];
-        for (const learner of learners) {
-          if (learnerIds.has(learner.id)) {
-            _learners.push(learner);
+          _learners = [];
+          for (const learner of learners) {
+            if (learnerIds.has(learner.id)) {
+              _learners.push(learner);
+            }
           }
         }
-      }
-      return _learners;
+        return _learners;
+      },
     },
-  },
-  vuex: {
-    getters: {
-      getClassrooms,
-      getSelectedClassroomId,
+    vuex: {
+      getters: {
+        getClassrooms,
+        getSelectedClassroomId,
+      },
+      actions: {
+        addClassroom,
+        setSelectedClassroomId,
+      },
     },
-    actions: {
-      addClassroom,
-      setSelectedClassroomId,
-    },
-  },
-};
+  };
+
 </script>
 
 
-<style lang="stylus" scoped>
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -28,7 +28,7 @@ const getSelectedClassroomId = getters.getSelectedClassroomId;
 const store = require('./vuex/store.js');
 const constants = store.constants;
 
-export default {
+module.exports = {
   components: {
     'learner-roster': learnerRoster,
     'drop-down': dropDown,

--- a/kolibri/plugins/management/assets/test/fixtures/fixture1.js
+++ b/kolibri/plugins/management/assets/test/fixtures/fixture1.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   learners: [
     {
       id: 1,

--- a/kolibri/plugins/navigation/assets/src/navigation.vue
+++ b/kolibri/plugins/navigation/assets/src/navigation.vue
@@ -1,4 +1,5 @@
 <template>
+
   <header id="navigation-module">
     <nav class="titlebar">
 
@@ -25,41 +26,44 @@
       </div>
     </nav>
   </header>
+
 </template>
+
 
 <script>
 
-module.exports = {
-  el: '#navigation-module',
-  data: {
-    // items that go in the title bar
-    nav_items: global.kolibri_reserved.nav_items,
-    title_bar: {
-      title: 'Kolibri',
-      home_link: '/',
-    },
-    user_nav_display: 'none',
+  module.exports = {
+    el: '#navigation-module',
+    data: {
+      // items that go in the title bar
+      nav_items: global.kolibri_reserved.nav_items,
+      title_bar: {
+        title: 'Kolibri',
+        home_link: '/',
+      },
+      user_nav_display: 'none',
 
-    // items that go into the user menu
-    user_nav_items: global.kolibri_reserved.user_nav_items,
-    user: {
-      username: 'foobar',
-      first_name: 'Foo',
-      last_name: 'Bar',
+      // items that go into the user menu
+      user_nav_items: global.kolibri_reserved.user_nav_items,
+      user: {
+        username: 'foobar',
+        first_name: 'Foo',
+        last_name: 'Bar',
+      },
     },
-  },
-  methods: {
-    user_nav_display_toggle() {
-      if (this.user_nav_display === 'none') {
-        this.user_nav_display = 'block';
-      } else {
-        this.user_nav_display = 'none';
-      }
+    methods: {
+      user_nav_display_toggle() {
+        if (this.user_nav_display === 'none') {
+          this.user_nav_display = 'block';
+        } else {
+          this.user_nav_display = 'none';
+        }
+      },
     },
-  },
-};
+  };
 
 </script>
+
 
 <style lang="stylus" scoped>
 

--- a/kolibri/plugins/navigation/assets/src/navigation.vue
+++ b/kolibri/plugins/navigation/assets/src/navigation.vue
@@ -28,11 +28,8 @@
 </template>
 
 <script>
-'use strict';
-const Navigation = Vue.extend({});
-import Vue from 'vue';
 
-export default new Navigation({
+module.exports = {
   el: '#navigation-module',
   data: {
     // items that go in the title bar
@@ -60,7 +57,8 @@ export default new Navigation({
       }
     },
   },
-});
+};
+
 </script>
 
 <style lang="stylus" scoped>
@@ -122,4 +120,5 @@ export default new Navigation({
     a
       color: $kolibri_gray
       text-decoration: none
+
 </style>


### PR DESCRIPTION
Proposal for a whitespace convention for .vue files. Let me know if you have feedback on this. It's not super compact, but I think it's very readable.

It would be nice to have a linter rule for this sort of thing, but I'm not sure offhand how that would be implemented.

The proposed rules are:
* two lines _between_ top-level tags (`template`, `script`, and `style`)
* one line of padding _inside_ top-level tags
* one level of indent for content inside top-level tags tags
* empty top-level tags are on one line

For example:

```html
<template>

  <select v-model="selected">
    <template v-for="option in list">
      <option :value="option">
        {{ option.name }}
      </option>
    </template>
  </select>

</template>


<script>

  module.exports = {
    props: {
      list: {
        type: Array,
      },
      selected: null,
    },
  };

</script>


<style lang="stylus" scoped></style>
```

Also migrated `export default` es6 syntax to `module.exports =`