### PR TITLE
dynamic number of content items

### DIFF
--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -89,6 +89,22 @@ function _sessionState(data) {
  *
  * These methods are used to update client-side state
  */
+
+
+const debounce = require('vue').util.debounce;
+const debouncedSetWindowInfo = debounce((store) => {
+  // http://stackoverflow.com/a/8876069
+  const w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  const h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+  store.dispatch('SET_VIEWPORT_SIZE', w, h);
+}, 33);
+
+
+function handleResize(store, event) {
+  debouncedSetWindowInfo(store);
+}
+
+
 function kolibriLogin(store, Kolibri, sessionPayload) {
   const SessionResource = Kolibri.resources.SessionResource;
   const sessionModel = SessionResource.createModel(sessionPayload);
@@ -364,6 +380,7 @@ function samePageCheckGenerator(store) {
 }
 
 module.exports = {
+  handleResize,
   kolibriLogin,
   kolibriLogout,
   currentLoggedInUser,

--- a/kolibri/core/assets/src/core-store.js
+++ b/kolibri/core/assets/src/core-store.js
@@ -23,11 +23,11 @@ const initialState = {
       summary: { progress: 0 },
       session: {},
     },
+    viewport: { width: 0, height: 0 },
   },
 };
 
 const mutations = {
-
   CORE_SET_SESSION(state, value) {
     state.core.session = value;
     state.core.loginModalVisible = false;
@@ -49,8 +49,6 @@ const mutations = {
   CORE_SET_LOGIN_MODAL_VISIBLE(state, value) {
     state.core.loginModalVisible = value;
   },
-
-
   CORE_SET_PAGE_LOADING(state, value) {
     const update = { loading: value };
     if (value) {
@@ -93,6 +91,10 @@ const mutations = {
   SET_LOGGING_THRESHOLD_CHECKS(state, progress, timeSpent) {
     state.core.logging.session.total_time_at_last_save = timeSpent;
     state.core.logging.session.progress_at_last_save = progress;
+  },
+  SET_VIEWPORT_SIZE(state, width, height) {
+    state.core.viewport.width = width;
+    state.core.viewport.height = height;
   },
 };
 

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -22,12 +22,17 @@
 
   require('vue-scroll');
 
+  const coreActions = require('kolibri/coreVue/vuex/actions');
+
   module.exports = {
     components: {
       'nav-bar': require('./nav-bar'),
       'error-box': require('./error-box'),
     },
     vuex: {
+      actions: {
+        handleResize: coreActions.handleResize,
+      },
       getters: {
         loading: state => state.core.loading,
         error: state => state.core.error,
@@ -49,6 +54,11 @@
           this.scrolled = false;
         }
       }, 75);
+      window.addEventListener('resize', this.handleResize);
+      this.handleResize();
+    },
+    beforeDestroy() {
+      window.removeEventListener('resize', this.handleResize);
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -308,7 +308,7 @@ function showLearnChannel(store, channelId, page = 1) {
   const sessionModel = SessionResource.getModel(id);
   const sessionPromise = sessionModel.fetch();
 
-  const ALL_PAGE_SIZE = 3;
+  const ALL_PAGE_SIZE = 6;
 
   sessionPromise.then(
     (session) => {

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/allcontent.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/allcontent.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <card-grid :header="'All Content'" v-if="all.content.length">
+  <card-grid :header="'All Content'" v-if="all.content.length" v-el:grid>
 
     <div slot="headerbox" class="allnav" role="navigation" :aria-label="$tr('pagesLabel')">
 
@@ -13,7 +13,7 @@
     </div>
 
     <content-grid-item
-      v-for="content in all.content"
+      v-for="content in contentToShow"
       :title="content.title"
       :thumbnail="content.thumbnail"
       :kind="content.kind"
@@ -37,7 +37,30 @@
       next: 'Next',
       pagesLabel: 'Browse all content',
     },
+    ready() {
+      /*
+        `this.gridWidth` is a quick hack to ensure that rows are completely filled.
+        The consequence is that some items are hidden if they spill over and don't
+        entirely fill up a line. We're also (ab)using a new viewport size watcher
+        and checking sizes that are usually handled with styles and media queries.
+      */
+      this.$watch('viewportWidth', () => {
+        this.gridWidth = this.$els.grid.offsetWidth;
+      });
+      this.gridWidth = this.$els.grid.offsetWidth;
+    },
+    data() {
+      return {
+        gridWidth: 0,
+      };
+    },
     computed: {
+      contentToShow() {
+        const CARD_WIDTH = 200;  // duplicate of $card-width
+        const CARD_GUTTER = 20;  // duplicate of $card-gutter
+        const nCols = Math.max(2, Math.floor(this.gridWidth / (CARD_WIDTH + CARD_GUTTER)));
+        return this.all.content.slice(0, nCols);
+      },
       hasNext() {
         return this.all.page < this.all.pageCount;
       },
@@ -68,6 +91,7 @@
     vuex: {
       getters: {
         all: state => state.pageState.all,
+        viewportWidth: state => state.core.viewport.width,
       },
     },
   };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "filesize": "3.3.0 ",
     "intl": "1.2.4",
     "js-cookie": "2.1.2",
+    "lodash.throttle": "4.1.1",
     "loglevel": "1.4.1",
     "normalize.css": "4.2.0",
     "rest": "1.3.2",


### PR DESCRIPTION
Now shows a variable number of items in the "All Content" section of the Learn page. Chooses the number of items to try and fill up the entire row on larger monitors, or show 2 items on mobile.

Uses something of a hack solution - we will probably need to do this sort of thing again, and we should look at cleaning up the pattern for future use.

**Large**

![image](https://cloud.githubusercontent.com/assets/2367265/19911563/912f63ca-a051-11e6-96f7-676762850098.png)

**Medium**

![image](https://cloud.githubusercontent.com/assets/2367265/19911589/b927b152-a051-11e6-8f50-9e3af7f4074c.png)

**Small**

![image](https://cloud.githubusercontent.com/assets/2367265/19911583/ad44d428-a051-11e6-953e-9c6bcc24b3cd.png)
