### PR TITLE
Properly Nest Headers in Learn

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <div class="header">
-      <h3 v-if="header">{{header}}</h3>
+      <h2 v-if="header">{{header}}</h2>
       <slot name="headerbox"/>
     </div>
     <div class="card-grid">

--- a/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/index.vue
@@ -67,7 +67,7 @@
     margin-top: 2em
     margin-bottom: 1.4em
 
-  .header h3
+  .header h2
     display: inline
 
   .card-grid

--- a/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h3 v-if="header">{{header}}</h3>
+    <h2 v-if="header">{{header}}</h2>
     <div class="card-list">
       <slot/>
     </div>


### PR DESCRIPTION
## Summary

* Changed `<h3>` to `<h2>`

## Issues addressed

https://trello.com/c/3pNhfU8Q/643-ensure-proper-nesting-of-headers-on-learn-page

## Screenshots

### Before

![image](https://cloud.githubusercontent.com/assets/7193975/22120681/a85b08c0-de35-11e6-8316-61198e9f3a67.png)

### After

![image](https://cloud.githubusercontent.com/assets/7193975/22120742/deb165f4-de35-11e6-9e6e-5128395a4e31.png)