### PR TITLE
fix login modal not shown and "Show More" and capitalize string

### DIFF
--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -2,13 +2,13 @@
 
   <!--TODO: VUE2 UNTESTED -->
   <div>
-    <nav-bar-item v-if="loggedIn" tabindex="0" @click="toggleDropdown" @keyup.enter="toggleDropdown">
+    <nav-bar-item v-if="loggedIn" tabindex="0" @click.native="toggleDropdown" @keyup.enter="toggleDropdown">
       <div class="wrapper">
         <div class="user-icon" id="user-dropdown">{{ initial }}</div>
       </div>
     </nav-bar-item>
 
-    <nav-bar-item v-else tabindex="0" @click="showLoginModal" @keyup.enter="showLoginModal">
+    <nav-bar-item v-else tabindex="0" @click.native="showLoginModal" @keyup.enter="showLoginModal">
       <div class="wrapper">
         <svg id="person" class="person-icon" src="./icons/person.svg"></svg>
         <div class="label">{{ $tr('logIn') }}</div>

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -13,10 +13,10 @@
     </card-grid>
 
     <div class="button-wrapper" v-if="contents.length > nCollapsed">
-      <icon-button @click="toggle()" :text="less" v-if="expanded">
+      <icon-button @click.native="toggle()" :text="less" v-if="expanded">
         <svg src="show-less.svg"></svg>
       </icon-button>
-      <icon-button @click="toggle()" :text="more" v-else>
+      <icon-button @click.native="toggle()" :text="more" v-else>
         <svg src="show-more.svg"></svg>
       </icon-button>
     </div>

--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -82,7 +82,7 @@
           <!-- Logic for role tags -->
           <td class="table-cell table-role">
             <span class="user-role" v-for="role in user.roles">
-              {{role.kind | capitalize}}
+              {{role.kind}}
             </span>
           </td>
 
@@ -307,6 +307,7 @@
     border-radius: 40px
     font-size: 0.875em
     display: inline-block
+    text-transform: capitalize;
 
   .searchbar .icon
     display: inline-block


### PR DESCRIPTION
vue2's new characteristic about how to handle click event, see here for detail https://github.com/vuejs/vue/issues/3253

Also vue2 does not support template filters anymore, details see here https://github.com/vuejs/vue/issues/2756
but for capitalizing string, we should use css solution instead.