### PR TITLE
Asset bundling performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ coverage
 # webpack built files
 kolibri/**/build/*
 kolibri/**/static/*
+js-dist
 
 # swap files
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ matrix:
       env:
         - TOX_ENV=postgres
         - TRAVIS_NODE_VERSION="0.12"
+    - python: "2.7"
+      env:
+        - TOX_ENV=npmbuild
+        - TRAVIS_NODE_VERSION="4"
 
 before_install:
   - pip install codecov

--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -139,6 +139,16 @@ We use `pre-commit <http://pre-commit.com/>`_ to help ensure consistent, clean c
   pre-commit install
 
 
+Linting
+~~~~~~~
+
+To improve build times, and facilitate rapid development, Javascript linting is turned off by default when you run the dev server. However, all frontend assets that are bundled will be linted by our Travis CI builds. It is a good idea, therefore, to test your linting before submitting code for PR. To run the devserver in this mode you can run the following command.
+
+.. code-block:: bash
+
+  kolibri manage devserver --debug -- --webpack --qcluster --lint
+
+
 Code Testing
 ~~~~~~~~~~~~
 

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -37,7 +37,8 @@ var parseBundlePlugin = function(data, base_dir) {
       (typeof data.static_url_root === "undefined") ||
       (typeof data.stats_file === "undefined") ||
       (typeof data.locale_data_folder === "undefined") ||
-      (typeof data.plugin_path === "undefined")) {
+      (typeof data.plugin_path === "undefined") ||
+      (typeof data.version === "undefined")) {
     logging.error(data.name + ' plugin is misconfigured, missing parameter(s)');
     return;
   }
@@ -102,8 +103,8 @@ var parseBundlePlugin = function(data, base_dir) {
   bundle.context = base_dir;
   bundle.output = {
     path: path.join(data.static_dir, data.name),
-    filename: "[name]-[hash].js",
     publicPath: path.join("/", data.static_url_root, data.name, "/"),
+    filename: "[name]-" + data.version + ".js",
     library: library
   };
 

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -101,13 +101,13 @@ var parseBundlePlugin = function(data, base_dir) {
   var publicPath, outputPath;
 
   if (process.env.DEV_SERVER) {
+    var devServerConfig = require('./webpackdevserverconfig');
     // If running webpack dev server point to that endpoint.
-    publicPath = "http://localhost:3000/";
+    publicPath = devServerConfig.publicPath;
     // Set output path to base dir, as no files will be written - all built files are cached in memory.
-    outputPath = path.resolve(base_dir);
+    outputPath = devServerConfig.basePath ? path.resolve(path.join(base_dir, devServerConfig.basePath)) : path.resolve(base_dir);
   } else {
     publicPath = path.join("/", data.static_url_root, data.name, "/");
-
     outputPath = path.join(data.static_dir, data.name);
   }
 

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -98,13 +98,26 @@ var parseBundlePlugin = function(data, base_dir) {
     new extract$trs(data.locale_data_folder, data.name)
   ]);
 
+  var publicPath, outputPath;
+
+  if (process.env.DEV_SERVER) {
+    // If running webpack dev server point to that endpoint.
+    publicPath = "http://localhost:3000/";
+    // Set output path to base dir, as no files will be written - all built files are cached in memory.
+    outputPath = path.resolve(base_dir);
+  } else {
+    publicPath = path.join("/", data.static_url_root, data.name, "/");
+
+    outputPath = path.join(data.static_dir, data.name);
+  }
+
   bundle.core_name = data.core_name;
   bundle.name = data.name;
   bundle.context = base_dir;
   bundle.output = {
-    path: path.join(data.static_dir, data.name),
-    publicPath: path.join("/", data.static_url_root, data.name, "/"),
+    path: outputPath,
     filename: "[name]-" + data.version + ".js",
+    publicPath: publicPath,
     library: library
   };
 

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -32,6 +32,7 @@ var fs = require('fs');
 var webpack = require('webpack');
 var jeet = require('jeet');
 var autoprefixer = require('autoprefixer');
+var merge = require('webpack-merge');
 
 var aliases = require('./apiSpecExportTools').coreAliases();
 
@@ -42,18 +43,6 @@ require('./htmlhint_custom'); // adds custom rules
 
 var config = {
   module: {
-    preLoaders: [
-      {
-        test: /\.(vue|js)$/,
-        loader: 'eslint',
-        exclude: /node_modules/
-      },
-      {
-        test: /\.(vue|html)/,
-        loader: 'htmlhint',
-        exclude: /node_modules/
-      }
-    ],
     loaders: [
       {
         test: /\.vue$/,
@@ -83,7 +72,7 @@ var config = {
       },
       {
         test: /\.styl$/,
-        loader: 'style-loader!css-loader?sourceMap!postcss-loader!stylus-loader!stylint'
+        loader: 'style-loader!css-loader?sourceMap!postcss-loader!stylus-loader'
       },
       // moved from parse_bundle_plugin.js
       {
@@ -127,7 +116,7 @@ var config = {
   },
   vue: {
     loaders: {
-      stylus: 'vue-style-loader!css-loader?sourceMap!stylus-loader!stylint',
+      stylus: 'vue-style-loader!css-loader?sourceMap!stylus-loader',
       html: 'vue-html-loader!svg-inline', // inlines SVGs
     }
   },
@@ -141,5 +130,37 @@ var config = {
     __filename: true
   }
 };
+
+if (process.env.LINT || process.env.NODE_ENV === 'production') {
+  // Only lint in dev mode if LINT env is set. Always lint in production.
+  var lintConfig = {
+    module: {
+      preLoaders: [
+        {
+          test: /\.(vue|js)$/,
+          loader: 'eslint',
+          exclude: /node_modules/
+        },
+        {
+          test: /\.(vue|html)/,
+          loader: 'htmlhint',
+          exclude: /node_modules/
+        }
+      ],
+      loaders: [
+        {
+          test: /\.styl$/,
+          loader: 'style-loader!css-loader?sourceMap!postcss-loader!stylus-loader!stylint'
+        }
+      ],
+    },
+    vue: {
+      loaders: {
+        stylus: 'vue-style-loader!css-loader?sourceMap!stylus-loader!stylint'
+      }
+    },
+  };
+  config = merge.smart(config, lintConfig);
+}
 
 module.exports = config;

--- a/frontend_build/src/webpack.config.dev.js
+++ b/frontend_build/src/webpack.config.dev.js
@@ -9,7 +9,7 @@ var webpack = require('webpack');
 var bundles = require('./webpack.config.js');
 
 for (var i=0; i < bundles.length; i++) {
-  bundles[i].devtool = '#inline-source-map';
+  bundles[i].devtool = '#cheap-module-eval-source-map';
   bundles[i].plugins = bundles[i].plugins.concat([
     new webpack.DefinePlugin({
       'process.env': {

--- a/frontend_build/src/webpack.config.prod.js
+++ b/frontend_build/src/webpack.config.prod.js
@@ -1,8 +1,6 @@
 /*
- * This takes all bundles defined in our production webpack configuration and adds inline source maps to all of them
- * for easier debugging.
- * Any dev specific modifications to the build should be specified in here, where each bundles[i] object is a webpack
- * configuration object that needs to be edited/manipulated to add features to.
+ * This defines the production settings for our webpack build.
+ * Anything defined here is only applied during production building.
  */
 
 var webpack = require('webpack');

--- a/frontend_build/src/webpack.config.prod.js
+++ b/frontend_build/src/webpack.config.prod.js
@@ -3,6 +3,8 @@
  * Anything defined here is only applied during production building.
  */
 
+process.env.NODE_ENV = 'production';
+
 var webpack = require('webpack');
 var bundles = require('./webpack.config.js');
 

--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -2,6 +2,7 @@ process.env.DEV_SERVER = true;
 
 var WebpackDevServer = require("webpack-dev-server");
 var webpack = require("webpack");
+var devServerConfig = require('./webpackdevserverconfig');
 
 var bundles = require('./webpack.config.dev');
 var compiler = webpack(bundles);
@@ -26,10 +27,10 @@ var server = new WebpackDevServer(compiler, {
     poll: 1000
   },
   // It's a required option.
-  publicPath: "http://localhost:3000/",
+  publicPath: devServerConfig.publicPath,
   stats: {
     colors: true,
     chunks: false
   }
 });
-server.listen(3000, "localhost", function() {});
+server.listen(devServerConfig.port, devServerConfig.address, function() {});

--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -1,0 +1,35 @@
+process.env.DEV_SERVER = true;
+
+var WebpackDevServer = require("webpack-dev-server");
+var webpack = require("webpack");
+
+var bundles = require('./webpack.config.dev');
+var compiler = webpack(bundles);
+var server = new WebpackDevServer(compiler, {
+  // webpack-dev-server options
+
+  // contentBase: "http://localhost:3000/",
+  // Can also be an array, or: contentBase: "http://localhost/",
+
+  // Set this as true if you want to access dev server from arbitrary url.
+  // This is handy if you are using a html5 router.
+  historyApiFallback: false,
+
+  // Set this if you want to enable gzip compression for assets
+  compress: false,
+
+  // webpack-dev-middleware options
+  quiet: false,
+  noInfo: true,
+  watchOptions: {
+    aggregateTimeout: 300,
+    poll: 1000
+  },
+  // It's a required option.
+  publicPath: "http://localhost:3000/",
+  stats: {
+    colors: true,
+    chunks: false
+  }
+});
+server.listen(3000, "localhost", function() {});

--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -1,5 +1,11 @@
 process.env.DEV_SERVER = true;
 
+process.argv.forEach(function(val) {
+  if (val === "--lint") {
+    process.env.LINT = true;
+  }
+});
+
 var WebpackDevServer = require("webpack-dev-server");
 var webpack = require("webpack");
 var devServerConfig = require('./webpackdevserverconfig');

--- a/frontend_build/src/webpackdevserverconfig.js
+++ b/frontend_build/src/webpackdevserverconfig.js
@@ -1,0 +1,8 @@
+module.exports = {
+  address: "localhost",
+  port: 3000,
+  basePath: "js-dist",
+  get publicPath() {
+    return "http://" + this.address + ":" + this.port + "/" + (this.basePath ? this.basePath + "/" : "");
+  },
+};

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -1,140 +1,105 @@
 var assert = require('assert');
 var rewire = require('rewire');
+var _ = require('lodash');
 
 var parseBundlePlugin = require('../src/parse_bundle_plugin');
 var readBundlePlugins = rewire('../src/read_bundle_plugins');
 
+var baseData = {
+  name: "kolibri.plugin.test.test_plugin",
+  src_file: "src/file.js",
+  stats_file: "output.json",
+  static_url_root: "static",
+  static_dir: "kolibri/plugin/test",
+  locale_data_folder: "kolibri/locale/test",
+  version: "test",
+  plugin_path: "kolibri/plugin"
+};
+
+var baseData1 = {
+  name: "kolibri.plugin.test.test_plugin1",
+  src_file: "src/file1.js",
+  stats_file: "output1.json",
+  static_url_root: "static1",
+  static_dir: "kolibri/plugin/test1",
+  locale_data_folder: "kolibri/locale/test1",
+  version: "test",
+  plugin_path: "kolibri/plugin1"
+};
+
 describe('parseBundlePlugin', function() {
+  var data;
+  beforeEach(function() {
+    data = _.clone(baseData);
+  });
   describe('input is valid, bundles output', function() {
     it('should have one entry', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        stats_file: "output.json",
-        static_url_root: "static",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
       assert(typeof parseBundlePlugin(data, "/")[0] !== "undefined");
       done();
     });
   });
   describe('input is missing name, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        src_file: "src/file.js",
-        stats_file: "output.json",
-        static_url_root: "static",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
+      delete data.name
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is missing src_file, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        stats_file: "output.json",
-        static_url_root: "static",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
+      delete data.src_file
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is missing stats_file, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        static_url_root: "static",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
+      delete data.stats_file
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is missing static_dir, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        static_url_root: "static",
-        stats_file: "output.json",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
+      delete data.static_dir
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is missing locale_data_folder, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        static_url_root: "static",
-        stats_file: "output.json",
-        static_dir: "kolibri/plugin/test",
-        plugin_path: "kolibri/plugin"
-      };
+      delete data.locale_data_folder
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is missing plugin_path, bundles output', function() {
     it('should be undefined', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        static_url_root: "static",
-        stats_file: "output.json",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test"
-      };
+      delete data.plugin_path;
+      assert(typeof parseBundlePlugin(data, "/") === "undefined");
+      done();
+    });
+  });
+  describe('input is missing version, bundles output', function() {
+    it('should be undefined', function (done) {
+      delete data.version
       assert(typeof parseBundlePlugin(data, "/") === "undefined");
       done();
     });
   });
   describe('input is valid, has externals flag and core_name value, externals output', function() {
     it('should have one entry', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        external: true,
-        stats_file: "output.json",
-        static_dir: "kolibri/plugin/test",
-        static_url_root: "static",
-        core_name: "test_core",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
+      data.external = true;
+      data.core_name = "test_core";
       assert(typeof parseBundlePlugin(data, "/")[1] !== "undefined");
       done();
     });
   });
   describe('input is valid, has core flag', function() {
     it('should have its name set to kolibriGlobal', function (done) {
-      var data = {
-        name: "kolibri.plugin.test.test_plugin",
-        src_file: "src/file.js",
-        external: true,
-        core_name: "kolibriGlobal",
-        stats_file: "output.json",
-        static_url_root: "static",
-        static_dir: "kolibri/plugin/test",
-        locale_data_folder: "kolibri/locale/test",
-        plugin_path: "kolibri/plugin"
-      };
-      assert.equal(parseBundlePlugin(data, "/")[0].output.library, "kolibriGlobal");
+      data.external = true;
+      data.core_name = "kolibriGlobal";
+      assert.equal(parseBundlePlugin(data, "/")[0].output.library, data.core_name);
       done();
     });
   });
@@ -152,24 +117,8 @@ describe('readBundlePlugins', function() {
   describe('two valid inputs, output', function() {
     it('should have two entries', function (done) {
       data = [
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          src_file: "src/file.js",
-          stats_file: "output.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        },
-        {
-          name: "kolibri.plugin.test.test_plugin1",
-          src_file: "src/file1.js",
-          stats_file: "output1.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        }
+        baseData,
+        baseData1
       ];
       assert(readBundlePlugins("", "").length === 2);
       done();
@@ -177,24 +126,11 @@ describe('readBundlePlugins', function() {
   });
   describe('one valid input out of two, output', function() {
     it('should have one entry', function (done) {
+      var badData = _.clone(baseData);
+      delete badData.src_file;
       data = [
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          stats_file: "output.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        },
-        {
-          name: "kolibri.plugin.test.test_plugin1",
-          src_file: "src/file1.js",
-          stats_file: "output1.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        }
+        badData,
+        baseData1
       ];
       assert(readBundlePlugins("", "").length === 1);
       done();
@@ -202,23 +138,13 @@ describe('readBundlePlugins', function() {
   });
   describe('no valid input, output', function() {
     it('should have no entries', function (done) {
+      var badData = _.clone(baseData);
+      delete badData.src_file;
+      var badData1 = _.clone(baseData1);
+      delete badData1.src_file;
       data = [
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          stats_file: "output.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        },
-        {
-          name: "kolibri.plugin.test.test_plugin1",
-          stats_file: "output1.json",
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        }
+        badData,
+        badData1
       ];
       assert(readBundlePlugins("", "").length === 0);
       done();
@@ -226,28 +152,14 @@ describe('readBundlePlugins', function() {
   });
   describe('two external flags on inputs, one with core_name value, externals output', function() {
     it('should have one entry', function (done) {
+      var coreData = _.clone(baseData);
+      coreData.external = true;
+      coreData.core_name = "test_global";
+      var coreData1 = _.clone(baseData1);
+      coreData1.external = true;
       data = [
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          src_file: "src/file.js",
-          stats_file: "output.json",
-          external: true,
-          static_dir: "kolibri/plugin/test",
-          static_url_root: "static",
-          core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        },
-        {
-          name: "kolibri.plugin.test.test_plugin1",
-          src_file: "src/file1.js",
-          stats_file: "output1.json",
-          external: true,
-          static_url_root: "static",
-          static_dir: "kolibri/plugin/test",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        }
+        coreData,
+        coreData1
       ];
       assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
       done();
@@ -255,29 +167,16 @@ describe('readBundlePlugins', function() {
   });
   describe('two identically named external flags on inputs, externals output', function() {
     it('should have one entry', function (done) {
+      var coreData = _.clone(baseData);
+      coreData.external = true;
+      coreData.core_name = "test_global";
+      var coreData1 = _.clone(baseData1);
+      coreData1.name = coreData.name;
+      coreData1.external = true;
+      coreData1.core_name = "test_global";
       data = [
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          src_file: "src/file.js",
-          stats_file: "output.json",
-          external: true,
-          static_dir: "kolibri/plugin/test",
-          static_url_root: "static",
-          core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        },
-        {
-          name: "kolibri.plugin.test.test_plugin",
-          src_file: "src/file1.js",
-          stats_file: "output1.json",
-          external: true,
-          static_dir: "kolibri/plugin/test",
-          static_url_root: "static",
-          core_name: "test_global",
-          locale_data_folder: "kolibri/locale/test",
-          plugin_path: "kolibri/plugin"
-        }
+        coreData,
+        coreData1
       ];
       assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
       done();

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -122,7 +122,10 @@ class WebpackBundleHook(hooks.KolibriHook):
             if any(regex.match(filename) for regex in settings.IGNORE_PATTERNS):
                 continue
             relpath = '{0}/{1}'.format(self.unique_slug, filename)
-            f['url'] = staticfiles_storage.url(relpath)
+            if django_settings.DEBUG:
+                f['url'] = f['publicPath']
+            else:
+                f['url'] = staticfiles_storage.url(relpath)
             yield f
 
     @property

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -15,6 +15,7 @@ import time
 
 from pkg_resources import resource_filename
 
+import kolibri
 from django.conf import settings as django_settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.functional import cached_property
@@ -55,6 +56,9 @@ class WebpackBundleHook(hooks.KolibriHook):
 
     # : A list of events to load the asset once
     once = {}
+
+    # : Kolibri version for build hashes
+    version = kolibri.__version__
 
     def __init__(self, *args, **kwargs):
         super(WebpackBundleHook, self).__init__(*args, **kwargs)
@@ -141,6 +145,7 @@ class WebpackBundleHook(hooks.KolibriHook):
             "once": self.once,
             "static_url_root": getattr(django_settings, 'STATIC_URL'),
             "locale_data_folder": os.path.join(getattr(django_settings, 'LOCALE_PATHS')[0], 'en', 'LC_FRONTEND_MESSAGES'),
+            "version": self.version,
         }
 
     @property

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test-mocha-cov": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha frontend_build/test/*.js --report lcovonly -- -R spec",
     "test-karma-cov": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.ci.js",
     "build": "webpack --config ./frontend_build/src/webpack.config.prod.js",
+    "test-build": "webpack --config ./frontend_build/src/webpack.config.prod.js --bail",
     "watch": "node ./frontend_build/src/webpackdevserver.js",
     "test-karma:watch": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.js",
     "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-mocha-cov": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha frontend_build/test/*.js --report lcovonly -- -R spec",
     "test-karma-cov": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.ci.js",
     "build": "webpack --config ./frontend_build/src/webpack.config.prod.js",
-    "watch": "webpack --config ./frontend_build/src/webpack.config.dev.js --watch --progress",
+    "watch": "node ./frontend_build/src/webpackdevserver.js",
     "test-karma:watch": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.js",
     "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer",
     "install": "node ./frontend_build/src/install_dependencies.js"
@@ -38,6 +38,7 @@
     "vue-scroll": "1.0.3",
     "vue-intl": "0.5.0",
     "vue-router": "0.7.13",
+    "vue-scroll": "1.0.3",
     "vuex": "0.6.3"
   },
   "devDependencies": {
@@ -107,6 +108,7 @@
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-bundle-tracker": "https://github.com/learningequality/webpack-bundle-tracker",
     "webpack-dev-middleware": "1.6.1",
+    "webpack-dev-server": "1.15.1",
     "webpack-hot-middleware": "2.12.1",
     "webpack-merge": "0.14.1"
   },

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ basepython =
     node0.12.x: python2.7
     node4.x: python2.7
     node5.x: python2.7
+    npmbuild: python2.7
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
@@ -77,3 +78,10 @@ commands = {[node_base]commands}
 [testenv:node5.x]
 whitelist_externals = {[node_base]whitelist_externals}
 commands = {[node_base]commands}
+
+[testenv:npmbuild]
+whitelist_externals = {[node_base]whitelist_externals}
+commands =
+    npm install
+    npm run build
+    npm run test-build


### PR DESCRIPTION
## Summary

Uses a cheaper source map method - now only have line numbers, not line and column numbers.

Uses webpack dev server to cache built assets in memory.

Reduces first build time on my machine from ~32000ms to ~27000ms.

Should also greatly reduce rebuild time.

One possible additional reduction could come from bundling 'vendor' JS into webpack DLL files.

Hot module replacement is now, in principle, possible. I did a first run at it, and it didn't work, so will leave that to others!

## TODO

- [x] Has documentation been written/updated?
- [X] New dependencies (if any) added to requirements file

## Reviewer guidance

New code for running webpack dev server is in `webpackdevserver.js` - otherwise, I have tried to leave the `webpack.config.dev.js` file intact, so that we can build from it independently if we so choose.

Worth noting that because of limitations of the webpack dev server for dealing with multiple configurations (i.e. having more than one publicPath base, like we do) for the dev server, we just dump everything at root. Because the devserver doesn't actually save the files, this is not a problem.

## Issues addressed

https://trello.com/b/bjHannKQ/kolibri-tasks
