### PR TITLE
Vue2: Update vue-scroll

### DIFF
--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -18,9 +18,11 @@
 
 <script>
 
-  require('vue-scroll');
-
+  const Vue = require('vue');
   const coreActions = require('kolibri.coreVue.vuex.actions');
+  const vueScroll = require('vue-scroll');
+
+  Vue.use(vueScroll);
 
   module.exports = {
     components: {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vue-focus": "2.1.0",
     "vue-intl": "https://github.com/learningequality/vue-intl.git#vue2",
     "vue-router": "2.0.3",
-    "vue-scroll": "1.0.3",
+    "vue-scroll": "2.0.0",
     "vuex": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
* Update vue-scroll to 2.0,
* Fun fact: vue-scroll 2.0.0 was released just a few hours ago. Perfect timing. 

## Issues addressed
* Vue-scroll 1 was incompatible with Vue 2.0.