### PR TITLE
Fixed returned data for node kinds that don't have logs.

### DIFF
--- a/kolibri/plugins/coach_tools/api_urls.py
+++ b/kolibri/plugins/coach_tools/api_urls.py
@@ -19,6 +19,7 @@ user_summary_router.register(r'usersummary', UserSummaryViewSet, base_name='user
 def return_404(*args, **kwargs):
     raise Http404
 
+
 urlpatterns = [
     url(r'^(?P<channel_id>[^/.]+)/(?P<content_node_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(reports_router.urls)),
     url(r'^(?P<channel_id>[^/.]+)/(?P<collection_kind>[^/.]+)/(?P<collection_id>[^/.]+)/', include(content_summary_router.urls)),

--- a/kolibri/plugins/coach_tools/serializers.py
+++ b/kolibri/plugins/coach_tools/serializers.py
@@ -76,6 +76,11 @@ class ContentReportSerializer(serializers.ModelSerializer):
             # add kind counts under this node to progress dict
             for kind in progress:
                 kind['node_count'] = kind_counts[kind['kind']]
+                del kind_counts[kind['kind']]
+            # evaluate queryset so we can add data for kinds that do not have logs
+            progress = list(progress)
+            for key in kind_counts:
+                progress.append({'kind': key, 'node_count': kind_counts[key], 'total_progress': 0})
             return progress
         else:
             # filter logs by a leaf node and annotate with specific stats


### PR DESCRIPTION
## Summary

Data was not returned for node kinds that do not have summary logs. For example, if there are no summary logs for any type of `exercise` problems, we will not get `node_count`'s for that kind. That is fixed in this PR.

## Issues addressed

Fixes https://github.com/learningequality/kolibri/issues/655.