### PR TITLE
should use f_frsize(fundamental file system block size)

### DIFF
--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -39,7 +39,7 @@ def _get_mocked_disk_usage(disk_sizes):
         sizes = disk_sizes[path]
 
         class MockDiskSizes(object):
-            f_bsize = 2
+            f_frsize = 2
             f_blocks = sizes["total"] / 2
             f_bavail = sizes["free"] / 2
             total = sizes["total"]

--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -87,8 +87,8 @@ def _get_drive_usage(path):
     else:
         # with os.statvfs, we need to multiple block sizes by block counts to get bytes
         stats = os.statvfs(path)
-        total = stats.f_bsize * stats.f_blocks
-        free = stats.f_bsize * stats.f_bavail
+        total = stats.f_frsize * stats.f_blocks
+        free = stats.f_frsize * stats.f_bavail
         return {
             "total": total,
             "free": free,


### PR DESCRIPTION
fix issue #862 
according to this post http://plug.org/pipermail/plug/2010-August/023606.html
it should use `f_frsize` to calculate storage space.
not very accurate though, which is mentioned at the method comment(_get_drive_usage)