### PR TITLE
Fixed various issues and updated api schema.

### DIFF
--- a/kolibri/plugins/coach_tools/api.py
+++ b/kolibri/plugins/coach_tools/api.py
@@ -4,7 +4,7 @@ from kolibri.content.models import ContentNode
 from kolibri.logger.models import ContentSummaryLog
 from rest_framework import pagination, permissions, viewsets
 
-from .serializers import ContentReportSerializer, UserReportSerializer
+from .serializers import ContentReportSerializer, ContentSummarySerializer, UserReportSerializer
 from .utils.return_users import get_collection_or_user
 
 
@@ -50,7 +50,7 @@ class ContentReportViewSet(viewsets.ModelViewSet):
 class ContentSummaryViewSet(viewsets.ModelViewSet):
 
     permission_classes = (KolibriReportPermissions,)
-    serializer_class = ContentReportSerializer
+    serializer_class = ContentSummarySerializer
 
     def get_queryset(self):
         return ContentNode.objects.all()

--- a/kolibri/plugins/coach_tools/api.py
+++ b/kolibri/plugins/coach_tools/api.py
@@ -43,8 +43,8 @@ class ContentReportViewSet(viewsets.ModelViewSet):
     serializer_class = ContentReportSerializer
 
     def get_queryset(self):
-        topic_id = self.kwargs['topic_id']
-        return ContentNode.objects.filter(parent=topic_id)
+        content_node_id = self.kwargs['content_node_id']
+        return ContentNode.objects.filter(parent=content_node_id)
 
 
 class ContentSummaryViewSet(viewsets.ModelViewSet):
@@ -72,6 +72,6 @@ class RecentReportViewSet(viewsets.ModelViewSet):
     serializer_class = ContentReportSerializer
 
     def get_queryset(self):
-        query_node = ContentNode.objects.get(pk=self.kwargs['topic_id'])
+        query_node = ContentNode.objects.get(pk=self.kwargs['content_node_id'])
         recent_content_items = ContentSummaryLog.objects.filter_by_topic(query_node).order_by('end_timestamp').values_list('content_id')
         return ContentNode.objects.filter(content_id__in=recent_content_items)

--- a/kolibri/plugins/coach_tools/api_urls.py
+++ b/kolibri/plugins/coach_tools/api_urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.http import Http404
 from rest_framework import routers
 
 from .api import ContentReportViewSet, ContentSummaryViewSet, RecentReportViewSet, UserReportViewSet, UserSummaryViewSet
@@ -15,9 +16,12 @@ content_summary_router.register(r'contentsummary', ContentSummaryViewSet, base_n
 user_summary_router = routers.SimpleRouter()
 user_summary_router.register(r'usersummary', UserSummaryViewSet, base_name='usersummary')
 
+def return_404(*args, **kwargs):
+    raise Http404
 
 urlpatterns = [
     url(r'^(?P<channel_id>[^/.]+)/(?P<content_node_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(reports_router.urls)),
     url(r'^(?P<channel_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(content_summary_router.urls)),
     url(r'^(?P<channel_id>[^/.]+)/(?P<content_node_id>[^/.]+)/', include(user_summary_router.urls)),
+    url(r'^', return_404)
 ]

--- a/kolibri/plugins/coach_tools/api_urls.py
+++ b/kolibri/plugins/coach_tools/api_urls.py
@@ -17,7 +17,7 @@ user_summary_router.register(r'usersummary', UserSummaryViewSet, base_name='user
 
 
 urlpatterns = [
-    url(r'^(?P<channel_id>[^/.]+)/(?P<topic_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_pk>[^/.]+)/', include(reports_router.urls)),
-    url(r'^(?P<channel_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_pk>[^/.]+)/', include(content_summary_router.urls)),
-    url(r'^(?P<channel_id>[^/.]+)/(?P<topic_id>[^/.]+)/', include(user_summary_router.urls)),
+    url(r'^(?P<channel_id>[^/.]+)/(?P<content_node_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(reports_router.urls)),
+    url(r'^(?P<channel_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(content_summary_router.urls)),
+    url(r'^(?P<channel_id>[^/.]+)/(?P<content_node_id>[^/.]+)/', include(user_summary_router.urls)),
 ]

--- a/kolibri/plugins/coach_tools/serializers.py
+++ b/kolibri/plugins/coach_tools/serializers.py
@@ -1,9 +1,10 @@
-from django.db.models import BooleanField, Case, Count, Sum, When
+from django.db.models import Case, Count, IntegerField, Sum, When
 from kolibri.auth.models import FacilityUser
 from kolibri.content.models import ContentNode
 from kolibri.logger.models import ContentSummaryLog
 from le_utils.constants import content_kinds
 from rest_framework import serializers
+
 from .utils.return_users import get_collection_or_user
 
 
@@ -18,7 +19,7 @@ class UserReportSerializer(serializers.ModelSerializer):
         )
 
     def get_details(self, target_user):
-        content_node = ContentNode.objects.get(pk=self.context['view'].kwargs['topic_id'])
+        content_node = ContentNode.objects.get(pk=self.context['view'].kwargs['content_node_id'])
         # progress details for a topic node and everything under it
         if content_node.kind == content_kinds.TOPIC:
             return ContentSummaryLog.objects \
@@ -27,16 +28,16 @@ class UserReportSerializer(serializers.ModelSerializer):
                 .values('kind') \
                 .annotate(total_progress=Sum('progress')) \
                 .annotate(log_count_total=Count('pk')) \
-                .annotate(log_count_complete=Sum(Case(When(progress=1, then=1), output_field=BooleanField())))
+                .annotate(log_count_complete=Sum(Case(When(progress=1, then=1), default=0, output_field=IntegerField())))
         else:
             # progress details for a leaf node (exercise, video, etc.)
             return ContentSummaryLog.objects \
                 .filter(user=target_user) \
                 .values('kind', 'time_spent', 'progress') \
-                .get(content_id=content_node.content_id)
+                .filter(content_id=content_node.content_id)
 
     def get_last_active(self, target_user):
-        content_node = ContentNode.objects.get(pk=self.context['view'].kwargs['topic_id'])
+        content_node = ContentNode.objects.get(pk=self.context['view'].kwargs['content_node_id'])
         try:
             if content_node.kind == content_kinds.TOPIC:
                 return ContentSummaryLog.objects \
@@ -54,11 +55,13 @@ class UserReportSerializer(serializers.ModelSerializer):
 class ContentReportSerializer(serializers.ModelSerializer):
     progress = serializers.SerializerMethodField()
     last_active = serializers.SerializerMethodField()
+    ancestors = serializers.SerializerMethodField()
+    num_users = serializers.SerializerMethodField()
 
     class Meta:
         model = ContentNode
         fields = (
-            'pk', 'content_id', 'title', 'progress', 'kind', 'last_active', 'parent',
+            'pk', 'content_id', 'title', 'progress', 'kind', 'last_active', 'ancestors', 'num_users',
         )
 
     def get_progress(self, target_node):
@@ -82,7 +85,7 @@ class ContentReportSerializer(serializers.ModelSerializer):
                 .filter(user__in=get_collection_or_user(kwargs)) \
                 .annotate(total_progress=Sum('progress')) \
                 .annotate(log_count_total=Count('pk')) \
-                .annotate(log_count_complete=Sum(Case(When(progress=1, then=1), output_field=BooleanField()))) \
+                .annotate(log_count_complete=Sum(Case(When(progress=1, then=1), default=0, output_field=IntegerField()))) \
                 .values('total_progress', 'log_count_total', 'log_count_complete')
 
     def get_last_active(self, target_node):
@@ -97,3 +100,12 @@ class ContentReportSerializer(serializers.ModelSerializer):
                 return ContentSummaryLog.objects.get(content_id=target_node.content_id).end_timestamp
         except ContentSummaryLog.DoesNotExist:
             return None
+
+    def get_ancestors(self, target_node):
+        """
+        in descending order (root ancestor first, immediate parent last)
+        """
+        return target_node.get_ancestors().values('pk', 'title')
+
+    def get_num_users(self, target_node):
+        return get_collection_or_user(self.context['view'].kwargs).count()

--- a/kolibri/plugins/coach_tools/serializers.py
+++ b/kolibri/plugins/coach_tools/serializers.py
@@ -55,13 +55,12 @@ class UserReportSerializer(serializers.ModelSerializer):
 class ContentReportSerializer(serializers.ModelSerializer):
     progress = serializers.SerializerMethodField()
     last_active = serializers.SerializerMethodField()
-    ancestors = serializers.SerializerMethodField()
-    num_users = serializers.SerializerMethodField()
+    parent = serializers.SerializerMethodField()
 
     class Meta:
         model = ContentNode
         fields = (
-            'pk', 'content_id', 'title', 'progress', 'kind', 'last_active', 'ancestors', 'num_users',
+            'pk', 'content_id', 'title', 'progress', 'kind', 'last_active', 'parent',
         )
 
     def get_progress(self, target_node):
@@ -100,6 +99,21 @@ class ContentReportSerializer(serializers.ModelSerializer):
                 return ContentSummaryLog.objects.get(content_id=target_node.content_id).end_timestamp
         except ContentSummaryLog.DoesNotExist:
             return None
+
+    def get_parent(self, target_node):
+        # returns immediate parent
+        return target_node.get_ancestors().values('pk', 'title').last()
+
+
+class ContentSummarySerializer(ContentReportSerializer):
+    ancestors = serializers.SerializerMethodField()
+    num_users = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ContentNode
+        fields = (
+            'pk', 'content_id', 'title', 'progress', 'kind', 'last_active', 'ancestors', 'num_users',
+        )
 
     def get_ancestors(self, target_node):
         """

--- a/kolibri/plugins/coach_tools/utils/return_users.py
+++ b/kolibri/plugins/coach_tools/utils/return_users.py
@@ -4,11 +4,11 @@ from kolibri.auth.models import Collection, FacilityUser
 
 def get_collection_or_user(kwargs):
     collection_kind = kwargs.get('collection_kind', None)
-    collection_pk = kwargs.get('collection_pk', None)
+    collection_id = kwargs.get('collection_id', None)
     user_pk = kwargs.get('pk', None)
     if any(collection_kind in kind for kind in collection_kinds.choices):
-        return Collection.objects.get(pk=collection_pk).get_members()
-    elif collection_pk:
-        return FacilityUser.objects.get(pk=collection_pk)
+        return Collection.objects.get(pk=collection_id).get_members()
+    elif collection_id:
+        return FacilityUser.objects.filter(pk=collection_id)
     else:
-        return FacilityUser.objects.get(pk=user_pk)
+        return FacilityUser.objects.filter(pk=user_pk)


### PR DESCRIPTION
## Summary

Fixes issues mentioned in this PR https://github.com/learningequality/kolibri/pull/625.
Also, changed `topic_id` to `content_node_id` and `collection_pk` to `collection_id` in the url schemas.
Passed ancestors and number of users to each content node. Regarding this, we currently return it for each node, but we will most likely only want to do this in the `contentsummary` case for 1 node.

## Issues addressed

Fixed `log_count_complete` being null. 
Fixed `DoesNotExist` errors for logs. 
Unresolvable API urls redirect to 404 now.
