### PR TITLE
Added django-extensions (shell_plus) req.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -12,11 +12,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-# This is essential! We load the kolibri conf INSIDE the Django conf
-from kolibri.utils import conf
-
 # import kolibri, so we can get the path to the module.
 import kolibri
+# This is essential! We load the kolibri conf INSIDE the Django conf
+from kolibri.utils import conf
 
 KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
 
@@ -61,6 +60,7 @@ INSTALLED_APPS = [
     'kolibri.core.discovery',
     'rest_framework',
     'django_js_reverse',
+    'django_extensions',
 ] + conf.config['INSTALLED_APPS']
 
 MIDDLEWARE_CLASSES = (

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -62,6 +62,7 @@ Examples:
   kolibri url               Tell me the address of Kolibri
   kolibri shell             Display a Django shell
   kolibri manage help       Show the Django management usage dialogue
+  kolibri manage shell_plus Preload all models in Django shell
   kolibri manage runserver  Runs Django's development server
   kolibri diagnose          Show system information for debugging
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@
 flake8
 pre-commit
 tox
+django-extensions


### PR DESCRIPTION
## Summary

Added django-extensions to dev requirements. Allows us to preload django models using `kolibri manage shell_plus`.

## TODO

- [x] New dependencies (if any) added to requirements file

## Documentation
http://django-extensions.readthedocs.io/en/latest/shell_plus.html

## Screenshots (if appropriate)

**_SO COOL!_**

![screen shot 2016-09-17 at 1 41 42 pm](https://cloud.githubusercontent.com/assets/6361732/18611143/e2e3e702-7ce5-11e6-98ee-c7bdf4e1a4bf.png)

