### PR TITLE
prevents the topic from 'jumping' down when breadcrumb appears. also made little arrow back to learn home bigger

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -10,7 +10,7 @@
         :crumbs='breadcrumbs'>
       </breadcrumbs>
       <a v-else slot='extra-nav' v-link="{ name: $options.PageNames.LEARN_ROOT }">
-        ← Learn
+        <span id="little-arrow">←</span> Learn
       </a>
       <content-icon
         slot='icon'
@@ -90,6 +90,10 @@
   .content-container
     height: 60vh
     margin-bottom: 1em
+    
+  #little-arrow
+    font-size: 28px
+    font-weight: 900
 
 </style>
 

--- a/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
@@ -54,14 +54,15 @@
 <style lang="stylus" scoped>
 
   .header-wrapper
-    margin-top: 2em
+    margin-top: 1em
 
   .extra-nav
     font-size: 12px
+    min-height: 16px
 
   .header
     position: relative
-    margin-top: 0.5em
+    margin-top: 0.3em
 
   .icon-wrapper
     display: block


### PR DESCRIPTION
## Summary

<img width="881" alt="screen shot 2016-07-14 at 6 23 19 pm" src="https://cloud.githubusercontent.com/assets/6668144/16860898/e2d1f7c2-49f0-11e6-8bb2-06095e1434eb.png">

<img width="777" alt="screen shot 2016-07-14 at 6 23 11 pm" src="https://cloud.githubusercontent.com/assets/6668144/16860894/ddc13068-49f0-11e6-84b2-4c650b47a24b.png">

<img width="875" alt="screen shot 2016-07-14 at 6 36 51 pm" src="https://cloud.githubusercontent.com/assets/6668144/16861042/fc944574-49f1-11e6-8ac2-0213a02d7df3.png">


## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

… explore mode