### PR TITLE
Deprecate node 0.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,47 +17,43 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=pythonbuild2.7
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "3.4"
       env:
         - TOX_ENV=pythonbuild3.4
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "3.5"
       env:
         - TOX_ENV=pythonbuild3.5
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=licenses
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=py2.7
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=docs
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=bdd
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "3.4"
       env:
         - TOX_ENV=py3.4
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "3.5"
       env:
         - TOX_ENV=py3.5
-        - TRAVIS_NODE_VERSION="0.12"
-    - python: "2.7"
-      env:
-        - TOX_ENV=node0.12.x
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=node4.x
@@ -69,7 +65,7 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=postgres
-        - TRAVIS_NODE_VERSION="0.12"
+        - TRAVIS_NODE_VERSION="4"
     - python: "2.7"
       env:
         - TOX_ENV=npmbuild

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node{0.12.x, 4.x, 5.x}, docs, bdd, node, postgres, pythonbuild{2.7, 3.4, 3.5}
+envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node{4.x, 5.x}, docs, bdd, node, postgres, pythonbuild{2.7, 3.4, 3.5}
 
 [testenv]
 usedevelop = True
@@ -20,7 +20,6 @@ basepython =
     docs: python2.7
     pythonlint: python2.7
     bdd: python2.7
-    node0.12.x: python2.7
     node4.x: python2.7
     node5.x: python2.7
     npmbuild: python2.7
@@ -70,10 +69,6 @@ whitelist_externals =
 commands =
     npm install
     npm run coverage
-
-[testenv:node0.12.x]
-whitelist_externals = {[node_base]whitelist_externals}
-commands = {[node_base]commands}
 
 [testenv:node4.x]
 whitelist_externals = {[node_base]whitelist_externals}


### PR DESCRIPTION

It looks like the latest `vue-loader` users fat arrow syntax, which was introduced in node 4.

https://travis-ci.org/learningequality/kolibri/jobs/183706052

