### PR TITLE
emit event with native name

### DIFF
--- a/kolibri/core/assets/src/vue/icon-button.vue
+++ b/kolibri/core/assets/src/vue/icon-button.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <button @click="$emit('buttonclicked')" class="icon-button-scope" :class="{'primary' : primary, 'single-line': !textbelow}">
+  <button @click="$emit('click')" class="icon-button-scope" :class="{'primary' : primary, 'single-line': !textbelow}">
     <slot></slot>
     <span v-if="text" class="btn-text" :class="{'btn-bottom-text' : textbelow, 'icon-padding' : !textbelow && hasIcon}">
       {{ text }}

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -13,10 +13,10 @@
     </card-grid>
 
     <div class="button-wrapper" v-if="contents.length > nCollapsed">
-      <icon-button @click.native="toggle()" :text="less" v-if="expanded">
+      <icon-button @click="toggle()" :text="less" v-if="expanded">
         <svg src="show-less.svg"></svg>
       </icon-button>
-      <icon-button @click.native="toggle()" :text="more" v-else>
+      <icon-button @click="toggle()" :text="more" v-else>
         <svg src="show-more.svg"></svg>
       </icon-button>
     </div>

--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -28,7 +28,7 @@
       </div>
 
       <div class="create">
-        <icon-button @buttonclicked="openCreateUserModal" class="create-user-button" text="Add New" :primary="true">
+        <icon-button @click="openCreateUserModal" class="create-user-button" text="Add New" :primary="true">
           <svg class="add-user" src="../icons/add_new_user.svg"></svg>
         </icon-button>
       </div>


### PR DESCRIPTION
We should try to follow this pattern in general, so that all existing users of `icon-button` which listen for `@click` will work as expected.

are there any other components that have new custom events which should be renamed?

