### PR TITLE
Corrected the focus order to match elements order on user management page

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -17,10 +17,6 @@
         <option value="learner"> Learners </option>
       </select>
 
-      <div class="create">
-        <user-create-modal></user-create-modal>
-      </div>
-
       <div class="searchbar" role="search">
         <svg class="icon" src="../icons/search.svg" role="presentation" aria-hidden="true"></svg>
         <input
@@ -28,6 +24,10 @@
           type="search"
           v-model="searchFilter"
           placeholder="Search for a user...">
+      </div>
+
+      <div class="create">
+        <user-create-modal></user-create-modal>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary

Input field for user search was behind the button for creating new user in the code, but visually positioned behind it on the page. Switching the positions in the code makes navigating by TAB key consistent with the order of elements on the page. 

## Reviewer guidance

Nothing has changed in the UI, just the focus order.
