### PR TITLE
Exercise attempts visualization

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/answer-icon.vue
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/answer-icon.vue
@@ -1,0 +1,64 @@
+<template>
+
+  <div>
+    <svg v-if="isRight" src="./icons/right.svg" class="yes" :class="{ yay: success }"></svg>
+    <svg v-if="isWrong" src="./icons/wrong.svg" class="no" :class="{ yay: success }"></svg>
+    <svg v-if="isHint" src="./icons/hint.svg" class="no" :class="{ yay: success }"></svg>
+  </div>
+
+</template>
+
+
+<script>
+
+  const AnswerTypes = require('./constants').AnswerTypes;
+
+  module.exports = {
+    props: {
+      // one of the AnswerTypes
+      answertype: {
+        type: Number,
+        required: true,
+      },
+      // Visually indicate that the user has succeeded
+      success: {
+        type: Boolean,
+        required: true,
+      },
+    },
+    computed: {
+      isRight() {
+        return this.answertype === AnswerTypes.RIGHT;
+      },
+      isWrong() {
+        return this.answertype === AnswerTypes.WRONG;
+      },
+      isHint() {
+        return this.answertype === AnswerTypes.HINT;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.coreTheme'
+
+  svg
+    transition: transform $core-time ease-in
+
+  .yes
+    fill: $core-action-normal
+
+  .yes.yay
+    transform: scale(1.5)
+
+  .no
+    fill: $core-text-annotation
+
+  .no.yay
+    transform: scale(0.75)
+
+</style>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/constants.js
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/constants.js
@@ -1,0 +1,10 @@
+
+const AnswerTypes = {
+  HINT: -1,
+  WRONG: 0,
+  RIGHT: 1,
+};
+
+module.exports = {
+  AnswerTypes,
+};

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/hint.svg
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/hint.svg
@@ -1,0 +1,9 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <path d="M0 0h24v24H0V0z" id="a"/>
+    </defs>
+    <clipPath id="b">
+        <use overflow="visible" xlink:href="#a"/>
+    </clipPath>
+    <path clip-path="url(#b)" d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"/>
+</svg>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/right.svg
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/right.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+</svg>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/wrong.svg
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/icons/wrong.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/exercise-attempts/index.vue
@@ -1,0 +1,131 @@
+<template>
+
+  <div class="wrapper">
+    <div
+      class="answer"
+      v-for="item in itemsToRender"
+      transition="fade"
+      track-by="originalIndex"
+      :style="styleForIndex($index, item.originalIndex)"
+    >
+      <answer-icon :answertype="item.answer" :success="success"></answer-icon>
+    </div>
+    <div
+      class="placeholder"
+      v-for="i in numspaces"
+      :class="{'placeholder-empty': i === 0 && waiting}"
+    ></div>
+  </div>
+
+</template>
+
+
+<script>
+
+  // const AnswerTypes = require('./constants').AnswerTypes;
+
+  module.exports = {
+    props: {
+      // Creates an empty space awaiting a new attempt
+      waiting: {
+        type: Boolean,
+        required: true,
+      },
+      // Visually indicate that the user has succeeded
+      success: {
+        type: Boolean,
+        required: true,
+      },
+      // Total number of answer spaces to show
+      numspaces: {
+        type: Number,
+        required: true,
+      },
+      // An array of AnswerTypes for all attempts (including those not shown).
+      // Ordered from first to most recent.
+      log: {
+        type: Array,
+        required: true,
+      },
+    },
+    components: {
+      'answer-icon': require('./answer-icon'),
+    },
+    computed: {
+      numItemsToRender() {
+        if (this.waiting) {
+          return this.numspaces;
+        }
+        return this.numspaces + 1;
+      },
+      // returns a list of items the items to be rendered in the DOM
+      itemsToRender() {
+        // save the original index of the item in the log and slice of the end
+        const visible = this.log
+          .map((answer, originalIndex) => ({ answer, originalIndex }))
+          .slice(-1 * this.numItemsToRender);
+        visible.reverse();
+        return visible;
+      },
+    },
+    methods: {
+      styleForIndex(visualIndex, originalIndex) {
+        const ANSWER_WIDTH = 4 + 30 + 4;  // margin + width + margin
+        let xPos = ANSWER_WIDTH * (this.log.length - 1 - originalIndex);
+        if (this.waiting) {
+          xPos += ANSWER_WIDTH;
+        }
+        const style = {};
+        // translateZ(0) is there to try and force GPU-acceleration.
+        // (see e.g. http://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css)
+        style.transform = `translate(${xPos}px) translateZ(0)`;
+        // hidden "slide-off" item
+        if (visualIndex === this.numItemsToRender - 1) {
+          style.opacity = 0;
+        }
+        return style;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.coreTheme'
+
+  $size = 30px
+  $margin = 4px
+
+  .wrapper
+    white-space: nowrap
+
+  .answer
+    width: $size
+    height: 20px
+    display: inline-block
+    margin: $margin
+    text-align: center
+    position: absolute
+    transition: transform 0.5s ease-in-out, opacity 1s ease-in-out
+
+    // try to improve performance - http://stackoverflow.com/a/10133679
+    backface-visibility: hidden
+    perspective: 1000
+
+  .fade-enter, .fade-leave
+    opacity: 0
+
+  .placeholder
+    display: inline-block
+    height: $size
+    width: $size
+    margin: $margin
+    border-bottom: 1px solid $core-text-annotation
+    transition: border-bottom 0.1s linear
+
+  .placeholder-empty
+    border-bottom: 3px solid $core-text-annotation
+
+</style>

--- a/kolibri/plugins/learn/assets/src/vue/scratchpad-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/scratchpad-page/index.vue
@@ -1,8 +1,45 @@
 <template>
 
   <div>
-    <h1>Learn Scratchpad</h1>
-    <p>Use this page for in-progress component prototyping.</p>
+    <h1>Exercise Attempt Visualization</h1>
+    <p>Demo of CSS transitions</p>
+    <ul>
+      <li>N: <input type="number" v-model="N"></li>
+      <li>
+        Log:
+        <button
+          class="answer"
+          @click="right"
+          :disabled="!waiting || success"> ✓
+        </button>
+        <button
+          class="answer"
+          @click="wrong"
+          :disabled="!waiting || success"> x
+        </button>
+        <button
+          class="answer"
+          @click="hint"
+          :disabled="!waiting || success"> ?
+        </button>
+        <button
+          @click="next"
+          :disabled="waiting || success"> next
+        </button>
+      </li>
+      <li>success: <input type="checkbox" v-model="success"></li>
+      <li><button @click="clear">clear</button></li>
+    </ul>
+    <hr>
+    <div>
+      <exercise-attempts
+        :waiting="waiting"
+        :success="success"
+        :numspaces="parseInt(N)"
+        :log="log"
+      >
+      </exercise-attempts>
+    </div>
   </div>
 
 </template>
@@ -10,7 +47,48 @@
 
 <script>
 
+  const AnswerTypes = require('./exercise-attempts/constants').AnswerTypes;
+
+
   module.exports = {
+    components: {
+      'exercise-attempts': require('./exercise-attempts'),
+    },
+    methods: {
+      clear() {
+        // http://stackoverflow.com/a/1232046
+        this.log.splice(0, this.log.length);
+        this.waiting = true;
+      },
+      right() {
+        this.log.push(AnswerTypes.RIGHT);
+        this.waiting = false;
+      },
+      wrong() {
+        this.log.push(AnswerTypes.WRONG);
+        this.waiting = false;
+      },
+      hint() {
+        this.log.push(AnswerTypes.HINT);
+        this.waiting = false;
+      },
+      next() {
+        this.waiting = true;
+      },
+    },
+    data() {
+      return {
+        waiting: true,
+        success: false,
+        // M: 4,
+        N: 6,
+        log: [
+          AnswerTypes.HINT,
+          AnswerTypes.RIGHT,
+          AnswerTypes.WRONG,
+        ],
+      };
+    },
   };
 
 </script>
@@ -19,5 +97,14 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.coreTheme'
+
+  h1
+    margin-top: 80px
+
+  li
+    margin-bottom: 8px
+
+  .answer
+    width: 25px
 
 </style>


### PR DESCRIPTION
This is a stand-alone, stateless component that handles learner attempt log visualization.

Currently implemented in the Learn app scratchpad as a demo. Will need to be moved to an appropriate location for use by the perseus exercise renderer.


![image](https://cloud.githubusercontent.com/assets/2367265/19859976/6b2abb10-9f44-11e6-81ed-ab0bab3a69dc.png)

