### PR TITLE
Removed H1.header top margin

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
@@ -61,7 +61,6 @@
 
   .header
     position: relative
-    margin-top: 0.3em
 
   .icon-wrapper
     display: block


### PR DESCRIPTION
## Summary

When viewing in Firefox `margin-top: 0.3em` was creating an overlap with above content (no overlap on Chrome):

![kolibri dev server - mozilla firefox_683](https://cloud.githubusercontent.com/assets/1457929/17756764/5ac9887e-64e2-11e6-891e-9348c25b77de.png)

It was visible on deeper Explore levels also:

![selection_684](https://cloud.githubusercontent.com/assets/1457929/17756783/7c58af88-64e2-11e6-804d-572e5bd27330.png)

## Reviewer guidance

I tested on various resolutions on both FF & Chrome, and deleting it doesn't seem to be creating any new issues. That line was[ last edited](https://github.com/learningequality/kolibri/commit/829f4ecf3466fd8290c44eec432c9eafab320135) back when breadcrumbs were below the top nav element.
