### PR TITLE
Fixed Spinner misalignment and removed empty divs.

### DIFF
--- a/kolibri/core/assets/src/vue/loading-spinner/index.vue
+++ b/kolibri/core/assets/src/vue/loading-spinner/index.vue
@@ -1,9 +1,7 @@
 <template>
 
-  <div>
-    <div class="loading-spinner-wrapper">
-      <div class="loading-spinner"></div>
-    </div>
+  <div class="loading-spinner-wrapper">
+    <div class="loading-spinner"></div>
   </div>
 
 </template>

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -1,12 +1,10 @@
 <template>
 
-  <div>
-    <div v-el:container class="container" allowfullscreen>
-      <button class='btn' v-if="supportsPDFs" v-on:click="togglefullscreen">
-        {{ inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen') }}
-      </button>
-      <div v-el:pdfcontainer class="pdfcontainer"></div>
-    </div>
+  <div v-el:container class="container" allowfullscreen>
+    <button class='btn' v-if="supportsPDFs" v-on:click="togglefullscreen">
+      {{ inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen') }}
+    </button>
+    <div v-el:pdfcontainer class="pdfcontainer"></div>
   </div>
 
 </template>

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -1,20 +1,17 @@
 <template>
 
-  <div>
-    <div v-el:videowrapperwrapper class="videowrapperwrapper">
-      <loading-spinner v-show="loading"></loading-spinner>
-      <div v-el:videowrapper v-show="!loading" class="videowrapper">
-        <video v-el:video class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
-          <template v-for="video in videoSources">
-            <source :src="video.storage_url" :type='"video/" + video.extension'>
-          </template>
-          <template v-for="track in trackSources">
-            <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
-          </template>
-        </video>
-      </div>
+  <div v-el:videowrapperwrapper class="videowrapperwrapper">
+    <loading-spinner v-show="loading"></loading-spinner>
+    <div v-el:videowrapper v-show="!loading" class="videowrapper">
+      <video v-el:video class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
+        <template v-for="video in videoSources">
+          <source :src="video.storage_url" :type='"video/" + video.extension'>
+        </template>
+        <template v-for="track in trackSources">
+          <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
+        </template>
+      </video>
     </div>
-
   </div>
 
 </template>


### PR DESCRIPTION
## Summary

* Empty div surrounding spinner was causing a misalignment. Realized empty divs are not required so removed them from the pdf and video renderer while I was at it.