### PR TITLE
Breadcrumb for content page : added 'back' next to the back.svg

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
@@ -19,7 +19,7 @@
       </template>
 
       <span v-if="pageName === PageNames.EXPLORE_CONTENT">
-        <breadcrumb :linkobject="parentExploreLink"></breadcrumb>
+        <breadcrumb :linkobject="parentExploreLink" :text="('Back')" ></breadcrumb>
       </span>
 
     </nav>


### PR DESCRIPTION
Bug Bash Suggestion: Learn-Content Player has `Learn` next to the back.svg. Should add some sort of text next to exploreplage-content player.

<img width="1271" alt="screen shot 2016-08-16 at 3 07 56 pm" src="https://cloud.githubusercontent.com/assets/12800136/17717549/7c6a02f8-63c3-11e6-809c-ff8f6e830b1c.png">



## Summary

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

