### PR TITLE
Adding Password Validation to User Create && Error Clearing

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -23,6 +23,11 @@
         </div>
 
         <div class="user-field">
+          <label for="confirm-password">Confirm Password</label>
+          <input type="password" class="add-form" id="confirm-password" required v-model="passwordConfirm">
+        </div>
+
+        <div class="user-field">
           <label for="user-role"><span class="visuallyhidden">User Role</span></label>
           <select v-model="role" id="user-role">
           <option value="learner" selected> Learner </option>
@@ -59,6 +64,7 @@
       return {
         username: '',
         password: '',
+        passwordConfirm: '',
         full_name: '',
         role: 'learner',
         errorMessage: '',
@@ -68,26 +74,32 @@
       createNewUser() {
         const newUser = {
           username: this.username,
-          password: this.password,
           full_name: this.full_name,
           facility: this.facility,
         };
-        // using promise to ensure that the user is created before closing
-        this.createUser(newUser, this.role).then(
-          () => {
-            this.full_name = '';
-            this.username = '';
-            this.password = '';
-            this.$refs.modal.closeModal();
-          }).catch((error) => {
-            if (error.status.code === 409) {
-              this.errorMessage = error.entity;
-            } else if (error.status.code === 403) {
-              this.errorMessage = error.entity;
-            } else {
-              this.errorMessage = `Whoops! Something went wrong.`;
-            }
-          });
+
+        if (this.password === this.passwordConfirm) {
+          newUser.password = this.password;
+          // using promise to ensure that the user is created before closing
+          this.createUser(newUser, this.role).then(
+            () => {
+              this.full_name = '';
+              this.username = '';
+              this.password = '';
+              this.errorMessage = '';
+              this.$refs.modal.closeModal();
+            }).catch((error) => {
+              if (error.status.code === 409) {
+                this.errorMessage = error.entity;
+              } else if (error.status.code === 403) {
+                this.errorMessage = error.entity;
+              } else {
+                this.errorMessage = `Whoops! Something went wrong.`;
+              }
+            });
+        } else {
+          this.errorMessage = 'Passwords do not match';
+        }
       },
     },
     vuex: {

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -9,27 +9,27 @@
 
         <div class="user-field">
           <label for="name">Name</label>
-          <input type="text" class="add-form" id="name" autocomplete="name"  autofocus="true" required v-model="full_name">
+          <input @focus="clearErrorMessage" type="text" class="add-form" id="name" autocomplete="name"  autofocus="true" required v-model="full_name">
         </div>
 
         <div class="user-field">
           <label for="username">Username</label>
-          <input type="text" class="add-form" autocomplete="username" id="username" required v-model="username">
+          <input @focus="clearErrorMessage" type="text" class="add-form" autocomplete="username" id="username" required v-model="username">
         </div>
 
         <div class="user-field">
           <label for="password">Password</label>
-          <input type="password" class="add-form" id="password" required v-model="password">
+          <input @focus="clearErrorMessage" type="password" class="add-form" id="password" required v-model="password">
         </div>
 
         <div class="user-field">
           <label for="confirm-password">Confirm Password</label>
-          <input type="password" class="add-form" id="confirm-password" required v-model="passwordConfirm">
+          <input @focus="clearErrorMessage" type="password" class="add-form" id="confirm-password" required v-model="passwordConfirm">
         </div>
 
         <div class="user-field">
           <label for="user-role"><span class="visuallyhidden">User Role</span></label>
-          <select v-model="role" id="user-role">
+          <select @focus="clearErrorMessage" v-model="role" id="user-role">
           <option value="learner" selected> Learner </option>
           <option value="admin"> Admin </option>
           </select>
@@ -86,7 +86,8 @@
               this.full_name = '';
               this.username = '';
               this.password = '';
-              this.errorMessage = '';
+              this.passwordConfirm = '';
+              this.clearErrorMessage();
               this.$refs.modal.closeModal();
             }).catch((error) => {
               if (error.status.code === 409) {
@@ -100,6 +101,9 @@
         } else {
           this.errorMessage = 'Passwords do not match';
         }
+      },
+      clearErrorMessage() {
+        this.errorMessage = '';
       },
     },
     vuex: {

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -99,7 +99,7 @@
               }
             });
         } else {
-          this.errorMessage = 'Passwords do not match';
+          this.errorMessage = 'Passwords do not match.';
         }
       },
       clearErrorMessage() {

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -38,7 +38,7 @@
       </div>
 
       <div class="footer" slot="footer">
-        <p v-if="errorMessage">{{errorMessage}}</p>
+        <p class="error-message" v-if="errorMessage">{{errorMessage}}</p>
         <button class="create-btn" type="button" @click="createNewUser">Create Account</button>
       </div>
 
@@ -169,5 +169,8 @@
 
   .add-user-button
     width: 100%
+
+  .error-message
+    color: $core-text-alert
 
 </style>


### PR DESCRIPTION
## Summary

Addresses:

- https://trello.com/c/yqvgo7a5/395-users-add-a-confirm-password-text-field-in-add-new-account-modal

Also added automatic error clearing on input focus and submission (so that users don't still have the error after attempting an edit).

@indirectlylit @whitzhu @rayykim @jtamiace feeling a little iffy on the implementation, but I think it's OK for MVP? Behavior isn't as expected by UX team, it's supposed to do automatic checking and alerts via icons:

![image](https://cloud.githubusercontent.com/assets/9877852/17638075/9bd9ba18-609c-11e6-95ea-d1deffd820d9.png)

Instead, it's doing this:

![image](https://cloud.githubusercontent.com/assets/9877852/17638138/f464de10-609c-11e6-9096-ea0571aeee36.png)


But I figure this will do for MVP? What do you guys think?