### PR TITLE
Fix transfers

### DIFF
--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -1,6 +1,7 @@
 import logging as logger
 import os
 import signal
+import shutil
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
@@ -86,11 +87,7 @@ class Transfer(object):
         return chunk
 
     def _move_tmp_to_dest(self):
-        try:
-            os.remove(self.dest)
-        except OSError:  # dest doesn't exist; no problem
-            pass
-        os.rename(self.dest_tmp, self.dest)
+        shutil.move(self.dest_tmp, self.dest)
 
     def __enter__(self):
         self.start()

--- a/kolibri/tasks/management/commands/base.py
+++ b/kolibri/tasks/management/commands/base.py
@@ -48,7 +48,7 @@ class ProgressTracker():
     def get_progress(self):
 
         return Progress(
-            progress_fraction= 0 if self.total == 0 else self.progress / float(self.total),
+            progress_fraction=0 if self.total == 0 else self.progress / float(self.total),
             message=self.message,
             extra_data=self.extra_data,
             level=self.level,

--- a/kolibri/tasks/management/commands/base.py
+++ b/kolibri/tasks/management/commands/base.py
@@ -48,7 +48,7 @@ class ProgressTracker():
     def get_progress(self):
 
         return Progress(
-            progress_fraction=self.progress / float(self.total),
+            progress_fraction= 0 if self.total == 0 else self.progress / float(self.total),
             message=self.message,
             extra_data=self.extra_data,
             level=self.level,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://github.com/fle-internal/django-q/archive/c76741747800bb00e5b821cbead1c203b148db4a.zip#egg=django-q
+https://github.com/fle-internal/django-q/archive/934d557d77ded18c4a73a702905a6f8fe932f97b.zip#egg=django-q
 porter2stemmer==1.0
 metafone==0.5
 le-utils==0.0.8


### PR DESCRIPTION
## Summary

Fixed Windows error on transferring files

## Issues addressed

- Windows `Access to file denied` when db is open
- Older version of django q did not print log
- Divide by 0 error on progress total