### PR TITLE
Learn Style Isolation

### DIFF
--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -29,50 +29,9 @@ $core-text-alert-bg = #FDFADF
 $radius = 4px
 $core-time = 0.25s
 
-
-/*
-  Styles below were moved from a Learn-specific style-sheet to here.
-  It was difficult to separate them because the $portrait-breakpoint
-  is defined in terms of the card width.
-
-  TODO: this needs to be cleaned up and organized significantly.
-  At the very least these variables need to be namespaced.
-*/
-
-$thumbnail-height = 122px     // fixed thumbnail height
-
-$card-height = 200px         // fixed card height
-$card-width = 200px         // fixed card width
-$card-gutter = 20px         // spacing between columns
-$n-cols-array = 1 2 3 4 5 6    // possible numbers of columns
-
 $nav-width = 75px
 $left-margin = 100px
 $right-margin = 25px
 
-$horizontal-card-width = 320px
-$horizontal-card-height = 100px
-
-$learn-toolbar-height = 42px
-
-// compute the target grid width based on the number of columns
-grid-width($n-cols)
-  ($card-width * $n-cols) + ($card-gutter * ($n-cols))
-
-$portrait-breakpoint = $left-margin * 2 + grid-width(1) + $right-margin
+$portrait-breakpoint = 520px // TODO - compute this based on variables
 $medium-breakpoint = 619px // TODO - compute this based on variables
-
-// compute the media query breakpoint, based on the target grid width
-breakpoint($width)
-  $width + 180px // Hard-code # please revisit
-
-// generate a range of media query breakpoints
-width-auto-adjust()
-  width: grid-width(1)
-  for $n-cols in $n-cols-array
-    $grid-width = grid-width($n-cols)
-    @media (min-width: breakpoint($grid-width))
-      width: $grid-width
-    @media screen and (max-width: $medium-breakpoint + 1)
-      width: $horizontal-card-width // Hard-code media query, potential to revisit
-

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -8,9 +8,7 @@
     <div class="main-wrapper" v-scroll="onScroll" v-if="!loading">
       <error-box v-if="error"></error-box>
       <slot name="above"></slot>
-      <main role="main" class="page-content">
-        <slot name="content"></slot>
-      </main>
+      <slot name="content"></slot>
       <slot name="below"></slot>
     </div>
   </div>
@@ -74,10 +72,6 @@
     @media screen and (max-width: $portrait-breakpoint)
       padding: 0 0.6em
       padding-bottom: 100px
-
-  .page-content
-    margin: auto
-    width-auto-adjust()
 
   .loading-spinner-fixed
     position: fixed

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -3,7 +3,9 @@
   <core-base @scroll="handleScroll">
     <main-nav slot="nav"></main-nav>
     <toolbar slot="above" :shown="showToolbar"></toolbar>
-    <component slot="content" :is="currentPage"></component>
+
+    <component class="content" slot="content" :is="currentPage"></component>
+
     <div slot="below" class="search-pane" v-show="searchOpen" transition="search-slide">
       <search-widget :show-topics="exploreMode"></search-widget>
     </div>
@@ -106,6 +108,10 @@
     width: 100%
     @media screen and (min-width: $portrait-breakpoint + 1)
       padding-left: $nav-width
+
+  .content
+    width-auto-adjust()
+    margin: auto
 
   .search-slide-transition
     transition: transform $core-time ease-out

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -8,3 +8,43 @@
   margin-top: 2em
   margin-bottom: 1.4em
   line-height: 1.8em
+
+/*
+  Styles below were moved from a Learn-specific style-sheet to here.
+  It was difficult to separate them because the $portrait-breakpoint
+  is defined in terms of the card width.
+
+  TODO: this needs to be cleaned up and organized significantly.
+  At the very least these variables need to be namespaced.
+*/
+
+$thumbnail-height = 122px     // fixed thumbnail height
+
+$card-height = 200px         // fixed card height
+$card-width = 200px         // fixed card width
+$card-gutter = 20px         // spacing between columns
+$n-cols-array = 1 2 3 4 5 6    // possible numbers of columns
+
+$horizontal-card-width = 320px
+$horizontal-card-height = 100px
+
+$learn-toolbar-height = 42px
+
+// compute the target grid width based on the number of columns
+grid-width($n-cols)
+  ($card-width * $n-cols) + ($card-gutter * ($n-cols))
+
+
+// compute the media query breakpoint, based on the target grid width
+breakpoint($width)
+  $width + 180px // Hard-code # please revisit
+
+// generate a range of media query breakpoints
+width-auto-adjust()
+  width: grid-width(1)
+  for $n-cols in $n-cols-array
+    $grid-width = grid-width($n-cols)
+    @media (min-width: breakpoint($grid-width))
+      width: $grid-width
+    @media screen and (max-width: $medium-breakpoint + 1)
+      width: $horizontal-card-width // Hard-code media query, potential to revisit

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -2,10 +2,10 @@
 
   <core-base>
     <main-nav slot="nav"></main-nav>
-    <div v-if="isAdminOrSuperuser" slot="above">
+    <div v-if="isAdminOrSuperuser" class="manage-content" slot="above">
       <top-nav></top-nav>
     </div>
-    <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="page"></component>
+    <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="manage-content page"></component>
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>
       <h3>You must be logged in as an Admin to view this page.</h3>
@@ -70,12 +70,18 @@
 
   @require '~kolibri/styles/coreTheme'
 
+  .manage-content
+    width: 100%
+    @media screen and (max-width: $medium-breakpoint)
+        width: 90%
+        margin-left: auto
+        margin-right: auto
+
   .page
     padding: 1em 2em
     padding-bottom: 3em
     background-color: $core-bg-light
     margin-top: 2em
-    width: 100%
     border-radius: $radius
 
   .login-message h1, h3

--- a/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
@@ -66,13 +66,12 @@
   .top
     position: relative
     top: 1em
-    width: 100%
     padding: 1em 2em
     background: $core-bg-light
     border-radius: $radius
     @media screen and (max-width: $medium-breakpoint)
-      width: 90%
-      margin: 0 auto
+      margin-top: 0
+      margin-bottom: 0
       padding: 1em 0.2em
 
   .links


### PR DESCRIPTION
## Summary

Cut out the learn styles from global scope and fiddled with management toolbar styles a little bit to align properly.

## Reviewer guidance

@whitzhu @indirectlylit It should all look identical, but I shifted around some of the styles to have them change with different screen sizes at the same time. lmk if you object to my methods.

## Issues addressed

https://trello.com/c/WMTv0A45/555-get-learn-specific-styles-out-of-core

## Screenshots (if appropriate)

Learn & Explore should look identical: 
![localhost-8000-learn- 2](https://cloud.githubusercontent.com/assets/9877852/19288100/5310314e-8fb9-11e6-8b00-5daa776c61a8.png)
![localhost-8000-learn- 1](https://cloud.githubusercontent.com/assets/9877852/19288101/5317956a-8fb9-11e6-81c7-ea7e0aff3ec5.png)

Management got a bit more real estate and some alignment fixes:
![localhost-8000-management-](https://cloud.githubusercontent.com/assets/9877852/19288099/53053f6e-8fb9-11e6-8f64-7910785fee20.png)

Here it is w/ vertical viewport:
![localhost-8000-management- nexus 5x](https://cloud.githubusercontent.com/assets/9877852/19288153/8d5c0738-8fb9-11e6-9bb2-012cd5f54576.png)

