### PR TITLE
Task status vue component and other client side fixes.

### DIFF
--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -20,14 +20,22 @@ class TaskResource extends Resource {
     return this.client(clientObj);
   }
 
+  localDrive() {
+    const clientObj = { path: this.localDriveUrl() };
+    return this.client(clientObj);
+  }
+
   get localExportUrl() {
-    return this.urls[`${this.name}_list/startlocalexportchannel`]; // not yet implemented in api
+    return this.urls[`${this.name}_startlocalexportchannel`]; // not yet implemented in api
   }
   get localImportUrl() {
-    return this.urls[`${this.name}_list/startlocalimportchannel`];
+    return this.urls[`${this.name}_startlocalimportchannel`];
   }
   get remoteImportUrl() {
-    return this.urls[`${this.name}_list/startremoteimport`];
+    return this.urls[`${this.name}_startremoteimport`];
+  }
+  get localDriveUrl() {
+    return this.urls[`${this.name}_localdrive`];
   }
 }
 

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -228,8 +228,7 @@ function showUserPage(store) {
 function showContentPage(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.CONTENT_MGMT_PAGE);
-  // const taskCollectionPromise = TaskResource.getCollection().fetch();
-  const taskCollectionPromise = Promise.resolve([]); // TODO - remove
+  const taskCollectionPromise = TaskResource.getCollection().fetch();
   taskCollectionPromise.then((taskList) => {
     const pageState = { showWizard: false };
     pageState.taskList = taskList.map(_taskState);
@@ -271,7 +270,7 @@ function cancelImportExportWizard(store) {
 
 // background worker calls this to continually update UI
 function updateTasks(store) {
-  const taskCollectionPromise = TaskResource.getCollection().fetch();
+  const taskCollectionPromise = TaskResource.getCollection().fetch({}, true);
   // get all running tasks
   taskCollectionPromise.then((taskList) => {
     const pageState = { showWizard: false };
@@ -325,7 +324,17 @@ function localExportContent(store, driveId) {
 function remoteImportContent(store, channelId) {
   const remoteImportPromise = TaskResource.remoteImportContent(channelId);
   remoteImportPromise.then((response) => {
-    store.dispatch('ADD_TASK', [_taskState(response.entity)]);
+    store.dispatch('SET_TASKS', [_taskState(response.entity)]);
+  })
+  .catch((error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+  });
+}
+
+function localDrive(store) {
+  const localDrivePromise = TaskResource.localDrive();
+  localDrivePromise.then((response) => {
+    store.dispatch('SET_LOCAL_DRIVES', response.entity);
   })
   .catch((error) => {
     store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
@@ -366,6 +375,7 @@ module.exports = {
   localExportContent,
   localImportContent,
   remoteImportContent,
+  localDrive,
 
   showDataPage,
   showScratchpad,

--- a/kolibri/plugins/management/assets/src/state/store.js
+++ b/kolibri/plugins/management/assets/src/state/store.js
@@ -20,6 +20,7 @@ Content import/export page:
     channelList: [] // list of objects
     showWizard: false // boolean
     wizardState: {} // object
+    localDriveList: [] // list of objects
   }
 
 **/
@@ -65,6 +66,9 @@ const mutations = {
   SET_CONTENT_WIZARD_STATE(state, shown, wizardState) {
     state.pageState.showWizard = shown;
     state.pageState.wizardState = wizardState;
+  },
+  SET_LOCAL_DRIVES(state, localDrives) {
+    state.pageState.localDriveList = localDrives;
   },
 };
 

--- a/kolibri/plugins/management/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/index.vue
@@ -2,11 +2,14 @@
 
   <div>
 
+    <task-status v-if="tasks.length !== 0">
+    </task-status>
+
     <button @click="incrementDebugTask">next task</button>
 
     <hr>
 
-    <icon-button v-if="!tasks.length" text="Add Channel" :primary="true" @click="startImportWizard">
+    <icon-button v-if="!tasks.length" text="Add Channel" :primary="true" @click="remoteImport">
       <svg src="../icons/add.svg"></svg>
     </icon-button>
 
@@ -16,7 +19,7 @@
 
     <div v-if="tasks.length">
       <ul>
-        <li>Progress: {{ tasks[0].progress }}</li>
+        <li>Progress: {{ tasks[0].percentage }}</li>
         <li>Status: {{ tasks[0].status }}</li>
         <li>Type: {{ tasks[0].type }}</li>
       </ul>
@@ -37,28 +40,28 @@
   const tasks = [
     {},
     {
-      progress: 0.5,
+      percentage: 0.5,
       status: 'in_progress',
       type: 'local_export',
       id: '12345678901234567890',
       metadata: {},
     },
     {
-      progress: 0.0,
+      percentage: 0.0,
       status: 'pending',
       type: 'local_export',
       id: '12345678901234567890',
       metadata: {},
     },
     {
-      progress: 0.3,
+      percentage: 0.3,
       status: 'error',
       type: 'local_export',
       id: '12345678901234567890',
       metadata: {},
     },
     {
-      progress: 1.0,
+      percentage: 1.0,
       status: 'success',
       type: 'local_export',
       id: '12345678901234567890',
@@ -72,11 +75,23 @@
     components: {
       'icon-button': require('icon-button'),
       'wizard': require('./wizard'),
+      'task-status': require('./task-status'),
     },
     data: () => ({
       i: 0,
+      intervalId: undefined,
     }),
-    methods: {},
+    attached() {
+      this.intervalId = setInterval(this.updateTasks, 1000);
+    },
+    detached() {
+      clearInterval(this.intervalId);
+    },
+    methods: {
+      remoteImport() {
+        this.downloadChannel('88623b4026f04df095604abf0f91ecfe');
+      },
+    },
     vuex: {
       getters: {
         localChannels: state => state.pageState.channelList,
@@ -95,6 +110,8 @@
         },
         startImportWizard: actions.startImportWizard,
         startExportWizard: actions.startExportWizard,
+        downloadChannel: actions.remoteImportContent,
+        updateTasks: actions.updateTasks,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
@@ -1,0 +1,95 @@
+<template>
+
+  <div v-if="showProgress" class="task">
+    <h1>
+      {{title}}
+    </h1>
+    <progress max="1" value={{taskProgress}}></progress>
+    <h2>
+      {{subTitle}}
+    </h2>
+    <button class="buttons" @click='hideProgressBar'>
+      {{buttonMessage}}
+    </button>
+    </div>
+
+</template>
+
+
+<script>
+
+  const actions = require('../../actions');
+
+  module.exports = {
+    components: {
+    },
+    $trNameSpace: 'contentPage',
+    $trs: {
+      buttonConfirm: 'Confirm',
+      buttonCancel: 'Cancel',
+      failed: 'Please confirm and try again.',
+      completed: `Please confirm to add channels to 'My Channels' list.`,
+      loading: 'Please wait...',
+
+    },
+    data: () => ({
+      showProgress: true,
+    }),
+    computed: {
+      buttonMessage() {
+        if (this.status === 'FAILED' || this.taskProgress === 1) {
+          return this.$tr('buttonConfirm');
+        }
+        return this.$tr('buttonCancel');
+      },
+      subTitle() {
+        if (this.status === 'FAILED') {
+          return this.$tr('failed');
+        } else if (this.taskProgress === 1) {
+          return this.$tr('completed');
+        }
+        return this.$tr('loading');
+      },
+    },
+    methods: {
+      hideProgressBar() {
+        if (this.showProgress) {
+          this.showProgress = false;
+          // this.clearTasks(this.id);
+        } else {
+          this.showProgress = true;
+        }
+      },
+    },
+    vuex: {
+      getters: {
+        title: state => state.pageState.taskList[0].type,
+        status: state => state.pageState.taskList[0].status,
+        taskProgress: state => state.pageState.taskList[0].percentage,
+        id: state => state.pageState.taskList[0].id,
+      },
+      actions: {
+        clearTasks: actions.clearTasks,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  div
+    background-color: #ffffe6
+
+  .buttons
+    margin: 10px
+    text-align: center
+
+  .task
+    text-align: center
+
+  progress
+    width: 100%
+
+</style>

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -2,11 +2,11 @@
 
   <core-base>
     <main-nav slot="nav"></main-nav>
-<!-- // disable log downloading until we track down some issues
+<!-- // disable log downloading until we track down some issues -->
     <div v-if="isAdminOrSuperuser" slot="above">
       <top-nav></top-nav>
     </div>
--->
+
     <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="page"></component>
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>

--- a/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
@@ -4,7 +4,7 @@
     <div class="links">
       <a v-link="usersLink" :class="{active: usersActive}" @click="blur">Users</a>
       <a v-link="dataLink" :class="{active: dataActive}" @click="blur">Data</a>
-      <!-- <a v-link="contentLink" :class="{active: contentActive}" @click="blur">Content</a> -->
+      <a v-link="contentLink" :class="{active: contentActive}" @click="blur">Content</a>
     </div>
   </div>
 

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -1,13 +1,11 @@
-import json
-from django.core.management import call_command
-from rest_framework import viewsets, serializers
-from rest_framework.decorators import list_route
-from rest_framework.response import Response
+import logging as logger
 
+from django.core.management import call_command
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.tasks.management.commands.base import Progress
-
-import logging as logger
+from rest_framework import serializers, viewsets
+from rest_framework.decorators import list_route
+from rest_framework.response import Response
 
 logging = logger.getLogger(__name__)
 
@@ -47,12 +45,11 @@ class TasksViewSet(viewsets.ViewSet):
         # Import here to avoid circular imports.
         from django_q.tasks import async
         from django_q.models import Task
-        data = json.loads(request.body.decode('utf-8'))
 
-        if "id" not in data:
+        if "id" not in request.data:
             raise serializers.ValidationError("The 'id' field is required.")
 
-        channel_id = data['id']
+        channel_id = request.data['id']
 
         task_id = async(_importchannel, channel_id, group=TASKTYPE, progress_updates=True)
 


### PR DESCRIPTION
## Summary

Built task status component. Right now we only have 1 task running at a time. We query the server every second to check on status of task. Deleting tasks is not yet implemented server side. 
Added client side api call for local drives. "Add Channel" button will download default channel from content curation server.

## Screenshots (if appropriate)

![screen shot 2016-08-22 at 8 55 26 pm](https://cloud.githubusercontent.com/assets/6361732/17879972/d42a1442-68aa-11e6-9f40-7c82941dbd63.png)

