### PR TITLE
Fixing sort to work on all browsers

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -160,7 +160,14 @@
           return hasRole && hasName;
 
           // aphabetize based on username
-        }).sort((user1, user2) => user1.username[0] > user2.username[0]);
+        }).sort((user1, user2) => {
+          if (user1.username[0] > user2.username[0]) {
+            return 1;
+          } else if (user1.username[0] < user2.username[0]) {
+            return -1;
+          }
+          return 0;
+        });
       },
     },
     vuex: {
@@ -233,6 +240,9 @@
   .roster
     width: 100%
     word-break: break-all
+
+  th
+    text-align: inherit
 
   .col-header
     padding-bottom: (1.2 * $row-padding)


### PR DESCRIPTION
## Summary

During testing, realized that sorting doesn't work for IE or Chrome, because their `Array.sort()` takes numbers as return values rather than booleans. Fixed in this patch.

Wasn't a trello card, but I wanted to fix it.