### PR TITLE
Shims window.location.origin for IE.

### DIFF
--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -66,6 +66,12 @@ module.exports = function CoreApp() {
     reversed: false,
   };
 
+  // Shim window.location.origin for IE.
+  if (!window.location.origin) {
+    window.location.origin = `${window.location.protocol}//${window.location.hostname}${(
+          window.location.port ? `:${window.location.port}` : '')}`;
+  }
+
   const self = this;
 
   function setUpVueIntl() {


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/AjovfhF4/502-undefined-in-urls