### PR TITLE
Proper verbs for log in/out and better user notification

### DIFF
--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -16,13 +16,13 @@
     <div class="user-dropdown">
       <ul class="dropdown-list">
         <li>
-          <h4 class="dropdown-name">{{ name }}</h4>
+          <p class="dropdown-name">{{ name }}</p>
           <p id="dropdown-username">{{ username }}</p>
           <p id="dropdown-usertype">{{ userkind }}</p>
         </li>
         <li id="logout-tab">
           <div tabindex="0" v-on:keyup.enter="userLogout" @click="userLogout" aria-label="Log out">
-            <span>Logout</span>
+            <span>Log out</span>
           </div>
         </li>
       </ul>
@@ -197,6 +197,7 @@
 
   .dropdown-name
     margin-top: 18px
+    font-weight: bold
     margin-bottom: 0 // html linting yelled at me for not being 'succinct' enough :(
 
   #dropdown-username
@@ -258,6 +259,7 @@
 
     .dropdown-name
       font-size: 16px
+      font-weight: bold
 
     #logout-tab
       div

--- a/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
@@ -9,10 +9,13 @@
         </div>
       </div>
       <div slot="body">
+        <div v-if="wrongCreds">
+          <h1>Log In Error!</h1>
+          <span aria-live="polite">Incorrect username or password.<br>Please try again!</span>
+        </div>
         <input type="text" class="login-form login-username" v-model="username_entered" placeholder="Username" v-on:keyup.enter="userLogin" aria-label="Username" v-el:usernamefield autofocus>
         <input type="password" class="login-form login-password" v-model="password_entered" placeholder="Password" v-on:keyup.enter="userLogin" aria-label="Password">
-        <button class="login-button" @click="userLogin">Login</button>
-        <div v-if="wrongCreds">Incorrect username or password.<br>Please try again!</div>
+        <button class="login-button" @click="userLogin">Log in</button>
       </div>
       <div slot="footer"></div>
       <div slot="openbtn" @click="clearForm">


### PR DESCRIPTION
## Summary

1. Corrected **Login** into **Log in** and **Logout** into **Log out**.
2. Moved the `<div v-if="wrongCreds">` above input fields and added proper user notification according to [WAI recommendations](https://www.w3.org/WAI/tutorials/forms/notifications/), but I cannot test it since it's not working even on master (see this [Trello card](https://trello.com/c/yjYjsg81/417-user-notification-for-incorrect-password-and-or-username-not-working)). 

## TODO

- [ ] Add the fix for the `v-if="wrongCreds"` errors?

