### PR TITLE
Do not allow the recommendedPromise to set the page loading to false.

### DIFF
--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -306,7 +306,6 @@ function showLearnContent(store, channelId, id) {
         recommended: recommended.map(_contentState),
       };
       store.dispatch('SET_PAGE_STATE', pageState);
-      store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
     },
     error => { coreActions.handleApiError(store, error); }


### PR DESCRIPTION
## Summary

Do not allow the recommendedPromise to set the page loading to false. 

## Issues addressed

https://github.com/learningequality/kolibri/issues/752