### PR TITLE
removing localhost links, which were causing the link-checker to fail

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -88,13 +88,13 @@ Wait for the build process to complete. This takes a while the first time, will 
 
 Now you should be able to access certain URLs, in particular:
 
-- http://127.0.0.1:8000/learn/
-- http://127.0.0.1:8000/management/
+- ``http://127.0.0.1:8000/learn/``
+- ``http://127.0.0.1:8000/management/``
 
 
 .. warning ::
 
-  Currently no page is set up at the root URL (*http://127.0.0.1:8000/*), so don't be suprised if that returns a 404.
+  Currently no page is set up at the root URL (``http://127.0.0.1:8000/``), so don't be suprised if that returns a 404.
 
 
 Additional Recommended Setup


### PR DESCRIPTION
## Summary

fix related to https://github.com/learningequality/kolibri/compare/3d614f69b69d...a51924f207fa

