### PR TITLE
Fixed margin around user notification for login modal

### DIFF
--- a/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
@@ -2,7 +2,7 @@
 
   <div>
     <modal>
-      <div class="title" aria-labelledby="loginModal" slot="header">
+      <div class="title" aria-label="Log in to Kolibri" slot="header">
         <div class="login-brand-box">
           <img src="./icons/kolibri-logo.svg" alt="Kolibri logo">
           <p id="login-brand">Kolibri</p>
@@ -73,7 +73,7 @@
         login: actions.kolibriLogin,
       },
     },
-	};
+  };
 
 </script>
 
@@ -107,7 +107,7 @@
 
   .login-brand-box
     text-align: center
-    margin: 15px auto
+    margin: 15px 5px auto
     img, p
       display: inline-block
     img
@@ -122,6 +122,7 @@
     letter-spacing: 0.1em
     font-weight: 100
     color: $core-action-normal
+    margin-bottom: 15px
 
   .login-form
     width: 300px
@@ -137,7 +138,7 @@
       border-bottom: 3px solid $core-action-normal
 
   .login-username
-    margin-bottom: 30px
+    margin: 30px auto
     background: url('./icons/user.svg') no-repeat 8px 6px
     transition: all 0.15s
     &:focus

--- a/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
@@ -2,7 +2,7 @@
 
   <div>
     <modal>
-      <div class="title" aria-label="Log in to Kolibri" slot="header">
+      <div class="title" aria-label="Log into Kolibri" slot="header">
         <div class="login-brand-box">
           <img src="./icons/kolibri-logo.svg" alt="Kolibri logo">
           <p id="login-brand">Kolibri</p>
@@ -10,7 +10,7 @@
       </div>
       <div slot="body">
         <div v-if="wrongCreds">
-          <h1>Log In Error!</h1>
+          <h1>Log-in Error</h1>
           <span aria-live="polite">Incorrect username or password.<br>Please try again!</span>
         </div>
         <input type="text" class="login-form login-username" v-model="username_entered" placeholder="Username" v-on:keyup.enter="userLogin" aria-label="Username" v-el:usernamefield autofocus>
@@ -82,6 +82,9 @@
 
   @require '~core-theme.styl'
   @require '~nav-bar-item.styl'
+
+  h1
+    font-size: 1.1em
 
   #person
     fill: $core-action-normal


### PR DESCRIPTION
## Summary

Commit with this fix didn't make it into my last PR before it was merged.

## Screenshot

**Before**
<img width="441" alt="screen shot 2016-08-15 at 1 48 52 pm" src="https://cloud.githubusercontent.com/assets/6668144/17679176/1e19b7d6-62ef-11e6-8bb1-b8f638aff8c6.png">


**After**
![selection_654](https://cloud.githubusercontent.com/assets/1457929/17678267/a4dc77a8-6336-11e6-9335-8387cf3f4ca9.png)


