### PR TITLE
Fixed renderer height issue in IE 10

### DIFF
--- a/kolibri/core/assets/src/content-renderer.vue
+++ b/kolibri/core/assets/src/content-renderer.vue
@@ -186,4 +186,7 @@
 
   @require '~core-theme.styl'
 
+  div
+    height: inherit
+
 </style>


### PR DESCRIPTION
## Summary

Fixed renderer height issue in IE 10

## Issues addressed

Height issue for renderers on IE 10.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/7193975/16961644/435c51f4-4da3-11e6-9498-a346201cd7be.png)
