### PR TITLE
Double arrow in IE Fix, Destroy Video Player, Etc.

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-icon/index.vue
@@ -81,11 +81,4 @@
 
   @require '~core-theme.styl'
 
-  // replace the correct path
-  .pageicon [fill='#996189']
-    fill: $core-text-default
-
-  .pageicon [fill='#FFF']
-    fill: none
-
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -93,6 +93,8 @@
 
         // only used on learn page
         recommended: (state) => state.pageState.recommended,
+
+        progress: (state) => state.pageState.content.progress,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/vue/icons/arrowdown.svg
+++ b/kolibri/plugins/learn/assets/src/vue/icons/arrowdown.svg
@@ -1,4 +1,0 @@
-<svg fill="#686868" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M7 10l5 5 5-5z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
-</svg>

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -140,6 +140,7 @@
       'content-grid-item': require('../content-grid-item'),
       'search-button': require('./search-button'),
       'card-grid': require('../card-grid'),
+      'card-list': require('../card-list'),
     },
     vuex: {
       getters: {

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -140,18 +140,14 @@
 
   .chan-select
     z-index: 1
-    height: 24px
     padding: 0.2em 0.8em
     padding-right: 1.8em
     min-width: 160px
     color: $core-text-annotation
     font-size: 0.9rem
     border: 1px solid $core-text-annotation
-    border-radius: 50px
-    background: url(../icons/arrowdown.svg) no-repeat right
+    border-radius: 0.5em
     background-color: $core-bg-canvas
-    -webkit-appearance: none
-    -moz-appearance: none
     outline: none
     position: absolute
     top: 0.5rem

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -221,6 +221,7 @@
       this.recordProgress();
       this.$emit('stopTracking');
       global.removeEventListener('resize', this.debouncedResizeVideo);
+      this.videoPlayer.dispose();
     },
   };
 

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -195,7 +195,7 @@
         textTrackDisplay: true,
         bigPlayButton: false,
         inactivityTimeout: 1000,
-        preload: 'auto',
+        preload: 'metadata',
         poster: this.posterSource,
         playbackRates: [0.5, 1.0, 1.25, 1.5, 2.0],
         controlBar: {


### PR DESCRIPTION
## Summary

* Removed the background arrow because IE does not support the css property 'appearance' so it was creating a 2nd arrow.
* Use the dispose() function to clean up videojs before navigating out of the page.
* Added missing component that was causing vue to throw an error. 

## Reviewer guidance

* I reduced the border radius because the arrow was getting cut off in Firefox.

## Issue addressed

* https://trello.com/c/DzlEJz0Z/511-ie-11-double-arrows-on-channel-switcher

## Screenshots (if appropriate)
### Before
![image](https://cloud.githubusercontent.com/assets/7193975/17783754/4861a7ba-652e-11e6-9852-e5d21342bfd7.png)

### After
![image](https://cloud.githubusercontent.com/assets/7193975/17783731/23052e9c-652e-11e6-8232-33ef10c5672f.png)


