### PR TITLE
quick fix so gutters stay consistently sized

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -14,7 +14,7 @@ $tool-bar-height = 40px
 
 // compute the target grid width based on the number of columns
 grid-width($n-cols)
-  ($card-width * $n-cols) + ($card-gutter * ($n-cols - 1))
+  ($card-width * $n-cols) + ($card-gutter * $n-cols)
 
 // compute the media query breakpoint, based on the target grid width
 breakpoint($width)


### PR DESCRIPTION
previously, resizing the screen (and changing the number of grid columns) caused the horizontal space between cards to change

now, the horizontal gutter space between cards stays consistent