### PR TITLE
WinXP disk enumeration - round 2

### DIFF
--- a/kolibri/core/discovery/test/dummydata/windows_data.py
+++ b/kolibri/core/discovery/test/dummydata/windows_data.py
@@ -3,7 +3,7 @@ import os
 with open(os.path.join(os.path.dirname(__file__), "windows_wmic_output.csv")) as f:
     wmic_csv = f.read()
 
-popen_responses = {
+os_system_responses = {
     "wmic logicaldisk list full /format:csv": wmic_csv,
 }
 

--- a/kolibri/core/discovery/test/dummydata/windows_data.py
+++ b/kolibri/core/discovery/test/dummydata/windows_data.py
@@ -3,10 +3,6 @@ import os
 with open(os.path.join(os.path.dirname(__file__), "windows_wmic_output.csv")) as f:
     wmic_csv = str(f.read())
 
-os_system_responses = {
-    "wmic logicaldisk list full /format:csv": wmic_csv,
-}
-
 os_access_read = {
     "C:\\": True,
     "D:\\": True,

--- a/kolibri/core/discovery/test/dummydata/windows_data.py
+++ b/kolibri/core/discovery/test/dummydata/windows_data.py
@@ -1,7 +1,7 @@
 import os
 
 with open(os.path.join(os.path.dirname(__file__), "windows_wmic_output.csv")) as f:
-    wmic_csv = f.read()
+    wmic_csv = str(f.read())
 
 os_system_responses = {
     "wmic logicaldisk list full /format:csv": wmic_csv,

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -28,6 +28,23 @@ def _get_mocked_popen(cmd_resp):
 
     return MockedPopen
 
+def _get_mocked_os_system(cmd_resp):
+
+    def mock_os_system(full_cmd):
+
+        if ' > ' not in full_cmd:
+            raise Exception("os.system run for '{}' without '>' output redirection".format(full_cmd))
+
+        cmd, output_path = full_cmd.split(' > ')
+
+        if cmd not in cmd_resp:
+            raise Exception("os.system called for an unmocked command '{}'!".format(cmd))
+
+        with open(output_path, 'w') as f:
+            f.write(cmd_resp[cmd])
+
+    return mock_os_system
+
 def _get_mocked_disk_usage(disk_sizes):
 
     def mock_disk_usage(path):
@@ -56,7 +73,15 @@ class patch_popen(object):
 
     def __call__(self, f):
         f = patch("subprocess.Popen", self.mocked_popen)(f)
-        f = patch("os.popen", self.mocked_popen)(f)
+        return f
+
+class patch_os_system(object):
+
+    def __init__(self, cmd_resp):
+        self.mocked_os_system = _get_mocked_os_system(cmd_resp)
+
+    def __call__(self, f):
+        f = patch("os.system", self.mocked_os_system)(f)
         return f
 
 class patch_disk_usage(object):
@@ -116,7 +141,7 @@ class WindowsFilesystemTestCase(TestCase):
     Test retrieval and parsing of disk info for Windows, using mocked command output.
     """
 
-    @patch_popen(windows_data.popen_responses)
+    @patch_os_system(windows_data.os_system_responses)
     @patch_os_access(windows_data.os_access_read, windows_data.os_access_write)
     @patch_os_path_exists_for_kolibri_folder(windows_data.has_kolibri_data_folder)
     @patch("sys.platform", "win32")

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -136,6 +136,10 @@ def patch_os_path_exists_for_kolibri_folder(folder_lookup):
     return wrapper
 
 
+def mocked_output_path():
+    return 'output.txt'
+
+
 class WindowsFilesystemTestCase(TestCase):
     """
     Test retrieval and parsing of disk info for Windows, using mocked command output.
@@ -146,6 +150,7 @@ class WindowsFilesystemTestCase(TestCase):
     @patch_os_path_exists_for_kolibri_folder(windows_data.has_kolibri_data_folder)
     @patch("sys.platform", "win32")
     @patch("os.path", ntpath)
+    @patch("kolibri.core.discovery.utils.filesystem.windows._output_path", mocked_output_path)
     def setUp(self):
         self.drives = enumerate_mounted_disk_partitions()
         self.c_drive = self.drives["3bd36621a8f83b8693a9443bca0f6249"]

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -41,7 +41,7 @@ def _get_mocked_os_system(cmd_resp):
             raise Exception("os.system called for an unmocked command '{}'!".format(cmd))
 
         with open(output_path, 'w') as f:
-            f.write(cmd_resp[cmd])
+            f.write(cmd_resp[cmd].encode('utf-16'))
 
     return mock_os_system
 

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -52,6 +52,12 @@ def get_drive_list():
 
     return drives
 
+def _output_path():
+    return os.path.join(
+        tempfile.gettempdir(),
+        "kolibri_disks-{}.txt".format(uuid.uuid4())
+    )
+
 def _wmic_output():
     """
     Returns the output from running the built-in `wmic` command.
@@ -62,10 +68,7 @@ def _wmic_output():
     happening because the script is not being run as a main process.)
     """
 
-    OUTPUT_PATH = os.path.join(
-        tempfile.gettempdir(),
-        "kolibri_disks-{}.txt".format(uuid.uuid4())
-    )
+    OUTPUT_PATH = _output_path()
 
     cmd = "wmic logicaldisk list full /format:csv > {}".format(OUTPUT_PATH)
     returnCode = os.system(cmd)

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import tempfile
@@ -71,7 +72,7 @@ def _wmic_output():
     if returnCode:
         raise Exception("Could not run command '{}'".format(cmd))
 
-    with open(OUTPUT_PATH, 'r', encoding='utf-16') as f:
+    with io.open(OUTPUT_PATH, 'r', encoding='utf-16') as f:
         output = f.read()
 
     os.remove(OUTPUT_PATH)

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -1,10 +1,9 @@
+import csv
 import io
 import logging
 import os
 import tempfile
 import uuid
-
-import unicodecsv as csv
 
 from .constants import drivetypes
 
@@ -52,11 +51,6 @@ def get_drive_list():
 
     return drives
 
-def _output_path():
-    return os.path.join(
-        tempfile.gettempdir(),
-        "kolibri_disks-{}.txt".format(uuid.uuid4())
-    )
 
 def _wmic_output():
     """
@@ -68,7 +62,10 @@ def _wmic_output():
     happening because the script is not being run as a main process.)
     """
 
-    OUTPUT_PATH = _output_path()
+    OUTPUT_PATH = os.path.join(
+        tempfile.gettempdir(),
+        "kolibri_disks-{}.txt".format(uuid.uuid4())
+    )
 
     cmd = "wmic logicaldisk list full /format:csv > {}".format(OUTPUT_PATH)
     returnCode = os.system(cmd)

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -1,8 +1,9 @@
-import csv
 import logging
 import os
 import tempfile
 import uuid
+
+import unicodecsv as csv
 
 from .constants import drivetypes
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,6 @@ requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
 https://github.com/fle-internal/django-q/archive/934d557d77ded18c4a73a702905a6f8fe932f97b.zip#egg=django-q
 porter2stemmer==1.0
+unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.8


### PR DESCRIPTION
re: https://trello.com/c/Ex03UItJ/615-mvp-fix-import-hang-related-to-disk-enumeration-on-windows-xp

Previous attempt: https://github.com/learningequality/kolibri/pull/595

Originally, I thought the freezing was happening because the python process was popping up a dialog when checking if an empty CD-ROM disk was readable. This was partially true (the dialog does pop up), but it turned out that the freeze was actually happening earlier. The confusing thing was that the freeze didn't happen when the disk enumeration code was run directly – only when it was run as a subprocess (or thread?) of the `kolibri` command.

After some investigation, it became clear that attempting to pipe information through stdout would cause a hang. In order to avoid stdout, this PR uses `os.system` to redirect `wmic`'s output to a temporary file, waits for the command to complete, reads the contents of the temp file, and deletes it.

