### PR TITLE
Minimal fixes for IE9 Compatibility

### DIFF
--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -41,7 +41,11 @@ var config = {
       {
         test: /\.js$/,
         loader: 'babel',
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015-ie'],
+          plugins: ['transform-runtime']
+        },
       },
       {
         test: /\.json$/,

--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -24,7 +24,6 @@ module.exports = function(config) {
     // list of files / patterns to load
     files: [
       './node_modules/phantomjs-polyfill-find/find-polyfill.js',
-      'node_modules/babel-polyfill/dist/polyfill.js',
       'kolibri/**/assets/test/*.js',
       {pattern: 'kolibri/**/assets/src/**/*.js', included: false} // load these, but not in the browser, just for linting
     ],

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -281,7 +281,11 @@ class ResourceManager {
       throw new TypeError('A resource with that name has already been registered!');
     }
     this._resources[name] = new ResourceClass(this._kolibri);
-    Object.defineProperty(this, ResourceClass.name, { value: this._resources[name] });
+    // Shim for IE9 compatibility of .name property.
+    // Modified from: http://matt.scharley.me/2012/03/monkey-patch-name-ie.html#comment-551654096
+    const className = ResourceClass.name || /function\s([^(]{1,})\(/.exec(
+        (ResourceClass).toString())[1].trim();
+    Object.defineProperty(this, className, { value: this._resources[name] });
     return this._resources[name];
   }
 

--- a/kolibri/core/assets/src/core_app_constructor.js
+++ b/kolibri/core/assets/src/core_app_constructor.js
@@ -5,7 +5,6 @@
 
 const vue = require('vue');
 const vuex = require('vuex');
-const VueIntl = require('vue-intl');
 const Mediator = require('./core_app_mediator');
 const ResourceManager = require('./api_resource').ResourceManager;
 const Resources = require('./apiResources/resources');
@@ -52,10 +51,6 @@ module.exports = function CoreApp() {
   const mediator = new Mediator();
 
   Resources.forEach((resourceClass) => this.resources.registerResource(resourceClass));
-  /**
-   * Use the vue-intl plugin.
-   **/
-  vue.use(VueIntl);
 
   vue.prototype.Kolibri = this;
   /**
@@ -77,10 +72,20 @@ module.exports = function CoreApp() {
       (require) => {
         require('intl');
         require('intl/locale-data/jsonp/en.js');
+        /**
+         * Use the vue-intl plugin.
+         **/
+        const VueIntl = require('vue-intl');
+        vue.use(VueIntl);
         mediator.setReady();
       }
     );
   } else {
+    /**
+     * Use the vue-intl plugin.
+     **/
+    const VueIntl = require('vue-intl');
+    vue.use(VueIntl);
     mediator.setReady();
   }
 

--- a/kolibri/core/assets/src/core_app_instance.js
+++ b/kolibri/core/assets/src/core_app_instance.js
@@ -3,6 +3,7 @@
 require('normalize.css');
 require('./font-NotoSans.css');
 require('./core-global.styl');
+require('babel-polyfill');
 
 // set up logging
 const logging = require('loglevel');

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,4 +1,5 @@
 {% load i18n kolibri_tags webpack_tags js_reverse cache %}<html>
+<meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <head>
   <title>{% block title %}{% endblock %} - {% trans "Kolibri" %}</title>
   {% kolibri_main_navigation %}

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
   "devDependencies": {
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
-    "babel-plugin-transform-runtime": "^6.0.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
     "babel-plugin-transform-strict-mode": "^6.8.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.0.0",
+    "babel-preset-es2015-ie": "^6.6.2",
     "babel-preset-stage-3": "^6.0.0",
     "colors": "^1.1.2",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
## Summary

Kolibri currently does not work at all on IE9.

This makes it work on IE9.

## Reviewer guidance

This is mostly just about shimming and polyfilling things that are missing in IE9.

I have done it on a 'per needs' basis, so we may yet add things that still need to be polyfilled or shimmed.

## Issues addressed

Fixes #149.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/16501402/18f4c32c-3ebe-11e6-85f6-ed00bad3a2bb.png)
