### PR TITLE
Bootstrap cache

### DIFF
--- a/kolibri/core/assets/src/apiResources/contentNode.js
+++ b/kolibri/core/assets/src/apiResources/contentNode.js
@@ -18,12 +18,12 @@ class ContentNodeResource extends Resource {
     // with the channelId that is currently set.
     // N.B. Here and below the super calls are to getters that return functions that are
     // immediately invoked.
-    return (...args) => super.modelUrl(this.channelId, ...args);
+    return (...args) => this.urls[`${this.name}_detail`](this.channelId, ...args);
   }
   get collectionUrl() {
     // Return a function that calls the collectionUrl method of the base class, but prefix the
     // arguments with the channelId that is currently set.
-    return (...args) => super.collectionUrl(this.channelId, ...args);
+    return (...args) => this.urls[`${this.name}_list`](this.channelId, ...args);
   }
   static resourceName() {
     return 'contentnode';

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -194,6 +194,7 @@ class Resource {
     );
     if (!this.collections[key]) {
       collection = new Collection(params, data, this);
+      this.collections[key] = collection;
     } else {
       collection = this.collections[key];
     }

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -88,6 +88,7 @@ class Collection {
     this.models = [];
     this._model_map = {};
     this.synced = false;
+    this.set(data);
   }
 
   /**
@@ -204,12 +205,14 @@ class Resource {
    * or will instantiate a model
    * that can later be fetched.
    * @param {String} id - The primary key of the Model instance.
+   * @param {Object} [data={}] - Optional additional data to pass into the Model.
    * @returns {Model} - Returns a Model instance.
    */
-  getModel(id) {
+  getModel(id, data = {}) {
     let model;
     if (!this.models[id]) {
-      model = new Model({ [this.idKey]: id }, this);
+      Object.assign(data, { [this.idKey]: id });
+      model = new Model(data, this);
     } else {
       model = this.models[id];
     }

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -1,5 +1,4 @@
 const Kolibri = require('kolibri');
-const logging = require('loglevel');
 
 /**
  * Action to fetch a particular content node from the API.
@@ -8,6 +7,9 @@ const logging = require('loglevel');
  */
 const fetchFullContent = ({ dispatch }, id) => {
   // Get the model from ContentNodeResource.
+  if (typeof id === 'undefined') {
+    id = 'root'; // eslint-disable-line no-param-reassign
+  }
   const contentModel = Kolibri.resources.ContentNodeResource.getModel(id);
   // Check to see if it is already synced from the server.
   if (contentModel.synced) {
@@ -33,11 +35,9 @@ const nodeAssignment = (nodes, dispatch) => {
   // clean up API response
   contents.forEach(content => {
     if (!content.progress) {
-      logging.warn('"progress" was not included in API response');
       content.progress = 'unstarted'; // eslint-disable-line no-param-reassign
     }
     if (!content.thumbnail) {
-      logging.warn('"thumbnail" was not included in API response');
       content.files.forEach(file => {
         if (file.thumbnail) {
           content.thumbnail = file.storage_url; // eslint-disable-line no-param-reassign
@@ -57,6 +57,9 @@ const nodeAssignment = (nodes, dispatch) => {
  */
 const fetchNodes = ({ dispatch }, id) => {
   // Get the collection from ContentNodeResource.
+  if (typeof id === 'undefined') {
+    id = 'root'; // eslint-disable-line no-param-reassign
+  }
   const contentCollection = Kolibri.resources.ContentNodeResource.getCollection({ parent: id });
   if (contentCollection.synced) {
     nodeAssignment(contentCollection.data, dispatch);

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -56,12 +56,6 @@ const nodeAssignment = (nodes, dispatch) => {
  * @param {String} id - The id of the model to fetch the children of.
  */
 const fetchNodes = ({ dispatch }, id) => {
-  if (id === undefined) {
-    // root node
-    nodeAssignment(global.bootstrappedTopics, dispatch);
-    return;
-  }
-
   // Get the collection from ContentNodeResource.
   const contentCollection = Kolibri.resources.ContentNodeResource.getCollection({ parent: id });
   if (contentCollection.synced) {

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -3,7 +3,9 @@
 
 {% block content %}
   <script>
-    window.bootstrappedTopics = JSON.parse("{{ topics|escapejs }}");
+    var collection = {{kolibri}}.resources.ContentNodeResource.getCollection({parent: undefined}, JSON.parse("{{ nodes|escapejs }}"));
+    collection.synced = true;
+    var model = {{kolibri}}.resources.ContentNodeResource.getModel(undefined, JSON.parse("{{ rootnode|escapejs }}"))
   </script>
   {% learn_async_assets %}
   {% learn_assets %}

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -3,9 +3,10 @@
 
 {% block content %}
   <script>
-    var collection = {{kolibri}}.resources.ContentNodeResource.getCollection({parent: undefined}, JSON.parse("{{ nodes|escapejs }}"));
+    var collection = {{kolibri}}.resources.ContentNodeResource.getCollection({parent: 'root'}, JSON.parse("{{ nodes|escapejs }}"));
     collection.synced = true;
-    var model = {{kolibri}}.resources.ContentNodeResource.getModel(undefined, JSON.parse("{{ rootnode|escapejs }}"))
+    var model = {{kolibri}}.resources.ContentNodeResource.getModel('root', JSON.parse("{{ rootnode|escapejs }}"));
+    model.synced = true;
   </script>
   {% learn_async_assets %}
   {% learn_assets %}

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.conf import settings
 from django.views.generic.base import TemplateView
 from kolibri.content.content_db_router import using_content_database
 from kolibri.content.models import ContentNode
@@ -13,11 +14,14 @@ class LearnView(TemplateView):
 
     def get_context_data(self, **kwargs):
         channel_id = getattr(self.request, "channel_id", "dummy_db")
+        context = super(LearnView, self).get_context_data(**kwargs)
         with using_content_database(channel_id):
-            context = super(LearnView, self).get_context_data(**kwargs)
-
-            top_level_nodes = ContentNode.objects.get(parent__isnull=True).get_children()
+            root_node = ContentNode.objects.get(parent__isnull=True)
+            top_level_nodes = root_node.get_children()
             mcontext = {'request': self.request}
             topics_serializer = ContentNodeSerializer(top_level_nodes, context=mcontext, many=True)
-            context['topics'] = JSONRenderer().render(topics_serializer.data)
+            root_node_serializer = ContentNodeSerializer(root_node, context=mcontext)
+            context['nodes'] = JSONRenderer().render(topics_serializer.data)
+            context['rootnode'] = JSONRenderer().render(root_node_serializer.data)
+        context['kolibri'] = settings.KOLIBRI_CORE_JS_NAME
         return context


### PR DESCRIPTION
## Summary

Loads boostrapped data into the API Resource cache.

Fixes an issue in the API resource inherited getters.

Fixes API collection caching, and uses 'root' as the id for the root node.