### PR TITLE
add top margin to learn's content-unavailable page

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-unavailable-page/index.vue
@@ -32,6 +32,7 @@
 
 <style lang="stylus" scoped>
 
-  @require '~kolibri.styles.coreTheme'
+  h1
+    margin-top: 42px // height of toolbar
 
 </style>


### PR DESCRIPTION

addresses:

https://trello.com/c/d3209HUZ/664-h1-cut-off-on-landing-page-fresh-dev-repo

