### PR TITLE
Vue2: init-renamed, index-and-key-removed, v-for-Argument-Order-for-Arrays-changed

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -82,7 +82,7 @@
         return Math.floor(this.progress * 100);
       },
     },
-    init() {
+    beforeCreate() {
       this._eventListeners = [];
     },
     created() {

--- a/kolibri/core/assets/src/vue/exercise-attempts/index.vue
+++ b/kolibri/core/assets/src/vue/exercise-attempts/index.vue
@@ -3,9 +3,9 @@
   <div class="wrapper">
     <div
       class="answer"
-      v-for="item in log"
+      v-for="(item, index) in log"
       transition="fade"
-      :style="styleForIndex($index)"
+      :style="styleForIndex(index)"
     >
       <answer-icon :answer="item" :success="success"></answer-icon>
     </div>

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
@@ -20,7 +20,7 @@
           <template v-if="writableDrives.length > 1">
             <h2>Writable drives detected:</h2>
             <div class="drive-list">
-              <div class="drive-names" v-for="(index, drive) in writableDrives">
+              <div class="drive-names" v-for="(drive, index) in writableDrives">
                 <input
                   type="radio"
                   :id="'drive-'+index"

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
@@ -22,7 +22,7 @@
           <template v-if="drivesWithData.length > 1">
             <h2>Drives detected with data:</h2>
             <div class="drive-list">
-              <div class="drive-names" v-for="(index, drive) in drivesWithData">
+              <div class="drive-names" v-for="(drive, index) in drivesWithData">
                 <input
                   type="radio"
                   :id="'drive-'+index"


### PR DESCRIPTION
## Summary
* `init()` -> `beforeCreate()`
* `$index` removed
* `(index, value)` -> `(value, index)`

## Issues addressed
* [init-renamed](https://vuejs.org/v2/guide/migration.html#init-renamed)
* [index-and-key-removed](https://vuejs.org/v2/guide/migration.html#index-and-key-removed)
* [v-for-Argument-Order-for-Arrays-changed](https://vuejs.org/v2/guide/migration.html#v-for-Argument-Order-for-Arrays-changed)
