### PR TITLE
Role calculation fix

### DIFF
--- a/kolibri/auth/filters.py
+++ b/kolibri/auth/filters.py
@@ -194,9 +194,12 @@ class HierarchyRelationsFilter(object):
             where_clause = ['target_user.id = {id}'.format(id=self._as_sql_reference(target_user))]
             self._add_extras(where=where_clause)
 
+        # build the left join clause if we have any left join tables; the "ON 1=1" is needed to avoid syntax errors on Postgres
+        left_join_sql = "LEFT JOIN {tables} ON 1=1".format(tables=", ".join(self.left_join_tables)) if self.left_join_tables else ""
+
         joined_condition = "EXISTS (SELECT * FROM {tables} {left_join_tables} WHERE {where})".format(
             tables=", ".join(self.tables),
-            left_join_tables="LEFT JOIN {tables}".format(tables=", ".join(self.left_join_tables)) if self.left_join_tables else "",
+            left_join_tables=left_join_sql,
             where=self._join_with_logical_operator(self.where, "AND"))
 
         return self.queryset.extra(where=[joined_condition])


### PR DESCRIPTION
## Summary

The way we calculate roles includes implicit membership in a facility for all FacilityUsers associated with the facility. Previously, we did an INNER JOIN on the Membership table, but this failed (returned an empty result set) if no membership rows yet existed. This PR instead brings in the Membership table as a LEFT JOIN, so it will not fail when no Membership rows yet exist.

## TODO

- [x] Have tests been written for the new code? (REGRESSION TESTS! :D)