### PR TITLE
Use server state for learner management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,13 @@ Kolibri 0.0.1
 +++++++++++++
 
 * Begin development of core auth app.
-  * Add core user types (BaseUser, FacilityUser, DeviceOwner)
-  * Add Collections and Roles, implemented using a special tree structure for efficient querying
-  * Add authentication & authorization backends
-  * Implement permissions for FacilityUsers by checking hierarchy relationships
-  * Adds pipelining and integration for building frontend assets with webpack and dynamically serving them in Django.
-  * Updates to *Users, Collections, and Roles, mostly to account for multiple facilities in one database
-  * Plugin API with hooks, documented and implemented
-  * Adds Django JS Reverse and loads into kolibriGlobal object
+* Add core user types (BaseUser, FacilityUser, DeviceOwner)
+* Add Collections and Roles, implemented using a special tree structure for efficient querying
+* Add authentication & authorization backends
+* Implement permissions for FacilityUsers by checking hierarchy relationships
+* Adds pipelining and integration for building frontend assets with webpack and dynamically serving them in Django.
+* Updates to Users, Collections, and Roles, mostly to account for multiple facilities in one database
+* Plugin API with hooks, documented and implemented
+* Adds Django JS Reverse and loads into kolibriGlobal object
+* Creates kolibri.auth API endpoint filtering
+* Adds management plugin for managing learners, classrooms, and groups

--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load
     files: [
+      './node_modules/phantomjs-polyfill-find/find-polyfill.js',
       'kolibri/**/assets/test/*.js',
       {pattern: 'kolibri/**/assets/src/**/*.js', included: false} // load these, but not in the browser, just for linting
     ],

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+
 from rest_framework import filters, permissions, viewsets
 
 from .models import (
@@ -26,6 +30,7 @@ class KolibriAuthPermissionsFilter(filters.BaseFilterBackend):
             # otherwise, return the full queryset, as permission checks will happen object-by-object
             # (and filtering here then leads to 404's instead of the more correct 403's)
             return queryset
+
 
 def _ensure_raw_dict(d):
     if hasattr(d, "dict"):
@@ -109,3 +114,10 @@ class LearnerGroupViewSet(viewsets.ModelViewSet):
     filter_backends = (KolibriAuthPermissionsFilter,)
     queryset = LearnerGroup.objects.all()
     serializer_class = LearnerGroupSerializer
+
+    def get_queryset(self):
+        queryset = LearnerGroup.objects.all()
+        parent_ids = self.request.query_params.get('parent_in', None)
+        if parent_ids:
+            queryset = queryset.filter(parent__in=json.loads(parent_ids))
+        return queryset

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -68,4 +68,4 @@ class LearnerGroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = LearnerGroup
-        exclude = ("dataset", "kind")
+        fields = ('id', 'name', 'parent')

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -59,7 +59,17 @@ class ClassroomSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Classroom
-        exclude = ("dataset", "kind")
+        fields = ('id', 'name', )
+
+    def to_representation(self, instance):
+        representation = super(ClassroomSerializer, self).to_representation(instance)
+        representation['learnerGroups'] = []
+        for lg in instance.get_learner_groups():
+            representation['learnerGroups'].append({
+                'id': lg.id,
+                'name': lg.name,
+            })
+        return representation
 
 
 class LearnerGroupSerializer(serializers.ModelSerializer):

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
 from rest_framework import serializers
 
 from .models import (
@@ -59,17 +61,7 @@ class ClassroomSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Classroom
-        fields = ('id', 'name', )
-
-    def to_representation(self, instance):
-        representation = super(ClassroomSerializer, self).to_representation(instance)
-        representation['learnerGroups'] = []
-        for lg in instance.get_learner_groups():
-            representation['learnerGroups'].append({
-                'id': lg.id,
-                'name': lg.name,
-            })
-        return representation
+        fields = ('id', 'name', 'parent')
 
 
 class LearnerGroupSerializer(serializers.ModelSerializer):

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -11,12 +11,29 @@ from .. import models
 
 DUMMY_PASSWORD = "password"
 
+
 class FacilityFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = models.Facility
 
     name = factory.Sequence(lambda n: "Rock N' Roll High School #%d" % n)
+
+
+class ClassroomFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = models.Classroom
+
+    name = factory.Sequence(lambda n: "Basic Rock Theory #%d" % n)
+
+
+class LearnerGroupFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = models.LearnerGroup
+
+    name = factory.Sequence(lambda n: "Group #%d" % n)
 
 
 class FacilityUserFactory(factory.DjangoModelFactory):
@@ -36,6 +53,22 @@ class DeviceOwnerFactory(factory.DjangoModelFactory):
 
     username = factory.Sequence(lambda n: 'deviceowner%d' % n)
     password = factory.PostGenerationMethodCall('set_password', DUMMY_PASSWORD)
+
+
+class ClassroomAPITestCase(APITestCase):
+
+    def setUp(self):
+        self.device_owner = DeviceOwnerFactory.create()
+        self.facility = FacilityFactory.create()
+        self.classroom = ClassroomFactory.create(parent=self.facility)
+        self.learner_group = LearnerGroupFactory.create(parent=self.classroom)
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+
+    def test_classroom_contains_learner_group_list(self):
+        response = self.client.get(reverse('classroom-detail', kwargs={'pk': self.classroom.pk}), format='json')
+        response_dict = dict(response.data)
+        self.assertListEqual(response_dict['learnerGroups'], [{'id': self.learner_group.id,
+                                                               'name': self.learner_group.name}])
 
 
 class FacilityAPITestCase(APITestCase):

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -3,15 +3,26 @@ from __future__ import absolute_import, print_function, unicode_literals
 import collections
 import factory
 import json
+import sys
 
 from django.core.urlresolvers import reverse
 
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase as BaseTestCase
 
 from .. import models
 
 DUMMY_PASSWORD = "password"
+
+
+# A weird hack because of http://bugs.python.org/issue17866
+if sys.version_info >= (3,):
+    class APITestCase(BaseTestCase):
+        def assertItemsEqual(self, *args, **kwargs):
+            self.assertCountEqual(*args, **kwargs)
+else:
+    class APITestCase(BaseTestCase):
+        pass
 
 
 class FacilityFactory(factory.DjangoModelFactory):

--- a/kolibri/plugins/management/assets/src/learner-roster.vue
+++ b/kolibri/plugins/management/assets/src/learner-roster.vue
@@ -35,8 +35,8 @@
       learners: {
         type: Array,
         default: () => [{
-          last_name: 'Duck',
-          first_name: 'John',
+          last_name: 'Default',
+          first_name: 'Value',
         }],
       },
     },

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -19,104 +19,105 @@
 
 <script>
 
-const store = require('./vuex/store.js');
-const constants = store.constants;
+  const store = require('./vuex/store.js');
+  const constants = store.constants;
 
-export default {
-  components: {
-    'learner-roster': learnerRoster,
-    'drop-down': dropDown,
-  },
-
-  computed: {
-    classrooms() {
-      const _classrooms = [{
-        id: constants.ALL_CLASSROOMS_ID,
-        name: 'All classrooms',
-        learnerGroups: [],
-      }];
-      _classrooms.push(...this.getClassrooms);
-      return _classrooms;
+  export default {
+    components: {
+      'core-base': require('core-base'),
+      'drop-down': require('./drop-down.vue'),
+      'learner-roster': require('./learner-roster.vue'),
     },
 
-    learnerGroups() {
-      let _groups = [];
-      if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
-        _groups = [{
-          id: constants.ALL_GROUPS_ID,
-          name: 'All groups',
-          learners: [],
+    computed: {
+      classrooms() {
+        const _classrooms = [{
+          id: constants.ALL_CLASSROOMS_ID,
+          name: 'All classrooms',
+          learnerGroups: [],
         }];
-        _groups.push(...this.selectedClassroom.learnerGroups);
-      }
-      return _groups;
-    },
-
-    selectedClassroom: {
-      get() {
-        return this.classrooms.find(c => c.id === this.getSelectedClassroomId) || this.classrooms[0];  // eslint-disable-line max-len
+        _classrooms.push(...this.getClassrooms);
+        return _classrooms;
       },
 
-      set({ id }) {
-        this.setSelectedClassroomId(id);
-        if (id === constants.ALL_CLASSROOMS_ID) {
-          this.setSelectedGroupId(constants.NO_GROUPS_ID);
-        } else {
-          this.setSelectedGroupId(constants.ALL_GROUPS_ID);
+      learnerGroups() {
+        let _groups = [];
+        if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
+          _groups = [{
+            id: constants.ALL_GROUPS_ID,
+            name: 'All groups',
+            learners: [],
+          }];
+          _groups.push(...this.selectedClassroom.learnerGroups);
         }
-      },
-    },
-
-    selectedGroup: {
-      get() {
-        return this.learnerGroups.find(g => g.id === this.getSelectedGroupId) ||
-          this.learnerGroups[0];
+        return _groups;
       },
 
-      set({ id }) {
-        this.setSelectedGroupId(id);
-      },
-    },
+      selectedClassroom: {
+        get() {
+          return this.classrooms.find(c => c.id === this.getSelectedClassroomId) || this.classrooms[0];  // eslint-disable-line max-len
+        },
 
-    filteredLearners() {
-      const learners = this.getLearners;
-      let _learners = learners;
-      if (this.getSelectedClassroomId !== constants.ALL_CLASSROOMS_ID) {
-        let learnerGroupIds;
-        const groupId = this.getSelectedGroupId;
-        if (groupId === constants.ALL_GROUPS_ID || groupId === constants.NO_GROUPS_ID) {  // eslint-disable-line
-          learnerGroupIds = this.selectedClassroom.learnerGroups;
-        } else {
-          learnerGroupIds = [groupId];
-        }
-        const learnerIds = new Set();
-        this.getLearnerGroups.filter(
-          g => learnerGroupIds.indexOf(g.id) !== -1
-        )
-        .forEach(group => {
-          group.learners.forEach(learnerId => {
-            if (!learnerIds.has(learnerId)) {
-              learnerIds.add(learnerId);
+        set({ id }) {
+          this.setSelectedClassroomId(id);
+          if (id === constants.ALL_CLASSROOMS_ID) {
+            this.setSelectedGroupId(constants.NO_GROUPS_ID);
+          } else {
+            this.setSelectedGroupId(constants.ALL_GROUPS_ID);
+          }
+        },
+      },
+
+      selectedGroup: {
+        get() {
+          return this.learnerGroups.find(g => g.id === this.getSelectedGroupId) ||
+            this.learnerGroups[0];
+        },
+
+        set({ id }) {
+          this.setSelectedGroupId(id);
+        },
+      },
+
+      filteredLearners() {
+        const learners = this.getLearners;
+        let _learners = learners;
+        if (this.getSelectedClassroomId !== constants.ALL_CLASSROOMS_ID) {
+          let learnerGroupIds;
+          const groupId = this.getSelectedGroupId;
+          if (groupId === constants.ALL_GROUPS_ID || groupId === constants.NO_GROUPS_ID) {  // eslint-disable-line
+            learnerGroupIds = this.selectedClassroom.learnerGroups;
+          } else {
+            learnerGroupIds = [groupId];
+          }
+          const learnerIds = new Set();
+          this.getLearnerGroups.filter(
+            g => learnerGroupIds.indexOf(g.id) !== -1
+          )
+          .forEach(group => {
+            group.learners.forEach(learnerId => {
+              if (!learnerIds.has(learnerId)) {
+                learnerIds.add(learnerId);
+              }
+            });
+          });
+
+          _learners = [];
+          learners.forEach(learner => {
+            if (learnerIds.has(learner.id)) {
+              _learners.push(learner);
             }
           });
-        });
-
-        _learners = [];
-        learners.forEach(learner => {
-          if (learnerIds.has(learner.id)) {
-            _learners.push(learner);
-          }
-        });
-      }
-      return _learners;
+        }
+        return _learners;
+      },
     },
-  },
 
-  vuex: {
-    getters: require('./vuex/getters.js'),
-    actions: require('./vuex/actions.js'),
-  },
-};
+    vuex: {
+      getters: require('./vuex/getters.js'),
+      actions: require('./vuex/actions.js'),
+    },
+  };
 
 </script>
 

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -1,4 +1,5 @@
 <template>
+
   <core-base>
     <div>
       <drop-down v-ref:classroom-selector :list="classrooms" :selected.sync="selectedClassroom"></drop-down>
@@ -6,7 +7,7 @@
       <button>Delete</button>
     </div>
     <div>
-      <drop-down v-ref:learner-group-selector :list="[]" :initial-selection=""></drop-down>
+      <drop-down v-ref:learner-group-selector :list="learnerGroups" :selected.sync="selectedGroup"></drop-down>
       <button>Create</button>
       <button>Delete</button>
     </div>
@@ -18,88 +19,98 @@
 
 <script>
 
-  const actions = require('./vuex/actions.js');
-  const addClassroom = actions.addClassroom;
-  const setSelectedClassroomId = actions.setSelectedClassroomId;
+const store = require('./vuex/store.js');
+const constants = store.constants;
 
-  const getters = require('./vuex/getters.js');
-  const getClassrooms = getters.getClassrooms;
-  const getSelectedClassroomId = getters.getSelectedClassroomId;
+export default {
+  components: {
+    'learner-roster': learnerRoster,
+    'drop-down': dropDown,
+  },
 
-  const store = require('./vuex/store.js');
-  const constants = store.constants;
-
-  module.exports = {
-    components: {
-      'core-base': require('core-base'),
-      'learner-roster': require('./learner-roster.vue'),
-      'drop-down': require('./drop-down.vue'),
+  computed: {
+    classrooms() {
+      const _classrooms = [{
+        id: constants.ALL_CLASSROOMS_ID,
+        name: 'All classrooms',
+        learnerGroups: [],
+      }];
+      _classrooms.push(...this.getClassrooms);
+      return _classrooms;
     },
 
-    computed: {
-      classrooms() {
-        const _classrooms = [{
-          id: constants.ALL_CLASSROOMS_ID,
-          name: 'All classrooms',
-          learnerGroups: [],
+    learnerGroups() {
+      let _groups = [];
+      if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
+        _groups = [{
+          id: constants.ALL_GROUPS_ID,
+          name: 'All groups',
+          learners: [],
         }];
-        _classrooms.push(...this.getClassrooms);
-        return _classrooms;
+        _groups.push(...this.selectedClassroom.learnerGroups);
+      }
+      return _groups;
+    },
+
+    selectedClassroom: {
+      get() {
+        return this.classrooms.find(c => c.id === this.getSelectedClassroomId) || this.classrooms[0];  // eslint-disable-line max-len
       },
 
-      selectedClassroom: {
-        get() {
-          for (const classroom of this.classrooms) {
-            if (classroom.id === this.getSelectedClassroomId) {
-              return classroom;
-            }
-          }
-          // Default value in case getSelectedClassroom is inconsistent
-          return this.classrooms[0];
-        },
-        set({ id }) {
-          this.setSelectedClassroomId(id);
-        },
-      },
-
-      filteredLearners() {
-        const learners = this.$store.state.learners;
-        let _learners = learners;
-        if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
-          const learnerGroupIds = this.selectedClassroom.learnerGroups;
-          const learnerIds = new Set();
-          for (const group of this.$store.state.learnerGroups) {
-            if (learnerGroupIds.indexOf(group.id) !== -1) {
-              for (const learnerId of group.learners) {
-                if (!learnerIds.has(learnerId)) {
-                  learnerIds.add(learnerId);
-                }
-              }
-            }
-          }
-
-          _learners = [];
-          for (const learner of learners) {
-            if (learnerIds.has(learner.id)) {
-              _learners.push(learner);
-            }
-          }
+      set({ id }) {
+        this.setSelectedClassroomId(id);
+        if (id === constants.ALL_CLASSROOMS_ID) {
+          this.setSelectedGroupId(constants.NO_GROUPS_ID);
+        } else {
+          this.setSelectedGroupId(constants.ALL_GROUPS_ID);
         }
-        return _learners;
       },
     },
 
-    vuex: {
-      getters: {
-        getClassrooms,
-        getSelectedClassroomId,
+    selectedGroup: {
+      get() {
+        return this.learnerGroups.find(g => g.id === this.getSelectedGroupId) ||
+          this.learnerGroups[0];
       },
-      actions: {
-        addClassroom,
-        setSelectedClassroomId,
+
+      set({ id }) {
+        this.setSelectedGroupId(id);
       },
     },
-  };
+
+    filteredLearners() {
+      const learners = this.getLearners;
+      let _learners = learners;
+      if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
+        const learnerGroupIds = this.selectedClassroom.learnerGroups;
+        const learnerIds = new Set();
+        this.getLearnerGroups.filter(
+          g => learnerGroupIds.indexOf(g.id) !== -1
+        )
+        .forEach(group => {
+          group.learners.forEach(learnerId => {
+            if (!learnerIds.has(learnerId)) {
+              learnerIds.add(learnerId);
+            }
+          });
+        });
+
+        _learners = [];
+        learners.forEach(learner => {
+          if (learnerIds.has(learner.id)) {
+            _learners.push(learner);
+          }
+        });
+      }
+      return _learners;
+    },
+  },
+
+  vuex: {
+    getters: require('./vuex/getters.js'),
+    actions: require('./vuex/actions.js'),
+  },
+};
 
 </script>
 

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -3,7 +3,7 @@
   <core-base>
     <div>
       <drop-down v-ref:classroom-selector :list="classrooms" :selected.sync="selectedClassroom"></drop-down>
-      <button v-on:click="addClassroom({name: 'foo'})">Create</button>
+      <button>Create</button>
       <button>Delete</button>
     </div>
     <div>

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -81,8 +81,14 @@ export default {
     filteredLearners() {
       const learners = this.getLearners;
       let _learners = learners;
-      if (this.selectedClassroom.id !== constants.ALL_CLASSROOMS_ID) {
-        const learnerGroupIds = this.selectedClassroom.learnerGroups;
+      if (this.getSelectedClassroomId !== constants.ALL_CLASSROOMS_ID) {
+        let learnerGroupIds;
+        const groupId = this.getSelectedGroupId;
+        if (groupId === constants.ALL_GROUPS_ID || groupId === constants.NO_GROUPS_ID) {  // eslint-disable-line
+          learnerGroupIds = this.selectedClassroom.learnerGroups;
+        } else {
+          learnerGroupIds = [groupId];
+        }
         const learnerIds = new Set();
         this.getLearnerGroups.filter(
           g => learnerGroupIds.indexOf(g.id) !== -1

--- a/kolibri/plugins/management/assets/src/management.js
+++ b/kolibri/plugins/management/assets/src/management.js
@@ -16,7 +16,10 @@ class ManagementModule extends KolibriModule {
         },
       },
     });
-    this.vm.fetch();
+    this.vm.fetch(
+      global.kolibriGlobal.urls.classroom_list(),
+      global.kolibriGlobal.urls.learnergroup_list()
+    );
   }
 }
 

--- a/kolibri/plugins/management/assets/src/management.js
+++ b/kolibri/plugins/management/assets/src/management.js
@@ -18,7 +18,9 @@ class ManagementModule extends KolibriModule {
     });
     this.vm.fetch(
       global.kolibriGlobal.urls.classroom_list(),
-      global.kolibriGlobal.urls.learnergroup_list()
+      global.kolibriGlobal.urls.learnergroup_list(),
+      global.kolibriGlobal.urls.facilityuser_list(),
+      global.kolibriGlobal.urls.membership_list()
     );
   }
 }

--- a/kolibri/plugins/management/assets/src/management.js
+++ b/kolibri/plugins/management/assets/src/management.js
@@ -1,5 +1,6 @@
 const KolibriModule = require('kolibri_module');
 const Vue = require('vue');
+const actions = require('./vuex/actions.js');
 
 class ManagementModule extends KolibriModule {
   ready() {
@@ -9,7 +10,13 @@ class ManagementModule extends KolibriModule {
         main: require('./main.vue'),
       },
       store: require('./vuex/store.js').store,
+      vuex: {
+        actions: {
+          fetch: actions.fetch,
+        },
+      },
     });
+    this.vm.fetch();
   }
 }
 

--- a/kolibri/plugins/management/assets/src/vuex/actions.js
+++ b/kolibri/plugins/management/assets/src/vuex/actions.js
@@ -10,78 +10,94 @@ function setSelectedGroupId({ dispatch }, id) {
   dispatch('SET_SELECTED_GROUP_ID', id);
 }
 
+/*
+Used to wrap xhrs below, but note that it sets the onreadystatechange function,
+trampling whatever is there.
+ */
+function promiseWrapper(xhr) {
+  return new Promise((resolve, reject) => {
+    xhr.onreadystatechange = () => { // eslint-disable-line no-param-reassign
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        resolve();
+      } else if (xhr.readyState === 4 && xhr.status !== 200) {
+        reject();
+      }
+    };
+  });
+}
 
 // An action for setting up the initial state of the app by fetching data from the server
 function fetch({ dispatch }, classroomListUrl, learnerGroupListUrl,
                              learnerListUrl, membershipListUrl) {
   /*
-  param urls: A django-js-reverse urls object for getting API urls.
+  Takes as parameters urls for the four API list endpoints that it uses.
    */
-  const xhr = new XMLHttpRequest();
+  const xhr1 = new XMLHttpRequest();
+  const xhr2 = new XMLHttpRequest();
+  const xhr3 = new XMLHttpRequest();
+  const xhr4 = new XMLHttpRequest();
 
-  xhr.open('GET', classroomListUrl);
-  xhr.onreadystatechange = () => {
-    if (xhr.readyState === 4 && xhr.status === 200) {
-      const classrooms = JSON.parse(xhr.response);
+  const promises = [xhr2, xhr3, xhr4].map(xhr => promiseWrapper(xhr));
+
+  xhr1.open('GET', classroomListUrl);
+  let classrooms = [];
+  xhr1.onreadystatechange = () => {
+    if (xhr1.readyState === 4 && xhr1.status === 200) {
+      classrooms = JSON.parse(xhr1.response);
       const cids = classrooms.map(c => c.id);
-      const xhr2 = new XMLHttpRequest();
-      xhr2.open('GET', `${learnerGroupListUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
-      xhr2.onreadystatechange = () => {
-        if (xhr2.readyState === 4 && xhr2.status === 200) {
-          const xhr3 = new XMLHttpRequest();
-          xhr3.open('GET', learnerListUrl);
-          xhr3.onreadystatechange = () => {
-            if (xhr3.readyState === 4 && xhr3.status === 200) {
-              const xhr4 = new XMLHttpRequest();
-              xhr4.open('GET', membershipListUrl);
-              xhr4.onreadystatechange = () => {
-                if (xhr4.readyState === 4 && xhr4.status === 200) {
-                  const learnerGroups = JSON.parse(xhr2.response);
-                  const learners = JSON.parse(xhr3.response);
-                  const memberships = JSON.parse(xhr4.response);
-
-                  const groupedLearners = new Set();
-                  dispatch('ADD_LEARNER_GROUPS', learnerGroups.map(group => {
-                    const learnerIds = memberships.filter(m => m.collection === group.id)
-                      .map(m => m.user);
-                    learnerIds.forEach(id => groupedLearners.add(id));
-                    return Object.assign({}, group, {
-                      learners: learners.filter(learner => learnerIds.indexOf(learner.id) !== -1)
-                        .map(learner => learner.id),
-                    });
-                  }));
-
-                  dispatch(
-                    'ADD_CLASSROOMS',
-                    classrooms.map(classroom => {
-                      const learnerIds = memberships.filter(m => m.collection === classroom.id)
-                        .map(m => m.user);
-                      const ungroupedLearners = learnerIds.filter(id => !groupedLearners.has(id));
-                      return Object.assign(
-                        {},
-                        classroom,
-                        {
-                          learnerGroups: learnerGroups.filter(g => g.parent === classroom.id)
-                            .map(g => g.id),
-                          ungroupedLearners,
-                        }
-                      );
-                    })
-                  );
-
-                  dispatch('ADD_LEARNERS', learners);
-                }
-              };
-              xhr4.send();
-            }
-          };
-          xhr3.send();
-        }
-      };
+      xhr2.open(
+        'GET',
+        `${learnerGroupListUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`
+      );
       xhr2.send();
     }
   };
-  xhr.send();
+  xhr1.send();
+
+  xhr3.open('GET', learnerListUrl);
+  xhr3.send();
+
+  xhr4.open('GET', membershipListUrl);
+  xhr4.send();
+
+  // This block of code is executed if xhr2, xhr3, and xhr4 all return with status code 200.
+  // xhr1 is not included because my simple promise wrapper sets the onreadystatechange property.
+  Promise.all(promises).then(() => {
+    const learnerGroups = JSON.parse(xhr2.response);
+    const learners = JSON.parse(xhr3.response);
+    const memberships = JSON.parse(xhr4.response);
+
+    const groupedLearners = new Set();
+    dispatch('ADD_LEARNER_GROUPS', learnerGroups.map(group => {
+      const learnerIds = memberships.filter(m => m.collection === group.id)
+        .map(m => m.user);
+      learnerIds.forEach(id => groupedLearners.add(id));
+      return Object.assign({}, group, {
+        learners: learners.filter(learner => learnerIds.indexOf(learner.id) !== -1)
+          .map(learner => learner.id),
+      });
+    }));
+
+    dispatch(
+      'ADD_CLASSROOMS',
+      classrooms.map(classroom => {
+        const learnerIds = memberships.filter(m => m.collection === classroom.id)
+          .map(m => m.user);
+        const ungroupedLearners = learnerIds.filter(id => !groupedLearners.has(id));
+        return Object.assign(
+          {},
+          classroom,
+          {
+            learnerGroups: learnerGroups.filter(g => g.parent === classroom.id)
+              .map(g => g.id),
+            ungroupedLearners,
+          }
+        );
+      })
+    );
+
+    dispatch('ADD_LEARNERS', learners);
+  });
 }
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/vuex/actions.js
+++ b/kolibri/plugins/management/assets/src/vuex/actions.js
@@ -6,7 +6,28 @@ function setSelectedClassroomId({ dispatch }, id) {
   dispatch('SET_SELECTED_CLASSROOM_ID', id);
 }
 
+function fetch({ dispatch }) {
+  const urls = global.kolibriGlobal.urls;
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', urls.classroom_list());
+  xhr.onreadystatechange = () => {
+    if (xhr.readyState === 4) { // DONE
+      if (xhr.status === 200) {
+        for (const classroom of JSON.parse(xhr.response)) {
+          console.log(classroom); // eslint-disable-line
+          dispatch('ADD_CLASSROOM', {
+            id: classroom.id,
+            name: classroom.name,
+          });
+        }
+      }
+    }
+  };
+  xhr.send();
+}
+
 module.exports = {
   addClassroom,
   setSelectedClassroomId,
+  fetch,
 };

--- a/kolibri/plugins/management/assets/src/vuex/actions.js
+++ b/kolibri/plugins/management/assets/src/vuex/actions.js
@@ -12,17 +12,20 @@ function setSelectedGroupId({ dispatch }, id) {
 
 
 // An action for setting up the initial state of the app by fetching data from the server
-function fetch({ dispatch }) {
-  const urls = global.kolibriGlobal.urls;
+function fetch({ dispatch }, classroomListUrl, learnerGroupUrl) {
+  /*
+  param urls: A django-js-reverse urls object for getting API urls.
+   */
   const xhr = new XMLHttpRequest();
 
-  xhr.open('GET', urls.classroom_list());
+  xhr.open('GET', classroomListUrl);
   xhr.onreadystatechange = () => {
     if (xhr.readyState === 4 && xhr.status === 200) {
       const classrooms = JSON.parse(xhr.response);
       const cids = classrooms.map(c => c.id);
-      xhr.open('GET', `${urls.learnergroup_list()}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
-      xhr.onreadystatechange = () => {
+      const xhr2 = new XMLHttpRequest();
+      xhr2.open('GET', `${learnerGroupUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
+      xhr2.onreadystatechange = () => {
         if (xhr.readyState === 4 && xhr.status === 200) {
           const learnerGroups = JSON.parse(xhr.response);
 
@@ -39,7 +42,7 @@ function fetch({ dispatch }) {
           ));
         }
       };
-      xhr.send();
+      xhr2.send();
     }
   };
   xhr.send();

--- a/kolibri/plugins/management/assets/src/vuex/actions.js
+++ b/kolibri/plugins/management/assets/src/vuex/actions.js
@@ -14,7 +14,8 @@ function setSelectedGroupId({ dispatch }, id) {
 
 
 // An action for setting up the initial state of the app by fetching data from the server
-function fetch({ dispatch }, classroomListUrl, learnerGroupUrl) {
+function fetch({ dispatch }, classroomListUrl, learnerGroupListUrl,
+                             learnerListUrl, membershipListUrl) {
   /*
   param urls: A django-js-reverse urls object for getting API urls.
    */
@@ -26,27 +27,49 @@ function fetch({ dispatch }, classroomListUrl, learnerGroupUrl) {
       const classrooms = JSON.parse(xhr.response);
       const cids = classrooms.map(c => c.id);
       const xhr2 = new XMLHttpRequest();
-      xhr2.open('GET', `${learnerGroupUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
+      xhr2.open('GET', `${learnerGroupListUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
       xhr2.onreadystatechange = () => {
         if (xhr2.readyState === 4 && xhr2.status === 200) {
-          const learnerGroups = JSON.parse(xhr2.response);
-          dispatch('ADD_CLASSROOMS', classrooms.map(classroom => {
-            const lgs = [{
-              id: constants.UNGROUPED_ID,
-              name: 'Ungrouped',
-              learners: [],
-            }];
-            lgs.push(...learnerGroups.filter(g => g.parent === classroom.id));
-            return Object.assign({}, classroom, {
-              learnerGroups: lgs,
-            });
-          }));
+          const xhr3 = new XMLHttpRequest();
+          xhr3.open('GET', learnerListUrl);
+          xhr3.onreadystatechange = () => {
+            if (xhr3.readyState === 4 && xhr3.status === 200) {
+              const xhr4 = new XMLHttpRequest();
+              xhr4.open('GET', membershipListUrl);
+              xhr4.onreadystatechange = () => {
+                if (xhr4.readyState === 4 && xhr4.status === 200) {
+                  const learnerGroups = JSON.parse(xhr2.response);
+                  const learners = JSON.parse(xhr3.response);
+                  const memberships = JSON.parse(xhr4.response);
 
-          dispatch('ADD_LEARNER_GROUPS', learnerGroups.map(group =>
-            Object.assign({}, group, {
-              learners: [],
-            })
-          ));
+                  dispatch('ADD_CLASSROOMS', classrooms.map(classroom => {
+                    const lgs = [{
+                      id: constants.UNGROUPED_ID,
+                      name: 'Ungrouped',
+                      learners: [],
+                    }];
+                    lgs.push(...learnerGroups.filter(g => g.parent === classroom.id));
+                    return Object.assign({}, classroom, {
+                      learnerGroups: lgs,
+                    });
+                  }));
+
+                  dispatch('ADD_LEARNER_GROUPS', learnerGroups.map(group => {
+                    const learnerIds = memberships.filter(m => m.collection === group.id)
+                      .map(m => m.user);
+                    return Object.assign({}, group, {
+                      learners: learners.filter(learner => learnerIds.indexOf(learner.id) !== -1)
+                        .map(learner => learner.id),
+                    });
+                  }));
+
+                  dispatch('ADD_LEARNERS', learners);
+                }
+              };
+              xhr4.send();
+            }
+          };
+          xhr3.send();
         }
       };
       xhr2.send();

--- a/kolibri/plugins/management/assets/src/vuex/actions.js
+++ b/kolibri/plugins/management/assets/src/vuex/actions.js
@@ -1,3 +1,5 @@
+const { constants } = require('./store.js');
+
 function addClassroom({ dispatch }, attrs) {
   dispatch('ADD_CLASSROOM', attrs);
 }
@@ -26,14 +28,19 @@ function fetch({ dispatch }, classroomListUrl, learnerGroupUrl) {
       const xhr2 = new XMLHttpRequest();
       xhr2.open('GET', `${learnerGroupUrl}?parent_in=${global.encodeURIComponent(JSON.stringify(cids))}`);  // eslint-disable-line max-len
       xhr2.onreadystatechange = () => {
-        if (xhr.readyState === 4 && xhr.status === 200) {
-          const learnerGroups = JSON.parse(xhr.response);
-
-          dispatch('ADD_CLASSROOMS', classrooms.map(classroom =>
-            Object.assign({}, classroom, {
-              learnerGroups: learnerGroups.filter(g => g.parent === classroom.id),
-            })
-          ));
+        if (xhr2.readyState === 4 && xhr2.status === 200) {
+          const learnerGroups = JSON.parse(xhr2.response);
+          dispatch('ADD_CLASSROOMS', classrooms.map(classroom => {
+            const lgs = [{
+              id: constants.UNGROUPED_ID,
+              name: 'Ungrouped',
+              learners: [],
+            }];
+            lgs.push(...learnerGroups.filter(g => g.parent === classroom.id));
+            return Object.assign({}, classroom, {
+              learnerGroups: lgs,
+            });
+          }));
 
           dispatch('ADD_LEARNER_GROUPS', learnerGroups.map(group =>
             Object.assign({}, group, {

--- a/kolibri/plugins/management/assets/src/vuex/getters.js
+++ b/kolibri/plugins/management/assets/src/vuex/getters.js
@@ -2,11 +2,26 @@ function getClassrooms(state) {
   return state.classrooms;
 }
 
+function getLearnerGroups(state) {
+  return state.learnerGroups;
+}
+
+function getLearners(state) {
+  return state.learners;
+}
+
 function getSelectedClassroomId(state) {
   return state.selectedClassroomId;
 }
 
+function getSelectedGroupId(state) {
+  return state.selectedGroupId;
+}
+
 module.exports = {
   getClassrooms,
+  getLearnerGroups,
+  getLearners,
   getSelectedClassroomId,
+  getSelectedGroupId,
 };

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -70,6 +70,7 @@ const mutations = {
         id: classroom.id,
         name: classroom.name,
         learnerGroups: classroom.learnerGroups,
+        ungroupedLearners: classroom.ungroupedLearners,
       });
     }
   },

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -4,21 +4,36 @@ const Vuex = require('vuex');
 Vue.use(Vuex);
 
 // Set up initial state
-let classroomCounter = 0;
-function getClassroomId() {
-  classroomCounter += 1;
-  return classroomCounter;
-}
-
 const ALL_CLASSROOMS_ID = null;
+// These constant values are totally arbitrary.
+// Just don't want them to clash with *actual* group ids
+const ALL_GROUPS_ID = 'allgroups';
+const NO_GROUPS_ID = 'nogroups';
 
 function getInitialState() {
-  const johnDuck = {
-    id: 2,
-    first_name: 'John',
-    last_name: 'Duck',
-    username: 'jduck',
-  };
+  /* It should have a classrooms attribute that looks like this
+  const classrooms = [
+    {
+      id: <my cool id>,
+      name: 'Classroom A',
+      learnerGroups: [<a list of learner group ids>],
+    },
+  ];
+  */
+  const classrooms = [];
+
+  /* and a learnerGroups attribute that looks like this
+  const learnerGroups = [
+    {
+      id: <my cool id>,
+      name: 'Excelling!',
+      learners: [<a list of learner ids>],
+    },
+  ];
+  */
+  const learnerGroups = [];
+
+  /* and finally a learners attribute that looks like this
   const learners = [
     {
       id: 1,
@@ -26,54 +41,15 @@ function getInitialState() {
       last_name: 'G',
       username: 'mike',
     },
-    johnDuck,
-    {
-      id: 3,
-      first_name: 'Abe',
-      last_name: 'Lincoln',
-      username: 'abe',
-    },
-    {
-      id: 4,
-      first_name: 'Jessica',
-      last_name: 'Aceret',
-      username: 'jbot',
-    },
-  ];
-
-  /* It should have a classrooms attribute that looks like this
-  const classrooms = [
-    {
-      id: getClassroomId(),
-      name: 'Classroom A',
-      learnerGroups: [1, 2],
-    },
-  ];
   */
-  const classrooms = [];
+  const learners = [];
 
-  const learnerGroups = [
-    {
-      id: 1,
-      name: 'Group 1',
-      learners: [1, 3],
-    },
-    {
-      id: 2,
-      name: 'Group 2',
-      learners: [3],
-    },
-    {
-      id: 3,
-      name: 'Group 3',
-      learners: [2],
-    },
-  ];
   return {
     classrooms,
     learners,
     learnerGroups,
     selectedClassroomId: ALL_CLASSROOMS_ID, // is the value `null`, which has special meaning here
+    selectedGroupId: NO_GROUPS_ID,
   };
 }
 
@@ -81,14 +57,40 @@ function getInitialState() {
 const mutations = {
   ADD_CLASSROOM(state, attrs) {
     state.classrooms.push({
-      id: getClassroomId(),
-      name: attrs.name ? attrs.name : 'Foo',
-      learnerGroups: attrs.learnerGroups ? attrs.learnerGroups : [],
+      id: attrs.id,
+      name: attrs.name,
+      learnerGroups: attrs.learnerGroups,
     });
   },
+
+  ADD_CLASSROOMS(state, classrooms) {
+    for (const classroom of classrooms) {
+      state.classrooms.push({
+        id: classroom.id,
+        name: classroom.name,
+        learnerGroups: classroom.learnerGroups,
+      });
+    }
+  },
+
+  ADD_LEARNER_GROUPS(state, groups) {
+    for (const group of groups) {
+      state.learnerGroups.push({
+        id: group.id,
+        name: group.name,
+        learners: group.learners,
+      });
+    }
+  },
+
   SET_SELECTED_CLASSROOM_ID(state, id) {
     // Disable no-param-reassign rule... that is expressly the purpose of this function
     state.selectedClassroomId = id; // eslint-disable-line no-param-reassign
+  },
+
+  SET_SELECTED_GROUP_ID(state, id) {
+    // Disable no-param-reassign rule... that is expressly the purpose of this function
+    state.selectedGroupId = id; // eslint-disable-line no-param-reassign
   },
 };
 
@@ -99,6 +101,8 @@ const store = new Vuex.Store({
 
 const constants = {
   ALL_CLASSROOMS_ID,
+  ALL_GROUPS_ID,
+  NO_GROUPS_ID,
 };
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -9,6 +9,7 @@ const ALL_CLASSROOMS_ID = null;
 // Just don't want them to clash with *actual* group ids
 const ALL_GROUPS_ID = 'allgroups';
 const NO_GROUPS_ID = 'nogroups';
+const UNGROUPED_ID = 'ungrouped';
 
 function getInitialState() {
   /* It should have a classrooms attribute that looks like this
@@ -103,6 +104,7 @@ const constants = {
   ALL_CLASSROOMS_ID,
   ALL_GROUPS_ID,
   NO_GROUPS_ID,
+  UNGROUPED_ID,
 };
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -40,26 +40,18 @@ function getInitialState() {
       username: 'jbot',
     },
   ];
+
+  /* It should have a classrooms attribute that looks like this
   const classrooms = [
     {
       id: getClassroomId(),
       name: 'Classroom A',
       learnerGroups: [1, 2],
-      // learners: [1, 3],
-    },
-    {
-      id: getClassroomId(),
-      name: 'Classroom B',
-      learnerGroups: [],
-      // learners: [],
-    },
-    {
-      id: getClassroomId(),
-      name: 'Classroom C',
-      learnerGroups: [3],
-      // learners: [2],
     },
   ];
+  */
+  const classrooms = [];
+
   const learnerGroups = [
     {
       id: 1,

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -18,6 +18,7 @@ function getInitialState() {
       id: <my cool id>,
       name: 'Classroom A',
       learnerGroups: [<a list of learner group ids>],
+      ungroupedLearners: [<a list of learner ids>]
     },
   ];
   */

--- a/kolibri/plugins/management/assets/src/vuex/store.js
+++ b/kolibri/plugins/management/assets/src/vuex/store.js
@@ -84,6 +84,17 @@ const mutations = {
     }
   },
 
+  ADD_LEARNERS(state, learners) {
+    learners.forEach(learner => {
+      state.learners.push({
+        id: learner.id,
+        username: learner.username,
+        first_name: learner.first_name,
+        last_name: learner.last_name,
+      });
+    });
+  },
+
   SET_SELECTED_CLASSROOM_ID(state, id) {
     // Disable no-param-reassign rule... that is expressly the purpose of this function
     state.selectedClassroomId = id; // eslint-disable-line no-param-reassign

--- a/kolibri/plugins/management/assets/test/fixtures/fixture1.js
+++ b/kolibri/plugins/management/assets/test/fixtures/fixture1.js
@@ -18,24 +18,40 @@ module.exports = {
       last_name: 'Lincoln',
       username: 'abe',
     },
+    {
+      id: 4,
+      first_name: 'Harriet',
+      last_name: 'Tubman',
+      username: 'htub',
+    },
   ],
   classrooms: [
     {
       id: 1,
       name: 'Classroom A',
       learnerGroups: [1, 3],
+      ungroupedLearners: [],
       // learners: [1, 2, 3],
     },
     {
       id: 2,
       name: 'Classroom B',
       learnerGroups: [],
+      ungroupedLearners: [],
     },
     {
       id: 3,
       name: 'Classroom C',
       learnerGroups: [2],
+      ungroupedLearners: [],
       // learners: [2],
+    },
+    {
+      id: 4,
+      name: 'Classroom with ungrouped learners',
+      learnerGroups: [],
+      ungroupedLearners: [4],
+      // learners: [4],
     },
   ],
   learnerGroups: [

--- a/kolibri/plugins/management/assets/test/fixtures/fixture1.js
+++ b/kolibri/plugins/management/assets/test/fixtures/fixture1.js
@@ -56,4 +56,5 @@ module.exports = {
     },
   ],
   selectedClassroomId: null, // `null` a special meaning for this app.
+  selectedGroupId: 'nogroups', // also has a special meaning for this app
 };

--- a/kolibri/plugins/management/assets/test/fixtures/responseFixtures.js
+++ b/kolibri/plugins/management/assets/test/fixtures/responseFixtures.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+module.exports = [
+  /* classrooms */ [{"id":2,"name":"Foo","parent":1},{"id":3,"name":"Bar","parent":1}],
+  /* learnerGroups */ [{"id":4,"name":"Foo's group","parent":2},{"id":5,"name":"Bar's group","parent":3}],
+  /* facilityUsers */ [{"id":1,"username":"mike","first_name":"mike","last_name":"gallaspy","facility":1},{"id":2,"username":"jessica","first_name":"Jessica","last_name":"Aceret","facility":1},{"id":3,"username":"jduck","first_name":"John","last_name":"Duck","facility":1}],
+  /* memberships */ [{"id":1,"user":1,"collection":2},{"id":2,"user":1,"collection":4},{"id":3,"user":2,"collection":2},{"id":4,"user":3,"collection":5}],
+];

--- a/kolibri/plugins/management/assets/test/management.js
+++ b/kolibri/plugins/management/assets/test/management.js
@@ -6,7 +6,9 @@ const Vue = require('vue');
 const Vuex = require('vuex');
 const assert = require('assert');
 const _ = require('lodash');
+const sinon = require('sinon');
 
+const { fetch } = require('../src/vuex/actions.js');
 const { store, mutations, constants } = require('../src/vuex/store.js');
 const Management = require('../src/main.vue');
 const fixture1 = require('./fixtures/fixture1.js');
@@ -53,6 +55,27 @@ describe('The management module', () => {
         const child = this.vm.$refs.learnerRoster;
         assert.notStrictEqual(child, undefined);
         done();
+      });
+    });
+
+    describe('a "fetch" action', function () {
+      before(function () {
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        this.requests = [];
+        this.xhr.onCreate = req => {
+          this.requests.push(req);
+        };
+      });
+
+      after(function () {
+        this.xhr.restore();
+      });
+
+      it('that makes 2 requests', function () {
+        const urls = sinon.spy();
+        fetch(store, urls, urls); // takes two urls that we don't care about...
+        this.requests.forEach(req => req.respond(200, {}, JSON.stringify([])));
+        assert.equal(this.requests.length, 2);
       });
     });
   });

--- a/kolibri/plugins/management/assets/test/management.js
+++ b/kolibri/plugins/management/assets/test/management.js
@@ -5,7 +5,6 @@
 const Vue = require('vue');
 const Vuex = require('vuex');
 const assert = require('assert');
-const _ = require('lodash');
 const sinon = require('sinon');
 
 const { fetch } = require('../src/vuex/actions.js');
@@ -103,12 +102,12 @@ describe('The management module', () => {
       // Look at the fixture file for the magic numbers here.
       this.store.dispatch('SET_SELECTED_CLASSROOM_ID', 3);
       Vue.nextTick(() => {
-        assert(_.isEqual(this.vm.$refs.learnerRoster.learners, [{
+        assert.deepStrictEqual(this.vm.$refs.learnerRoster.learners, [{
           id: 2,
           first_name: 'John',
           last_name: 'Duck',
           username: 'jduck',
-        }]));
+        }]);
         done();
       });
     });
@@ -138,7 +137,7 @@ describe('The management module', () => {
     it('The roster shows no students when you select "Classroom B".', function (done) {
       this.store.dispatch('SET_SELECTED_CLASSROOM_ID', 2);
       Vue.nextTick(() => {
-        assert(_.isEqual(this.vm.$refs.learnerRoster.learners, []));
+        assert.deepStrictEqual(this.vm.$refs.learnerRoster.learners, []);
         done();
       });
     });

--- a/kolibri/plugins/management/assets/test/management.js
+++ b/kolibri/plugins/management/assets/test/management.js
@@ -141,5 +141,17 @@ describe('The management module', () => {
         done();
       });
     });
+
+    it('The roster shows one student when you select "Classroom with ungrouped learners" and "Ungrouped".', function (done) {  // eslint-disable-line max-len
+      this.store.dispatch('SET_SELECTED_CLASSROOM_ID', 4);
+      Vue.nextTick(() => {
+        this.store.dispatch('SET_SELECTED_GROUP_ID', constants.UNGROUPED_ID);
+        Vue.nextTick(() => {
+          const expectedIds = [4];
+          assert.deepStrictEqual(this.vm.$refs.learnerRoster.learners.map(learner => learner.id), expectedIds);  // eslint-disable-line max-len
+          done();
+        });
+      });
+    });
   });
 });

--- a/kolibri/plugins/management/assets/test/management.js
+++ b/kolibri/plugins/management/assets/test/management.js
@@ -70,11 +70,11 @@ describe('The management module', () => {
         this.xhr.restore();
       });
 
-      it('that makes 2 requests', function () {
+      it('that makes 4 requests', function () {
         const urls = sinon.spy();
         fetch(store, urls, urls); // takes two urls that we don't care about...
         this.requests.forEach(req => req.respond(200, {}, JSON.stringify([])));
-        assert.equal(this.requests.length, 2);
+        assert.equal(this.requests.length, 4);
       });
     });
   });

--- a/kolibri/plugins/management/assets/test/management.js
+++ b/kolibri/plugins/management/assets/test/management.js
@@ -93,7 +93,29 @@ describe('The management module', () => {
     it('The roster shows all learners when you select "All classrooms".', function (done) {
       this.store.dispatch('SET_SELECTED_CLASSROOM_ID', constants.ALL_CLASSROOMS_ID);
       Vue.nextTick(() => {
-        assert(_.isEqual(this.vm.$refs.learnerRoster.learners, fixture1.learners));
+        assert.deepStrictEqual(this.vm.$refs.learnerRoster.learners, fixture1.learners);
+        done();
+      });
+    });
+
+    it('The roster shows two students when you select "Classroom A" and "Group 1".', function (done) {  // eslint-disable-line max-len
+      this.store.dispatch('SET_SELECTED_CLASSROOM_ID', 1);
+      Vue.nextTick(() => {
+        this.store.dispatch('SET_SELECTED_GROUP_ID', 1);
+        Vue.nextTick(() => {
+          const expectedIds = [1, 2];
+          assert.deepStrictEqual(this.vm.$refs.learnerRoster.learners.map(learner =>
+            learner.id
+          ), expectedIds);
+          done();
+        });
+      });
+    });
+
+    it('The roster shows no students when you select "Classroom B".', function (done) {
+      this.store.dispatch('SET_SELECTED_CLASSROOM_ID', 2);
+      Vue.nextTick(() => {
+        assert(_.isEqual(this.vm.$refs.learnerRoster.learners, []));
         done();
       });
     });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
+    "phantomjs-polyfill-find": "ptim/phantomjs-polyfill-find",
     "phantomjs-prebuilt": "^2.1.4",
     "rewire": "^2.5.1",
     "rewire-webpack": "^1.0.1",


### PR DESCRIPTION
## Summary

Fetches server state to populate the user management app. Also adds functionality to filter the list of displayed learners by selecting classrooms and groups, as well as the special options "All classrooms", and (on a per-classroom basis) "All groups" and "Ungrouped". The other buttons don't do anything right now, they're just reserved space.

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file
- [X] Add an entry to CHANGELOG.rst
- [X] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

First, run the server and take a peek at `http://localhost:8000/management/`: `kolibri --debug manage -- --webpack` (@radinamatic you can do this to check out the resulting html!).
You'll want to create a device owner account with the createsuperuser cmd: `kolibri manage createsuperuser`.
This will allow you to create some data to populate the management app with. You can use django rest framework human-friendly API pages:
* Create a facility at `http://localhost:8000/api/facility`
* Create classrooms at `http://localhost:8000/api/classroom`. For well-formed data, set the classroom's parent to the facility you created.
* Create learner groups at `http://localhost:8000/api/learnergroup`. For well-formed data, set the group's parent to one of the classrooms you created.
* Create facility users: `http://localhost:8000/api/facilityuser`
* To create associations between users and groups/classrooms, create memberships: `http://localhost:8000/api/membership`

When you're ready to review the files, take note:

* Start with `test/management.js` to understand the intended functionality of the management app.
* Move on to `main.vue` and `src/management.js` to see changes in the application logic. Basically I make the classroom and group selectors functional.
* Changes to `getters.js`, `store.js`, and `fixture1.js` are pretty minimal. The currently selected group is now a state variable, similar to the currently selected classroom. It has two special values -- one corresponding to all groups within the currently selected classroom, and one corresponding to *no* groups selected, which is the state it should be in when the classroom selector takes the special value `ALL_CLASSROOMS_ID`.
* In `actions.js` a new action is defined which fetches classroom and learner group data from the server. It attaches the `learnerGroups` property and the (new) `ungroupedLeaners` property to classrooms. It also attaches a `learners` property to groups.
* The remaining python files deal with the `kolibri.auth` module http API -- I add filtering functionality and polish up the fields exposed by the model serializers, as well as writing some new test cases.

## Screenshots (if appropriate)

Looks something like this:

![image](https://cloud.githubusercontent.com/assets/8888020/15588241/b8e9df72-2341-11e6-88f0-0c6f8a1a321e.png)
![image](https://cloud.githubusercontent.com/assets/8888020/15588257/cc57f558-2341-11e6-9dbe-e5ba3bd5321d.png)

