### PR TITLE
Use replace whenever we do any URL redirecting to prevent 'back' hell loop

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -61,6 +61,10 @@ class Router {
     this._vueRouter.start(vm, selector);
   }
 
+  replace(options) {
+    this._vueRouter.replace(options);
+  }
+
   /**
    * Make the router reexecute actions for its current location.
    */

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -148,14 +148,14 @@ function redirectToExploreChannel(store) {
       if (currentChannelId) {
         store.dispatch('SET_CURRENT_CHANNEL', currentChannelId);
         cookiejs.set('currentChannel', currentChannelId);
-        router.go({
+        router.replace({
           name: constants.PageNames.EXPLORE_CHANNEL,
           params: {
             channel_id: currentChannelId,
           },
         });
       } else {
-        router.go({ name: constants.PageNames.CONTENT_UNAVAILABLE });
+        router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
     })
     .catch((error) => {
@@ -175,14 +175,14 @@ function redirectToLearnChannel(store) {
       if (currentChannelId) {
         store.dispatch('SET_CURRENT_CHANNEL', currentChannelId);
         cookiejs.set('currentChannel', currentChannelId);
-        router.go({
+        router.replace({
           name: constants.PageNames.LEARN_CHANNEL,
           params: {
             channel_id: currentChannelId,
           },
         });
       } else {
-        router.go({ name: constants.PageNames.CONTENT_UNAVAILABLE });
+        router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
     })
     .catch((error) => {


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/YX7Msee4/543-our-use-of-redirects-is-breaking-the-browser-s-back-button