### PR TITLE
Fixes setup_wizard plugin not having store.

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/state/store.js
+++ b/kolibri/plugins/setup_wizard/assets/src/state/store.js
@@ -1,0 +1,16 @@
+
+const Vuex = require('vuex');
+const coreStore = require('core-store');
+
+const initialState = {};
+const mutations = {};
+
+// assigns core state and mutations
+Object.assign(initialState, coreStore.initialState);
+Object.assign(mutations, coreStore.mutations);
+
+
+module.exports = new Vuex.Store({
+  state: initialState,
+  mutations,
+});

--- a/kolibri/plugins/setup_wizard/assets/src/vue/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/vue/index.vue
@@ -31,6 +31,7 @@
 <script>
 
   const actions = require('../actions');
+  const store = require('../state/store');
 
   module.exports = {
     data() {
@@ -78,6 +79,7 @@
         createDeviceOwnerAndFacility: actions.createDeviceOwnerAndFacility,
       },
     },
+    store, // make this and all child components aware of the store
   };
 
 </script>


### PR DESCRIPTION
## Issues addressed

Addresses this issue https://trello.com/c/E4tZjwv3/373-bug-setup-wizard-references-vuex-actions-but-has-no-vuex-store