### PR TITLE
Update to latest version of exercise perseus plugin

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc11
-kolibri-exercise-perseus-plugin==0.3.0
+kolibri-exercise-perseus-plugin==0.3.1


### PR DESCRIPTION
## Summary

Exercise perseus renderer has been fixed, so update the version to let exercises render properly.

## TODO

- [X] New dependencies (if any) added to requirements file