### PR TITLE
Encode strings with utf-8 before passing to hashlib for Python3 compatability

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/__init__.py
+++ b/kolibri/core/discovery/utils/filesystem/__init__.py
@@ -45,7 +45,7 @@ def enumerate_mounted_disk_partitions():
     for drive in drive_list:
 
         path = drive["path"]
-        drive_id = hashlib.sha1(drive["guid"] or path).hexdigest()[:32]
+        drive_id = hashlib.sha1((drive["guid"] or path).encode('utf-8')).hexdigest()[:32]
 
         drives[drive_id] = DriveData(
             id=drive_id,


### PR DESCRIPTION
## Summary

Encodes strings as utf-8 before passing them into hashlib in the drive-id generation for the discovery app.

Aims to fix currently failing tests on master.

## TODO

- [X] Have tests been written for the new code?