### PR TITLE
User Plugin Routes

### DIFF
--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -14,9 +14,17 @@
         <svg class="nav-icon" src="../icons/coach.svg"/>
         <div class="label">{{ $tr('coach') }}</div>
       </nav-bar-item>
-      <nav-bar-item v-if="isAdminOrSuperuser" href="/management" :active="manageActive">
+      <nav-bar-item v-if="loggedIn" href="/management" :active="profileActive">
         <svg class="nav-icon" src="../icons/manage.svg"/>
-        <div class="label">{{ $tr('manage') }}</div>
+        <div class="label">{{ $tr('profile') }}</div>
+      </nav-bar-item>
+      <nav-bar-item v-if="loggedIn">
+        <svg class="nav-icon" src="../icons/manage.svg"/>
+        <div class="label">{{ $tr('logOut') }}</div>
+      </nav-bar-item>
+      <nav-bar-item v-else href="/signin">
+        <svg class="nav-icon" src="../icons/manage.svg"/>
+        <div class="label">{{ $tr('signIn') }}</div>
       </nav-bar-item>
       <session-nav-widget/>
     </nav>
@@ -33,6 +41,7 @@
   const values = require('lodash.values');
   const getters = require('kolibri.coreVue.vuex.getters');
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
+  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
 
 
   module.exports = {
@@ -43,6 +52,9 @@
       explore: 'Explore',
       manage: 'Manage',
       coach: 'Coach',
+      signIn: 'Sign in',
+      profile: 'Profile',
+      logOut: 'Log out',
     },
     props: {
       topLevelPageName: {
@@ -71,6 +83,9 @@
       manageActive() {
         return this.topLevelPageName === TopLevelPageNames.MANAGE;
       },
+      profileActive() {
+        return this.topLevelPageName === TopLevelPageNames.PROFILE;
+      },
     },
     components: {
       'session-nav-widget': require('../session-nav-widget'),
@@ -80,6 +95,7 @@
     vuex: {
       getters: {
         session: state => state.core.session,
+        loggedIn: state => state.core.session.kind[0] !== UserKinds.ANONYMOUS,
         isAdminOrSuperuser: getters.isAdminOrSuperuser,
         isCoachAdminOrSuperuser: getters.isCoachAdminOrSuperuser,
         loginModalVisible: state => state.core.loginModalVisible,

--- a/kolibri/plugins/user/assets/src/actions.js
+++ b/kolibri/plugins/user/assets/src/actions.js
@@ -21,6 +21,27 @@ const PageNames = constants.PageNames;
  * These methods are used to update client-side state
  */
 
+function showSignIn(store) {
+  store.dispatch('SET_PAGE_NAME', PageNames.SIGN_IN);
+  store.dispatch('SET_PAGE_STATE', {});
+  store.dispatch('CORE_SET_PAGE_LOADING', false);
+  store.dispatch('CORE_SET_ERROR', null);
+  store.dispatch('CORE_SET_TITLE', 'User Sign In');
+}
+function showSignUp(store) {
+  store.dispatch('SET_PAGE_NAME', PageNames.SIGN_UP);
+  store.dispatch('SET_PAGE_STATE', {});
+  store.dispatch('CORE_SET_PAGE_LOADING', false);
+  store.dispatch('CORE_SET_ERROR', null);
+  store.dispatch('CORE_SET_TITLE', 'User Sign Up');
+}
+function showProfile(store) {
+  store.dispatch('SET_PAGE_NAME', PageNames.PROFILE);
+  store.dispatch('SET_PAGE_STATE', {});
+  store.dispatch('CORE_SET_PAGE_LOADING', false);
+  store.dispatch('CORE_SET_ERROR', null);
+  store.dispatch('CORE_SET_TITLE', 'User Profile');
+}
 function showScratchpad(store) {
   store.dispatch('SET_PAGE_NAME', PageNames.SCRATCHPAD);
   store.dispatch('SET_PAGE_STATE', {});
@@ -30,5 +51,8 @@ function showScratchpad(store) {
 }
 
 module.exports = {
+  showSignIn,
+  showSignUp,
+  showProfile,
   showScratchpad,
 };

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -14,6 +14,27 @@ class UserModule extends KolibriModule {
   ready() {
     const routes = [
       {
+        name: PageNames.SIGN_IN,
+        path: '/signin',
+        handler: (toRoute, fromRoute) => {
+          actions.showSignIn(store);
+        },
+      },
+      {
+        name: PageNames.SIGN_UP,
+        path: '/signup',
+        handler: (toRoute, fromRoute) => {
+          actions.showSignUp(store);
+        },
+      },
+      {
+        name: PageNames.PROFILE,
+        path: '/profile',
+        handler: (toRoute, fromRoute) => {
+          actions.showProfile(store);
+        },
+      },
+      {
         name: PageNames.SCRATCHPAD,
         path: '/scratchpad',
         handler: (toRoute, fromRoute) => {
@@ -22,7 +43,7 @@ class UserModule extends KolibriModule {
       },
       {
         path: '/',
-        redirect: '/scratchpad',
+        redirect: '/signin',
       },
     ];
 

--- a/kolibri/plugins/user/assets/src/state/constants.js
+++ b/kolibri/plugins/user/assets/src/state/constants.js
@@ -1,9 +1,9 @@
 
 // a name for every URL pattern
 const PageNames = {
-  LOGIN: 'LOGIN',
+  SIGN_IN: 'SIGN_IN',
   SIGN_UP: 'SIGN_UP',
-  EDIT: 'EDIT',
+  PROFILE: 'PROFILE',
   SCRATCHPAD: 'SCRATCHPAD',
 };
 

--- a/kolibri/plugins/user/assets/src/vue/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/index.vue
@@ -1,12 +1,19 @@
 <template>
 
-  <core-base :topLevelPageName="topLevelPageName">
+  <core-base v-if="navBarNeeded" :topLevelPageName="topLevelPageName">
     <component
       slot="content"
       class="user page"
       :is="currentPage"
     />
   </core-base>
+
+  <component
+    v-else
+    slot="content"
+    class="user page"
+    :is="currentPage"
+    />
 
 </template>
 
@@ -20,15 +27,36 @@
   module.exports = {
     name: 'User-Plugin',
     components: {
+      'sign-in-page': require('./sign-in-page'),
+      'sign-up-page': require('./sign-up-page'),
+      'profile-page': require('./profile-page'),
       'scratchpad-page': require('./scratchpad-page'),
     },
     computed: {
       topLevelPageName: () => TopLevelPageNames.USER,
       currentPage() {
+        if (this.pageName === PageNames.SIGN_IN) {
+          return 'sign-in-page';
+        }
+        if (this.pageName === PageNames.SIGN_UP) {
+          return 'sign-up-page';
+        }
+        if (this.pageName === PageNames.PROFILE) {
+          return 'profile-page';
+        }
         if (this.pageName === PageNames.SCRATCHPAD) {
           return 'scratchpad-page';
         }
         return null;
+      },
+      navBarNeeded() {
+        if (this.pageName === PageNames.SIGN_IN) {
+          return false;
+        }
+        if (this.pageName === PageNames.SIGN_UP) {
+          return false;
+        }
+        return true;
       },
     },
     vuex: {

--- a/kolibri/plugins/user/assets/src/vue/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/profile-page/index.vue
@@ -1,0 +1,23 @@
+<template>
+
+  <div>
+    <h1>User Profile</h1>
+    <p>Use this page for in-progress component prototyping.</p>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.coreTheme'
+
+</style>

--- a/kolibri/plugins/user/assets/src/vue/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/sign-in-page/index.vue
@@ -1,0 +1,23 @@
+<template>
+
+  <div>
+    <h1>Sign In</h1>
+    <p>Use this page for in-progress component prototyping.</p>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.coreTheme'
+
+</style>

--- a/kolibri/plugins/user/assets/src/vue/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/sign-up-page/index.vue
@@ -1,0 +1,23 @@
+<template>
+
+  <div>
+    <h1>User Sign Up</h1>
+    <p>Use this page for in-progress component prototyping.</p>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.coreTheme'
+
+</style>


### PR DESCRIPTION
## Summary

Quick add of all the routes discussed by @christianmemije and I

Also added selective use of core-base, which seems to be used for nav-bar styling primarily.

No error box. @indirectlylit do you think it would be worth giving `core-base` a toggle for all the nav bar styling? Inside of `/signin` and `/signup` we'd end up with no `error-box` component. 