### PR TITLE
remove some of the search pane styles

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -143,22 +143,12 @@
     left: 0
     height: 100%
     width:100%
+
   .search-pane
     overflow-y: scroll
-    box-shadow: 0 0 6px #ddd
     height: 100%
     width: 100%
     padding-left: ($nav-bar-padding / 2)
-
-  .slide-transition
-    transition: all $core-time ease-in-out
-    left: 0
-
-  .slide-enter, .slide-leave
-    left: 100vw
-
-  .slide-enter
-    position: absolute
 
   .page-content
     margin-left: $nav-bar-width + $nav-bar-padding


### PR DESCRIPTION
remove left-over styles from https://github.com/learningequality/kolibri/pull/274 and https://github.com/learningequality/kolibri/pull/277

addresses https://trello.com/c/LS7uFydR/251-styling-search-an-extra-gutter-is-shown-on-the-right-of-the-sidenav
