### PR TITLE
Corrected the focus order to match elements order AND adjusted CSS

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -17,17 +17,18 @@
         <option value="learner"> Learners </option>
       </select>
 
-      <div class="create">
-        <user-create-modal></user-create-modal>
-      </div>
-
       <div class="searchbar" role="search">
         <svg class="icon" src="../icons/search.svg" role="presentation" aria-hidden="true"></svg>
         <input
+          id="search-field"
           aria-label="Search for a user..."
           type="search"
           v-model="searchFilter"
           placeholder="Search for a user...">
+      </div>
+
+      <div class="create">
+        <user-create-modal></user-create-modal>
       </div>
 
     </div>
@@ -289,12 +290,16 @@
   @media screen and (min-width: $portrait-breakpoint + 1)
     .searchbar
       font-size: 1em
+      width: 53%
+    #search-field
       width: 80%
 
   @media screen and (max-width: $portrait-breakpoint)
     .create, #type-filter
       box-sizing: border-box
       width: 49%
+    .create
+      margin-top: -78px
     .searchbar
       font-size: 0.9em
       width: 100%

--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -221,6 +221,7 @@
     &:focus
       outline: none
       border-color: transparent
+      border-bottom: 2px solid $core-action-normal
 
   #type-filter
     float: left
@@ -289,8 +290,9 @@
 
   @media screen and (min-width: $portrait-breakpoint + 1)
     .searchbar
-      font-size: 1em
-      width: 53%
+      font-size: 0.9em
+      min-width: 170px
+      width: 45%
     #search-field
       width: 80%
 


### PR DESCRIPTION
## Summary

#467 was reverted because I didn't bother to check all resolutions... :disappointed: 

Annoying thing is that Firefox and Chrome render responsive widths differently, so the first commit here looked fine in FF, but not in Chrome for iPad width:

**Firefox**

![selection_001](https://cloud.githubusercontent.com/assets/1457929/17949683/e8388ef2-6a56-11e6-9faf-3493f589269a.png)

![selection_004](https://cloud.githubusercontent.com/assets/1457929/17949690/f290b53c-6a56-11e6-883c-aa97ddf8e1c3.png)


**Chrome**

![kolibri - chromium_002](https://cloud.githubusercontent.com/assets/1457929/17949701/fb5fb73a-6a56-11e6-922e-0787475bd9a4.png)



Few more retouches rendered OK in Chrome too, but now it leaves a few unused pixels in FF: 

**Firefox**

![selection_005](https://cloud.githubusercontent.com/assets/1457929/17949718/11d5a704-6a57-11e6-9086-35817e369853.png)


**Chrome**

![kolibri - chromium_006](https://cloud.githubusercontent.com/assets/1457929/17949722/1a1f2b88-6a57-11e6-82a3-065a22a52bd7.png)

@indirectlylit @DXCanas @rayykim 