### PR TITLE
Basic cherrypy foreground server implementation under `kolibri start`.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -24,6 +24,7 @@ from docopt import docopt  # noqa
 from logging import config as logging_config  # noqa
 from django.core.management import call_command  # noqa
 
+
 USAGE = """
 Kolibri
 
@@ -272,4 +273,9 @@ def main(args=None):
     if arguments['plugin']:
         plugin_name = arguments['PLUGIN']
         plugin(plugin_name, **arguments)
+        return
+
+    if arguments['start']:
+        from . import server
+        server.start()
         return

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -276,6 +276,7 @@ def main(args=None):
         return
 
     if arguments['start']:
+        # import from server.py here to avoid circular imports caused by importing kolibri.deployment.default.wsgi
         from . import server
         server.start()
         return

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -1,0 +1,53 @@
+import os
+
+import cherrypy
+from django.conf import settings
+from django.core.management import call_command
+from kolibri.deployment.default.wsgi import application
+
+
+def start():
+
+    # TODO(aronasorman): move to install/plugin-enabling scripts, and remove from here
+    call_command("collectstatic", interactive=False)
+    call_command("collectstatic_js_reverse", interactive=False)
+    call_command("migrate", interactive=False)
+
+    run_server()
+
+def run_server():
+
+    # Mount the application
+    cherrypy.tree.graft(application, "/")
+
+    serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
+    serve_static_dir(settings.CONTENT_DATABASE_DIR, settings.CONTENT_DATABASE_URL)
+    serve_static_dir(settings.CONTENT_STORAGE_DIR, settings.CONTENT_STORAGE_URL)
+
+    # Unsubscribe the default server
+    cherrypy.server.unsubscribe()
+
+    # Instantiate a new server object
+    server = cherrypy._cpserver.Server()
+
+    # Configure the server object
+    server.socket_host = "0.0.0.0"
+    server.socket_port = 8080
+    server.thread_pool = 30
+
+    # Subscribe this server
+    server.subscribe()
+
+    # Start the server engine (Option 1 *and* 2)
+
+    cherrypy.engine.start()
+    cherrypy.engine.block()
+
+def serve_static_dir(root, url):
+
+    static_handler = cherrypy.tools.staticdir.handler(
+        section="/",
+        dir=os.path.split(root)[1],
+        root=os.path.abspath(os.path.split(root)[0])
+    )
+    cherrypy.tree.mount(static_handler, url)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ djangorestframework==3.3.3
 six==1.10.0
 django-js-reverse==0.7.2
 django-filter==0.13.0
+cherrypy==6.0.2


### PR DESCRIPTION
When `kolibri start` is called, run a very basic `cherrypy` "production" server (in the foreground). Note: server starts on port 8080 for now.