### PR TITLE
Use the official crowdin api client to upload and download translations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ Icon
 
 #ignore added files with DS_Store
 .DS_Store
+/crowdin.yaml

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,14 @@ makemessages: assets
 
 compilemessages:
 	python -m kolibri manage compilemessages -- -l en > /dev/null
+
+syncmessages: ensurecrowdinclient uploadmessages downloadmessages
+
+ensurecrowdinclient:
+	ls -l crowdin-cli.jar || wget https://crowdin.com/downloads/crowdin-cli.jar # make sure we have the official crowdin cli client
+
+uploadmessages:
+	java -jar crowdin-cli.jar upload sources -b `git symbolic-ref HEAD | xargs basename`
+
+downloadmessages:
+	java -jar crowdin-cli.jar download -b `git symbolic-ref HEAD | xargs basename`

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,0 +1,10 @@
+project_identifier: kolibri
+api_key: <insert API key here>
+base_path: .
+
+files:
+  - source: '/kolibri/locale/en/LC_FRONTEND_MESSAGES/*.json'
+    translation: '/kolibri/locale/%locale_with_underscore%/LC_FRONTEND_MESSAGES/%original_file_name%'
+
+  - source: '/kolibri/locale/en/LC_MESSAGES/*.po'
+    translation: '/kolibri/locale/%locale_with_underscore%/LC_MESSAGES/%original_file_name%'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 -r base.txt
--r i18n.txt
 flake8
 pre-commit
 tox

--- a/requirements/i18n.txt
+++ b/requirements/i18n.txt
@@ -1,1 +1,0 @@
-crowdin-cli-py


### PR DESCRIPTION
## Summary

Changes:
- Remove the unofficial python client dependency. Use the official crowdin client.
- Add a new make command that uploads strings and then downloads the translations.

