### PR TITLE
fix toolbar 1px black line flicking issue on Chrome

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -133,7 +133,7 @@
     background: $core-bg-canvas
     z-index: 100
     transition: top 0.2s ease-in-out
-    outline: 1px solid $core-bg-canvas
+    outline: 1px solid $core-bg-canvas // prevent box outline flicking on Chrome
 
   .toolbar-hide
     top: -40px

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -133,10 +133,9 @@
     background: $core-bg-canvas
     z-index: 100
     transition: top 0.2s ease-in-out
+    outline: 1px solid $core-bg-canvas
 
   .toolbar-hide
-    position: fixed
-    left: -20px
     top: -40px
 
   .breadcrumbs


### PR DESCRIPTION
can merge in case others also encounter this issue, currently I only observed on my machine