### PR TITLE
add a ‘clean’ command for static files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ help:
 	@echo "release - package and upload a release"
 	@echo "sdist - package"
 
-clean: clean-build clean-pyc clean-docs
+clean: clean-build clean-pyc clean-docs clean-static
+
+clean-static:
+	npm run clean
 
 clean-build:
 	rm -fr build/

--- a/frontend_build/src/clean.js
+++ b/frontend_build/src/clean.js
@@ -1,0 +1,28 @@
+var readWebpackJson = require('./read_webpack_json');
+var path = require('path');
+var fs = require('fs');
+var logging = require('./logging');
+
+
+var deleteRecursive = function(p) {
+  if (fs.existsSync(p)) {
+    if (fs.lstatSync(p).isDirectory()) {
+      fs.readdirSync(p).forEach(function(name) {
+        deleteRecursive(path.join(p, name));
+      });
+      logging.info("Removing " + p);
+      fs.rmdirSync(p);
+    } else {
+      logging.info("Removing " + p);
+      fs.unlinkSync(p);
+    }
+  }
+}
+
+var plugins = readWebpackJson();
+var cwd = path.resolve(process.cwd());
+
+plugins.forEach(function(plugin) {
+  deleteRecursive(path.join(cwd, plugin.static_dir, plugin.name));
+  deleteRecursive(path.join(cwd, plugin.stats_file));
+})

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "watch": "node ./frontend_build/src/webpackdevserver.js",
     "test-karma:watch": "./node_modules/karma/bin/karma start ./karma_config/karma.conf.js",
     "bundle-stats": "webpack --config ./frontend_build/src/webpack.config.prod.js --json | node ./node_modules/webpack-bundle-size-analyzer/webpack-bundle-size-analyzer",
-    "install": "node ./frontend_build/src/install_dependencies.js"
+    "install": "node ./frontend_build/src/install_dependencies.js",
+    "clean": "node ./frontend_build/src/clean.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* add a command `npm run clean` which deletes all webpack artifacts in all plugins
* add hooks to run that command from the Makefile

original discussion: https://trello.com/c/K9EA1XVM/589-create-npm-clean-command