### PR TITLE
Fixing explore page top margin for fixed toolbar

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -100,16 +100,14 @@
   @require '~core-theme.styl'
   @require '../learn'
 
-  /* positional styling for toolbar */
   .tool-bar
     width-auto-adjust()
     position: fixed
     top: 0
-    height: $tool-bar-height
-    padding: $tool-bar-height
+    padding-top: ($tool-bar-height / 4)
+    padding-bottom: ($tool-bar-height / 4)
     box-sizing: border-box
     background-color: $core-bg-canvas
-    float: left
     z-index: 1
   .breadcrumbs
     float: left
@@ -119,9 +117,8 @@
     margin-top: $tool-bar-height
 
   .breadcrumbs
-  select
-  label
-    height: $tool-bar-height/3
+  .search-tools
+    height: ($tool-bar-height / 2)
 
   select
     font-size: 0.8rem

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -8,7 +8,7 @@ $card-width = 196px
 $card-gutter = 10px
 $card-presets = 2 3 4
 $nav-bar-width = 80px
-$tool-bar-height = 30px
+$tool-bar-height = 40px
 
 width-auto-adjust()
   for $preset in $card-presets


### PR DESCRIPTION
## Summary

Quick fix for the top margin (the reason title and descriptions keep getting obscured