### PR TITLE
Made current facility api consistent.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -113,7 +113,7 @@ class CurrentFacilityViewSet(viewsets.ViewSet):
         elif type(logged_in_user) is AnonymousUser:
             return Response(Facility.objects.all().values_list('id', flat=True))
         else:
-            return Response(logged_in_user.facility_id)
+            return Response([logged_in_user.facility_id])
 
 
 class ClassroomViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

If user is an admin or learner, api should return an array for current facility.

## Issues addressed

Fixes this issue -> https://trello.com/c/bo6gija9/444-new-learner-accounts-cannot-be-created

