### PR TITLE
Load i18n frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,4 +91,4 @@ downloadmessages:
 	java -jar crowdin-cli.jar download -b `git symbolic-ref HEAD | xargs basename`
 
 distributefrontendmessages:
-	python ./kolibri/utils/distribute_frontend_messages.py
+	python ./utils/distribute_frontend_messages.py

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ makemessages: assets makedocsmessages
 compilemessages:
 	python -m kolibri manage compilemessages -- -l en > /dev/null
 
-syncmessages: ensurecrowdinclient uploadmessages downloadmessages
+syncmessages: ensurecrowdinclient uploadmessages downloadmessages distributefrontendmessages
 
 ensurecrowdinclient:
 	ls -l crowdin-cli.jar || wget https://crowdin.com/downloads/crowdin-cli.jar # make sure we have the official crowdin cli client
@@ -89,3 +89,6 @@ uploadmessages:
 
 downloadmessages:
 	java -jar crowdin-cli.jar download -b `git symbolic-ref HEAD | xargs basename`
+
+distributefrontendmessages:
+	python ./kolibri/utils/distribute_frontend_messages.py

--- a/docs/dev/conventions.rst
+++ b/docs/dev/conventions.rst
@@ -48,16 +48,8 @@ Note that the top-level tags of `Vue.js components <https://vuejs.org/guide/comp
 
 - Put child components inside the directory of a parent component if they are *only* used by the parent. Otherwise, put shared child components in the *vue* director.
 
-- Any user visisble interface text should be rendered translatable, this can be done by supplementing the Vue.js component definition with the following properties:
-  - ``$trs``, an object of the form::
+- Any user visisble interface text should be rendered translatable, see :doc:`/i18n` for details.
 
-    {
-      msgId: 'Message text',
-    }
-
-  - ``$trNameSpace``, a string that namespaces the messages.
-
-- User visible strings should then either be rendered directly in the template with ``{{ $tr('msgId') }}`` or can be made available through computed properties (note, if you want to pass rendered strings into tag/component properties, this will be necessary as Vue.js does not evaluate Javascript expressions in these cases).
 
 JavaScript Code
 ---------------

--- a/docs/dev/i18n.rst
+++ b/docs/dev/i18n.rst
@@ -1,0 +1,32 @@
+i18n
+====
+
+As a platform intended for use around the world, Kolibri has a strong mandate for translation and internationalization. As such, it has been designed with technologies to enable this built in.
+
+
+Backend Translation
+-------------------
+
+For any strings in Django, we are using the standard Django i18n machinery (gettext and associated functions) to provide translations. See the `Django i18n documentation <https://docs.djangoproject.com/en/1.10/topics/i18n/>`_ for more information.
+
+
+Frontend Translation
+--------------------
+
+For any strings in the frontend, we are using `Vue-Intl <https://www.npmjs.com/package/vue-intl>`_ an in house port of `React-intl <https://www.npmjs.com/package/react-intl>`_.
+
+Within Kolibri, messages are defined on the body of the Vue component::
+
+  - ``$trs``, an object of the form::
+
+    {
+      msgId: 'Message text',
+    }
+
+  - ``$trNameSpace``, a string that namespaces the messages.
+
+User visible strings should be rendered directly in the template with ``{{ $tr('msgId') }}``. These strings are collected during the build process, and bundled into exported JSON files. These files are then uploaded to Crowdin for translation.
+
+Downloaded files from crowdin need to be copied into the relevant plugins from which they have come using the `distributefrontendmessages` make command.
+
+These messages will then be discovered for any registered plugins and loaded into the page if that language is set as the Django language. All language setting for the Frontend is based off the current Django language for the request.

--- a/docs/dev/i18n.rst
+++ b/docs/dev/i18n.rst
@@ -27,6 +27,33 @@ Within Kolibri, messages are defined on the body of the Vue component::
 
 User visible strings should be rendered directly in the template with ``{{ $tr('msgId') }}``. These strings are collected during the build process, and bundled into exported JSON files. These files are then uploaded to Crowdin for translation.
 
+An example Vue component would then look like this::
+
+  <template>
+
+    <div>
+      <p>{{ $tr('exampleMessage') }}</p>
+    </div>
+
+  </template>
+
+
+  <script>
+
+    module.exports = {
+
+      $trNameSpace: 'example',
+      $trs: {
+        exampleMessage: 'This message is just an example',
+      },
+    };
+
+  </script>
+
+
+  <style lang="stylus" scoped></style>
+
+
 Downloaded files from crowdin need to be copied into the relevant plugins from which they have come using the `distributefrontendmessages` make command.
 
 These messages will then be discovered for any registered plugins and loaded into the page if that language is set as the Django language. All language setting for the Frontend is based off the current Django language for the request.

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -19,6 +19,7 @@ Architecture
    building
    conventions
    frontend
+   i18n
 
 Themes
 ------

--- a/frontend_build/src/extract_$trs.js
+++ b/frontend_build/src/extract_$trs.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
 
+
 function extract$trs(messageDir, messagesName) {
   this.messageDir = messageDir;
   this.messagesName = messagesName;
@@ -79,6 +80,9 @@ extract$trs.prototype.apply = function(compiler) {
     if (Object.keys(messageExport).length) {
       // If we've got any messages to write out, write them out. Otherwise, don't bother.
       self.writeOutput(messageExport);
+      compilation.bundleHasMessages = true;
+    } else {
+      compilation.bundleHasMessages = false;
     }
     callback();
   });

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -77,6 +77,17 @@ var readBundlePlugin = function(base_dir) {
     }
   });
 
+  // Create name to path mapping to allow translated json files to be copied into
+  // the correct static directory.
+
+  var namePathMapping = {};
+
+  bundles.forEach(function (bundle) {
+    namePathMapping[bundle.name] = path.resolve(path.dirname(bundle.output.path));
+  });
+
+  fs.writeFileSync(path.join(base_dir, 'kolibri', 'locale', 'pathMapping.json'), JSON.stringify(namePathMapping));
+
   return bundles;
 
 };

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -91,6 +91,10 @@ var readBundlePlugin = function(base_dir) {
 
   mkdirp.sync(locale_dir);
 
+  // This will output a file mapping from the bundle name to the static directory where
+  // the built files for this mapping are put. This is used for redistributing translated message files
+  // back to their plugins.
+
   fs.writeFileSync(path.join(locale_dir, 'pathMapping.json'), JSON.stringify(namePathMapping));
 
   return bundles;

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -7,6 +7,8 @@
 var readWebpackJson = require('./read_webpack_json');
 var logging = require('./logging');
 var _ = require("lodash");
+var path = require('path');
+var fs = require('fs');
 var mkdirp = require('mkdirp');
 
 var parseBundlePlugin = require('./parse_bundle_plugin');

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -7,6 +7,7 @@
 var readWebpackJson = require('./read_webpack_json');
 var logging = require('./logging');
 var _ = require("lodash");
+var mkdirp = require('mkdirp');
 
 var parseBundlePlugin = require('./parse_bundle_plugin');
 
@@ -86,7 +87,11 @@ var readBundlePlugin = function(base_dir) {
     namePathMapping[bundle.name] = path.resolve(path.dirname(bundle.output.path));
   });
 
-  fs.writeFileSync(path.join(base_dir, 'kolibri', 'locale', 'pathMapping.json'), JSON.stringify(namePathMapping));
+  var locale_dir = path.join(base_dir, 'kolibri', 'locale')
+
+  mkdirp.sync(locale_dir);
+
+  fs.writeFileSync(path.join(locale_dir, 'pathMapping.json'), JSON.stringify(namePathMapping));
 
   return bundles;
 

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -110,6 +110,14 @@ module.exports = class CoreApp {
         }
         return this.$formatHTMLMessage(message, ...args);
       };
+
+      if (global.languageCode) {
+        vue.setLocale(global.languageCode);
+        if (global.coreLanguageMessages) {
+          vue.registerMessages(global.languageCode, global.coreLanguageMessages);
+        }
+      }
+
       mediator.setReady();
     }
 

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -29,6 +29,8 @@ const publicMethods = [
   'on',
   'once',
   'off',
+  'registerLanguageAssets',
+  'registerLanguageAssetsUrl',
 ];
 
 /**

--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -366,8 +366,6 @@ module.exports = class Mediator {
             // Language assets already loaded, just resolve the promise right away.
             resolve();
           } else {
-            // Store the promise in the registry for later reference.
-            this._languageAssetRegistry[moduleName][language].promise = promise;
             // Fetch the language asset from the url stored in the registry.
             client({ path: this._languageAssetRegistry[moduleName][language].url }).then(
               (response) => {
@@ -381,12 +379,18 @@ module.exports = class Mediator {
               }, (error) => {
               logging.error(
                 `Message file for ${moduleName} for language: ${language} did not load`);
+              reject();
             });
           }
         } else {
           resolve();
         }
       });
+      if (moduleName in this._languageAssetRegistry &&
+        this._languageAssetRegistry[moduleName][language]) {
+        // Store the promise in the registry for later reference.
+        this._languageAssetRegistry[moduleName][language].promise = promise;
+      }
     }
     return promise;
   }

--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -102,6 +102,8 @@ module.exports = class Mediator {
         });
       }
     };
+    // Ensure all language assets that are needed for this module have been fetched
+    // before we declare this module ready!
     this._fetchLanguageAssets(kolibriModule.name, Vue.locale).then(ready, ready);
   }
 
@@ -283,6 +285,7 @@ module.exports = class Mediator {
               });
             }
           });
+          // Start fetching any language assets that this module might need also.
           this._fetchLanguageAssets(kolibriModuleName, Vue.locale);
         }
       };
@@ -337,24 +340,43 @@ module.exports = class Mediator {
     this._eventDispatcher.$off(...args);
   }
 
+  /**
+   * Internal method for loading language assets from server when needed.
+   * @param  {String} moduleName name of the module.
+   * @param  {String} language   language code whose assets we are loading.
+   * @return {Promise}           a promise that resolves when the assets are loaded.
+   */
   _fetchLanguageAssets(moduleName, language) {
+    // We either return a new promise, or a promise that has already been
+    // instantiated when this method was called previously.
     let promise;
     if (this._languageAssetRegistry[moduleName] &&
       this._languageAssetRegistry[moduleName][language] &&
       this._languageAssetRegistry[moduleName][language].promise) {
+      // We have previously instantiated a promise for fetching language assets,
+      // so return that and we're done!
       promise = this._languageAssetRegistry[moduleName][language].promise;
     } else {
+      // No promise has been defined and stored for this previously, so create a new one.
       promise = new Promise((resolve, reject) => {
         if (moduleName in this._languageAssetRegistry &&
           this._languageAssetRegistry[moduleName][language]) {
+          // Check that we have information in the registry that we need to load language assets.
           if (this._languageAssetRegistry[moduleName][language].loaded) {
+            // Language assets already loaded, just resolve the promise right away.
             resolve();
           } else {
+            // Store the promise in the registry for later reference.
             this._languageAssetRegistry[moduleName][language].promise = promise;
+            // Fetch the language asset from the url stored in the registry.
             client({ path: this._languageAssetRegistry[moduleName][language].url }).then(
               (response) => {
+                // We are loading a JSON file so the response body will be the messages object
+                // for the language in question.
                 const messageMap = response.entity;
+                // Register this messages object for the language.
                 this.registerLanguageAssets(moduleName, language, messageMap);
+                // Resolve with no value, all relevant changes have been made already.
                 resolve();
               }, (error) => {
               logging.error(
@@ -368,17 +390,37 @@ module.exports = class Mediator {
     }
     return promise;
   }
-
+  /**
+   * A method for directly registering language assets on the mediator.
+   * This is used to set language assets as loaded and register them to the Vue intl
+   * translation apparatus.
+   * @param  {String} moduleName name of the module.
+   * @param  {String} language   language code whose messages we are registering.
+   * @param  {Object} messageMap an object with message id to message mappings.
+   */
   registerLanguageAssets(moduleName, language, messageMap) {
+    // Create empty entry in the language asset registry for this module if needed
     this._languageAssetRegistry[moduleName] = this._languageAssetRegistry[moduleName] || {};
+    // Create empty entry in the language asset registry for this module/language if needed.
     this._languageAssetRegistry[moduleName][language] =
       this._languageAssetRegistry[moduleName][language] || {};
+    // Set this asset as loaded in the registry so any future async loading will be resolved
+    // without needing a server request.
     this._languageAssetRegistry[moduleName][language].loaded = true;
+    // Register the message object on the Vue intl translation layer.
     Vue.registerMessages(language, messageMap);
   }
-
+  /**
+   * A method for registering urls from which to fetch language assets.
+   * Mainly used for asynchronously loading modules.
+   * @param  {String} moduleName name of the module.
+   * @param  {String} language   language code whose messages we are registering.
+   * @param  {String} messageMapUrl The URL from which to fetch the message object.
+   */
   registerLanguageAssetsUrl(moduleName, language, messageMapUrl) {
+    // Create empty entry in the language asset registry for this module if needed
     this._languageAssetRegistry[moduleName] = this._languageAssetRegistry[moduleName] || {};
+    // Set loaded as false, and add url for later use.
     this._languageAssetRegistry[moduleName][language] = {
       loaded: false,
       url: messageMapUrl,

--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -93,13 +93,16 @@ module.exports = class Mediator {
     this._executeCallbackBuffer(kolibriModule);
     logging.info(`KolibriModule: ${kolibriModule.name} registered`);
     this.emit('kolibri_register', kolibriModule);
-    if (this._ready) {
-      kolibriModule.ready();
-    } else {
-      this._eventDispatcher.$once('ready', () => {
+    const ready = () => {
+      if (this._ready) {
         kolibriModule.ready();
-      });
-    }
+      } else {
+        this._eventDispatcher.$once('ready', () => {
+          kolibriModule.ready();
+        });
+      }
+    };
+    this._fetchLanguageAssets(kolibriModule.name, Vue.locale).then(ready, ready);
   }
 
   /**
@@ -280,6 +283,7 @@ module.exports = class Mediator {
               });
             }
           });
+          this._fetchLanguageAssets(kolibriModuleName, Vue.locale);
         }
       };
       // Listen to the event and call the above function

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,5 +1,6 @@
 {% load i18n kolibri_tags webpack_tags js_reverse cache %}
 {% load staticfiles %}
+{% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -45,6 +46,10 @@
   </script>
 </rootvue>
 {% block frontend_assets %}
+<script>
+  // Set global language variable.
+  var languageCode = "{{ LANGUAGE_CODE }}";
+</script>
 {% webpack_asset 'default_frontend' %}
 <script type="text/javascript">
   {% cache 5000 js_urls %}

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -102,7 +102,7 @@ class WebpackBundleHook(hooks.KolibriHook):
             if stats['status'] == 'error':
                 raise WebpackError('Webpack compilation has errored')
         return {
-            "files": stats.get("chunks", {}).get(self.unique_slug, [])
+            "files": stats.get("chunks", {}).get(self.unique_slug, []),
             "hasMessages": stats["messages"],
         }
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -103,7 +103,7 @@ class WebpackBundleHook(hooks.KolibriHook):
                 raise WebpackError('Webpack compilation has errored')
         return {
             "files": stats.get("chunks", {}).get(self.unique_slug, []),
-            "hasMessages": stats["messages"],
+            "hasMessages": stats.get("messages", False),
         }
 
     @property

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -102,6 +102,7 @@ class WebpackBundleHook(hooks.KolibriHook):
                 raise WebpackError('Webpack compilation has errored')
         return {
             "files": stats.get("chunks", {}).get(self.unique_slug, [])
+            "hasMessages": stats["messages"],
         }
 
     @property

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -332,6 +332,18 @@ class FrontEndCoreAssetHook(WebpackBundleHook):
         dct['external'] = True
         return dct
 
+    def render_to_page_load_sync_html(self):
+        """
+        Generates the appropriate script tags for the core bundle, be they JS or CSS
+        files.
+
+        :return: HTML of script tags for insertion into a page.
+        """
+        tags = ['<script>var coreLanguageMessages = {messages};</script>'.format(
+            messages=self.frontend_messages)] + list(self.js_and_css_tags())
+
+        return mark_safe('\n'.join(tags))
+
     class Meta:
         abstract = True
 

--- a/kolibri/core/webpack/test/base.py
+++ b/kolibri/core/webpack/test/base.py
@@ -16,7 +16,8 @@ TEST_STATS_FILE_DATA = {
             }
         ]
     },
-    "publicPath": "default_frontend/"
+    "publicPath": "default_frontend/",
+    "messages": "true",
 }
 
 

--- a/kolibri/utils/distribute_frontend_messages.py
+++ b/kolibri/utils/distribute_frontend_messages.py
@@ -1,0 +1,34 @@
+import glob
+import json
+import logging
+import os
+import re
+import shutil
+
+
+def main():
+    try:
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, '../locale/pathMapping.json'), 'r') as f:
+            mapping = json.load(f)
+        filename_re = re.compile('([a-zA-Z\-]+)/LC_FRONTEND_MESSAGES/(\S+)-messages.json')
+        for file in glob.glob(os.path.join(current_dir, '../locale/*/LC_FRONTEND_MESSAGES/*-messages.json')):
+            match = filename_re.search(file)
+            lang_code = match.groups()[0]
+            plugin_name = match.groups()[1]
+
+            if lang_code != "en":
+                dir_name = os.path.join(mapping.get(plugin_name), lang_code)
+
+                if not os.path.exists(dir_name):
+                    os.makedirs(dir_name)
+
+                logging.info('Copying message file {file} to static folder {dir_name}.'.format(file=file, dir_name=dir_name))
+                shutil.copy(file, dir_name)
+
+    except OSError:
+        logging.debug('No pathMapping.json found.')
+
+
+if __name__ == "__main__":
+    main()

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "vue-style-loader": "1.0.0",
     "webpack": "1.13.1",
     "webpack-bundle-size-analyzer": "2.0.2",
-    "webpack-bundle-tracker": "0.0.93",
+    "webpack-bundle-tracker": "https://github.com/learningequality/webpack-bundle-tracker",
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.12.1",
     "webpack-merge": "0.14.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vue": "1.0.26",
     "vue-focus": "0.1.1",
     "vue-scroll": "1.0.3",
-    "vue-intl": "0.4.0",
+    "vue-intl": "0.5.0",
     "vue-router": "0.7.13",
     "vuex": "0.6.3"
   },

--- a/utils/distribute_frontend_messages.py
+++ b/utils/distribute_frontend_messages.py
@@ -1,6 +1,5 @@
 import glob
 import json
-import logging
 import os
 import re
 import shutil
@@ -9,25 +8,29 @@ import shutil
 def main():
     try:
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        with open(os.path.join(current_dir, '../locale/pathMapping.json'), 'r') as f:
+        # pathMapping.json maps from the bundle name used in the json message file name
+        # to the folder path where built frontend files are stored, per module.
+        with open(os.path.join(current_dir, '../kolibri/locale/pathMapping.json'), 'r') as f:
             mapping = json.load(f)
+        # Regex to infer language code and module name as group 0 and 1 respectively.
         filename_re = re.compile('([a-zA-Z\-]+)/LC_FRONTEND_MESSAGES/(\S+)-messages.json')
-        for file in glob.glob(os.path.join(current_dir, '../locale/*/LC_FRONTEND_MESSAGES/*-messages.json')):
+        for file in glob.glob(os.path.join(current_dir, '../kolibri/locale/*/LC_FRONTEND_MESSAGES/*-messages.json')):
             match = filename_re.search(file)
             lang_code = match.groups()[0]
             plugin_name = match.groups()[1]
 
+            # Don't bother copying English files over, as they are the originals.
             if lang_code != "en":
                 dir_name = os.path.join(mapping.get(plugin_name), lang_code)
 
                 if not os.path.exists(dir_name):
                     os.makedirs(dir_name)
 
-                logging.info('Copying message file {file} to static folder {dir_name}.'.format(file=file, dir_name=dir_name))
+                print('Copying message file {file} to static folder {dir_name}.'.format(file=file, dir_name=dir_name))
                 shutil.copy(file, dir_name)
 
     except OSError:
-        logging.debug('No pathMapping.json found.')
+        print('No pathMapping.json found.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A PR to allow the proper loading of language specific message files into the frontend, for the purposes of translating said frontend into the user's selected language.

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file

## Reviewer guidance

This PR has a few parts, one that adds language resource handling to the Module loading and registration machinery, another that utilizes that machinery in the Python template side to register any existing language resources properly.

## Issues addressed

https://trello.com/c/49OZ1RLm/557-rendering-translations-from-crowdin

## Documentation

Could probably use a little.

## Screenshots (if appropriate)

Will collaborate with @aron to get some properly translated strings in!
