### PR TITLE
Build and upload our docs catalog files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,11 @@ dist: staticdeps assets compilemessages
 	pex . --disable-cache -o dist/`python setup.py --fullname`.pex -m kolibri --python-shebang=/usr/bin/python
 	ls -l dist
 
-makemessages: assets
+makedocsmessages:
+	make -C docs/ gettext
+	cd docs && sphinx-intl update -p _build/locale -l en
+
+makemessages: assets makedocsmessages
 	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*' --ignore 'docs/conf.py'
 
 compilemessages:

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -8,3 +8,6 @@ files:
 
   - source: '/kolibri/locale/en/LC_MESSAGES/*.po'
     translation: '/kolibri/locale/%locale_with_underscore%/LC_MESSAGES/%original_file_name%'
+
+  - source: '/kolibri/locale/docs/en/LC_MESSAGES/*.po'
+    translation: '/kolibri/locale/docs/%locale_with_underscore%/LC_MESSAGES/%original_file_name%'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -335,4 +335,6 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 # Use Django's LOCALE_PATHS config as the target destinations for built po files
-locale_dirs = django.conf.settings.LOCALE_PATHS
+locale_dirs = [
+    os.path.join(django.conf.settings.KOLIBRI_MODULE_PATH, "locale", "docs"),
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -333,3 +333,6 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+# Use Django's LOCALE_PATHS config as the target destinations for built po files
+locale_dirs = django.conf.settings.LOCALE_PATHS

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,6 +2,7 @@
 # This does not depend on runtime stuff so we do not
 # include base.txt
 sphinx
+sphinx-intl
 sphinx-rtd-theme
 pex
 wheel


### PR DESCRIPTION
When we run `make makemessages`, not only do we build and upload interface strings, we now also include docs po files as well.
