### PR TITLE
Make headers smaller and migrate to h1's on every page

### DIFF
--- a/kolibri/core/assets/src/styles/core-global.styl
+++ b/kolibri/core/assets/src/styles/core-global.styl
@@ -42,6 +42,14 @@ html, body
   color: $core-text-default
   background-color: $core-bg-canvas
 
+h1
+  font-size: 1.5em
+
+h2
+  font-size: 1.17em
+
+h3, h4, h5, h6
+  font-size: 1em
 
 a
   color: $core-action-normal

--- a/kolibri/core/assets/src/vue/error-box/index.vue
+++ b/kolibri/core/assets/src/vue/error-box/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h2>Whoops!</h2>
+    <h1>Whoops!</h1>
     <p>We've encountered an issue:</p>
     <textarea>
       {{ error }}

--- a/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
@@ -4,14 +4,14 @@
     <div class='extra-nav'>
       <slot name='extra-nav'></slot>
     </div>
-    <h2 class='header'>
+    <h1 class='header'>
       <div class='icon-wrapper'>
         <slot name='icon'></slot>
       </div>
       <div class='text'>
         {{ title }}
       </div>
-    </h2>
+    </h1>
   </div>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h2>Learn Scratchpad</h2>
+    <h1>Learn Scratchpad</h1>
     <p>Use this page for in-progress component prototyping.</p>
   </div>
 

--- a/kolibri/plugins/management/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h2>CONTENT</h2>
+    <h1>CONTENT</h1>
     <p>...</p>
   </div>
 

--- a/kolibri/plugins/management/assets/src/vue/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/data-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h2>DATA</h2>
+    <h1>DATA</h1>
     <icon-button @click="downloadCSV" text="Download CSV">
       <svg src="../icons/download.svg"></svg>
     </icon-button>

--- a/kolibri/plugins/management/assets/src/vue/scratchpad-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/scratchpad-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h2>Mgmt Scratchpad</h2>
+    <h1>Mgmt Scratchpad</h1>
     <p>Use this page for in-progress component prototyping.</p>
   </div>
 


### PR DESCRIPTION

For A11Y reasons we want an H1 on every page, but they looked too big by default.

This updates the header sizes globally to be a bit smaller.

