### PR TITLE
Replaced fullscreen logic within pdf and html5 plugins with screenfull.js.

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -4,8 +4,8 @@
     <icon-button
       class="btn"
       v-if="supportsPDFs"
-      :text="inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
-      @click="togglefullscreen"/>
+      :text="isFullScreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+      @click="toggleFullScreen"/>
     <div ref="pdfcontainer" class="pdfcontainer"></div>
   </div>
 
@@ -15,6 +15,7 @@
 <script>
 
   const PDFobject = require('pdfobject');
+  const ScreenFull = require('screenfull');
 
   module.exports = {
 
@@ -27,46 +28,13 @@
     data: () => ({
       supportsPDFs: PDFobject.supportsPDFs,
       timeout: null,
-      inFullscreen: false,
+      isFullScreen: false,
     }),
 
     methods: {
-      togglefullscreen() {
-        const container = this.$refs.container;
-        if (!document.fullscreenElement
-          && !document.webkitFullscreenElement
-          && !document.mozFullScreenElement
-          && !document.msFullscreenElement) {
-          if (container.requestFullscreen) {
-            container.requestFullscreen();
-          } else if (container.webkitRequestFullscreen) {
-            container.webkitRequestFullscreen();
-          } else if (container.mozRequestFullScreen) {
-            container.mozRequestFullScreen();
-          } else if (container.msRequestFullscreen) {
-            container.msRequestFullscreen();
-          }
-          this.inFullscreen = true;
-        } else {
-          if (document.exitFullscreen) {
-            document.exitFullscreen();
-          } else if (document.webkitExitFullscreen) {
-            document.webkitExitFullscreen();
-          } else if (document.mozCancelFullScreen) {
-            document.mozCancelFullScreen();
-          } else if (document.msExitFullscreen) {
-            document.msExitFullscreen();
-          }
-          this.inFullscreen = false;
-        }
-      },
-      updateFullscreenState() {
-        if (!document.fullscreenElement
-          && !document.webkitFullscreenElement
-          && !document.mozFullScreenElement
-          && !document.msFullscreenElement) {
-          this.inFullscreen = false;
-        }
+      toggleFullScreen() {
+        ScreenFull.toggle(this.$refs.container);
+        this.isFullScreen = ScreenFull.isFullscreen;
       },
     },
     mounted() {
@@ -76,22 +44,12 @@
       this.timeout = setTimeout(() => {
         self.$emit('progressUpdate', 1);
       }, 15000);
-
-      document.addEventListener('fullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('mozfullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('MSFullscreenChange', this.updateFullscreenState, false);
     },
     beforeDestroy() {
       if (this.timeout) {
         clearTimeout(this.timeout);
       }
       this.$emit('stopTracking');
-
-      document.removeEventListener('fullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('mozfullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('MSFullscreenChange', this.updateFullscreenState, false);
     },
     $trNameSpace: 'pdfRenderer',
     $trs: {

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -3,8 +3,8 @@
   <div ref="container" class="container" allowfullscreen>
     <icon-button
       class="btn"
-      :text="inFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
-      @click="togglefullscreen"/>
+      :text="isFullScreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+      @click="toggleFullScreen"/>
     <iframe ref="sandbox" class="sandbox" :src="rooturl" sandbox="allow-scripts"></iframe>
   </div>
 
@@ -12,6 +12,8 @@
 
 
 <script>
+
+  const ScreenFull = require('screenfull');
 
   module.exports = {
     components: {
@@ -24,7 +26,7 @@
       },
     },
     data: () => ({
-      inFullscreen: false,
+      isFullScreen: false,
     }),
     computed: {
       rooturl() {
@@ -32,42 +34,9 @@
       },
     },
     methods: {
-      togglefullscreen() {
-        const container = this.$refs.container;
-        if (!document.fullscreenElement
-          && !document.webkitFullscreenElement
-          && !document.mozFullScreenElement
-          && !document.msFullscreenElement) {
-          if (container.requestFullscreen) {
-            container.requestFullscreen();
-          } else if (container.webkitRequestFullscreen) {
-            container.webkitRequestFullscreen();
-          } else if (container.mozRequestFullScreen) {
-            container.mozRequestFullScreen();
-          } else if (container.msRequestFullscreen) {
-            container.msRequestFullscreen();
-          }
-          this.inFullscreen = true;
-        } else {
-          if (document.exitFullscreen) {
-            document.exitFullscreen();
-          } else if (document.webkitExitFullscreen) {
-            document.webkitExitFullscreen();
-          } else if (document.mozCancelFullScreen) {
-            document.mozCancelFullScreen();
-          } else if (document.msExitFullscreen) {
-            document.msExitFullscreen();
-          }
-          this.inFullscreen = false;
-        }
-      },
-      updateFullscreenState() {
-        if (!document.fullscreenElement
-          && !document.webkitFullscreenElement
-          && !document.mozFullScreenElement
-          && !document.msFullscreenElement) {
-          this.inFullscreen = false;
-        }
+      toggleFullScreen() {
+        ScreenFull.toggle(this.$refs.container);
+        this.isFullScreen = ScreenFull.isFullscreen;
       },
     },
     ready() {
@@ -76,22 +45,12 @@
       this.timeout = setTimeout(() => {
         self.$emit('progressUpdate', 1);
       }, 15000);
-
-      document.addEventListener('fullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('mozfullscreenchange', this.updateFullscreenState, false);
-      document.addEventListener('MSFullscreenChange', this.updateFullscreenState, false);
     },
     beforeDestroy() {
       if (this.timeout) {
         clearTimeout(this.timeout);
       }
       this.$emit('stopTracking');
-
-      document.removeEventListener('fullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('webkitfullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('mozfullscreenchange', this.updateFullscreenState, false);
-      document.removeEventListener('MSFullscreenChange', this.updateFullscreenState, false);
     },
     $trNameSpace: 'html5Renderer',
     $trs: {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "loglevel": "1.4.1",
     "normalize.css": "4.2.0",
     "rest": "1.3.2",
+    "screenfull": "3.0.2",
     "scriptjs": "2.5.8",
     "vue": "2.1.6",
     "vue-focus": "2.1.0",


### PR DESCRIPTION
## Summary

Replaced fullscreen logic within pdf and html5 plugins with [screenfull.js](https://github.com/sindresorhus/screenfull.js).

## Issues addressed

* Repeated logic in both plugins.