### PR TITLE
fix for scrolling issue in ie10

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -99,8 +99,8 @@
   @require 'learn.styl'
 
   .main
+    position: fixed // must be fixed for ie10
     overflow-y: scroll
-    position: relative
     height: 100%
     width: 100%
 


### PR DESCRIPTION
addresses:

* https://trello.com/c/qpQIhDmq/267-scrolling-is-broken-on-ie10
* https://trello.com/c/o69sgJiT/259-windows-7-ie-10-on-the-learn-tab-show-more-button-isn-t-responsive-to-the-page
