### PR TITLE
Fixed renderer's incorrect height.

### DIFF
--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -186,4 +186,7 @@
 
   @require '~core-theme.styl'
 
+  div
+    height: inherit
+
 </style>


### PR DESCRIPTION
## Summary

Fixed renderer's incorrect height.

## Issue addressed

Renderers had incorrect height in IE 10.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/7193975/16960906/2e38f1fe-4da0-11e6-8363-1a33ae4141e5.png)

