### PR TITLE
Externalize messages for external plugins.

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -152,11 +152,21 @@ class WebpackBundleHook(hooks.KolibriHook):
                 "events": self.events,
                 "once": self.once,
                 "static_url_root": getattr(django_settings, 'STATIC_URL'),
-                "locale_data_folder": os.path.join(getattr(django_settings, 'LOCALE_PATHS')[0], 'en', 'LC_FRONTEND_MESSAGES'),
+                "locale_data_folder": self.locale_data_folder,
                 "version": self.version,
             }
         else:
             logger.warn("{src_file} not found for plugin {name}.".format(src_file=self.src_file, name=self.unique_slug))
+
+    @property
+    def locale_data_folder(self):
+        if self.module_path.startswith('kolibri.'):
+            return os.path.join(getattr(django_settings, 'LOCALE_PATHS')[0], 'en', 'LC_FRONTEND_MESSAGES')
+        # Is an external plugin, do otherwise!
+        else:
+            return os.path.join(
+                os.path.dirname(self.build_path),
+                getattr(self, 'locale_path', 'locale'), 'en', 'LC_FRONTEND_MESSAGES')
 
     @property
     def module_path(self):


### PR DESCRIPTION
Set the locale_data_folder for plugins outside of the kolibri app to inside their own app.