### PR TITLE
Small fixes to ensure that API calls are properly cached.

### DIFF
--- a/kolibri/core/assets/src/apiResources/contentNode.js
+++ b/kolibri/core/assets/src/apiResources/contentNode.js
@@ -28,8 +28,8 @@ class ContentNodeResource extends Resource {
   static resourceName() {
     return 'contentnode';
   }
-  static idkey() {
-    return 'content_id';
+  static idKey() {
+    return 'pk';
   }
 }
 

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -104,6 +104,9 @@ class Collection {
         this.set(response.entity);
         // Mark that the fetch has completed.
         this.synced = true;
+        this.models.forEach((model) => {
+          model.synced = true; // eslint-disable-line no-param-reassign
+        });
         // Return the data from the models, not the models themselves.
         resolve(this.models.map((model) => model.attributes));
       }, (response) => {


### PR DESCRIPTION
## Summary

Fixes typo in 'idKey' property of contentNode resource definition.

Sets 'synced' property to be true on all Models after they have been fetched via a Collection fetch.

This means that caching now works properly.

