### PR TITLE
Added label for the error-box

### DIFF
--- a/kolibri/core/assets/src/vue/error-box/index.vue
+++ b/kolibri/core/assets/src/vue/error-box/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h1>{{ $tr('errorHeader') }}</h1>
-    <label for="error-textxbox">{{ $tr('errorPrefixText') }}</label><br>
+    <label for="error-textxbox" aria-live="polite">{{ $tr('errorPrefixText') }}</label><br>
     <textarea id="error-textbox">
       {{ error }}
     </textarea>

--- a/kolibri/core/assets/src/vue/error-box/index.vue
+++ b/kolibri/core/assets/src/vue/error-box/index.vue
@@ -2,8 +2,8 @@
 
   <div>
     <h1>{{ $tr('errorHeader') }}</h1>
-    <p>{{ $tr('errorPrefixText') }}</p>
-    <textarea>
+    <label for="error-textxbox">{{ $tr('errorPrefixText') }}</label><br>
+    <textarea id="error-textbox">
       {{ error }}
     </textarea>
   </div>

--- a/kolibri/core/assets/src/vue/error-box/index.vue
+++ b/kolibri/core/assets/src/vue/error-box/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h1>{{ $tr('errorHeader') }}</h1>
-    <label for="error-textxbox" aria-live="polite">{{ $tr('errorPrefixText') }}</label><br>
+    <label for="error-textbox" aria-live="polite">{{ $tr('errorPrefixText') }}</label><br>
     <textarea id="error-textbox">
       {{ error }}
     </textarea>
@@ -30,6 +30,9 @@
 
 
 <style lang="stylus" scoped>
+
+  h1
+    margin-top: 50px
 
   textarea
     width: 100%


### PR DESCRIPTION
## Summary

Plus a bit of the top margin for the heading as it was ducking under the toolbar.

## TODO

- [ ] I find `We've encountered an issue` messages extremely annoying, if meant for the user. Is this just to give us some error background, or is it envisioned as something users might have to act upon? @indirectlylit 

If latter, we should definitely add something more, like button to send the error to support team, or just the phrase: `Please copy this error and file an issue at GitHub, or send to xxx@learningequality.org.` 

## Screenshots

Invisible **Error** heading prior to adding top-margin:

![kolibri - chromium_680](https://cloud.githubusercontent.com/assets/1457929/17753694/3cc56f66-64d1-11e6-8d9e-9a1783bdf554.png)

With the margin:

![selection_682](https://cloud.githubusercontent.com/assets/1457929/17753793/bbb3be54-64d1-11e6-9cff-a22ec92b3809.png)
