### PR TITLE
Prevent flash

### DIFF
--- a/kolibri/core/assets/src/vue/core-modal/index.vue
+++ b/kolibri/core/assets/src/vue/core-modal/index.vue
@@ -154,6 +154,10 @@
     transition: all 0.3s ease
     margin: 0 auto
     padding: 15px 30px
+
+    &:focus
+      outline: none
+
     @media (max-width: $portrait-breakpoint)
       width: 85%
       top: 45%

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
@@ -3,7 +3,6 @@
   <core-modal
     title="Export to a Local Drive"
     :error="wizardState.error ? true : false"
-    :disableclose="wizardState.busy"
     :enablebgclickcancel="false"
     @cancel="cancel"
     @enter="submit"
@@ -49,8 +48,7 @@
     <div class="button-wrapper">
       <icon-button
         @click="cancel"
-        text="Cancel"
-        :disabled="wizardState.busy">
+        text="Cancel">
       </icon-button>
       <icon-button
         text="Export"

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
@@ -41,7 +41,7 @@
           </icon-button>
         </div>
       </template>
-      <loading-spinner v-else :delay="0" class="spinner"></loading-spinner>
+      <loading-spinner v-else :delay="500" class="spinner"></loading-spinner>
     </div>
     <div class="core-text-alert">
       {{ wizardState.error }}
@@ -135,9 +135,12 @@
 
   @require '~kolibri/styles/coreTheme'
 
+  $min-height = 200px
+
   .main
     text-align: center
     margin: 3em 0
+    min-height: $min-height
 
   h2
     font-size: 1em
@@ -166,6 +169,6 @@
     text-align: center
 
   .spinner
-    height: 200px
+    height: $min-height
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
@@ -45,7 +45,7 @@
           </icon-button>
         </div>
       </template>
-      <loading-spinner v-else :delay="0" class="spinner"></loading-spinner>
+      <loading-spinner v-else :delay="500" class="spinner"></loading-spinner>
     </div>
     <div class="core-text-alert">
       {{ wizardState.error }}
@@ -137,9 +137,12 @@
 
   @require '~kolibri/styles/coreTheme'
 
+  $min-height = 200px
+
   .main
     text-align: center
     margin: 3em 0
+    min-height: $min-height
 
   h2
     font-size: 1em
@@ -168,7 +171,7 @@
     text-align: center
 
   .spinner
-    height: 200px
+    height: $min-height
 
   .core-text-alert
     text-align: center

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
@@ -4,7 +4,6 @@
     title="Import from a Local Drive"
     :error="wizardState.error"
     :enablebgclickcancel="false"
-    :disableclose="wizardState.busy"
     :enablebackbtn="true"
     @cancel="cancel"
     @enter="submit"
@@ -53,8 +52,7 @@
     <div class="button-wrapper">
       <icon-button
         @click="cancel"
-        text="Cancel"
-        :disabled="wizardState.busy">
+        text="Cancel">
       </icon-button>
       <icon-button
         text="Import"

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-network.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-network.vue
@@ -4,7 +4,6 @@
     title="Import from the Internet"
     :error="wizardState.error"
     :enablebgclickcancel="false"
-    :disableclose="wizardState.busy"
     :enablebackbtn="true"
     @cancel="cancel"
     @enter="submit"


### PR DESCRIPTION
addresses

* https://trello.com/c/ZLqC5fLw/591-import-export-minor-flash-within-modal-upon-clicking-export
* https://trello.com/c/0FgpjK7q/594-import-export-refresh-ux

additional drive-by change: remove unnecessary focus outline on modals
