### PR TITLE
Move content storage and DB dirs into KOLIBRI_HOME, and rename settings

### DIFF
--- a/kolibri/content/apps.py
+++ b/kolibri/content/apps.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.apps import AppConfig
+
+
+class KolibriContentConfig(AppConfig):
+    name = 'kolibri.content'
+    label = 'kolibricontent'
+    verbose_name = 'Kolibri Content'

--- a/kolibri/content/content_db_router.py
+++ b/kolibri/content/content_db_router.py
@@ -40,7 +40,7 @@ def get_active_content_database(return_none_if_not_set=False):
     try:
         connections[alias]
     except ConnectionDoesNotExist:
-        filename = os.path.join(settings.CONTENT_DB_DIR, alias + '.sqlite3')
+        filename = os.path.join(settings.CONTENT_DATABASE_DIR, alias + '.sqlite3')
         if not os.path.isfile(filename):
             raise KeyError("Content DB '%s' doesn't exist!!" % alias)
         connections.databases[alias] = {

--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -131,7 +131,7 @@ class File(ContentDatabaseModel):
         The same url will also be exposed by the file serializer
         """
         if self.available:
-            return settings.STORAGE_URL + self.checksum[0] + '/' + self.checksum[1] + '/' + self.checksum + '.' + self.extension
+            return settings.CONTENT_STORAGE_URL + self.checksum[0] + '/' + self.checksum[1] + '/' + self.checksum + '.' + self.extension
         else:
             return None
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -22,10 +22,6 @@ class FileSerializer(serializers.ModelSerializer):
 
 class ContentNodeSerializer(serializers.ModelSerializer):
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
-
-    # Here we use a FileSerializer instead just the files reverse FK is because we want to get the computed field storage_url
-    # In order to improve performance in production, we should implement a client side method to calculate the file url using
-    # extension and checksum field along with the setting.STORAGE_ROOT, which can be passed to front end at template boostrapping.
     files = FileSerializer(many=True, read_only=True)
     ancestors = serializers.SerializerMethodField()
     thumbnail = serializers.SerializerMethodField()

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -16,12 +16,12 @@ from ..content_db_router import set_active_content_database, using_content_datab
 from ..errors import ContentModelUsedOutsideDBContext
 from rest_framework.test import APITestCase
 
-STORAGE_ROOT_TEMP = tempfile.mkdtemp()
-CONTENT_DB_DIR_TEMP = tempfile.mkdtemp()
+CONTENT_STORAGE_DIR_TEMP = tempfile.mkdtemp()
+CONTENT_DATABASE_DIR_TEMP = tempfile.mkdtemp()
 
 @override_settings(
-    STORAGE_ROOT=STORAGE_ROOT_TEMP,
-    CONTENT_DB_DIR=CONTENT_DB_DIR_TEMP,
+    CONTENT_STORAGE_DIR=CONTENT_STORAGE_DIR_TEMP,
+    CONTENT_DATABASE_DIR=CONTENT_DATABASE_DIR_TEMP,
 )
 class ContentNodeTestCase(TestCase):
     """
@@ -149,8 +149,8 @@ class ContentNodeTestCase(TestCase):
 
 
 @override_settings(
-    STORAGE_ROOT=STORAGE_ROOT_TEMP,
-    CONTENT_DB_DIR=CONTENT_DB_DIR_TEMP,
+    CONTENT_STORAGE_DIR=CONTENT_STORAGE_DIR_TEMP,
+    CONTENT_DATABASE_DIR=CONTENT_DATABASE_DIR_TEMP,
 )
 class DatabaseRoutingTests(TestCase):
     multi_db = True
@@ -182,7 +182,7 @@ class DatabaseRoutingTests(TestCase):
 
     def test_database_on_disk_works_too(self):
         the_other_channel_id = 'content_test_2'
-        filename = os.path.join(settings.CONTENT_DB_DIR, the_other_channel_id + '.sqlite3')
+        filename = os.path.join(settings.CONTENT_DATABASE_DIR, the_other_channel_id + '.sqlite3')
         connections.databases[the_other_channel_id] = {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': filename,
@@ -194,7 +194,7 @@ class DatabaseRoutingTests(TestCase):
 
     def test_empty_database_on_disk_throws_error(self):
         yet_another_channel_id = 'content_test_3'
-        filename = os.path.join(settings.CONTENT_DB_DIR, yet_another_channel_id + '.sqlite3')
+        filename = os.path.join(settings.CONTENT_DATABASE_DIR, yet_another_channel_id + '.sqlite3')
         open(filename, 'a').close()  # touch the file to create an empty DB
         with self.assertRaises(KeyError):
             with using_content_database(yet_another_channel_id):
@@ -203,8 +203,8 @@ class DatabaseRoutingTests(TestCase):
 
 
 @override_settings(
-    STORAGE_ROOT=STORAGE_ROOT_TEMP,
-    CONTENT_DB_DIR=CONTENT_DB_DIR_TEMP,
+    CONTENT_STORAGE_DIR=CONTENT_STORAGE_DIR_TEMP,
+    CONTENT_DATABASE_DIR=CONTENT_DATABASE_DIR_TEMP,
 )
 class ContentNodeAPITestCase(APITestCase):
     """

--- a/kolibri/content/utils/annotation.py
+++ b/kolibri/content/utils/annotation.py
@@ -8,21 +8,21 @@ from ..models import ChannelMetadata, ChannelMetadataCache
 
 
 def _get_channel_list_from_scanning_contentdb_dir():
-    db_list = fnmatch.filter(os.listdir(settings.CONTENT_DB_DIR), '*.sqlite3')
+    db_list = fnmatch.filter(os.listdir(settings.CONTENT_DATABASE_DIR), '*.sqlite3')
     db_names = [db.split('.sqlite3', 1)[0] for db in db_list]
     return db_names
 
 
 def sync_channelmetadata():
     """
-    Everytime kolibri runs, scan through the settings.CONTENT_DB_DIR folder to collect the names for all ContentDB,
+    Everytime kolibri runs, scan through the settings.CONTENT_DATABASE_DIR folder to collect the names for all ContentDB,
     and use the name to query each ContentDB to get the ChannelMetadata object,
     and use them to update the ChannelMetadata object in the default database to ensure they are insync
     """
     db_names = _get_channel_list_from_scanning_contentdb_dir()
-    # delete channelmetadata obejcts in default db that cannot be found in CONTENT_DB_DIR
+    # delete channelmetadata obejcts in default db that cannot be found in CONTENT_DATABASE_DIR
     ChannelMetadataCache.objects.exclude(id__in=db_names).delete()
-    # sync the channelmetadata objects in default db with channelmetadata objects in CONTENT_DB_DIR
+    # sync the channelmetadata objects in default db with channelmetadata objects in CONTENT_DATABASE_DIR
     for db_name in db_names:
         with using_content_database(db_name):
             update_values = ChannelMetadata.objects.values()[0]

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -33,7 +33,7 @@ return the module.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.conf import settings
-from django.conf.urls import url
+from django.conf.urls.static import static
 from kolibri.plugins.registry import get_urls as plugin_urls
 
 app_name = 'kolibri'
@@ -41,7 +41,5 @@ app_name = 'kolibri'
 
 urlpatterns = plugin_urls()
 
-urlpatterns += [
-    url(r'^' + settings.STORAGE_URL[1:-1] + '(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': settings.STORAGE_ROOT})
-]
+urlpatterns += static(settings.CONTENT_STORAGE_URL, document_root=settings.CONTENT_STORAGE_DIR)
+urlpatterns += static(settings.CONTENT_DATABASE_URL, document_root=settings.CONTENT_DATABASE_DIR)

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -91,7 +91,7 @@ WSGI_APPLICATION = 'kolibri.deployment.default.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(conf.KOLIBRI_HOME, 'db.sqlite3'),
+        'NAME': os.path.join(KOLIBRI_HOME, 'db.sqlite3'),
     }
 }
 
@@ -119,6 +119,8 @@ if not os.path.exists(CONTENT_STORAGE_DIR):
 OLD_CONTENT_DATABASE_DIR = os.path.join(BASE_DIR, 'kolibri', 'content', 'content_db')
 OLD_CONTENT_STORAGE_DIR = os.path.join(BASE_DIR, "storage")
 def movetree(src, dst):
+    if not os.path.exists(src):
+        return
     if not os.path.exists(dst):
         os.makedirs(dst)
     for item in os.listdir(src):
@@ -127,7 +129,8 @@ def movetree(src, dst):
         if os.path.isdir(s):
             movetree(s, d)
         else:
-            shutil.move(s, d)
+            if not os.path.exists(d):
+                shutil.move(s, d)
 
 movetree(OLD_CONTENT_DATABASE_DIR, CONTENT_DATABASE_DIR)
 movetree(OLD_CONTENT_STORAGE_DIR, CONTENT_STORAGE_DIR)
@@ -151,6 +154,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(KOLIBRI_HOME, "static")
 
 
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -97,11 +97,17 @@ DATABASES = {
 # Enable dynamic routing for content databases
 DATABASE_ROUTERS = ['kolibri.content.content_db_router.ContentDBRouter']
 
-# DIR for storing contentDBs
-CONTENT_DB_DIR = os.path.join(BASE_DIR, 'kolibri', 'content', 'content_db')
-# DIR for storing content files for all channels
-STORAGE_ROOT = os.path.join(BASE_DIR, "storage")
-STORAGE_URL = '/storage/'
+
+# Content directories and URLs for channel metadata and content files
+
+# Directory and URL for storing content databases for channel data
+CONTENT_DATABASE_DIR = os.path.join(KOLIBRI_HOME, 'content', 'databases')
+CONTENT_DATABASE_URL = '/content/databases/'
+
+# Directory and URL for storing de-duped content files for all channels
+CONTENT_STORAGE_DIR = os.path.join(KOLIBRI_HOME, 'content', 'storage')
+CONTENT_STORAGE_URL = '/content/storage/'
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
@@ -121,6 +127,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+
 
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
 # https://docs.djangoproject.com/en/1.9/topics/logging/
@@ -202,15 +209,25 @@ LOGGING = {
 }
 
 
+# Customizing Django auth system
+# https://docs.djangoproject.com/en/1.9/topics/auth/customizing/
+
 AUTH_USER_MODEL = 'kolibriauth.DeviceOwner'
 
 AUTHENTICATION_BACKENDS = ['kolibri.auth.backends.DeviceOwnerBackend', 'kolibri.auth.backends.FacilityUserBackend']
+
+
+# Django REST Framework
+# http://www.django-rest-framework.org/api-guide/settings/
 
 REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": "kolibri.auth.models.KolibriAnonymousUser",
 }
 
+
 # Configuration for Django JS Reverse
+# https://github.com/ierror/django-js-reverse#options
+
 JS_REVERSE_JS_VAR_NAME = 'urls'
 
 JS_REVERSE_JS_GLOBAL_OBJECT_NAME = KOLIBRI_CORE_JS_NAME

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import shutil
 
 # This is essential! We load the kolibri conf INSIDE the Django conf
 from kolibri.utils import conf
@@ -103,10 +104,33 @@ DATABASE_ROUTERS = ['kolibri.content.content_db_router.ContentDBRouter']
 # Directory and URL for storing content databases for channel data
 CONTENT_DATABASE_DIR = os.path.join(KOLIBRI_HOME, 'content', 'databases')
 CONTENT_DATABASE_URL = '/content/databases/'
+if not os.path.exists(CONTENT_DATABASE_DIR):
+    os.makedirs(CONTENT_DATABASE_DIR)
 
 # Directory and URL for storing de-duped content files for all channels
 CONTENT_STORAGE_DIR = os.path.join(KOLIBRI_HOME, 'content', 'storage')
 CONTENT_STORAGE_URL = '/content/storage/'
+if not os.path.exists(CONTENT_STORAGE_DIR):
+    os.makedirs(CONTENT_STORAGE_DIR)
+
+
+# TEMPORARY: Move existing content DBs and content storage dirs into new locations.
+# (July 9, 2016: Remove this in a couple of weeks once everyone is switched over)
+OLD_CONTENT_DATABASE_DIR = os.path.join(BASE_DIR, 'kolibri', 'content', 'content_db')
+OLD_CONTENT_STORAGE_DIR = os.path.join(BASE_DIR, "storage")
+def movetree(src, dst):
+    if not os.path.exists(dst):
+        os.makedirs(dst)
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            movetree(s, d)
+        else:
+            shutil.move(s, d)
+
+movetree(OLD_CONTENT_DATABASE_DIR, CONTENT_DATABASE_DIR)
+movetree(OLD_CONTENT_STORAGE_DIR, CONTENT_STORAGE_DIR)
 
 
 # Internationalization

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -19,7 +19,6 @@ Including another URLconf
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
@@ -29,6 +28,4 @@ urlpatterns = [
     url(r'^api/', include('kolibri.auth.api_urls')),
     url(r'^api/', include('kolibri.content.api_urls')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^' + settings.STORAGE_URL[1:-1] + '(?P<path>.*)$', 'django.views.static.serve', {
-        'document_root': settings.STORAGE_ROOT}),
 ]


### PR DESCRIPTION
## Summary

Rather than storing content and content databases in project sub-directories, store them in a systematic location within `KOLIBRI_HOME`. Also, some associated cleanup.

## TODO

- [x] Have tests been written for the new code? *(tests have been updated)*
