### PR TITLE
Fix for transfer module to properly support python 3 iteration

### DIFF
--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -57,7 +57,7 @@ class Transfer(object):
 
     def next(self):
         try:
-            chunk = self._content_iterator.next()
+            chunk = next(self._content_iterator)
         except StopIteration:
             self.completed = True
             self.finalize()


### PR DESCRIPTION
This should solve the issue @radinamatic was having with downloading; I was calling `.next()` on an iterator, which only works in python 2. Wrapping it in the `next` function instead is cross-version.