### PR TITLE
adding prop validation for content-card

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
@@ -18,14 +18,47 @@
 <script>
 
   module.exports = {
-    props: [
-      'title',
-      'thumbsrc',
-      'linkhref',
-      'kind',
-      'progress',
-      'pk',
-    ],
+    props: {
+      pk: {
+        type: String,
+        required: true,
+      },
+      title: {
+        type: String,
+        required: true,
+      },
+      thumbsrc: {
+        type: String,
+        required: true,
+      },
+      linkhref: {
+        type: String,
+        required: true,
+      },
+      kind: {
+        type: String,
+        required: true,
+        validator(value) {
+          return [
+            'audio',
+            'video',
+            'document',
+            'exercise',
+          ].some(elem => elem === value);
+        },
+      },
+      progress: {
+        type: String,
+        required: true,
+        validator(value) {
+          return [
+            'complete',
+            'partial',
+            'unstarted',
+          ].some(elem => elem === value);
+        },
+      },
+    },
     computed: {
       icon() {
         // Note: dynamic requires should be used carefully because


### PR DESCRIPTION
The `content-card` component requires that the `kind` and `progress` properties are very specific strings because it uses those strings to look up a custom SVG icon. This validation ensures that appropriate values are passed in.

Also, added basic variable type checking for the other fields, and set them all as required.