### PR TITLE
Fixes topic card height issue on firefox and a11y issues

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h3 class="header">{{header}}</h3>
+    <h3 v-if="header" class="header">{{header}}</h3>
     <div class="card-grid">
       <slot></slot>
     </div>

--- a/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
@@ -1,11 +1,11 @@
 <template>
 
-  <section>
+  <div>
     <h3 class="header">{{header}}</h3>
     <div class="card-grid">
       <slot></slot>
     </div>
-  </section>
+  </div>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h3>{{header}}</h3>
+    <h3 v-if="header">{{header}}</h3>
     <div class="card-list">
       <slot></slot>
     </div>

--- a/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
@@ -1,11 +1,11 @@
 <template>
 
-  <section>
+  <div>
     <h3>{{header}}</h3>
     <div class="card-list">
       <slot></slot>
     </div>
-  </section>
+  </div>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
@@ -65,7 +65,7 @@
   .title
     display: table-cell
     width: 100%
-    height: 100%
+    height: $min-height
     padding: 0.8em
     padding-left: $min-height
     vertical-align: middle


### PR DESCRIPTION
## Summary

Fixes this issue with topic card height on Firefox:
https://trello.com/c/dPKtvOyF/326-bug-correct-misaligned-folders-in-firefox

<img width="410" alt="screen shot 2016-08-08 at 5 11 27 pm" src="https://cloud.githubusercontent.com/assets/6668144/17500538/3158a866-5d8b-11e6-9486-965d5bae15ac.png">

This PR also fixes an a11y issue with < section > tags and turns them into < div >'s 
https://trello.com/c/p1gg726N/329-a11y-replace-section-tags-with-divs-for-mvp


## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

