### PR TITLE
Delete that ContentTag.UUID field!

### DIFF
--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -50,7 +50,6 @@ class ContentQuerySet(models.QuerySet):
 
 class ContentTag(models.Model):
     tag_name = models.CharField(max_length=30, blank=True)
-    channel = UUIDField(null=True, blank=True)
 
     objects = ContentQuerySet.as_manager()
 


### PR DESCRIPTION


not needed. Content DBs are per-channel and thus content tags don't need
to refer to the channel.