### PR TITLE
Breadcrumb channel overlap

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -234,7 +234,7 @@
     right: 1.2rem
     z-index: 1
     @media screen and (max-width: 840px)
-      right: 3rem
+      right: 2.4rem
 
   .more
     display: none

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -208,7 +208,7 @@
     -webkit-appearance: none
     -moz-appearance: none
     outline: none
-    @media screen and (max-width: $portrait-breakpoint)
+    @media screen and (max-width: 840px)
       display: none
 
   .chan-select-location
@@ -233,12 +233,12 @@
     top: 0.1rem
     right: 1.2rem
     z-index: 1
-    @media screen and (max-width: $portrait-breakpoint)
+    @media screen and (max-width: 840px)
       right: 3rem
 
   .more
     display: none
-    @media screen and (max-width: $portrait-breakpoint)
+    @media screen and (max-width: 840px)
       position: absolute
       display: block
       top: 0.3rem


### PR DESCRIPTION
Channel switch button converts to `more` as soon as the min column/row = 2 

 **3 Columns, channel button is shown**
<img width="842" alt="screen shot 2016-08-17 at 11 51 08 am" src="https://cloud.githubusercontent.com/assets/12800136/17749385/5274fbf6-6472-11e6-9cec-ac18e255744a.png">

**2 Columns, channel button is replaced by the show more button**
<img width="818" alt="screen shot 2016-08-17 at 11 51 16 am" src="https://cloud.githubusercontent.com/assets/12800136/17749387/5277d0e2-6472-11e6-9b54-ec293cd8a4d0.png">
<img width="819" alt="screen shot 2016-08-17 at 11 51 23 am" src="https://cloud.githubusercontent.com/assets/12800136/17749386/5276e010-6472-11e6-9857-aedf87aed001.png">
<img width="447" alt="screen shot 2016-08-17 at 11 51 36 am" src="https://cloud.githubusercontent.com/assets/12800136/17749388/5279881a-6472-11e6-9c3f-1bc6dfc272a8.png">

NOTE: currently the media query is a hard-coded number (840px). Tried using ` grid-width(2)` but didn't work?? revisit later. 

NOTE: currently the dummy data only has folders 2 levels deep. In the future, there could be an overlap of breadcrumb with the collapse version if there are many levels to the breadcrumb 


## Summary

*Short description*

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)
