### PR TITLE
Make sure old assets aren't included in the whl files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clean-build:
 	rm -fr dist/
 	rm -fr dist-packages-cache/
 	rm -fr dist-packages-temp/
+	rm -fr kolibri/plugins/*/static/*/*.js
 	rm -fr *.egg-info
 	rm -fr .eggs
 	rm -fr .cache


### PR DESCRIPTION
By deleting them before we build the new ones.

Needed for faster installation.