### PR TITLE
PDF renderer no longer overlaps recommendations.

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -70,4 +70,8 @@
       width: 100%
       height: 100%
 
+  .pdfcontainer
+    /* Accounts for the button height. */
+    height: calc(100% - 28.75px)
+
 </style>


### PR DESCRIPTION
## Summary

PDF renderer no longer overlaps recommendations.


## Issues addressed

pdf overlaps section below it

## Screenshot

![screenshot from 2016-07-15 10 59 36](https://cloud.githubusercontent.com/assets/7193975/16883895/4960eaea-4a7b-11e6-8b84-edcd9facbb1c.png)