### PR TITLE
hides the seek bar for audio player in IE9. short term hack.

### DIFF
--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -11,11 +11,15 @@
         {{ currentMinutes }} : {{ formattedCurrentSec }}
       </div>
       <input
+        v-if="notIE9"
         v-el:timebar
         class="timeline"
         type="range" min="0" value="0"
         :max="max"
         v-model="rawTime">
+      <!--[if lte IE 9]>
+      <span> / </span>
+      <![endif]-->
       <div id="total-time">
         {{ totalMinutes }} : {{ formattedTotalSec }}
       </div>
@@ -33,7 +37,7 @@
       @ended="endPlay"
       @seeking="handleSeek"
       :src="defaultFile.storage_url"
-    ></audio>
+    >Your browser cannot play this audio file correctly! Please consider updating your browser to the latest version.</audio>
   </div>
 
 </template>
@@ -84,6 +88,16 @@
       formattedTotalSec() {
         return this.formatTime(this.totalSeconds);
       },
+      notIE9() {
+         // For version of IE 9 and below, hides the seeker due to incompatibility.
+         // This is a short term MVP hack, longer term is to integrate video.js with audio tracks.
+         const ieVersion = parseFloat(navigator.appVersion.split('MSIE')[1]);
+         if (ieVersion === 9) {
+           return false;
+         }
+         return true;
+       },
+ 
       rawTime: {
         cache: false,
         get() {


### PR DESCRIPTION
## Summary

<img width="750" alt="screen shot 2016-09-12 at 3 45 37 pm" src="https://cloud.githubusercontent.com/assets/6668144/18455638/089dbc82-7900-11e6-8362-649e11b3f385.png">

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
- [ ] Add an entry to CHANGELOG.rst
- [ ] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)

## Screenshots (if appropriate)

They're nice. :)

