### PR TITLE
Case insensitive usernames are now in effect.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 from django.contrib.auth import authenticate, get_user, login, logout
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import filters, permissions, status, viewsets
-from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from .models import Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership, Role
@@ -69,12 +68,6 @@ class FacilityUserViewSet(viewsets.ModelViewSet):
     filter_backends = (KolibriAuthPermissionsFilter,)
     queryset = FacilityUser.objects.all()
     serializer_class = FacilityUserSerializer
-
-    def create(self, request, *args, **kwargs):
-        try:
-            return super(FacilityUserViewSet, self).create(request, *args, **kwargs)
-        except ValidationError:
-            return Response("An account with that username already exists.", status=status.HTTP_409_CONFLICT)
 
 
 class DeviceOwnerViewSet(viewsets.ModelViewSet):

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -34,6 +34,11 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         else:
             return super(FacilityUserSerializer, self).update(instance, validated_data)
 
+    def validate_username(self, value):
+        if FacilityUser.objects.filter(username__iexact=value).exists():
+            raise serializers.ValidationError('An account with that username already exists.')
+        return value
+
 
 class DeviceOwnerSerializer(serializers.ModelSerializer):
 
@@ -47,6 +52,20 @@ class DeviceOwnerSerializer(serializers.ModelSerializer):
         user.set_password(validated_data['password'])
         user.save()
         return user
+
+    def update(self, instance, validated_data):
+        if 'password' in validated_data:
+            serializers.raise_errors_on_nested_writes('update', self, validated_data)
+            instance.set_password(validated_data['password'])
+            instance.save()
+            return instance
+        else:
+            return super(DeviceOwnerSerializer, self).update(instance, validated_data)
+
+    def validate_username(self, value):
+        if DeviceOwner.objects.filter(username__iexact=value).exists():
+            raise serializers.ValidationError('An account with that username already exists.')
+        return value
 
 
 class MembershipSerializer(serializers.ModelSerializer):

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -228,14 +228,23 @@ class UserCreationTestCase(APITestCase):
         self.assertTrue(models.FacilityUser.objects.get(username=new_username).check_password(new_password))
         self.assertFalse(models.FacilityUser.objects.get(username=new_username).check_password(bad_password))
 
-    def test_creating_same_user_throws_409_error(self):
+    def test_creating_same_facility_user_throws_400_error(self):
         new_username = "goliath"
         new_password = "davidsucks"
         data = {"username": new_username, "password": new_password, "facility": self.facility.id}
         response = self.client.post(reverse('facilityuser-list'), data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.post(reverse('facilityuser-list'), data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_creating_same_device_owner_throws_400_error(self):
+        new_username = "goliath"
+        new_password = "davidsucks"
+        data = {"username": new_username, "password": new_password}
+        response = self.client.post(reverse('deviceowner-list'), data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.post(reverse('deviceowner-list'), data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class UserUpdateTestCase(APITestCase):
@@ -256,6 +265,18 @@ class UserUpdateTestCase(APITestCase):
         self.client.patch(reverse('facilityuser-detail', kwargs={'pk': self.user.pk}), {'password': new_password}, format="json")
         self.client.logout()
         response = self.client.login(username=self.user.username, password=new_password, facility=self.facility)
+        self.assertTrue(response)
+
+    def test_device_owner_update_info(self):
+        self.client.patch(reverse('deviceowner-detail', kwargs={'pk': self.device_owner.pk}), {'username': 'foo'}, format="json")
+        self.device_owner.refresh_from_db()
+        self.assertEqual(self.device_owner.username, "foo")
+
+    def test_device_owner_update_password(self):
+        new_password = 'baz'
+        self.client.patch(reverse('deviceowner-detail', kwargs={'pk': self.device_owner.pk}), {'password': new_password}, format="json")
+        self.client.logout()
+        response = self.client.login(username=self.device_owner.username, password=new_password)
         self.assertTrue(response)
 
 

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -91,8 +91,9 @@
               this.close();
             }).catch((error) => {
               this.clear();
-              if (error.status.code === 409) {
-                this.errorMessage = error.entity;
+              if (error.status.code === 400) {
+                // access the first error message
+                this.errorMessage = error.entity[Object.keys(error.entity)[0]];
               } else if (error.status.code === 403) {
                 this.errorMessage = error.entity;
               } else {


### PR DESCRIPTION
## Summary

We now check if the case insensitive version of a username is already in the database before storing it. If the username is being used already, we return 400 Bad Request to the client, with an error message.

## TODO

- [x] Have tests been written for the new code?
