### PR TITLE
Adding roles and labels for the search-widget elements

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -3,10 +3,11 @@
   <div class='wrapper'>
 
     <!-- search block -->
-    <div class='top'>
+    <div class='top' role="search">
       <input
         type="search"
         v-el:search
+        aria-label="Type to find content"
         placeholder="Find content..."
         autocomplete="off"
         v-focus="searchOpen"
@@ -15,7 +16,7 @@
         name="search"
         @keyup="search() | debounce 500"
         @keydown.esc.prevent="clear()">
-      <button class="reset" type="reset" @click="clear()" :style="{ visibility: localSearchTerm ? 'inherit' : 'hidden' }">
+      <button aria-label="Reset" class="reset" type="reset" @click="clear()" :style="{ visibility: localSearchTerm ? 'inherit' : 'hidden' }">
         <svg height="24" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
           <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
           <path d="M0 0h24v24H0z" fill="none"></path>

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <button class='search-btn' :class="{ active: searchOpen }" @click='toggleSearch'>
+  <button aria-label="Search" class='search-btn' :class="{ active: searchOpen }" @click='toggleSearch'>
     <svg src="search.svg"></svg>
   </button>
 


### PR DESCRIPTION
## Summary

Good work so far on the keyboard navigability of the search widget, it was only missing some proper elements labeling.

## TODO

Maybe not really a TODO at this point but I'm thinking it would be good to have the computed message indicate the number of topics/content found in results...? Sighted users can easily see and/or scroll to get the idea, but if would be great to have that information available to SR users too.  

## Screenshots

![kolibri - google chrome_570](https://cloud.githubusercontent.com/assets/1457929/17229805/93f7104a-5519-11e6-8bad-ce6360d4481d.png)



