### PR TITLE
Introduce a global mock.

### DIFF
--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 webpack_config.plugins.push(new RewirePlugin());
 webpack_config.devtool = '#inline-source-map';
-webpack_config.resolve.alias['kolibri'] = path.resolve('kolibri/core/assets/src/core_app_instance');
+webpack_config.resolve.alias['kolibri'] = path.resolve(__dirname, './kolibriGlobalMock');
 
 module.exports = function(config) {
   config.set({

--- a/karma_config/kolibriGlobalMock.js
+++ b/karma_config/kolibriGlobalMock.js
@@ -1,0 +1,1 @@
+module.exports = global.kolibriGlobal = {};


### PR DESCRIPTION
## Summary

In honour of the inauguration of the 45th President, I introduce a global mock for frontend testing.

Fixes an extant issue with our testing where the core app instance cannot be resolved by our frontend tests. Didn't fail anything, but just made a lot of mess in the Travis logs.

This will also allow for better testing in the future, as we can mock the right things on the global Kolibri object using this.