### PR TITLE
Cancel promises

### DIFF
--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -349,6 +349,20 @@ function stopTrackingProgress(store, Kolibri) {
   updateTimeSpent(store, Kolibri, true);
 }
 
+
+/**
+ * Action inhibition check
+ *
+ * This generator function produces checks that help determine whether the
+ * asynchronous outcomes should still be run based on whether the user is
+ * still on the same page as when the action was first triggered.
+ */
+
+function samePageCheckGenerator(store) {
+  const pageId = store.state.core.pageSessionId;
+  return () => store.state.core.pageSessionId === pageId;
+}
+
 module.exports = {
   kolibriLogin,
   kolibriLogout,
@@ -361,4 +375,5 @@ module.exports = {
   updateTimeSpent,
   updateProgress,
   saveLogs,
+  samePageCheckGenerator,
 };

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -302,34 +302,36 @@ function showLearnChannel(store, channelId) {
   const id = 'current';
   const sessionModel = SessionResource.getModel(id);
   const sessionPromise = sessionModel.fetch();
-  sessionPromise.then((session) => {
-    const nextStepsPayload = { next_steps: session.user_id, channel: channelId };
-    const popularPayload = { popular: session.user_id, channel: channelId };
-    const resumePayload = { resume: session.user_id, channel: channelId };
-    const nextStepsPromise = ContentNodeResource.getCollection(nextStepsPayload).fetch();
-    const popularPromise = ContentNodeResource.getCollection(popularPayload).fetch();
-    const resumePromise = ContentNodeResource.getCollection(resumePayload).fetch();
-    _updateChannelList(store);
-    ConditionalPromise.all([nextStepsPromise, popularPromise, resumePromise]).only(
-      samePageCheckGenerator(store),
-      ([nextSteps, popular, resume]) => {
-        const pageState = { recommendations: { nextSteps: nextSteps.map(_contentState),
-                                               popular: popular.map(_contentState),
-                                               resume: resume.map(_contentState) } };
-        store.dispatch('SET_PAGE_STATE', pageState);
-        store.dispatch('CORE_SET_PAGE_LOADING', false);
-        store.dispatch('CORE_SET_ERROR', null);
-      },
-      (error) => {
-        store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-        store.dispatch('CORE_SET_PAGE_LOADING', false);
-      }
-    );
-  })
-  .catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
+  sessionPromise.then(
+    (session) => {
+      const nextStepsPayload = { next_steps: session.user_id, channel: channelId };
+      const popularPayload = { popular: session.user_id, channel: channelId };
+      const resumePayload = { resume: session.user_id, channel: channelId };
+      const nextStepsPromise = ContentNodeResource.getCollection(nextStepsPayload).fetch();
+      const popularPromise = ContentNodeResource.getCollection(popularPayload).fetch();
+      const resumePromise = ContentNodeResource.getCollection(resumePayload).fetch();
+      _updateChannelList(store);
+      ConditionalPromise.all([nextStepsPromise, popularPromise, resumePromise]).only(
+        samePageCheckGenerator(store),
+        ([nextSteps, popular, resume]) => {
+          const pageState = { recommendations: { nextSteps: nextSteps.map(_contentState),
+                                                 popular: popular.map(_contentState),
+                                                 resume: resume.map(_contentState) } };
+          store.dispatch('SET_PAGE_STATE', pageState);
+          store.dispatch('CORE_SET_PAGE_LOADING', false);
+          store.dispatch('CORE_SET_ERROR', null);
+        },
+        (error) => {
+          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+          store.dispatch('CORE_SET_PAGE_LOADING', false);
+        }
+      );
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
 }
 
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -6,6 +6,7 @@ const PageNames = constants.PageNames;
 const cookiejs = require('js-cookie');
 const router = require('kolibri/coreVue/router');
 const ConditionalPromise = require('kolibri/lib/conditionalPromise');
+const samePageCheckGenerator = require('kolibri/coreVue/vuex/actions').samePageCheckGenerator;
 
 /**
  * Vuex State Mappers
@@ -139,24 +140,12 @@ function _updateChannelList(store) {
   return channelPromise;
 }
 
-/**
- * Action inhibition checks
- *
- * These generator functions produce functions that help to determine whether the
- * asynchronous outcomes of certain actions should still be applied as mutations.
- */
-
-function checkSamePageId(store) {
-  const pageId = store.state.core.pageSessionId;
-  return () => store.state.core.pageSessionId === pageId;
-}
 
 /**
  * Actions
  *
  * These methods are used to update client-side state
  */
-
 
 function redirectToExploreChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
@@ -183,7 +172,6 @@ function redirectToExploreChannel(store) {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
     });
 }
-
 
 function redirectToLearnChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
@@ -225,8 +213,9 @@ function showExploreChannel(store, channelId) {
       const childrenPromise = ContentNodeResource.getCollection({ parent: rootTopicId }).fetch();
       _updateChannelList(store);
 
-      ConditionalPromise.all([attributesPromise, childrenPromise])
-        .only(checkSamePageId(store), ([attributes, children]) => {
+      ConditionalPromise.all([attributesPromise, childrenPromise]).only(
+        samePageCheckGenerator(store),
+        ([attributes, children]) => {
           const pageState = { rootTopicId };
           pageState.topic = _topicState(attributes);
           const collection = _collectionState(children);
@@ -235,11 +224,14 @@ function showExploreChannel(store, channelId) {
           store.dispatch('SET_PAGE_STATE', pageState);
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
-        }).catch((error) => {
+        },
+        (error) => {
           store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
           store.dispatch('CORE_SET_PAGE_LOADING', false);
-        });
-    }, (error) => {
+        }
+      );
+    },
+    (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
     });
@@ -255,8 +247,9 @@ function showExploreTopic(store, channelId, id) {
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
   _updateChannelList(store);
-  ConditionalPromise.all([attributesPromise, childrenPromise])
-    .only(checkSamePageId(store), ([attributes, children]) => {
+  ConditionalPromise.all([attributesPromise, childrenPromise]).only(
+    samePageCheckGenerator(store),
+    ([attributes, children]) => {
       const pageState = { id };
       pageState.topic = _topicState(attributes);
       const collection = _collectionState(children);
@@ -265,10 +258,12 @@ function showExploreTopic(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-    }, (error) => {
+    },
+    (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+    }
+  );
 }
 
 
@@ -281,15 +276,19 @@ function showExploreContent(store, channelId, id) {
   const attributesPromise = ContentNodeResource.getModel(id).fetch();
   _updateChannelList(store);
 
-  attributesPromise.only(checkSamePageId(store), (attributes) => {
-    const pageState = { content: _contentState(attributes) };
-    store.dispatch('SET_PAGE_STATE', pageState);
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-    store.dispatch('CORE_SET_ERROR', null);
-  }, (error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
+  attributesPromise.only(
+    samePageCheckGenerator(store),
+    (attributes) => {
+      const pageState = { content: _contentState(attributes) };
+      store.dispatch('SET_PAGE_STATE', pageState);
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('CORE_SET_ERROR', null);
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
 }
 
 
@@ -311,23 +310,26 @@ function showLearnChannel(store, channelId) {
     const popularPromise = ContentNodeResource.getCollection(popularPayload).fetch();
     const resumePromise = ContentNodeResource.getCollection(resumePayload).fetch();
     _updateChannelList(store);
-    ConditionalPromise.all([nextStepsPromise, popularPromise, resumePromise])
-      .only(checkSamePageId(store), ([nextSteps, popular, resume]) => {
+    ConditionalPromise.all([nextStepsPromise, popularPromise, resumePromise]).only(
+      samePageCheckGenerator(store),
+      ([nextSteps, popular, resume]) => {
         const pageState = { recommendations: { nextSteps: nextSteps.map(_contentState),
                                                popular: popular.map(_contentState),
                                                resume: resume.map(_contentState) } };
         store.dispatch('SET_PAGE_STATE', pageState);
         store.dispatch('CORE_SET_PAGE_LOADING', false);
         store.dispatch('CORE_SET_ERROR', null);
-      }, (error) => {
+      },
+      (error) => {
         store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
         store.dispatch('CORE_SET_PAGE_LOADING', false);
-      });
+      }
+    );
   })
-    .catch((error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+  .catch((error) => {
+    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+  });
 }
 
 
@@ -340,30 +342,38 @@ function showLearnContent(store, channelId, id) {
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
   _updateChannelList(store);
 
-  attributesPromise.only(checkSamePageId(store), (attributes) => {
-    const pageState = {
-      content: _contentState(attributes),
-      recommended: store.state.pageState.recommended,
-    };
-    store.dispatch('SET_PAGE_STATE', pageState);
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-    store.dispatch('CORE_SET_ERROR', null);
-  }, (error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
-  recommendedPromise.only(checkSamePageId(store), (recommended) => {
-    const pageState = {
-      content: store.state.pageState.content,
-      recommended: recommended.map(_contentState),
-    };
-    store.dispatch('SET_PAGE_STATE', pageState);
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-    store.dispatch('CORE_SET_ERROR', null);
-  }, (error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
+  attributesPromise.only(
+    samePageCheckGenerator(store),
+    (attributes) => {
+      const pageState = {
+        content: _contentState(attributes),
+        recommended: store.state.pageState.recommended,
+      };
+      store.dispatch('SET_PAGE_STATE', pageState);
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('CORE_SET_ERROR', null);
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
+  recommendedPromise.only(
+    samePageCheckGenerator(store),
+    (recommended) => {
+      const pageState = {
+        content: store.state.pageState.content,
+        recommended: recommended.map(_contentState),
+      };
+      store.dispatch('SET_PAGE_STATE', pageState);
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('CORE_SET_ERROR', null);
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
 }
 
 

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -6,10 +6,12 @@ const ChannelResource = Kolibri.resources.ChannelResource;
 const TaskResource = Kolibri.resources.TaskResource;
 const RoleResource = Kolibri.resources.RoleResource;
 
+const ConditionalPromise = require('kolibri/lib/conditionalPromise');
 const constants = require('./state/constants');
 const UserKinds = require('kolibri/coreVue/vuex/constants').UserKinds;
 const PageNames = constants.PageNames;
 const ContentWizardPages = constants.ContentWizardPages;
+const samePageCheckGenerator = require('kolibri/coreVue/vuex/actions').samePageCheckGenerator;
 
 
 // ================================
@@ -205,21 +207,24 @@ function showUserPage(store) {
 
   const promises = [facilityIdPromise, userPromise];
 
-  Promise.all(promises).then(([facilityId, users]) => {
-    store.dispatch('SET_FACILITY', facilityId[0]); // for mvp, we assume only one facility exists
+  ConditionalPromise.all(promises).only(
+    samePageCheckGenerator(store),
+    ([facilityId, users]) => {
+      store.dispatch('SET_FACILITY', facilityId[0]); // for mvp, we assume only one facility exists
 
-    const pageState = {
-      users: users.map(_userState),
-    };
+      const pageState = {
+        users: users.map(_userState),
+      };
 
-    store.dispatch('SET_PAGE_STATE', pageState);
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-    store.dispatch('CORE_SET_ERROR', null);
-  },
-  rejects => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(rejects, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
+      store.dispatch('SET_PAGE_STATE', pageState);
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('CORE_SET_ERROR', null);
+    },
+    (rejects) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(rejects, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
 }
 
 
@@ -231,22 +236,25 @@ function showContentPage(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.CONTENT_MGMT_PAGE);
   const taskCollectionPromise = TaskResource.getCollection().fetch();
-  taskCollectionPromise.then((taskList) => {
-    const pageState = {
-      taskList: taskList.map(_taskState),
-      wizardState: { shown: false },
-    };
-    const channelCollectionPromise = ChannelResource.getCollection({}).fetch();
-    channelCollectionPromise.then((channelList) => {
-      pageState.channelList = channelList;
-      store.dispatch('SET_PAGE_STATE', pageState);
+  taskCollectionPromise.only(
+    samePageCheckGenerator(store),
+    (taskList) => {
+      const pageState = {
+        taskList: taskList.map(_taskState),
+        wizardState: { shown: false },
+      };
+      const channelCollectionPromise = ChannelResource.getCollection({}).fetch();
+      channelCollectionPromise.then((channelList) => {
+        pageState.channelList = channelList;
+        store.dispatch('SET_PAGE_STATE', pageState);
+        store.dispatch('CORE_SET_PAGE_LOADING', false);
+      });
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
-  })
-  .catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    store.dispatch('CORE_SET_PAGE_LOADING', false);
-  });
+    }
+  );
 }
 
 function updateWizardLocalDriveList(store) {
@@ -320,19 +328,31 @@ function cancelImportExportWizard(store) {
 
 // called from a timer to continually update UI
 function pollTasksAndChannels(store) {
-  TaskResource.getCollection().fetch({}, true).then(
+  const samePageCheck = samePageCheckGenerator(store);
+  TaskResource.getCollection().fetch({}, true).only(
+    () => {
+      // don't handle response if we've switched pages
+      if (!samePageCheck()) {
+        return false;
+      }
+      // don't handle response if we're in the middle of another operation
+      return !store.state.pageState.wizardState.busy;
+    },
     (taskList) => {
-      ChannelResource.getCollection({}).fetch({}, true).then((channelList) => {
-        store.dispatch('SET_CONTENT_PAGE_TASKS', taskList.map(_taskState));
-        store.dispatch('SET_CONTENT_PAGE_CHANNELS', channelList);
+      ChannelResource.getCollection({}).fetch({}, true).only(
+        samePageCheckGenerator(store),
+        (channelList) => {
+          store.dispatch('SET_CONTENT_PAGE_TASKS', taskList.map(_taskState));
+          store.dispatch('SET_CONTENT_PAGE_CHANNELS', channelList);
 
-        // Close the wizard if there's an outstanding task.
-        // (this can be removed when we support more than one
-        // concurrent task.)
-        if (taskList.length && store.state.pageState.wizardState.shown) {
-          cancelImportExportWizard(store);
+          // Close the wizard if there's an outstanding task.
+          // (this can be removed when we support more than one
+          // concurrent task.)
+          if (taskList.length && store.state.pageState.wizardState.shown) {
+            cancelImportExportWizard(store);
+          }
         }
-      });
+      );
     },
     (error) => {
       logging.error(`poll error: ${error}`);


### PR DESCRIPTION

Adding conditional-promise logic to management.

This includes preventing polling callbacks from being used when task-creation is in-progress. Perhaps helps with #538 ?

also related to:

* https://trello.com/c/x9iUHqie/598-make-sure-ajax-requests-are-canceled-when-user-leaves-the-page-or-when-a-new-request-is-submitted
* https://trello.com/c/azY7Az0b/559-import-export-pending-tasks-do-not-seem-to-be-returned
