### PR TITLE
Video buttons now visible in smaller viewports.

### DIFF
--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -150,11 +150,9 @@
     .vjs-slider
       background-color: #545454
       background-color: rgba(84, 84, 84, 0.5)
-
     .vjs-load-progress
       background: ligthen(#545454, 25%)
       background: rgba(84, 84, 84, 0.5)
-
       div
         background: ligthen(#545454, 50%)
         background: rgba(84, 84, 84, 0.75)

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -154,6 +154,7 @@
     .vjs-load-progress
       background: ligthen(#545454, 25%)
       background: rgba(84, 84, 84, 0.5)
+
       div
         background: ligthen(#545454, 50%)
         background: rgba(84, 84, 84, 0.75)
@@ -165,69 +166,69 @@
     background-color: rgba(0, 0, 0, 0.7)
 
    // Custom style
-  .vjs-menu
+  .videowrapper
+    position: relative
+
+  .video-js .vjs-menu
     font-family: 'NotoSans', 'sans-serif'
 
   .video-js .vjs-current-time
     display: block
 
-  .videowrapper
-    position: relative
-
   .video-js .vjs-play-progress
     background-color: #996189
-
-  .video-js .videoreplay
-    background: url('../icons/ic_replay_10_white.svg')
-    background-repeat: no-repeat
-    background-size: contain
-    cursor: pointer
-    position: absolute
-    top: 50%
-    left: 40%
-    transform: translate(-50%, -50%)
-    height: 3em
-    width: 3em
-    display: none
-
-  .video-js .videoforward
-    background: url('../icons/ic_forward_10_white.svg')
-    background-repeat: no-repeat
-    background-size: contain
-    cursor: pointer
-    position: absolute
-    top: 50%
-    left: 60%
-    transform: translate(-50%, -50%)
-    height: 3em
-    width: 3em
-    display: none
-
-  .video-js .videotoggle
-    background: url('../icons/ic_play_circle_outline_white.svg')
-    background-repeat: no-repeat
-    background-size: contain
-    cursor: pointer
-    position: absolute
-    top: 50%
-    left: 50%
-    transform: translate(-50%, -50%)
-    height: 7em
-    width: 7em
-
-  .video-js .videopaused
-    background: url('../icons/ic_pause_circle_outline_white.svg')
-    background-repeat: no-repeat
-    background-size: contain
 
   .video-js .userInactive
     visibility: visible
     opacity: 0
     transition: visibility 1s, opacity 1s
 
-  .video-js .vjs-playing .vjs-tech
-    pointer-events: none
+  .video-js .videoreplay,
+  .video-js .videoforward,
+  .video-js .videotoggle
+    background-repeat: no-repeat
+    background-size: contain
+    cursor: pointer
+    position: absolute
+    top: 50%
+    transform: translate(-50%, -50%)
 
+  .video-js .videoreplay,
+  .video-js .videoforward
+    display: none
+    height: 10vw
+    width: 10vw
+    max-height: 133px
+    max-width: 133px
+
+  .video-js .videoreplay
+    background: url('../icons/ic_replay_10_white.svg')
+    background-repeat: no-repeat
+    background-size: contain
+    left: 35%
+
+  .video-js .videoforward
+    background: url('../icons/ic_forward_10_white.svg')
+    background-repeat: no-repeat
+    background-size: contain
+    left: 65%
+
+  .video-js .videotoggle
+    background: url('../icons/ic_play_circle_outline_white.svg')
+    background-repeat: no-repeat
+    background-size: contain
+    left: 50%
+    height: 15vw
+    width: 15vw
+    max-height: 200px
+    max-width: 200px
+
+  .video-js .videopaused
+    background: url('../icons/ic_pause_circle_outline_white.svg')
+    background-repeat: no-repeat
+    background-size: contain
+
+  .video-js .display,
   .video-js .display
     display: block
 

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -140,7 +140,7 @@
 <style lang="stylus">
 
   // Default videojs stylesheet
-  // Unable to refrence the videojs using require since videojs dosen't have good webpack support
+  // Unable to reference the videojs using require since videojs doesn't have good webpack support
   @import '../../../../../../node_modules/video.js/dist/video-js.css'
 
   // Videojs skin customization


### PR DESCRIPTION
## Summary

Video buttons now visible in smaller viewports.

## Reviewer guidance

Also cleaned and organized CSS. 

## Issues addressed

"jump fwd/back buttons aren't clickable when video player is small"

## Screenshot
![screenshot from 2016-07-14 14 26 37](https://cloud.githubusercontent.com/assets/7193975/16856469/0c8b5fa8-49cf-11e6-8bf6-080581c47afe.png)

