### PR TITLE
Kill Videoplayer Before Destroy & Small Optimization

### DIFF
--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -195,7 +195,7 @@
         textTrackDisplay: true,
         bigPlayButton: false,
         inactivityTimeout: 1000,
-        preload: 'auto',
+        preload: 'metadata',
         poster: this.posterSource,
         playbackRates: [0.5, 1.0, 1.25, 1.5, 2.0],
         controlBar: {
@@ -221,6 +221,7 @@
       this.recordProgress();
       this.$emit('stopTracking');
       global.removeEventListener('resize', this.debouncedResizeVideo);
+      this.videoPlayer.dispose();
     },
   };
 


### PR DESCRIPTION
## Summary

* Kill Videoplayer Before Destroy
* Only load metadata at first.