### PR TITLE
Fixed content-icons.

### DIFF
--- a/kolibri/core/assets/src/vue/content-icon/index.vue
+++ b/kolibri/core/assets/src/vue/content-icon/index.vue
@@ -1,37 +1,35 @@
 <template>
 
-  <div>
-    <svg
-      v-if="is(Constants.ContentNodeKinds.TOPIC)"
-      src="./content-icons/topic.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-    <svg
-      v-if="is(Constants.ContentNodeKinds.VIDEO)"
-      src="./content-icons/video.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-    <svg
-      v-if="is(Constants.ContentNodeKinds.AUDIO)"
-      src="./content-icons/audio.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-    <svg
-      v-if="is(Constants.ContentNodeKinds.DOCUMENT)"
-      src="./content-icons/document.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-    <svg
-      v-if="is(Constants.ContentNodeKinds.EXERCISE)"
-      src="./content-icons/exercise.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-    <svg
-      v-if="is(Constants.USER)"
-      src="./content-icons/user.svg"
-      :class="['content-icon', colorClass]"
-    ></svg>
-  </div>
+  <svg
+    v-if="is(Constants.ContentNodeKinds.TOPIC)"
+    src="./content-icons/topic.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
+  <svg
+    v-if="is(Constants.ContentNodeKinds.VIDEO)"
+    src="./content-icons/video.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
+  <svg
+    v-if="is(Constants.ContentNodeKinds.AUDIO)"
+    src="./content-icons/audio.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
+  <svg
+    v-if="is(Constants.ContentNodeKinds.DOCUMENT)"
+    src="./content-icons/document.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
+  <svg
+    v-if="is(Constants.ContentNodeKinds.EXERCISE)"
+    src="./content-icons/exercise.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
+  <svg
+    v-if="is(Constants.USER)"
+    src="./content-icons/user.svg"
+    :class="['content-icon', colorClass]"
+  ></svg>
 
 </template>
 


### PR DESCRIPTION
## Summary

Fixed content-icons.

## Issues addressed
[content cards get cut off in IE 9](https://trello.com/c/gMg2lk0X/663-content-cards-get-cut-off-in-ie-9)

## Screenshots
### Before: 
![image](https://cloud.githubusercontent.com/assets/7193975/20322667/caedbebc-ab2e-11e6-962d-fda2490e1b5f.png)

### After: 
![image](https://cloud.githubusercontent.com/assets/7193975/20322650/b4ed951a-ab2e-11e6-8eac-22fef647e18e.png)