### PR TITLE
Standardized bootstrapping data.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -151,7 +151,7 @@ class SessionViewSet(viewsets.ViewSet):
     def get_session(self, request):
         user = get_user(request)
         if isinstance(user, AnonymousUser):
-            return {'id': None,
+            return {'id': 'current',
                     'username': '',
                     'full_name': '',
                     'user_id': None,

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -25,7 +25,6 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
 class ContentNodeFilter(filters.FilterSet):
     search = filters.django_filters.MethodFilter(action='title_description_filter')
     recommendations_for = filters.django_filters.MethodFilter()
-    recommendations = filters.django_filters.MethodFilter()
     next_steps = filters.django_filters.MethodFilter()
     popular = filters.django_filters.MethodFilter()
     resume = filters.django_filters.MethodFilter()
@@ -33,7 +32,7 @@ class ContentNodeFilter(filters.FilterSet):
 
     class Meta:
         model = models.ContentNode
-        fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related', 'recommendations_for', 'recommendations']
+        fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related', 'recommendations_for']
 
     def title_description_filter(self, queryset, value):
         """

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db.models import Q
 from django.db.models.aggregates import Count
 from kolibri.content import models, serializers
+from kolibri.content.content_db_router import get_active_content_database
 from kolibri.logger.models import ContentSessionLog, ContentSummaryLog
 from le_utils.constants import content_kinds
 from rest_framework import filters, pagination, viewsets
@@ -71,42 +72,31 @@ class ContentNodeFilter(filters.FilterSet):
         if not value:
             return queryset.none()
 
-        if self.data['channel']:
-            from kolibri.content.content_db_router import using_content_database
-            from kolibri.content.models import ContentNode
-            with using_content_database(self.data['channel']):
-                tables = [
-                    '"{summarylog_table}" AS "complete_log"',
-                    '"{summarylog_table}" AS "incomplete_log"',
-                    '"{content_table}" AS "complete_node"',
-                    '"{content_table}" AS "incomplete_node"',
-                ]
-                table_names = {
-                    "summarylog_table": ContentSummaryLog._meta.db_table,
-                    "content_table": ContentNode._meta.db_table,
-                }
-                # aliases for sql table names
-                sql_tables_and_aliases = [table.format(**table_names) for table in tables]
-                # where conditions joined by ANDs
-                where_statements = ["NOT (incomplete_log.progress < 1 AND incomplete_log.content_id = incomplete_node.content_id)",
-                                    "complete_log.user_id = {user_id}".format(user_id=value),
-                                    "incomplete_log.user_id = {user_id}".format(user_id=value),
-                                    "complete_log.progress = 1",
-                                    "complete_node.rght = incomplete_node.lft - 1",
-                                    "complete_log.content_id = complete_node.content_id"]
-                # custom SQL query to get uncompleted content based on mptt algorithm
-                next_steps_recommendations = "SELECT incomplete_node.* FROM {tables} WHERE {where}".format(
-                    tables=", ".join(sql_tables_and_aliases),
-                    where=_join_with_logical_operator(where_statements, "AND")
-                )
-                return ContentNode.objects.raw(next_steps_recommendations)
-        else:
-            summary_logs = ContentSummaryLog.objects.filter(user=value).exclude(progress=1)
-
-        content_ids = summary_logs.values_list('content_id', flat=True)
-        unfinished_nodes = queryset.filter(content_id__in=list(content_ids[:10]))
-
-        return unfinished_nodes
+        tables = [
+            '"{summarylog_table}" AS "complete_log"',
+            '"{summarylog_table}" AS "incomplete_log"',
+            '"{content_table}" AS "complete_node"',
+            '"{content_table}" AS "incomplete_node"',
+        ]
+        table_names = {
+            "summarylog_table": ContentSummaryLog._meta.db_table,
+            "content_table": models.ContentNode._meta.db_table,
+        }
+        # aliases for sql table names
+        sql_tables_and_aliases = [table.format(**table_names) for table in tables]
+        # where conditions joined by ANDs
+        where_statements = ["NOT (incomplete_log.progress < 1 AND incomplete_log.content_id = incomplete_node.content_id)",
+                            "complete_log.user_id = {user_id}".format(user_id=value),
+                            "incomplete_log.user_id = {user_id}".format(user_id=value),
+                            "complete_log.progress = 1",
+                            "complete_node.rght = incomplete_node.lft - 1",
+                            "complete_log.content_id = complete_node.content_id"]
+        # custom SQL query to get uncompleted content based on mptt algorithm
+        next_steps_recommendations = "SELECT incomplete_node.* FROM {tables} WHERE {where}".format(
+            tables=", ".join(sql_tables_and_aliases),
+            where=_join_with_logical_operator(where_statements, "AND")
+        )
+        return models.ContentNode.objects.raw(next_steps_recommendations)
 
     def filter_popular(self, queryset, value):
         """
@@ -116,26 +106,23 @@ class ContentNodeFilter(filters.FilterSet):
         :param value: id of currently logged in user, or none if user is anonymous
         :return: 10 most popular content nodes
         """
-
         if ContentSessionLog.objects.count() < 50:
             # return 25 random content nodes if not enough session logs
             pks = queryset.values_list('pk', flat=True).exclude(kind__in=['topic', ''])
             count = min(pks.count(), 25)
             return queryset.filter(pk__in=sample(list(pks), count))
 
-        if self.data['channel']:  # filter by channel if available
-            session_logs = ContentSessionLog.objects.filter(channel_id=self.data['channel'])
-            cache_key = 'popular_for_{}'.format(self.data['channel'])
-            if cache.get(cache_key):
-                return cache.get(cache_key)
-        else:
-            session_logs = ContentSessionLog.objects.all()
-            cache_key = 'popular'
-            if cache.get(cache_key):
-                return cache.get(cache_key)
+        cache_key = 'popular_for_{}'.format(get_active_content_database())
+        if cache.get(cache_key):
+            return cache.get(cache_key)
 
         # get the most accessed content nodes
-        content_counts_sorted = session_logs.values_list('content_id', flat=True).annotate(Count('content_id')).order_by('-content_id__count')
+        content_counts_sorted = ContentSessionLog.objects \
+            .filter(channel_id=get_active_content_database()) \
+            .values_list('content_id', flat=True) \
+            .annotate(Count('content_id')) \
+            .order_by('-content_id__count')
+
         most_popular = queryset.filter(content_id__in=list(content_counts_sorted[:10]))
 
         # cache the popular results queryset for 10 minutes, for efficiency
@@ -155,13 +142,14 @@ class ContentNodeFilter(filters.FilterSet):
         if not value:
             return queryset.none()
 
-        if self.data['channel']:  # filter by channel if available
-            user_summary_logs = ContentSummaryLog.objects.filter(user=value, channel_id=self.data['channel'])
-        else:
-            user_summary_logs = ContentSummaryLog.objects.filter(user=value)
-
         # get the most recently viewed, but not finished, content nodes
-        content_ids = user_summary_logs.exclude(progress=1).order_by('end_timestamp').values_list('content_id', flat=True).distinct()
+        content_ids = ContentSummaryLog.objects \
+            .filter(user=value, channel_id=get_active_content_database()) \
+            .exclude(progress=1) \
+            .order_by('end_timestamp') \
+            .values_list('content_id', flat=True) \
+            .distinct()
+
         resume = queryset.filter(content_id__in=list(content_ids[:10]))
 
         return resume

--- a/kolibri/content/utils/channels.py
+++ b/kolibri/content/utils/channels.py
@@ -74,3 +74,22 @@ def get_mounted_drives_with_channel_info():
     for drive in drives.values():
         drive.metadata["channels"] = get_channels_for_data_folder(drive.datafolder) if drive.datafolder else []
     return drives
+
+def get_current_or_first_channel(request):
+    # import here to avoid circular imports whenever kolibri.content.models imports utils too
+    from kolibri.content.models import ChannelMetadataCache
+
+    currentChannelId = request.COOKIES.get('currentChannelId')
+    firstChannel = ChannelMetadataCache.objects.first()
+    # try to get channel from cookie
+    if currentChannelId:
+        try:
+            return ChannelMetadataCache.objects.get(pk=currentChannelId)
+        except ChannelMetadataCache.DoesNotExist:
+            return None
+    # if no id from cookie, grab first channel from list of channels
+    elif firstChannel:
+        return firstChannel
+    # if no cookie and no content databases, return None
+    else:
+        return None

--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -350,8 +350,10 @@ function initContentSession(store, coreApp, channelId, contentId, contentKind) {
 function _setChannelState(store, coreApp, currentChannelId, channelList) {
   store.dispatch('SET_CORE_CHANNEL_LIST', channelList);
   store.dispatch('SET_CORE_CURRENT_CHANNEL', currentChannelId);
-  coreApp.resources.ContentNodeResource.setChannel(currentChannelId);
-  cookiejs.set('currentChannelId', currentChannelId);
+  if (currentChannelId !== null) {
+    coreApp.resources.ContentNodeResource.setChannel(currentChannelId);
+    cookiejs.set('currentChannelId', currentChannelId);
+  }
   if (!coreGetters.getCurrentChannelObject(store.state)) {
     handleError(store, 'Channel not found');
   }

--- a/kolibri/core/assets/src/core-getters.js
+++ b/kolibri/core/assets/src/core-getters.js
@@ -32,6 +32,10 @@ function getDefaultChannelId(channelList) {
 
 /* return the current channel object, according to vuex state */
 function getCurrentChannelObject(state) {
+  // if no channels to match against, return true
+  if (!state.core.channels.list.length) {
+    return true;
+  }
   return state.core.channels.list.find(channel => channel.id === state.core.channels.currentId);
 }
 

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -55,10 +55,8 @@
   {% cache 5000 js_urls %}
     {% js_reverse_inline %}
   {% endcache %}
-  var session = JSON.parse('{{ session | escapejs }}');
-  sessionModel = {{kolibri}}.resources.SessionResource.createModel(session);
-  sessionModel.synced = true;
 </script>
+{% kolibri_bootstrap_model 'session' 'SessionResource' kwargs_pk='current'%}
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}
 {% endblock %}

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -56,6 +56,7 @@
     {% js_reverse_inline %}
   {% endcache %}
 </script>
+<!-- Bootstrapping the currently logged in user's session object into the page. -->
 {% kolibri_bootstrap_model 'session' 'SessionResource' kwargs_pk='current'%}
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -48,6 +48,10 @@ def kolibri_main_navigation():
 
 @register.simple_tag(takes_context=True)
 def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
+    # check necessary for when there is no initial content databases
+    if 'kwargs_channel_id' in kwargs:
+        if not context['currentChannel']:
+            return ''
     response, kwargs = _kolibri_bootstrap_helper(context, base_name, api_resource, 'detail', **kwargs)
     html = ("<script type='text/javascript'>"
             "var model = {0}.resources.{1}.createModel(JSON.parse({2}));"
@@ -57,6 +61,10 @@ def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
 
 @register.simple_tag(takes_context=True)
 def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
+    # check necessary for when there is no initial content databases
+    if 'kwargs_channel_id' in kwargs:
+        if not context['currentChannel']:
+            return ''
     response, kwargs = _kolibri_bootstrap_helper(context, base_name, api_resource, 'list', **kwargs)
     html = ("<script type='text/javascript'>"
             "var collection = {0}.resources.{1}.createCollection({2}, JSON.parse({3}));"

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -5,10 +5,15 @@ Kolibri template tags
 from __future__ import absolute_import, print_function, unicode_literals
 
 import json
+import re
 
 from django import template
+from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.utils.html import mark_safe
 from kolibri.core.hooks import NavigationHook, UserNavigationHook
+from rest_framework.renderers import JSONRenderer
+from rest_framework.test import APIClient
 
 register = template.Library()
 
@@ -40,3 +45,46 @@ def kolibri_main_navigation():
             "window._nav={0};"
             "</script>".format(json.dumps(init_data)))
     return mark_safe(html)
+
+@register.simple_tag(takes_context=True)
+def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
+    response, kwargs = _kolibri_bootstrap_helper(context, base_name, api_resource, 'detail', **kwargs)
+    html = ("<script type='text/javascript'>"
+            "var model = {0}.resources.{1}.createModel(JSON.parse({2}));"
+            "model.synced = true;"
+            "</script>".format(settings.KOLIBRI_CORE_JS_NAME, api_resource, JSONRenderer().render(response.content)))
+    return mark_safe(html)
+
+@register.simple_tag(takes_context=True)
+def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
+    response, kwargs = _kolibri_bootstrap_helper(context, base_name, api_resource, 'list', **kwargs)
+    html = ("<script type='text/javascript'>"
+            "var collection = {0}.resources.{1}.createCollection({2}, JSON.parse({3}));"
+            "collection.synced = true;"
+            "</script>".format(settings.KOLIBRI_CORE_JS_NAME, api_resource, json.dumps(kwargs), JSONRenderer().render(response.content)))
+    return mark_safe(html)
+
+def _replace_dict_values(check, replace, dict):
+    for (key, value) in dict.iteritems():
+        if dict[key] is check:
+            dict[key] = replace
+
+def _kolibri_bootstrap_helper(context, base_name, api_resource, route, **kwargs):
+    # instantiate client instance to make requests to server
+    client = APIClient()
+    # copy session key to client to make requests on behalf of user
+    client.cookies[settings.SESSION_COOKIE_NAME] = context['request'].session.session_key
+    reversal = dict()
+    kwargs_check = 'kwargs_'
+    # remove prepended string and matching items from kwargs
+    for key in kwargs.keys():
+        if kwargs_check in key:
+            item = kwargs.pop(key)
+            key = re.sub(kwargs_check, '', key)
+            reversal[key] = item
+    url = reverse('{0}-{1}'.format(base_name, route), kwargs=reversal)
+    # switch out None temporarily because invalid filtering and caching can occur
+    _replace_dict_values(None, str(''), kwargs)
+    response = client.get(url, data=kwargs)
+    _replace_dict_values(str(''), None, kwargs)
+    return response, kwargs

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -218,10 +218,10 @@ function showLearnChannel(store, channelId, page = 1) {
       if (!coreGetters.getCurrentChannelObject(store.state)) {
         return;
       }
-      const nextStepsPayload = { next_steps: session.user_id, channel: channelId };
-      const popularPayload = { popular: session.user_id, channel: channelId };
-      const resumePayload = { resume: session.user_id, channel: channelId };
-      const allPayload = { kind: 'content', channel: channelId };
+      const nextStepsPayload = { next_steps: session.user_id };
+      const popularPayload = { popular: session.user_id };
+      const resumePayload = { resume: session.user_id };
+      const allPayload = { kind: 'content' };
       const nextStepsPromise = ContentNodeResource.getCollection(nextStepsPayload).fetch();
       const popularPromise = ContentNodeResource.getCollection(popularPayload).fetch();
       const resumePromise = ContentNodeResource.getCollection(resumePayload).fetch();

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -1,18 +1,19 @@
 {% extends "kolibri/base.html" %}
 {% load learn_tags %}
+{% load kolibri_tags %}
 
 {% block content %}
+{% kolibri_bootstrap_collection 'channel' 'ChannelResource' %}
   <script>
-    var channelCollection = {{kolibri}}.resources.ChannelResource.createCollection({}, JSON.parse("{{ channelList | escapejs }}"));
-    channelCollection.synced = true;
-    {{kolibri}}.resources.ContentNodeResource.setChannel("{{ channel_id }}");
+    {{kolibri}}.resources.ContentNodeResource.setChannel("{{ request.COOKIES.currentChannel }}");
     var root_node = JSON.parse("{{ rootnode|escapejs }}");
-    var root_node_pk = String(root_node.pk);
     var model = {{kolibri}}.resources.ContentNodeResource.createModel(root_node);
     model.synced = true;
-    var collection = {{kolibri}}.resources.ContentNodeResource.createCollection({parent: root_node_pk}, JSON.parse("{{ nodes|escapejs }}"));
-    collection.synced = true;
   </script>
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' parent=rootnode_pk kwargs_channel_id=request.COOKIES.currentChannel %}
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' popular=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' resume=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' next_steps=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
   {% learn_async_assets %}
   {% learn_assets %}
 {% endblock %}

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -3,17 +3,21 @@
 {% load kolibri_tags %}
 
 {% block content %}
+<!-- Bootstrapping the initial information for all channels. -->
 {% kolibri_bootstrap_collection 'channel' 'ChannelResource' %}
   <script>
-    {{kolibri}}.resources.ContentNodeResource.setChannel("{{ request.COOKIES.currentChannel }}");
-    var root_node = JSON.parse("{{ rootnode|escapejs }}");
-    var model = {{kolibri}}.resources.ContentNodeResource.createModel(root_node);
-    model.synced = true;
+    {{kolibri}}.resources.ContentNodeResource.setChannel("{{ request.COOKIES.currentChannelId }}");
   </script>
-  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' parent=rootnode_pk kwargs_channel_id=request.COOKIES.currentChannel %}
-  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' popular=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
-  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' resume=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
-  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' next_steps=user.id channel=request.COOKIES.currentChannel kwargs_channel_id=request.COOKIES.currentChannel %}
+  <!-- Bootstrapping the root node for the current channel in Explore tab. -->
+  {% kolibri_bootstrap_model 'contentnode' 'ContentNodeResource' kwargs_channel_id=currentChannel.id kwargs_pk=currentChannel.root_pk %}
+  <!-- Bootstrapping the top level topics for current channel in Explore tab. -->
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' parent=currentChannel.root_pk kwargs_channel_id=currentChannel.id %}
+  <!-- Bootstrapping the popular content recommendations for this user in Learn tab. -->
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' popular=user.id kwargs_channel_id=currentChannel.id %}
+  <!-- Bootstrapping the resume content recommendations for this user in Learn tab. -->
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' resume=user.id kwargs_channel_id=currentChannel.id %}
+  <!-- Bootstrapping the next steps content recommendations for this user in Learn tab. -->
+  {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' next_steps=user.id kwargs_channel_id=currentChannel.id %}
   {% learn_async_assets %}
   {% learn_assets %}
 {% endblock %}

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -2,12 +2,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging as logger
 
-from django.db import OperationalError
 from django.views.generic.base import TemplateView
-from kolibri.content.content_db_router import using_content_database
-from kolibri.content.models import ChannelMetadataCache, ContentNode
-from kolibri.content.serializers import ContentNodeSerializer
-from rest_framework.renderers import JSONRenderer
+from kolibri.content.utils.channels import get_current_or_first_channel
 
 logging = logger.getLogger(__name__)
 
@@ -17,33 +13,9 @@ class LearnView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(LearnView, self).get_context_data(**kwargs)
 
-        context['nodes'] = []
-        context['rootnode'] = []
-        context['rootnode_pk'] = []
-
-        channels = ChannelMetadataCache.objects.all()
-        if not channels:
-            return context
-        else:
-            cookie_current_channel = self.request.COOKIES.get("currentChannelId")
-            channelExists = False
-            for channel in ChannelMetadataCache.objects.all():
-                if channel.id == cookie_current_channel:
-                    channelExists = True
-                    break
-            if (cookie_current_channel is not None) and channelExists:
-                channel_id = cookie_current_channel
-            else:
-                channel_id = ChannelMetadataCache.objects.first().id
-
-            try:
-                with using_content_database(channel_id):
-                    root_node = ContentNode.objects.get(parent__isnull=True)
-                    mcontext = {'request': self.request}
-                    root_node_serializer = ContentNodeSerializer(root_node, context=mcontext)
-                    context['rootnode'] = JSONRenderer().render(root_node_serializer.data)
-                    context['rootnode_pk'] = root_node.pk
-            except OperationalError as e:
-                logging.debug('Database error while loading content data', e)
+        context['currentChannel'] = []
+        channel = get_current_or_first_channel(context['view'].request)
+        if channel:
+            context['currentChannel'] = channel
 
         return context


### PR DESCRIPTION
## Summary
Bootstrapping data using resource layer and api calls. Handled edge cases on client side and template tags for when there is no available channels to pick from. 

## TODO
- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?

## Reviewer guidance
For the parameters passed into the bootstrapping method, if a call needs to be made to the server, pass in the url reversal parameters prepended with `kwargs_` (ex. `kwargs_channel_id=1`). Any query params for the url can be passed as is. (ex. `next_steps=2`)

## Documentation
To be written..
## Screenshots (if appropriate)

**Before** Accessing the learn page without bootstrapping.
![screen shot 2016-10-13 at 11 50 07 am](https://cloud.githubusercontent.com/assets/6361732/19363027/b2137d74-913d-11e6-8617-bf1a1c72cc21.png)

**After** bootstrapping the recommendations.
![screen shot 2016-10-13 at 11 56 22 am](https://cloud.githubusercontent.com/assets/6361732/19363051/c0ee50d0-913d-11e6-8821-c0859d78edb2.png)
