### PR TITLE
Log user out if they delete their own account.

### DIFF
--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -101,7 +101,7 @@ var config = {
       'kolibri_module': path.resolve('kolibri/core/assets/src/kolibri_module'),
       'core-constants': path.resolve('kolibri/core/assets/src/constants'),
       'core-base': path.resolve('kolibri/core/assets/src/vue/core-base'),
-      'core-actions': path.resolve('kolibri/core/assets/src/actions'),
+      'core-actions': path.resolve('kolibri/core/assets/src/core-actions'),
       'learn-actions': path.resolve('kolibri/plugins/learn/assets/src/actions'),
       'nav-bar-item': path.resolve('kolibri/core/assets/src/vue/nav-bar/nav-bar-item'),
       'nav-bar-item.styl': path.resolve('kolibri/core/assets/src/vue/nav-bar/nav-bar-item.styl'),

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -18,7 +18,7 @@
 <script>
 
   const logging = require('logging').getLogger(__filename);
-  const actions = require('../../core-actions');
+  const actions = require('core-actions');
 
   module.exports = {
     $trNameSpace: 'contentRender',

--- a/kolibri/core/assets/src/vue/modal/index.vue
+++ b/kolibri/core/assets/src/vue/modal/index.vue
@@ -39,7 +39,7 @@
 
 <script>
 
-  const actions = require('../../core-actions');
+  const actions = require('core-actions');
 
   module.exports = {
 

--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -35,7 +35,7 @@
 <script>
 
   const UserKinds = require('../../constants').UserKinds;
-  const actions = require('../../core-actions');
+  const actions = require('core-actions');
 
   module.exports = {
     $trNameSpace: 'sessionWidget',

--- a/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/login-modal.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  const actions = require('../../core-actions');
+  const actions = require('core-actions');
 
   module.exports = {
     $trNameSpace: 'sessionWidget',

--- a/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
@@ -11,7 +11,7 @@
 
 <script>
 
-  const UserKinds = require('core-constants').UserKinds;
+  const UserKinds = require('kolibri').constants.UserKinds;
 
   module.exports = {
 

--- a/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
@@ -26,7 +26,7 @@
 
   const pageMode = require('../../state/getters').pageMode;
   const constants = require('../../state/constants');
-  const UserKinds = require('core-constants').UserKinds;
+  const UserKinds = require('kolibri').constants.UserKinds;
 
   module.exports = {
     $trNameSpace: 'learnNav',

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -22,7 +22,7 @@
 
   const store = require('../state/store');
   const PageNames = require('../state/constants').PageNames;
-  const UserKinds = require('core-constants').UserKinds;
+  const UserKinds = require('kolibri').constants.UserKinds;
 
   module.exports = {
     components: {

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -101,6 +101,7 @@
 
   const actions = require('../../actions');
   const coreActions = require('core-actions');
+  const constants = require('core-constants');
 
   module.exports = {
     components: {
@@ -130,11 +131,18 @@
           facility: this.facility,
         };
         this.updateUser(this.userid, payload, this.role_new);
+        // if logged in admin updates role to learner, redirect to learn page
+        if (Number(this.userid) === this.session_user_id) {
+          if (this.role_new === constants.UserKinds.LEARNER.toLowerCase()) {
+            window.location.href = window.location.origin;
+          }
+        }
 
         // close the modal after successful submission
         this.close();
       },
       delete() {
+        // if logged in admin deleted their own account, log them out
         if (Number(this.userid) === this.session_user_id) {
           this.logout(this.Kolibri);
         }

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -100,6 +100,7 @@
 <script>
 
   const actions = require('../../actions');
+  const coreActions = require('core-actions');
 
   module.exports = {
     components: {
@@ -134,6 +135,9 @@
         this.close();
       },
       delete() {
+        if (Number(this.userid) === this.session_user_id) {
+          this.logout(this.Kolibri);
+        }
         this.deleteUser(this.userid);
       },
       changePassword() {
@@ -178,8 +182,12 @@
     },
     vuex: {
       actions: {
+        logout: coreActions.kolibriLogout,
         updateUser: actions.updateUser,
         deleteUser: actions.deleteUser,
+      },
+      getters: {
+        session_user_id: state => state.core.session.user_id,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -100,8 +100,8 @@
 <script>
 
   const actions = require('../../actions');
-  const coreActions = require('core-actions');
-  const constants = require('core-constants');
+  const coreActions = require('kolibri').coreActions;
+  const UserKinds = require('kolibri').constants.UserKinds;
 
   module.exports = {
     components: {
@@ -133,7 +133,7 @@
         this.updateUser(this.userid, payload, this.role_new);
         // if logged in admin updates role to learner, redirect to learn page
         if (Number(this.userid) === this.session_user_id) {
-          if (this.role_new === constants.UserKinds.LEARNER.toLowerCase()) {
+          if (this.role_new === UserKinds.LEARNER.toLowerCase()) {
             window.location.href = window.location.origin;
           }
         }


### PR DESCRIPTION
## Summary

Added equality check for session id and deleted user id. If equal, log the user out. Also, replaced references with 'core-actions' since we alias the path.

## Issues addressed

Fixes this issue -> https://trello.com/c/lNKfWIBU/484-after-self-deleting-client-should-log-out

ALSO added commit to address this issue -> https://trello.com/c/FBnWtxa3/475-if-a-user-switches-themselves-from-admin-to-learner-they-should-be-expelled-from-management-and-their-session-should-update

