### PR TITLE
Removed line showing up in Firefox.

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/index.vue
@@ -54,7 +54,6 @@
     background: $core-bg-canvas
     z-index: 100
     transition: top 0.2s ease-in-out
-    outline: 1px solid $core-bg-canvas // prevent box outline flicking on Chrome
 
   .toolbar-hide
     position: fixed


### PR DESCRIPTION
## Summary

* Removed line showing up in Firefox.
* https://trello.com/c/NuwvHqML/456-random-white-line-striking-through-content-title-on-a-smaller-screen-on-firefox

## Screenshots

### Before
![image](https://cloud.githubusercontent.com/assets/7193975/18100320/46413b2e-6e9f-11e6-9480-45af815aedca.png)

### After
![image](https://cloud.githubusercontent.com/assets/7193975/18100301/35d9f852-6e9f-11e6-8744-39ddb03c7c7f.png)