### PR TITLE
Round time_spent and progress.

### DIFF
--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -47,7 +47,7 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
             return ""
 
     def get_time_spent(self, obj):
-        return round(obj.time_spent, 3)
+        return round(obj.time_spent, 5)
 
     def get_progress(self, obj):
         return round(obj.progress, 1)

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -50,7 +50,7 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
         return int(round(obj.time_spent))
 
     def get_progress(self, obj):
-        return round(obj.progress, 4)
+        return "{:10.4f}".format(round(obj.progress, 4))
 
 
 class ContentSummaryLogCSVSerializer(LogCSVSerializerBase):

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -47,10 +47,16 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
             return ""
 
     def get_time_spent(self, obj):
-        return "{:10.1f}".format(round(obj.time_spent, 1))
+        seconds_float = float(str("{:.1f}".format(round(obj.time_spent, 1))))  # e.g. 30.2
+        seconds_int = int(seconds_float)  # e.g. 30
+        seconds_decimal = str(seconds_float)[-1:]   # e.g. 2
+        minutes, seconds = divmod(seconds_int, 60)
+        hours, minutes = divmod(minutes, 60)
+        days, hours = divmod(hours, 24)
+        return "%d:%02d:%02d:%02d.%s" % (days, hours, minutes, seconds, seconds_decimal)
 
     def get_progress(self, obj):
-        return "{:10.4f}".format(round(obj.progress, 4))
+        return str("{:.4f}".format(round(obj.progress, 4)))
 
 
 class ContentSummaryLogCSVSerializer(LogCSVSerializerBase):
@@ -63,6 +69,8 @@ class ContentSummaryLogCSVSerializer(LogCSVSerializerBase):
             "start_timestamp": "Time of first interaction",
             "end_timestamp": "Time of last interaction",
             "completion_timestamp": "Time of completion",
+            "time_spent": "Time Spent (D:HH:MM:SS.d)",
+            "progress": "Progress (0-1)",
         }
 
 
@@ -75,6 +83,8 @@ class ContentSessionLogCSVSerializer(LogCSVSerializerBase):
         labels = {
             "start_timestamp": "Time of first interaction",
             "end_timestamp": "Time of last interaction",
+            "time_spent": "Time Spent (D:HH:MM:SS.d)",
+            "progress": "Progress (0-1)",
         }
 
 

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -47,10 +47,10 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
             return ""
 
     def get_time_spent(self, obj):
-        return round(obj.time_spent, 5)
+        return int(round(obj.time_spent))
 
     def get_progress(self, obj):
-        return round(obj.progress, 1)
+        return round(obj.progress, 4)
 
 
 class ContentSummaryLogCSVSerializer(LogCSVSerializerBase):

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -47,7 +47,7 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
             return ""
 
     def get_time_spent(self, obj):
-        return int(round(obj.time_spent))
+        return "{:10.1f}".format(round(obj.time_spent, 1))
 
     def get_progress(self, obj):
         return "{:10.4f}".format(round(obj.progress, 4))

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -47,13 +47,7 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
             return ""
 
     def get_time_spent(self, obj):
-        seconds_float = float(str("{:.1f}".format(round(obj.time_spent, 1))))  # e.g. 30.2
-        seconds_int = int(seconds_float)  # e.g. 30
-        seconds_decimal = str(seconds_float)[-1:]   # e.g. 2
-        minutes, seconds = divmod(seconds_int, 60)
-        hours, minutes = divmod(minutes, 60)
-        days, hours = divmod(hours, 24)
-        return "%d:%02d:%02d:%02d.%s" % (days, hours, minutes, seconds, seconds_decimal)
+        return str("{:.1f}".format(round(obj.time_spent, 1)))
 
     def get_progress(self, obj):
         return str("{:.4f}".format(round(obj.progress, 4)))
@@ -69,7 +63,7 @@ class ContentSummaryLogCSVSerializer(LogCSVSerializerBase):
             "start_timestamp": "Time of first interaction",
             "end_timestamp": "Time of last interaction",
             "completion_timestamp": "Time of completion",
-            "time_spent": "Time Spent (D:HH:MM:SS.d)",
+            "time_spent": "Time Spent (sec)",
             "progress": "Progress (0-1)",
         }
 
@@ -83,7 +77,7 @@ class ContentSessionLogCSVSerializer(LogCSVSerializerBase):
         labels = {
             "start_timestamp": "Time of first interaction",
             "end_timestamp": "Time of last interaction",
-            "time_spent": "Time Spent (D:HH:MM:SS.d)",
+            "time_spent": "Time Spent (sec)",
             "progress": "Progress (0-1)",
         }
 


### PR DESCRIPTION
## Summary

* Round tme_spent to 1 decimal place.
* Round progress to 4 decimal places.

## Issues addressed

https://trello.com/c/rvH9pDCN/679-add-a-couple-decimals-of-resolution-on-exported-logs

## Screenshots

![image](https://cloud.githubusercontent.com/assets/7193975/22130587/db017ac6-de61-11e6-9633-938f7b258cfe.png)