### PR TITLE
I18n String parsing and Extraction

### DIFF
--- a/docs/dev/conventions.rst
+++ b/docs/dev/conventions.rst
@@ -48,6 +48,16 @@ Note that the top-level tags of `Vue.js components <https://vuejs.org/guide/comp
 
 - Put child components inside the directory of a parent component if they are *only* used by the parent. Otherwise, put shared child components in the *vue* director.
 
+- Any user visisble interface text should be rendered translatable, this can be done by supplementing the Vue.js component definition with the following properties:
+  - ``$trs``, an object of the form::
+
+    {
+      msgId: 'Message text',
+    }
+
+  - ``$trNameSpace``, a string that namespaces the messages.
+
+- User visible strings should then either be rendered directly in the template with ``{{ $tr('msgId') }}`` or can be made available through computed properties (note, if you want to pass rendered strings into tag/component properties, this will be necessary as Vue.js does not evaluate Javascript expressions in these cases).
 
 JavaScript Code
 ---------------

--- a/frontend_build/src/extract_$trs.js
+++ b/frontend_build/src/extract_$trs.js
@@ -76,8 +76,6 @@ extract$trs.prototype.apply = function(compiler) {
         }
       });
     });
-    // Grab the current compilation hash to version the filename.
-    self.hash = compilation.hash || '';
     if (Object.keys(messageExport).length) {
       // If we've got any messages to write out, write them out. Otherwise, don't bother.
       self.writeOutput(messageExport);
@@ -90,7 +88,7 @@ extract$trs.prototype.writeOutput = function(messageExport) {
   // Make sure the directory we are using exists.
   mkdirp.sync(this.messageDir);
   // Write out the data to JSON.
-  fs.writeFileSync(path.join(this.messageDir, this.messagesName + '-' + this.hash + '-messages.json'), JSON.stringify(messageExport));
+  fs.writeFileSync(path.join(this.messageDir, this.messagesName + '-messages.json'), JSON.stringify(messageExport));
 };
 
 module.exports = extract$trs;

--- a/frontend_build/src/extract_$trs.js
+++ b/frontend_build/src/extract_$trs.js
@@ -1,0 +1,72 @@
+var esprima = require('esprima');
+var logging = require('./logging');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
+
+function extract$trs(messageDir, messagesName) {
+  this.messageDir = messageDir;
+  this.messagesName = messagesName;
+}
+
+extract$trs.prototype.apply = function(compiler) {
+
+  var self = this;
+
+  compiler.plugin("emit", function(compilation, callback) {
+    var messageExport = {};
+
+    compilation.chunks.forEach(function(chunk) {
+      // Explore each module within the chunk (built inputs):
+      chunk.modules.forEach(function(module) {
+        if (module.resource && module.resource.indexOf('.vue') === module.resource.length - 4) {
+          // Explore each source file path that was included into the module:
+          var messageNameSpace;
+          var messages = {};
+          var ast = esprima.parse(module._source.source());
+          ast.body.forEach(function (node) {
+            if (node.type === 'ExpressionStatement'
+              && node.expression.type === 'AssignmentExpression'
+              && ((node.expression.left || {}).object || {}).name == 'module'
+              && ((node.expression.left || {}).property || {}).name == 'exports'
+              && node.expression.right.properties) {
+              node.expression.right.properties.forEach(function (property){
+                if (property.key.name === '$trs') {
+                  property.value.properties.forEach(function(message) {
+                    messages[message.key.name] = message.value.value;
+                  });
+                } else if (property.key.name === '$trNameSpace') {
+                  messageNameSpace = property.value.value;
+                }
+              });
+            }
+          });
+          if (messageNameSpace) {
+            Object.keys(messages).forEach(function(key) {
+              var msgId = messageNameSpace + '.' + key;
+              if (messageExport[msgId]) {
+                logging.warn('Duplicate translation id ' + msgId + ' found in ' + module.resource)
+              } else {
+                messageExport[msgId] = messages[key];
+              }
+            });
+          } else if (Object.keys(messages).length) {
+            logging.warn('Translatable messages have been defined in ' + module.resource + ' but no messageNameSpace was specified.');
+          }
+        }
+      });
+    });
+    self.hash = compilation.hash || '';
+    if (Object.keys(messageExport).length) {
+      self.writeOutput(messageExport);
+    }
+    callback();
+  });
+};
+
+extract$trs.prototype.writeOutput = function(messageExport) {
+    mkdirp.sync(this.messageDir);
+    fs.writeFileSync(path.join(this.messageDir, this.messagesName + '-' + this.hash + '-messages.json'), JSON.stringify(messageExport));
+};
+
+module.exports = extract$trs;

--- a/frontend_build/src/extract_$trs.js
+++ b/frontend_build/src/extract_$trs.js
@@ -20,21 +20,36 @@ extract$trs.prototype.apply = function(compiler) {
       // Explore each module within the chunk (built inputs):
       chunk.modules.forEach(function(module) {
         if (module.resource && module.resource.indexOf('.vue') === module.resource.length - 4) {
-          // Explore each source file path that was included into the module:
+          // Inspect each source file in the chunk if it is a vue file.
           var messageNameSpace;
           var messages = {};
+          // Parse the AST for the Vue file.
           var ast = esprima.parse(module._source.source());
           ast.body.forEach(function (node) {
+            // Look through each top level node until we find the module.exports
+            // N.B. this relies on our convention of directly exporting the Vue component
+            // with the module.exports, rather than defining it and then setting it to export.
+
+            // Is it an expression?
             if (node.type === 'ExpressionStatement'
+              // Is it an assignment expression?
               && node.expression.type === 'AssignmentExpression'
+              // Is the first part of the assignment 'module'?
               && ((node.expression.left || {}).object || {}).name == 'module'
+              // Is it assining to the 'exports' property of 'module'?
               && ((node.expression.left || {}).property || {}).name == 'exports'
+              // Does the right hand side of the assignment expression have any properties?
+              // (We don't want to both parsing it if it is an empty object)
               && node.expression.right.properties) {
+              // Look through each of the properties in the object that is being exported.
               node.expression.right.properties.forEach(function (property){
+                // If the property is called $trs we have hit paydirt! Some messages for us to grab!
                 if (property.key.name === '$trs') {
+                  // Grab every message in our $trs property and save it into our messages object.
                   property.value.properties.forEach(function(message) {
                     messages[message.key.name] = message.value.value;
                   });
+                  // We also want to take a note of the name space these messages have been put in too!
                 } else if (property.key.name === '$trNameSpace') {
                   messageNameSpace = property.value.value;
                 }
@@ -42,22 +57,29 @@ extract$trs.prototype.apply = function(compiler) {
             }
           });
           if (messageNameSpace) {
+            // Every message needs to be namespaced - don't pollute our top level!
             Object.keys(messages).forEach(function(key) {
+              // Create a new message id from the name space and the message id joined with '.'
               var msgId = messageNameSpace + '.' + key;
               if (messageExport[msgId]) {
+                // Warn about duplicate ids *within* a bundle (no way to warn across).
                 logging.warn('Duplicate translation id ' + msgId + ' found in ' + module.resource)
               } else {
+                // If all is good, save it onto our export object for the whole bundle.
                 messageExport[msgId] = messages[key];
               }
             });
+            // Someone defined a $trs object, but didn't namespace it - warn them about it here so they can fix their foolishness.
           } else if (Object.keys(messages).length) {
             logging.warn('Translatable messages have been defined in ' + module.resource + ' but no messageNameSpace was specified.');
           }
         }
       });
     });
+    // Grab the current compilation hash to version the filename.
     self.hash = compilation.hash || '';
     if (Object.keys(messageExport).length) {
+      // If we've got any messages to write out, write them out. Otherwise, don't bother.
       self.writeOutput(messageExport);
     }
     callback();
@@ -65,8 +87,10 @@ extract$trs.prototype.apply = function(compiler) {
 };
 
 extract$trs.prototype.writeOutput = function(messageExport) {
-    mkdirp.sync(this.messageDir);
-    fs.writeFileSync(path.join(this.messageDir, this.messagesName + '-' + this.hash + '-messages.json'), JSON.stringify(messageExport));
+  // Make sure the directory we are using exists.
+  mkdirp.sync(this.messageDir);
+  // Write out the data to JSON.
+  fs.writeFileSync(path.join(this.messageDir, this.messagesName + '-' + this.hash + '-messages.json'), JSON.stringify(messageExport));
 };
 
 module.exports = extract$trs;

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -12,6 +12,7 @@ var logging = require('./logging');
 var webpack = require('webpack');
 var base_config = require('./webpack.config.base');
 var _ = require('lodash');
+var extract$trs = require('./extract_$trs');
 
 /**
  * Turn an object containing the vital information for a frontend plugin and return a bundle configuration for webpack.
@@ -72,7 +73,8 @@ var parseBundlePlugin = function(data, base_dir) {
       __kolibriModuleName: JSON.stringify(data.name),
       __events: JSON.stringify(data.events || {}),
       __once: JSON.stringify(data.once || {})
-    })
+    }),
+    new extract$trs(path.relative(base_dir, path.dirname(data.stats_file)), data.name)
   ]);
 
   bundle.core_name = data.core_name;

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -62,6 +62,22 @@ module.exports = function CoreApp() {
    */
   vue.use(vuex);
 
+  function setUpVueIntl() {
+    /**
+     * Use the vue-intl plugin.
+     **/
+    const VueIntl = require('vue-intl');
+    vue.use(VueIntl);
+    vue.prototype.$tr = function (messageId, ...args) {
+      const message = {
+        id: `${this.$options.$trNameSpace}.${messageId}`,
+        defaultMessage: this.$options.$trs[messageId],
+      };
+      return this.$formatMessage(message, ...args);
+    };
+    mediator.setReady();
+  }
+
   /**
    * If the browser doesn't support the Intl polyfill, we retrieve that and
    * the modules need to wait until that happens.
@@ -76,21 +92,12 @@ module.exports = function CoreApp() {
       (require) => {
         require('intl');
         require('intl/locale-data/jsonp/en.js');
-        /**
-         * Use the vue-intl plugin.
-         **/
-        const VueIntl = require('vue-intl');
-        vue.use(VueIntl);
-        mediator.setReady();
+
+        setUpVueIntl();
       }
     );
   } else {
-    /**
-     * Use the vue-intl plugin.
-     **/
-    const VueIntl = require('vue-intl');
-    vue.use(VueIntl);
-    mediator.setReady();
+    setUpVueIntl();
   }
 
   // Bind 'this' value for public methods - those that will be exposed in the Facade.

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -68,7 +68,7 @@ module.exports = function CoreApp() {
      **/
     const VueIntl = require('vue-intl');
     vue.use(VueIntl);
-    vue.prototype.$tr = function (messageId, ...args) {
+    vue.prototype.$tr = function $tr(messageId, ...args) {
       const message = {
         id: `${this.$options.$trNameSpace}.${messageId}`,
         defaultMessage: this.$options.$trs[messageId],

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -5,7 +5,7 @@
       <div v-el:container></div>
     </div>
     <div v-else>
-      This content is not available.
+      {{ $tr('contentRender') }}
     </div>
   </div>
 
@@ -17,6 +17,10 @@
   const logging = require('logging').getLogger(__filename);
 
   module.exports = {
+    $trNameSpace: 'contentRender',
+    $trs: {
+      msgNotAvailable: 'This content is not available.',
+    },
     props: {
       id: {
         type: String,

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -5,7 +5,7 @@
       <div v-el:container></div>
     </div>
     <div v-else>
-      {{ $tr('contentRender') }}
+      {{ $tr('msgNotAvailable') }}
     </div>
   </div>
 

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <page-header title="Learn">
+    <page-header :title="learnName">
       <svg slot="icon" class="pageicon" src="../icons/learn.svg"></svg>
     </page-header>
     <expandable-content-grid :contents="recommendations"></expandable-content-grid>
@@ -13,6 +13,16 @@
 <script>
 
   module.exports = {
+    $trNameSpace: 'learnIndex',
+
+    $trs: {
+      learnName: 'Learn',
+    },
+    computed: {
+      learnName() {
+        return this.$tr('learnName');
+      },
+    },
     components: {
       'page-header': require('../page-header'),
       'expandable-content-grid': require('../expandable-content-grid'),

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "video.js": "5.10.4",
     "vue": "1.0.26",
     "vue-focus": "0.1.1",
-    "vue-intl": "0.3.0",
+    "vue-intl": "0.4.0",
     "vue-router": "0.7.13",
     "vuex": "0.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-loader": "1.4.1",
     "eslint-plugin-html": "1.5.1",
     "eslint-plugin-react": "4.3.0",
+    "esprima": "^2.7.2",
     "exports-loader": "0.6.3",
     "extract-text-webpack-plugin": "1.0.1",
     "fg-loadcss": "1.2.0",


### PR DESCRIPTION
## Summary

This PR provides a generalized interface to the vue-intl library, allowing us to use `$tr` as a method in all our Vue components to render interface text.

Messages should be defined on the Vue component object in a `$trs` property, and a name space for the messages should be defined in the `$trNameSpace` property.

In addition, the webpack build process will now extract these strings and put them (namespaced) into a JSON file that is amenable for uploading to CrowdIn. These files are versioned by build hash.

## TODO

- [ ] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file

## Documentation

Needs updating.