### PR TITLE
Hotfix/208 no module named kolibri utils

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.rst
 include CHANGELOG.rst
 include LICENSE
 include README.rst
+recursive-include kolibri/utils *
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/dist *
 recursive-exclude kolibri/dist *pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,16 @@ include CONTRIBUTING.rst
 include CHANGELOG.rst
 include LICENSE
 include README.rst
+recursive-include kolibri/auth *
+recursive-include kolibri/content *
+recursive-include kolibri/core *
+recursive-include kolibri/deployment *
+recursive-include kolibri/dist *
+recursive-include kolibri/logger *
+recursive-include kolibri/plugins *
+recursive-include kolibri/test *
 recursive-include kolibri/utils *
+recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/dist *
 recursive-exclude kolibri/dist *pyc


### PR DESCRIPTION
## Summary

Hi @cpauya and @aronasorman this fixes #208 
We need to include the necessary directories in our source distribution so that the pip installation will not fail

## Documentation
https://docs.python.org/2/distutils/sourcedist.html#the-manifest-in-template

## Screenshots 
The screenshots below demonstrate that the pip installation is success using the `.tar` file generated in `make sdist` command
![screen shot 2016-07-08 at 12 07 55 am](https://cloud.githubusercontent.com/assets/4099119/16660230/12f0321c-44a0-11e6-8d62-23dbcc4915eb.png)
