### PR TITLE
Use filter instead of get for last_active in ContentReportSerializer.

### DIFF
--- a/kolibri/plugins/coach_tools/serializers.py
+++ b/kolibri/plugins/coach_tools/serializers.py
@@ -101,7 +101,9 @@ class ContentReportSerializer(serializers.ModelSerializer):
                     .filter(user__in=get_members_or_user(kwargs['collection_kind'], kwargs['collection_id'])) \
                     .latest('end_timestamp').end_timestamp
             else:
-                return ContentSummaryLog.objects.get(content_id=target_node.content_id).end_timestamp
+                return ContentSummaryLog.objects \
+                    .filter(content_id=target_node.content_id) \
+                    .latest('end_timestamp').end_timestamp
         except ContentSummaryLog.DoesNotExist:
             return None
 


### PR DESCRIPTION
## Summary

Should use `filter` since we expect multiple summary logs to be returned for a leaf content node, as `get` only expects to return 1 node.

## Issues addressed

Solves this issue https://github.com/learningequality/kolibri/issues/660.


