### PR TITLE
HTML5 app content renderer

### DIFF
--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -71,6 +71,9 @@ class ZipContentView(View):
         # ensure the browser knows not to try byte-range requests, as we don't support them here
         response["Accept-Ranges"] = "none"
 
+        # allow all origins so that content can be read from within zips within sandboxed iframes
+        response["Access-Control-Allow-Origin"] = "*"
+
         return response
 
 

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -35,6 +35,10 @@ class ZipContentView(View):
 
         with zipfile.ZipFile(zipped_path) as zf:
 
+            # if no path, or a directory, is being referenced, look for an index.html file
+            if not embedded_filepath or embedded_filepath.endswith("/"):
+                embedded_filepath += "index.html"
+
             # get the details about the embedded file, and ensure it exists
             try:
                 info = zf.getinfo(embedded_filepath)

--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -12,6 +12,7 @@ const ContentNodeKinds = {
   VIDEO: 'video',
   EXERCISE: 'exercise',
   TOPIC: 'topic',
+  HTML5: 'html5',
 };
 
 // used internally on the client as a hack to allow content-icons to display users

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -71,6 +71,7 @@
       },
     },
     ready() {
+
       PDFobject.embed(this.defaultFile.storage_url, this.$els.pdfcontainer);
       this.$emit('startTracking');
       const self = this;
@@ -117,6 +118,8 @@
     &:fullscreen
       width: 100%
       height: 100%
+      min-height: inherit
+      max-height: inherit
 
   .pdfcontainer
     /* Accounts for the button height. */

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -71,7 +71,6 @@
       },
     },
     ready() {
-
       PDFobject.embed(this.defaultFile.storage_url, this.$els.pdfcontainer);
       this.$emit('startTracking');
       const self = this;

--- a/kolibri/plugins/html5_app_renderer/assets/src/module.js
+++ b/kolibri/plugins/html5_app_renderer/assets/src/module.js
@@ -1,0 +1,14 @@
+
+const ContentRendererModule = require('content_renderer_module');
+const HTML5AppComponent = require('./vue/index');
+
+class HTML5AppModule extends ContentRendererModule {
+  get rendererComponent() {
+    return HTML5AppComponent;
+  }
+  get contentType() {
+    return 'html5/zip';
+  }
+}
+
+module.exports = new HTML5AppModule();

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -29,7 +29,7 @@
     computed: {
       rooturl() {
         return this.defaultFile.storage_url;
-      }
+      },
     },
 
     methods: {
@@ -72,7 +72,6 @@
       },
     },
     ready() {
-      
       this.$emit('startTracking');
       const self = this;
       this.timeout = setTimeout(() => {

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -6,7 +6,7 @@
       :text="inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
       @click="togglefullscreen">
     </icon-button>
-    <iframe v-el:sandbox class="sandbox" :src="indexpath" sandbox="allow-scripts"></iframe>
+    <iframe v-el:sandbox class="sandbox" :src="rooturl" sandbox="allow-scripts"></iframe>
   </div>
 
 </template>
@@ -27,8 +27,8 @@
     }),
 
     computed: {
-      indexpath() {
-        return this.defaultFile.storage_url + "index.html";
+      rooturl() {
+        return this.defaultFile.storage_url;
       }
     },
 

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -18,7 +18,12 @@
     components: {
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
-    props: ['defaultFile'],
+    props: {
+      defaultFile: {
+        type: Object,
+        required: true,
+      },
+    },
     data: () => ({
       inFullscreen: false,
     }),

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -1,0 +1,129 @@
+<template>
+
+  <div v-el:container class="container" allowfullscreen>
+    <icon-button
+      class="btn"
+      :text="inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+      @click="togglefullscreen">
+    </icon-button>
+    <iframe v-el:sandbox class="sandbox" :src="indexpath" sandbox="allow-scripts"></iframe>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+
+    components: {
+      'icon-button': require('kolibri.coreVue.components.iconButton'),
+    },
+
+    props: ['defaultFile'],
+
+    data: () => ({
+      inFullscreen: false,
+    }),
+
+    computed: {
+      indexpath() {
+        return this.defaultFile.storage_url + "index.html";
+      }
+    },
+
+    methods: {
+      togglefullscreen() {
+        const container = this.$els.container;
+        if (!document.fullscreenElement
+          && !document.webkitFullscreenElement
+          && !document.mozFullScreenElement
+          && !document.msFullscreenElement) {
+          if (container.requestFullscreen) {
+            container.requestFullscreen();
+          } else if (container.webkitRequestFullscreen) {
+            container.webkitRequestFullscreen();
+          } else if (container.mozRequestFullScreen) {
+            container.mozRequestFullScreen();
+          } else if (container.msRequestFullscreen) {
+            container.msRequestFullscreen();
+          }
+          this.inFullscreen = true;
+        } else {
+          if (document.exitFullscreen) {
+            document.exitFullscreen();
+          } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
+          } else if (document.mozCancelFullScreen) {
+            document.mozCancelFullScreen();
+          } else if (document.msExitFullscreen) {
+            document.msExitFullscreen();
+          }
+          this.inFullscreen = false;
+        }
+      },
+      updateFullscreenState() {
+        if (!document.fullscreenElement
+          && !document.webkitFullscreenElement
+          && !document.mozFullScreenElement
+          && !document.msFullscreenElement) {
+          this.inFullscreen = false;
+        }
+      },
+    },
+    ready() {
+      
+      this.$emit('startTracking');
+      const self = this;
+      this.timeout = setTimeout(() => {
+        self.$emit('progressUpdate', 1);
+      }, 15000);
+
+      document.addEventListener('fullscreenchange', this.updateFullscreenState, false);
+      document.addEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
+      document.addEventListener('mozfullscreenchange', this.updateFullscreenState, false);
+      document.addEventListener('MSFullscreenChange', this.updateFullscreenState, false);
+    },
+    beforeDestroy() {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+      this.$emit('stopTracking');
+
+      document.removeEventListener('fullscreenchange', this.updateFullscreenState, false);
+      document.removeEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
+      document.removeEventListener('mozfullscreenchange', this.updateFullscreenState, false);
+      document.removeEventListener('MSFullscreenChange', this.updateFullscreenState, false);
+    },
+    $trNameSpace: 'html5Renderer',
+    $trs: {
+      exitFullscreen: 'Exit Fullscreen',
+      enterFullscreen: 'Enter Fullscreen',
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  .btn
+    margin-bottom: 1em
+
+  .container
+    text-align: center
+    height: 100vh
+    max-height: calc(100vh - 24em)
+    min-height: 400px
+    &:fullscreen
+      width: 100%
+      height: 100%
+      min-height: inherit
+      max-height: inherit
+
+  .sandbox
+    /* Accounts for the button height. */
+    height: calc(100% - 4em)
+    width: 100%
+
+</style>

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -15,23 +15,18 @@
 <script>
 
   module.exports = {
-
     components: {
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
-
     props: ['defaultFile'],
-
     data: () => ({
       inFullscreen: false,
     }),
-
     computed: {
       rooturl() {
         return this.defaultFile.storage_url;
       },
     },
-
     methods: {
       togglefullscreen() {
         const container = this.$els.container;

--- a/kolibri/plugins/html5_app_renderer/kolibri_plugin.py
+++ b/kolibri/plugins/html5_app_renderer/kolibri_plugin.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from kolibri.core.webpack import hooks as webpack_hooks
+from kolibri.plugins.base import KolibriPluginBase
+from kolibri.plugins.learn import hooks
+
+
+class HTML5AppPlugin(KolibriPluginBase):
+    pass
+
+
+class HTML5AppAsset(webpack_hooks.WebpackBundleHook):
+    unique_slug = "html5_app_renderer_module"
+    src_file = "assets/src/module.js"
+    events = {
+        "content_render:html5/zip": "render"
+    }
+
+
+class HTML5AppInclusionHook(hooks.LearnAsyncHook):
+    bundle_class = HTML5AppAsset

--- a/kolibri/plugins/html5_app_renderer/package.json
+++ b/kolibri/plugins/html5_app_renderer/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "kolibri-html5-app-renderer-plugin",
+  "description": "HTML5 App Renderer Plugin for Kolibri",
+  "private": true,
+  "dependencies": {}
+}

--- a/kolibri/tasks/management/commands/base.py
+++ b/kolibri/tasks/management/commands/base.py
@@ -58,7 +58,7 @@ class ProgressTracker():
         return self.update_progress
 
     def __exit__(self, *exc_details):
-        if self.progressbar:
+        if self.progressbar is not None:
             self.progressbar.close()
 
 

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -45,6 +45,7 @@ config['INSTALLED_APPS'] = [
     "kolibri.plugins.management",
     "kolibri.plugins.learn",
     "kolibri.plugins.document_pdf_render",
+    "kolibri.plugins.html5_app_renderer",
     "kolibri.plugins.video_mp4_render",
     "kolibri.plugins.audio_mp3_render",
     "kolibri.plugins.setup_wizard",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,5 +14,5 @@ https://github.com/fle-internal/django-q/archive/934d557d77ded18c4a73a702905a6f8
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
-le-utils==0.0.9rc11
+le-utils==0.0.9rc13
 kolibri-exercise-perseus-renderer==0.2.0


### PR DESCRIPTION
## Summary

Allows zip files containing HTML5 apps to be rendered as content nodes in Kolibri. A lot of code borrowed from PDF renderer (e.g. fullscreen-ing). The zip file must contain a file named index.html as an entry point. Strict sandbox is applied to the iframe, with basic scripts allowed.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/618416/20588789/c802a9e8-b1cc-11e6-805b-dffc538f2a3a.png)

