### PR TITLE
Added html5 content icon.

### DIFF
--- a/kolibri/core/assets/src/vue/content-icon/content-icons/widget.svg
+++ b/kolibri/core/assets/src/vue/content-icon/content-icons/widget.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13 13v8h8v-8h-8zM3 21h8v-8H3v8zM3 3v8h8V3H3zm13.66-1.31L11 7.34 16.66 13l5.66-5.66-5.66-5.65z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/kolibri/core/assets/src/vue/content-icon/index.vue
+++ b/kolibri/core/assets/src/vue/content-icon/index.vue
@@ -22,6 +22,10 @@
       src="./content-icons/exercise.svg"
       :class="[colorClass]"/>
     <svg
+      v-if="is(Constants.ContentNodeKinds.HTML5)"
+      src="./content-icons/widget.svg"
+      :class="[colorClass]"/>
+    <svg
       v-if="is(Constants.USER)"
       src="./content-icons/user.svg"
       :class="[colorClass]"/>


### PR DESCRIPTION
## Summary

Added html5 content icon. Used the [Material Design "widgets" icon](https://material.io/icons/#ic_widgets) since html5 pieces of content can be various different things. 

## Screenshot

![image](https://cloud.githubusercontent.com/assets/7193975/21941774/3e187156-d97f-11e6-90ae-cbebc5d4e1c0.png)