### PR TITLE
Modifies all content renderers to have consistent sizing and to be constrained by parent content renderer.

### DIFF
--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -25,15 +25,14 @@
       <button class="audio-button" @click="minus20">- 20s</button>
       <button class="audio-button" @click="plus20">+ 20s</button>
     </div>
+    <audio
+      id="audio" 
+      v-el:audio
+      @timeupdate="updateDummyTime"
+      @loadedmetadata="setTotalTime"
+      :src="defaultFile.storage_url"
+    ></audio>
   </div>
-
-  <audio
-    id="audio" 
-    v-el:audio
-    @timeupdate="updateDummyTime"
-    @loadedmetadata="setTotalTime"
-    :src="defaultFile.storage_url"
-  ></audio>
 
 </template>
 
@@ -165,7 +164,8 @@
 <style lang="stylus" scoped>
 
   #audio-wrapper
-    margin: 8% 5%
+    padding: 8% 5%
+    height: 100%
     
   .play-button
     margin-right: 2%

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -65,13 +65,9 @@
 
   .container
     text-align: center
-    margin-top: 20px
-    margin-bottom: 20px
+    height: 100%
     &:fullscreen
       width: 100%
       height: 100%
-
-  .pdfcontainer
-    height: 75vh
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -12,12 +12,12 @@
     <div v-if="pageMode === $options.PageModes.LEARN">
       <a v-link="{ name: $options.PageNames.LEARN_ROOT }">Home</a>
       <h1>{{ title }}</h1>
-    </div>
-
-    <div>
       <p>
         {{ description }}
       </p>
+    </div>
+
+    <div class="content-container">
       <content-render
         :id="id"
         :kind="kind"
@@ -83,5 +83,10 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .content-container
+    height: 60vh
+
+</style>
 

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -73,7 +73,6 @@
       this.videoPlayer = videojs(this.$els.video, {
         controls: true,
         autoplay: false,
-        fluid: true,
         preload: 'auto',
         poster: this.posterSource,
         playbackRates: [0.25, 0.5, 1.0, 1.25, 1.5, 2.0],
@@ -147,6 +146,7 @@
   .video-js
     font-size: 1em
     color: #fff
+    height: 100%
     .vjs-slider
       background-color: #545454
       background-color: rgba(84, 84, 84, 0.5)


### PR DESCRIPTION
## Summary

Modifies all content renderers to constrain themselves to the content renderer container.

Note: produces a slightly undesirable black border on videojs.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/16856742/bd1d3e1c-49d0-11e6-9f9e-916d0005abfe.png)

![image](https://cloud.githubusercontent.com/assets/1680573/16856778/ef7ed4b0-49d0-11e6-8511-b4424aac2be7.png)

![image](https://cloud.githubusercontent.com/assets/1680573/16856801/0b4cd21e-49d1-11e6-876a-abd08b0af1d1.png)
