### PR TITLE
Add a new field in ContentNode called instance_id

### DIFF
--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -64,7 +64,24 @@ class ContentNode(MPTTModel):
     tags = models.ManyToManyField(ContentTag, symmetrical=False, related_name='tagged_content', blank=True)
 
     title = models.CharField(max_length=200)
+
+    # the instance_id is used for mapping a node between kolibri and the
+    # content curation server. We can't use the raw id, since ids aren't
+    # guaranteed to be consistent across different content curation servers
+    # (once we have a distributed content curation server), and content ids may
+    # be the same across different nodes within the same channel (for student
+    # logging and analytics purposes.) Apart from generating the instance_id
+    # upon node creation, we also change the instance_id whenever we move or
+    # copy a node).
+    instance_id = UUIDField(default=uuid.uuid4, editable=False, unique=True)
+
+    # the content_id is used for tracking a user's interaction with a piece of
+    # content, in the face of possibly many copies of that content. When a user
+    # interacts with a piece of content, all substantially similar pieces of
+    # content should be marked as such as well. We track these "substantially
+    # similar" types of content by having them have the same content_id.
     content_id = UUIDField(primary_key=False, default=uuid.uuid4, editable=False)
+
     description = models.CharField(max_length=400, blank=True, null=True)
     sort_order = models.FloatField(blank=True, null=True)
     license_owner = models.CharField(max_length=200, blank=True)


### PR DESCRIPTION
This PR adds a new field called `instance_id`.

Basically, we want a new content node identifier that has the following properties:

0. an id that's unique within a channel.
0. likely not to collide once we have content curation available within the distributed kolibri app (`kolibri-studio`)
0. does not change often (i.e. when the user makes simple edits to the content metadata), but can be used to distinguish one node from its copies.

Said requirements eliminate a bunch of preexisting identifiers that we have:

- An auto-integer `pk` isn't guaranteed to be unique in the face of multiple distributed content curation servers. We still want to keep it around though to make foreign keys space efficient.
- A `content_id` will not necessarily change when we copy nodes (my understanding is we use it to track content engagement across copies of nodes), and is thus not unique within a channel.
 

Thus, we're adding a new field called `instance_id`, which is set whenever we create a node, or move/make copies of it. Said id fulfills all the requirements outlined above. It's also a convenient mapping between a node's content-curation and kolibri instance, making my life easier :)

