### PR TITLE
Fixes to get Kolibri running in cherrypy, after installing through an sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,6 @@ recursive-include kolibri/utils *
 recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/dist *
+recursive-include kolibri/core/build/*
 recursive-exclude kolibri/dist *pyc
 prune kolibri/dist/*/__pycache___

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ test:
 test-all:
 	tox
 
+assets:
+	npm run build
+
 coverage:
 	coverage run --source kolibri setup.py test
 	coverage report -m
@@ -52,11 +55,11 @@ docs: clean-docs
 	sphinx-apidoc -d 10 -H "Python Reference" -o docs/py_modules/ kolibri kolibri/test kolibri/deployment/ kolibri/dist/
 	$(MAKE) -C docs html
 
-release: clean
+release: clean assets
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-sdist: clean
+sdist: clean assets
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -8,6 +8,7 @@ var fs = require("fs");
 var path = require("path");
 var logging = require('./logging');
 var execSync = require('child_process').execSync;
+var temp = require('temp').track();
 var _ = require("lodash");
 
 var parseBundlePlugin = require('./parse_bundle_plugin');
@@ -42,8 +43,15 @@ var readBundlePlugin = function(base_dir) {
   var bundles = [];
   var externals = {};
 
+  // the temporary path where the webpack_json json is stored
+  var webpack_json_tempfile = temp.openSync({suffix: '.json'}).path;
+
   // Run the script below to extract the relevant information about the plugin configuration from the Python code.
-  var result = execSync("python -m kolibri manage webpack_json").toString();
+  execSync("python -m kolibri manage webpack_json -- " + " --outputfile " + webpack_json_tempfile);
+
+  var result = fs.readFileSync(webpack_json_tempfile);
+
+  temp.cleanupSync();           // cleanup the tempfile immediately!
 
   if (result.length > 0) {
     // The above script prints JSON to stdout, here we parse that JSON and use it as input to our webpack

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -102,9 +102,9 @@ describe('readBundlePlugins', function() {
   var data = [];
 
   beforeEach(function() {
-    readBundlePlugins.__set__("execSync", function() {
-      var output = JSON.stringify(data);
-      return new Buffer(output);
+    readBundlePlugins.__set__("execSync", function() {});
+    readBundlePlugins.__set__("fs.readFileSync", function() {
+      return JSON.stringify(data);
     });
   });
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import time
+from pkg_resources import resource_filename
 
 from django.conf import settings as django_settings
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -158,11 +159,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         An auto-generated path to where the build-time files are stored,
         containing information about the built bundles.
         """
-        return os.path.join(
-            os.path.abspath(os.path.dirname(__name__)),
-            self._module_file_path,
-            "build"
-        )
+        return resource_filename('kolibri.core', 'build')
 
     @property
     def stats_file(self):
@@ -175,7 +172,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         """
         return os.path.join(
             self.build_path,
-            "{plugin}_stats.json".format(plugin=self.unique_slug)
+            '{plugin}_stats.json'.format(plugin=self.unique_slug)
         )
 
     @property

--- a/kolibri/core/webpack/management/commands/webpack_json.py
+++ b/kolibri/core/webpack/management/commands/webpack_json.py
@@ -12,12 +12,21 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = ()
     help = 'Creates a new schema'  # @ReservedAssignment
-    option_list = BaseCommand.option_list + ()
+
+    def add_arguments(self, parser):
+        parser.add_argument('--outputfile', type=str, default=None, dest="output_file")
 
     def handle(self, *args, **options):
 
         logging.debug(args)
 
-        print(json.dumps([hook.webpack_bundle_data for hook in WebpackBundleHook().registered_hooks]))
+        result = [hook.webpack_bundle_data for hook in WebpackBundleHook().registered_hooks]
+
+        if options["output_file"]:
+            logger.info("Writing webpack_json output to {}".format(options["output_file"]))
+            with open(options["output_file"], "w") as f:
+                json.dump(result, f)
+        else:
+            logger.info("No output file argument; writing webpack_json output to stdout.")
+            self.stdout.write(json.dumps(result))

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -27,13 +27,13 @@ def run_server():
     # Unsubscribe the default server
     cherrypy.server.unsubscribe()
 
+    cherrypy.config.update({'server.socket_host': "0.0.0.0",
+                            'server.socket_port': 8080,
+                            'server.thread_pool': 30,
+                            'log.screen': True})
+
     # Instantiate a new server object
     server = cherrypy._cpserver.Server()
-
-    # Configure the server object
-    server.socket_host = "0.0.0.0"
-    server.socket_port = 8080
-    server.thread_pool = 30
 
     # Subscribe this server
     server.subscribe()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,2 @@
-# Kolibri runtime requirements
-docopt==0.6.2
-colorlog==2.6.0
-django==1.9.7
-# we need some unreleased django-mptt fixes that came in after 0.8.4; can switch to 0.8.5 when released
-git+https://github.com/django-mptt/django-mptt.git@9e131f91a9992d0495e1217bdcf7036a5e11d8c5#egg=django-mptt
-djangorestframework==3.3.3
-six==1.10.0
-django-js-reverse==0.7.2
-django-filter==0.13.0
-cherrypy==6.0.2
+# Base requirements are empty. All of our minimum requirements are specified in setup.py's install_requires variable!
+-e .

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ static_dir = os.path.dirname(os.path.realpath(kolibri_dist.__file__))
 
 install_requires = [
     'colorlog',
+    'CherryPy==6.0.2',
     'django>=1.9,<1.10',
     'django-filter>=0.13.0',
     'django-mptt==0.8.4',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import sys
 
-from pip.req import parse_requirements
 from setuptools import setup
 from setuptools.command.install_scripts import install_scripts
 
@@ -54,14 +53,29 @@ is_building_dist = any(
 static_requirements = []
 static_dir = os.path.dirname(os.path.realpath(kolibri_dist.__file__))
 
-install_requires = [str(ir.req) for ir in parse_requirements('./requirements.txt', session=False)]
+install_requires = [
+    'cherrypy==6.0.2',
+    'django-filter==0.13.0',
+    'django-js-reverse==0.7.2',
+    'six==1.10.0',
+    'djangorestframework==3.3.3',
+    'django==1.9.7',
+    'colorlog==2.6.0',
+    'docopt==0.6.2',
+    'django-mptt>=0.8.4',              # apparently you also need to have the dependency_links packages be included in install_requires
+]
+
+dependency_links = [
+    'http://github.com/django-mptt/django-mptt/tarball/9e131f91#egg=django-mptt-0.8.4'
+]
 
 # Check if user supplied the special '--static' option
 if '--static' in sys.argv:
     sys.argv.remove('--static')
     dist_name = 'kolibri-static'
     description += " This static version bundles all dependencies."
-    install_requires, static_requirements = [], install_requires
+    install_requires, static_requirements = [], (install_requires + dependency_links)
+    dependency_links = []
     static_build = True
 
 
@@ -195,7 +209,6 @@ elif is_building_dist:
             )
         )
 
-
 setup(
     name=dist_name,
     version=kolibri.__version__,
@@ -218,6 +231,7 @@ setup(
     package_dir={'kolibri': 'kolibri'},
     include_package_data=True,
     install_requires=install_requires,
+    dependency_links=dependency_links,
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'tox', 'flake8'],
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 
+from pip.req import parse_requirements
 from setuptools import setup
 from setuptools.command.install_scripts import install_scripts
 
@@ -53,17 +54,7 @@ is_building_dist = any(
 static_requirements = []
 static_dir = os.path.dirname(os.path.realpath(kolibri_dist.__file__))
 
-install_requires = [
-    'colorlog',
-    'CherryPy==6.0.2',
-    'django>=1.9,<1.10',
-    'django-filter>=0.13.0',
-    'django-mptt==0.8.4',
-    'django-js-reverse==0.7.2',
-    'djangorestframework==3.3.3',
-    'docopt',
-    'six',
-]
+install_requires = [str(ir.req) for ir in parse_requirements('./requirements.txt', session=False)]
 
 # Check if user supplied the special '--static' option
 if '--static' in sys.argv:

--- a/test/conditional/test_build.sh
+++ b/test/conditional/test_build.sh
@@ -12,6 +12,7 @@ cd "$DIR/../../"
 pip install -r requirements/build.txt
 
 # Build .whl
+npm install
 make sdist
 pip install dist/kolibri-*.whl
 


### PR DESCRIPTION
## Summary

Kolibri can now run in any python environment, after installing the Kolibri sdist generated by `make sdist`.

Changes should be detailed inside each commit.

You can create and sdist, install sdist and run Kolibri in production mode in the following steps:

1. `make sdist`
2. Your sdist is now inside `dist/`. Install it in your python environment of choice by running `pip install dist/*.whl`.
3. Go to any directory and then run `kolibri start`.
4. Visit `127.0.0.1:8080`. 

Tada! Kolibri should be running in its full glory.
