### PR TITLE
Fixed the progress bar's border-radius.

### DIFF
--- a/kolibri/core/assets/src/vue/progress-bar/index.vue
+++ b/kolibri/core/assets/src/vue/progress-bar/index.vue
@@ -63,13 +63,13 @@
     border-radius: 15px
     float: left
     margin-right: 5px
+    overflow: hidden
 
   .progress-bar-complete
     height: 100%
     width: 0
     background-color: $core-action-normal
     transition: width, $core-time, ease
-    border-radius: 15px
 
   .progress-bar-text
     display: inline-block


### PR DESCRIPTION
## Summary

Fixed the progress bar's border-radius.

## Screenshots

### Before

![image](https://cloud.githubusercontent.com/assets/7193975/21731597/ed1d0994-d409-11e6-8bd8-27036afefab2.png)

### After

![image](https://cloud.githubusercontent.com/assets/7193975/21731579/d7c34e28-d409-11e6-9eef-4290b1d80816.png)
