### PR TITLE
Fix Data Page button styling.

### DIFF
--- a/kolibri/core/assets/src/vue/core-modal/index.vue
+++ b/kolibri/core/assets/src/vue/core-modal/index.vue
@@ -153,6 +153,7 @@
     background: rgba(0, 0, 0, 0.7)
     transition: opacity 0.3s ease
     background-attachment: fixed
+    z-index: 10
 
   .modal
     position: absolute

--- a/kolibri/core/assets/src/vue/icon-button.vue
+++ b/kolibri/core/assets/src/vue/icon-button.vue
@@ -4,12 +4,15 @@
     @click="$emit('click')"
     :color="primary ? 'primary' : 'default'"
     class="koli-icon-button">
-    <span v-if="text">
+    <span v-if="hasIcon && text">
       <ui-icon class="icon-margin"><slot/></ui-icon>
       {{ text }}
     </span>
+    <span v-else-if="hasIcon">
+      <ui-icon class="icon-margin"><slot/></ui-icon>
+    </span>
     <span v-else>
-      <ui-icon><slot/></ui-icon>
+      {{ text }}
     </span>
   </ui-button>
 

--- a/kolibri/plugins/management/assets/src/vue/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/data-page/index.vue
@@ -13,11 +13,11 @@
       <p>
         {{$tr('detailsSubHeading')}}
       </p>
-      <a :href="sessionlogurl">
+      <form :action="sessionlogurl" method="get">
         <icon-button :text="$tr('download')">
           <mat-svg category="file" name="file_download"/>
         </icon-button>
-      </a>
+      </form>
       <p class="infobox">
         <b>{{$tr('note')}}</b>: {{$tr('detailsInfo')}}.
       </p>
@@ -28,11 +28,11 @@
       <p>
         {{$tr('summarySubHeading')}}
       </p>
-      <a :href="summarylogurl">
+      <form :action="summarylogurl" method="get">
         <icon-button :text="$tr('download')">
           <mat-svg category="file" name="file_download"/>
         </icon-button>
-      </a>
+      </form>
       <p class="infobox">
         <b>{{$tr('note')}}</b>: {{$tr('summaryInfo')}}
       </p>
@@ -105,5 +105,8 @@
 
   .wrapper
     cf()
+
+  form
+    display: inline
 
 </style>


### PR DESCRIPTION
## Summary

* A `<button>` inside an `<a>` tag is not valid HTML.

## Issues addressed

* Text within button was underlined because the button was wrapped by an `<a>` that has `text-decoration: underline` 

## Screenshot

![image](https://cloud.githubusercontent.com/assets/7193975/22753407/d729cfae-edf0-11e6-8067-18ddc03b914a.png)
