### PR TITLE
Bump mvp version

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -8,7 +8,7 @@ from .utils.version import get_version
 # building straight from a git repo-
 # Example:
 # 0.0.1.dev20160511132442
-VERSION = (0, 0, 1, 'alpha', 0)
+VERSION = (0, 1, 0, 'rc', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -14,5 +14,5 @@ class TestKolibriVersion(KolibriTestBase):
         """
         Test that the major version is set as expected
         """
-        major_version = ".".join(map(str, kolibri.VERSION[:3]))
+        major_version = ".".join(map(str, kolibri.VERSION[:2]))
         self.assertIn(major_version, kolibri.__version__)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,3 +6,4 @@ sphinx-intl
 sphinx-rtd-theme
 pex
 wheel
+setuptools<20.11,>=2.2          # needed to get pex working

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,6 @@ setup(
     zip_safe=False,
     keywords='kolibri',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',


### PR DESCRIPTION
Version of kolibri is now `0.1.0rc0`!