### PR TITLE
Coach permissions

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -40,6 +40,9 @@ module.exports = {
         constants: {
           module: require('../constants'),
         },
+        getters: {
+          module: require('../core-getters'),
+        },
         actions: {
           module: require('../core-actions'),
         },

--- a/kolibri/core/assets/src/core-getters.js
+++ b/kolibri/core/assets/src/core-getters.js
@@ -1,0 +1,14 @@
+
+const UserKinds = require('./constants').UserKinds;
+
+function isAdminOrSuperuser(state) {
+  const kind = state.core.session.kind;
+  if (kind[0] === UserKinds.SUPERUSER || kind[0] === UserKinds.ADMIN) {
+    return true;
+  }
+  return false;
+}
+
+module.exports = {
+  isAdminOrSuperuser,
+};

--- a/kolibri/core/assets/src/vue/nav-bar/nav-bar-item.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/nav-bar-item.vue
@@ -54,7 +54,6 @@
       vertical-align: middle
 
   .link
-    width: $nav-width
     margin: 0
     padding: 6px
     text-align: center
@@ -62,6 +61,7 @@
     @media screen and (min-width: $portrait-breakpoint + 1)
       display: table-cell
       vertical-align: middle
+      width: $nav-width
       height: 125px
     @media screen and (max-width: $portrait-breakpoint)
       display: block

--- a/kolibri/plugins/coach_tools/assets/src/vue/index.vue
+++ b/kolibri/plugins/coach_tools/assets/src/vue/index.vue
@@ -3,12 +3,19 @@
   <core-base>
     <main-nav slot="nav"></main-nav>
 
-    <div v-if="!currentPage" slot="content">
-      <h1>Coach Root</h1>
-      <a href="/coach/#!/reports">Go to Reports.</a>
+    <template v-if="isAdminOrSuperuser">
+      <div v-if="!currentPage" slot="content">
+        <h1>Coach Root</h1>
+        <a href="/coach/#!/reports">Go to Reports.</a>
+      </div>
+      <component slot="content" :is="currentPage" class="page"></component>
+    </template>
+
+    <div v-else slot="content" class="login-message">
+      <h1>Did you forget to log in?</h1>
+      <p>You must be logged in as an Admin to view this page.</p>
     </div>
 
-    <component slot="content" :is="currentPage" class="page"></component>
   </core-base>
 
 </template>
@@ -18,15 +25,14 @@
 
   const store = require('../state/store');
   const constants = require('../state/constants');
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
     components: {
       'main-nav': require('./main-nav'),
       'reports': require('./reports'),
     },
-
     computed: {
-
       currentPage() {
         if (this.pageName === constants.PageNames.REPORTS) {
           return 'reports';
@@ -34,15 +40,13 @@
         return null;
       },
     },
-
     vuex: {
       getters: {
         pageName: state => state.pageName,
+        isAdminOrSuperuser,
       },
     },
-
     store,
-
   };
 
 </script>
@@ -51,5 +55,9 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.coreTheme'
+
+  .login-message
+    text-align: center
+    margin-top: 200px
 
 </style>

--- a/kolibri/plugins/coach_tools/assets/src/vue/index.vue
+++ b/kolibri/plugins/coach_tools/assets/src/vue/index.vue
@@ -10,8 +10,8 @@
     <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="page"></component>
 
     <div v-else slot="content" class="login-message">
-      <h1>Did you forget to log in?</h1>
-      <p>You must be logged in as an Admin to view this page.</p>
+      <h1>{{ $tr('logInPrompt') }}</h1>
+      <p>{{ $tr('logInCommand') }}</p>
     </div>
 
   </core-base>
@@ -26,6 +26,11 @@
   const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
+    $trNameSpace: 'coach-root',
+    $trs: {
+      logInPrompt: 'Did you forget to log in?',
+      logInCommand: 'You must be logged in as an Admin to view this page.',
+    },
     components: {
       'main-nav': require('./main-nav'),
       'reports': require('./reports'),

--- a/kolibri/plugins/coach_tools/assets/src/vue/index.vue
+++ b/kolibri/plugins/coach_tools/assets/src/vue/index.vue
@@ -3,13 +3,11 @@
   <core-base>
     <main-nav slot="nav"></main-nav>
 
-    <template v-if="isAdminOrSuperuser">
-      <div v-if="!currentPage" slot="content">
-        <h1>Coach Root</h1>
-        <a href="/coach/#!/reports">Go to Reports.</a>
-      </div>
-      <component slot="content" :is="currentPage" class="page"></component>
-    </template>
+    <div v-if="!currentPage && isAdminOrSuperuser" slot="content">
+      <h1>Coach Root</h1>
+      <a href="/coach/#!/reports">Go to Reports.</a>
+    </div>
+    <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="page"></component>
 
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>

--- a/kolibri/plugins/coach_tools/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/coach_tools/assets/src/vue/main-nav/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!--
-    In order to get the nev to work right, it seemed necessary to
+    In order to get the nav to work right, it seemed necessary to
     have multiple root nodes in this template.
 
     TODO: would be best to refactor this.
@@ -14,19 +14,21 @@
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="./icons/explore.svg"></svg>
     <div class="label">{{ $tr('explore') }}</div>
   </nav-bar-item>
+  <nav-bar-item v-if="isAdminOrSuperuser" href="/coach" :active="true">
+    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="./icons/coach.svg"></svg>
+    <div class="label">{{ $tr('coach') }}</div>
+  </nav-bar-item>
   <nav-bar-item v-if="isAdminOrSuperuser" href="/management">
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="./icons/manage.svg"></svg>
     <div class="label">{{ $tr('manage') }}</div>
-  </nav-bar-item>
-  <nav-bar-item href="/coach" :active="true">
-    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="./icons/coach.svg"></svg>
-    <div class="label">{{ $tr('coach') }}</div>
   </nav-bar-item>
 
 </template>
 
 
 <script>
+
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
     $trNameSpace: 'coachNav',
@@ -38,6 +40,11 @@
     },
     components: {
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
+    },
+    vuex: {
+      getters: {
+        isAdminOrSuperuser,
+      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
@@ -11,31 +11,21 @@
 
 <script>
 
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
-
     $trNameSpace: 'learnContentUnavailable',
     $trs: {
       header: 'No Content Channels Available',
       adminLink: 'Download content channels from the <a href="/management/#!/content">Content Management</a> page', // eslint-disable-line max-len
       notAdmin: 'You need to log in as an administrator to manage your content channels.',
     },
-
-    computed: {
-      isAdminOrSuperuser() {
-        if (this.kind[0] === UserKinds.SUPERUSER || this.kind[0] === UserKinds.ADMIN) {
-          return true;
-        }
-        return false;
-      },
-    },
     vuex: {
       getters: {
-        kind: state => state.core.session.kind,
+        isAdminOrSuperuser,
       },
     },
-};
+  };
 
 </script>
 

--- a/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!--
-    In order to get the nev to work right, it seemed necessary to
+    In order to get the nav to work right, it seemed necessary to
     have multiple root nodes in this template.
 
     TODO: would be best to refactor this.
@@ -14,13 +14,13 @@
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
     <div class="label">{{ $tr('explore') }}</div>
   </nav-bar-item>
+  <nav-bar-item v-if="isAdminOrSuperuser" href="/coach">
+    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/coach.svg"></svg>
+    <div class="label">Coach</div>
+  </nav-bar-item>
   <nav-bar-item v-if="isAdminOrSuperuser" href="/management">
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/manage.svg"></svg>
     <div class="label">{{ $tr('manage') }}</div>
-  </nav-bar-item>
-  <nav-bar-item href="/coach">
-    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/coach.svg"></svg>
-    <div class="label">Coach</div>
   </nav-bar-item>
 
 </template>
@@ -31,7 +31,6 @@
   const pageMode = require('../../state/getters').pageMode;
   const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
   const constants = require('../../state/constants');
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
 
   module.exports = {
     $trNameSpace: 'learnNav',

--- a/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/main-nav/index.vue
@@ -29,6 +29,7 @@
 <script>
 
   const pageMode = require('../../state/getters').pageMode;
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
   const constants = require('../../state/constants');
   const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
 
@@ -45,6 +46,7 @@
     vuex: {
       getters: {
         kind: state => state.core.session.kind,
+        isAdminOrSuperuser,
         pageMode,
       },
     },
@@ -60,12 +62,6 @@
       },
       exploreActive() {
         return this.pageMode === constants.PageModes.EXPLORE;
-      },
-      isAdminOrSuperuser() {
-        if (this.kind[0] === UserKinds.SUPERUSER || this.kind[0] === UserKinds.ADMIN) {
-          return true;
-        }
-        return false;
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -2,13 +2,16 @@
 
   <core-base>
     <main-nav slot="nav"></main-nav>
-    <div v-if="isAdminOrSuperuser" class="manage-content" slot="above">
-      <top-nav></top-nav>
-    </div>
-    <component v-if="isAdminOrSuperuser" slot="content" :is="currentPage" class="manage-content page"></component>
+
+    <template v-if="isAdminOrSuperuser">
+      <div class="manage-content" slot="above">
+        <top-nav></top-nav>
+      </div>
+      <component slot="content" :is="currentPage" class="manage-content page"></component>
+    </template>
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>
-      <h3>You must be logged in as an Admin to view this page.</h3>
+      <p>You must be logged in as an Admin to view this page.</p>
     </div>
 
   </core-base>
@@ -78,9 +81,8 @@
     margin-top: 2em
     border-radius: $radius
 
-  .login-message h1, h3
+  .login-message
     text-align: center
-  .login-message h1
     margin-top: 200px
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -13,8 +13,8 @@
       :is="currentPage"
     ></component>
     <div v-else slot="content" class="login-message">
-      <h1>Did you forget to log in?</h1>
-      <p>You must be logged in as an Admin to view this page.</p>
+      <h1>{{ $tr('logInPrompt') }}</h1>
+      <p>{{ $tr('logInCommand') }}</p>
     </div>
 
   </core-base>
@@ -29,6 +29,11 @@
   const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
+    $trNameSpace: 'management-root',
+    $trs: {
+      logInPrompt: 'Did you forget to log in?',
+      logInCommand: 'You must be logged in as an Admin to view this page.',
+    },
     components: {
       'top-nav': require('./top-nav'),
       'main-nav': require('./main-nav'),

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -20,7 +20,7 @@
 
   const store = require('../state/store');
   const PageNames = require('../state/constants').PageNames;
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
 
   module.exports = {
     components: {
@@ -47,17 +47,11 @@
         }
         return null;
       },
-      isAdminOrSuperuser() {
-        if (this.kind[0] === UserKinds.SUPERUSER || this.kind[0] === UserKinds.ADMIN) {
-          return true;
-        }
-        return false;
-      },
     },
     vuex: {
       getters: {
         pageName: state => state.pageName,
-        kind: state => state.core.session.kind,
+        isAdminOrSuperuser,
       },
     },
     store, // make this and all child components aware of the store

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -3,12 +3,15 @@
   <core-base>
     <main-nav slot="nav"></main-nav>
 
-    <template v-if="isAdminOrSuperuser">
-      <div class="manage-content" slot="above">
-        <top-nav></top-nav>
-      </div>
-      <component slot="content" :is="currentPage" class="manage-content page"></component>
-    </template>
+    <div v-if="isAdminOrSuperuser" slot="above" class="manage-content">
+      <top-nav></top-nav>
+    </div>
+    <component
+      v-if="isAdminOrSuperuser"
+      slot="content"
+      class="manage-content page"
+      :is="currentPage"
+    ></component>
     <div v-else slot="content" class="login-message">
       <h1>Did you forget to log in?</h1>
       <p>You must be logged in as an Admin to view this page.</p>

--- a/kolibri/plugins/management/assets/src/vue/main-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/main-nav/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!--
-    In order to get the nev to work right, it seemed necessary to
+    In order to get the nav to work right, it seemed necessary to
     have multiple root nodes in this template.
 
     TODO: would be best to refactor this.
@@ -14,13 +14,13 @@
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
     <div class="label">Explore</div>
   </nav-bar-item>
-  <nav-bar-item href="/management" :active="true">
-    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/manage.svg"></svg>
-    <div class="label">Manage</div>
-  </nav-bar-item>
-  <nav-bar-item href="/coach">
+  <nav-bar-item v-if="isAdminOrSuperuser" href="/coach">
     <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/coach.svg"></svg>
     <div class="label">Coach</div>
+  </nav-bar-item>
+  <nav-bar-item v-if="isAdminOrSuperuser" href="/management" :active="true">
+    <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/manage.svg"></svg>
+    <div class="label">Manage</div>
   </nav-bar-item>
 
 </template>
@@ -28,9 +28,16 @@
 
 <script>
 
+  const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
+
   module.exports = {
     components: {
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
+    },
+    vuex: {
+      getters: {
+        isAdminOrSuperuser,
+      },
     },
   };
 


### PR DESCRIPTION
re: https://trello.com/c/VrZqfbub/640-make-coach-reports-only-accessible-to-admins-and-coaches

* Update coach tools to only be accessible by admins and device owners
* Display coach tools above management in the nav bars






