### PR TITLE
New focus style

### DIFF
--- a/kolibri/core/assets/src/styles/core-global.styl
+++ b/kolibri/core/assets/src/styles/core-global.styl
@@ -51,6 +51,8 @@ a
   &:hover
     color: $core-action-dark
 
+:focus
+  outline: $core-action-light 2px solid
 
 // https://davidwalsh.name/html5-boilerplate
 img

--- a/kolibri/core/assets/src/styles/core-global.styl
+++ b/kolibri/core/assets/src/styles/core-global.styl
@@ -90,8 +90,7 @@ button
     border-color: $core-action-dark
 
   &:focus
-    background:$core-action-light
-    outline: none
+    outline: $core-action-light 2px solid
 
 
 // Firefox: Get rid of the inner focus border

--- a/kolibri/core/assets/src/vue/nav-bar/nav-bar-item.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/nav-bar-item.vue
@@ -72,12 +72,4 @@
   .content
     display: inline-block
 
-  a:focus
-    background: $core-action-light
-    outline: none
-
-  .link.active:focus
-    color: $core-action-normal
-    background: $core-action-light
-
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/grid-item/index.vue
@@ -41,10 +41,6 @@
     overflow: hidden
     border-radius: $radius
 
-  .root:focus
-    background-color: $core-action-light
-    outline: none
-
   .thumb-wrapper
     position: relative
     display: block

--- a/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
@@ -43,10 +43,6 @@
     display: table
     width: 100%
 
-  .root:focus
-    background-color: $core-action-light
-    outline: none
-
   .thumb-wrapper
     position: absolute
     left: 0.4em

--- a/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
@@ -60,6 +60,6 @@
   @require '~nav-bar-item.styl'
 
   a.active:focus svg
-    fill: $core-action-normal
+    fill: $core-bg-light
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
@@ -43,9 +43,6 @@
         fill: #FFFFFF
 
     &:focus
-      background:$core-action-light
-      outline: none
-      svg
-        fill: $core-action-normal
+      outline: $core-action-light 2px solid
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/main-nav/index.vue
@@ -38,6 +38,6 @@
   @require '~nav-bar-item.styl'
 
   a.active:focus svg
-    fill: $core-action-normal
+    fill: $core-bg-light
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
@@ -78,9 +78,6 @@
     @media screen and (max-width: $portrait-breakpoint)
       padding: 0.6em 1em
 
-  .top a:focus , .top a:hover
-    border-bottom: 0.3em $core-action-light solid
-
   .top .active
     color: $core-action-normal
     cursor: default


### PR DESCRIPTION
NOTE: There's going to be a follow-up PR that'll change the style of the main nav.

NOTE: There's room to play around with the focus color, for time sakes, it's arbitartly set to $core-action-light 

NOTE: After MPV we can make this focus only show up when users use 'tab' via keyboard. 

<img width="1412" alt="screen shot 2016-08-08 at 4 04 12 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499431/3dc7722a-5d82-11e6-91f2-08f1e6030c03.png">
<img width="1424" alt="screen shot 2016-08-08 at 4 04 17 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499427/3dc65c5a-5d82-11e6-8404-2933e3bb003c.png">
<img width="1423" alt="screen shot 2016-08-08 at 4 04 30 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499429/3dc7011e-5d82-11e6-80bf-83f3d2019859.png">
<img width="1426" alt="screen shot 2016-08-08 at 4 04 37 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499430/3dc71686-5d82-11e6-9430-0100604eb4e5.png">
<img width="1425" alt="screen shot 2016-08-08 at 4 04 43 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499428/3dc66984-5d82-11e6-8d38-856a9adf3048.png">
<img width="1425" alt="screen shot 2016-08-08 at 4 04 52 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499434/3dd50f5c-5d82-11e6-98ba-619230a32302.png">
<img width="1427" alt="screen shot 2016-08-08 at 4 04 58 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499433/3dd4c362-5d82-11e6-9940-00ef742a8714.png">
<img width="1428" alt="screen shot 2016-08-08 at 4 05 07 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499432/3dd4b282-5d82-11e6-8b75-1a55249b0108.png">
<img width="1424" alt="screen shot 2016-08-08 at 4 05 17 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499435/3dd541ca-5d82-11e6-9338-5915351993a2.png">
<img width="723" alt="screen shot 2016-08-08 at 4 05 24 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499436/3dd6ce96-5d82-11e6-91c5-a84e1f4a9fe3.png">
<img width="721" alt="screen shot 2016-08-08 at 4 05 31 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499439/3de70608-5d82-11e6-9690-9ed5f741b6d1.png">
<img width="1437" alt="screen shot 2016-08-08 at 4 05 37 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499437/3de38c3a-5d82-11e6-8c03-275a128495ff.png">
<img width="1438" alt="screen shot 2016-08-08 at 4 05 47 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499438/3de5c2c0-5d82-11e6-9dc8-4464255a0739.png">
<img width="1434" alt="screen shot 2016-08-08 at 4 05 52 pm" src="https://cloud.githubusercontent.com/assets/12800136/17499440/3de9a944-5d82-11e6-96dd-3d7feaeb5e21.png">





## Summary

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)
