### PR TITLE
Vue2: Remove Leftover Code

### DIFF
--- a/kolibri/plugins/coach_tools/assets/src/vue/reports/index.vue
+++ b/kolibri/plugins/coach_tools/assets/src/vue/reports/index.vue
@@ -35,7 +35,6 @@
           :singleuser="isSingleUser"
           :usercount="userCount"
           :completioncount="completionCount"
-          :userscompleted="usersCompleted"
           :isrecentview="isRecentView"
         ></summary-section>
       </div>


### PR DESCRIPTION
## Summary
* `usersCompleted` was replaced by `completionCount` but never removed.