### PR TITLE
Makes thin wrapper around Javascript loglevel module.

### DIFF
--- a/docs/dev/conventions.rst
+++ b/docs/dev/conventions.rst
@@ -55,6 +55,11 @@ JavaScript Code
 - We use the `AirBnB Javascript Style guide <https://github.com/airbnb/javascript>`_ for client-side ES6 code in Vue components.
 - ``use strict`` is automatically inserted.
 - Use CommonJS-style ``require`` and ``module.exports`` statements, not ES6 ``import``/``export`` statements.
+- For logging statements we use a thin wrapper around the ``log-level`` JS library, that prefixes the log statements with information about the logging level and current file. To access the logger, simply include the following code snippet:
+
+.. code-block:: javascript
+
+  const logging = require('logging').getLogger(__filename);
 
 
 Stylus and CSS

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -20,7 +20,7 @@ var parseBundlePlugin = require('./parse_bundle_plugin');
 // kolibri_name is always == kolibriGlobal (this is defined in the base settings - base.py)
 var libs = function(kolibri_name) {
   return {
-    'loglevel': kolibri_name + '.lib.loglevel',
+    'logging': kolibri_name + '.lib.logging',
     'vue': kolibri_name + '.lib.vue',
     'kolibri': kolibri_name,
     'core-base': kolibri_name + '.lib.coreBase',

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -103,6 +103,7 @@ var config = {
       'core-theme.styl': path.resolve('kolibri/core/assets/src/core-theme.styl'),
       'content-renderer': path.resolve('kolibri/core/assets/src/content-renderer'),
       'content_renderer_module': path.resolve('kolibri/core/assets/src/content_renderer_module'),
+      'logging': path.resolve('kolibri/core/assets/src/logging'),
     },
     extensions: ["", ".vue", ".js"],
   },

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -52,6 +52,7 @@ var config = {
       {
         test: /\.json$/,
         loader: 'json',
+        exclude: /node_modules/
       },
       {
         test: /\.css$/,
@@ -122,6 +123,9 @@ var config = {
   },
   postcss: function () {
     return [autoprefixer];
+  },
+  node: {
+    __filename: true
   }
 };
 

--- a/kolibri/core/assets/src/api_resource.js
+++ b/kolibri/core/assets/src/api_resource.js
@@ -1,4 +1,4 @@
-const logging = require('loglevel');
+const logging = require('logging').getLogger(__filename);
 const rest = require('rest');
 const mime = require('rest/interceptor/mime');
 const errorCode = require('rest/interceptor/errorCode');

--- a/kolibri/core/assets/src/asset_loader.js
+++ b/kolibri/core/assets/src/asset_loader.js
@@ -9,7 +9,7 @@
 const scriptjs = require('scriptjs');
 const loadcss = require('fg-loadcss').loadCSS;
 const onloadcss = require('fg-loadcss/src/onloadCSS');
-const logging = require('loglevel');
+const logging = require('./logging').getLogger(__filename);
 
 /**
  * Take an Array of frontend asset files and asynchronously load in order.

--- a/kolibri/core/assets/src/asset_loader.js
+++ b/kolibri/core/assets/src/asset_loader.js
@@ -9,7 +9,7 @@
 const scriptjs = require('scriptjs');
 const loadcss = require('fg-loadcss').loadCSS;
 const onloadcss = require('fg-loadcss/src/onloadCSS');
-const logging = require('./logging').getLogger(__filename);
+const logging = require('logging').getLogger(__filename);
 
 /**
  * Take an Array of frontend asset files and asynchronously load in order.

--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -14,7 +14,7 @@
 
 <script>
 
-  const logging = require('./logging').getLogger(__filename);
+  const logging = require('logging').getLogger(__filename);
 
   module.exports = {
     props: {

--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -14,7 +14,7 @@
 
 <script>
 
-  const logging = require('loglevel');
+  const logging = require('./logging').getLogger(__filename);
 
   module.exports = {
     props: {

--- a/kolibri/core/assets/src/core_app_constructor.js
+++ b/kolibri/core/assets/src/core_app_constructor.js
@@ -33,7 +33,7 @@ const publicMethods = [
  */
 function Lib() {
   // libraries
-  this.loglevel = require('./logging');
+  this.logging = require('./logging');
   this.vue = vue;
   this.vuex = vuex;
   // views

--- a/kolibri/core/assets/src/core_app_constructor.js
+++ b/kolibri/core/assets/src/core_app_constructor.js
@@ -33,7 +33,7 @@ const publicMethods = [
  */
 function Lib() {
   // libraries
-  this.loglevel = require('loglevel');
+  this.loglevel = require('./logging');
   this.vue = vue;
   this.vuex = vuex;
   // views

--- a/kolibri/core/assets/src/core_app_instance.js
+++ b/kolibri/core/assets/src/core_app_instance.js
@@ -8,7 +8,7 @@ require('./core-global.styl');
 require('babel-polyfill');
 
 // set up logging
-const logging = require('loglevel');
+const logging = require('logging');
 logging.setDefaultLevel(process.env.NODE_ENV === 'production' ? 2 : 0);
 
 // Create an instance of the global app object.

--- a/kolibri/core/assets/src/core_app_mediator.js
+++ b/kolibri/core/assets/src/core_app_mediator.js
@@ -8,7 +8,7 @@
 
 const assetLoader = require('./asset_loader');
 const Vue = require('vue');
-const logging = require('loglevel');
+const logging = require('./logging').getLogger(__filename);
 
 /**
  * @constructor

--- a/kolibri/core/assets/src/core_app_mediator.js
+++ b/kolibri/core/assets/src/core_app_mediator.js
@@ -8,7 +8,7 @@
 
 const assetLoader = require('./asset_loader');
 const Vue = require('vue');
-const logging = require('./logging').getLogger(__filename);
+const logging = require('logging').getLogger(__filename);
 
 /**
  * @constructor

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -1,0 +1,104 @@
+/**
+ * Provides thin wrapper around loglevel to allow a Python like interface for logging.
+ * @module logging
+ */
+
+const logging = require('loglevel');
+
+class Logger {
+  constructor(loggerName) {
+    this.loggerName = loggerName;
+    this.logger = logging.getLogger(loggerName);
+    Object.keys(logging.levels).forEach((methodName) => {
+      const name = methodName.toLowerCase();
+      this[name] = (msg) => this.logger[name](this.formatMessage(msg, name));
+    });
+  }
+
+  formatMessage(msg, type) {
+    return `[${new Date()} ${type.toUpperCase()}: ${this.loggerName}] ${msg}`;
+  }
+
+  setLevel(level, persist) {
+    this.logger.setLevel(level, persist);
+  }
+
+  setDefaultLevel(level) {
+    this.logger.setDefaultLevel(level);
+  }
+
+  enableAll(persist) {
+    this.logger.enableAll(persist);
+  }
+
+  disableAll(persist) {
+    this.logger.disableAll(persist);
+  }
+}
+
+class Logging {
+  constructor() {
+    this.registeredLoggers = {};
+    this.defaultLogger = new Logger('root');
+  }
+
+  trace(msg) {
+    this.defaultLogger.trace(msg);
+  }
+
+  debug(msg) {
+    this.defaultLogger.debug(msg);
+  }
+
+  info(msg) {
+    this.defaultLogger.info(msg);
+  }
+
+  warn(msg) {
+    this.defaultLogger.warn(msg);
+  }
+
+  error(msg) {
+    this.defaultLogger.error(msg);
+  }
+
+  getLogger(loggerName) {
+    if (!loggerName) {
+      return this.defaultLogger;
+    }
+    if (this.registeredLoggers[loggerName]) {
+      return this.registeredLoggers[loggerName];
+    }
+    const logger = new Logger(loggerName);
+    this.registeredLoggers[loggerName] = logger;
+    return logger;
+  }
+
+  callAllLoggersOrNamed(args, methodName, loggerName) {
+    if (!loggerName) {
+      logging[methodName](...args);
+      Object.keys(this.registeredLoggers).forEach(
+        (name) => this.registeredLoggers[name][methodName](...args));
+    } else {
+      this.registeredLoggers[loggerName][methodName](...args);
+    }
+  }
+
+  setLevel(level, persist, loggerName) {
+    this.callAllLoggersOrNamed([level, persist], 'setLevel', loggerName);
+  }
+
+  setDefaultLevel(level, loggerName) {
+    this.callAllLoggersOrNamed([level], 'setDefaultLevel', loggerName);
+  }
+
+  enableAll(persist) {
+    this.callAllLoggersOrNamed([persist], 'enableAll');
+  }
+
+  disableAll(persist) {
+    this.callAllLoggersOrNamed([persist], 'disableAll');
+  }
+}
+
+module.exports = new Logging();

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -40,26 +40,10 @@ class Logging {
   constructor() {
     this.registeredLoggers = {};
     this.defaultLogger = new Logger('root');
-  }
-
-  trace(msg) {
-    this.defaultLogger.trace(msg);
-  }
-
-  debug(msg) {
-    this.defaultLogger.debug(msg);
-  }
-
-  info(msg) {
-    this.defaultLogger.info(msg);
-  }
-
-  warn(msg) {
-    this.defaultLogger.warn(msg);
-  }
-
-  error(msg) {
-    this.defaultLogger.error(msg);
+    Object.keys(logging.levels).forEach((methodName) => {
+      const name = methodName.toLowerCase();
+      this[name] = (msg) => this.defaultLogger[name](msg);
+    });
   }
 
   getLogger(loggerName) {


### PR DESCRIPTION
## Summary

Creates an interface directly analogous to our Python logging interface for frontend Javascript logging.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/16893364/54a6b8b6-4aea-11e6-971a-c87c6b1a56c2.png)

Main downside of this is that the stacktrace for the logging is lost, it will now point to the exact line in `logging.js` where the logging call is made, rather than the line in the JS where the logging call originates.