### PR TITLE
WIP - Adding 'alt' attribute to images and icons

### DIFF
--- a/kolibri/core/assets/src/core-global.styl
+++ b/kolibri/core/assets/src/core-global.styl
@@ -30,3 +30,13 @@ a
 
   &:hover
     color: $core-action-dark
+
+.visuallyhidden
+  border: none
+  clip: rect(0 0 0 0)
+  height: 1px
+  margin: -1px
+  overflow: hidden
+  padding: 0
+  position: absolute
+  width: 1px

--- a/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
@@ -5,7 +5,7 @@
     <img :src="validatedThumbnail" class="thumbnail" v-if="showThumbnail" alt="">
     <div class="thumbnail" v-else>&nbsp;</div>
     <h3>
-      <span class="visuallyhidden">{{ progress }} {{ kind }} </span>{{ title }}
+      {{ title }}
     </h3>
 
   </a>
@@ -105,15 +105,5 @@
     left: 0.5em
     margin-top: -1em
     margin-bottom: -1em
-
-  .visuallyhidden
-    border: none
-    clip: rect(0 0 0 0)
-    height: 1px
-    margin: -1px
-    overflow: hidden
-    padding: 0
-    position: absolute
-    width: 1px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-card/index.vue
@@ -2,10 +2,10 @@
 
   <a v-link="link">
     <content-icon class="content-icon" v-if="kind" :kind="kind" :progress="progress"></content-icon>
-    <img :src="validatedThumbnail" class="thumbnail" v-if="showThumbnail">
+    <img :src="validatedThumbnail" class="thumbnail" v-if="showThumbnail" alt="">
     <div class="thumbnail" v-else>&nbsp;</div>
     <h3>
-      {{ title }}
+      <span class="visuallyhidden">{{ progress }} {{ kind }} </span>{{ title }}
     </h3>
 
   </a>
@@ -105,5 +105,15 @@
     left: 0.5em
     margin-top: -1em
     margin-bottom: -1em
+
+  .visuallyhidden
+    border: none
+    clip: rect(0 0 0 0)
+    height: 1px
+    margin: -1px
+    overflow: hidden
+    padding: 0
+    position: absolute
+    width: 1px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <img :src="src" alt="">
+  <img :src="src" :alt="altText">
 
 </template>
 
@@ -19,6 +19,10 @@
       },
     },
     computed: {
+      altText() {
+        // TODO - I18N
+        return `${this.progress} - ${this.kind}`;
+      },
       src() {
         // Note: dynamic requires should be used carefully because
         //  they greedily add items to the webpack bundle.

--- a/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <img :src="src">
+  <img :src="src" alt="">
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -33,7 +33,7 @@
       {{ topic.description }}
     </p>
 
-    <span class="visuallyhidden">You can navigate groups of content through headings.</span>
+    <span class="visuallyhidden" v-if="subtopics.length">You can navigate groups of content through headings.</span>
 
     <card-grid :header="isRoot ? 'Topics' : '' " v-if="subtopics.length">
       <topic-card
@@ -135,15 +135,5 @@
   .fast-leave
     opacity: 0
     transform: translateX(-100%)
-
-  .visuallyhidden
-    border: none
-    clip: rect(0 0 0 0)
-    height: 1px
-    margin: -1px
-    overflow: hidden
-    padding: 0
-    position: absolute
-    width: 1px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -33,6 +33,8 @@
       {{ topic.description }}
     </p>
 
+    <span class="visuallyhidden">You can navigate groups of content through headings.</span>
+
     <card-grid :header="isRoot ? 'Topics' : '' " v-if="subtopics.length">
       <topic-card
         v-for="topic in subtopics"
@@ -133,5 +135,15 @@
   .fast-leave
     opacity: 0
     transform: translateX(-100%)
+
+  .visuallyhidden
+    border: none
+    clip: rect(0 0 0 0)
+    height: 1px
+    margin: -1px
+    overflow: hidden
+    padding: 0
+    position: absolute
+    width: 1px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/topic-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/topic-card/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <a v-link="link">
-    <img src="../folder.svg">
+    <img src="../folder.svg" alt="">
     <h3 class="title">
       {{ title }}
     </h3>


### PR DESCRIPTION
## Summary

Empty 'alt' attribute for both thumbnail and icon on content card, with addition of `visuallyhidden` content that renders progress and content kind. 

With the same logic svg folder icon is also rendered invisible with the empty `alt` in order to avoid constant repetition with each content group. The lazy solution would be to add `alt="folder"`, but screen reader users do not have the option of visually ignoring purely presentational icon like sighted users, and will be forced to listen to SR output `grafic folder topic title 1` `grafic folder topic title 2` `grafic folder topic title 3` `grafic folder topic title 4`, etc... 

## TODO

- [x] How do I exclude a `span` on final node of the breadcrumb? Is there a `v-if-not`? :stuck_out_tongue:
- [x] Discuss the inclusion of `visuallyhidden` class into `core-global.styl`


## Issues addressed

Accessibility errors regarding the missing `alt` attributes. 

## Screenshots (if appropriate)

![- kolibri - google chrome_544](https://cloud.githubusercontent.com/assets/1457929/16783657/3e4d2bf2-4885-11e6-84a2-4f5c4e3d185a.png)


