### PR TITLE
Fixed user passwords not being saved correctly.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -72,7 +72,7 @@ class FacilityUserViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         try:
-            return super(viewsets.ModelViewSet, self).create(request, *args, **kwargs)
+            return super(FacilityUserViewSet, self).create(request, *args, **kwargs)
         except ValidationError:
             return Response("An account with that username already exists.", status=status.HTTP_409_CONFLICT)
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -25,6 +25,15 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         user.save()
         return user
 
+    def update(self, instance, validated_data):
+        if 'password' in validated_data:
+            serializers.raise_errors_on_nested_writes('update', self, validated_data)
+            instance.set_password(validated_data['password'])
+            instance.save()
+            return instance
+        else:
+            return super(FacilityUserSerializer, self).update(instance, validated_data)
+
 
 class DeviceOwnerSerializer(serializers.ModelSerializer):
 

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -238,6 +238,27 @@ class UserCreationTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
 
+class UserUpdateTestCase(APITestCase):
+
+    def setUp(self):
+        self.device_owner = DeviceOwnerFactory.create()
+        self.facility = FacilityFactory.create()
+        self.user = FacilityUserFactory.create(facility=self.facility)
+        self.client.login(username=self.device_owner.username, password=DUMMY_PASSWORD)
+
+    def test_user_update_info(self):
+        self.client.patch(reverse('facilityuser-detail', kwargs={'pk': self.user.pk}), {'username': 'foo'}, format="json")
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, "foo")
+
+    def test_user_update_password(self):
+        new_password = 'baz'
+        self.client.patch(reverse('facilityuser-detail', kwargs={'pk': self.user.pk}), {'password': new_password}, format="json")
+        self.client.logout()
+        response = self.client.login(username=self.user.username, password=new_password, facility=self.facility)
+        self.assertTrue(response)
+
+
 class LoginLogoutTestCase(APITestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Summary

When updating a user's password, we must update manually in serializer or else raw password will get saved, therefore user can't log in with changed password.

## Issues addressed

Fixes this issue -> https://trello.com/c/uJ2koa1P/471-passwords-don-t-reset
