### PR TITLE
Timer fixes 2

### DIFF
--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -176,7 +176,7 @@ function initContentSession(store, Kolibri, channelId, contentId, contentKind) {
           pk: null,
           start_timestamp: new Date(),
           completion_timestamp: null,
-          end_timestamp: null,
+          end_timestamp: new Date(),
           progress: 0,
           time_spent: 0,
           extra_fields: '{}',
@@ -203,7 +203,7 @@ function initContentSession(store, Kolibri, channelId, contentId, contentKind) {
   store.dispatch('SET_LOGGING_SESSION_STATE', _contentSessionLoggingState({
     pk: null,
     start_timestamp: new Date(),
-    end_timestamp: null,
+    end_timestamp: new Date(),
     time_spent: 0,
     progress: 0,
     extra_fields: '{}',

--- a/kolibri/core/assets/src/timer.js
+++ b/kolibri/core/assets/src/timer.js
@@ -32,6 +32,10 @@ class Timer {
    * Get time that has elapsed since last time elapsed time was checked
    */
   getNewTimeElapsed() {
+    // Timer has not been started
+    if (!this.lastElapsedTimeCheck) {
+      return 0;
+    }
     const currentTime = new Date();
     const timeElapsed = (currentTime - this.lastElapsedTimeCheck) / 1000;
     this.lastElapsedTimeCheck = currentTime;


### PR DESCRIPTION
cherry-pick the appropriate commit

https://trello.com/c/krbv0Av4/616-fix-erroneous-large-time-spent-values-in-usage-logs