### PR TITLE
Fixes the hacky implementation of two-way data binding in the audio player.

### DIFF
--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -30,7 +30,7 @@
   <audio
     id="audio" 
     v-el:audio
-    @timeupdate="updateRawTime"
+    @timeupdate="updateDummyTime"
     @loadedmetadata="setTotalTime"
     :src="defaultFile.storage_url"
   ></audio>
@@ -47,19 +47,14 @@
       'defaultFile',
     ],
 
-    watch: {
-      rawTime(newVal, oldVal) {
-        if (Math.abs(newVal - oldVal) >= 1) {
-          this.$els.audio.currentTime = this.rawTime;
-        }
-      },
-    },
-
     data: () => ({
       isPlay: true,
       isPause: false,
       max: 0,
-      rawTime: 0,
+      // This data attribute is required, as we cannot use this.$els.audio in our getter for
+      // rawTime, because at the time of getter initialization for the computed property,
+      // the DOM does not exist, so the above object path is undefined, which causes problems.
+      dummyTime: 0,
     }),
 
     computed: {
@@ -86,6 +81,17 @@
       formattedTotalSec() {
         return this.formatTime(this.totalSeconds);
       },
+      rawTime: {
+        cache: false,
+        get() {
+          return this.dummyTime;
+        },
+        set(value) {
+          // Set the actual time here and let the updateDummyTime method take care of updating
+          // based on the change event happening here on the currentTime.
+          this.$els.audio.currentTime = value;
+        },
+      },
     },
 
     methods: {
@@ -109,8 +115,8 @@
         }
       },
 
-      updateRawTime() {
-        this.rawTime = this.$els.audio.currentTime;
+      updateDummyTime() {
+        this.dummyTime = this.$els.audio.currentTime;
       },
 
       setTotalTime() {


### PR DESCRIPTION
## Summary

Currently, the audio player has to assume that changes of a second or more are user driven, while changes of less than a second are player driven. This was due to difficulties getting the two way data binding of v-model to function as expected.

The bug appears to have been due to the fact that the computed property getter was referencing the `this.$els.audio` element, which would not have been present in the DOM at the time of computed property initialization.

This PR addresses this problem by creating a third dummy variable which gets updated any time the `this.$els.audio.currentTime` property is updated (regardless of whether it is by user or player intervention). This is then used as the getter for the `rawTime` property that we use to drive the `v-model` binding. The setter for the `rawTime` property just directly sets the `currentTime` on the audio element.

## Reviewer guidance

Take a peek, take a listen!