### PR TITLE
Add context processor for session object.

### DIFF
--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -1,0 +1,8 @@
+import json
+
+from django.conf import settings
+from kolibri.auth.api import SessionViewSet
+
+
+def return_session(request):
+    return {'session': json.dumps(SessionViewSet().get_session(request)), 'kolibri': settings.KOLIBRI_CORE_JS_NAME}

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -16,6 +16,9 @@
   {% cache 5000 js_urls %}
     {% js_reverse_inline %}
   {% endcache %}
+  var session = JSON.parse('{{ session | escapejs }}');
+  sessionModel = {{kolibri}}.resources.SessionResource.createModel(session);
+  sessionModel.synced = true;
 </script>
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}

--- a/kolibri/core/test/test_context_processor.py
+++ b/kolibri/core/test/test_context_processor.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from kolibri.auth.models import Facility, DeviceOwner, FacilityUser
+
+
+class ContextProcessorTestCase(APITestCase):
+
+    def test_context_processor_anonymous_user(self):
+        response = self.client.get(reverse('kolibri:setupwizardplugin:setupwizard'))
+        self.assertEqual(json.loads(response.context['session'])['kind'], ['ANONYMOUS'])
+
+    def test_context_processor_user(self):
+        self.facility = Facility.objects.create(name="QQQ")
+        DeviceOwner.objects.create(username="admin", password="***")
+        self.user = FacilityUser.objects.create(username="foo", facility=self.facility)
+        self.user.set_password("bar")
+        self.user.save()
+        self.client.login(username="foo", password="bar")
+        response = self.client.get(reverse('kolibri:learnplugin:learn'))
+        self.assertEqual(json.loads(response.context['session'])['username'], "foo")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -79,6 +79,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'kolibri.core.context_processors.custom_context_processor.return_session',
             ],
         },
     },

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.conf import settings
 from django.views.generic.base import TemplateView
 from kolibri.content.content_db_router import using_content_database
-from kolibri.content.models import ContentNode, ChannelMetadataCache
-from kolibri.content.serializers import ContentNodeSerializer, ChannelMetadataCacheSerializer
+from kolibri.content.models import ChannelMetadataCache, ContentNode
+from kolibri.content.serializers import ChannelMetadataCacheSerializer, ContentNodeSerializer
 from rest_framework.renderers import JSONRenderer
 
 
@@ -13,7 +12,6 @@ class LearnView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(LearnView, self).get_context_data(**kwargs)
-        context['kolibri'] = settings.KOLIBRI_CORE_JS_NAME
         context['channelList'] = []
         context['channel_id'] = ''
         context['nodes'] = []


### PR DESCRIPTION
## Summary

Added a custom context processor that adds the session info and core kolibri app into each template. You can access the core kolibri app as {{ kolibri }}.

## Issues addressed

Fixes this issue https://trello.com/c/hdcwl0Y5/377-bug-brief-flash-of-log-in-state-in-nav-bar-on-refresh-even-when-already-logged-in