### PR TITLE
Intl String Wrap Sweep | Learn/Explore > Search Widget & Core Nav > Session Widget

### DIFF
--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -55,6 +55,8 @@
       admin: 'Admin',
       coach: 'Coach',
       learner: 'Learner',
+      superuser: 'Superuser',
+      deviceOwner: 'Device Owner',
     },
     components: {
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
@@ -74,16 +76,19 @@
       },
       name() {
         if (this.deviceOwner) {
-          return 'Device Owner';
+          return this.$tr('deviceOwner');
         }
         return this.fullname;
       },
       userkind() {
+        console.log(this.kind[0]);
         if (this.kind[0]) {
           if (this.kind[0] === UserKinds.ADMIN) {
             return this.$tr('admin');
           } else if (this.kind[0] === UserKinds.COACH) {
             return this.$tr('coach');
+          } else if (this.kind[0] === UserKinds.SUPERUSER) {
+            return this.$tr('superuser');
           }
         }
         return this.$tr('learner');

--- a/kolibri/core/assets/src/vue/session-nav-widget/index.vue
+++ b/kolibri/core/assets/src/vue/session-nav-widget/index.vue
@@ -28,7 +28,7 @@
               <p id="dropdown-usertype">{{ userkind }}</p>
             </li>
             <li id="logout-tab">
-              <div tabindex="0" @keyup.enter="userLogout" @click="logout" :aria-label="logOutText">
+              <div tabindex="0" @keyup.enter="userLogout" @click="logout" :aria-label="$tr('logOut')">
                 <span>{{ $tr('logOut') }}</span>
               </div>
             </li>
@@ -52,6 +52,9 @@
     $trs: {
       logOut: 'Log Out',
       logIn: 'Log In',
+      admin: 'Admin',
+      coach: 'Coach',
+      learner: 'Learner',
     },
     components: {
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
@@ -76,7 +79,14 @@
         return this.fullname;
       },
       userkind() {
-        return this.kind[0];
+        if (this.kind[0]) {
+          if (this.kind[0] === UserKinds.ADMIN) {
+            return this.$tr('admin');
+          } else if (this.kind[0] === UserKinds.COACH) {
+            return this.$tr('coach');
+          }
+        }
+        return this.$tr('learner');
       },
       logOutText() {
         return this.$tr('logOut');

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -10,8 +10,8 @@
             <input
               type="search"
               ref="search"
-              aria-label="Type to find content"
-              placeholder="Find content..."
+              :aria-label="$tr('ariaLabel')"
+              :placeholder="$tr('placeHolder')"
               autocomplete="off"
               v-focus="searchOpen"
               v-model="localSearchTerm"
@@ -31,7 +31,7 @@
             </button>
           </div>
           <div class="cancel-btn-table-cell">
-            <button @click="toggleSearch" class="search-btn">Cancel</button>
+            <button @click="toggleSearch" class="search-btn">{{$tr('cancel')}}</button>
           </div>
         </div>
       </div>
@@ -90,6 +90,9 @@
     $trs: {
       ariaLabel: 'Type to find content',
       placeHolder: 'Find content...',
+      searchResults: 'Search results:',
+      noMatches: 'Could not find any matches.',
+      cancel: 'Cancel',
     },
     directives: { focus },
     props: {
@@ -109,10 +112,10 @@
     computed: {
       message() {
         if ((this.showTopics && this.topics.length) || this.contents.length) {
-          return 'Search results:';
+          return this.$tr('searchResults');
         } else if (!(this.showTopics && this.topics.length) &&
           !this.contents.length) {
-          return 'Could not find any matches.';
+          return this.$tr('noMatches');
         }
         return '';
       },


### PR DESCRIPTION
## Summary

Continuing the string sweep, covering the learn widget. Looks like some of these were wrapped previously, but had to be overwritten.

Decided to add the session widget because the search widget was pretty small