### PR TITLE
WinXP disk enumeration - round 3

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -8,7 +8,7 @@ from .utils.version import get_version
 # building straight from a git repo-
 # Example:
 # 0.0.1.dev20160511132442
-VERSION = (0, 1, 0, 'rc', 1)
+VERSION = (0, 1, 0, 'rc', 2)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION

see earlier round here: https://github.com/learningequality/kolibri/pull/603

this change addresses a problem that only occurred on the _first_ disk enumeration of the _first_ run of kolibri on a _new_ Windows installation.

thanks to @radinamatic for flagging this issue and help tracking it down!


