### PR TITLE
Quick CSS Fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -28,7 +28,7 @@
   </div>
 
   <!-- Toggles top margin if sidebar overlay is exposed -->
-  <section class="explore" :style="{'margin-top': searchToggled ? '0' : ''}">
+  <section class="explore">
 
     <p v-if='topic.description'>
       {{ topic.description }}
@@ -114,7 +114,7 @@
   .search-tools
     float: right
   .explore
-    margin-top: $tool-bar-height
+    padding-top: $tool-bar-height
 
   .breadcrumbs
   .search-tools
@@ -125,10 +125,6 @@
     padding: 0
     position: relative
     top: -8px
-
-  /* overwriting default HTML styles */
-  p
-    margin-top: 0
 
   .fast-transition
     transition: all 0.3s ease-out

--- a/kolibri/plugins/learn/assets/src/vue/topic-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/topic-card/index.vue
@@ -50,8 +50,5 @@
 
   h3
     font-size: 0.8rem
-    overflow: hidden
-    white-space: nowrap
-    text-overflow: ellipsis
 
 </style>


### PR DESCRIPTION
## Summary

Used padding instead of margin to get rid of the white line up top that Eli mentioned earlier.

Also stopped clipping titles.