### PR TITLE
Vue2: Replacing-vm-data-removed

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -74,7 +74,7 @@
     },
     mounted() {
       // clear form on load
-      this.$data = this.$options.data();
+      Object.assign(this.$data, this.$options.data());
     },
     methods: {
       createNewUser() {

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -147,7 +147,7 @@
     },
     methods: {
       clear() {
-        this.$data = this.$options.data();
+        Object.assign(this.$data, this.$options.data());
       },
       submit() {
         // mirrors logic of how the 'confirm' buttons are displayed


### PR DESCRIPTION
## Summary
* Replacing-vm-data-removed

## Issues addressed
* [Replacing-vm-data-removed](https://vuejs.org/v2/guide/migration.html#Replacing-vm-data-removed)
* `Instead of replacing $data with this.$data = this.$options.data();, update individual properties or scope all the properties you want to update under a new object property, then replace that object`

## Reviewer Guidance
* It there more too it, or just that? :thinking: 