### PR TITLE
Silence the `make dist` output.

### DIFF
--- a/test/conditional/test_build.sh
+++ b/test/conditional/test_build.sh
@@ -14,7 +14,7 @@ pip install -r requirements/test.txt
 
 # Build .whl
 npm install
-make dist
+make dist > /dev/null
 pip install dist/kolibri*.whl
 
 cd "$PREVIOUS_CWD"


### PR DESCRIPTION
To minimize test logs.