### PR TITLE
Add HTML5 download attr to <a> tags in the download content button.

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -21,6 +21,7 @@
         class="dropdown-item"
         role="presentation">
         <a
+          download
           class="dropdown-item-link"
           @click="toggleDropdown"
           :href="file.download_url"


### PR DESCRIPTION
## Summary

Add HTML5 download attr to a tags in the download content button. 
http://stackoverflow.com/a/17452321

## Issues addressed

Chrome would throw the following error:
 `Resource interpreted as Document but transferred with MIME type video/mp4:`