### PR TITLE
fix for focus issues in modals

### DIFF
--- a/kolibri/core/assets/src/vue/core-modal/index.vue
+++ b/kolibri/core/assets/src/vue/core-modal/index.vue
@@ -76,11 +76,11 @@
     attached() {
       this.lastFocus = document.activeElement;
       this.focusModal();
-      window.addEventListener('blur', this.focusElementTest, true);
+      window.addEventListener('focus', this.focusElementTest, true);
       window.addEventListener('scroll', this.preventScroll, true);
     },
     detached() {
-      window.removeEventListener('blur', this.focusElementTest, true);
+      window.removeEventListener('focus', this.focusElementTest, true);
       window.removeEventListener('scroll', this.preventScroll, true);
       // Wait for events to finish propagating before changing the focus.
       // Otherwise the `lastFocus` item receives events such as 'enter'.
@@ -106,7 +106,7 @@
       },
       focusElementTest(event) {
         // FocusOut happens when the element is about to be blurred
-        if (this.$els.modal && !this.$els.modal.contains(event.relatedTarget)) {
+        if (this.$els.modal && !this.$els.modal.contains(event.target)) {
           this.focusModal();
         }
       },


### PR DESCRIPTION
This PR updates the logic that handles our modal dialog focus trapping:

* instead of listening for `blur` events, listen for `focus` events
* watch check `event.target` instead of `event.relatedTarget`

Addresses:

* #557 (and https://trello.com/c/LCUg5RUS/602-login-modal-does-not-work-on-ie9)
* #555 

The problem appears to be that `FocusEvent.relatedTarget` is not a consistently-supported property. See e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=962251

@DXCanas - When you initially implemented focus trapping, we'd discussed using `focus` events instead of `blur`, and you'd mentioned that there were issues doing it that way. I haven't run into anything yet, but I'd like to get your eyes on this.


