### PR TITLE
Assorted fixes for tasks and task API

### DIFF
--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -25,7 +25,7 @@ class TransferNotYetClosed(Exception):
 
 class Transfer(object):
 
-    def __init__(self, source, dest, block_size=2048, remove_existing_temp_file=True):
+    def __init__(self, source, dest, block_size=2097152, remove_existing_temp_file=True):
         self.source = source
         self.dest = dest
         self.dest_tmp = dest + ".transfer"

--- a/kolibri/plugins/management/assets/src/state/constants.js
+++ b/kolibri/plugins/management/assets/src/state/constants.js
@@ -23,10 +23,10 @@ const TaskTypes = {
 };
 
 const TaskStatuses = {
-  IN_PROGRESS: 'in_progress',
-  SUCCESS: 'success',
-  ERROR: 'error',
-  PENDING: 'pending',
+  IN_PROGRESS: 'IN_PROGRESS',
+  SUCCESS: 'SUCCESS',
+  FAILED: 'FAILED',
+  PENDING: 'PENDING',
 };
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/vue/content-page/task-status.vue
@@ -23,7 +23,7 @@
   module.exports = {
     $trNameSpace: 'contentPage',
     $trs: {
-      buttonConfirm: 'Confirm',
+      buttonClose: 'Close',
       buttonCancel: 'Cancel',
       failed: 'Failed.',
       completed: `Finished!`,
@@ -34,8 +34,8 @@
     },
     computed: {
       buttonMessage() {
-        if (this.status === TaskStatuses.ERROR || this.percentage === 1) {
-          return this.$tr('buttonConfirm');
+        if (this.status === TaskStatuses.FAILED || this.status === TaskStatuses.SUCCESS) {
+          return this.$tr('buttonClose');
         }
         return this.$tr('buttonCancel');
       },
@@ -53,9 +53,9 @@
         }
       },
       subTitle() {
-        if (this.status === TaskStatuses.ERROR) {
+        if (this.status === TaskStatuses.FAILED) {
           return this.$tr('failed');
-        } else if (this.percentage === 1) {
+        } else if (this.status === TaskStatuses.SUCCESS) {
           return this.$tr('completed');
         }
         return this.$tr('loading');

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -3,7 +3,8 @@ import logging as logger
 from django.core.management import call_command
 from django_q.models import Task
 from django_q.tasks import async
-from kolibri.content.utils.channels import get_channels_for_data_folder, get_mounted_drives_with_channel_info
+from kolibri.content.models import ChannelMetadataCache
+from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.tasks.management.commands.base import Progress
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import list_route
@@ -126,9 +127,9 @@ def _localimport(drive_id, update_state=None):
 def _localexport(drive_id, update_state=None):
     drives = get_mounted_drives_with_channel_info()
     drive = drives[drive_id]
-    for channel in get_channels_for_data_folder(drive.datafolder):
-        call_command("exportchannel", channel["id"], drive.datafolder, update_state=update_state)
-        call_command("exportcontent", channel["id"], drive.datafolder, update_state=update_state)
+    for channel in ChannelMetadataCache.objects.all():
+        call_command("exportchannel", channel.id, drive.datafolder, update_state=update_state)
+        call_command("exportcontent", channel.id, drive.datafolder, update_state=update_state)
 
 def _task_to_response(task_instance, task_type=None, task_id=None):
     """"

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -1,10 +1,14 @@
 import logging as logger
 
+import requests
 from django.core.management import call_command
+from django.http import Http404
+from django.utils.translation import ugettext as _
 from django_q.models import Task
 from django_q.tasks import async
 from kolibri.content.models import ChannelMetadataCache
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
+from kolibri.content.utils.paths import get_content_database_file_url
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
@@ -44,7 +48,14 @@ class TasksViewSet(viewsets.ViewSet):
         if "channel_id" not in request.data:
             raise serializers.ValidationError("The 'channel_id' field is required.")
 
-        task_id = async(_networkimport, request.data['channel_id'], group=TASKTYPE, progress_updates=True)
+        channel_id = request.data['channel_id']
+
+        # ensure the requested channel_id can be found on the central server, otherwise error
+        status = requests.head(get_content_database_file_url(channel_id)).status_code
+        if status == 404:
+            raise Http404(_("The requested channel does not exist on the content server."))
+
+        task_id = async(_networkimport, channel_id, group=TASKTYPE, progress_updates=True)
 
         # attempt to get the created Task, otherwise return pending status
         resp = _task_to_response(Task.get_task(task_id), task_type=TASKTYPE, task_id=task_id)


### PR DESCRIPTION
## Summary

Content import/export should now work seamlessly via the API, and progress should be displayed correctly.

## Reviewer guidance

Even though the PR isn't huge overall, it may be productive to review commit-by-commit, as they're chunked into meaningful units.

## Issues addressed

- https://github.com/learningequality/kolibri/issues/489 (https://trello.com/c/QvLkPIzg/560-import-export-tasks-api-reports-random-completion-percentage)
- https://trello.com/c/N3sptoAQ/537-import-export-startremoteimport-api-call-should-synchronously-return-an-error-if-channel-doesn-t-exist
- Queued transfers were slow due to small block size (-> frequent ormq database saves)
- Task status constants on client didn't match those on server, so status wasn't displayed correctly.
- Exporting to external drive via API was broken
