### PR TITLE
Add qcluster starting option to devserver

### DIFF
--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -84,7 +84,7 @@ Then, start up the development server and build the client-side dependencies:
 
 .. code-block:: bash
 
-  kolibri manage devserver --debug -- --webpack
+  kolibri manage devserver --debug -- --webpack --qcluster
 
 Wait for the build process to complete. This takes a while the first time, will complete faster as you make edits and the assets are automatically re-built.
 

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -11,8 +11,11 @@ In addition to the docs displayed below, there are some special forms of the ``k
   # runs the dev server and re-run client-side tests when files changes
   kolibri manage devserver --debug -- --karma
 
-  # both
-  kolibri manage devserver --debug -- --webpack --karma
+  # runs the dev server and also spawns the qcluster task queue in the background
+  kolibri manage devserver --debug -- --qcluster
+
+  # runs all of the above
+  kolibri manage devserver --debug -- --webpack --karma --qcluster
 
 
 .. note::

--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -89,15 +89,15 @@
         return this.formatTime(this.totalSeconds);
       },
       notIE9() {
-         // For version of IE 9 and below, hides the seeker due to incompatibility.
-         // This is a short term MVP hack, longer term is to integrate video.js with audio tracks.
-         const ieVersion = parseFloat(navigator.appVersion.split('MSIE')[1]);
-         if (ieVersion === 9) {
-           return false;
-         }
-         return true;
-       },
- 
+      // For version of IE 9 and below, hides the seeker due to incompatibility.
+      // This is a short term MVP hack, longer term is to integrate video.js with audio tracks.
+        const ieVersion = parseFloat(navigator.appVersion.split('MSIE')[1]);
+        if (ieVersion === 9) {
+          return false;
+        }
+        return true;
+      },
+
       rawTime: {
         cache: false,
         get() {


### PR DESCRIPTION
## Summary

As in https://github.com/learningequality/kolibri/pull/531, but starts `qcluster` from the `devserver`, also, if the `--qcluster` option is specified.

## TODO

- [x] Has documentation been written/updated?

## Reviewer guidance

Wait until https://github.com/learningequality/kolibri/pull/532 is merged, as this is built on those changes.
