### PR TITLE
Add better breadcrumbs label and put separators in CSS.

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
@@ -1,11 +1,15 @@
 <template>
 
-  <nav class="nav" role="navigation" aria-label="Breadcrumbs navigation">
+  <nav class="nav" role="navigation" aria-label="You are here:">
     <span class="parent">
-      <a v-link="rootLink">Explore</a> <span class='sep'>»</span>
+      <a v-link="rootLink">Explore</a> 
     </span>
     <span class="parent" v-for="crumb in crumbs">
-      <a v-link="crumbLink(crumb.id)">{{ crumb.title }}</a> <span class='sep'>»</span>
+      <a v-link="crumbLink(crumb.id)">{{ crumb.title }}</a> 
+    </span>
+    <span class="current">
+      <span class="visuallyhidden">Current: </span>
+        <!-- TODO: Get current topic title -->
     </span>
   </nav>
 
@@ -47,15 +51,16 @@
 
 <style lang="stylus" scoped>
 
-  .sep
-    margin-left: 0.5em
-    margin-right: 0.5em
-
   .nav
     margin-top: 2em
     margin-bottom:1.4em
 
   .parent a:link
     font-weight: 300
+
+  span.parent::after
+    content: '»'
+    margin-left: 0.5em
+    margin-right: 0.5em
 
 </style>


### PR DESCRIPTION
## Summary

After reading the [eBay MIND Patterns](https://ebay.gitbooks.io/mindpatterns/content/navigation/breadcrumbs.html) I realized we are missing two things:
1. Better label (`You are here:` is recommended even on [WAI tutorials page](https://www.w3.org/WAI/tutorials/menus/multiple-ways/))
2. Put separators in CSS (separate presentation and content). 

However, breadcrumbs should also include the full path, from home/root page all the way to the current location, and we are missing that. Was it intentional @indirectlylit @DXCanas ? 

## TODO

- [ ] Get current topic title as the last item in breadcrumbs.

## Reviewer guidance

I tried requiring several components in order to pull the current topic title, but couldn't get the winning combination, so some help needed @indirectlylit... :disappointed_relieved: 

