### PR TITLE
Session Widget Role Patch

### DIFF
--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -18,7 +18,14 @@
         <svg class="nav-icon" src="../icons/manage.svg"/>
         <div class="label">{{ $tr('manage') }}</div>
       </nav-bar-item>
-      <session-nav-widget/>
+      <session-nav-widget
+        :loggedIn="loggedIn"
+        :deviceOwner="deviceOwner"
+        :fullname="fullname"
+        :username="username"
+        :kind="kind"
+        :loginModalVisible="loginModalVisible"
+      />
     </nav>
   </div>
 
@@ -29,6 +36,7 @@
 
   const values = require('lodash.values');
   const isAdminOrSuperuser = require('kolibri.coreVue.vuex.getters').isAdminOrSuperuser;
+  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
 
 
@@ -75,7 +83,13 @@
     },
     vuex: {
       getters: {
-        session: state => state.core.session,
+        // session: state => state.core.session,
+        loggedIn: state => state.core.session.kind[0] !== UserKinds.ANONYMOUS,
+        deviceOwner: state => state.core.session.kind[0] === UserKinds.SUPERUSER,
+        fullname: state => state.core.session.full_name,
+        username: state => state.core.session.username,
+        kind: state => state.core.session.kind,
+        loginModalVisible: state => state.core.loginModalVisible,
         isAdminOrSuperuser,
       },
     },

--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -46,7 +46,6 @@
 
 <script>
 
-  const UserKinds = require('../../constants').UserKinds;
   const actions = require('kolibri.coreVue.vuex.actions');
 
   module.exports = {
@@ -59,6 +58,7 @@
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
       'login-modal': require('./login-modal'),
     },
+    props: ['loggedIn', 'deviceOwner', 'fullname', 'username', 'kind'],
     data: () => ({
       showDropdown: false,
     }),
@@ -79,10 +79,7 @@
         return this.fullname;
       },
       userkind() {
-        if (this.deviceOwner) {
-          return '';
-        }
-        return this.kind;
+        return this.kind[0];
       },
       logOutText() {
         return this.$tr('logOut');
@@ -107,14 +104,6 @@
       actions: {
         logout: actions.kolibriLogout,
         showLoginModal: actions.showLoginModal,
-      },
-      getters: {
-        loggedIn: state => state.core.session.kind[0] !== UserKinds.ANONYMOUS,
-        deviceOwner: state => state.core.session.kind[0] === UserKinds.SUPERUSER,
-        fullname: state => state.core.session.full_name,
-        username: state => state.core.session.username,
-        kind: state => state.core.session.kind,
-        loginModalVisible: state => state.core.loginModalVisible,
       },
     },
   };

--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -58,7 +58,32 @@
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
       'login-modal': require('./login-modal'),
     },
-    props: ['loggedIn', 'deviceOwner', 'fullname', 'username', 'kind'],
+    props: {
+      loggedIn: {
+        type: Boolean,
+        required: true,
+      },
+      deviceOwner: {
+        type: Boolean,
+        required: true,
+      },
+      fullname: {
+        type: String,
+        required: true,
+      },
+      username: {
+        type: String,
+        required: true,
+      },
+      kind: {
+        type: Array,
+        required: true,
+      },
+      loginModalVisible: {
+        type: Boolean,
+        required: true,
+      },
+    },
     data: () => ({
       showDropdown: false,
     }),


### PR DESCRIPTION
## Summary

A bugfix for the way that kind is displayed in the session widget. Used to show up as an array, now shows up as type.

## Notes

Changed structure of widget so that info is passed in as a prop, per Devon's directions. Added validation as well. I poked around and couldn't find anything broken, but I do have some questions. See inline comments.

## Issues addressed

Array display of roles in session widget.

## Screenshots (if appropriate)

Before:
![image](https://cloud.githubusercontent.com/assets/9877852/21787802/1ecba23e-d680-11e6-910e-a1cc7915576d.png)

After:

![image](https://cloud.githubusercontent.com/assets/9877852/21787834/44d44346-d680-11e6-9f1f-9a49023c98f4.png)
