### PR TITLE
Content recommendations based on recently viewed and most popular.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -67,7 +67,7 @@ class ContentNodeFilter(filters.FilterSet):
         """
 
         # if user is anonymous, don't return any nodes
-        if value == '':
+        if not value:
             return queryset.none()
 
         if self.data['channel']:
@@ -151,7 +151,7 @@ class ContentNodeFilter(filters.FilterSet):
         """
 
         # if user is anonymous, return no nodes
-        if value == '':
+        if not value:
             return queryset.none()
 
         if self.data['channel']:  # filter by channel if available

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -284,10 +284,6 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(reverse("channel-detail", kwargs={'pk': data["id"]}))
         self.assertEqual(response.data['name'], 'testing')
 
-    def test_channelmetadata_recommendations(self):
-        response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"recommendations": ""})
-        self.assertEqual(len(response.data), 4)
-
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
         self.assertEqual(len(response.data), 5)

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -45,11 +45,11 @@
       },
       nCollapsed: {
         type: Number,
-        default: 6,
+        default: 3,
       },
       nExpanded: {
         type: Number,
-        default: 12,
+        default: 9,
       },
     },
     components: {

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
@@ -4,7 +4,18 @@
     <page-header :title="learnName">
       <svg slot="icon" class="pageicon" src="../icons/learn.svg"></svg>
     </page-header>
-    <expandable-content-grid :contents="recommendations"></expandable-content-grid>
+    <expandable-content-grid
+      :contents="recommendations.popular"
+      :title="'Most Popular'">
+    </expandable-content-grid>
+    <expandable-content-grid
+      :contents="recommendations.nextSteps"
+      :title="'Next Steps'">
+    </expandable-content-grid>
+    <expandable-content-grid
+      :contents="recommendations.resume"
+      :title="'Resume'">
+    </expandable-content-grid>
   </div>
 
 </template>


### PR DESCRIPTION
## Summary

Most popular, next steps, and resume endpoints for recommendations added. If user is anonymous, return no nodes for next steps and resume. 
**Most popular** returns most accessed content nodes, or random if not enough logs.
**Next steps** returns uncompleted content, based on user completed content.
**Resume** returns recently uncompleted content.

## Reviewer guidance

I would like if we can discuss on this PR what can be improved or what algorithms can be added.

## Screenshots
We now have categories in Learn page! **Most Popular, Next Steps, Resume**

![screen shot 2016-08-29 at 4 25 32 pm](https://cloud.githubusercontent.com/assets/6361732/18070807/50506378-6e05-11e6-8155-92944839e3d2.png)
![screen shot 2016-08-29 at 4 25 57 pm](https://cloud.githubusercontent.com/assets/6361732/18070809/538dc5b2-6e05-11e6-973e-b3f6e6e6a054.png)
