### PR TITLE
Make sure topics and content are not null.

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -8,35 +8,36 @@
         <svg v-else class="pageicon" src="../icons/folder.svg"></svg>
       </div>
     </page-header>
+    <div v-if="topic">
+      <p class="page-description" v-if='topic.description'>
+        {{ topic.description }}
+      </p>
 
-    <p class="page-description" v-if='topic.description'>
-      {{ topic.description }}
-    </p>
+      <span class="visuallyhidden" v-if="subtopics.length">{{ $tr('navigate') }}</span>
 
-    <span class="visuallyhidden" v-if="subtopics.length">{{ $tr('navigate') }}</span>
-
-    <card-list v-if="subtopics.length">
-      <topic-list-item
-        v-for="topic in subtopics"
-        :id="topic.id"
-        :title="topic.title"
-        :ntotal="topic.n_total"
-        :ncomplete="topic.n_complete">
-      </topic-list-item>
-    </card-list>
-
-    <card-grid v-if="contents.length">
-      <content-grid-item
-        v-for="content in contents"
-        class="card"
-        :title="content.title"
-        :thumbnail="content.thumbnail"
-        :kind="content.kind"
-        :progress="content.progress"
-        :id="content.id">
-      </content-grid-item>
-    </card-grid>
-
+      <card-list v-if="subtopics.length">
+        <topic-list-item
+          v-for="topic in subtopics"
+          :id="topic.id"
+          :title="topic.title"
+          :ntotal="topic.n_total"
+          :ncomplete="topic.n_complete">
+        </topic-list-item>
+      </card-list>
+    </div>
+    <div v-if="contents">
+      <card-grid v-if="contents.length">
+        <content-grid-item
+          v-for="content in contents"
+          class="card"
+          :title="content.title"
+          :thumbnail="content.thumbnail"
+          :kind="content.kind"
+          :progress="content.progress"
+          :id="content.id">
+        </content-grid-item>
+      </card-grid>
+    </div>
   </div>
 
 </template>
@@ -59,7 +60,11 @@
     },
     computed: {
       title() {
-        return this.isRoot ? this.$tr('explore') : this.topic.title;
+        let title = '';
+        if (this.topic) {
+          title = this.isRoot ? this.$tr('explore') : this.topic.title;
+        }
+        return title;
       },
     },
     vuex: {


### PR DESCRIPTION
## Summary

* Make sure topics and content are not null.
* https://trello.com/c/GWlP1ThY/490-switching-between-learn-and-explore-really-quickly-causes-console-errors
