### PR TITLE
Include kolibri.tasks for creating the sdist source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include kolibri/logger *
 recursive-include kolibri/plugins *
 recursive-include kolibri/test *
 recursive-include kolibri/utils *
+recursive-include kolibri/tasks *
 recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/dist *


### PR DESCRIPTION
## Summary

Include the `kolibri.tasks` module in the `MANIFEST.in` so that it will be included during building `sdist`

## Screenshots (if appropriate)
Run `kolibri start` to start the server.
![screen shot 2016-08-16 at 2 18 32 pm](https://cloud.githubusercontent.com/assets/20859877/17689836/f942483c-63bc-11e6-911c-d51f28f6d7b2.png)

Test in the browser.
![screen shot 2016-08-16 at 2 19 33 pm](https://cloud.githubusercontent.com/assets/20859877/17689849/18f5ddc4-63bd-11e6-9e80-a6389adbea8b.png)



