### PR TITLE
Fixed broken heights for pdf and video plugins.

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -111,7 +111,9 @@
 
   .container
     text-align: center
-    height: 100%
+    height: 100vh
+    max-height: calc(100vh - 24em)
+    min-height: 400px
     &:fullscreen
       width: 100%
       height: 100%

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -241,7 +241,7 @@
   // Containers
   .videowrapperwrapper
     width: 100%
-    height: 100%
+    height: 480px
     background-color: rgba(0, 0, 0, 0)
     position: relative
 


### PR DESCRIPTION
## Summary
Fixed broken heights for pdf and video plugins.

## Issues addressed
https://github.com/learningequality/kolibri/commit/5c33b0684a7cce4e1df0ee5357018f7d7e2b82ea


## Screenshots (if appropriate)


### Before:
![image](https://cloud.githubusercontent.com/assets/7193975/19667913/a8e69032-9a08-11e6-998f-d1bc3be6dd6f.png)
![image](https://cloud.githubusercontent.com/assets/7193975/19667918/b475e880-9a08-11e6-9e6d-cc475c1da870.png)


### After:
![image](https://cloud.githubusercontent.com/assets/7193975/19667883/809b0d38-9a08-11e6-8274-83d2d975dca9.png)
![image](https://cloud.githubusercontent.com/assets/7193975/19667899/924946e4-9a08-11e6-97bc-6e2e76ac3ee6.png)

