### PR TITLE
Allow non-anon users to save anonymous logs, to avoid post-login errors

### DIFF
--- a/kolibri/logger/models.py
+++ b/kolibri/logger/models.py
@@ -16,13 +16,13 @@ from kolibri.auth.permissions.base import RoleBasedPermissions
 from kolibri.auth.permissions.general import IsOwn
 from kolibri.content.models import UUIDField
 
-from .permissions import AnonymousUsersCanWriteAnonymousLogs
+from .permissions import AnyoneCanWriteAnonymousLogs
 
 
 class BaseLogModel(AbstractFacilityDataModel):
 
     permissions = (
-        AnonymousUsersCanWriteAnonymousLogs() |
+        AnyoneCanWriteAnonymousLogs() |
         IsOwn() |
         RoleBasedPermissions(
             target_field="user",

--- a/kolibri/logger/permissions.py
+++ b/kolibri/logger/permissions.py
@@ -1,13 +1,13 @@
 from kolibri.auth.permissions.base import BasePermissions
 
 
-class AnonymousUsersCanWriteAnonymousLogs(BasePermissions):
+class AnyoneCanWriteAnonymousLogs(BasePermissions):
     """
     Permissions class that allows anonymous users to create logs with no associated user.
     """
 
     def user_can_create_object(self, user, obj):
-        return user.is_anonymous() and not obj.user
+        return obj.user is None
 
     def user_can_read_object(self, user, obj):
         return False
@@ -16,7 +16,7 @@ class AnonymousUsersCanWriteAnonymousLogs(BasePermissions):
         # this one is a bit worrying, since anybody could update anonymous logs, but at least only if they have the ID
         # (and this is needed, in order to allow a ContentSessionLog to be updated within a session -- in theory,
         # we could add date checking in here to not allow further updating after a couple of days)
-        return user.is_anonymous() and not obj.user
+        return obj.user is None
 
     def user_can_delete_object(self, user, obj):
         return False


### PR DESCRIPTION
Currently, we only allow non-logged-in (anon) users to save anonymous logs (those with `user=None`). This led to a problem when someone is viewing a piece of content and then logged in from that page. The login happened, then a redirect happened, and this triggered a teardown of the content renderer, which triggered a final save of the anon log. However, as there was now a logged-in user, the saving didn't pass permission checks. Now it will. 