### PR TITLE
Fix import error blocking learn plugin, and improve error messages.

### DIFF
--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.views.generic.base import TemplateView
-from kolibri.content.api import get_top_level_topics
 from kolibri.content.content_db_router import using_content_database
+from kolibri.content.models import ContentNode
 from kolibri.content.serializers import ContentNodeSerializer
 from rest_framework.renderers import JSONRenderer
 
@@ -16,8 +16,8 @@ class LearnView(TemplateView):
         with using_content_database(channel_id):
             context = super(LearnView, self).get_context_data(**kwargs)
 
-            mcontext = {'request': self.request, 'channel_id': channel_id}
-            topics_serializer = ContentNodeSerializer(get_top_level_topics(), context=mcontext,
-                                                      many=True)
+            top_level_nodes = ContentNode.objects.get(parent__isnull=True).get_children()
+            mcontext = {'request': self.request}
+            topics_serializer = ContentNodeSerializer(top_level_nodes, context=mcontext, many=True)
             context['topics'] = JSONRenderer().render(topics_serializer.data)
         return context

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -205,8 +205,11 @@ def plugin(plugin_name, **args):
         for obj in plugin_module.__dict__.values():
             if type(obj) == type and obj is not KolibriPluginBase and issubclass(obj, KolibriPluginBase):
                 plugin_classes.append(obj)
-    except ImportError:
-        raise PluginDoesNotExist("Plugin does not exist")
+    except ImportError as e:
+        if e.message.startswith("No module named"):
+            raise PluginDoesNotExist("Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?".format(plugin_name))
+        else:
+            raise
 
     if args.get('enable', False):
         for klass in plugin_classes:


### PR DESCRIPTION
Fixes the error @whitzhu was experiencing with not being able to enable the learn plugin (it was working for me and probably @66eli77 because the api.pyc file was still around), and improves error messages for future cases.