### PR TITLE
Define current version as node global.

### DIFF
--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -93,7 +93,8 @@ var parseBundlePlugin = function(data, base_dir) {
     new webpack.DefinePlugin({
       __kolibriModuleName: JSON.stringify(data.name),
       __events: JSON.stringify(data.events || {}),
-      __once: JSON.stringify(data.once || {})
+      __once: JSON.stringify(data.once || {}),
+      __version: JSON.stringify(data.version)
     }),
     new extract$trs(data.locale_data_folder, data.name)
   ]);

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -27,6 +27,9 @@
         <div class="label">{{ $tr('signIn') }}</div>
       </nav-bar-item>
       <session-nav-widget/>
+      <div>
+        Kolibri Version: {{ version }}
+      </div>
     </nav>
 
     <!-- log-in modal -->
@@ -67,6 +70,9 @@
         },
       },
     },
+    data: () => ({
+      version: __version, // eslint-disable-line no-undef
+    }),
     computed: {
       ariaLabel() {
         return this.$tr('navigationLabel');


### PR DESCRIPTION
## Summary

Define the current version as a node global and adds an example of use in side bar nav.

Deliberately ugly, as will soon be overwritten.

Also, as the version property can be overwritten in external plugins, this allows them to have their own versions included in front end code as well.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1680573/22908091/6f4e50a2-f201-11e6-9cb1-bd1132c0ab44.png)
