### PR TITLE
Generalize expandable-content-grid and use on both learn page and learn content

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -28,16 +28,11 @@
       </content-render>
     </div>
 
-    <card-grid header='Recommended' v-if="pageMode === $options.PageModes.LEARN">
-      <content-card
-        v-for="content in recommended"
-        :id="content.id"
-        :title="content.title"
-        :thumbnail="content.thumbnail"
-        :kind="content.kind"
-        :progress="content.progress">
-      </content-card>
-    </card-grid>
+    <expandable-content-grid
+      v-if="pageMode === $options.PageModes.LEARN"
+      title="Recommended"
+      :contents="recommended"
+    ></expandable-content-grid>
 
   </div>
 
@@ -53,9 +48,8 @@
     mixins: [constants], // makes constants available in $options
     components: {
       'breadcrumbs': require('../breadcrumbs'),
-      'content-card': require('../content-card'),
       'content-render': require('content-renderer'),
-      'card-grid': require('../card-grid'),
+      'expandable-content-grid': require('../expandable-content-grid'),
     },
     vuex: {
       getters: {

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -1,0 +1,77 @@
+<template>
+
+  <card-grid :header="title" v-if="slicedContents.length">
+    <content-card
+      v-for="content in slicedContents"
+      :title="content.title"
+      :thumbnail="content.thumbnail"
+      :kind="content.kind"
+      :progress="content.progress"
+      :id="content.id">
+    </content-card>
+  </card-grid>
+
+  <div class='button-wrapper' v-if="contents.length > nCollapsed">
+    <button @click='toggle()' v-if='expanded'>
+      <i class="material-icons">&#xE5CE;</i> Show Less
+    </button>
+    <button class='pure-button' @click='toggle()' v-else>
+      <i class="material-icons">&#xE5CF;</i> <span>Show More</span>
+    </button>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+    props: {
+      title: {
+        type: String,
+        default: 'Contents',
+      },
+      contents: {
+        type: Array,
+        default: [],
+      },
+      nCollapsed: {
+        type: Number,
+        default: 6,
+      },
+      nExpanded: {
+        type: Number,
+        default: 12,
+      },
+    },
+    components: {
+      'content-card': require('../content-card'),
+      'card-grid': require('../card-grid'),
+    },
+    data() {
+      return {
+        expanded: false,
+      };
+    },
+    computed: {
+      slicedContents() {
+        const num = this.expanded ? this.nExpanded : this.nCollapsed;
+        return this.contents.slice(0, num);
+      },
+    },
+    methods: {
+      toggle() {
+        this.expanded = !this.expanded;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  .button-wrapper
+    text-align: center
+
+</style>

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
@@ -1,53 +1,18 @@
 <template>
 
-  <card-grid header="Recommended" v-if="contents.length">
-    <content-card
-      v-for="content in contents"
-      :title="content.title"
-      :thumbnail="content.thumbnail"
-      :kind="content.kind"
-      :progress="content.progress"
-      :id="content.id">
-    </content-card>
-  </card-grid>
-
-  <div class='button-wrapper'>
-    <button @click='toggle()' v-if='expanded'>
-      <i class="material-icons">&#xE5CE;</i> Show Less
-    </button>
-    <button class='pure-button' @click='toggle()' v-else>
-      <i class="material-icons">&#xE5CF;</i> <span>Show More</span>
-    </button>
-  </div>
+  <expandable-content-grid
+    title="Recommended"
+    :contents="recommendations"
+  ></expandable-content-grid>
 
 </template>
 
 
 <script>
 
-  const N_COLLAPSED = 6;
-  const N_EXPANDED = 12;
-
   module.exports = {
     components: {
-      'content-card': require('../content-card'),
-      'card-grid': require('../card-grid'),
-    },
-    data() {
-      return {
-        expanded: false,
-      };
-    },
-    computed: {
-      contents() {
-        const num = this.expanded ? N_EXPANDED : N_COLLAPSED;
-        return this.recommendations.slice(0, num);
-      },
-    },
-    methods: {
-      toggle() {
-        this.expanded = !this.expanded;
-      },
+      'expandable-content-grid': require('../expandable-content-grid'),
     },
     vuex: {
       getters: {


### PR DESCRIPTION
## Summary

Use the same expandable content grid on the learn page and the learn content page.

Opening this for now - will work on resizing content renderers in a subsequent PR (videojs is being recalcitrant, so it might not be done in time for MMVP).

