### PR TITLE
Removing Top Margin

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
@@ -48,6 +48,9 @@
 
   @require 'jeet'
 
+  h2
+    margin-top: 0
+
   .card-grid
     cf()
 


### PR DESCRIPTION
## Summary

@whitzhu found a margin at the top of the page and [corrected it](https://github.com/learningequality/kolibri/pull/217), but the PR was a little out of date.

Just passing a long a fix.
