### PR TITLE
Content refactor

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -7,161 +7,147 @@ from kolibri.content import models as KolibriContent
 from kolibri.content.utils import validate
 
 from .constants import content_kinds
-from .content_db_router import using_content_database
 
 """ContentDB API methods"""
 
-def get_instance_with_pk_or_uuid(channel_id, content):
-    with using_content_database(channel_id):
-        if validate.is_valid_uuid(content):
-            return KolibriContent.ContentNode.objects.get(content_id=content)
-        elif isinstance(content, KolibriContent.ContentNode):
-            return content
-        else:
-            try:
-                pk = int(content)
-            except (ValueError, TypeError):
-                raise TypeError("Must provide a pk or a ContentNode object or a UUID content_id.")
-            return KolibriContent.ContentNode.objects.get(pk=pk)
 
-def get_content_with_id_list(channel_id, content):
+def get_instance_with_pk_or_uuid(content):
+    if validate.is_valid_uuid(content):
+        return KolibriContent.ContentNode.objects.get(content_id=content)
+    elif isinstance(content, KolibriContent.ContentNode):
+        return content
+    else:
+        try:
+            pk = int(content)
+        except (ValueError, TypeError):
+            raise TypeError("Must provide a pk or a ContentNode object or a UUID content_id.")
+        return KolibriContent.ContentNode.objects.get(pk=pk)
+
+
+def get_content_with_id_list(content):
     """
     Get arbitrary sets of ContentNode objects based on content ids.
-    :param channel_id: str
     :param content_id: list of uuid
     :return: QuerySet of ContentNode
     """
+    if isinstance(content, list):
+        return KolibriContent.ContentNode.objects.filter(content_id__in=content)
+    else:
+        raise TypeError("Must provide a list of UUID content_id in order to use this method.")
 
-    with using_content_database(channel_id):
-        if isinstance(content, list):
-            return KolibriContent.ContentNode.objects.filter(content_id__in=content)
-        else:
-            raise TypeError("Must provide a list of UUID content_id in order to use this method.")
 
-def get_ancestor_topics(channel_id, content, **kwargs):
+def get_ancestor_topics(content, **kwargs):
     """"
     Get all ancestors that the their kind are topics
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return content_instance.get_ancestors().filter(kind=content_kinds.TOPIC)
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return content_instance.get_ancestors().filter(kind=content_kinds.TOPIC)
 
-def immediate_children(channel_id, content, **kwargs):
+
+def immediate_children(content, **kwargs):
     """
     Get a set of ContentNodes that have this ContentNode as the immediate parent.
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return content_instance.get_children()
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return content_instance.get_children()
 
-def leaves(channel_id, content, **kwargs):
+
+def leaves(content, **kwargs):
     """
     Get all ContentNodes that are the terminal nodes and also the descendants of the this ContentNode.
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return content_instance.get_leafnodes()
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return content_instance.get_leafnodes()
 
-def get_missing_files(channel_id, content, **kwargs):
+
+def get_missing_files(content, **kwargs):
     """
     Get all missing files of the content.
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of File
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        if content_instance.kind == content_kinds.TOPIC:
-            all_end_nodes = leaves(channel_id=channel_id, content=content_instance)
-            return KolibriContent.File.objects.filter(available=False, contentnode__in=all_end_nodes)
-        else:
-            return KolibriContent.File.objects.filter(available=False, contentnode=content_instance)
+    content_instance = get_instance_with_pk_or_uuid(content)
+    if content_instance.kind == content_kinds.TOPIC:
+        all_end_nodes = leaves(content=content_instance)
+        return KolibriContent.File.objects.filter(available=False, contentnode__in=all_end_nodes)
+    else:
+        return KolibriContent.File.objects.filter(available=False, contentnode=content_instance)
 
-def get_all_prerequisites(channel_id, content, **kwargs):
+
+def get_all_prerequisites(content, **kwargs):
     """
     Get cotents that are the prerequisites of this content.
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return KolibriContent.ContentNode.objects.filter(is_prerequisite_of=content_instance)
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return KolibriContent.ContentNode.objects.filter(is_prerequisite_of=content_instance)
 
-def get_all_related(channel_id, content, **kwargs):
+
+def get_all_related(content, **kwargs):
     """
     Get cotents that are related to this content.
 
-    :param channel_id: str
     :param content: ContentNode or str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return KolibriContent.ContentNode.objects.filter(Q(relate_to=content_instance) | Q(is_related=content_instance))
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return KolibriContent.ContentNode.objects.filter(Q(relate_to=content_instance) | Q(is_related=content_instance))
 
-def set_prerequisite(channel_id, target_node, prerequisite, **kwargs):
+
+def set_prerequisite(target_node, prerequisite, **kwargs):
     """
     Set prerequisite relationship between content1 and content2.
 
-    :param channel_id: str
     :param content1: ContentNode or str
     :param content2: ContentNode or str
     """
-    with using_content_database(channel_id):
-        target_instance = get_instance_with_pk_or_uuid(channel_id, target_node)
-        prerequisite_instance = get_instance_with_pk_or_uuid(channel_id, prerequisite)
-        KolibriContent.PrerequisiteContentRelationship.objects.create(
-            target_node=target_instance, prerequisite=prerequisite_instance)
+    target_instance = get_instance_with_pk_or_uuid(target_node)
+    prerequisite_instance = get_instance_with_pk_or_uuid(prerequisite)
+    KolibriContent.PrerequisiteContentRelationship.objects.create(
+        target_node=target_instance, prerequisite=prerequisite_instance)
 
-def set_is_related(channel_id, content1, content2, **kwargs):
+
+def set_is_related(content1, content2, **kwargs):
     """
     Set is related relationship between content1 and content2.
 
-    :param channel_id: str
     :param content1: ContentNode or str
     :param content2: ContentNode or str
     """
-    with using_content_database(channel_id):
-        content1_instance = get_instance_with_pk_or_uuid(channel_id, content1)
-        content2_instance = get_instance_with_pk_or_uuid(channel_id, content2)
-        KolibriContent.RelatedContentRelationship.objects.create(
-            contentnode_1=content1_instance, contentnode_2=content2_instance)
+    content1_instance = get_instance_with_pk_or_uuid(content1)
+    content2_instance = get_instance_with_pk_or_uuid(content2)
+    KolibriContent.RelatedContentRelationship.objects.create(
+        contentnode_1=content1_instance, contentnode_2=content2_instance)
 
-def children_of_kind(channel_id, content, kind, **kwargs):
+
+def children_of_kind(content, kind, **kwargs):
     """
     Get all ContentNodes of a particular kind under the given ContentNode.
     For kind argument, please pass in a string like "topic" or "video" or "exercise".
 
-    :param channel_id: str
     :param content: ContentNode or str
     :param kind: str
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        content_instance = get_instance_with_pk_or_uuid(channel_id, content)
-        return content_instance.get_descendants(include_self=False).filter(kind=kind)
+    content_instance = get_instance_with_pk_or_uuid(content)
+    return content_instance.get_descendants(include_self=False).filter(kind=kind)
 
 
-def get_top_level_topics(channel_id):
+def get_top_level_topics():
     """
     Get all the top level topics for a channel.
-    :param channel_id: str - the id for the channel.
     :return: QuerySet of ContentNode
     """
-    with using_content_database(channel_id):
-        return KolibriContent.ContentNode.objects.get(parent__isnull=True).get_children().filter(kind="topic")
+    return KolibriContent.ContentNode.objects.get(parent__isnull=True).get_children().filter(kind="topic")

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -295,10 +295,6 @@ class ContentNodeAPITestCase(APITestCase):
         return reverse(pattern_name, kwargs=kwargs)
 
     def test_ancestor_topics_endpoint(self):
-        c1_id = content.ContentNode.objects.get(title="c1").content_id
-        response = self.client.get(self._reverse_channel_url("contentnode-ancestor-topics", {"content_id": c1_id}))
-        self.assertEqual(response.data[0]['title'], 'root')
-
         c1_pk = content.ContentNode.objects.using(self.the_channel_id).get(title="c1").pk
         response = self.client.get(self._reverse_channel_url("contentnode-ancestor-topics", {"pk": c1_pk}))
         self.assertEqual(response.data[0]['title'], 'root')

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -12,15 +12,13 @@ from kolibri.content import models as content
 from kolibri.content import api
 from django.conf import settings
 from django.core.exceptions import ValidationError
-
 from ..constants import content_kinds
 from ..content_db_router import set_active_content_database
-
 from rest_framework.test import APITestCase
 
 
 @override_settings(
-    CONTENT_COPY_DIR=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+"/test_content_copy"
+    CONTENT_COPY_DIR=os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/test_content_copy"
 )
 class ContentNodeTestCase(TestCase):
     """
@@ -55,33 +53,35 @@ class ContentNodeTestCase(TestCase):
         self.assertEqual(self.temp_f_2.read(), 'The owl are not what they seem')
 
     """Tests for content API methods"""
+
     def test_get_instance_with_pk_or_uuid(self):
         # pass content_id
         root_id = content.ContentNode.objects.get(title="root").content_id
         expected_output = content.ContentNode.objects.get(title='root')
-        actual_output = api.get_instance_with_pk_or_uuid(channel_id=self.the_channel_id, content=str(root_id))
+        actual_output = api.get_instance_with_pk_or_uuid(content=str(root_id))
         self.assertEqual(expected_output, actual_output)
 
         # pass pk
         cn_pk = content.ContentNode.objects.get(title='c1').pk
         expected_output = content.ContentNode.objects.get(title='c1')
-        actual_output = api.get_instance_with_pk_or_uuid(channel_id=self.the_channel_id, content=cn_pk)
+        actual_output = api.get_instance_with_pk_or_uuid(content=cn_pk)
         self.assertEqual(expected_output, actual_output)
 
         # pass invalid type
         with self.assertRaises(TypeError):
-            api.get_instance_with_pk_or_uuid(channel_id=self.the_channel_id, content='asdf')
+            api.get_instance_with_pk_or_uuid(content='asdf')
 
     def test_get_content_with_id_list(self):
         # test for single content_id
         the_content_id = content.ContentNode.objects.get(title="root").content_id
         with self.assertRaises(TypeError):
-            api.get_content_with_id_list(self.the_channel_id, the_content_id)
+            api.get_content_with_id_list(the_content_id)
 
         # test for a list of content_ids
-        the_content_ids = [cm.content_id for cm in content.ContentNode.objects.all() if cm.title in ["root", "c1", "c2c2"]]
+        the_content_ids = [cm.content_id for cm in content.ContentNode.objects.all() if
+                           cm.title in ["root", "c1", "c2c2"]]
         expected_output2 = content.ContentNode.objects.filter(title__in=["root", "c1", "c2c2"])
-        actual_output2 = api.get_content_with_id_list(self.the_channel_id, the_content_ids)
+        actual_output2 = api.get_content_with_id_list(the_content_ids)
 
         self.assertEqual(set(expected_output2), set(actual_output2))
 
@@ -96,21 +96,21 @@ class ContentNodeTestCase(TestCase):
 
         p = content.ContentNode.objects.get(title="c2c3")
         expected_output = content.ContentNode.objects.filter(title__in=["root", "c2"])
-        actual_output = api.get_ancestor_topics(channel_id=self.the_channel_id, content=p)
+        actual_output = api.get_ancestor_topics(content=p)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_immediate_children(self):
 
         p = content.ContentNode.objects.get(title="root")
         expected_output = content.ContentNode.objects.filter(title__in=["c1", "c2"])
-        actual_output = api.immediate_children(channel_id=self.the_channel_id, content=p)
+        actual_output = api.immediate_children(content=p)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_leaves(self):
 
         p = content.ContentNode.objects.get(title="c2")
         expected_output = content.ContentNode.objects.filter(title__in=["c2c1", "c2c2", "c2c3"])
-        actual_output = api.leaves(channel_id=self.the_channel_id, content=p)
+        actual_output = api.leaves(content=p)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_get_missing_files(self):
@@ -118,12 +118,12 @@ class ContentNodeTestCase(TestCase):
         # for non-topic contentnode
         p = content.ContentNode.objects.get(title="c1")
         expected_output = content.File.objects.filter(id__in=[1, 2])
-        actual_output = api.get_missing_files(channel_id=self.the_channel_id, content=p)
+        actual_output = api.get_missing_files(content=p)
         self.assertEqual(set(expected_output), set(actual_output))
         # for topic contentnode
         p = content.ContentNode.objects.get(title="c2")
         expected_output = content.File.objects.filter(id__in=[3, 4, 5])
-        actual_output = api.get_missing_files(channel_id=self.the_channel_id, content=p)
+        actual_output = api.get_missing_files(content=p)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_get_all_prerequisites(self):
@@ -135,11 +135,11 @@ class ContentNodeTestCase(TestCase):
         root = content.ContentNode.objects.get(title="root")
         # if root is the prerequisite of c1
         expected_output = content.ContentNode.objects.filter(title__in=["root"])
-        actual_output = api.get_all_prerequisites(channel_id=self.the_channel_id, content=c1)
+        actual_output = api.get_all_prerequisites(content=c1)
         self.assertEqual(set(expected_output), set(actual_output))
         # then c1 should not be the prerequisite of root
         expected_output = content.ContentNode.objects.filter(title__in=["c1"])
-        actual_output = api.get_all_prerequisites(channel_id=self.the_channel_id, content=root)
+        actual_output = api.get_all_prerequisites(content=root)
         self.assertNotEqual(set(actual_output), set(expected_output))
 
     def test_get_all_related(self):
@@ -151,45 +151,45 @@ class ContentNodeTestCase(TestCase):
         c2 = content.ContentNode.objects.get(title="c2")
         # if c1 is related to c2
         expected_output = content.ContentNode.objects.filter(title__in=["c2"])
-        actual_output = api.get_all_related(channel_id=self.the_channel_id, content=c1)
+        actual_output = api.get_all_related(content=c1)
         self.assertEqual(set(expected_output), set(actual_output))
         # then c2 should be related to c1
         expected_output = content.ContentNode.objects.filter(title__in=["c1"])
-        actual_output = api.get_all_related(channel_id=self.the_channel_id, content=c2)
+        actual_output = api.get_all_related(content=c2)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_set_prerequisite(self):
 
         root = content.ContentNode.objects.get(title="root")
         c2 = content.ContentNode.objects.get(title="c2")
-        self.assertFalse(api.get_all_prerequisites(channel_id=self.the_channel_id, content=root))
-        api.set_prerequisite(channel_id=self.the_channel_id, target_node=root, prerequisite=c2)
-        self.assertTrue(api.get_all_prerequisites(channel_id=self.the_channel_id, content=root))
+        self.assertFalse(api.get_all_prerequisites(content=root))
+        api.set_prerequisite(target_node=root, prerequisite=c2)
+        self.assertTrue(api.get_all_prerequisites(content=root))
 
     def test_set_prerequisite_self_reference(self):
 
         c2 = content.ContentNode.objects.get(title="c2")
         # test for self reference exception
         with self.assertRaises(IntegrityError):
-            api.set_prerequisite(channel_id=self.the_channel_id, target_node=c2, prerequisite=c2)
+            api.set_prerequisite(target_node=c2, prerequisite=c2)
 
     def test_set_prerequisite_uniqueness(self):
 
         root = content.ContentNode.objects.get(title="root")
         c2 = content.ContentNode.objects.get(title="c2")
-        api.set_prerequisite(channel_id=self.the_channel_id, target_node=c2, prerequisite=root)
+        api.set_prerequisite(target_node=c2, prerequisite=root)
         # test for uniqueness exception
         with self.assertRaises(ValidationError):
-            api.set_prerequisite(channel_id=self.the_channel_id, target_node=c2, prerequisite=root)
+            api.set_prerequisite(target_node=c2, prerequisite=root)
 
     def test_set_prerequisite_immediate_cyclic(self):
 
         root = content.ContentNode.objects.get(title="root")
         c2 = content.ContentNode.objects.get(title="c2")
-        api.set_prerequisite(channel_id=self.the_channel_id, target_node=c2, prerequisite=root)
+        api.set_prerequisite(target_node=c2, prerequisite=root)
         # test for immediate cyclic exception
         with self.assertRaises(IntegrityError):
-            api.set_prerequisite(channel_id=self.the_channel_id, target_node=root, prerequisite=c2)
+            api.set_prerequisite(target_node=root, prerequisite=c2)
 
     # <the exception hasn't been implemented yet, may add in the future>
     # def test_set_prerequisite_distant_cyclic(self):
@@ -205,34 +205,34 @@ class ContentNodeTestCase(TestCase):
 
         root = content.ContentNode.objects.get(title="root")
         c1 = content.ContentNode.objects.get(title="c1")
-        self.assertFalse(root in api.get_all_related(channel_id=self.the_channel_id, content=c1))
-        api.set_is_related(channel_id=self.the_channel_id, content1=c1, content2=root)
-        self.assertTrue(root in api.get_all_related(channel_id=self.the_channel_id, content=c1))
+        self.assertFalse(root in api.get_all_related(content=c1))
+        api.set_is_related(content1=c1, content2=root)
+        self.assertTrue(root in api.get_all_related(content=c1))
 
     def test_set_is_related_self_reference(self):
 
         c1 = content.ContentNode.objects.get(title="c1")
         # test for self reference exception
         with self.assertRaises(IntegrityError):
-            api.set_is_related(channel_id=self.the_channel_id, content1=c1, content2=c1)
+            api.set_is_related(content1=c1, content2=c1)
 
     def test_set_is_related_uniqueness(self):
 
         root = content.ContentNode.objects.get(title="root")
         c1 = content.ContentNode.objects.get(title="c1")
-        api.set_is_related(channel_id=self.the_channel_id, content1=c1, content2=root)
+        api.set_is_related(content1=c1, content2=root)
         # test for uniqueness exception
         with self.assertRaises(IntegrityError):
-            api.set_is_related(channel_id=self.the_channel_id, content1=c1, content2=root)
+            api.set_is_related(content1=c1, content2=root)
 
     def test_set_is_related_immediate_cyclic(self):
 
         root = content.ContentNode.objects.get(title="root")
         c1 = content.ContentNode.objects.get(title="c1")
-        api.set_is_related(channel_id=self.the_channel_id, content1=c1, content2=root)
+        api.set_is_related(content1=c1, content2=root)
         # test for silently canceling save on immediate cyclic related_relationship
         try:
-            api.set_is_related(channel_id=self.the_channel_id, content1=root, content2=c1)
+            api.set_is_related(content1=root, content2=c1)
         except:
             self.assertTrue(False)
 
@@ -240,7 +240,7 @@ class ContentNodeTestCase(TestCase):
 
         p = content.ContentNode.objects.get(title="root")
         expected_output = content.ContentNode.objects.filter(title__in=["c2", "c2c2", "c2c3"])
-        actual_output = api.children_of_kind(channel_id=self.the_channel_id, content=p, kind=content_kinds.TOPIC)
+        actual_output = api.children_of_kind(content=p, kind=content_kinds.TOPIC)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_all_str(self):
@@ -295,7 +295,7 @@ class ContentNodeAPITestCase(APITestCase):
         return reverse(pattern_name, kwargs=kwargs)
 
     def test_ancestor_topics_endpoint(self):
-        c1_pk = content.ContentNode.objects.using(self.the_channel_id).get(title="c1").pk
+        c1_pk = content.ContentNode.objects.get(title="c1").pk
         response = self.client.get(self._reverse_channel_url("contentnode-ancestor-topics", {"pk": c1_pk}))
         self.assertEqual(response.data[0]['title'], 'root')
 

--- a/kolibri/content/urls.py
+++ b/kolibri/content/urls.py
@@ -20,12 +20,14 @@ class ChannelMetadataViewSet(viewsets.ViewSet):
 
     def list(self, request, channel_pk=None):
         with using_content_database("default"):
-            channels = serializers.ChannelMetadataSerializer(models.ChannelMetadata.objects.all(), context={'request': request}, many=True).data
+            channels = serializers.ChannelMetadataSerializer(models.ChannelMetadata.objects.all(),
+                                                             context={'request': request}, many=True).data
             return Response(channels)
 
     def retrieve(self, request, pk=None, channel_id=None):
         with using_content_database("default"):
-            channel = serializers.ChannelMetadataSerializer(models.ChannelMetadata.objects.get(channel_id=channel_id), context={'request': request}).data
+            channel = serializers.ChannelMetadataSerializer(models.ChannelMetadata.objects.get(channel_id=channel_id),
+                                                            context={'request': request}).data
             return Response(channel)
 
 
@@ -76,7 +78,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.ContentNodeSerializer(
-                api.get_ancestor_topics(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.get_ancestor_topics(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -89,7 +91,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.ContentNodeSerializer(
-                api.immediate_children(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.immediate_children(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -102,7 +104,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.ContentNodeSerializer(
-                api.leaves(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.leaves(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -115,7 +117,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.ContentNodeSerializer(
-                api.get_all_prerequisites(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.get_all_prerequisites(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -128,7 +130,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.ContentNodeSerializer(
-                api.get_all_related(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.get_all_related(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -141,7 +143,7 @@ class ContentNodeViewset(viewsets.ViewSet):
         with using_content_database(channelmetadata_channel_id):
             context = {'request': request, 'channel_id': channelmetadata_channel_id}
             data = serializers.FileSerializer(
-                api.get_missing_files(channel_id=channelmetadata_channel_id, content=self.kwargs['pk']), context=context, many=True
+                api.get_missing_files(content=self.kwargs['pk']), context=context, many=True
             ).data
             return Response(data)
 
@@ -168,7 +170,6 @@ router.register(r'api/content', ChannelMetadataViewSet, base_name='channelmetada
 channel_router = routers.NestedSimpleRouter(router, r'api/content', lookup='channelmetadata')
 channel_router.register(r'contentnode', ContentNodeViewset, base_name='contentnode')
 channel_router.register(r'file', FileViewset, base_name='file')
-
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -15,7 +15,7 @@ class LearnView(TemplateView):
         channel_id = getattr(self.request, "channel_id", "dummy_db")
         with using_content_database(channel_id):
             context = super(LearnView, self).get_context_data(**kwargs)
-            topics_serializer = ContentNodeSerializer(get_top_level_topics(channel_id),
+            topics_serializer = ContentNodeSerializer(get_top_level_topics(),
                                                       many=True)
             topics_serializer.context["channel_id"] = channel_id
             context['topics'] = JSONRenderer().render(topics_serializer.data)


### PR DESCRIPTION
## Summary

Fixes tests from previous slightly bad merge resolution.

Utilizes content db router work to no longer require `channel_id` arguments to all content API functions.

All functions must now be invoked within a context manager, as with the ContentNode models.

## TODO

- [X] Have tests been written for the new code?
