### PR TITLE
disable content logging and log downloading

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -182,10 +182,13 @@
           Object.assign(options, this.currentViewClass);
           // Instantiate the Vue instance directly using the Kolibri Vue constructor.
           this.contentView = new this.Kolibri.lib.vue(options); // eslint-disable-line new-cap
-          this.contentView.$on('startTracking', this.wrappedStartTracking);
-          this.contentView.$on('stopTracking', this.wrappedStopTracking);
-          this.contentView.$on('progressUpdate', this.wrappedUpdateProgress);
-          this.initSession(this.Kolibri, this.channelId, this.contentId, this.kind);
+
+          // ====== disable content logging until we track down some issues =======
+
+          // this.contentView.$on('startTracking', this.wrappedStartTracking);
+          // this.contentView.$on('stopTracking', this.wrappedStopTracking);
+          // this.contentView.$on('progressUpdate', this.wrappedUpdateProgress);
+          // this.initSession(this.Kolibri, this.channelId, this.contentId, this.kind);
         }
       },
       wrappedStartTracking() {

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -2,9 +2,11 @@
 
   <core-base>
     <main-nav slot="nav"></main-nav>
+<!-- // disable log downloading until we track down some issues
     <div v-if="isAdminOrSuperuser" slot="above">
       <top-nav></top-nav>
     </div>
+-->
     <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="page"></component>
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>


### PR DESCRIPTION
we need to resolve some issues before re-enabling.

most critical:
* https://trello.com/c/a9JLQi6v/488-repeatedly-loading-learn-recommendations-eventually-freezes-server
* https://trello.com/c/kPFWF9k8/481-csv-log-does-not-contain-new-user-usage-data

also:
* https://trello.com/c/iqrrhO1o/468-possible-logging-error-after-completely-viewing-one-of-unicef-s-channel-videos
* https://trello.com/c/WvaXba6v/453-learn-error-logging-in-as-a-learner-while-on-a-content-viewer-as-a-guest-anonymous-user
