### PR TITLE
Current time was not showing up on IE.

### DIFF
--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -169,7 +169,7 @@
     font-family: 'NotoSans', 'sans-serif'
 
   .video-js .vjs-current-time
-    display: inline
+    display: block
 
   .videowrapper
     position: relative
@@ -229,6 +229,6 @@
     pointer-events: none
 
   .video-js .display
-    display: inline
+    display: block
 
 </style>


### PR DESCRIPTION
## Summary

Current time was not showing up on IE. Now it is. 

![screenshot from 2016-07-12 13 00 25](https://cloud.githubusercontent.com/assets/7193975/16781565/b60176f8-4830-11e6-8e40-0382039ad675.png)
