### PR TITLE
Display author, license, and license owner info on content page.

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -118,5 +118,5 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         model = ContentNode
         fields = (
             'pk', 'content_id', 'title', 'description', 'kind', 'available', 'tags', 'sort_order', 'license_owner',
-            'license', 'files', 'ancestors', 'parent', 'thumbnail', 'progress_fraction', 'next_content'
+            'license', 'files', 'ancestors', 'parent', 'thumbnail', 'progress_fraction', 'next_content', 'author'
         )

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -153,6 +153,8 @@
 
   .dropdown-button
     padding: 0.5em
+    margin-top: 1em
+    margin-bottom: 1em
     font-size: smaller
 
   .dropdown-button-text

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -171,7 +171,7 @@
     list-style: none
     padding: 0
     margin: 0
-    margin-top: 2px
+    margin-top: -0.8em
     display: none
     position: absolute
 

--- a/kolibri/plugins/learn/assets/src/actions.js
+++ b/kolibri/plugins/learn/assets/src/actions.js
@@ -58,6 +58,9 @@ function _contentState(data) {
     content_id: data.content_id,
     breadcrumbs: _crumbState(data.ancestors),
     next_content: data.next_content,
+    author: data.author,
+    license: data.license,
+    license_owner: data.license_owner,
   };
   return state;
 }

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -26,17 +26,17 @@
 
     <div class="metadata">
       <p>
-        <strong>{{ $tr("author") }}: </strong>
+        <strong>{{ $tr('author') }}: </strong>
         <span v-if="content.author">{{ content.author }}</span>
         <span v-else>-</span>
       </p>
       <p>
-        <strong>{{ $tr("license") }}: </strong>
+        <strong>{{ $tr('license') }}: </strong>
         <span v-if="content.license">{{ content.license }}</span>
         <span v-else>-</span>
       </p>
       <p>
-        <strong>{{ $tr("copyrightHolder") }}: </strong>
+        <strong>{{ $tr('copyrightHolder') }}: </strong>
         <span v-if="content.license_owner">{{ content.license_owner }}</span>
         <span v-else>-</span>
       </p>

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -22,6 +22,8 @@
 
     <p class="page-description">{{ content.description }}</p>
 
+    <download-button v-if="canDownload" :files="content.files" class="download-button-left-align"/>
+
     <div class="metadata">
       <p>
         <strong>{{ $tr("author") }}: </strong>
@@ -39,8 +41,6 @@
         <span v-else>-</span>
       </p>
     </div>
-
-    <download-button v-if="canDownload" :files="content.files"/>
 
     <expandable-content-grid
       class="recommendation-section"
@@ -177,6 +177,9 @@
   .right-arrow:hover
     fill: $core-bg-light
 
+  .metadata
+    display: inline-block
+
   .metadata p
     font-size: small
 
@@ -184,6 +187,10 @@
     margin-top: 1em
     margin-bottom: 1em
     line-height: 1.5em
+
+  .download-button-left-align
+    vertical-align: top
+    margin-right: 1.5em
 
 </style>
 

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -22,6 +22,24 @@
 
     <p class="page-description">{{ content.description }}</p>
 
+    <div class="metadata">
+      <p>
+        <strong>{{ $tr("author") }}: </strong>
+        <span v-if="content.author">{{ content.author }}</span>
+        <span v-else>-</span>
+      </p>
+      <p>
+        <strong>{{ $tr("license") }}: </strong>
+        <span v-if="content.license">{{ content.license }}</span>
+        <span v-else>-</span>
+      </p>
+      <p>
+        <strong>{{ $tr("licenseOwner") }}: </strong>
+        <span v-if="content.license_owner">{{ content.license_owner }}</span>
+        <span v-else>-</span>
+      </p>
+    </div>
+
     <download-button v-if="canDownload" :files="content.files"/>
 
     <expandable-content-grid
@@ -47,6 +65,9 @@
     $trs: {
       recommended: 'Recommended',
       nextContent: 'Next Content',
+      author: 'Author',
+      license: 'License',
+      licenseOwner: 'License Owner',
     },
     computed: {
       Constants() {
@@ -155,6 +176,9 @@
 
   .right-arrow:hover
     fill: $core-bg-light
+
+  .metadata p
+    font-size: small
 
 </style>
 

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -16,7 +16,7 @@
       :extraFields="content.extra_fields"/>
 
     <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn">
-      {{ $tr("nextContent") }}
+      {{ $tr('nextContent') }}
       <svg class="right-arrow" src="../icons/arrow_right.svg"/>
     </icon-button>
 

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -34,7 +34,7 @@
         <span v-else>-</span>
       </p>
       <p>
-        <strong>{{ $tr("licenseOwner") }}: </strong>
+        <strong>{{ $tr("copyrightHolder") }}: </strong>
         <span v-if="content.license_owner">{{ content.license_owner }}</span>
         <span v-else>-</span>
       </p>
@@ -67,7 +67,7 @@
       nextContent: 'Next Content',
       author: 'Author',
       license: 'License',
-      licenseOwner: 'License Owner',
+      copyrightHolder: 'Copyright Holder',
     },
     computed: {
       Constants() {
@@ -179,6 +179,11 @@
 
   .metadata p
     font-size: small
+
+  .page-description
+    margin-top: 1em
+    margin-bottom: 1em
+    line-height: 1.5em
 
 </style>
 

--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -4,8 +4,8 @@
 
     <page-header :title="title">
       <div slot="icon">
-        <svg v-if="isRoot" class="pageicon" src="../icons/explore.svg"/>
-        <svg v-else class="pageicon" src="../icons/folder.svg"/>
+        <svg v-if="isRoot" src="../icons/explore.svg"/>
+        <svg v-else src="../icons/folder.svg"/>
       </div>
     </page-header>
 
@@ -75,4 +75,11 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .page-description
+    margin-top: 1em
+    margin-bottom: 1em
+    line-height: 1.5em
+
+</style>

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <page-header :title="$tr('learnName')">
-      <svg slot="icon" class="pageicon" src="../icons/learn.svg"/>
+      <svg slot="icon" src="../icons/learn.svg"/>
     </page-header>
     <allcontent/>
     <expandable-content-grid

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -1,13 +1,6 @@
 
 @require '~kolibri.styles.coreTheme'
 
-.pageicon
-  fill: $core-text-default
-
-.page-description
-  margin-top: 2em
-  margin-bottom: 1.4em
-  line-height: 1.8em
 
 /*
   TODO: this needs to be cleaned up and organized significantly.


### PR DESCRIPTION
## Summary

* Display author, license, and license owner info on content page.
* Minimal styling.

## TODO

* Styling?

## Screenshot

![image](https://cloud.githubusercontent.com/assets/7193975/22228360/7b85f38e-e185-11e6-80e0-6231e5072474.png)
