### PR TITLE
Removed .25 speed, fixed button styling, reduced hide timeout to 1 sec

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -180,7 +180,4 @@
   html
     overflow: hidden
 
-  div
-    height: 100%
-
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -180,4 +180,7 @@
   html
     overflow: hidden
 
+  div
+    height: 100%
+
 </style>

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -105,6 +105,7 @@
 
     ready() {
       this.videoPlayer = videojs(this.$els.video, {
+        inactivityTimeout: 1000,
         controls: true,
         autoplay: false,
         preload: 'auto',
@@ -237,37 +238,37 @@
   .video-js .videoreplay,
   .video-js .videoforward
     display: none
-    height: 10vw
-    width: 10vw
-    max-height: 133px
-    max-width: 133px
+    height: 75px
+    width: 75px
 
   .video-js .videoreplay
     background: url('../icons/ic_replay_10_white.svg')
     background-repeat: no-repeat
     background-size: contain
-    left: 35%
+    background-color: rgba(0, 0, 0, 0.3)
+    left: calc(50% - 125px)
 
   .video-js .videoforward
     background: url('../icons/ic_forward_10_white.svg')
     background-repeat: no-repeat
     background-size: contain
-    left: 65%
+    background-color: rgba(0, 0, 0, 0.3)
+    left: calc(50% + 125px)
 
   .video-js .videotoggle
     background: url('../icons/ic_play_circle_outline_white.svg')
     background-repeat: no-repeat
     background-size: contain
+    background-color: rgba(0, 0, 0, 0.3)
     left: 50%
-    height: 15vw
-    width: 15vw
-    max-height: 200px
-    max-width: 200px
+    height: 125px
+    width: 125px
 
   .video-js .videopaused
     background: url('../icons/ic_pause_circle_outline_white.svg')
     background-repeat: no-repeat
     background-size: contain
+    background-color: rgba(0, 0, 0, 0.3)
 
   .video-js .display,
   .video-js .display

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -110,7 +110,7 @@
         autoplay: false,
         preload: 'auto',
         poster: this.posterSource,
-        playbackRates: [0.25, 0.5, 1.0, 1.25, 1.5, 2.0],
+        playbackRates: [0.5, 1.0, 1.25, 1.5, 2.0],
         textTrackDisplay: true,
         ReplayButton: true,
         ForwardButton: true,

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -35,9 +35,13 @@
     computed: {
       posterSource() {
         const posterFileExtensions = ['png', 'jpg'];
-        return this.files.filter(
+        const posterArray = this.files.filter(
           (file) => posterFileExtensions.some((ext) => ext === file.extension)
-        )[0].storage_url;
+        );
+        if (posterArray.length === 0) {
+          return '';
+        }
+        return posterArray[0].storage_url;
       },
 
       videoSources() {


### PR DESCRIPTION
## Summary

Removed .25 speed, fixed button styling, reduced hide timeout from 2 to 1 sec, handle when there is no poster.

## Screenshot
![uh](https://cloud.githubusercontent.com/assets/7193975/16926861/88c56308-4cdf-11e6-8501-73ee1860df79.png)


