### PR TITLE
Handle Learn errors more gracefully

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -74,6 +74,10 @@
           (file) => !file.thumbnail & !file.supplementary & file.available
         );
       },
+      defaultFile() {
+        return this.availableFiles &&
+          this.availableFiles.length ? this.availableFiles[0] : undefined;
+      },
     },
     init() {
       this._eventListeners = [];
@@ -168,7 +172,7 @@
             }
           }
           // Add a defaultFile to the propsData, which is the first file in the availableFiles.
-          propsData.defaultFile = this.availableFiles[0];
+          propsData.defaultFile = this.defaultFile;
           // Create an options object for the soon to be instantiated renderer component.
           const options = {
             // Set the parent so that it is in the Vue family.

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -130,6 +130,14 @@ function _getCurrentChannelRootTopicId() {
   });
 }
 
+function _updateChannelList(store) {
+  const channelPromise = _getChannelList();
+  channelPromise.then((channelList) => {
+    store.dispatch('SET_CHANNEL_LIST', channelList);
+  });
+  return channelPromise;
+}
+
 /**
  * Action inhibition checks
  *
@@ -202,14 +210,6 @@ function redirectToLearnChannel(store) {
     });
 }
 
-function showChannelList(store) {
-  const channelPromise = _getChannelList();
-  channelPromise.then((channelList) => {
-    store.dispatch('SET_CHANNEL_LIST', channelList);
-  });
-  return channelPromise;
-}
-
 function showExploreChannel(store, channelId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
@@ -222,7 +222,7 @@ function showExploreChannel(store, channelId) {
       store.dispatch('SET_ROOT_TOPIC_ID', rootTopicId);
       const attributesPromise = ContentNodeResource.getModel(rootTopicId).fetch();
       const childrenPromise = ContentNodeResource.getCollection({ parent: rootTopicId }).fetch();
-      showChannelList(store);
+      _updateChannelList(store);
 
       ConditionalPromise.all([attributesPromise, childrenPromise])
         .only(checkSamePageId(store), ([attributes, children]) => {
@@ -253,7 +253,7 @@ function showExploreTopic(store, channelId, id) {
 
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
-  showChannelList(store);
+  _updateChannelList(store);
   ConditionalPromise.all([attributesPromise, childrenPromise])
     .only(checkSamePageId(store), ([attributes, children]) => {
       const pageState = { id };
@@ -278,7 +278,7 @@ function showExploreContent(store, channelId, id) {
   cookiejs.set('currentChannel', channelId);
 
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
-  showChannelList(store);
+  _updateChannelList(store);
 
   attributesPromise.only(checkSamePageId(store), (attributes) => {
     const pageState = { content: _contentState(attributes) };
@@ -301,7 +301,7 @@ function showLearnChannel(store, channelId) {
 
   const recommendedPromise =
     ContentNodeResource.getCollection({ recommendations: '' }).fetch({}, true);
-  showChannelList(store);
+  _updateChannelList(store);
   recommendedPromise.only(checkSamePageId(store), (recommendations) => {
     const pageState = { recommendations: recommendations.map(_contentState) };
     store.dispatch('SET_PAGE_STATE', pageState);
@@ -321,7 +321,7 @@ function showLearnContent(store, channelId, id) {
   cookiejs.set('currentChannel', channelId);
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
-  showChannelList(store);
+  _updateChannelList(store);
 
   attributesPromise.only(checkSamePageId(store), (attributes) => {
     const pageState = {

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -323,19 +323,30 @@ function showLearnContent(store, channelId, id) {
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
   showChannelList(store);
 
-  ConditionalPromise.all([attributesPromise, recommendedPromise])
-    .only(checkSamePageId(store), ([attributes, recommended]) => {
-      const pageState = {
-        content: _contentState(attributes),
-        recommended: recommended.map(_contentState),
-      };
-      store.dispatch('SET_PAGE_STATE', pageState);
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_ERROR', null);
-    }, (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+  attributesPromise.only(checkSamePageId(store), (attributes) => {
+    const pageState = {
+      content: _contentState(attributes),
+      recommended: store.state.pageState.recommended,
+    };
+    store.dispatch('SET_PAGE_STATE', pageState);
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+    store.dispatch('CORE_SET_ERROR', null);
+  }, (error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+  });
+  recommendedPromise.only(checkSamePageId(store), (recommended) => {
+    const pageState = {
+      content: store.state.pageState.content,
+      recommended: recommended.map(_contentState),
+    };
+    store.dispatch('SET_PAGE_STATE', pageState);
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+    store.dispatch('CORE_SET_ERROR', null);
+  }, (error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+  });
 }
 
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -226,6 +226,9 @@ function showExploreChannel(store, channelId) {
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
           store.dispatch('SET_CHANNEL_LIST', channelList);
+        }).catch((error) => {
+          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+          store.dispatch('CORE_SET_PAGE_LOADING', false);
         });
     }, (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -202,6 +202,14 @@ function redirectToLearnChannel(store) {
     });
 }
 
+function showChannelList(store) {
+  const channelPromise = _getChannelList();
+  channelPromise.then((channelList) => {
+    store.dispatch('SET_CHANNEL_LIST', channelList);
+  });
+  return channelPromise;
+}
+
 function showExploreChannel(store, channelId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
@@ -214,9 +222,10 @@ function showExploreChannel(store, channelId) {
       store.dispatch('SET_ROOT_TOPIC_ID', rootTopicId);
       const attributesPromise = ContentNodeResource.getModel(rootTopicId).fetch();
       const childrenPromise = ContentNodeResource.getCollection({ parent: rootTopicId }).fetch();
-      const channelPromise = _getChannelList();
-      ConditionalPromise.all([attributesPromise, childrenPromise, channelPromise])
-        .only(checkSamePageId(store), ([attributes, children, channelList]) => {
+      showChannelList(store);
+
+      ConditionalPromise.all([attributesPromise, childrenPromise])
+        .only(checkSamePageId(store), ([attributes, children]) => {
           const pageState = { rootTopicId };
           pageState.topic = _topicState(attributes);
           const collection = _collectionState(children);
@@ -225,7 +234,6 @@ function showExploreChannel(store, channelId) {
           store.dispatch('SET_PAGE_STATE', pageState);
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
-          store.dispatch('SET_CHANNEL_LIST', channelList);
         }).catch((error) => {
           store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
           store.dispatch('CORE_SET_PAGE_LOADING', false);
@@ -245,9 +253,9 @@ function showExploreTopic(store, channelId, id) {
 
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
-  const channelPromise = _getChannelList();
-  ConditionalPromise.all([attributesPromise, childrenPromise, channelPromise])
-    .only(checkSamePageId(store), ([attributes, children, channelList]) => {
+  showChannelList(store);
+  ConditionalPromise.all([attributesPromise, childrenPromise])
+    .only(checkSamePageId(store), ([attributes, children]) => {
       const pageState = { id };
       pageState.topic = _topicState(attributes);
       const collection = _collectionState(children);
@@ -256,7 +264,6 @@ function showExploreTopic(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('SET_CHANNEL_LIST', channelList);
     }, (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
@@ -271,19 +278,17 @@ function showExploreContent(store, channelId, id) {
   cookiejs.set('currentChannel', channelId);
 
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
-  const channelPromise = _getChannelList();
+  showChannelList(store);
 
-  ConditionalPromise.all([attributesPromise, channelPromise])
-    .only(checkSamePageId(store), ([attributes, channelList]) => {
-      const pageState = { content: _contentState(attributes) };
-      store.dispatch('SET_PAGE_STATE', pageState);
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('SET_CHANNEL_LIST', channelList);
-    }, (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+  attributesPromise.only(checkSamePageId(store), (attributes) => {
+    const pageState = { content: _contentState(attributes) };
+    store.dispatch('SET_PAGE_STATE', pageState);
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+    store.dispatch('CORE_SET_ERROR', null);
+  }, (error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+  });
 }
 
 
@@ -296,18 +301,16 @@ function showLearnChannel(store, channelId) {
 
   const recommendedPromise =
     ContentNodeResource.getCollection({ recommendations: '' }).fetch({}, true);
-  const channelPromise = _getChannelList();
-  ConditionalPromise.all([recommendedPromise, channelPromise])
-    .only(checkSamePageId(store), ([recommendations, channelList]) => {
-      const pageState = { recommendations: recommendations.map(_contentState) };
-      store.dispatch('SET_PAGE_STATE', pageState);
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('SET_CHANNEL_LIST', channelList);
-    }, (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+  showChannelList(store);
+  recommendedPromise.only(checkSamePageId(store), (recommendations) => {
+    const pageState = { recommendations: recommendations.map(_contentState) };
+    store.dispatch('SET_PAGE_STATE', pageState);
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+    store.dispatch('CORE_SET_ERROR', null);
+  }, (error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+  });
 }
 
 
@@ -318,10 +321,10 @@ function showLearnContent(store, channelId, id) {
   cookiejs.set('currentChannel', channelId);
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
-  const channelPromise = _getChannelList();
+  showChannelList(store);
 
-  ConditionalPromise.all([attributesPromise, recommendedPromise, channelPromise])
-    .only(checkSamePageId(store), ([attributes, recommended, channelList]) => {
+  ConditionalPromise.all([attributesPromise, recommendedPromise])
+    .only(checkSamePageId(store), ([attributes, recommended]) => {
       const pageState = {
         content: _contentState(attributes),
         recommended: recommended.map(_contentState),
@@ -329,7 +332,6 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('SET_CHANNEL_LIST', channelList);
     }, (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -41,7 +41,7 @@
       },
       contents: {
         type: Array,
-        default: [],
+        default: () => [],
       },
       nCollapsed: {
         type: Number,


### PR DESCRIPTION
## Summary

Fixes https://trello.com/c/pzL3p3Ga/531-invalid-url-under-explore-does-not-an-throw-error and https://trello.com/c/luwo6lYT/541-gracefully-handle-out-of-date-channels and https://trello.com/c/qyEV8zko/538-optimize-loading-order

Pulls out the Channel List setting logic for actions into a separate function that gets called in every action that uses it. Also doesn't wait on anything else to resolve so that the Channel list is always available to the user.

Separately resolves the content metadata loading and recommendation loading promises for learn content page, so that they can load and be set independently.

Adds a `try... except` block to the learn page view, so that if we're missing a content DB or something else goes awry in the database lookup for bootstrapped data, we can still render the page.