### PR TITLE
IE10 side nav style fix - 'px' was missing from '$nav-element-height' variable

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -106,7 +106,7 @@
   @require 'learn'
 
   // Navbar styling
-  $nav-element-height = 150
+  $nav-element-height = 150px
   $font-size = 1em
 
   #learn-nav


### PR DESCRIPTION
## Summary

Fixes this:

<img width="187" alt="screen shot 2016-07-11 at 12 18 39 pm" src="https://cloud.githubusercontent.com/assets/6668144/16745521/09075820-476b-11e6-986a-a8475a848742.png">


## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)
