### PR TITLE
Update the steps when installing the requirements for Kolibri.

### DIFF
--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -66,12 +66,12 @@ Run the following commands:
 
 .. code-block:: bash
 
-  # Node.js dependencies
-  npm install
-
   # Python requirements
   pip install -r requirements.txt
   pip install -r requirements/dev.txt
+
+  # Node.js dependencies
+  npm install
 
   # Kolibri Python package in 'editable' mode
   pip install -e .


### PR DESCRIPTION
## Summary

Using the current steps of installing library requirements for Kolibri, will spawn an error during `npm install`, because some packages cannot be found by the npm.

## TODO

- [ ] test

## Reviewer guidance

#537 

##Screenshot

![screen shot 2016-09-22 at 2 45 52 pm](https://cloud.githubusercontent.com/assets/8663934/18739108/c66640a6-80d3-11e6-99b1-ecdc4496b5db.png)

/cc @aronasorman 