### PR TITLE
Download Button Changes

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -1,16 +1,13 @@
 <template>
 
   <div class="dropdown">
-    <icon-button
+    <button
       v-el:dropdownbutton
-      :text="$tr('downloadContent')"
-      :primary="false"
-      :icononright="true"
       class="dropdown-button"
       @click="toggleDropdown"
       aria-haspopup="true">
-      <svg src="./expand.svg"></svg>
-    </icon-button>
+      <span class="dropdown-button-text">{{ $tr('downloadContent') }}</span>
+    </button>
     <ul
       v-el:dropdownitems
       class="dropdown-items"
@@ -152,9 +149,13 @@
     position: relative
 
   .dropdown-button
-    padding-right: 0.5em
-    padding-left: 0.5em
+    padding: 0.5em
     font-size: smaller
+
+  .dropdown-button-text
+    &:after
+      content: '\25BC'
+      padding-left: 0.5em
 
   .dropdown-items
     background-color: white

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -6,7 +6,9 @@
       class="dropdown-button"
       @click="toggleDropdown"
       aria-haspopup="true">
-      <span class="dropdown-button-text">{{ $tr('downloadContent') }}</span>
+      <span class="dropdown-button-text" :class="{uparrow: dropdownopen}">
+        {{ $tr('downloadContent') }}
+      </span>
     </button>
     <ul
       v-el:dropdownitems
@@ -154,8 +156,12 @@
 
   .dropdown-button-text
     &:after
-      content: '\25BC'
       padding-left: 0.5em
+      content: '\25BC'
+
+  .uparrow
+    &:after
+      content: '\25b2'
 
   .dropdown-items
     background-color: white

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -2,16 +2,17 @@
 
   <div class="dropdown">
     <icon-button
+      v-el:dropdownbutton
       :text="$tr('downloadContent')"
       :primary="false"
       :icononright="true"
       class="dropdown-button"
       @click="toggleDropdown"
-      aria-haspopup="true"
-    >
+      aria-haspopup="true">
       <svg src="./expand.svg"></svg>
     </icon-button>
     <ul
+      v-el:dropdownitems
       class="dropdown-items"
       :class="{ dropdownopen: dropdownopen }"
       :aria-hidden="dropDownOpenText"
@@ -55,26 +56,80 @@
     data() {
       return {
         dropdownopen: false,
+        itemSelected: 0,
       };
     },
     computed: {
       dropDownOpenText() {
         return String(this.dropdownopen);
       },
+      dropDownItems() {
+        let listItems = this.$els.dropdownitems.children;
+        listItems = [...listItems];
+        const anchorItems = [];
+        listItems.forEach((li) => {
+          anchorItems.push(li.children[0]);
+        });
+        return anchorItems;
+      },
+      focusableItems() {
+        let focusableItems = [];
+        focusableItems.push(this.$els.dropdownbutton);
+        focusableItems = focusableItems.concat(this.dropDownItems);
+        return focusableItems;
+      },
     },
     methods: {
-      toggleDropdown() {
-        this.dropdownopen = !this.dropdownopen;
-      },
       prettifyFileSize(bytes) {
         return filesize(bytes);
       },
+      toggleDropdown() {
+        this.dropdownopen = !this.dropdownopen;
+        this.itemSelected = 0;
+      },
       handleKeys(e) {
         if (this.dropdownopen) {
-          if (e.keyCode === 27) {
-            this.toggleDropdown();
+          switch (e.keyCode) {
+            case 40: // down
+              e.stopPropagation();
+              e.preventDefault();
+              this.itemSelected++;
+              this.focusOnItem();
+              return;
+
+            case 38: // up
+              e.stopPropagation();
+              e.preventDefault();
+              this.itemSelected--;
+              this.focusOnItem();
+              return;
+
+            case 9: // tab
+              e.stopPropagation();
+              e.preventDefault();
+              if (this.itemSelected === (this.focusableItems.length - 1)) {
+                this.toggleDropdown();
+                return;
+              }
+              this.itemSelected++;
+              this.focusOnItem();
+              return;
+
+            case 27: // esc
+              e.stopPropagation();
+              e.preventDefault();
+              this.toggleDropdown();
+              return;
+
+            default:
+              return;
           }
         }
+      },
+      focusOnItem() {
+        this.itemSelected =
+          Math.min(Math.max(this.itemSelected, 0), (this.focusableItems.length - 1));
+        this.focusableItems[this.itemSelected].focus();
       },
     },
     ready() {
@@ -106,24 +161,30 @@
     list-style: none
     padding: 0
     margin: 0
-    margin-top: 1px
+    margin-top: 2px
     display: none
     position: absolute
 
   .dropdown-item
-    padding: 0.5em
+    padding: 0
     margin: 0
     width: 100%
     position: relative
     display: block
-    &:hover
-      background-color: $core-action-light
 
   .dropdown-item-link
+    padding: 0.5em
+    margin: 0
+    width: 100%
     display: block
     text-decoration: none
     white-space: nowrap
     font-size: smaller
+    &:focus
+      background-color: $core-action-light
+    &:hover
+      background-color: $core-action-light
+      outline: $core-action-light 2px solid
 
   .dropdownopen
     display: block

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -1,12 +1,16 @@
 <template>
 
   <div class="dropdown">
-    <button
+    <icon-button
+      :text="$tr('downloadContent')"
+      :primary="false"
+      :icononright="true"
       class="dropdown-button"
       @click="toggleDropdown"
-      aria-haspopup="true">
-      {{ $tr('downloadContent') }} &#9660
-    </button>
+      aria-haspopup="true"
+    >
+      <svg src="./expand.svg"></svg>
+    </icon-button>
     <ul
       class="dropdown-items"
       :class="{ dropdownopen: dropdownopen }"
@@ -35,6 +39,9 @@
   const filesize = require('filesize');
 
   module.exports = {
+    components: {
+      'icon-button': require('kolibri.coreVue.components.iconButton'),
+    },
     $trNameSpace: 'downloadButton',
     $trs: {
       downloadContent: 'Download Content',
@@ -90,7 +97,8 @@
     position: relative
 
   .dropdown-button
-    padding: 0.5em
+    padding-right: 0.5em
+    padding-left: 0.5em
     font-size: smaller
 
   .dropdown-items

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -1,12 +1,30 @@
 <template>
 
   <div class="dropdown">
-    <button>{{ $tr('downloadContent') }} &#9660</button>
-    <div class="dropdown-items">
-      <a class="dropdown-item" v-for="file in files" href="{{ file.download_url }}">
-        {{ file.preset + ' (' + prettifyFileSize(file.file_size) + ')' }}
-      </a>
-    </div>
+    <button
+      class="dropdown-button"
+      @click="toggleDropdown"
+      aria-haspopup="true">
+      {{ $tr('downloadContent') }} &#9660
+    </button>
+    <ul
+      class="dropdown-items"
+      :class="{ dropdownopen: dropdownopen }"
+      :aria-hidden="dropDownOpenText"
+      role="menu">
+      <li
+        v-for="file in files"
+        class="dropdown-item"
+        role="presentation">
+        <a
+          class="dropdown-item-link"
+          @click="toggleDropdown"
+          href="{{ file.download_url }}"
+          role="menuitem">
+          {{ file.preset + ' (' + prettifyFileSize(file.file_size) + ')' }}
+        </a>
+      </li>
+    </ul>
   </div>
 
 </template>
@@ -17,7 +35,7 @@
   const filesize = require('filesize');
 
   module.exports = {
-    $trNameSpace: 'contentRender',
+    $trNameSpace: 'downloadButton',
     $trs: {
       downloadContent: 'Download Content',
     },
@@ -27,16 +45,36 @@
         default: () => [],
       },
     },
-    components: {
-      'icon-button': require('kolibri.coreVue.components.iconButton'),
+    data() {
+      return {
+        dropdownopen: false,
+      };
+    },
+    computed: {
+      dropDownOpenText() {
+        return String(this.dropdownopen);
+      },
     },
     methods: {
-      /**
-       * Creates a human readable file size.
-       */
+      toggleDropdown() {
+        this.dropdownopen = !this.dropdownopen;
+      },
       prettifyFileSize(bytes) {
         return filesize(bytes);
       },
+      handleKeys(e) {
+        if (this.dropdownopen) {
+          if (e.keyCode === 27) {
+            this.toggleDropdown();
+          }
+        }
+      },
+    },
+    ready() {
+      document.addEventListener('keydown', this.handleKeys);
+    },
+    beforeDestroy() {
+      document.removeEventListener('keydown', this.handleKeys);
     },
   };
 
@@ -45,26 +83,41 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.coreTheme'
+
   .dropdown
-    position: relative
     display: inline-block
-    &:hover
-      .dropdown-items
-        display: block
+    position: relative
+
+  .dropdown-button
+    padding: 0.5em
+    font-size: smaller
 
   .dropdown-items
-    position: absolute
-    display: none
-    width: 100%
     background-color: white
-    box-shadow: 1px 1px 4px 0 #cccccc
+    list-style: none
+    padding: 0
+    margin: 0
+    margin-top: 1px
+    display: none
+    position: absolute
 
   .dropdown-item
+    padding: 0.5em
+    margin: 0
+    width: 100%
+    position: relative
     display: block
-    padding: 1em
-    text-decoration: none
-    color: #3a3a3a
     &:hover
-      background-color: #e2d1e0
+      background-color: $core-action-light
+
+  .dropdown-item-link
+    display: block
+    text-decoration: none
+    white-space: nowrap
+    font-size: smaller
+
+  .dropdownopen
+    display: block
 
 </style>

--- a/kolibri/core/assets/src/vue/content-renderer/expand.svg
+++ b/kolibri/core/assets/src/vue/content-renderer/expand.svg
@@ -1,4 +1,0 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
-</svg>

--- a/kolibri/core/assets/src/vue/content-renderer/expand.svg
+++ b/kolibri/core/assets/src/vue/content-renderer/expand.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/kolibri/core/assets/src/vue/icon-button.vue
+++ b/kolibri/core/assets/src/vue/icon-button.vue
@@ -1,13 +1,8 @@
 <template>
 
   <button class="icon-button-scope" :class="{'primary' : primary, 'single-line': !textbelow}">
-    <span v-if="text && icononright" class="btn-text"
-          :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
-      {{ text }}
-    </span>
     <slot v-el:icon></slot>
-    <span v-if="text && !icononright" class="btn-text"
-          :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
+    <span v-if="text" class="btn-text" :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
       {{ text }}
     </span>
   </button>
@@ -27,10 +22,6 @@
         default: false,
       },
       textbelow: {
-        type: Boolean,
-        default: false,
-      },
-      icononright: {
         type: Boolean,
         default: false,
       },

--- a/kolibri/core/assets/src/vue/icon-button.vue
+++ b/kolibri/core/assets/src/vue/icon-button.vue
@@ -1,8 +1,13 @@
 <template>
 
   <button class="icon-button-scope" :class="{'primary' : primary, 'single-line': !textbelow}">
+    <span v-if="text && icononright" class="btn-text"
+          :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
+      {{ text }}
+    </span>
     <slot v-el:icon></slot>
-    <span v-if="text" class="btn-text" :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
+    <span v-if="text && !icononright" class="btn-text"
+          :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
       {{ text }}
     </span>
   </button>
@@ -22,6 +27,10 @@
         default: false,
       },
       textbelow: {
+        type: Boolean,
+        default: false,
+      },
+      icononright: {
         type: Boolean,
         default: false,
       },
@@ -57,7 +66,7 @@
     &:disabled svg
       fill: $core-text-disabled
 
-    // styles specific to primary button
+  // styles specific to primary button
   .icon-button-scope.primary
     svg
       fill: $core-bg-canvas


### PR DESCRIPTION
## Summary

* Made use of the `<ul>` tag.
* Added aria labels.
* Open via click vs hover.
* Smaller font size.
* Made use of the `icon-button`. (Had to add an `icononright` prop to handle situations where the icon should be on right side.)
* Attempted to make it keyboard navigable. 

## TODO

- [x] Accessibility

## Screenshots

### Before
![before](https://cloud.githubusercontent.com/assets/7193975/20505311/e84c0ea6-b000-11e6-93da-eb23573bdc53.gif)


### After
![after](https://cloud.githubusercontent.com/assets/7193975/20576365/9024684a-b172-11e6-9b91-ed2e3d0624c5.gif)

