### PR TITLE
main-wrapper : added padding-top, so page titles aren't right next to…

### DIFF
--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -63,6 +63,7 @@
     overflow-y: scroll
     height: 100%
     width: 100%
+    padding-top: $right-margin
     padding-left: $left-margin
     padding-right: $right-margin
     padding-bottom: 50px


### PR DESCRIPTION
Added `padding-top` to the `main-wrapper` to push it down. So the title of the page aren't right next to the toolbar-breadcrumb

<img width="1176" alt="screen shot 2016-08-17 at 8 52 55 am" src="https://cloud.githubusercontent.com/assets/12800136/17743278/09e303e8-6458-11e6-978e-d6ba740e84c6.png">
## Summary

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

… the toolbar breadcrumb