### PR TITLE
New Nav Iteration

### DIFF
--- a/kolibri/core/assets/src/navigation.vue
+++ b/kolibri/core/assets/src/navigation.vue
@@ -1,33 +1,13 @@
 <template>
-
   <header role="banner">
     <nav class="titlebar" role="navigation" aria-label="Main navigation">
-
-      <div>
-        <span>{{title_bar.title}}</span>
-        <a href="{{title_bar.home_link}}">Home</a>
-      </div>
-
-      <div>
-        <button class="user-menu-btn" v-on:click="userNavDisplayToggle" aria-haspopup="true">{{user.first_name}}</button>
-
-        <div class="user-menu-popup" v-show="userNavDisplay">
-          <ul aria-label="User options submenu">
-            <li v-for="item in user_nav_items">
-              <a href={{item.url}}>{{item.text}}</a>
-            </li>
-          </ul>
-        </div>
-      </div>
+      <ul aria-label="User options submenu">
+        <li v-for="item in nav_items">
+          <a href={{item.url}}>{{item.text}}</a>
+        </li>
+      </ul>
     </nav>
-
-    <nav class="navlinks" aria-label="Content navigation">
-      <div class="navlinks-item" v-for="item in nav_items">
-        <a href="{{item.url}}">{{ item.text }}</a>
-      </div>
-    </nav>
-  </header>
-
+    </header>
 </template>
 
 
@@ -42,21 +22,9 @@
           title: 'Kolibri',
           home_link: '/',
         },
-        userNavDisplay: false,
-
-        // items that go into the user menu
-        user_nav_items: window._nav ? window._nav.user_nav_items || [] : [],
-        user: {
-          username: 'foobar',
-          first_name: 'Foo',
-          last_name: 'Bar',
-        },
       };
     },
     methods: {
-      userNavDisplayToggle() {
-        this.userNavDisplay = !this.userNavDisplay;
-      },
     },
   };
 
@@ -64,37 +32,4 @@
 
 
 <style lang="stylus" scoped>
-
-  @require '~core-theme.styl'
-
-
-  header
-    background-color: $core-bg-light
-
-  .titlebar
-    display: flex
-    justify-content: space-between
-    padding: 10px
-
-  .user-menu-btn
-    cursor: pointer
-
-  .user-menu-popup
-    text-align: right
-    position: absolute
-    top: 2em
-    right: 1em
-    box-shadow: 2px 2px 3px $core-text-default
-    background-color: $core-bg-light
-
-    ul
-      padding: 3px
-      list-style: none
-
-  .navlinks
-    display: flex
-
-  .navlinks-item
-    margin: 0 0.5em
-
 </style>

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -37,24 +37,3 @@ class NavigationHook(KolibriHook):
     class Meta:
 
         abstract = True
-
-
-class UserNavigationHook(KolibriHook):
-    """
-    A hook for adding navigation items to the user menu.
-    """
-    # : A string label for the menu item
-    label = "Untitled"
-
-    # : A string or lazy proxy for the url
-    url = "/"
-
-    def get_menu(self):
-        menu = {}
-        for hook in self.registered_hooks:
-            menu[hook.label] = self.url
-        return menu
-
-    class Meta:
-
-        abstract = True

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -10,6 +10,7 @@
 {% block frontend_assets %}
 {% webpack_asset 'default_frontend' %}
 <script type="text/javascript" charset="utf-8">
+  var rootURL = "learn";
   {% cache 5000 js_urls %}
     {% js_reverse_inline %}
   {% endcache %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -8,7 +8,7 @@ import json
 
 from django import template
 from django.utils.html import mark_safe
-from kolibri.core.hooks import NavigationHook, UserNavigationHook
+from kolibri.core.hooks import NavigationHook
 
 register = template.Library()
 
@@ -30,13 +30,7 @@ def kolibri_main_navigation():
             'url': str(hook.url),
         })
 
-    for hook in UserNavigationHook().registered_hooks:
-        init_data['user_nav_items'].append({
-            'text': str(hook.label),
-            'url': str(hook.url),
-        })
-
-    html = ("<script type='text/javascript'>"
-            "window._nav={0};"
-            "</script>".format(json.dumps(init_data)))
+        html = ("<script type='text/javascript'>"
+                "window._nav={0};"
+                "</script>".format(json.dumps(init_data)))
     return mark_safe(html)

--- a/kolibri/plugins/management/kolibri_plugin.py
+++ b/kolibri/plugins/management/kolibri_plugin.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
-from kolibri.core.hooks import UserNavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
+from kolibri.core.hooks import NavigationHook
 
 from . import hooks, urls
 
@@ -26,6 +26,6 @@ class ManagementInclusionHook(hooks.ManagementSyncHook):
     bundle_class = ManagementAsset
 
 
-class ManagementNavItem(UserNavigationHook):
-    label = _("Management!")
-    url = '#'
+class ManagementNavItem(NavigationHook):
+    label = _("Manage!")
+    url = '/manage'


### PR DESCRIPTION
## Summary

Bringing in Radina's accessibility edits while stripping away unneeded code according to the Visual Design Team's current mock ups. 

From what I saw in the demos, the content inside this navigation bar is going to be changing to show the content hierarchy among other things. I'm under the impression that this can be done using Vue's data binding so that we don't have to have a bunch of hidden navigation bars floating around.

@rtibbles @66eli77 @radinamatic Please look it over and see if you have any problems with the way I'm approaching this. See comments for some of my thoughts as well.

## TODO

- [ ] Review to make sure I didn't step on anyone's toes

## Reviewer guidance

[This is the Trello card](https://trello.com/c/YFvDDWmS/125-kolibri-navigation-iteration) where I'm justifying this carving out of code. 

[This is the Trello card](https://trello.com/c/lOYc0F4V/137-build-out-semantic-html-skeleton-not-focused-on-styling-yet-for-overall-site-within-vue-js) that I think is most relevant to this feature branch as of right now.
## Issues addressed

Seems to meet Radina's accessibility standards thus far, and paves the way for further iteration on the vis design team's new nav.

## Screenshots (if appropriate)

There are a handful in the trello card referenced above.
