### PR TITLE
Change bootstrapping to use createModel instead of getModel.

### DIFF
--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -6,7 +6,7 @@
     {{kolibri}}.resources.ContentNodeResource.setChannel("{{ channel_id }}");
     var root_node = JSON.parse("{{ rootnode|escapejs }}");
     var root_node_pk = String(root_node.pk);
-    var model = {{kolibri}}.resources.ContentNodeResource.getModel(root_node_pk, root_node);
+    var model = {{kolibri}}.resources.ContentNodeResource.createModel(root_node);
     model.synced = true;
     var collection = {{kolibri}}.resources.ContentNodeResource.getCollection({parent: root_node_pk}, JSON.parse("{{ nodes|escapejs }}"));
     collection.synced = true;


### PR DESCRIPTION
## Summary

Fixes bug reported in https://github.com/learningequality/kolibri/pull/329#issuecomment-237403593 by fixing the bootstrapping to use the new `createModel` method instead of `getModel`.