### PR TITLE
unstyled content import/export UI

### DIFF
--- a/kolibri/content/utils/channels.py
+++ b/kolibri/content/utils/channels.py
@@ -14,11 +14,18 @@ def get_channel_ids_for_content_database_dir(content_database_dir):
     """
     Returns a list of channel IDs for the channel databases that exist in a content database directory.
     """
+
+    # immediately return an empty list if the content database directory doesn't exist
+    if not os.path.isdir(content_database_dir):
+        return []
+
+    # get a list of all the database files in the directory, and extract IDs
     db_list = fnmatch.filter(os.listdir(content_database_dir), '*.sqlite3')
     db_names = [db.split('.sqlite3', 1)[0] for db in db_list]
+
+    # determine which database names are valid, and only use those ones
     valid_db_names = [name for name in db_names if is_valid_uuid(name)]
     invalid_db_names = set(db_names) - set(valid_db_names)
-
     if invalid_db_names:
         logging.warning("Ignoring databases in content database directory '{directory}' with invalid names: {names}"
                         .format(directory=content_database_dir, names=invalid_db_names))
@@ -65,5 +72,5 @@ def get_channels_for_data_folder(datafolder):
 def get_mounted_drives_with_channel_info():
     drives = enumerate_mounted_disk_partitions()
     for drive in drives.values():
-        drive.metadata["channels"] = get_channels_for_data_folder(drive.data_folder) if drive.datafolder else []
+        drive.metadata["channels"] = get_channels_for_data_folder(drive.datafolder) if drive.datafolder else []
     return drives

--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -25,6 +25,12 @@ class TaskResource extends Resource {
     return this.client(clientObj);
   }
 
+// TODO: switch to Model.delete()
+  clearTask(taskId) {
+    const clientObj = { path: this.clearTaskUrl(), entity: { id: taskId } };
+    return this.client(clientObj);
+  }
+
   get localExportUrl() {
     return this.urls[`${this.name}_startlocalexportchannel`]; // not yet implemented in api
   }
@@ -36,6 +42,9 @@ class TaskResource extends Resource {
   }
   get localDriveUrl() {
     return this.urls[`${this.name}_localdrive`];
+  }
+  get clearTaskUrl() {
+    return this.urls[`${this.name}_cleartask`];
   }
 }
 

--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -16,7 +16,7 @@ class TaskResource extends Resource {
   }
 
   remoteImportContent(channelId) {
-    const clientObj = { path: this.remoteImportUrl(), entity: { id: channelId } };
+    const clientObj = { path: this.remoteImportUrl(), entity: { channel_id: channelId } };
     return this.client(clientObj);
   }
 

--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -6,12 +6,12 @@ class TaskResource extends Resource {
   }
 
   localExportContent(driveId) {
-    const clientObj = { path: this.localExportUrl(), entity: { id: driveId } };
+    const clientObj = { path: this.localExportUrl(), entity: { drive_id: driveId } };
     return this.client(clientObj);
   }
 
   localImportContent(driveId) {
-    const clientObj = { path: this.localImportUrl(), entity: { id: driveId } };
+    const clientObj = { path: this.localImportUrl(), entity: { drive_id: driveId } };
     return this.client(clientObj);
   }
 
@@ -20,8 +20,8 @@ class TaskResource extends Resource {
     return this.client(clientObj);
   }
 
-  localDrive() {
-    const clientObj = { path: this.localDriveUrl() };
+  localDrives() {
+    const clientObj = { path: this.localDrivesUrl() };
     return this.client(clientObj);
   }
 
@@ -32,15 +32,15 @@ class TaskResource extends Resource {
   }
 
   get localExportUrl() {
-    return this.urls[`${this.name}_startlocalexportchannel`]; // not yet implemented in api
+    return this.urls[`${this.name}_startlocalexport`];
   }
   get localImportUrl() {
-    return this.urls[`${this.name}_startlocalimportchannel`];
+    return this.urls[`${this.name}_startlocalimport`];
   }
   get remoteImportUrl() {
     return this.urls[`${this.name}_startremoteimport`];
   }
-  get localDriveUrl() {
+  get localDrivesUrl() {
     return this.urls[`${this.name}_localdrive`];
   }
   get clearTaskUrl() {

--- a/kolibri/core/assets/src/vue/loading-spinner/index.vue
+++ b/kolibri/core/assets/src/vue/loading-spinner/index.vue
@@ -18,9 +18,13 @@
 
 <style lang="stylus" scoped>
 
+  $size = 125px
+
   .loading-spinner-wrapper
     width: 100%
     height: 100%
+    min-width: $size
+    min-height: $size
     position: relative
     opacity: 0
     animation-duration: 0s
@@ -35,8 +39,8 @@
       opacity: 1
 
   .loading-spinner
-    width: 125px
-    height: 125px
+    width: $size
+    height: $size
     position: absolute
     top: 50%
     left: 50%

--- a/kolibri/core/discovery/utils/filesystem/__init__.py
+++ b/kolibri/core/discovery/utils/filesystem/__init__.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import sys
@@ -30,7 +31,7 @@ DriveData = namedtuple(
 def enumerate_mounted_disk_partitions():
     """
     Searches the local device for attached partitions/drives, and computes metadata about each one.
-    Returns a dict that maps mount paths to DriveData objects containing metadata about each drive.
+    Returns a dict that maps drive IDs to DriveData objects containing metadata about each drive.
     Note that drives for which the current user does not have read permissions are not included.
     """
 
@@ -44,13 +45,14 @@ def enumerate_mounted_disk_partitions():
     for drive in drive_list:
 
         path = drive["path"]
+        drive_id = hashlib.sha1(drive["guid"] or path).hexdigest()[:32]
 
-        drives[path] = DriveData(
-            id=drive["guid"] or path,
+        drives[drive_id] = DriveData(
+            id=drive_id,
             path=path,
             name=drive["name"],
             writable=os.access(path, os.W_OK),
-            datafolder=find_kolibri_data_folder(path),
+            datafolder=get_kolibri_data_folder_path(path),
             freespace=drive["freespace"],
             totalspace=drive["totalspace"],
             filesystem=drive["filesystem"],
@@ -61,18 +63,13 @@ def enumerate_mounted_disk_partitions():
     return drives
 
 
-def find_kolibri_data_folder(folder):
+def get_kolibri_data_folder_path(folder):
     """
-    Looks for a folder with name matching EXPORT_FOLDER_NAME underneath the provided folder path.
-    If it is found, the full path to the data folder is returned. Otherwise, None is returned.
+    Constructs an export data folder path by concatenating the parent folder
+    to the EXPORT_FOLDER_NAME folder name.
     """
 
-    kolibri_data_dir = os.path.join(
+    return os.path.join(
         folder,
         EXPORT_FOLDER_NAME,
     )
-
-    if os.path.exists(kolibri_data_dir):
-        return kolibri_data_dir
-    else:
-        return None

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -249,12 +249,27 @@ function showContentPage(store) {
   });
 }
 
+function updateWizardLocalDriveList(store) {
+  const localDrivesPromise = TaskResource.localDrives();
+  store.dispatch('SET_CONTENT_PAGE_WIZARD_BUSY', true);
+  localDrivesPromise.then((response) => {
+    store.dispatch('SET_CONTENT_PAGE_WIZARD_BUSY', false);
+    store.dispatch('SET_CONTENT_PAGE_WIZARD_DRIVES', response.entity);
+  })
+  .catch((error) => {
+    store.dispatch('SET_CONTENT_PAGE_WIZARD_BUSY', false);
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+  });
+}
+
 function startImportWizard(store) {
   store.dispatch('SET_CONTENT_PAGE_WIZARD_STATE', {
     shown: true,
     page: ContentWizardPages.CHOOSE_IMPORT_SOURCE,
     error: null,
     busy: false,
+    drivesLoading: false,
+    driveList: null,
   });
 }
 
@@ -264,6 +279,8 @@ function startExportWizard(store) {
     page: ContentWizardPages.EXPORT,
     error: null,
     busy: false,
+    drivesLoading: false,
+    driveList: null,
   });
 }
 
@@ -273,6 +290,8 @@ function showImportNetworkWizard(store) {
     page: ContentWizardPages.IMPORT_NETWORK,
     error: null,
     busy: false,
+    drivesLoading: false,
+    driveList: null,
   });
 }
 
@@ -282,7 +301,10 @@ function showImportLocalWizard(store) {
     page: ContentWizardPages.IMPORT_LOCAL,
     error: null,
     busy: false,
+    drivesLoading: false,
+    driveList: null,
   });
+  updateWizardLocalDriveList(store);
 }
 
 function cancelImportExportWizard(store) {
@@ -290,17 +312,8 @@ function cancelImportExportWizard(store) {
     shown: false,
     error: null,
     busy: false,
-  });
-}
-
-function updateWizardLocalDriveList(store) {
-  const localDrivePromise = TaskResource.localDrive();
-  localDrivePromise.then((response) => {
-    // ### put in wizard state
-    // store.dispatch('SET_LOCAL_DRIVES', response.entity);
-  })
-  .catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    drivesLoading: false,
+    driveList: null,
   });
 }
 

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -282,6 +282,7 @@ function startExportWizard(store) {
     drivesLoading: false,
     driveList: null,
   });
+  updateWizardLocalDriveList(store);
 }
 
 function showImportNetworkWizard(store) {

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -326,20 +326,14 @@ function pollTasksAndChannels(store) {
   );
 }
 
-function deleteTask(store, id) {
-  console.log('NOT IMPLEMENTED');
-  console.log('To clear tasks, from the command-line, run:');
-  console.log(
-    `sqlite3 ~/.kolibri/ormq.sqlite3 'delete from django_q_task; delete from django_q_ormq;'`
-  );
-  // const currentTaskPromise = TaskResource.getModel(id).delete();
-  // currentTaskPromise.then(() => {
-  //   // only 1 task should be running, but we set to empty array
-  //   store.dispatch('SET_CONTENT_PAGE_TASKS', []);
-  // })
-  // .catch((error) => {
-  //   store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-  // });
+function clearTask(store, taskId) {
+  const clearTaskPromise = TaskResource.clearTask(taskId);
+  clearTaskPromise.then(() => {
+    store.dispatch('SET_CONTENT_PAGE_TASKS', []);
+  })
+  .catch((error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+  });
 }
 
 function triggerLocalContentImportTask(store, driveId) {
@@ -408,7 +402,7 @@ module.exports = {
 
   showContentPage,
   pollTasksAndChannels,
-  deleteTask,
+  clearTask,
   startImportWizard,
   startExportWizard,
   showImportNetworkWizard,

--- a/kolibri/plugins/management/assets/src/state/store.js
+++ b/kolibri/plugins/management/assets/src/state/store.js
@@ -68,6 +68,9 @@ const mutations = {
   SET_CONTENT_PAGE_WIZARD_STATE(state, wizardState) {
     state.pageState.wizardState = wizardState;
   },
+  SET_CONTENT_PAGE_WIZARD_DRIVES(state, driveList) {
+    state.pageState.wizardState.driveList = driveList;
+  },
   SET_CONTENT_PAGE_WIZARD_ERROR(state, error) {
     state.pageState.wizardState.error = error;
   },

--- a/kolibri/plugins/management/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/index.vue
@@ -9,9 +9,11 @@
       :id="pageState.taskList[0].id"
     ></task-status>
 
-    <icon-button v-if="!pageState.taskList.length" text="Add Channel" :primary="true" @click="startImportWizard">
-      <svg src="../icons/add.svg"></svg>
-    </icon-button>
+
+    <div>
+      <button @click="startImportWizard">Import</button>
+      <button @click="startExportWizard">Export</button>
+    </div>
 
     <component v-if="pageState.wizardState.shown" :is="wizardComponent"></component>
 
@@ -71,6 +73,7 @@
       },
       actions: {
         startImportWizard: actions.startImportWizard,
+        startExportWizard: actions.startExportWizard,
         pollTasksAndChannels: actions.pollTasksAndChannels,
       },
     },

--- a/kolibri/plugins/management/assets/src/vue/content-page/modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/modal.vue
@@ -2,7 +2,7 @@
 
   <div class="fake-modal" @keyup.esc="cancel" @keyup.enter="submit">
     <div>
-      <button class="back-btn" v-if="showback">Back</button>
+      <button class="back-btn" @click="back" v-if="showback">Back</button>
       <button class="close-btn" @click="cancel" :disabled="noclose">X</button>
     </div>
     <h1 v-if="title">{{ title }}</h1>
@@ -50,7 +50,14 @@
         }
       },
       submit() {
-        this.$emit('submit');
+        if (!this.noclose) {
+          this.$emit('submit');
+        }
+      },
+      back() {
+        if (!this.noclose) {
+          this.$emit('back');
+        }
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
@@ -63,7 +63,7 @@
     },
     methods: {
       clearTask() {
-        this.deleteTask(this.id);
+        this.clearTask(this.id);
       },
     },
     props: {
@@ -86,7 +86,7 @@
     },
     vuex: {
       actions: {
-        deleteTask: actions.deleteTask,
+        clearTask: actions.clearTask,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/wizard-export.vue
@@ -8,19 +8,41 @@
     @submit="submit"
   >
     <div slot="body">
-      <p>Please select a drive to export to:</p>
-      <select>
-        <option value="A">A</option>
-        <option value="B">B</option>
-        <option value="C">C</option>
-      </select>
+
+      <template v-if="!drivesLoading">
+        <p v-if="writableDrives.length === 0">
+          No writable driveswere detected.
+        </p>
+        <p v-if="writableDrives.length === 1">
+          Writable drive detected: {{ writableDrives[0].name }}
+        </p>
+        <template v-if="writableDrives.length > 1">
+          <p>Writable drives detected:</p>
+          <div v-for="(index, drive) in writableDrives">
+            <input
+              type="radio"
+              :id="'drive-'+index"
+              :value="drive.id"
+              v-model="selectedDrive"
+            >
+            <label :for="'drive-'+index">{{drive.name}} {{index}}</label>
+          </div>
+        </template>
+
+        <p v-if="unwritableDrives.length">Note: {{unwritableDrives.length}} additional drives were detected, but don't appear to be writable.</p>
+      </template>
+      <loading-spinner v-else></loading-spinner>
+
+      <button @click="updateWizardLocalDriveList" :disabled="wizardState.busy">
+        Refresh
+      </button>
     </div>
     <div slot="buttons">
       <button @click="cancel" :disabled="wizardState.busy">
         Cancel
       </button>
-      <button @click="submit" :disabled="wizardState.busy">
-        Import
+      <button @click="submit" :disabled="!canSubmit">
+        Export
       </button>
     </div>
   </modal>
@@ -37,8 +59,39 @@
       'modal': require('./modal'),
       'icon-button': require('icon-button'),
     },
+    data: () => ({
+      selectedDrive: undefined, // used when there's more than one option
+    }),
+    computed: {
+      driveToUse() {
+        if (this.writableDrives.length === 1) {
+          return this.writableDrives[0].id;
+        }
+        return this.selectedDrive;
+      },
+      drivesLoading() {
+        return this.wizardState.driveList === null;
+      },
+      writableDrives() {
+        return this.wizardState.driveList.filter(
+          (drive) => drive.writable
+        );
+      },
+      unwritableDrives() {
+        return this.wizardState.driveList.filter(
+          (drive) => !drive.writable
+        );
+      },
+      canSubmit() {
+        if (this.drivesLoading || this.wizardState.busy) {
+          return false;
+        }
+        return Boolean(this.driveToUse);
+      },
+    },
     methods: {
       submit() {
+        this.triggerLocalContentExportTask(this.driveToUse);
       },
       cancel() {
         if (!this.wizardState.busy) {
@@ -51,7 +104,10 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
+        startImportWizard: actions.startImportWizard,
+        updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
         cancelImportExportWizard: actions.cancelImportExportWizard,
+        triggerLocalContentExportTask: actions.triggerLocalContentExportTask,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-local.vue
@@ -4,8 +4,10 @@
     title="Import Channel from a Local Drive"
     :error="wizardState.error"
     :noclose="wizardState.busy"
+    :showback="true"
     @cancel="cancel"
     @submit="submit"
+    @back="startImportWizard"
   >
     <div slot="body">
 
@@ -33,7 +35,7 @@
       </template>
       <loading-spinner v-else></loading-spinner>
 
-      <button @click="refresh" :disabled="wizardState.busy">
+      <button @click="updateWizardLocalDriveList" :disabled="wizardState.busy">
         Refresh
       </button>
     </div>
@@ -90,9 +92,6 @@
       },
     },
     methods: {
-      refresh() {
-        this.updateWizardLocalDriveList();
-      },
       submit() {
         this.triggerLocalContentImportTask(this.driveToUse);
       },
@@ -107,6 +106,7 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
+        startImportWizard: actions.startImportWizard,
         updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
         cancelImportExportWizard: actions.cancelImportExportWizard,
         triggerLocalContentImportTask: actions.triggerLocalContentImportTask,

--- a/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-local.vue
@@ -8,18 +8,40 @@
     @submit="submit"
   >
     <div slot="body">
-      <p>Please select a drive to import from:</p>
-      <select>
-        <option value="A">A</option>
-        <option value="B">B</option>
-        <option value="C">C</option>
-      </select>
+
+      <template v-if="!drivesLoading">
+        <p v-if="drivesWithData.length === 0">
+          No drives with data were detected.
+        </p>
+        <p v-if="drivesWithData.length === 1">
+          Drive detected with data: {{ drivesWithData[0].name }}
+        </p>
+        <template v-if="drivesWithData.length > 1">
+          <p>Drives detected with data:</p>
+          <div v-for="(index, drive) in drivesWithData">
+            <input
+              type="radio"
+              :id="'drive-'+index"
+              :value="drive.id"
+              v-model="selectedDrive"
+            >
+            <label :for="'drive-'+index">{{drive.name}} {{index}}</label>
+          </div>
+        </template>
+
+        <p v-if="drivesWithoutData.length">Note: {{drivesWithoutData.length}} additional drives were detected, but don't appear to have data on them.</p>
+      </template>
+      <loading-spinner v-else></loading-spinner>
+
+      <button @click="refresh" :disabled="wizardState.busy">
+        Refresh
+      </button>
     </div>
     <div slot="buttons">
       <button @click="cancel" :disabled="wizardState.busy">
         Cancel
       </button>
-      <button @click="submit" :disabled="wizardState.busy">
+      <button @click="submit" :disabled="!canSubmit">
         Import
       </button>
     </div>
@@ -37,8 +59,42 @@
       'modal': require('./modal'),
       'icon-button': require('icon-button'),
     },
+    data: () => ({
+      selectedDrive: undefined, // used when there's more than one option
+    }),
+    computed: {
+      driveToUse() {
+        if (this.drivesWithData.length === 1) {
+          return this.drivesWithData[0].id;
+        }
+        return this.selectedDrive;
+      },
+      drivesLoading() {
+        return this.wizardState.driveList === null;
+      },
+      drivesWithData() {
+        return this.wizardState.driveList.filter(
+          (drive) => drive.metadata.channels.length
+        );
+      },
+      drivesWithoutData() {
+        return this.wizardState.driveList.filter(
+          (drive) => !drive.metadata.channels.length
+        );
+      },
+      canSubmit() {
+        if (this.drivesLoading || this.wizardState.busy) {
+          return false;
+        }
+        return Boolean(this.driveToUse);
+      },
+    },
     methods: {
+      refresh() {
+        this.updateWizardLocalDriveList();
+      },
       submit() {
+        this.triggerLocalContentImportTask(this.driveToUse);
       },
       cancel() {
         if (!this.wizardState.busy) {
@@ -51,7 +107,9 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
+        updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
         cancelImportExportWizard: actions.cancelImportExportWizard,
+        triggerLocalContentImportTask: actions.triggerLocalContentImportTask,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-network.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/wizard-import-network.vue
@@ -4,8 +4,10 @@
     title="Import Channel from the Internet"
     :error="wizardState.error"
     :noclose="wizardState.busy"
+    :showback="true"
     @cancel="cancel"
     @submit="submit"
+    @back="startImportWizard"
   >
     <div slot="body">
       <p>Please enter a content channel ID:</p>
@@ -51,6 +53,7 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
+        startImportWizard: actions.startImportWizard,
         triggerRemoteContentImportTask: actions.triggerRemoteContentImportTask,
         cancelImportExportWizard: actions.cancelImportExportWizard,
       },

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -71,6 +71,21 @@ class TasksViewSet(viewsets.ViewSet):
         return Response(resp)
 
     @list_route(methods=['post'])
+    def cleartask(self, request):
+        '''
+        Temporary hack to clear all tasks. Should actually take a single task ID.
+        '''
+        import subprocess
+        import os
+        print("CLEAR TASKS HACK")
+        subprocess.check_output([
+            "sqlite3",
+            os.path.expanduser("~/.kolibri/ormq.sqlite3"),
+            "delete from django_q_task; delete from django_q_ormq;"
+        ])
+        return Response({})
+
+    @list_route(methods=['post'])
     def startlocalimportchannel(self, request):
         '''
         Import a channel locally, and move content to the local machine.

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -108,14 +108,7 @@ class TasksViewSet(viewsets.ViewSet):
 
         # make sure everything is a dict, before converting to JSON
         assert isinstance(drives, dict)
-
-        out = []
-        for mountdata in drives.values():
-            mountdata = mountdata._asdict()
-            if mountdata['metadata']['channels']:
-                mountdata['channels'] = [c._asdict() for c in mountdata['channels']]
-
-            out.append(mountdata)
+        out = [mountdata._asdict() for mountdata in drives.values()]
 
         return Response(out)
 

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -95,7 +95,7 @@ class TasksViewSet(viewsets.ViewSet):
         return Response(out)
 
 def _importchannel(channel_id, update_state=None):
-    call_command("importchannel", channel_id, update_state=update_state)
+    call_command("importchannel", "network", channel_id, update_state=update_state)
     call_command("importcontent", "network", channel_id, update_state=update_state)
 
 


### PR DESCRIPTION
Mostly-functional but bare-bones, unstyled UI.

* includes https://github.com/learningequality/kolibri/pull/501
* includes hack for clearing tasks by trigging a remote process
* does not include styling
* does not include new modal dialog work from David or promise-canceling work from Richard
* does not include `$tr` strings - need to figure out pluralization syntax (cc @rtibbles - any existing examples in our code base?)
