### PR TITLE
Creates conditional promises so that we can resolve handlers only if a certain condition still pertains.

### DIFF
--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -25,6 +25,7 @@ var libs = function(kolibri_name) {
     'vue': kolibri_name + '.lib.vue',
     'kolibri': kolibri_name,
     'vuex': kolibri_name + '.lib.vuex',
+    'conditionalPromise': kolibri_name + '.lib.conditionalPromise',
   };
 };
 

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -3,6 +3,7 @@ const rest = require('rest');
 const mime = require('rest/interceptor/mime');
 const csrf = require('rest/interceptor/csrf');
 const errorCode = require('rest/interceptor/errorCode');
+const ConditionalPromise = require('./conditionalPromise');
 
 /**
  * A helping method to get specific cookie based on its name.
@@ -61,7 +62,7 @@ class Model {
    * returns, otherwise reject is called with the response object.
    */
   fetch(params = {}, force = false) {
-    const promise = new Promise((resolve, reject) => {
+    const promise = new ConditionalPromise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
         if (!force && this.synced) {
           resolve(this.attributes);
@@ -100,7 +101,7 @@ class Model {
    * returns, otherwise reject is called with the response object.
    */
   save(attrs) {
-    const promise = new Promise((resolve, reject) => {
+    const promise = new ConditionalPromise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
         let payload = {};
         if (this.synced) {
@@ -170,7 +171,7 @@ class Model {
    * returns, otherwise reject is called with the response object.
    */
   delete() {
-    const promise = new Promise((resolve, reject) => {
+    const promise = new ConditionalPromise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
         if (!this.id) {
           // Nothing to delete, so just resolve the promise now.
@@ -256,7 +257,7 @@ class Collection {
    */
   fetch(extraParams = {}, force = false) {
     const params = Object.assign({}, this.params, extraParams);
-    const promise = new Promise((resolve, reject) => {
+    const promise = new ConditionalPromise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
         if (!force && this.synced) {
           resolve(this.data);

--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -1,0 +1,41 @@
+class ConditionalPromise {
+  /**
+   * Create a conditional promise - like a promise, but cancelable!
+   */
+  constructor(...args) {
+    if ([...args].length) {
+      this._promise = new Promise(...args);
+    }
+  }
+
+  catch(...args) {
+    this._promise.catch(...args);
+    return this;
+  }
+
+  then(...args) {
+    this._promise.then(...args);
+    return this;
+  }
+
+  only(cancelCheck, resolve, reject) {
+    this._promise.then((success) => {
+      if (cancelCheck() && resolve) {
+        resolve(success);
+      }
+    }, (error) => {
+      if (cancelCheck() && reject) {
+        reject(error);
+      }
+    });
+    return this;
+  }
+
+  static all(promises) {
+    const conditionalPromise = new ConditionalPromise();
+    conditionalPromise._promise = Promise.all(promises);
+    return conditionalPromise;
+  }
+}
+
+module.exports = ConditionalPromise;

--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -1,6 +1,8 @@
 class ConditionalPromise {
   /**
-   * Create a conditional promise - like a promise, but cancelable!
+   * Create a conditional promise - like a promise, but with an additional method 'only'
+   * that allows for chaining resolve/reject handlers that will only be called if a
+   * certain condition pertains.
    */
   constructor(...args) {
     if ([...args].length) {
@@ -18,19 +20,19 @@ class ConditionalPromise {
     return this;
   }
 
-  only(cancelCheck, resolve, reject) {
+  only(continueCheck, resolve, reject) {
     /*
-     * When the promise resolves, call the resolve function, only if cancelCheck evaluates to true.
-     * @param {cancelCheck} Function - Function that returns a Boolean.
+     * When the promise resolves, call resolve function, only if continueCheck evaluates to true.
+     * @param {continueCheck} Function - Function that returns a Boolean,
      * @param {resolve} Function - Function to call if the Promise succeeds.
      * @param {reject} Function - Function to call if the Promise fails.
      */
     this._promise.then((success) => {
-      if (cancelCheck() && resolve) {
+      if (continueCheck() && resolve) {
         resolve(success);
       }
     }, (error) => {
-      if (cancelCheck() && reject) {
+      if (continueCheck() && reject) {
         reject(error);
       }
     });

--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -19,6 +19,12 @@ class ConditionalPromise {
   }
 
   only(cancelCheck, resolve, reject) {
+    /*
+     * When the promise resolves, call the resolve function, only if cancelCheck evaluates to true.
+     * @param {cancelCheck} Function - Function that returns a Boolean.
+     * @param {resolve} Function - Function to call if the Promise succeeds.
+     * @param {reject} Function - Function to call if the Promise fails.
+     */
     this._promise.then((success) => {
       if (cancelCheck() && resolve) {
         resolve(success);
@@ -32,6 +38,10 @@ class ConditionalPromise {
   }
 
   static all(promises) {
+    /*
+     * Equivalent of Promise.all, but return a ConditionalPromise instead.
+     * @param {promises} [Promise|ConditionalPromise] - an array of Promises
+     */
     const conditionalPromise = new ConditionalPromise();
     conditionalPromise._promise = Promise.all(promises);
     return conditionalPromise;

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -36,6 +36,7 @@ function Lib() {
   this.logging = require('../logging');
   this.vue = vue;
   this.vuex = vuex;
+  this.conditionalPromise = require('../conditionalPromise');
 }
 
 /**

--- a/kolibri/core/assets/src/core-store.js
+++ b/kolibri/core/assets/src/core-store.js
@@ -7,6 +7,7 @@ const initialState = {
   core: {
     error: '',
     loading: true,
+    pageSessionId: 0,
     session: { id: undefined,
                username: '',
                full_name: '',
@@ -42,7 +43,11 @@ const mutations = {
                            error: '200' };
   },
   CORE_SET_PAGE_LOADING(state, value) {
-    state.core.loading = value;
+    const update = { loading: value };
+    if (value) {
+      Object.assign(update, { pageSessionId: state.core.pageSessionId + 1 });
+    }
+    Object.assign(state.core, update);
   },
   CORE_SET_ERROR(state, error) {
     state.core.error = error;

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -139,10 +139,7 @@ function _getCurrentChannelRootTopicId() {
 
 function checkSamePageId(store) {
   const pageId = store.state.core.pageSessionId;
-  return () => {
-    console.log(store.state.core.pageSessionId, pageId);
-    return store.state.core.pageSessionId === pageId;
-  };
+  return () => store.state.core.pageSessionId === pageId;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/GWlP1ThY/490-switching-between-learn-and-explore-really-quickly-causes-console-errors

Here a new ConditionalPromise class is created that, by composition, exposes a (nearly - some static methods are not implemented) identical API to Promise.

We then use this in all server side API Requests, so that we can cancel the results.

Also add a pageSessionId on the core store state, and autoincrement any time we set the pageLoading state to true.

Also adds a function generator to create the check for the pageSessionId based on the current store state.

Then uses this in all places where we call the mutations on the pageState in learn.