### PR TITLE
Make coreActions just like any other actions.

### DIFF
--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -66,6 +66,11 @@ var readBundlePlugin = function(base_dir) {
   // One bundle is special - that is the one for the core bundle.
   var core_bundle = _.find(bundles, function(bundle) {return bundle.core_name && bundle.core_name !== null;});
 
+  // Check that there is only one core bundle and throw an error if there is more than one.
+  if (_.filter(bundles, function(bundle) {return bundle.core_name && bundle.core_name !== null;}).length > 1) {
+    throw new RangeError('You have more than one core bundle specified.');
+  }
+
   // For that bundle, we replace all references to library modules (like Backbone) that we bundle into the core app
   // with references to the core app itself, so if someone does `var Backbone = require('backbone');` webpack
   // will replace it with a reference to Bacbkone bundled into the core Kolibri app.

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -76,7 +76,7 @@ var readBundlePlugin = function(base_dir) {
       // If this is not the core bundle, then we need to add the external library mappings.
       bundle.externals = _.extend({}, externals, core_externals);
     } else {
-      bundle.externals = externals;
+      bundle.externals = _.extend({kolibri: core_bundle.output.library}, externals);
     }
   });
 

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -151,7 +151,7 @@ describe('readBundlePlugins', function() {
     });
   });
   describe('two external flags on inputs, one with core_name value, externals output', function() {
-    it('should have one entry', function (done) {
+    it('should have two entries', function (done) {
       var coreData = _.clone(baseData);
       coreData.external = true;
       coreData.core_name = "test_global";
@@ -161,12 +161,12 @@ describe('readBundlePlugins', function() {
         coreData,
         coreData1
       ];
-      assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
+      assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 2);
       done();
     });
   });
-  describe('two identically named external flags on inputs, externals output', function() {
-    it('should have one entry', function (done) {
+  describe('two core bundles specified', function() {
+    it('should throw an error', function (done) {
       var coreData = _.clone(baseData);
       coreData.external = true;
       coreData.core_name = "test_global";
@@ -178,7 +178,7 @@ describe('readBundlePlugins', function() {
         coreData,
         coreData1
       ];
-      assert(Object.keys(readBundlePlugins("", function(){return {};})[0].externals).length === 1);
+      assert.throws(function() {readBundlePlugins("", function(){return {};});});
       done();
     });
   });

--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -530,7 +530,7 @@ function samePageCheckGenerator(store) {
  */
 function stopTrackingProgress(store) {
   intervalTimer.stopTimer();
-  updateTimeSpent(store, coreApp, true);
+  updateTimeSpent(store, true);
 }
 
 function saveMasteryLog(store) {
@@ -640,7 +640,7 @@ function initMasteryLog(store, masterySpacingTime, masteryCriterion) {
   if (!store.state.core.logging.mastery.id) {
     // id has not been set on the masterylog state, so this is undefined.
     // Either way, we need to create a new masterylog, with a masterylevel of 1!
-    createMasteryLog(store, coreApp, 1, masteryCriterion);
+    createMasteryLog(store, 1, masteryCriterion);
   } else if (store.state.core.logging.mastery.complete &&
     ((new Date() - new Date(store.state.core.logging.mastery.completion_timestamp)) >
       masterySpacingTime)) {

--- a/kolibri/core/assets/src/core-actions.js
+++ b/kolibri/core/assets/src/core-actions.js
@@ -13,7 +13,6 @@ const progressThreshold = 0.1; // Update logs if user has reached 20% more progr
 const timeThreshold = 30; // Update logs if 30 seconds have passed since last update
 
 
-
 /**
  * Vuex State Mappers
  *

--- a/kolibri/core/assets/src/vue/assessment-wrapper/index.vue
+++ b/kolibri/core/assets/src/vue/assessment-wrapper/index.vue
@@ -45,7 +45,7 @@ oriented data synchronization.
         this.initMasteryLog();
       } else {
         // if userKind is anonymous user or deviceOwner.
-        this.createDummyMasteryLogAction(this.Kolibri);
+        this.createDummyMasteryLogAction();
       }
 
       this.$on('updateAMLogs', (correct, complete, firstAttempt, hinted) => {
@@ -64,10 +64,10 @@ oriented data synchronization.
         this.updateMasteryAttemptStateAction(new Date(), correct, complete, firstAttempt, hinted);
       },
       saveAttemptLogMasterLog(exercisePassed) {
-        this.saveAttemptLogAction(this.Kolibri).then(() => {
+        this.saveAttemptLogAction().then(() => {
           if (this.isFacilityUser && exercisePassed) {
             this.setMasteryLogCompleteAction(new Date());
-            this.saveMasteryLogAction(this.Kolibri);
+            this.saveMasteryLogAction();
           }
         });
       },
@@ -86,7 +86,7 @@ oriented data synchronization.
         });
       },
       initMasteryLog() {
-        this.initMasteryLogAction(this.Kolibri, this.masterySpacingTime, this.masteryCriterion);
+        this.initMasteryLogAction(this.masterySpacingTime, this.masteryCriterion);
       },
       createAttemptLog() {
         return new Promise((resolve, reject) => {
@@ -94,13 +94,13 @@ oriented data synchronization.
           if (!this.itemId) {
             const watchRevoke = this.$watch('itemId', () => {
               if (this.itemId) {
-                this.createAttemptLogAction(this.Kolibri, this.itemId, this.newAttemptlogReady);
+                this.createAttemptLogAction(this.itemId, this.newAttemptlogReady);
                 resolve();
                 watchRevoke();
               }
             });
           } else {
-            this.createAttemptLogAction(this.Kolibri, this.itemId, this.newAttemptlogReady);
+            this.createAttemptLogAction(this.itemId, this.newAttemptlogReady);
             resolve();
           }
         });

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -204,13 +204,13 @@
         // Assume that as soon as we have started tracking data for this content item,
         // our ContentNode cache is no longer valid.
         this.Kolibri.resources.ContentNodeResource.unCacheModel(this.id);
-        this.startTracking(this.Kolibri);
+        this.startTracking();
       },
       wrappedStopTracking() {
-        this.stopTracking(this.Kolibri);
+        this.stopTracking();
       },
       wrappedUpdateProgress(progress) {
-        this.updateProgress(this.Kolibri, progress);
+        this.updateProgress(progress);
       },
     },
     vuex: {

--- a/kolibri/core/assets/src/vue/login-modal/index.vue
+++ b/kolibri/core/assets/src/vue/login-modal/index.vue
@@ -76,7 +76,7 @@
           username: this.username_entered,
           password: this.password_entered,
         };
-        this.kolibriLogin(this.Kolibri, payload);
+        this.kolibriLogin(payload);
         this.$refs.usernamefield.focus();
       },
     },

--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -28,7 +28,7 @@
               <p id="dropdown-usertype">{{ userkind }}</p>
             </li>
             <li id="logout-tab">
-              <div tabindex="0" @keyup.enter="userLogout" @click="userLogout" :aria-label="logOutText">
+              <div tabindex="0" @keyup.enter="userLogout" @click="logout" :aria-label="logOutText">
                 <span>{{ $tr('logOut') }}</span>
               </div>
             </li>
@@ -92,9 +92,6 @@
       },
       hideDropdown() {
         this.showDropdown = false;
-      },
-      userLogout() {
-        this.logout(this.Kolibri);
       },
     },
     vuex: {

--- a/kolibri/plugins/coach_tools/assets/src/actions.js
+++ b/kolibri/plugins/coach_tools/assets/src/actions.js
@@ -1,5 +1,4 @@
 const coreActions = require('kolibri.coreVue.vuex.actions');
-const coreApp = require('kolibri');
 const getDefaultChannelId = require('kolibri.coreVue.vuex.getters').getDefaultChannelId;
 const ConditionalPromise = require('kolibri.lib.conditionalPromise');
 const router = require('kolibri.coreVue.router');
@@ -148,7 +147,7 @@ function showReport(store, params, oldParams) {
   }
 
   // CHANNELS
-  const channelPromise = coreActions.setChannelInfo(store, coreApp);
+  const channelPromise = coreActions.setChannelInfo(store);
   promises.push(channelPromise);
 
   // API response handlers

--- a/kolibri/plugins/coach_tools/assets/src/app.js
+++ b/kolibri/plugins/coach_tools/assets/src/app.js
@@ -1,5 +1,4 @@
 const KolibriModule = require('kolibri_module');
-const coreApp = require('kolibri');
 const coreActions = require('kolibri.coreVue.vuex.actions');
 const router = require('kolibri.coreVue.router');
 
@@ -54,7 +53,7 @@ class CoachToolsModule extends KolibriModule {
       router: router.init(routes),
     });
 
-    coreActions.getCurrentSession(store, coreApp);
+    coreActions.getCurrentSession(store);
   }
 }
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -6,7 +6,6 @@ const coreActions = require('kolibri.coreVue.vuex.actions');
 const ConditionalPromise = require('kolibri.lib.conditionalPromise');
 const samePageCheckGenerator = require('kolibri.coreVue.vuex.actions').samePageCheckGenerator;
 const coreGetters = require('kolibri.coreVue.vuex.getters');
-const coreApp = require('kolibri');
 const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const router = require('kolibri.coreVue.router');
 
@@ -85,7 +84,7 @@ function redirectToExploreChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_ROOT);
 
-  coreActions.setChannelInfo(store, coreApp).then(
+  coreActions.setChannelInfo(store).then(
     () => {
       const currentChannel = coreGetters.getCurrentChannelObject(store.state);
       if (currentChannel) {
@@ -106,7 +105,7 @@ function redirectToLearnChannel(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.LEARN_ROOT);
 
-  coreActions.setChannelInfo(store, coreApp).then(
+  coreActions.setChannelInfo(store).then(
     () => {
       const currentChannel = coreGetters.getCurrentChannelObject(store.state);
       if (currentChannel) {
@@ -133,7 +132,7 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
 
   const topicPromise = ContentNodeResource.getModel(id).fetch();
   const childrenPromise = ContentNodeResource.getCollection({ parent: id }).fetch();
-  const channelsPromise = coreActions.setChannelInfo(store, coreApp, channelId);
+  const channelsPromise = coreActions.setChannelInfo(store, channelId);
   ConditionalPromise.all([topicPromise, childrenPromise, channelsPromise]).only(
     samePageCheckGenerator(store),
     ([topic, children]) => {
@@ -165,7 +164,7 @@ function showExploreChannel(store, channelId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CHANNEL);
 
-  coreActions.setChannelInfo(store, coreApp, channelId).then(
+  coreActions.setChannelInfo(store, channelId).then(
     () => {
       const currentChannel = coreGetters.getCurrentChannelObject(store.state);
       if (!currentChannel) {
@@ -183,7 +182,7 @@ function showExploreContent(store, channelId, id) {
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CONTENT);
 
   const contentPromise = ContentNodeResource.getModel(id).fetch();
-  const channelsPromise = coreActions.setChannelInfo(store, coreApp, channelId);
+  const channelsPromise = coreActions.setChannelInfo(store, channelId);
   ConditionalPromise.all([contentPromise, channelsPromise]).only(
     samePageCheckGenerator(store),
     ([content]) => {
@@ -215,7 +214,7 @@ function showLearnChannel(store, channelId, page = 1) {
   const ALL_PAGE_SIZE = 6;
 
   const sessionPromise = SessionResource.getModel('current').fetch();
-  const channelsPromise = coreActions.setChannelInfo(store, coreApp, channelId);
+  const channelsPromise = coreActions.setChannelInfo(store, channelId);
   ConditionalPromise.all([sessionPromise, channelsPromise]).only(
     samePageCheckGenerator(store),
     ([session]) => {
@@ -278,7 +277,7 @@ function showLearnContent(store, channelId, id) {
   store.dispatch('SET_PAGE_NAME', PageNames.LEARN_CONTENT);
   const contentPromise = ContentNodeResource.getModel(id).fetch();
   const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
-  const channelsPromise = coreActions.setChannelInfo(store, coreApp, channelId);
+  const channelsPromise = coreActions.setChannelInfo(store, channelId);
   ConditionalPromise.all([contentPromise, channelsPromise]).only(
     samePageCheckGenerator(store),
     ([content]) => {

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -1,5 +1,4 @@
 const KolibriModule = require('kolibri_module');
-const coreApp = require('kolibri');
 const coreActions = require('kolibri.coreVue.vuex.actions');
 const router = require('kolibri.coreVue.router');
 
@@ -89,7 +88,7 @@ class LearnModule extends KolibriModule {
       router: router.init(routes),
     });
 
-    coreActions.getCurrentSession(store, coreApp);
+    coreActions.getCurrentSession(store);
   }
 }
 

--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -271,7 +271,7 @@ function showContentPage(store) {
         taskList: taskList.map(_taskState),
         wizardState: { shown: false },
       };
-      coreActions.setChannelInfo(store, coreApp).then(() => {
+      coreActions.setChannelInfo(store).then(() => {
         store.dispatch('SET_PAGE_STATE', pageState);
         store.dispatch('CORE_SET_PAGE_LOADING', false);
         store.dispatch('CORE_SET_TITLE', _managePageTitle('Content'));
@@ -359,7 +359,7 @@ function pollTasksAndChannels(store) {
     (taskList) => {
       // Perform channel poll AFTER task poll to ensure UI is always in a consistent state.
       // I.e. channel list always reflects the current state of ongoing task(s).
-      coreActions.setChannelInfo(store, coreApp).only(
+      coreActions.setChannelInfo(store).only(
         samePageCheckGenerator(store),
         () => {
           store.dispatch('SET_CONTENT_PAGE_TASKS', taskList.map(_taskState));

--- a/kolibri/plugins/management/assets/src/app.js
+++ b/kolibri/plugins/management/assets/src/app.js
@@ -1,5 +1,4 @@
 const KolibriModule = require('kolibri_module');
-const coreApp = require('kolibri');
 const coreActions = require('kolibri.coreVue.vuex.actions');
 const router = require('kolibri.coreVue.router');
 
@@ -54,7 +53,7 @@ class ManagementModule extends KolibriModule {
       router: router.init(routes),
     });
 
-    coreActions.getCurrentSession(store, coreApp);
+    coreActions.getCurrentSession(store);
   }
 }
 

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -197,7 +197,7 @@
       deleteUserHandler() {
         // if logged in admin deleted their own account, log them out
         if (Number(this.userid) === this.session_user_id) {
-          this.logout(this.Kolibri);
+          this.logout();
         }
         this.deleteUser(this.userid);
         this.emitCloseSignal();


### PR DESCRIPTION
## Summary

Removes the need to pass in the coreApp into coreActions when invoked.

Removes all such instances from the code base.

## Reviewer guidance

This is achieved by doing a `const coreApp = require('kolibri')` inside the scope of the action functions, and by letting the kolibriGlobal object mapping be put into the coreApp bundling itself. This means, that as long as the actions are not invoked during the constructor of the kolibriGlobal object, then all these references will be properly defined and not cause a problem.