### PR TITLE
switch from $els to $refs - vue2

### DIFF
--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -1,11 +1,11 @@
 <template>
 
-  <div v-el:container class="container" allowfullscreen>
+  <div ref="container" class="container" allowfullscreen>
     <icon-button
       class="btn"
       :text="inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
       @click="togglefullscreen"/>
-    <iframe v-el:sandbox class="sandbox" :src="rooturl" sandbox="allow-scripts"></iframe>
+    <iframe ref="sandbox" class="sandbox" :src="rooturl" sandbox="allow-scripts"></iframe>
   </div>
 
 </template>
@@ -33,7 +33,7 @@
     },
     methods: {
       togglefullscreen() {
-        const container = this.$els.container;
+        const container = this.$refs.container;
         if (!document.fullscreenElement
           && !document.webkitFullscreenElement
           && !document.mozFullScreenElement


### PR DESCRIPTION
fixes full-screen functionality in the html5 renderer