### PR TITLE
adding basic support for stylus source maps – thanks @rtibbles!

### DIFF
--- a/webpack_config/webpack.config.base.js
+++ b/webpack_config/webpack.config.base.js
@@ -35,6 +35,9 @@ var config = {
                 loader: 'babel',
                 exclude: /node_modules/
             },
+            // Hack to make the onloadCSS node module properly export-able.
+            // Not currently used - we may be able to delete this if we
+            // deprecate our custom KolibriModule async css loading functionality.
             {
                 test: /fg-loadcss\/src\/onloadCSS/,
                 loader: 'exports?onloadCSS'
@@ -65,7 +68,7 @@ var config = {
     },
     vue: {
         loaders: {
-            stylus: 'vue-style-loader!css-loader!stylus-loader!stylint',
+            stylus: 'vue-style-loader!css-loader?sourceMap!stylus-loader!stylint',
         }
     }
 };


### PR DESCRIPTION
Now shows the vue file and line number of styles in chrome dev tools via source maps.

Unfortunately, the referenced files have a bunch of whitespace padding because of my changes here: https://github.com/vuejs/vue-loader/pull/230

Would be better if the original .vue file was shown.