### PR TITLE
Search fixes

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from random import sample
 
 from django.db.models import Q
@@ -29,6 +30,7 @@ class ContentNodeFilter(filters.FilterSet):
         if exact_match:
             return exact_match
         # if no exact match, search for non-adjacent match
+
         return queryset.filter(
             Q(parent__isnull=False),
             reduce(lambda x, y: x & y, [Q(title__icontains=word) for word in value.split()]) |

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -357,6 +357,13 @@ function triggerSearch(store, searchTerm) {
     });
 }
 
+function clearSearch(store) {
+  store.dispatch('SET_SEARCH_STATE', {
+    topics: [],
+    contents: [],
+    searchTerm: '',
+  });
+}
 
 function toggleSearch(store) {
   store.dispatch('TOGGLE_SEARCH');
@@ -391,4 +398,5 @@ module.exports = {
   showContentUnavailable,
   triggerSearch,
   toggleSearch,
+  clearSearch,
 };

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -105,6 +105,9 @@
         localSearchTerm: '',
       };
     },
+    ready() {
+      this.localSearchTerm = this.searchTerm;
+    },
     computed: {
       message() {
         if (this.topics.length || this.contents.length) {

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -110,9 +110,10 @@
     },
     computed: {
       message() {
-        if (this.topics.length || this.contents.length) {
+        if ((this.showTopics && this.topics.length) || this.contents.length) {
           return 'Search results:';
-        } else if (!this.topics.length && !this.contents.length) {
+        } else if (!(this.showTopics && this.topics.length) &&
+          !this.contents.length) {
           return 'Could not find any matches.';
         }
         return '';

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -80,6 +80,7 @@
         } else {
           rootPage = constants.PageNames.LEARN_CHANNEL;
         }
+        this.clearSearch();
         this.$router.go(
           {
             name: rootPage,
@@ -103,6 +104,9 @@
         currentChannel: state => state.currentChannel,
         channelList: state => state.channelList,
         searchOpen: state => state.searchOpen,
+      },
+      actions: {
+        clearSearch: require('../../actions').clearSearch,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -7,9 +7,8 @@
         name="chan-select"
         id="chan-select"
         class="chan-select"
-        v-model="getCurrentChannel"
-        @change="switchChannel($event)">
-        <option v-for="channel in getChannels" :value="channel.id">{{ channel.name }}</option>
+        v-model="currentChannel">
+        <option v-for="channel in channelList" :value="channel.id">{{ channel.name }}</option>
       </select>
     <search-button @scrolling="handleScroll" class='search-btn'></search-button>
   </div>
@@ -43,14 +42,21 @@
       'breadcrumbs': require('../breadcrumbs'),
     },
     computed: {
-      getChannels() {
-        return this.channelList;
-      },
-      getCurrentChannel() {
-        return this.currentChannel;
+      /*
+      * Get and set the current channel ID.
+      */
+      currentChannel: {
+        get() {
+          return this.currentChannelGetter;
+        },
+        set(newChannelId, oldChannelId) {
+          if (newChannelId !== oldChannelId) {
+            this.switchChannel(newChannelId);
+          }
+        },
       },
       channelsExist() {
-        return !((Object.keys(this.getChannels).length === 0) &&
+        return !(this.getChannels && (Object.keys(this.getChannels).length === 0) &&
           (this.getChannels.constructor === Object));
       },
     },
@@ -72,7 +78,7 @@
         }
         this.lastScrollTop = this.currScrollTop;
       },
-      switchChannel(event) {
+      switchChannel(channelId) {
         let rootPage;
         this.more = false;
         if (this.pageMode === PageModes.EXPLORE) {
@@ -85,7 +91,7 @@
           {
             name: rootPage,
             params: {
-              channel_id: event.target.value,
+              channel_id: channelId,
             },
           }
         );
@@ -101,7 +107,7 @@
         isRoot: (state) => state.pageState.topic.id === state.rootTopicId,
         pageMode: getters.pageMode,
         pageName: state => state.pageName,
-        currentChannel: state => state.currentChannel,
+        currentChannelGetter: state => state.currentChannel,
         channelList: state => state.channelList,
         searchOpen: state => state.searchOpen,
       },

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -55,10 +55,6 @@
           }
         },
       },
-      channelsExist() {
-        return !(this.getChannels && (Object.keys(this.getChannels).length === 0) &&
-          (this.getChannels.constructor === Object));
-      },
     },
     methods: {
       handleScroll(position) {


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/ANnXe67M/503-500-error-from-search-endpoint-when-no-exact-match

Fixes https://trello.com/c/igkaRD6B/463-learn-switching-channels-while-in-search-mode-keeps-the-last-content-searched-from-the-other-channel

Fixes https://trello.com/c/igkaRD6B/463-learn-switching-channels-while-in-search-mode-keeps-the-last-content-searched-from-the-other-channel

Cleans up v-model usage in channel switching to use `v-model` and not require an additional `@change` handler. Directly reference value input value rather than introspecting event target.

Cleans up topic filtering on Learn search - if only topics are found, don't show as a search result.
