### PR TITLE
Make developer docs more accessible and move dumped 'User log' section

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,22 +1,35 @@
 Developer Guide
 ===============
 
+.. toctree::
+   :maxdepth: 1
+
+   getting_started
+
+
 Architecture
 ------------
 
 .. toctree::
    :maxdepth: 1
 
-   getting_started
    tests
    stack
    plugins
    building
+   conventions
+   frontend
+
+Themes
+------
+
+.. toctree::
+   :maxdepth: 1
+
    uap
    user_management
-   frontend
    asset_loading
-   conventions
+   logger
 
 References
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,6 @@ Getting Started
 
   user/index
   dev/index
-  dev/logger
   cli
   changelog
   contributing


### PR DESCRIPTION
## Summary

Tidy up the structure of our dev docs.

Perhaps "Themes" is a bad name, but it's better than before :)

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file
- [x] Add an entry to CHANGELOG.rst
- [x] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

None really, this is just to ensure we keep a more strict docs structure so there's some kind of theoretical chance that our docs will be used.

## Issues addressed

-

## Documentation

![screenshot from 2016-08-02 14 28 38](https://cloud.githubusercontent.com/assets/374612/17328348/6bffd584-58bd-11e6-8567-7e6839b65bd5.png)

