### PR TITLE
Fix to show more than one item fetched from the API at a time!

### DIFF
--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -139,8 +139,8 @@ class Collection {
       // Note: this method ensures instantiation deduplication of models within the collection
       //  and across collections.
       const setModel = this.resource.addModel(model);
-      if (!this._model_map[model.id]) {
-        this._model_map[model.id] = setModel;
+      if (!this._model_map[setModel.id]) {
+        this._model_map[setModel.id] = setModel;
         this.models.push(setModel);
       }
     });


### PR DESCRIPTION
## Summary

Reads the 'id' getter of the instantiate Model, not the raw data object.

## Screenshots (if appropriate)

Now shows all fetched ContentNodes.

![image](https://cloud.githubusercontent.com/assets/1680573/16534646/369be274-3f96-11e6-8ceb-bedfbd216a64.png)
