### PR TITLE
Small fixes for i18n to prevent JS error and Vue warnings.

### DIFF
--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -81,7 +81,8 @@ module.exports = class CoreApp {
        * Use the vue-intl plugin.
        **/
       const VueIntl = require('vue-intl');
-      vue.use(VueIntl);
+      vue.use(VueIntl, { defaultLocale: 'en-us' });
+
       vue.prototype.$tr = function $tr(messageId, ...args) {
         const defaultMessageText = this.$options.$trs[messageId];
         const message = {

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -350,8 +350,8 @@ class FrontEndCoreAssetHook(WebpackBundleHook):
 
         :return: HTML of script tags for insertion into a page.
         """
-        tags = ['<script>var coreLanguageMessages = {messages};</script>'.format(
-            messages=self.frontend_messages)] + list(self.js_and_css_tags())
+        tags = (['<script>var coreLanguageMessages = {messages};</script>'.format(
+            messages=self.frontend_messages)] if self.frontend_messages else []) + list(self.js_and_css_tags())
 
         return mark_safe('\n'.join(tags))
 


### PR DESCRIPTION
## Summary

Sets defaultLocale on vue-intl.

Doesn't try to render `coreLanguageMessages` variable in template if there are none.