### PR TITLE
Fly by fixes for kolibri and tasks.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -22,6 +22,11 @@ from docopt import docopt  # noqa
 from logging import config as logging_config  # noqa
 from django.core.management import call_command  # noqa
 
+# Force python2 to interpret every string as unicode.
+if sys.version[0] == '2':
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
 
 USAGE = """
 Kolibri

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://github.com/fle-internal/django-q/archive/d6a4d00f42bf3ba3b888f3861de5c518a314c4e1.zip#egg=django-q
+https://github.com/fle-internal/django-q/archive/c76741747800bb00e5b821cbead1c203b148db4a.zip#egg=django-q
 porter2stemmer==1.0
 metafone==0.5
 le-utils==0.0.8


### PR DESCRIPTION
## Summary

Change the requirements to fix an issue with killing the workers. Also, we forced python to interpret all strings as unicode, because we were having problems with some imported content not being interpreted as unicode, thus the server was crashing. 

## TODO

- [x] New dependencies (if any) added to requirements file

