### PR TITLE
Page titles (and drive-by channel actions refactor)

### DIFF
--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -89,6 +89,14 @@ function _sessionState(data) {
  *
  * These methods are used to update client-side state
  */
+
+
+function handleApiError(store, errorObject) {
+  store.dispatch('CORE_SET_ERROR', JSON.stringify(errorObject, null, '\t'));
+  store.dispatch('CORE_SET_PAGE_LOADING', false);
+  store.dispatch('CORE_SET_TITLE', 'Error');
+}
+
 function kolibriLogin(store, Kolibri, sessionPayload) {
   const SessionResource = Kolibri.resources.SessionResource;
   const sessionModel = SessionResource.createModel(sessionPayload);
@@ -364,6 +372,7 @@ function samePageCheckGenerator(store) {
 }
 
 module.exports = {
+  handleApiError,
   kolibriLogin,
   kolibriLogout,
   currentLoggedInUser,

--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -91,10 +91,14 @@ function _sessionState(data) {
  */
 
 
-function handleApiError(store, errorObject) {
-  store.dispatch('CORE_SET_ERROR', JSON.stringify(errorObject, null, '\t'));
+function handleError(store, errorString) {
+  store.dispatch('CORE_SET_ERROR', errorString);
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_TITLE', 'Error');
+}
+
+function handleApiError(store, errorObject) {
+  handleError(JSON.stringify(errorObject, null, '\t'));
 }
 
 function kolibriLogin(store, Kolibri, sessionPayload) {

--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -115,11 +115,11 @@ function kolibriLogin(store, Kolibri, sessionPayload) {
       Kolibri.emit('refresh');
     }
     Kolibri.resources.clearCaches();
-  }).catch((error) => {
+  }).catch(error => {
     if (error.status.code === 401) {
       store.dispatch('CORE_SET_LOGIN_ERROR', 401);
     } else {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      handleApiError(store, error);
     }
   });
 }
@@ -134,9 +134,7 @@ function kolibriLogout(store, Kolibri) {
     /* Very hacky solution to redirect a user back to Learn tab on logout*/
     window.location.href = window.location.origin;
     Kolibri.resources.clearCaches();
-  }).catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-  });
+  }).catch(error => { handleApiError(store, error); });
 }
 
 function currentLoggedInUser(store, Kolibri) {
@@ -146,9 +144,7 @@ function currentLoggedInUser(store, Kolibri) {
   const sessionPromise = sessionModel.fetch({});
   sessionPromise.then((session) => {
     store.dispatch('CORE_SET_SESSION', _sessionState(session));
-  }).catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-  });
+  }).catch(error => { handleApiError(store, error); });
 }
 
 function showLoginModal(store, bool) {
@@ -254,9 +250,7 @@ function saveLogs(store, Kolibri) {
     const sessionModel = ContentSessionLogResource.getModel(sessionLog.id);
     sessionModel.save(_contentSessionModel(store)).then((data) => {
       /* PLACEHOLDER */
-    }).catch((error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    });
+    }).catch(error => { handleApiError(store, error); });
   }
 
   /* If a summary model exists, save it with updated values */
@@ -264,9 +258,7 @@ function saveLogs(store, Kolibri) {
     const summaryModel = ContentSummaryLogResource.getModel(summaryLog.id);
     summaryModel.save(_contentSummaryModel(store)).then((data) => {
       /* PLACEHOLDER */
-    }).catch((error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    });
+    }).catch(error => { handleApiError(store, error); });
   }
 }
 

--- a/kolibri/core/assets/src/core-store.js
+++ b/kolibri/core/assets/src/core-store.js
@@ -7,6 +7,7 @@ const initialState = {
   core: {
     error: '',
     loading: true,
+    title: '',
     pageSessionId: 0,
     session: {
       id: undefined,
@@ -60,6 +61,9 @@ const mutations = {
   },
   CORE_SET_ERROR(state, error) {
     state.core.error = error;
+  },
+  CORE_SET_TITLE(state, title) {
+    state.core.title = title;
   },
   SET_LOGGING_SUMMARY_STATE(state, summaryState) {
     state.core.logging.summary = summaryState;

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -31,6 +31,12 @@
       getters: {
         loading: state => state.core.loading,
         error: state => state.core.error,
+        title: state => state.core.title,
+      },
+    },
+    watch: {
+      title(newVal, oldVal) {
+        document.title = newVal;
       },
     },
     data: () => ({

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -36,7 +36,7 @@
     },
     watch: {
       title(newVal, oldVal) {
-        document.title = newVal;
+        document.title = `${newVal} - Kolibri`;
       },
     },
     data: () => ({

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -6,6 +6,7 @@ const getters = require('./state/getters');
 const PageNames = constants.PageNames;
 const cookiejs = require('js-cookie');
 const router = require('kolibri/coreVue/router');
+const coreActions = require('kolibri/coreVue/vuex/actions');
 const ConditionalPromise = require('kolibri/lib/conditionalPromise');
 const samePageCheckGenerator = require('kolibri/coreVue/vuex/actions').samePageCheckGenerator;
 
@@ -170,11 +171,7 @@ function redirectToExploreChannel(store) {
         router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -197,11 +194,7 @@ function redirectToLearnChannel(store) {
         router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -238,11 +231,7 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
         store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.topic.title));
       }
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -282,11 +271,7 @@ function showExploreContent(store, channelId, id) {
       store.dispatch('CORE_SET_ERROR', null);
       store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.content.title));
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -321,18 +306,10 @@ function showLearnChannel(store, channelId) {
           const currentChannel = getters.currentChannel(store.state);
           store.dispatch('CORE_SET_TITLE', _learnPageTitle(currentChannel.title));
         },
-        (error) => {
-          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-          store.dispatch('CORE_SET_PAGE_LOADING', false);
-          store.dispatch('CORE_SET_TITLE', _errorTitle());
-        }
+        error => { coreActions.handleApiError(store, error); }
       );
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -358,11 +335,7 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('CORE_SET_ERROR', null);
       store.dispatch('CORE_SET_TITLE', _learnPageTitle(pageState.content.title));
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
   recommendedPromise.only(
     samePageCheckGenerator(store),
@@ -375,11 +348,7 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -206,9 +206,13 @@ function redirectToLearnChannel(store) {
 }
 
 
-function showExploreTopic(store, channelId, id, customTitle) {
+function showExploreTopic(store, channelId, id, isRoot = false) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_TOPIC);
+  if (isRoot) {
+    store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
+  } else {
+    store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_TOPIC);
+  }
 
   const topicPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
@@ -227,8 +231,9 @@ function showExploreTopic(store, channelId, id, customTitle) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      if (customTitle) {
-        document.title = _explorePageTitle(customTitle);
+      if (isRoot) {
+        const currentChannel = getters.currentChannel(store.state);
+        document.title = _explorePageTitle(currentChannel.title);
       } else {
         document.title = _explorePageTitle(pageState.topic.title);
       }
@@ -253,7 +258,7 @@ function showExploreChannel(store, channelId) {
       }
       const currentChannel = getters.currentChannel(store.state);
       store.dispatch('SET_ROOT_TOPIC_ID', currentChannel.root_id);
-      showExploreTopic(store, channelId, currentChannel.root_id, currentChannel.title);
+      showExploreTopic(store, channelId, currentChannel.root_id, true);
     }
   );
 }

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -139,7 +139,7 @@ function _handleChannels(store, currentChannelId, channelList) {
   if (!channelList.find(channel => channel.id === currentChannelId)) {
     store.dispatch('CORE_SET_ERROR', 'Channel not found');
     store.dispatch('CORE_SET_PAGE_LOADING', false);
-    document.title = _errorTitle();
+    store.dispatch('CORE_SET_TITLE', _errorTitle());
     return false;
   }
   return true;
@@ -173,7 +173,7 @@ function redirectToExploreChannel(store) {
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -200,7 +200,7 @@ function redirectToLearnChannel(store) {
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -233,15 +233,15 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
       store.dispatch('CORE_SET_ERROR', null);
       if (isRoot) {
         const currentChannel = getters.currentChannel(store.state);
-        document.title = _explorePageTitle(currentChannel.title);
+        store.dispatch('CORE_SET_TITLE', _explorePageTitle(currentChannel.title));
       } else {
-        document.title = _explorePageTitle(pageState.topic.title);
+        store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.topic.title));
       }
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -280,12 +280,12 @@ function showExploreContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      document.title = _explorePageTitle(pageState.content.title);
+      store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.content.title));
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -319,19 +319,19 @@ function showLearnChannel(store, channelId) {
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
           const currentChannel = getters.currentChannel(store.state);
-          document.title = _learnPageTitle(currentChannel.title);
+          store.dispatch('CORE_SET_TITLE', _learnPageTitle(currentChannel.title));
         },
         (error) => {
           store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
           store.dispatch('CORE_SET_PAGE_LOADING', false);
-          document.title = _errorTitle();
+          store.dispatch('CORE_SET_TITLE', _errorTitle());
         }
       );
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -356,12 +356,12 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      document.title = _learnPageTitle(pageState.content.title);
+      store.dispatch('CORE_SET_TITLE', _learnPageTitle(pageState.content.title));
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
   recommendedPromise.only(
@@ -378,7 +378,7 @@ function showLearnContent(store, channelId, id) {
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -431,7 +431,7 @@ function showScratchpad(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
-  document.title = 'Scratchpad';
+  store.dispatch('CORE_SET_TITLE', 'Scratchpad');
 }
 
 
@@ -440,7 +440,7 @@ function showContentUnavailable(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
-  document.title = 'Content Unavailable';
+  store.dispatch('CORE_SET_TITLE', 'Content Unavailable');
 }
 
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -83,25 +83,6 @@ function _channelListState(data) {
 }
 
 
-/**
- * Title Helpers
- */
-
-function _explorePageTitle(title) {
-  if (title) {
-    return `Explore - ${title}`;
-  }
-  return 'Explore';
-}
-
-function _learnPageTitle(title) {
-  if (title) {
-    return `Learn - ${title}`;
-  }
-  return 'Learn';
-}
-
-
 /*
  * Returns the 'default' channel ID:
  * - if there are channels and they match the cookie, return that
@@ -212,11 +193,11 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
+      const currentChannel = getters.currentChannel(store.state);
       if (isRoot) {
-        const currentChannel = getters.currentChannel(store.state);
-        store.dispatch('CORE_SET_TITLE', _explorePageTitle(currentChannel.title));
+        store.dispatch('CORE_SET_TITLE', `Explore - ${currentChannel.title}`);
       } else {
-        store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.topic.title));
+        store.dispatch('CORE_SET_TITLE', `${pageState.topic.title} - ${currentChannel.title}`);
       }
     },
     error => { coreActions.handleApiError(store, error); }
@@ -252,14 +233,15 @@ function showExploreContent(store, channelId, id) {
     samePageCheckGenerator(store),
     ([content, channelsData]) => {
       _setChannelState(store, channelId, _channelListState(channelsData));
-      if (!getters.currentChannel(store.state)) {
+      const currentChannel = getters.currentChannel(store.state);
+      if (!currentChannel) {
         return;
       }
       const pageState = { content: _contentState(content) };
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', _explorePageTitle(pageState.content.title));
+      store.dispatch('CORE_SET_TITLE', `${pageState.content.title} - ${currentChannel.title}`);
     },
     error => { coreActions.handleApiError(store, error); }
   );
@@ -295,7 +277,7 @@ function showLearnChannel(store, channelId) {
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
           const currentChannel = getters.currentChannel(store.state);
-          store.dispatch('CORE_SET_TITLE', _learnPageTitle(currentChannel.title));
+          store.dispatch('CORE_SET_TITLE', `Learn - ${currentChannel.title}`);
         },
         error => { coreActions.handleApiError(store, error); }
       );
@@ -315,7 +297,8 @@ function showLearnContent(store, channelId, id) {
     samePageCheckGenerator(store),
     ([content, channelsData]) => {
       _setChannelState(store, channelId, _channelListState(channelsData));
-      if (!getters.currentChannel(store.state)) {
+      const currentChannel = getters.currentChannel(store.state);
+      if (!currentChannel) {
         return;
       }
       const pageState = {
@@ -325,7 +308,7 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', _learnPageTitle(pageState.content.title));
+      store.dispatch('CORE_SET_TITLE', `${pageState.content.title} - ${currentChannel.title}`);
     },
     error => { coreActions.handleApiError(store, error); }
   );

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -151,8 +151,8 @@ function redirectToExploreChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_ROOT);
 
-  _getCurrentChannelId()
-    .then((currentChannelId) => {
+  _getCurrentChannelId().then(
+    (currentChannelId) => {
       store.dispatch('CORE_SET_ERROR', null);
       if (currentChannelId) {
         store.dispatch('SET_CURRENT_CHANNEL', currentChannelId);
@@ -166,19 +166,21 @@ function redirectToExploreChannel(store) {
       } else {
         router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
-    })
-    .catch((error) => {
+    },
+    (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+    }
+  );
 }
+
 
 function redirectToLearnChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.LEARN_ROOT);
 
-  _getCurrentChannelId()
-    .then((currentChannelId) => {
+  _getCurrentChannelId().then(
+    (currentChannelId) => {
       store.dispatch('CORE_SET_ERROR', null);
       if (currentChannelId) {
         store.dispatch('SET_CURRENT_CHANNEL', currentChannelId);
@@ -192,11 +194,12 @@ function redirectToLearnChannel(store) {
       } else {
         router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });
       }
-    })
-    .catch((error) => {
+    },
+    (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+    }
+  );
 }
 
 function showExploreChannel(store, channelId) {
@@ -206,8 +209,8 @@ function showExploreChannel(store, channelId) {
   cookiejs.set('currentChannel', channelId);
   ContentNodeResource.setChannel(channelId);
 
-  _getCurrentChannelRootTopicId()
-    .then((rootTopicId) => {
+  _getCurrentChannelRootTopicId().then(
+    (rootTopicId) => {
       store.dispatch('SET_ROOT_TOPIC_ID', rootTopicId);
       const attributesPromise = ContentNodeResource.getModel(rootTopicId).fetch();
       const childrenPromise = ContentNodeResource.getCollection({ parent: rootTopicId }).fetch();
@@ -234,7 +237,8 @@ function showExploreChannel(store, channelId) {
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-    });
+    }
+  );
 }
 
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -202,45 +202,6 @@ function redirectToLearnChannel(store) {
   );
 }
 
-function showExploreChannel(store, channelId) {
-  store.dispatch('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
-  store.dispatch('SET_CURRENT_CHANNEL', channelId);
-  cookiejs.set('currentChannel', channelId);
-  ContentNodeResource.setChannel(channelId);
-
-  _getCurrentChannelRootTopicId().then(
-    (rootTopicId) => {
-      store.dispatch('SET_ROOT_TOPIC_ID', rootTopicId);
-      const attributesPromise = ContentNodeResource.getModel(rootTopicId).fetch();
-      const childrenPromise = ContentNodeResource.getCollection({ parent: rootTopicId }).fetch();
-      _updateChannelList(store);
-
-      ConditionalPromise.all([attributesPromise, childrenPromise]).only(
-        samePageCheckGenerator(store),
-        ([attributes, children]) => {
-          const pageState = { rootTopicId };
-          pageState.topic = _topicState(attributes);
-          const collection = _collectionState(children);
-          pageState.subtopics = collection.topics;
-          pageState.contents = collection.contents;
-          store.dispatch('SET_PAGE_STATE', pageState);
-          store.dispatch('CORE_SET_PAGE_LOADING', false);
-          store.dispatch('CORE_SET_ERROR', null);
-        },
-        (error) => {
-          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-          store.dispatch('CORE_SET_PAGE_LOADING', false);
-        }
-      );
-    },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-    }
-  );
-}
-
 
 function showExploreTopic(store, channelId, id) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
@@ -262,6 +223,26 @@ function showExploreTopic(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
+    },
+    (error) => {
+      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+      store.dispatch('CORE_SET_PAGE_LOADING', false);
+    }
+  );
+}
+
+
+function showExploreChannel(store, channelId) {
+  store.dispatch('CORE_SET_PAGE_LOADING', true);
+  store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
+  store.dispatch('SET_CURRENT_CHANNEL', channelId);
+  cookiejs.set('currentChannel', channelId);
+  ContentNodeResource.setChannel(channelId);
+
+  _getCurrentChannelRootTopicId().then(
+    (rootTopicId) => {
+      store.dispatch('SET_ROOT_TOPIC_ID', rootTopicId);
+      showExploreTopic(store, channelId, rootTopicId);
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -215,7 +215,7 @@ function showExploreTopic(store, channelId, id) {
   ConditionalPromise.all([topicPromise, childrenPromise]).only(
     samePageCheckGenerator(store),
     ([topic, children]) => {
-      const pageState = { id };
+      const pageState = {};
       pageState.topic = _topicState(topic);
       const collection = _collectionState(children);
       pageState.subtopics = collection.topics;

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -368,10 +368,7 @@ function triggerSearch(store, searchTerm) {
     searchState.contents = collection.contents;
     store.dispatch('SET_SEARCH_STATE', searchState);
   })
-    .catch((error) => {
-      // TODO - how to parse and format?
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    });
+  .catch(error => { coreActions.handleApiError(store, error); });
 }
 
 function clearSearch(store) {

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -209,14 +209,14 @@ function showExploreTopic(store, channelId, id) {
   store.dispatch('SET_CURRENT_CHANNEL', channelId);
   cookiejs.set('currentChannel', channelId);
 
-  const attributesPromise = ContentNodeResource.getModel(id).fetch();
+  const topicPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
   _updateChannelList(store);
-  ConditionalPromise.all([attributesPromise, childrenPromise]).only(
+  ConditionalPromise.all([topicPromise, childrenPromise]).only(
     samePageCheckGenerator(store),
-    ([attributes, children]) => {
+    ([topic, children]) => {
       const pageState = { id };
-      pageState.topic = _topicState(attributes);
+      pageState.topic = _topicState(topic);
       const collection = _collectionState(children);
       pageState.subtopics = collection.topics;
       pageState.contents = collection.contents;
@@ -258,13 +258,13 @@ function showExploreContent(store, channelId, id) {
   store.dispatch('SET_CURRENT_CHANNEL', channelId);
   cookiejs.set('currentChannel', channelId);
 
-  const attributesPromise = ContentNodeResource.getModel(id).fetch();
+  const contentPromise = ContentNodeResource.getModel(id).fetch();
   _updateChannelList(store);
 
-  attributesPromise.only(
+  contentPromise.only(
     samePageCheckGenerator(store),
-    (attributes) => {
-      const pageState = { content: _contentState(attributes) };
+    (content) => {
+      const pageState = { content: _contentState(content) };
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
@@ -325,15 +325,15 @@ function showLearnContent(store, channelId, id) {
   store.dispatch('SET_PAGE_NAME', PageNames.LEARN_CONTENT);
   store.dispatch('SET_CURRENT_CHANNEL', channelId);
   cookiejs.set('currentChannel', channelId);
-  const attributesPromise = ContentNodeResource.getModel(id).fetch();
+  const contentPromise = ContentNodeResource.getModel(id).fetch();
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
   _updateChannelList(store);
 
-  attributesPromise.only(
+  contentPromise.only(
     samePageCheckGenerator(store),
-    (attributes) => {
+    (content) => {
       const pageState = {
-        content: _contentState(attributes),
+        content: _contentState(content),
         recommended: store.state.pageState.recommended,
       };
       store.dispatch('SET_PAGE_STATE', pageState);

--- a/kolibri/plugins/learn/assets/src/state/getters.js
+++ b/kolibri/plugins/learn/assets/src/state/getters.js
@@ -22,6 +22,13 @@ function pageMode(state) {
   return undefined;
 }
 
+
+function currentChannel(state) {
+  return state.channelList.find(channel => channel.id === state.currentChannelId);
+}
+
+
 module.exports = {
   pageMode,
+  currentChannel,
 };

--- a/kolibri/plugins/learn/assets/src/state/store.js
+++ b/kolibri/plugins/learn/assets/src/state/store.js
@@ -14,7 +14,7 @@ const initialState = {
     searchTerm: '',
   },
   channelList: {},
-  currentChannel: '',
+  currentChannelId: '',
   rootTopicId: '',
 };
 
@@ -37,7 +37,7 @@ const mutations = {
     state.searchOpen = !state.searchOpen;
   },
   SET_CURRENT_CHANNEL(state, channelId) {
-    state.currentChannel = channelId;
+    state.currentChannelId = channelId;
   },
   SET_CHANNEL_LIST(state, channelList) {
     state.channelList = channelList;

--- a/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
@@ -72,13 +72,13 @@
       learnRootLink() {
         return {
           name: PageNames.LEARN_CHANNEL,
-          channel: this.currentChannel,
+          channel: this.currentChannelId,
         };
       },
       exploreRootLink() {
         return {
           name: PageNames.EXPLORE_CHANNEL,
-          channel: this.currentChannel,
+          channel: this.currentChannelId,
         };
       },
       parentExploreLink() {
@@ -99,7 +99,7 @@
         return {
           name: PageNames.EXPLORE_TOPIC,
           params: {
-            channel: this.currentChannel,
+            channel: this.currentChannelId,
             id: topicId,
           },
         };
@@ -112,7 +112,7 @@
         contentCrumbs: state => state.pageState.content.breadcrumbs,
         pageName: state => state.pageName,
         pageState: state => state.pageState,
-        currentChannel: state => state.currentChannel,
+        currentChannelId: state => state.currentChannelId,
         title: state => state.pageState.topic.title,
       },
     },

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -70,7 +70,7 @@
         kind: (state) => state.pageState.content.kind,
         files: (state) => state.pageState.content.files,
         contentId: (state) => state.pageState.content.content_id,
-        channelId: (state) => state.currentChannel,
+        channelId: (state) => state.currentChannelId,
         available: (state) => state.pageState.content.available,
         extraFields: (state) => state.pageState.content.extra_fields,
 

--- a/kolibri/plugins/learn/assets/src/vue/toolbar/channel-switcher.vue
+++ b/kolibri/plugins/learn/assets/src/vue/toolbar/channel-switcher.vue
@@ -7,7 +7,7 @@
       id="chan-select"
       class="chan-select"
       v-model="localCurrentChannel">
-      <option v-for="channel in channelList" :value="channel.id">{{ channel.name }}</option>
+      <option v-for="channel in channelList" :value="channel.id">{{ channel.title }}</option>
     </select>
   </div>
 
@@ -63,7 +63,7 @@
       getters: {
         isRoot: (state) => state.pageState.topic.id === state.rootTopicId,
         pageMode: getters.pageMode,
-        globalCurrentChannel: state => state.currentChannel,
+        globalCurrentChannel: state => state.currentChannelId,
         channelList: state => state.channelList,
       },
       actions: {

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -54,6 +54,25 @@ function _taskState(data) {
 
 
 /**
+ * Title Helpers
+ */
+
+function _managePageTitle(title) {
+  if (title) {
+    return `Manage - ${title}`;
+  }
+  return 'Manage';
+}
+
+function _errorTitle(title) {
+  if (title) {
+    return `Error - ${title}`;
+  }
+  return 'Error';
+}
+
+
+/**
  * Actions
  *
  * These methods are used to update client-side state
@@ -219,10 +238,12 @@ function showUserPage(store) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
+      document.title = _managePageTitle('Users');
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
+      document.title = _errorTitle();
     }
   );
 }
@@ -248,11 +269,13 @@ function showContentPage(store) {
         pageState.channelList = channelList;
         store.dispatch('SET_PAGE_STATE', pageState);
         store.dispatch('CORE_SET_PAGE_LOADING', false);
+        document.title = _managePageTitle('Content');
       });
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
+      document.title = _errorTitle();
     }
   );
 }
@@ -419,6 +442,7 @@ function showDataPage(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
+  document.title = _managePageTitle('Data');
 }
 
 function showScratchpad(store) {
@@ -426,6 +450,7 @@ function showScratchpad(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
+  document.title = _managePageTitle('Scratchpad');
 }
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -238,12 +238,12 @@ function showUserPage(store) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      document.title = _managePageTitle('Users');
+      store.dispatch('CORE_SET_TITLE', _managePageTitle('Users'));
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -269,13 +269,13 @@ function showContentPage(store) {
         pageState.channelList = channelList;
         store.dispatch('SET_PAGE_STATE', pageState);
         store.dispatch('CORE_SET_PAGE_LOADING', false);
-        document.title = _managePageTitle('Content');
+        store.dispatch('CORE_SET_TITLE', _managePageTitle('Content'));
       });
     },
     (error) => {
       store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
-      document.title = _errorTitle();
+      store.dispatch('CORE_SET_TITLE', _errorTitle());
     }
   );
 }
@@ -442,7 +442,7 @@ function showDataPage(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
-  document.title = _managePageTitle('Data');
+  store.dispatch('CORE_SET_TITLE', _managePageTitle('Data'));
 }
 
 function showScratchpad(store) {
@@ -450,7 +450,7 @@ function showScratchpad(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
-  document.title = _managePageTitle('Scratchpad');
+  store.dispatch('CORE_SET_TITLE', _managePageTitle('Scratchpad'));
 }
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -6,6 +6,7 @@ const ChannelResource = Kolibri.resources.ChannelResource;
 const TaskResource = Kolibri.resources.TaskResource;
 const RoleResource = Kolibri.resources.RoleResource;
 
+const coreActions = require('kolibri/coreVue/vuex/actions');
 const ConditionalPromise = require('kolibri/lib/conditionalPromise');
 const constants = require('./state/constants');
 const UserKinds = require('kolibri/coreVue/vuex/constants').UserKinds;
@@ -64,13 +65,6 @@ function _managePageTitle(title) {
   return 'Manage';
 }
 
-function _errorTitle(title) {
-  if (title) {
-    return `Error - ${title}`;
-  }
-  return 'Error';
-}
-
 
 /**
  * Actions
@@ -103,9 +97,7 @@ function createUser(store, payload, role) {
         FacilityUserModel.fetch({}, true).then(updatedModel => {
           store.dispatch('ADD_USER', _userState(updatedModel));
         });
-      }).catch((error) => {
-        store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      });
+      }).catch(error => { coreActions.handleApiError(store, error); });
     }
   }).catch((error) => Promise.reject(error));
 }
@@ -163,14 +155,10 @@ function updateUser(store, id, payload, role) {
             responses.roles = [newRole];
             store.dispatch('UPDATE_USERS', [responses]);
           })
-          .catch((error) => {
-            store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-          });
+          .catch(error => { coreActions.handleApiError(store, error); });
         });
       })
-      .catch((error) => {
-        store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      });
+      .catch(error => { coreActions.handleApiError(store, error); });
     } else {
     // role is learner and oldRole is admin or coach.
       const OldRoleModel = RoleResource.getModel(oldRoldID);
@@ -181,9 +169,7 @@ function updateUser(store, id, payload, role) {
           responses.roles = [];
           store.dispatch('UPDATE_USERS', [responses]);
         })
-        .catch((error) => {
-          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-        });
+        .catch(error => { coreActions.handleApiError(store, error); });
       });
     }
   } else {
@@ -191,9 +177,7 @@ function updateUser(store, id, payload, role) {
     FacilityUserModel.save(payload).then(responses => {
       store.dispatch('UPDATE_USERS', [responses]);
     })
-    .catch((error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-    });
+    .catch(error => { coreActions.handleApiError(store, error); });
   }
 }
 
@@ -211,9 +195,7 @@ function deleteUser(store, id) {
   deleteUserPromise.then((user) => {
     store.dispatch('DELETE_USER', id);
   })
-  .catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-  });
+  .catch(error => { coreActions.handleApiError(store, error); });
 }
 
 // An action for setting up the initial state of the app by fetching data from the server
@@ -240,11 +222,7 @@ function showUserPage(store) {
       store.dispatch('CORE_SET_ERROR', null);
       store.dispatch('CORE_SET_TITLE', _managePageTitle('Users'));
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -272,11 +250,7 @@ function showContentPage(store) {
         store.dispatch('CORE_SET_TITLE', _managePageTitle('Content'));
       });
     },
-    (error) => {
-      store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
-      store.dispatch('CORE_SET_TITLE', _errorTitle());
-    }
+    error => { coreActions.handleApiError(store, error); }
   );
 }
 
@@ -289,7 +263,7 @@ function updateWizardLocalDriveList(store) {
   })
   .catch((error) => {
     store.dispatch('SET_CONTENT_PAGE_WIZARD_BUSY', false);
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
+    coreActions.handleApiError(store, error);
   });
 }
 
@@ -373,9 +347,7 @@ function pollTasksAndChannels(store) {
         }
       );
     },
-    (error) => {
-      logging.error(`poll error: ${error}`);
-    }
+    error => { logging.error(`poll error: ${error}`); }
   );
 }
 
@@ -384,9 +356,7 @@ function clearTask(store, taskId) {
   clearTaskPromise.then(() => {
     store.dispatch('SET_CONTENT_PAGE_TASKS', []);
   })
-  .catch((error) => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-  });
+  .catch(error => { coreActions.handleApiError(store, error); });
 }
 
 function triggerLocalContentImportTask(store, driveId) {

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -132,9 +132,7 @@ function updateUser(store, id, payload, role) {
           responses.roles = [newRole];
           store.dispatch('UPDATE_USERS', [responses]);
         })
-        .catch((error) => {
-          store.dispatch('CORE_SET_ERROR', JSON.stringify(error, null, '\t'));
-        });
+        .catch(error => { coreActions.handleApiError(store, error); });
       });
     } else if (role !== 'learner') {
     // oldRole is admin and role is coach or oldRole is coach and role is admin.

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -55,14 +55,11 @@ function _taskState(data) {
 
 
 /**
- * Title Helpers
+ * Title Helper
  */
 
 function _managePageTitle(title) {
-  if (title) {
-    return `Manage - ${title}`;
-  }
-  return 'Manage';
+  return `Manage ${title}`;
 }
 
 

--- a/kolibri/plugins/setup_wizard/assets/src/actions.js
+++ b/kolibri/plugins/setup_wizard/assets/src/actions.js
@@ -2,6 +2,7 @@ const Kolibri = require('kolibri');
 
 const DeviceOwnerResource = Kolibri.resources.DeviceOwnerResource;
 const FacilityResource = Kolibri.resources.FacilityResource;
+const coreActions = require('kolibri/coreVue/vuex/actions');
 
 function createDeviceOwnerAndFacility(store, deviceownerpayload, facilitypayload) {
   const DeviceOwnerModel = DeviceOwnerResource.createModel(deviceownerpayload);
@@ -9,13 +10,13 @@ function createDeviceOwnerAndFacility(store, deviceownerpayload, facilitypayload
   const FacilityModel = FacilityResource.createModel(facilitypayload);
   const facilityPromise = FacilityModel.save();
   const promises = [deviceOwnerPromise, facilityPromise];
-  Promise.all(promises).then(responses => {
-    // redirect to learn page after successfully created the DeviceOwner and Facility.
-    window.location = Kolibri.urls['kolibri:learnplugin:learn']();
-  },
-  rejects => {
-    store.dispatch('CORE_SET_ERROR', JSON.stringify(rejects, null, '\t'));
-  });
+  Promise.all(promises).then(
+    responses => {
+      // redirect to learn page after successfully created the DeviceOwner and Facility.
+      window.location = Kolibri.urls['kolibri:learnplugin:learn']();
+    },
+    error => { coreActions.handleApiError(store, error); }
+  );
 }
 
 


### PR DESCRIPTION
This PR adds unique page titles to every major page-switching action in the Learn and Management apps.

While working on this, I got sucked into a refactor of channels and Promises, mainly in learn's `actions.js`. High-level changes there:

* Made helper functions synchronous instead of returning Promises.
* Now treats the Channels resource more consistently with other resources.
* Added a `_channelListState` mapper function, similar to other state mappers
* Added explicit checks channel ID availability
* Consolidated cookie handling into helper functions


