### PR TITLE
URL endpoint to allow client-side indexing into files within zip files.

### DIFF
--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -165,7 +165,7 @@ class File(ContentDatabaseModel):
     def get_filename(self):
         return "{}.{}".format(self.checksum, self.extension)
 
-    def get_url(self):
+    def get_storage_url(self):
         """
         Return a url for the client side to retrieve the content file.
         The same url will also be exposed by the file serializer.

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -17,7 +17,7 @@ class FileSerializer(serializers.ModelSerializer):
     storage_url = serializers.SerializerMethodField()
 
     def get_storage_url(self, target_node):
-        return target_node.get_url()
+        return target_node.get_storage_url()
 
     class Meta:
         model = File
@@ -77,7 +77,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
 
     def get_thumbnail(self, target_node):
         thumbnail_model = target_node.files.filter(thumbnail=True, available=True).first()
-        return thumbnail_model.get_url() if thumbnail_model else None
+        return thumbnail_model.get_storage_url() if thumbnail_model else None
 
     class Meta:
         model = ContentNode

--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+from django.test import TestCase
+from django.test import Client
+from django.test.utils import override_settings
+from kolibri.auth.models import DeviceOwner
+import hashlib
+import zipfile
+
+from ..models import File
+from ..utils.paths import get_content_storage_file_path
+
+CONTENT_STORAGE_DIR_TEMP = tempfile.mkdtemp()
+
+@override_settings(
+    CONTENT_STORAGE_DIR=CONTENT_STORAGE_DIR_TEMP,
+)
+class ZipContentTestCase(TestCase):
+    """
+    Testcase for zipcontent endpoint
+    """
+
+    test_name_1 = "testfile1.txt"
+    test_str_1 = "This is a test!"
+    test_name_2 = "testfile2.txt"
+    test_str_2 = "And another test..."
+
+    def setUp(self):
+
+        self.client = Client()
+
+        # create DeviceOwner to pass the setup_wizard middleware check
+        DeviceOwner.objects.create(username='test-device-owner', password=123)
+
+        self.hash = hashlib.md5("DUMMYDATA").hexdigest()
+        self.extension = "zip"
+        self.filename = "{}.{}".format(self.hash, self.extension)
+
+        self.zip_path = get_content_storage_file_path(self.filename)
+        zip_path_dir = os.path.dirname(self.zip_path)
+        if not os.path.exists(zip_path_dir):
+            os.makedirs(zip_path_dir)
+
+        with zipfile.ZipFile(self.zip_path, "w") as zf:
+            zf.writestr(self.test_name_1, self.test_str_1)
+            zf.writestr(self.test_name_2, self.test_str_2)
+
+        self.zip_file_obj = File(checksum=self.hash, extension=self.extension, available=True)
+        self.zip_file_base_url = self.zip_file_obj.get_storage_url()
+
+    def test_zip_file_url_reversal(self):
+        file = File(checksum=self.hash, extension=self.extension, available=True)
+        self.assertEqual(file.get_storage_url(), "/zipcontent/{}/".format(self.filename))
+
+    def test_non_zip_file_url_reversal(self):
+        file = File(checksum=self.hash, extension="otherextension", available=True)
+        filename = file.get_filename()
+        self.assertEqual(file.get_storage_url(), "/content/storage/{}/{}/{}".format(filename[0], filename[1], filename))
+
+    def test_zip_file_internal_file_access(self):
+
+        # test reading the data from file #1 inside the zip
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.streaming_content.next(), self.test_str_1)
+
+        # test reading the data from file #2 inside the zip
+        response = self.client.get(self.zip_file_base_url + self.test_name_2)
+        self.assertEqual(response.streaming_content.next(), self.test_str_2)
+
+    def test_nonexistent_zip_file_access(self):
+        bad_base_url = self.zip_file_base_url.replace(self.zip_file_base_url[20:25], "aaaaa")
+        response = self.client.get(bad_base_url + self.test_name_1)
+        self.assertEqual(response.status_code, 404)
+
+    def test_zip_file_nonexistent_internal_file_access(self):
+        response = self.client.get(self.zip_file_base_url + "qqq" + self.test_name_1)
+        self.assertEqual(response.status_code, 404)
+
+    def test_not_modified_response_when_if_modified_since_header_set(self):
+        caching_client = Client(HTTP_IF_MODIFIED_SINCE="Sat, 10-Sep-2016 19:14:07 GMT")
+        response = caching_client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.status_code, 304)

--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -32,7 +32,7 @@ class ZipContentTestCase(TestCase):
         # create DeviceOwner to pass the setup_wizard middleware check
         DeviceOwner.objects.create(username='test-device-owner', password=123)
 
-        self.hash = hashlib.md5("DUMMYDATA").hexdigest()
+        self.hash = hashlib.md5("DUMMYDATA".encode()).hexdigest()
         self.extension = "zip"
         self.filename = "{}.{}".format(self.hash, self.extension)
 
@@ -61,11 +61,11 @@ class ZipContentTestCase(TestCase):
 
         # test reading the data from file #1 inside the zip
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
-        self.assertEqual(response.streaming_content.next(), self.test_str_1)
+        self.assertEqual(next(response.streaming_content).decode(), self.test_str_1)
 
         # test reading the data from file #2 inside the zip
         response = self.client.get(self.zip_file_base_url + self.test_name_2)
-        self.assertEqual(response.streaming_content.next(), self.test_str_2)
+        self.assertEqual(next(response.streaming_content).decode(), self.test_str_2)
 
     def test_nonexistent_zip_file_access(self):
         bad_base_url = self.zip_file_base_url.replace(self.zip_file_base_url[20:25], "aaaaa")

--- a/kolibri/content/urls.py
+++ b/kolibri/content/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from .views import ZipContentView
+
+urlpatterns = [
+    url(r'^zipcontent/(?P<zipped_filename>[^/]+)/(?P<embedded_filepath>.*)', ZipContentView.as_view(), {}, "zipcontent"),
+]

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -1,0 +1,60 @@
+import datetime
+import mimetypes
+import os
+import zipfile
+
+from django.http import Http404
+from django.http.response import FileResponse, HttpResponseNotModified
+from django.utils.http import http_date
+from django.views.generic.base import View
+
+from .utils.paths import get_content_storage_file_path
+
+
+class ZipContentView(View):
+
+    def get(self, request, zipped_filename, embedded_filepath):
+        """
+        Handles GET requests and serves a static file from within the zip file.
+        """
+
+        # calculate the local file path to the zip file
+        zipped_path = get_content_storage_file_path(zipped_filename)
+
+        # if the zipfile doesn't not exist on disk, return a 404
+        if not os.path.exists(zipped_path):
+            raise Http404('"%(filename)s" does not exist locally' % {'filename': zipped_filename})
+
+        # if client has a cached version, use that (we can safely assume nothing has changed, due to MD5)
+        if request.META.get('HTTP_IF_MODIFIED_SINCE'):
+            return HttpResponseNotModified()
+
+        with zipfile.ZipFile(zipped_path) as zf:
+
+            # get the details about the embedded file, and ensure it exists
+            try:
+                info = zf.getinfo(embedded_filepath)
+            except KeyError:
+                raise Http404('"{}" does not exist inside "{}"'.format(embedded_filepath, zipped_filename))
+
+            # try to guess the MIME type of the embedded file being referenced
+            content_type = mimetypes.guess_type(embedded_filepath)[0] or 'application/octet-stream'
+
+            # generate a streaming response object, pulling data from within the zip  file
+            response = FileResponse(zf.open(info), content_type=content_type)
+
+        # set the last-modified header to the date marked on the embedded file
+        if info.date_time:
+            response["Last-Modified"] = http_date(float(datetime.datetime(*info.date_time).strftime("%s")))
+
+        # cache these resources forever; this is safe due to the MD5-naming used on content files
+        response["Expires"] = "Sun, 17-Jan-2038 19:14:07 GMT"
+
+        # set the content-length header to the size of the embedded file
+        if info.file_size:
+            response["Content-Length"] = info.file_size
+
+        # ensure the browser knows not to try byte-range requests, as we don't support them here
+        response["Accept-Ranges"] = "none"
+
+        return response

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     url(r'^$', RedirectView.as_view(url=reverse_lazy('kolibri:learnplugin:learn'))),
     url(r'^admin/', include(admin.site.urls)),
     url(r'', include('kolibri.core.urls')),
+    url(r'', include('kolibri.content.urls')),
     url(r'^api/', include('kolibri.auth.api_urls')),
     url(r'^api/', include('kolibri.content.api_urls')),
     url(r'^api/', include('kolibri.logger.api_urls')),


### PR DESCRIPTION
## Summary

For Perseus, embedded HTML5 apps, and EPUB, we need to be able to index into files contained within files encoded in ZIP format. This PR adds an endpoint for enabling this access.

For zip-like files (.perseus etc), the backend will automatically set their `storage_url` to point to the base URL for the ZIP indexing. E.g. if `storage_url` is "/zipcontent/c2111111111111111111111111111111.perseus/", then a json file within that path might be indexed as "/zipcontent/c2111111111111111111111111111111.perseus/exercises.json".

## TODO

- [ ] Have tests been written for the new code?

## Reviewer guidance

Not yet ready to merge (no tests), but needed for @rtibbles and @christianmemije, so opening this for their reference/inclusion.