### PR TITLE
Foundations for server-side i18n

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.rst
 include CHANGELOG.rst
 include LICENSE
 include README.rst
+recursive-include kolibri/locale *.mo
 recursive-include kolibri/auth *
 recursive-include kolibri/content *
 recursive-include kolibri/core *
@@ -15,7 +16,6 @@ recursive-include kolibri/utils *
 recursive-include kolibri/tasks *
 recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
-recursive-include kolibri/dist *
-recursive-include kolibri/core/build/*
+recursive-include kolibri/core/build/ *
 recursive-exclude kolibri/dist *pyc
 prune kolibri/dist/*/__pycache___

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,15 @@ release: clean assets
 staticdeps: clean
 	DISABLE_SQLALCHEMY_CEXT=1 pip install -t kolibri/dist/ -r requirements.txt
 
-dist: staticdeps assets
+dist: staticdeps assets compilemessages
 	pip install -r requirements/build.txt
 	python setup.py sdist > /dev/null # silence the sdist output! Too noisy!
 	python setup.py bdist_wheel
 	pex . --disable-cache -o dist/`python setup.py --fullname`.pex -m kolibri --python-shebang=/usr/bin/python
 	ls -l dist
+
+makemessages: assets
+	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*' --ignore 'docs/conf.py'
+
+compilemessages:
+	python -m kolibri manage compilemessages -- -l en > /dev/null

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -15,11 +15,20 @@ import os
 # This is essential! We load the kolibri conf INSIDE the Django conf
 from kolibri.utils import conf
 
+# import kolibri, so we can get the path to the module.
+import kolibri
+
+KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
+
 BASE_DIR = os.path.abspath(os.path.dirname(__name__))
 
 KOLIBRI_HOME = os.environ['KOLIBRI_HOME']
 
 KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
+
+LOCALE_PATHS = [
+    os.path.join(KOLIBRI_MODULE_PATH, "locale"),
+]
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r base.txt
+-r i18n.txt
 flake8
 pre-commit
 tox

--- a/requirements/i18n.txt
+++ b/requirements/i18n.txt
@@ -1,0 +1,1 @@
+crowdin-cli-py


### PR DESCRIPTION
## Summary

Defines `LOCALE_PATHS`, as well as some new `make` commands, to build our catalog files.

Pretty simple, and doesn't handle syncing catalog files with CrowdIn. But this PR should be self-contained enough and is needed for extending our webpack i18n pipeline (specifically the `LOCALE_PATHS` setting).