### PR TITLE
Cleanup some frontend tests that were silently failing

### DIFF
--- a/karma_config/vueLocal.js
+++ b/karma_config/vueLocal.js
@@ -32,4 +32,6 @@ vue.prototype.$trHtml = function $trHtml(messageId, args) {
   return $trWrapper.call(this, this.$formatHTMLMessage, messageId, args);
 };
 
+vue.config.silent = true;
+
 module.exports = vue;

--- a/karma_config/vueLocal.js
+++ b/karma_config/vueLocal.js
@@ -4,11 +4,16 @@ const router = require('vue-router');
 const vueintl = require('vue-intl');
 
 vue.prototype.Kolibri = require('kolibri');
+vue.config.silent = true;
 vue.use(vuex);
 vue.use(router);
 require('intl');
 require('intl/locale-data/jsonp/en.js');
 vue.use(vueintl, { defaultLocale: 'en-us' });
+
+vue.mixin({
+  store: new vuex.Store({}),
+});
 
 function $trWrapper(formatter, messageId, args) {
   if (args) {
@@ -31,7 +36,5 @@ vue.prototype.$tr = function $tr(messageId, args) {
 vue.prototype.$trHtml = function $trHtml(messageId, args) {
   return $trWrapper.call(this, this.$formatHTMLMessage, messageId, args);
 };
-
-vue.config.silent = true;
 
 module.exports = vue;

--- a/kolibri/core/assets/test/vue.content-renderer.js
+++ b/kolibri/core/assets/test/vue.content-renderer.js
@@ -361,9 +361,9 @@ describe('contentRenderer Component', function () {
               files: this.files,
             },
           }).$mount();
-          this.constructorSpy = sinon.spy(() => {
-            this.instanceSpy = sinon.createStubInstance(Vue);
-          });
+          this.instanceSpy = sinon.createStubInstance(Vue);
+          this.constructorSpy = sinon.stub();
+          this.constructorSpy.returns(this.instanceSpy);
           this.vm.Kolibri = {
             lib: {
               vue: this.constructorSpy,
@@ -382,47 +382,56 @@ describe('contentRenderer Component', function () {
           assert.ok(this.vm.rendered);
         });
         describe('when initSession completes', function () {
-          it('should create a new component', function () {
+          it('should create a new component', function (done) {
             this.vm.renderContent().then(() => {
               assert.ok(this.constructorSpy.calledWithNew());
+              done();
             });
           });
-          it('should create a new component with parent option', function () {
+          it('should create a new component with parent option', function (done) {
             this.vm.renderContent().then(() => {
               assert.equal(this.constructorSpy.args[0][0].parent, this.vm);
+              done();
             });
           });
-          it('should create a new component with el option', function () {
+          it('should create a new component with el option', function (done) {
+            this.testContainer = { test: 'test' };
+            this.vm.$refs.container = this.testContainer;
             this.vm.renderContent().then(() => {
-              assert.equal(this.constructorSpy.args[0][0].el, this.vm.$refs.container);
+              assert.equal(this.constructorSpy.args[0][0].el, this.testContainer);
+              done();
             });
           });
-          it('should create a new component with propsData option', function () {
+          it('should create a new component with propsData option', function (done) {
             this.vm.renderContent().then(() => {
               assert.deepEqual(this.constructorSpy.args[0][0].propsData, {
                 id: this.id,
                 kind: this.kind,
                 files: this.files,
                 defaultFile: this.files[0],
+                contentId: '',
+                channelId: '',
+                available: true,
               });
+              done();
             });
           });
-          it('should call $on for startTracking', function () {
+          it('should call $on for startTracking', function (done) {
             this.vm.renderContent().then(() => {
-              assert.ok(this.instanceSpy.firstCall.calledWithExactly(
-                'startTracking', this.vm.wrappedStartTracking));
+              assert.ok(this.instanceSpy.$on.firstCall.calledWith('startTracking'));
+              done();
             });
           });
-          it('should call $on for stopTracking', function () {
+          it('should call $on for stopTracking', function (done) {
             this.vm.renderContent().then(() => {
-              assert.ok(this.instanceSpy.firstCall.calledWithExactly(
-                'stopTracking', this.vm.stopTracking));
+              assert.ok(this.instanceSpy.$on.secondCall.calledWith('stopTracking'));
+              done();
             });
           });
-          it('should call $on for progressUpdate', function () {
+          it('should call $on for progressUpdate', function (done) {
             this.vm.renderContent().then(() => {
-              assert.ok(this.instanceSpy.firstCall.calledWithExactly(
-                'progressUpdate', this.vm.progressUpdate));
+              assert.ok(this.instanceSpy.$on.thirdCall.calledWith('progressUpdate'));
+              done();
             });
           });
         });


### PR DESCRIPTION
## Summary

Due to uncaught promise exceptions and not waiting for a done call back in the test, some tests were silently failing. In addition, uncaught exceptions in promises and vuex warnings were producing a lot of console output that obscure errors for debugging purposes in tests. This cleans up those too.

Vue Intl warnings remain, as I am not entirely sure they are not valid concerns in production.

## TODO

- [X] Have tests been written for the new code?