### PR TITLE
PDF and HTML5 renderers updates.

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -68,7 +68,7 @@
 <style lang="stylus" scoped>
 
   .btn
-    position: fixed
+    position: absolute
     left: 50%
     transform: translateX(-50%)
 
@@ -84,7 +84,6 @@
       max-height: inherit
 
   .pdfcontainer
-    /* Accounts for the button height. */
-    height: calc(100% - 4em)
+    height: 100%
 
 </style>

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -69,7 +69,7 @@
 <style lang="stylus" scoped>
 
   .btn
-    position: fixed
+    position: absolute
     left: 50%
     transform: translateX(-50%)
 
@@ -86,8 +86,7 @@
       max-height: inherit
 
   .sandbox
-    /* Accounts for the button height. */
-    height: calc(100% - 4em)
+    height: 100%
     width: 100%
 
 </style>


### PR DESCRIPTION
## Summary

* Fixed and absolute are very different. Oops.
* Removed leftover code `height: calc(100% - 4em)`
