### PR TITLE
No longer center video player.

### DIFF
--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -1,17 +1,15 @@
 <template>
 
-  <div ref="videowrapperwrapper" class="videowrapperwrapper">
+  <div ref="wrapper" class="wrapper">
     <loading-spinner v-if="loading"/>
-    <div ref="videowrapper" v-show="!loading" class="videowrapper">
-      <video ref="video" class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
-        <template v-for="video in videoSources">
-          <source :src="video.storage_url" :type="'video/' + video.extension">
-        </template>
-        <template v-for="track in trackSources">
-          <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
-        </template>
-      </video>
-    </div>
+    <video ref="video" class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
+      <template v-for="video in videoSources">
+        <source :src="video.storage_url" :type="'video/' + video.extension">
+      </template>
+      <template v-for="track in trackSources">
+        <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
+      </template>
+    </video>
   </div>
 
 </template>
@@ -93,26 +91,10 @@
       },
 
       resizeVideo() {
-        const wrapperWrapperWidth = this.$refs.videowrapperwrapper.clientWidth;
-        const wrapperWrapperHeight = this.$refs.videowrapperwrapper.clientHeight;
-
+        const wrapperWidth = this.$refs.wrapper.clientWidth;
         const aspectRatio = 16 / 9;
-
-        const neededHeightGivenWidth = wrapperWrapperWidth * (1 / aspectRatio);
-        const neededWidthGivenHeight = wrapperWrapperHeight * aspectRatio;
-
-        let newWidth = 0;
-        let newHeight = 0;
-
-        if (neededHeightGivenWidth <= wrapperWrapperHeight) {
-          newWidth = wrapperWrapperWidth;
-          newHeight = neededHeightGivenWidth;
-        } else {
-          newWidth = neededWidthGivenHeight;
-          newHeight = wrapperWrapperHeight;
-        }
-
-        this.$refs.videowrapper.setAttribute('style', `width:${newWidth}px;height:${newHeight}px`);
+        const adjustedHeight = wrapperWidth * (1 / aspectRatio);
+        this.$refs.wrapper.setAttribute('style', `height:${adjustedHeight}px`);
       },
 
       throttledResizeVideo: throttle(function resizeVideo() {
@@ -158,8 +140,8 @@
       },
 
       focusOnPlayControl() {
-        const videoWrapper = this.$refs.videowrapper;
-        videoWrapper.getElementsByClassName('vjs-play-control')[0].focus();
+        const wrapper = this.$refs.wrapper;
+        wrapper.getElementsByClassName('vjs-play-control')[0].focus();
       },
     },
 
@@ -171,42 +153,44 @@
     },
 
     mounted() {
-      this.videoPlayer = videojs(this.$refs.video, {
-        fluid: true,
-        aspectRatio: '16:9',
-        autoplay: false,
-        controls: true,
-        textTrackDisplay: true,
-        bigPlayButton: true,
-        inactivityTimeout: 1000,
-        preload: 'metadata',
-        // poster: this.posterSource,
-        playbackRates: [0.5, 1.0, 1.25, 1.5, 2.0],
-        controlBar: {
-          children: [
-            { name: 'playToggle' },
-            { name: 'ReplayButton' },
-            { name: 'ForwardButton' },
-            { name: 'currentTimeDisplay' },
-            { name: 'timeDivider' },
-            { name: 'durationDisplay' },
-            { name: 'progressControl' },
-            {
-              name: 'VolumeMenuButton',
-              inline: false,
-              vertical: true,
-            },
-            { name: 'playbackRateMenuButton' },
-            { name: 'captionsButton' },
-            { name: 'fullscreenToggle' },
-          ],
-        },
-      });
+      this.$nextTick(() => {
+        this.videoPlayer = videojs(this.$refs.video, {
+          fluid: true,
+          aspectRatio: '16:9',
+          autoplay: false,
+          controls: true,
+          textTrackDisplay: true,
+          bigPlayButton: true,
+          inactivityTimeout: 1000,
+          preload: 'metadata',
+          // poster: this.posterSource,
+          playbackRates: [0.5, 1.0, 1.25, 1.5, 2.0],
+          controlBar: {
+            children: [
+              { name: 'playToggle' },
+              { name: 'ReplayButton' },
+              { name: 'ForwardButton' },
+              { name: 'currentTimeDisplay' },
+              { name: 'timeDivider' },
+              { name: 'durationDisplay' },
+              { name: 'progressControl' },
+              {
+                name: 'VolumeMenuButton',
+                inline: false,
+                vertical: true,
+              },
+              { name: 'playbackRateMenuButton' },
+              { name: 'captionsButton' },
+              { name: 'fullscreenToggle' },
+            ],
+          },
+        });
 
-      this.videoPlayer.on('loadedmetadata', this.loadedMetaData);
-      this.videoPlayer.on('play', this.focusOnPlayControl);
-      this.videoPlayer.on('pause', this.focusOnPlayControl);
-      global.addEventListener('resize', this.throttledResizeVideo);
+        this.videoPlayer.on('loadedmetadata', this.loadedMetaData);
+        this.videoPlayer.on('play', this.focusOnPlayControl);
+        this.videoPlayer.on('pause', this.focusOnPlayControl);
+        global.addEventListener('resize', this.throttledResizeVideo);
+      });
     },
 
     beforeDestroy() {
@@ -220,13 +204,28 @@
 </script>
 
 
-<style lang="stylus">
+<style lang="stylus" scoped>
 
-  @require '~kolibri.styles.coreTheme'
   // Unable to reference the videojs using require since videojs doesn't have good webpack support
   @import '../../../node_modules/video.js/dist/video-js.css'
   // Custom build icons.
   @import '../videojs-font/css/videojs-icons.css'
+
+  // Containers
+  .wrapper
+    width: 854px
+    height: 480px
+    max-width: 100%
+    max-height: 480px
+
+</style>
+
+
+<style lang="stylus">
+
+  // UNSCOPED
+
+  @require '~kolibri.styles.coreTheme'
 
   // Shades of Grey
   $dark-grey = #212121
@@ -237,21 +236,6 @@
   $video-player-color = $dark-grey
   $video-player-accent-color = #9c27b0
   $video-player-font-size = 14px
-
-  // Containers
-  .videowrapperwrapper
-    width: 100%
-    height: 480px
-    background-color: rgba(0, 0, 0, 0)
-    position: relative
-
-  .videowrapper
-    top: 50%
-    left: 50%
-    transform: translate(-50%, -50%)
-    position: relative
-    height: 100%
-    background-color: black
 
   // Video Player
   .video-js
@@ -330,7 +314,6 @@
       background-color: $video-player-color
 
     .vjs-control-bar
-      display: block
       display: flex
 
     // Menus
@@ -356,6 +339,16 @@
     .vjs-duration,
     .vjs-time-divider
       display: inline-block
+
+    .vjs-current-time
+      padding-right: 0
+
+    .vjs-time-divider
+      padding: 0
+      text-align: center
+
+    .vjs-duration
+      padding-left: 0
 
     .vjs-volume-menu-button
       margin-left: auto

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -1,15 +1,19 @@
 <template>
 
   <div ref="wrapper" class="wrapper">
-    <loading-spinner v-if="loading"/>
-    <video ref="video" class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
-      <template v-for="video in videoSources">
-        <source :src="video.storage_url" :type="'video/' + video.extension">
-      </template>
-      <template v-for="track in trackSources">
-        <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
-      </template>
-    </video>
+    <div v-show="loading" class="fill-space">
+      <loading-spinner/>
+    </div>
+    <div v-show="!loading" class="fill-space">
+      <video ref="video" class="video-js vjs-default-skin" @seeking="handleSeek" @timeupdate="updateTime">
+        <template v-for="video in videoSources">
+          <source :src="video.storage_url" :type="'video/' + video.extension">
+        </template>
+        <template v-for="track in trackSources">
+          <track kind="captions" :src="track.storage_url" :srclang="track.lang" :label="getLangName(track.lang)">
+        </template>
+      </video>
+    </div>
   </div>
 
 </template>
@@ -217,6 +221,10 @@
     height: 480px
     max-width: 100%
     max-height: 480px
+
+  .fill-space
+    width: 100%
+    height: 100%
 
 </style>
 


### PR DESCRIPTION
## Summary

* No longer centering videos. 
  * Fixes IE9 issue (https://github.com/learningequality/kolibri/issues/773) 
  * Makes better use of space. Before, there was a set height, but now there is just a max-height. So no more useless empty white space. 
  * Simplifies resizing logic. 

* Scoped styling that should have been scoped in the first place.


## Reviewer guidance

* I did not address the seekbar positioning issue on IE9. 
* `v-show=!loading` within the `video` tag did not work, so I placed it within a div wrapping the `video` tag. Is this expected behavior?

## Issues addressed

https://github.com/learningequality/kolibri/issues/773

## Screenshots

### Before

![bs_win7_ie_9 0 2](https://cloud.githubusercontent.com/assets/7193975/21903750/f2e314c6-d8b5-11e6-8534-400f24904a0e.jpg)

### After
![bs_win7_ie_9 0](https://cloud.githubusercontent.com/assets/7193975/21903777/f695fcdc-d8b5-11e6-9d79-c1b3f0ead2d6.jpg)
