### PR TITLE
Added a height to the parent so the pdf does not get caught off.

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -70,6 +70,6 @@
       height: 100%
 
   .pdfcontainer
-    height: 80vh
+    height: 75vh
 
 </style>

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -3,7 +3,7 @@
   <div>
     <div v-el:container class="container" allowfullscreen>
       <button v-if="supportsPDFs" v-on:click="togglefullscreen">Toggle Fullscreen</button>
-      <div v-el:pdfcontainer></div>
+      <div v-el:pdfcontainer class="pdfcontainer"></div>
     </div>
   </div>
 
@@ -68,5 +68,8 @@
     &:fullscreen
       width: 100%
       height: 100%
+
+  .pdfcontainer
+    height: 80vh
 
 </style>

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -65,6 +65,8 @@
 
   .container
     text-align: center
+    margin-top: 20px
+    margin-bottom: 20px
     &:fullscreen
       width: 100%
       height: 100%


### PR DESCRIPTION
## Summary

Added a height to the parent so the pdf does not get caught off.


## Reviewer guidance

There has to be a better way of doing this.

## Issues addressed

PDF got caught off on IE. In IE, a parent must have a height in order for a child to have 100% height.


## Screenshot

![screenshot from 2016-07-11 16 38 17](https://cloud.githubusercontent.com/assets/7193975/16750336/f44c3c50-4785-11e6-9967-a004a3bc2db2.png)


