### PR TITLE
Removing the label tag for Learn & Explore

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
@@ -6,7 +6,7 @@
         <a class='link' v-link="learnLink" @click='closeSearch' :class="learnClass">
           <div class='content'>
             <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/learn.svg"></svg>
-            <label>Learn</label>
+            Learn
           </div>
         </a>
       </div>
@@ -14,7 +14,7 @@
         <a class='link' v-link="exploreLink" @click='closeSearch' :class="exploreClass">
           <div class='content'>
             <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
-            <label>Explore</label>
+            Explore
           </div>
         </a>
       </div>

--- a/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
@@ -6,7 +6,7 @@
         <a class='link' v-link="learnLink" @click='closeSearch' :class="learnClass">
           <div class='content'>
             <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/learn.svg"></svg>
-            Learn
+            <div class="label">Learn</div>
           </div>
         </a>
       </div>
@@ -14,7 +14,7 @@
         <a class='link' v-link="exploreLink" @click='closeSearch' :class="exploreClass">
           <div class='content'>
             <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
-            Explore
+            <div class="label">Explore</div>
           </div>
         </a>
       </div>
@@ -110,8 +110,7 @@
     color: $core-bg-light
     background: $core-action-normal
 
-  label
-    display: block
+  .label
     text-align: center
 
   svg


### PR DESCRIPTION
## Summary

Not sure at which point they were introduced, but if it was for accessibility reasons, `<label>` alone is not enough, it needs a `for` attribute pointing the `id` of the control they are labeling. I tried doing it [implicitly](https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly), but it messes the styling and is not solving the link context issue I'm getting with the a11y checkers.

Either we find the way to do it with the `for` attribute or we leave Learn & Explore without `<label>`  tag altogether.  This would not be an a11y issue, I already tested it.

## Screenshots

Errors shown on Explore nav element with `<label>` tag, and no errors on Learn without `<label>` tag:

![kolibri - mozilla firefox_572](https://cloud.githubusercontent.com/assets/1457929/17233225/7189d47e-552e-11e6-9059-7d3407e439d5.png)
