### PR TITLE
Move misplaced coverage omit clause, add something about assertions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,17 @@ omit =
   */migrations/*
   */tests/*
   */test_*.py
+  kolibri/core/webpack/management/commands/devserver.py
 
 [coverage:report]
 ignore_errors = True
 show_missing = True
 precision = 2
-exclude_lines = raise NotImplementedError
-omit =
-  kolibri/core/webpack/management/commands/devserver.py
+exclude_lines =
+  raise NotImplementedError
+  # Don't complain if tests don't hit defensive assertion code:
+  raise AssertionError
+  raise NotImplementedError
+
+  # Don't complain if non-runnable code isn't run:
+  if __name__ == .__main__.:


### PR DESCRIPTION
[this comment](https://github.com/learningequality/kolibri/pull/100#issuecomment-221003523) had an error that propagated. Fixing that and then adding something so we don't count blocks of code that shouldn't be covered for obvious reasons (from [Coverage docs](http://coverage.readthedocs.io/en/coverage-4.0.3/config.html)).