### PR TITLE
Further enhancements that will help in deploying Kolibri

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,5 @@ dist: staticdeps assets
 	pip install -r requirements/build.txt
 	python setup.py sdist
 	python setup.py bdist_wheel
-	pex -r requirements.txt . --disable-cache -o `python setup.py --fullname`.pex -m kolibri
+	pex . --disable-cache -o dist/`python setup.py --fullname`.pex -m kolibri --python-shebang=/usr/bin/python
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test:
 test-all:
 	tox
 
-assets:
+assets: staticdeps
 	npm run build
 
 coverage:
@@ -59,7 +59,12 @@ release: clean assets
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-sdist: clean assets
+staticdeps:
+	pip install -t kolibri/dist/ -r requirements.txt
+
+dist: staticdeps assets
+	pip install -r requirements/build.txt
 	python setup.py sdist
 	python setup.py bdist_wheel
+	python setup.py bdist_pex --pex-args '--disable-cache'
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,5 @@ dist: staticdeps assets
 	pip install -r requirements/build.txt
 	python setup.py sdist
 	python setup.py bdist_wheel
-	python setup.py bdist_pex --pex-args '--disable-cache --python-shebang=/usr/bin/python'
+	pex -r requirements.txt . --disable-cache -o `python setup.py --fullname`.pex -m kolibri
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ release: clean assets
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-staticdeps:
+staticdeps: clean
 	pip install -t kolibri/dist/ -r requirements.txt
 
 dist: staticdeps assets
 	pip install -r requirements/build.txt
 	python setup.py sdist
 	python setup.py bdist_wheel
-	python setup.py bdist_pex --pex-args '--disable-cache'
+	python setup.py bdist_pex --pex-args '--disable-cache --python-shebang=/usr/bin/python'
 	ls -l dist

--- a/docs/dev/building.rst
+++ b/docs/dev/building.rst
@@ -28,7 +28,7 @@ Make targets
 ------------
 
 To build both the slim Kolibri and the one with bundled dependencies, simply
-run `make sdist`. The `.whl` files will now be available in `dist/*whl` and
+run `make dist`. The `.whl` files will now be available in `dist/*whl` and
 you can install them with `pip install dist/filename.whl`.
 
 Automated CI tests

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -11,9 +11,7 @@ import kolibri  # noqa
 from kolibri import dist as kolibri_dist  # noqa
 
 # Setup path in case we are running with dependencies bundled into Kolibri
-sys.path.append(
-    os.path.realpath(os.path.dirname(kolibri_dist.__file__))
-)
+sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
 
 import django  # noqa
 import importlib  # noqa

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = test/ kolibri/
 DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
+norecursedirs = dist tmp* .svn .*

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
-cherrypy==6.0.2
 django-filter==0.13.0
 django-js-reverse==0.7.2
 six==1.10.0
@@ -6,4 +5,5 @@ djangorestframework==3.3.3
 django==1.9.7
 colorlog==2.6.0
 docopt==0.6.2
+https://github.com/cherrypy/cherrypy/archive/v6.0.2.zip
 https://github.com/django-mptt/django-mptt/archive/master.zip#egg=django-mptt-0.8.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,5 @@ djangorestframework==3.3.3
 django==1.9.7
 colorlog==2.6.0
 docopt==0.6.2
+django-mptt==0.8.5
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip
-https://github.com/django-mptt/django-mptt/archive/master.zip#egg=django-mptt-0.8.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,5 @@ djangorestframework==3.3.3
 django==1.9.7
 colorlog==2.6.0
 docopt==0.6.2
-https://github.com/cherrypy/cherrypy/archive/v6.0.2.zip
+https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip
 https://github.com/django-mptt/django-mptt/archive/master.zip#egg=django-mptt-0.8.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,9 @@
-# Base requirements are empty. All of our minimum requirements are specified in setup.py's install_requires variable!
--e .
+cherrypy==6.0.2
+django-filter==0.13.0
+django-js-reverse==0.7.2
+six==1.10.0
+djangorestframework==3.3.3
+django==1.9.7
+colorlog==2.6.0
+docopt==0.6.2
+https://github.com/django-mptt/django-mptt/archive/master.zip#egg=django-mptt-0.8.4

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -3,3 +3,4 @@
 # include base.txt
 sphinx
 sphinx-rtd-theme
+pex

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@
 # These are for testing
 factory-boy==2.7.0
 fake-factory==0.5.7
-nose
 coverage
 mock
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@
 # These are for testing
 factory-boy==2.7.0
 fake-factory==0.5.7
+nose
 coverage
 mock
 pytest

--- a/setup.py
+++ b/setup.py
@@ -53,30 +53,8 @@ is_building_dist = any(
 static_requirements = []
 static_dir = os.path.dirname(os.path.realpath(kolibri_dist.__file__))
 
-install_requires = [
-    'cherrypy==6.0.2',
-    'django-filter==0.13.0',
-    'django-js-reverse==0.7.2',
-    'six==1.10.0',
-    'djangorestframework==3.3.3',
-    'django==1.9.7',
-    'colorlog==2.6.0',
-    'docopt==0.6.2',
-    'django-mptt>=0.8.4',              # apparently you also need to have the dependency_links packages be included in install_requires
-]
-
-dependency_links = [
-    'http://github.com/django-mptt/django-mptt/tarball/9e131f91#egg=django-mptt-0.8.4'
-]
-
-# Check if user supplied the special '--static' option
-if '--static' in sys.argv:
-    sys.argv.remove('--static')
-    dist_name = 'kolibri-static'
-    description += " This static version bundles all dependencies."
-    install_requires, static_requirements = [], (install_requires + dependency_links)
-    dependency_links = []
-    static_build = True
+install_requires = []
+dependency_links = []
 
 
 ################

--- a/setup.py
+++ b/setup.py
@@ -128,65 +128,6 @@ def enable_log_to_stdout(logname):
     # add ch to logger
     log.addHandler(ch)
 
-
-# If it's a static build, we invoke pip to bundle dependencies in python-packages
-# This would be the case for commands "bdist" and "sdist"
-if static_requirements and is_building_dist:
-
-    sys.stderr.write(
-        "This is a static build... invoking pip to put static dependencies in "
-        "dist-packages/\n\n"
-        "Requirements:\n\n" + "\n".join(static_requirements)
-    )
-
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    static_cache_dir = os.path.join(current_dir, 'dist-packages-cache')
-    static_temp_dir = os.path.join(current_dir, 'dist-packages-temp')
-
-    # Create directory where dynamically created dependencies are put
-    if not os.path.exists(static_cache_dir):
-        os.mkdir(static_cache_dir)
-
-    # Should remove the temporary directory always
-    if os.path.exists(static_temp_dir):
-        sys.stderr.write("Removing previous temporary sources for pip {}".format(static_temp_dir))
-        shutil.rmtree(static_temp_dir)
-
-    # Install from pip
-
-    # Code modified from this example:
-    # http://threebean.org/blog/2011/06/06/installing-from-pip-inside-python-or-a-simple-pip-api/
-    import pip.commands.install
-
-    # Ensure we get output from pip
-    enable_log_to_stdout('pip.commands.install')
-
-    def install_distributions(distributions):
-        command = pip.commands.install.InstallCommand()
-        opts, ___ = command.parser.parse_args([])
-        opts.target_dir = static_dir
-        opts.build_dir = static_temp_dir
-        opts.download_cache = static_cache_dir
-        opts.isolated = True
-        opts.compile = False
-        opts.ignore_dependencies = True
-        # opts.use_wheel = False
-        opts.no_clean = False
-        command.run(opts, distributions)
-        # requirement_set.source_dir = STATIC_DIST_PACKAGES_TEMP
-        # requirement_set.install(opts)
-
-    install_distributions(static_requirements)
-
-elif is_building_dist:
-
-    if len(os.listdir(static_dir)) > 3:
-        raise RuntimeError(
-            "Please empty {} - make clean!".format(
-                static_dir
-            )
-        )
-
 setup(
     name=dist_name,
     version=kolibri.__version__,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read_file(fname):
         return open(fname).read().decode("utf-8")
     return open(fname).read()
 
-dist_name = 'kolibri'
+dist_name = 'kolibri-static'
 
 readme = read_file('README.rst')
 doclink = """

--- a/test/conditional/test_build.sh
+++ b/test/conditional/test_build.sh
@@ -15,7 +15,7 @@ pip install -r requirements/test.txt
 # Build .whl
 npm install
 make dist
-pip install dist/kolibri-*.whl
+pip install dist/kolibri*.whl
 
 cd "$PREVIOUS_CWD"
 

--- a/test/conditional/test_build.sh
+++ b/test/conditional/test_build.sh
@@ -13,7 +13,7 @@ pip install -r requirements/build.txt
 
 # Build .whl
 npm install
-make sdist
+make dist
 pip install dist/kolibri-*.whl
 
 cd "$PREVIOUS_CWD"

--- a/test/conditional/test_build.sh
+++ b/test/conditional/test_build.sh
@@ -10,6 +10,7 @@ cd "$DIR/../../"
 
 # Install build deps
 pip install -r requirements/build.txt
+pip install -r requirements/test.txt
 
 # Build .whl
 npm install


### PR DESCRIPTION
## Summary

- `make dist` now also generates a pex file -- a self-contained, executable python environment that contains all the dependencies. Will be used for online deployments.
- Made a static sdist the default (cc @benjaoming), and removed some conditionals in setup.py that handled the sdist vs non-sdist building case.
- Brought back our requirements specifications back to requirements/base.txt, since I couldn't find a consistent way to pull in dependencies from zip files that works across pip/setuptools/pex where dependencies are specified inside `setup.install_requires`.
- Pull in CherryPy from Github, to avoid the Python 3 restriction from the sdist that comes from there. A single kolibri sdist is now runnable on both Python 2 and Python 3 (CherryPy was restricting us before).

