### PR TITLE
Content renderer props

### DIFF
--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -50,9 +50,22 @@
       },
       renderContent() {
         if (this.currentViewClass !== null) {
+          const propsData = {};
+          const enumerables = Object.keys(this.contentData);
+          const properties = Object.getOwnPropertyNames(this.contentData).filter(
+            (name) => enumerables.indexOf(name) > -1
+          );
+          for (const key in properties) {
+            if (key !== 'extra_fields') {
+              propsData[key] = this.contentData[key];
+            } else {
+              Object.assign(propsData, JSON.parse(this.contentData[key]));
+            }
+          }
           const options = {
             parent: this,
             el: this.$els.container,
+            propsData,
           };
           Object.assign(options, this.currentViewClass);
           this.contentView = new this.Kolibri.lib.vue(options); // eslint-disable-line new-cap

--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -92,6 +92,7 @@
               Object.assign(propsData, JSON.parse(this.contentData[key]));
             }
           }
+          propsData.defaultFile = this.availableFiles[0];
           const options = {
             parent: this,
             el: this.$els.container,

--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -25,8 +25,7 @@
       },
       extension() {
         if (this.availableFiles.length > 0) {
-          // Remove leading full stop (editor's note: period) from extension field.
-          return this.availableFiles[0].extension.replace(/^./, '');
+          return this.availableFiles[0].extension;
         }
         return '';
       },
@@ -65,7 +64,6 @@
         this.rendered = false;
         this.clearListeners();
         const event = `component_render:${this.contentType}`;
-        console.log(event);
         const callback = this.setRendererComponent;
         this.Kolibri.once(event, callback);
         this._eventListeners.push({ event, callback });

--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -79,50 +79,96 @@
       currentViewClass: null,
     }),
     methods: {
+      /**
+       * Clear any active listeners - this ensures that if the current content node changes,
+       * but the previous one has not received its renderer callback, no shenanigans will occur.
+       */
       clearListeners() {
         this._eventListeners.forEach((listener) => {
           this.Kolibri.off(listener.event, listener.callback);
         });
         this._eventListeners = [];
       },
+      /**
+       * Broadcast through the Kolibri core app for a content renderer module that is able to
+       * handle the rendering of the current content node. This is the entrance point for changes
+       * in the props,so any change in the props will trigger this function first.
+       */
       findRendererComponent() {
+        // Clear any existing listeners so that two renderings do not collide in this component.
         this.clearListeners();
+        // Only bother to do this is if the node is available. Otherwise the template can handle it.
         if (this.available) {
+          // The internal content rendering component is currently unrendered.
           this.rendered = false;
+          // This is the event that content renderers will broadcast in response to our call.
           const event = `component_render:${this.contentType}`;
+          // This is the method that will accept the component passed by the content renderer.
           const callback = this.setRendererComponent;
+          // Set up listening for the response.
           this.Kolibri.once(event, callback);
+          // Keep a track of this listener so that we can unbind it later if needed.
           this._eventListeners.push({ event, callback });
+          // This is the event that is broadcast out to the content renderers.
           this.Kolibri.emit(`content_render:${this.contentType}`);
+        }
       },
+    /**
+     * Method that is invoked by a callback from an event listener. Accepts a Vue component
+     * options object as an argument. This is then set as the current renderer for the node,
+     * and is used later in rendering.
+     * @param {Object} component - an options object for a Vue component.
+     */
       setRendererComponent(component) {
+        // Keep track of the current renderer.
         this.currentViewClass = component;
+        // If the Vue component is attached to the DOM, and it is unrendered, then render now!
         if (this.ready && !this.rendered) {
           this.renderContent();
         }
       },
+      /**
+       * Method that renders the dynamically retrieved component into the wrapper component.
+       */
       renderContent() {
+        // Only render if we have a component type to render and the content is available.
         if (this.currentViewClass !== null & this.available & !this.rendered) {
+          // We are rendering, so don't let setRendererComponent call this again.
           this.rendered = true;
+          // Start building up an object of all props that the content renderers might get passed.
           const propsData = {};
+          // List enumerable properties of the props object.
           const enumerables = Object.keys(this.$options.props);
+          // Only get non-inherited properties of the props object.
           const properties = Object.getOwnPropertyNames(this.$options.props).filter(
+            // Only use non-enumerable, non-inherited properties of the props object.
             (name) => enumerables.indexOf(name) > -1
           );
           for (const key in properties) {
+            // Loop through all the properties, see if one of them is extraFields.
             if (key !== 'extraFields') {
+              // If it isn't just put it directly into the data.
               propsData[key] = this[key];
             } else {
+              // If it is, then parse it as JSON and assign each key to the propsData.
               Object.assign(propsData, JSON.parse(this[key]));
             }
           }
+          // Add a defaultFile to the propsData, which is the first file in the availableFiles.
           propsData.defaultFile = this.availableFiles[0];
+          // Create an options object for the soon to be instantiated renderer component.
           const options = {
+            // Set the parent so that it is in the Vue family.
             parent: this,
+            // Let it mount on the DOM in the container div set up in the template.
             el: this.$els.container,
+            // Pass in the propsData!
             propsData,
           };
+          // Add the specified options for the Vue component that we received from the plugin
+          // into the options object.
           Object.assign(options, this.currentViewClass);
+          // Instantiate the Vue instance directly using the Kolibri Vue constructor.
           this.contentView = new this.Kolibri.lib.vue(options); // eslint-disable-line new-cap
         }
       },

--- a/kolibri/core/assets/src/core_app_constructor.js
+++ b/kolibri/core/assets/src/core_app_constructor.js
@@ -22,6 +22,7 @@ const publicMethods = [
   'emit',
   'on',
   'once',
+  'off',
 ];
 
 /**

--- a/kolibri/core/assets/src/core_app_mediator.js
+++ b/kolibri/core/assets/src/core_app_mediator.js
@@ -314,4 +314,11 @@ module.exports = class Mediator {
   once(...args) {
     this._eventDispatcher.$once(...args);
   }
+  /**
+   * Proxy to the Vue object that is the global dispatcher.
+   * Takes any arguments and passes them on.
+   */
+  off(...args) {
+    this._eventDispatcher.$off(...args);
+  }
 };

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -32,9 +32,16 @@ return the module.
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.conf import settings
+from django.conf.urls import url
 from kolibri.plugins.registry import get_urls as plugin_urls
 
 app_name = 'kolibri'
 
 
 urlpatterns = plugin_urls()
+
+urlpatterns += [
+    url(r'^' + settings.STORAGE_URL[1:-1] + '(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': settings.STORAGE_ROOT})
+]

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -13,7 +13,7 @@
   module.exports = {
     props: ['defaultFile'],
     ready() {
-      PDFobject.embed(this.defaultFile.url, this.$els.container);
+      PDFobject.embed(this.defaultFile.storage_url, this.$els.container);
     },
   };
 

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -11,8 +11,9 @@
 
   const PDFobject = require('pdfobject');
   module.exports = {
+    props: ['defaultFile'],
     ready() {
-      PDFobject.embed('http://www.benlandis.com/sheet-music/piano-rickroll.pdf', this.$els.container);
+      PDFobject.embed(this.defaultFile.url, this.$els.container);
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -6,10 +6,12 @@ const sync = require('vuex-router-sync').sync;
 const Kolibri = require('kolibri');
 
 class LearnModule extends KolibriModule {
+  initialize() {
+    Kolibri.resources.ContentNodeResource.setChannel('dummy_db');
+  }
   ready() {
     sync(store, router);
     router.start(rootvue, 'rootvue');
-    Kolibri.resources.ContentNodeResource.setChannel('dummy_db');
   }
 }
 

--- a/kolibri/plugins/learn/assets/src/store.js
+++ b/kolibri/plugins/learn/assets/src/store.js
@@ -13,6 +13,9 @@ function initialState() {
       kind: '',
       files: [],
       pk: 0,
+      available: false,
+      extra_fields: '{}',
+      content_id: '',
     },
     channel: 'dummy_db',
   };

--- a/kolibri/plugins/learn/assets/src/store.js
+++ b/kolibri/plugins/learn/assets/src/store.js
@@ -7,7 +7,13 @@ function initialState() {
     topics: global.bootstrappedTopics || [],
     contents: [],
     recommended: require('./demo-data/content_recommendation_data.json'),
-    full: {},
+    full: {
+      title: '',
+      description: '',
+      kind: '',
+      files: [],
+      pk: 0,
+    },
     channel: 'dummy_db',
   };
 }

--- a/kolibri/plugins/learn/assets/src/store.js
+++ b/kolibri/plugins/learn/assets/src/store.js
@@ -7,7 +7,7 @@ function initialState() {
     topics: global.bootstrappedTopics || [],
     contents: [],
     recommended: require('./demo-data/content_recommendation_data.json'),
-    full: require('./demo-data/video__full_metadata.json'),
+    full: {},
     channel: 'dummy_db',
   };
 }

--- a/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
@@ -8,7 +8,14 @@
     <p>
       {{ description }}
     </p>
-    <content-render :content-data="contentData">
+    <content-render
+      :pk="pk"
+      :kind="kind"
+      :files="files"
+      :content-id="contentId"
+      :channel-id="channelId"
+      :available="available"
+      :extra-fields="extraFields">
     </content-render>
     <div class="rec-grid card-list">
       <content-card
@@ -30,10 +37,10 @@
 
   module.exports = {
     created() {
-      this.fetchFullContent(this.pk);
+      this.fetchFullContent(this.primaryKey);
     },
     props: {
-      pk: {
+      primaryKey: {
         type: Number,
         default: 4,
       },
@@ -48,7 +55,13 @@
         title: (state) => state.full.title,
         description: (state) => state.full.description,
         recommended: (state) => state.full.recommended,
-        contentData: (state) => state.full,
+        pk: (state) => state.full.pk,
+        kind: (state) => state.full.kind,
+        files: (state) => state.full.files,
+        contentId: (state) => state.full.content_id,
+        channelId: (state) => state.channel,
+        available: (state) => state.full.available,
+        extraFields: (state) => state.full.extra_fields,
       },
       actions: require('../actions'),
     },

--- a/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
@@ -2,14 +2,14 @@
 
   <div>
     <h2>Learn Content</h2>
-    <content-render :kind="kind" :extension="extension" :content-data="contentData">
-    </content-render>
     <h3>
       {{ title }}
     </h3>
     <p>
       {{ description }}
     </p>
+    <content-render :content-data="contentData">
+    </content-render>
     <div class="rec-grid card-list">
       <content-card
         v-for="content in recommended"
@@ -48,8 +48,6 @@
         title: (state) => state.full.title,
         description: (state) => state.full.description,
         recommended: (state) => state.full.recommended,
-        kind: (state) => state.full.kind,
-        extension: (state) => state.full.extension,
         contentData: (state) => state.full,
       },
       actions: require('../actions'),

--- a/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page-general.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h2>Learn Content</h2>
-    <content-render kind="audio" extension="mp3">
+    <content-render :kind="kind" :extension="extension" :content-data="contentData">
     </content-render>
     <h3>
       {{ title }}
@@ -29,11 +29,15 @@
 <script>
 
   module.exports = {
-    props: [
-      'title',
-      'description',
-      'recommended',
-    ],
+    created() {
+      this.fetchFullContent(this.pk);
+    },
+    props: {
+      pk: {
+        type: Number,
+        default: 4,
+      },
+    },
     components: {
       'content-render': require('content-renderer'),
       'content-card': require('./content-card'),
@@ -44,7 +48,11 @@
         title: (state) => state.full.title,
         description: (state) => state.full.description,
         recommended: (state) => state.full.recommended,
+        kind: (state) => state.full.kind,
+        extension: (state) => state.full.extension,
+        contentData: (state) => state.full,
       },
+      actions: require('../actions'),
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/vue/explore-content-page.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-content-page.vue
@@ -2,10 +2,8 @@
 
   <div>
     <breadcrumbs :crumbs="breadcrumbs.crumbs" :current="breadcrumbs.current"></breadcrumbs>
-    <content-page-general 
-      :title="title" 
-      :description="description"
-      :recommended="recommended"
+    <content-page-general
+      :pk="pk"
     ></content-page-general>
   </div>
 
@@ -22,10 +20,7 @@
     vuex: {
       getters: {
         // better practice would be to define vuex getter functions globally
-        title: (state) => state.full.title,
-        description: (state) => state.full.description,
-        recommended: (state) => state.full.recommended,
-        breadcrumbs: state => state.breadcrumbs,
+        breadcrumbs: (state) => state.breadcrumbs,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/vue/explore-content-page.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-content-page.vue
@@ -3,7 +3,7 @@
   <div>
     <breadcrumbs :crumbs="breadcrumbs.crumbs" :current="breadcrumbs.current"></breadcrumbs>
     <content-page-general
-      :pk="pk"
+      :primary-key="pk"
     ></content-page-general>
   </div>
 

--- a/kolibri/plugins/learn/assets/src/vue/learn-content-page.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-content-page.vue
@@ -2,10 +2,8 @@
 
   <div>
     <a v-link="{ path: '/learn', exact: true }">Home</a>
-    <content-page-general 
-      :title="title" 
-      :description="description"
-      :recommended="recommended"
+    <content-page-general
+      :pk="pk"
     ></content-page-general>
   </div>
 
@@ -17,14 +15,6 @@
   module.exports = {
     components: {
       'content-page-general': require('./content-page-general'),
-    },
-    vuex: {
-      getters: {
-        // better practice would be to define vuex getter functions globally
-        title: (state) => state.full.title,
-        description: (state) => state.full.description,
-        recommended: (state) => state.full.recommended,
-      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/vue/learn-content-page.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-content-page.vue
@@ -3,7 +3,7 @@
   <div>
     <a v-link="{ path: '/learn', exact: true }">Home</a>
     <content-page-general
-      :pk="pk"
+      :primary-key="pk"
     ></content-page-general>
   </div>
 


### PR DESCRIPTION
## Summary

Sets up the content renderer component to reactively render based on passed in contentData.

Passes contentData to individual components as props.

Does proof of concept implementation for PDF renderer.

## Reviewer guidance

This requires an updated dummy_db that does not have an error in the 'extension' filed for files.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/16468594/85777f5c-3e01-11e6-9613-4a4229ff91e7.png)
