### PR TITLE
Element script must not have attribute charset unless attribute src is also specified.

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -13,7 +13,7 @@
 <rootvue></rootvue>
 {% block frontend_assets %}
 {% webpack_asset 'default_frontend' %}
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   {% cache 5000 js_urls %}
     {% js_reverse_inline %}
   {% endcache %}


### PR DESCRIPTION
## Summary

Element script must not have attribute charset unless attribute src is also specified according to HTML validator.