### PR TITLE
Add loading spinner to content-renderer.

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -6,7 +6,7 @@
           {{ Math.floor(progress * 100) }}%
         </h3>
       <div v-el:container>
-        <loading-spinner></loading-spinner>
+        <loading-spinner v-if="!currentViewClass"></loading-spinner>
       </div>
     </div>
     <div v-else>

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -5,9 +5,8 @@
         <h3 class="progress-percent" v-if="progress > 0">
           {{ Math.floor(progress * 100) }}%
         </h3>
-      <div v-el:container>
-        <loading-spinner v-if="!currentViewClass"></loading-spinner>
-      </div>
+      <loading-spinner v-if="!currentViewClass"></loading-spinner>
+      <div v-el:container></div>
     </div>
     <div v-else>
       {{ $tr('msgNotAvailable') }}

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -5,7 +5,9 @@
         <h3 class="progress-percent" v-if="progress > 0">
           {{ Math.floor(progress * 100) }}%
         </h3>
-      <div v-el:container></div>
+      <div v-el:container>
+        <loading-spinner></loading-spinner>
+      </div>
     </div>
     <div v-else>
       {{ $tr('msgNotAvailable') }}

--- a/kolibri/core/assets/src/vue/loading-spinner/index.vue
+++ b/kolibri/core/assets/src/vue/loading-spinner/index.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <div class="loading-spinner"></div>
+  <div>
+    <div class="loading-spinner-wrapper">
+      <div class="loading-spinner"></div>
+    </div>
+  </div>
 
 </template>
 
@@ -16,9 +20,30 @@
 
 <style lang="stylus" scoped>
 
-  .loading-spinner
+  .loading-spinner-wrapper
     width: 100%
     height: 100%
+    position: relative
+    opacity: 0
+    animation-duration: 0s
+    animation-delay: 250ms
+    animation-name: delaydisplay
+    animation-fill-mode: forwards
+
+  @keyframes delaydisplay
+    from
+      opacity: 0
+    to
+      opacity: 1
+
+  .loading-spinner
+    width: 50%
+    height: 50%
+    position: absolute
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%)
     background: url('loading-spinner.gif') no-repeat center
+    background-size: contain
 
 </style>

--- a/kolibri/core/assets/src/vue/loading-spinner/index.vue
+++ b/kolibri/core/assets/src/vue/loading-spinner/index.vue
@@ -37,8 +37,8 @@
       opacity: 1
 
   .loading-spinner
-    width: 50%
-    height: 50%
+    width: 25%
+    height: 25%
     position: absolute
     top: 50%
     left: 50%

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -9,40 +9,40 @@
   <link rel="shortcut icon" href="{% static 'images/logo.ico' %}">
   <title>{% trans "Kolibri" %}</title>
 </head>
-<style>
-  .loading-spinner-wrapper-base{
-    width: 97vw;
-    height: 97vh;
-    position: relative;
-    opacity: 0;
-    animation-duration: 0s;
-    animation-delay: 250ms;
-    animation-name: delaydisplay;
-    animation-fill-mode: forwards;
-  }
-
-  @keyframes delaydisplay {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  .loading-spinner-base {
-    width: 25%;
-    height: 25%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: url("{% static 'images/loading-spinner.gif' %}") no-repeat center;
-    background-size: contain;
-  }
-</style>
 <body>
 <rootvue>
+  <style>
+    .loading-spinner-wrapper-base{
+      width: 97vw;
+      height: 97vh;
+      position: relative;
+      opacity: 0;
+      animation-duration: 0s;
+      animation-delay: 250ms;
+      animation-name: delaydisplay;
+      animation-fill-mode: forwards;
+    }
+
+    @keyframes delaydisplay {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    .loading-spinner-base {
+      width: 25%;
+      height: 25%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: url("{% static 'images/loading-spinner.gif' %}") no-repeat center;
+      background-size: contain;
+    }
+  </style>
   <div class="loading-spinner-wrapper-base">
     <div class="loading-spinner-base"></div>
   </div>

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -10,15 +10,42 @@
   <title>{% trans "Kolibri" %}</title>
 </head>
 <style>
-  .loading-spinner {
+  .loading-spinner-wrapper-base{
     width: 97vw;
     height: 97vh;
+    position: relative;
+    opacity: 0;
+    animation-duration: 0s;
+    animation-delay: 250ms;
+    animation-name: delaydisplay;
+    animation-fill-mode: forwards;
+  }
+
+  @keyframes delaydisplay {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  .loading-spinner-base {
+    width: 50%;
+    height: 50%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     background: url("{% static 'images/loading-spinner.gif' %}") no-repeat center;
+    background-size: contain;
   }
 </style>
 <body>
 <rootvue>
-  <div class="loading-spinner"></div>
+  <div class="loading-spinner-wrapper-base">
+    <div class="loading-spinner-base"></div>
+  </div>
 </rootvue>
 {% block frontend_assets %}
 {% webpack_asset 'default_frontend' %}

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -31,8 +31,8 @@
   }
 
   .loading-spinner-base {
-    width: 50%;
-    height: 50%;
+    width: 25%;
+    height: 25%;
     position: absolute;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
## Summary

* Add loading spinner to content-renderer for when the content renderers' js modules are being loaded.
* Added delay.
* Still using the gif until find/create a cross-platform spinner smh.

