### PR TITLE
Upgrade to vue-intl 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "scriptjs": "2.5.8",
     "vue": "2.1.6",
     "vue-focus": "2.1.0",
-    "vue-intl": "https://github.com/learningequality/vue-intl.git#vue2",
+    "vue-intl": "2.0.0",
     "vue-router": "2.1.1",
     "vue-scroll": "2.0.1",
     "vuex": "1.0.0"


### PR DESCRIPTION
## Summary

Use the newly minted vue-intl 2.0.0 package, rather than pointing to a github branch.