### PR TITLE
remove slight scaling effect

### DIFF
--- a/kolibri/core/assets/src/vue/core-modal/index.vue
+++ b/kolibri/core/assets/src/vue/core-modal/index.vue
@@ -188,6 +188,5 @@
 
   .fade-enter, .fade-leave-active
     opacity: 0
-    transform: scale(1.1)
 
 </style>


### PR DESCRIPTION

We had a slight scaling effect when modals were hiding and showing, but this caused some scroll-bar flickering under certain conditions: #788

I tried a workaround where the scrollbar was hidden until the transition completed, but that caused similar flickering when the scrollbar _was_ supposed to show up.

This PR simply gets rid of the scale effect, which ought to address the flicker issue.
