### PR TITLE
Worker migrations

### DIFF
--- a/kolibri/core/webpack/management/commands/devserver.py
+++ b/kolibri/core/webpack/management/commands/devserver.py
@@ -66,6 +66,9 @@ class Command(RunserverCommand):
 
         update_channel_metadata_cache()
 
+        # migrate the ormq DB before starting.
+        call_command("migrate", interactive=False, database="ormq")
+
         return super(Command, self).handle(*args, **options)
 
     def spawn_webpack(self, lint):

--- a/kolibri/core/webpack/management/commands/devserver.py
+++ b/kolibri/core/webpack/management/commands/devserver.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import multiprocessing
 import os
+import platform
 import subprocess
 import sys
 from threading import Thread
@@ -60,7 +61,7 @@ class Command(RunserverCommand):
         if options["karma"]:
             self.spawn_karma()
 
-        if options["qcluster"]:
+        if options["qcluster"] and platform.system() != "Windows":
             self.spawn_qcluster()
 
         update_channel_metadata_cache()


### PR DESCRIPTION
Fixes #574. It's because we don't run migrate when we start the dev server (unlike the prod server).