### PR TITLE
Point directly to postcss loader config

### DIFF
--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -62,8 +62,6 @@ var parseBundlePlugin = function(data, base_dir) {
     local_config.coreAPISpec = path.resolve(path.join(data.plugin_path, local_config.coreAPISpec));
   }
 
-  bundle = merge.smart(bundle, local_config);
-
   // This might be non-standard use of the entry option? It seems to
   // interact with read_bundle_plugins.js
   bundle.entry = {}
@@ -102,6 +100,8 @@ var parseBundlePlugin = function(data, base_dir) {
     }),
     new extract$trs(data.locale_data_folder, data.name)
   ]);
+
+  bundle = merge.smart(bundle, local_config);
 
   var publicPath, outputPath;
 

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -29,6 +29,7 @@ process.env.NODE_PATH = path.resolve(path.join(__dirname, '..', '..', 'node_modu
 require('module').Module._initPaths();
 
 var fs = require('fs');
+var path = require('path');
 var webpack = require('webpack');
 var merge = require('webpack-merge');
 
@@ -44,8 +45,15 @@ aliases['keen_ui_variables'] = path.resolve('kolibri/core/assets/src/keen-config
 // helps convert to older string syntax for vue-loader
 var combineLoaders = require('webpack-combine-loaders');
 
+var postCSSLoader = {
+  loader: 'postcss-loader',
+  options: {
+    config: path.resolve(__dirname, '../../postcss.config.js')
+  }
+};
+
 // for stylus blocks in vue files
-const vueStylusLoaders = [
+var vueStylusLoaders = [
   'vue-style-loader', // includes postcss processing
   {
     loader: 'css-loader',
@@ -59,7 +67,7 @@ if (lint) {
 }
 
 // for scss blocks in vue files (e.g. Keen-UI files)
-const vueSassLoaders = [
+var vueSassLoaders = [
   'vue-style-loader', // includes postcss processing
   {
     loader: 'css-loader',
@@ -95,7 +103,8 @@ var config = {
       },
       {
         test: /\.js$/,
-        loader: 'buble-loader'
+        loader: 'buble-loader',
+        exclude: /node_modules\/(?!(keen-ui)\/).*/
       },
       {
         test: /\.css$/,
@@ -116,7 +125,7 @@ var config = {
             loader: 'css-loader',
             options: { minimize: production, sourceMap: !production }
           },
-          'postcss-loader',
+          postCSSLoader,
           'stylus-loader',
         ]
       },
@@ -128,7 +137,7 @@ var config = {
             loader: 'css-loader',
             options: { minimize: production, sourceMap: !production }
           },
-          'postcss-loader',
+          postCSSLoader,
           'sass-loader',
         ]
       },


### PR DESCRIPTION
## Summary

Point to absolute path of post-css loader configuration in order to ensure that external plugins are properly prefixed.

Also changed the point where we merge in local configurations to allow extensions of module resolution paths (webpack2 is lazier when it comes to searching for node_modules folders, apparently).