### PR TITLE
Nuanced cache buster

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -465,8 +465,12 @@ class Resource {
     this.collections = {};
   }
 
+  removeModelById(id) {
+    delete this.models[id];
+  }
+
   removeModel(model) {
-    delete this.models[model.id];
+    this.removeModelById(model.id);
   }
 
   get urls() {

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -63,7 +63,7 @@ class Model {
   fetch(params = {}, force = false) {
     const promise = new Promise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
-        if (!force && this.synced) {
+        if (!force && this.synced && this.cached) {
           resolve(this.attributes);
         } else {
           this.synced = false;
@@ -218,6 +218,10 @@ class Model {
     }
     Object.assign(this.attributes, attributes);
   }
+
+  get cached() {
+    return this.id && this.id in this.resource.models;
+  }
 }
 
 /** Class representing a 'view' of a single API resource.
@@ -258,7 +262,7 @@ class Collection {
     const params = Object.assign({}, this.params, extraParams);
     const promise = new Promise((resolve, reject) => {
       Promise.all(this.promises).then(() => {
-        if (!force && this.synced) {
+        if (!force && this.synced && this.cached) {
           resolve(this.data);
         } else {
           this.synced = false;
@@ -340,6 +344,10 @@ class Collection {
 
   get data() {
     return this.models.map((model) => model.attributes);
+  }
+
+  get cached() {
+    return this.models.reduce((currentValue, model) => currentValue && model.cached, true);
   }
 }
 

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -192,6 +192,9 @@
         }
       },
       wrappedStartTracking() {
+        // Assume that as soon as we have started tracking data for this content item,
+        // our ContentNode cache is no longer valid.
+        this.Kolibri.resources.ContentNodeResource.removeModelById(this.id);
         this.startTracking(this.Kolibri);
       },
       wrappedStopTracking() {

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -194,7 +194,7 @@
       wrappedStartTracking() {
         // Assume that as soon as we have started tracking data for this content item,
         // our ContentNode cache is no longer valid.
-        this.Kolibri.resources.ContentNodeResource.removeModelById(this.id);
+        this.Kolibri.resources.ContentNodeResource.unCacheModel(this.id);
         this.startTracking(this.Kolibri);
       },
       wrappedStopTracking() {


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/g8M0IpOh/518-content-progress-not-reflected-in-parent-topic-view-without-refresh

Achieves this by adding `cached` getters to both the Model and Collection classes.

Model `cached` is determined by whether it, itself, is in the Resource's model cache.

Collection `cached` is determined by whether its constituent models are all in the Resource's model cache.

The content renderer now, as soon as logging starts, removes the model it is rendering from the Resource's cache. Hence, when a page that it is rendered on is loaded again, it is not cached, and a fetch from the server is forced.

One possible refinement would be to allow Collections to be removed from the cache as well, and check for their presence, and the presence of all their constituent models. Currently, I can't think of a use case for this, so have not implemented it.

To test - uncomment the logger lines in content-render.vue login, access a piece of content, and then return to the page before. It should now show progress properly updated on that piece of content.