### PR TITLE
make all content icon centered and added in default thumbnail

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-grid-item/index.vue
@@ -2,11 +2,11 @@
 
   <div>
     <grid-item v-link="link" :title="title">
-      <div class='thumbnail' :class="{ 'thumbnail-center' : !thumb }" :style='{ "background-image": thumb }'>
+      <div class='thumbnail' :class="'thumbnail-center'" :style='{ "background-image": thumb }'>
         <content-icon
-          :class='thumb ? "content-icon" : "content-icon-center" '
+          class="content-icon-center"
           v-if="kind"
-          :size="thumb ? 30 : 60"
+          :size="60"
           :kind="kind"
           :progress="progress">
         </content-icon>
@@ -82,7 +82,7 @@
         if (this.thumbnail) {
           return `url(${this.thumbnail})`;
         }
-        return ``;
+        return '';
       },
     },
     vuex: {
@@ -104,6 +104,7 @@
     height: 100%
     background-size: cover
     background-position: center
+    background: url('./images/default_thumbnail.png')
 
   .thumbnail-center
     text-align: center
@@ -113,11 +114,6 @@
     display: inline-block
     vertical-align: middle
     height:100%
-
-  .content-icon
-    position: absolute
-    top: 0.5em
-    left: 0.5em
 
   .content-icon-center
     width: 70%


### PR DESCRIPTION
No more blank thumbnail

NOTE: change looks better and more apparent with the square cards

<img width="1434" alt="screen shot 2016-08-09 at 4 36 22 pm" src="https://cloud.githubusercontent.com/assets/12800136/17537209/79b99736-5e4f-11e6-905e-cfec55ed8126.png">
## Summary

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

