### PR TITLE
Default plugins

### DIFF
--- a/kolibri/core/settings.py
+++ b/kolibri/core/settings.py
@@ -21,9 +21,7 @@ from django.conf import settings
 DEFAULT_PLUGINS = getattr(
     settings,
     'KOLIBRI_DEFAULT_PLUGINS',
-    [
-        'kolibri.plugins.example_plugin',
-    ]
+    []
 )
 
 #: Skips automatically migrating the database when running kolibri commands

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -44,7 +44,16 @@ if not os.path.isfile(conf_file):
 config = {}
 
 #: Everything in this list is added to django.conf.settings.INSTALLED_APPS
-config['INSTALLED_APPS'] = []
+config['INSTALLED_APPS'] = [
+    # Note from Devon -
+    # Temporarily adding these here to get things working for most devs.
+    # It's not clear to me where the correct place to add them is.
+    "kolibri.plugins.management",
+    "kolibri.plugins.learn",
+    "kolibri.plugins.document_pdf_render",
+    "kolibri.plugins.video_mp4_render",
+    "kolibri.plugins.audio_mp3_render"
+]
 
 #: Well-known plugin names that are automatically searched for and enabled on
 #: first-run.

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -57,7 +57,7 @@ config['INSTALLED_APPS'] = [
 
 #: Well-known plugin names that are automatically searched for and enabled on
 #: first-run.
-config['AUTO_SEARCH_PLUGINS'] = ['some.plugin.module.path']
+config['AUTO_SEARCH_PLUGINS'] = []
 
 #: If a config file does not exist, we assume it's the first run
 config['FIRST_RUN'] = True


### PR DESCRIPTION

Temporarily adding the "known", standard plugins to `config['INSTALLED_APPS']` in conf.py.

I imagine this is probably incorrect, but I couldn't figure out how to use `AUTO_SEARCH_PLUGINS` (in conf.py) or `KOLIBRI_DEFAULT_PLUGINS` (in settings.py).

This comment was also interesting to me:

> These plugins are automatically enabled if they exist at the first run of Kolibri. After that, they are not searched for automatically since that would require explicitly disabling them in case they were to be removed on purpose from INSTALLED_APPS.

It seems like this would prevent us from adding new plugins to the default list?

@benjaoming @rtibbles let's discuss what the intended behavior is at some point. I personally need to learn more about the concepts of django "configuration" versus "settings", and how these apply to the plugin system.

