### PR TITLE
Reassigning role and label to proper modal container

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/modal/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/modal/index.vue
@@ -9,14 +9,18 @@
     @keydown.esc="closeModal"
     @click="bgClick($event)"
     v-el:modal-overlay
-    id="modal-window"
-    role="dialog"
-    aria-labelledby="modal-title">
+    id="modal-window">
 
-    <div class="modal" v-el:modal :tabindex="0" transition="modal">
+    <div class="modal"
+      v-el:modal
+      :tabindex="0"
+      transition="modal"
+      role="dialog"
+      aria-labelledby="modal-title">
+      
       <!-- Close Button -->
-      <button aria-label="close" @click="closeModal" class="btn-close">
-        <svg src="../icons/close.svg"></svg>
+      <button aria-label="Close dialog window" @click="closeModal" class="btn-close">
+        <svg src="../icons/close.svg" role="presentation"></svg>
       </button>
 
       <!-- Modal Title -->


### PR DESCRIPTION
## Summary

`role="dialog"` & `aria-labelledby="modal-title"` were assigned to overlay and not to the modal itself:

![kolibri - chromium_018](https://cloud.githubusercontent.com/assets/1457929/18039254/50c6d47c-6da1-11e6-8458-10eef0826049.png)




