### PR TITLE
update to card-list component for topic-cards. Also included in conte…

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -26,11 +26,15 @@
 
     <!-- results -->
     <div class='results' v-if="!loading">
-      <h4 v-if="searchTerm">
+      <h1 v-if="searchTerm">
         {{ message }}
+      </h1>
+
+      <h4 v-if="topics.length && showTopics">
+        Topic
       </h4>
 
-      <card-grid v-if="topics.length && showTopics">
+      <card-list class="card-list" v-if="topics.length && showTopics">
         <topic-list-item
           v-for="topic in topics"
           class="card"
@@ -39,7 +43,11 @@
           :ntotal="topic.n_total"
           :ncomplete="topic.n_complete">
         </topic-list-item>
-      </card-grid>
+      </card-list>
+
+      <h4 v-if="contents.length">
+        Content
+      </h4>
 
       <card-grid v-if="contents.length">
         <content-grid-item
@@ -143,6 +151,12 @@
   @require '../learn.styl'
 
   $top-offset = 120px
+
+  h4
+    margin-top: 3em
+
+  .card-list
+    margin-bottom: $card-gutter
 
   .wrapper
     margin: auto


### PR DESCRIPTION
## Summary

Updated to `card-list` component for topic-cards. 
Also added content-type as section titles. 


<img width="1530" alt="chrome" src="https://cloud.githubusercontent.com/assets/12800136/17712327/4ba4d3c8-63aa-11e6-8568-4e9505c2f4a7.png">
<img width="1672" alt="firefox" src="https://cloud.githubusercontent.com/assets/12800136/17712328/4baaff5a-63aa-11e6-8c94-ad12d217b17a.png">


***NOTE***
`content-cards` and `topic-cards` have a different width. A trello card has been made for this issue: https://trello.com/c/b7PsH8oo/448-learn-topic-card-content-card-have-different-widths

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

…nt-type section title.