### PR TITLE
Import export failure messaging

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/index.vue
@@ -5,7 +5,7 @@
     <component v-if="pageState.wizardState.shown" :is="wizardComponent"></component>
 
     <div v-if="pageState.taskList.length" class="main alert-bg">
-      <task-status v-if="pageState.taskList.length"
+      <task-status
         :type="pageState.taskList[0].type"
         :status="pageState.taskList[0].status"
         :percentage="pageState.taskList[0].percentage"

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/task-status.vue
@@ -4,6 +4,7 @@
     <h1>{{ title }}</h1>
     <progress max="1" :value="percentage"></progress>
     <h2>{{ subTitle }}</h2>
+    <p v-if="statusFailed">{{ $tr('failed_msg') }}</p>
     <icon-button class="buttons" @click="clearTaskHandler">
       {{ buttonMessage }}
     </icon-button>
@@ -26,6 +27,7 @@
       buttonClose: 'Close',
       buttonCancel: 'Cancel',
       failed: 'Failed.',
+      failed_msg: 'The transfer did not succeed. If you restart, any progress will be retained.',
       completed: `Finished!`,
       loading: 'Please wait...',
       remoteImport: 'Importing from Curation Server',
@@ -42,6 +44,12 @@
         }
         return this.$tr('buttonCancel');
       },
+      statusFailed() {
+        return this.status === TaskStatuses.FAILED;
+      },
+      statusSuccess() {
+        return this.status === TaskStatuses.SUCCESS;
+      },
       title() {
         switch (this.type) {
           case TaskTypes.REMOTE_IMPORT:
@@ -56,9 +64,9 @@
         }
       },
       subTitle() {
-        if (this.status === TaskStatuses.FAILED) {
+        if (this.statusFailed) {
           return this.$tr('failed');
-        } else if (this.status === TaskStatuses.SUCCESS) {
+        } else if (this.statusSuccess) {
           return this.$tr('completed');
         }
         return this.$tr('loading');


### PR DESCRIPTION

Small update to the 'failure' messaging. related to: https://trello.com/c/Vm0Igg2W/611-update-messaging-for-failed-import-exports


New:

![image](https://cloud.githubusercontent.com/assets/2367265/19575316/cc301e30-96c2-11e6-96f9-2d56a2a2762d.png)

old:

![image](https://cloud.githubusercontent.com/assets/2367265/19575338/e347a9da-96c2-11e6-8711-d7f10563a06f.png)

