### PR TITLE
adding a browserlist config file for the css autoprefixer

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,9 @@
+# Browsers that we support.
+
+# This file is used by the css autoprefixer
+# see https://github.com/ai/browserslist#config-file
+
+> 0.1%
+last 2 versions
+ie >= 9
+Firefox ESR


### PR DESCRIPTION
This overwrites the defaults and ensures we get all the important prefixes - some from IE9 were not showing up previously.