### PR TITLE
Updated constants names

### DIFF
--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -15,13 +15,13 @@ from django.utils.text import get_valid_filename
 
 from mptt.models import MPTTModel, TreeForeignKey
 
-from le_utils.constants import kind_choices, format_choices, preset_choices
+from le_utils.constants import content_kinds, file_formats, format_presets
 from .content_db_router import get_active_content_database
 from .utils import paths
 from gettext import gettext as _
 
 
-PRESET_LOOKUP = dict(preset_choices)
+PRESET_LOOKUP = dict(format_presets.choices)
 
 
 class UUIDField(models.CharField):
@@ -119,7 +119,7 @@ class ContentNode(MPTTModel, ContentDatabaseModel):
     sort_order = models.FloatField(blank=True, null=True)
     license_owner = models.CharField(max_length=200, blank=True)
     author = models.CharField(max_length=200, blank=True)
-    kind = models.CharField(max_length=200, choices=kind_choices, blank=True)
+    kind = models.CharField(max_length=200, choices=content_kinds.choices, blank=True)
     available = models.BooleanField(default=False)
     stemmed_metaphone = models.CharField(max_length=1800, blank=True)  # for fuzzy search in title and description
 
@@ -148,11 +148,11 @@ class File(ContentDatabaseModel):
     """
     id = UUIDField(primary_key=True)
     checksum = models.CharField(max_length=400, blank=True)
-    extension = models.CharField(max_length=40, choices=format_choices, blank=True)
+    extension = models.CharField(max_length=40, choices=file_formats.choices, blank=True)
     available = models.BooleanField(default=False)
     file_size = models.IntegerField(blank=True, null=True)
     contentnode = models.ForeignKey(ContentNode, related_name='files', blank=True, null=True)
-    preset = models.CharField(max_length=150, choices=preset_choices, blank=True)
+    preset = models.CharField(max_length=150, choices=format_presets.choices, blank=True)
     lang = models.ForeignKey(Language, blank=True, null=True)
     supplementary = models.BooleanField(default=False)
     thumbnail = models.BooleanField(default=False)

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -12,7 +12,7 @@ from django.db import connections
 from django.test.utils import override_settings
 from kolibri.content import models as content
 from django.conf import settings
-from le_utils.constants import CK_TOPIC
+from le_utils.constants import content_kinds
 from ..content_db_router import set_active_content_database, using_content_database
 from ..errors import ContentModelUsedOutsideDBContext
 from rest_framework.test import APITestCase
@@ -115,14 +115,14 @@ class ContentNodeTestCase(TestCase):
 
         p = content.ContentNode.objects.get(title="root")
         expected_output = content.ContentNode.objects.filter(title__in=["c2"])
-        actual_output = p.get_descendants(include_self=False).filter(kind=CK_TOPIC)
+        actual_output = p.get_descendants(include_self=False).filter(kind=content_kinds.TOPIC)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_get_top_level_topics(self):
 
         p = content.ContentNode.objects.get(title="root")
-        expected_output = content.ContentNode.objects.filter(parent=p, kind=CK_TOPIC)
-        actual_output = content.ContentNode.objects.get(parent__isnull=True).get_children().filter(kind=CK_TOPIC)
+        expected_output = content.ContentNode.objects.filter(parent=p, kind=content_kinds.TOPIC)
+        actual_output = content.ContentNode.objects.get(parent__isnull=True).get_children().filter(kind=content_kinds.TOPIC)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_all_str(self):

--- a/kolibri/content/test/test_downloadcontent.py
+++ b/kolibri/content/test/test_downloadcontent.py
@@ -7,7 +7,7 @@ from django.test.utils import override_settings
 from kolibri.auth.models import DeviceOwner
 from kolibri.content.models import File, ContentNode
 from kolibri.content.utils.paths import get_content_storage_file_path
-from le_utils import constants
+from le_utils.constants import file_formats, format_presets
 
 CONTENT_STORAGE_DIR_TEMP = tempfile.mkdtemp()
 
@@ -26,12 +26,12 @@ class DownloadContentTestCase(TestCase):
 
         self.client = Client()
         self.hash = hashlib.md5("DUMMYDATA".encode()).hexdigest()
-        self.extension = dict(constants.format_choices).get("pdf")
+        self.extension = dict(file_formats.choices).get("pdf")
         self.filename = "{}.{}".format(self.hash, self.extension)
         self.title = "abc123!@#$%^&*();'[],./?><"
         self.contentnode = ContentNode(title=self.title)
         self.available = True
-        self.preset = constants.FP_DOCUMENT
+        self.preset = format_presets.DOCUMENT
         self.file = File(checksum=self.hash, extension=self.extension, available=self.available,
                          contentnode=self.contentnode, preset=self.preset)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,4 +13,4 @@ https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
 https://github.com/fle-internal/django-q/archive/bf6ae635af2cba4e92d35e69c937a5e96318095b.zip#egg=django-q
 porter2stemmer==1.0
 metafone==0.5
-le-utils==0.0.3
+le-utils==0.0.8


### PR DESCRIPTION
## Summary

Updated constants to match what is in le_utils now

## Issues addressed
Unifies constant names across kolibri, content curation, and ricecooker
## Documentation

## Screenshots (if appropriate)


