### PR TITLE
Upgrade to kolibri-exercise-perseus-render 0.2.8 to fix btoa bug.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc11
-kolibri-exercise-perseus-renderer==0.2.6
+kolibri-exercise-perseus-renderer==0.2.8


### PR DESCRIPTION
## Summary

Upgrade to kolibri-exercise-perseus-render 0.2.8 to fix btoa bug.

## Issues addressed

https://github.com/learningequality/kolibri/issues/776