### PR TITLE
Self contained plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,4 +37,4 @@ Added
 Changed
 ^^^^^^^
 
- - Nothing so far
+ - Webpack build process now compatible with plugins housed outside the kolibri directory.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,12 @@ recursive-include kolibri/utils *
 recursive-include kolibri/tasks *
 recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
-recursive-include kolibri/core/build/ *
+recursive-include kolibri/*/build/ *.json
+recursive-include kolibri/plugins/*/build *.json
+
+recursive-exclude kolibri/core/assets *
+recursive-exclude kolibri/plugins/*/assets *
+recursive-exclude kolibri/plugins/*/node_modules *
+
 recursive-exclude kolibri/dist *pyc
 prune kolibri/dist/*/__pycache___

--- a/docs/dev/frontend.rst
+++ b/docs/dev/frontend.rst
@@ -209,3 +209,7 @@ We distinguish development dependencies from runtime dependencies, and these sho
 Note that we currently don't have a way of mapping dependencies to plugins - dependencies are installed globally.
 
 To assist in tracking the source of bloat in our codebase, the command ``npm run bundle-stats`` is available to give a full readout of the size that uglified packages take up in the final Javascript code.
+
+Individual plugins can also have their own package.json for their own dependencies. Running ``npm install`` will also install all the dependencies for each activated plugin (inside a node_modules folder inside the plugin itself). These dependencies will only be available to that plugin at build time.
+
+In addition, a plugin can have its own webpack.config.js for plugin specific webpack configuration (loaders, plugins, etc.). These options will be merged with the base options using ``webpack-merge``.

--- a/frontend_build/src/install_dependencies.js
+++ b/frontend_build/src/install_dependencies.js
@@ -1,0 +1,20 @@
+var recursiveInstall = require('recursive-install');
+var readWebpackJson = require('./read_webpack_json');
+var path = require('path');
+var fs = require('fs');
+
+var plugins = readWebpackJson();
+
+plugins.map(function(plugin) {
+  var packageJson = path.join(plugin.plugin_path, 'package.json');
+  try {
+    fs.lstatSync(packageJson);
+    return recursiveInstall.npmInstall(plugin.plugin_path);
+  } catch (e) {
+    return {
+      exitCode: 0
+    };
+  }
+}).reduce(function (code, result) {
+    return result.exitCode > code ? result.exitCode : code
+  }, 0);

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -70,7 +70,14 @@ var parseBundlePlugin = function(data, base_dir) {
     library = data.core_name;
   }
 
-  bundle.resolve.root = [base_dir, path.join(data.plugin_path, 'node_modules')];
+  // Add local resolution paths
+  bundle.resolve.root = [path.join(data.plugin_path, 'node_modules'), base_dir, path.join(base_dir, 'node_modules')];
+  // Add local and global resolution paths for loaders to allow any plugin to
+  // access kolibri/node_modules loaders during bundling.
+  bundle["resolveLoader"] = {
+    root: [path.join(data.plugin_path, 'node_modules'), base_dir, path.join(base_dir, 'node_modules')]
+  };
+
   bundle.plugins = bundle.plugins.concat([
     // BundleTracker creates stats about our built files which we can then pass to Django to allow our template
     // tags to load the correct frontend files.

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -13,6 +13,7 @@ var webpack = require('webpack');
 var base_config = require('./webpack.config.base');
 var _ = require('lodash');
 var extract$trs = require('./extract_$trs');
+var merge = require('webpack-merge');
 
 /**
  * Turn an object containing the vital information for a frontend plugin and return a bundle configuration for webpack.
@@ -46,6 +47,16 @@ var parseBundlePlugin = function(data, base_dir) {
   var bundle = _.cloneDeep(base_config);
   var external;
   var library;
+
+  var local_config;
+
+  try {
+    local_config = require(path.join(data.plugin_path, 'webpack.config.js'));
+  } catch (e) {
+    local_config = {};
+  }
+
+  bundle = merge.smart(bundle, local_config);
 
   // This might be non-standard use of the entry option? It seems to
   // interact with read_bundle_plugins.js

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -82,7 +82,7 @@ var parseBundlePlugin = function(data, base_dir) {
   bundle.name = data.name;
   bundle.context = base_dir;
   bundle.output = {
-    path: path.relative(base_dir, path.join(data.static_dir, data.name)),
+    path: path.join(data.static_dir, data.name),
     filename: "[name]-[hash].js",
     publicPath: path.join("/", data.static_url_root, data.name, "/"),
     library: library

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -61,7 +61,7 @@ var parseBundlePlugin = function(data, base_dir) {
   // This might be non-standard use of the entry option? It seems to
   // interact with read_bundle_plugins.js
   bundle.entry = {}
-  bundle.entry[data.name] = data.src_file;
+  bundle.entry[data.name] = path.join(data.plugin_path, data.src_file);
 
   if (typeof data.external !== "undefined" && data.external && data.core_name) {
     // If we want to create a plugin that can be directly referenced by other plugins, this sets it to be

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -35,7 +35,8 @@ var parseBundlePlugin = function(data, base_dir) {
       (typeof data.static_dir === "undefined") ||
       (typeof data.static_url_root === "undefined") ||
       (typeof data.stats_file === "undefined") ||
-      (typeof data.locale_data_folder === "undefined")) {
+      (typeof data.locale_data_folder === "undefined") ||
+      (typeof data.plugin_path === "undefined")) {
     logging.error(data.name + ' plugin is misconfigured, missing parameter(s)');
     return;
   }
@@ -58,7 +59,7 @@ var parseBundlePlugin = function(data, base_dir) {
     library = data.core_name;
   }
 
-  bundle.resolve.root = base_dir;
+  bundle.resolve.root = [base_dir, path.join(data.plugin_path, 'node_modules')];
   bundle.plugins = bundle.plugins.concat([
     // BundleTracker creates stats about our built files which we can then pass to Django to allow our template
     // tags to load the correct frontend files.

--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -1,0 +1,23 @@
+var temp = require('temp').track();
+var fs = require("fs");
+var execSync = require('child_process').execSync;
+
+module.exports = function () {
+  // the temporary path where the webpack_json json is stored
+  var webpack_json_tempfile = temp.openSync({suffix: '.json'}).path;
+
+  // Run the script below to extract the relevant information about the plugin configuration from the Python code.
+  execSync("python -m kolibri manage webpack_json -- --outputfile " + webpack_json_tempfile);
+
+  var result = fs.readFileSync(webpack_json_tempfile);
+
+  temp.cleanupSync();           // cleanup the tempfile immediately!
+
+  if (result.length > 0) {
+    // The above script prints JSON to stdout, here we parse that JSON and use it as input to our webpack
+    // configuration builder module, parseBundlePlugin.
+    return JSON.parse(result);
+  }
+
+  return [];
+};

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -86,11 +86,6 @@ var config = {
       {
         test: /fg-loadcss\/src\/onloadCSS/,
         loader: 'exports?onloadCSS'
-      },
-      // Allows <video> and <audio> HTML5 tags work on all major browsers.
-      {
-        test: require.resolve('html5media/dist/api/1.1.8/html5media'),
-        loader: "imports?this=>window"
       }
     ]
   },

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -12,9 +12,23 @@
  *  and used as a template, with additional plugin-specific
  *  modifications made on top.
  */
+var path = require('path');
+
+/*
+ * This is a filthy hack. Do as I say, not as I do.
+ * Taken from: https://gist.github.com/branneman/8048520#6-the-hack
+ * This forces the NODE_PATH environment variable to include the main
+ * kolibri node_modules folder, so that even plugins being built outside
+ * of the kolibri folder will have access to all installed loaders, etc.
+ * Doing it here, rather than at command invocation, allows us to do this
+ * in a cross platform way, and also to avoid having to prepend it to all
+ * our commands that end up invoking webpack.
+ */
+
+process.env.NODE_PATH = path.resolve(path.join(__dirname, '..', '..', 'node_modules'));
+require('module').Module._initPaths();
 
 var fs = require('fs');
-var path = require('path');
 var webpack = require('webpack');
 var jeet = require('jeet');
 var autoprefixer = require('autoprefixer');
@@ -45,8 +59,12 @@ var config = {
         loader: 'babel',
         exclude: /node_modules/,
         query: {
-          presets: ['es2015-ie'],
-          plugins: ['transform-runtime']
+          // Babel loader ignores Webpack config options
+          // So we pass a module reference rather than a path here
+          // to ensure that they get properly resolved when building happens
+          // outside of the kolibri base path.
+          presets: [require.resolve('babel-preset-es2015-ie')],
+          plugins: [require.resolve('babel-plugin-transform-runtime')]
         },
       },
       {

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -144,9 +144,8 @@ describe('readBundlePlugins', function() {
   var data = [];
 
   beforeEach(function() {
-    readBundlePlugins.__set__("execSync", function() {});
-    readBundlePlugins.__set__("fs.readFileSync", function() {
-      return JSON.stringify(data);
+    readBundlePlugins.__set__("readWebpackJson", function() {
+      return data;
     });
   });
 

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -13,7 +13,8 @@ describe('parseBundlePlugin', function() {
         stats_file: "output.json",
         static_url_root: "static",
         static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/")[0] !== "undefined");
       done();
@@ -26,7 +27,8 @@ describe('parseBundlePlugin', function() {
         stats_file: "output.json",
         static_url_root: "static",
         static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
@@ -39,7 +41,8 @@ describe('parseBundlePlugin', function() {
         stats_file: "output.json",
         static_url_root: "static",
         static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
@@ -52,7 +55,8 @@ describe('parseBundlePlugin', function() {
         src_file: "src/file.js",
         static_url_root: "static",
         static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
@@ -65,7 +69,8 @@ describe('parseBundlePlugin', function() {
         src_file: "src/file.js",
         static_url_root: "static",
         stats_file: "output.json",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
@@ -78,7 +83,22 @@ describe('parseBundlePlugin', function() {
         src_file: "src/file.js",
         static_url_root: "static",
         stats_file: "output.json",
-        static_dir: "kolibri/plugin/test"
+        static_dir: "kolibri/plugin/test",
+        plugin_path: "kolibri/plugin"
+      };
+      assert(typeof parseBundlePlugin(data, "/") === "undefined");
+      done();
+    });
+  });
+  describe('input is missing plugin_path, bundles output', function() {
+    it('should be undefined', function (done) {
+      var data = {
+        name: "kolibri.plugin.test.test_plugin",
+        src_file: "src/file.js",
+        static_url_root: "static",
+        stats_file: "output.json",
+        static_dir: "kolibri/plugin/test",
+        locale_data_folder: "kolibri/locale/test"
       };
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
@@ -94,7 +114,8 @@ describe('parseBundlePlugin', function() {
         static_dir: "kolibri/plugin/test",
         static_url_root: "static",
         core_name: "test_core",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert(typeof parseBundlePlugin(data, "/")[1] !== "undefined");
       done();
@@ -110,7 +131,8 @@ describe('parseBundlePlugin', function() {
         stats_file: "output.json",
         static_url_root: "static",
         static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
+        locale_data_folder: "kolibri/locale/test",
+        plugin_path: "kolibri/plugin"
       };
       assert.equal(parseBundlePlugin(data, "/")[0].output.library, "kolibriGlobal");
       done();
@@ -137,7 +159,8 @@ describe('readBundlePlugins', function() {
           stats_file: "output.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         },
         {
           name: "kolibri.plugin.test.test_plugin1",
@@ -145,7 +168,8 @@ describe('readBundlePlugins', function() {
           stats_file: "output1.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         }
       ];
       assert(readBundlePlugins("", "").length === 2);
@@ -160,7 +184,8 @@ describe('readBundlePlugins', function() {
           stats_file: "output.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         },
         {
           name: "kolibri.plugin.test.test_plugin1",
@@ -168,7 +193,8 @@ describe('readBundlePlugins', function() {
           stats_file: "output1.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         }
       ];
       assert(readBundlePlugins("", "").length === 1);
@@ -183,14 +209,16 @@ describe('readBundlePlugins', function() {
           stats_file: "output.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         },
         {
           name: "kolibri.plugin.test.test_plugin1",
           stats_file: "output1.json",
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         }
       ];
       assert(readBundlePlugins("", "").length === 0);
@@ -208,7 +236,8 @@ describe('readBundlePlugins', function() {
           static_dir: "kolibri/plugin/test",
           static_url_root: "static",
           core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         },
         {
           name: "kolibri.plugin.test.test_plugin1",
@@ -217,7 +246,8 @@ describe('readBundlePlugins', function() {
           external: true,
           static_url_root: "static",
           static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         }
       ];
       assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
@@ -235,7 +265,8 @@ describe('readBundlePlugins', function() {
           static_dir: "kolibri/plugin/test",
           static_url_root: "static",
           core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         },
         {
           name: "kolibri.plugin.test.test_plugin",
@@ -245,7 +276,8 @@ describe('readBundlePlugins', function() {
           static_dir: "kolibri/plugin/test",
           static_url_root: "static",
           core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test"
+          locale_data_folder: "kolibri/locale/test",
+          plugin_path: "kolibri/plugin"
         }
       ];
       assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -12,11 +12,10 @@ class KolibriCore(KolibriPluginBase):
     pass
 
 
-class FrontEndCoreAssetHook(FrontEndCoreAssetHook):
+class FrontEndCoreAppAssetHook(FrontEndCoreAssetHook):
     unique_slug = "default_frontend"
     src_file = "kolibri/core/assets/src/core-app"
-    static_dir = "kolibri/core/static"
 
 
 class FrontEndCoreInclusionHook(FrontEndCoreHook):
-    bundle_class = FrontEndCoreAssetHook
+    bundle_class = FrontEndCoreAppAssetHook

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -14,7 +14,7 @@ class KolibriCore(KolibriPluginBase):
 
 class FrontEndCoreAppAssetHook(FrontEndCoreAssetHook):
     unique_slug = "default_frontend"
-    src_file = "kolibri/core/assets/src/core-app"
+    src_file = "assets/src/core-app"
 
 
 class FrontEndCoreInclusionHook(FrontEndCoreHook):

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -49,9 +49,6 @@ class WebpackBundleHook(hooks.KolibriHook):
     # : For instance: "kolibri/core/assets/src/kolibri_core_app.js"
     src_file = ""
 
-    # : The static directory where you want stuff to be written to
-    static_dir = "kolibri/core/static"
-
     # : A list of events to listen to
     events = {}
 
@@ -156,12 +153,20 @@ class WebpackBundleHook(hooks.KolibriHook):
         }
 
     @property
+    def module_path(self):
+        return '.'.join(self.__module__.split('.')[:-1])
+
+    @property
     def build_path(self):
         """
         An auto-generated path to where the build-time files are stored,
         containing information about the built bundles.
         """
-        return resource_filename('kolibri.core', 'build')
+        return resource_filename(self.module_path, 'build')
+
+    @property
+    def static_dir(self):
+        return resource_filename(self.module_path, 'static')
 
     @property
     def stats_file(self):

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -101,7 +101,7 @@ class WebpackBundleHook(hooks.KolibriHook):
             if stats['status'] == 'error':
                 raise WebpackError('Webpack compilation has errored')
         return {
-            "files": stats["chunks"][self.unique_slug]
+            "files": stats.get("chunks", {}).get(self.unique_slug, [])
         }
 
     @property
@@ -172,9 +172,6 @@ class WebpackBundleHook(hooks.KolibriHook):
     @property
     def stats_file(self):
         """
-        TODO: Do we want to rely on a generated stats file? It will have to be
-        read for every bundle, every time stuff is loaded.
-
         An auto-generated path to where the build-time files are stored,
         containing information about the built bundles.
         """

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -145,6 +145,7 @@ class WebpackBundleHook(hooks.KolibriHook):
             "name": self.unique_slug,
             "src_file": self.src_file,
             "static_dir": self.static_dir,
+            "plugin_path": os.path.dirname(self.build_path),
             "stats_file": self.stats_file,
             "events": self.events,
             "once": self.once,

--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -302,7 +302,7 @@
   /* hides popup label on slider */
   input[type=range]::-ms-tooltip
     display: none
-    
+
   @media screen and (max-width: $medium-breakpoint + 1)
     #play-and-time
       input

--- a/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
+++ b/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
@@ -11,7 +11,7 @@ class AudioMP3RenderPlugin(KolibriPluginBase):
 
 class AudioMP3RenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "audio_mp3_render_module"
-    src_file = "kolibri/plugins/audio_mp3_render/assets/src/module.js"
+    src_file = "assets/src/module.js"
     events = {
         "content_render:audio/mp3": "render"
     }

--- a/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
+++ b/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
@@ -12,7 +12,6 @@ class AudioMP3RenderPlugin(KolibriPluginBase):
 class AudioMP3RenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "audio_mp3_render_module"
     src_file = "kolibri/plugins/audio_mp3_render/assets/src/module.js"
-    static_dir = "kolibri/plugins/audio_mp3_render/static"
     events = {
         "content_render:audio/mp3": "render"
     }

--- a/kolibri/plugins/audio_mp3_render/package.json
+++ b/kolibri/plugins/audio_mp3_render/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "kolibri-audio-mp3-render-plugin",
+  "description": "Audio/MP3 Render Plugin for Kolibri",
+  "private": true,
+  "dependencies": {
+    "html5media": "1.1.8"
+  }
+}

--- a/kolibri/plugins/audio_mp3_render/webpack.config.js
+++ b/kolibri/plugins/audio_mp3_render/webpack.config.js
@@ -1,0 +1,16 @@
+/*
+ * This file defines additional webpack configuration for this plugin.
+ * It will be bundled into the webpack configuration at build time.
+ */
+
+module.exports = {
+  module: {
+    loaders: [
+      // Allows <video> and <audio> HTML5 tags work on all major browsers.
+      {
+        test: require.resolve('html5media/dist/api/1.1.8/html5media'),
+        loader: "imports?this=>window"
+      }
+    ]
+  }
+};

--- a/kolibri/plugins/document_pdf_render/kolibri_plugin.py
+++ b/kolibri/plugins/document_pdf_render/kolibri_plugin.py
@@ -11,7 +11,7 @@ class DocumentPDFRenderPlugin(KolibriPluginBase):
 
 class DocumentPDFRenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "document_pdf_render_module"
-    src_file = "kolibri/plugins/document_pdf_render/assets/src/module.js"
+    src_file = "assets/src/module.js"
     events = {
         "content_render:document/pdf": "render"
     }

--- a/kolibri/plugins/document_pdf_render/kolibri_plugin.py
+++ b/kolibri/plugins/document_pdf_render/kolibri_plugin.py
@@ -12,7 +12,6 @@ class DocumentPDFRenderPlugin(KolibriPluginBase):
 class DocumentPDFRenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "document_pdf_render_module"
     src_file = "kolibri/plugins/document_pdf_render/assets/src/module.js"
-    static_dir = "kolibri/plugins/document_pdf_render/static"
     events = {
         "content_render:document/pdf": "render"
     }

--- a/kolibri/plugins/document_pdf_render/package.json
+++ b/kolibri/plugins/document_pdf_render/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "kolibri-document-pdf-render-plugin",
+  "description": "Document/PDF Render Plugin for Kolibri",
+  "private": true,
+  "dependencies": {
+    "pdfobject": "2.0.201604172"
+  }
+}

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -16,7 +16,7 @@ class LearnPlugin(KolibriPluginBase):
 
 class LearnAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "learn_module"
-    src_file = "kolibri/plugins/learn/assets/src/app.js"
+    src_file = "assets/src/app.js"
 
 
 class LearnInclusionHook(hooks.LearnSyncHook):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -17,7 +17,6 @@ class LearnPlugin(KolibriPluginBase):
 class LearnAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "learn_module"
     src_file = "kolibri/plugins/learn/assets/src/app.js"
-    static_dir = "kolibri/plugins/learn/static"
 
 
 class LearnInclusionHook(hooks.LearnSyncHook):

--- a/kolibri/plugins/management/kolibri_plugin.py
+++ b/kolibri/plugins/management/kolibri_plugin.py
@@ -19,7 +19,6 @@ class ManagementPlugin(KolibriPluginBase):
 class ManagementAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "management_module"
     src_file = "kolibri/plugins/management/assets/src/app.js"
-    static_dir = "kolibri/plugins/management/static"
 
 
 class ManagementInclusionHook(hooks.ManagementSyncHook):

--- a/kolibri/plugins/management/kolibri_plugin.py
+++ b/kolibri/plugins/management/kolibri_plugin.py
@@ -18,7 +18,7 @@ class ManagementPlugin(KolibriPluginBase):
 
 class ManagementAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "management_module"
-    src_file = "kolibri/plugins/management/assets/src/app.js"
+    src_file = "assets/src/app.js"
 
 
 class ManagementInclusionHook(hooks.ManagementSyncHook):

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -16,7 +16,7 @@ class SetupWizardPlugin(KolibriPluginBase):
 
 class SetupWizardAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "setup_wizard"
-    src_file = "kolibri/plugins/setup_wizard/assets/src/app.js"
+    src_file = "assets/src/app.js"
 
 
 class SetupWizardInclusionHook(hooks.SetupWizardSyncHook):

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -17,7 +17,6 @@ class SetupWizardPlugin(KolibriPluginBase):
 class SetupWizardAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "setup_wizard"
     src_file = "kolibri/plugins/setup_wizard/assets/src/app.js"
-    static_dir = "kolibri/plugins/setup_wizard/static"
 
 
 class SetupWizardInclusionHook(hooks.SetupWizardSyncHook):

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -231,7 +231,7 @@
 
   // Default videojs stylesheet
   // Unable to reference the videojs using require since videojs doesn't have good webpack support
-  @import '../../../../../../node_modules/video.js/dist/video-js.css'
+  @import '../../../node_modules/video.js/dist/video-js.css'
 
   // Videojs skin customization
   .video-js

--- a/kolibri/plugins/video_mp4_render/kolibri_plugin.py
+++ b/kolibri/plugins/video_mp4_render/kolibri_plugin.py
@@ -11,7 +11,7 @@ class VideoMP4RenderPlugin(KolibriPluginBase):
 
 class VideoMP4RenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "video_mp4_render_module"
-    src_file = "kolibri/plugins/video_mp4_render/assets/src/module.js"
+    src_file = "assets/src/module.js"
     events = {
         "content_render:video/mp4": "render"
     }

--- a/kolibri/plugins/video_mp4_render/kolibri_plugin.py
+++ b/kolibri/plugins/video_mp4_render/kolibri_plugin.py
@@ -12,7 +12,6 @@ class VideoMP4RenderPlugin(KolibriPluginBase):
 class VideoMP4RenderAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "video_mp4_render_module"
     src_file = "kolibri/plugins/video_mp4_render/assets/src/module.js"
-    static_dir = "kolibri/plugins/video_mp4_render/static"
     events = {
         "content_render:video/mp4": "render"
     }

--- a/kolibri/plugins/video_mp4_render/package.json
+++ b/kolibri/plugins/video_mp4_render/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "kolibri-video-mp4-render-plugin",
+  "description": "Video/MP4 Render Plugin for Kolibri",
+  "private": true,
+  "dependencies": {
+    "video.js": "5.10.8"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "webpack --config ./frontend_build/src/webpack.config.prod.js",
     "watch": "webpack --config ./frontend_build/src/webpack.config.dev.js --watch --progress",
     "test-karma:watch": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.js",
-    "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer"
+    "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer",
+    "plugin-install": "node ./frontend_build/src/install_dependencies.js"
   },
   "repository": {
     "type": "git",
@@ -31,10 +32,8 @@
     "js-cookie": "2.1.2",
     "loglevel": "1.4.1",
     "normalize.css": "4.2.0",
-    "pdfobject": "2.0.201604172",
     "rest": "1.3.2",
     "scriptjs": "2.5.8",
-    "video.js": "5.10.8",
     "vue": "1.0.26",
     "vue-focus": "0.1.1",
     "vue-scroll": "1.0.3",
@@ -86,6 +85,7 @@
     "phantomjs-polyfill-find": "ptim/phantomjs-polyfill-find",
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.9.1",
+    "recursive-install": "https://github.com/learningequality/recursive-install.git",
     "rewire": "2.5.2",
     "rewire-webpack": "1.0.1",
     "sinon": "2.0.0-pre.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch": "webpack --config ./frontend_build/src/webpack.config.dev.js --watch --progress",
     "test-karma:watch": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.js",
     "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer",
-    "plugin-install": "node ./frontend_build/src/install_dependencies.js"
+    "install": "node ./frontend_build/src/install_dependencies.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "private": true,
   "dependencies": {
     "babel-runtime": "6.9.2",
-    "html5media": "1.1.8",
     "intl": "1.2.4",
     "js-cookie": "2.1.2",
     "loglevel": "1.4.1",
@@ -108,7 +107,7 @@
     "webpack-bundle-tracker": "0.0.93",
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.12.1",
-    "webpack-merge": "0.8.4"
+    "webpack-merge": "0.14.1"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "phantomjs-polyfill-find": "ptim/phantomjs-polyfill-find",
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.9.1",
-    "recursive-install": "https://github.com/learningequality/recursive-install.git",
+    "recursive-install": "1.2.0",
     "rewire": "2.5.2",
     "rewire-webpack": "1.0.1",
     "sinon": "2.0.0-pre.2",


### PR DESCRIPTION
## Summary

Allows plugins to have their own package.json, and webpack.config.js - to allow for all plugin specific configuration and dependencies to be bundled into the plugin only.

Note: this *does* also allow for the building and use of plugins with frontend code that reside outside of the main Kolibri folder, and allow for plugins to be pip installed!

## TODO

- [X] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file
- [x] Add an entry to CHANGELOG.rst

## Reviewer guidance

Adds a new command to install dependencies in plugins.

Reconfigures all the renderer plugins to use the new system.

To test, run and build as usual!

This should not be merged until after we have branched for the MVP, but I wanted to get feedback on it, so we can merge it pretty swiftly, so this can be used in developing the Perseus Exercise renderer plugin.

## Issues addressed

Fixes #193 

## Documentation

https://github.com/rtibbles/kolibri/blob/8bf0aed36cb5d7d6b5d3eb84bb3b08f388522c01/docs/dev/frontend.rst