### PR TITLE
Fix for production build of Javascript assets.

### DIFF
--- a/kolibri/core/assets/src/apiResources/resources.js
+++ b/kolibri/core/assets/src/apiResources/resources.js
@@ -1,7 +1,7 @@
-module.exports = [
-  require('./classroom'),
-  require('./contentNode'),
-  require('./facilityUser'),
-  require('./learnerGroup'),
-  require('./membership'),
-];
+module.exports = {
+  ClassroomResource: require('./classroom'),
+  ContentNodeResource: require('./contentNode'),
+  FacilityUserResource: require('./facilityUser'),
+  LearnerGroupResource: require('./learnerGroup'),
+  MembershipResource: require('./membership'),
+};

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -345,7 +345,7 @@ class ResourceManager {
    * resource.
    * @returns {Resource} - Return the instantiated Resource.
    */
-  registerResource(ResourceClass) {
+  registerResource(className, ResourceClass) {
     const name = ResourceClass.resourceName();
     if (!name) {
       throw new TypeError('A resource must have a defined resource name!');
@@ -354,10 +354,6 @@ class ResourceManager {
       throw new TypeError('A resource with that name has already been registered!');
     }
     this._resources[name] = new ResourceClass(this._kolibri);
-    // Shim for IE9 compatibility of .name property.
-    // Modified from: http://matt.scharley.me/2012/03/monkey-patch-name-ie.html#comment-551654096
-    const className = ResourceClass.name || /function\s([^(]{1,})\(/.exec(
-        (ResourceClass).toString())[1].trim();
     Object.defineProperty(this, className, { value: this._resources[name] });
     return this._resources[name];
   }

--- a/kolibri/core/assets/src/core_app_constructor.js
+++ b/kolibri/core/assets/src/core_app_constructor.js
@@ -51,7 +51,8 @@ module.exports = function CoreApp() {
   this.resources = new ResourceManager(this);
   const mediator = new Mediator();
 
-  Resources.forEach((resourceClass) => this.resources.registerResource(resourceClass));
+  Object.keys(Resources).forEach((resourceClassName) =>
+    this.resources.registerResource(resourceClassName, Resources[resourceClassName]));
 
   vue.prototype.Kolibri = this;
   /**


### PR DESCRIPTION
## Summary

Explicitly name all the resource classes, rather than relying on constructor introspection to retrieve the name.

This means that built assets will now work properly.