### PR TITLE
Side nav

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -69,6 +69,9 @@ const TopLevelPageNames = {
   COACH: 'COACH',
   MANAGE: 'MANAGE',
   USER: 'USER',
+  ABOUT: 'ABOUT',
+  PROFILE: 'PROFILE',
+  SETTINGS: 'SETTINGS',
 };
 
 module.exports = {

--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -71,7 +71,6 @@ const TopLevelPageNames = {
   USER: 'USER',
   ABOUT: 'ABOUT',
   PROFILE: 'PROFILE',
-  SETTINGS: 'SETTINGS',
 };
 
 module.exports = {

--- a/kolibri/core/assets/src/keen-config/variables.scss
+++ b/kolibri/core/assets/src/keen-config/variables.scss
@@ -1,2 +1,3 @@
 
 $brand-primary-color: #996189;
+$font-stack: 'NotoSans';

--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -22,5 +22,3 @@ $core-bg-warning = #fff3e1
 
 $core-text-error = #b93329
 $core-bg-error = #fee9e7
-
-

--- a/kolibri/core/assets/src/styles/definitions.styl
+++ b/kolibri/core/assets/src/styles/definitions.styl
@@ -31,7 +31,7 @@ clearfix()
 
 
 // need factor these variables out
-$nav-width = 75px
+$nav-width = 300px
 $portrait-breakpoint = 520px
 $medium-breakpoint = 619px
 

--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -133,16 +133,16 @@ button::-moz-focus-inner
   font-style: normal
   font-weight: 400
   src: local('Material Icons'),
-       local('MaterialIcons-Regular'),
-       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'),
-       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff'),
-       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype');
+local('MaterialIcons-Regular'),
+url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'),
+url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff'),
+url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype')
 
 .material-icons
   font-family: 'Material Icons'
   font-weight: normal
   font-style: normal
-  font-size: 24px  /* Preferred icon size */
+  font-size: 24px /* Preferred icon size */
   display: inline-block
   line-height: 1
   text-transform: none

--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -125,3 +125,39 @@ button::-moz-focus-inner
 .core-text-annotation
   color: $core-text-annotation
 
+// Definitions for Google Material Design Icons
+// from http://google.github.io/material-design-icons/
+
+@font-face
+  font-family: 'Material Icons'
+  font-style: normal
+  font-weight: 400
+  src: local('Material Icons'),
+       local('MaterialIcons-Regular'),
+       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'),
+       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff'),
+       url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype');
+
+.material-icons
+  font-family: 'Material Icons'
+  font-weight: normal
+  font-style: normal
+  font-size: 24px  /* Preferred icon size */
+  display: inline-block
+  line-height: 1
+  text-transform: none
+  letter-spacing: normal
+  word-wrap: normal
+  white-space: nowrap
+  direction: ltr
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale
+
+  /* Support for IE. */
+  font-feature-settings: 'liga'

--- a/kolibri/core/assets/src/vue/app-bar/index.vue
+++ b/kolibri/core/assets/src/vue/app-bar/index.vue
@@ -7,7 +7,7 @@
     class="app-bar"
     :removeNavIcon="navShown"
     @nav-icon-click="$emit('toggleSideNav')"
-    v-bind:style="{ height: height + 'px' }">
+    :style="{ height: height + 'px' }">
     <div slot="actions">
       <slot name="app-bar-actions"/>
     </div>

--- a/kolibri/core/assets/src/vue/app-bar/index.vue
+++ b/kolibri/core/assets/src/vue/app-bar/index.vue
@@ -6,7 +6,9 @@
       type="colored"
       textColor="white"
       class="app-bar"
-      @nav-icon-click="$emit('toggleSideNav')">
+      :removeNavIcon="navShown"
+      @nav-icon-click="$emit('toggleSideNav')"
+      v-bind:style="{ height: height + 'px' }">
       <div slot="actions">
         <ui-icon-button
           icon="search"
@@ -39,6 +41,14 @@
     props: {
       title: {
         type: String,
+        required: true,
+      },
+      navShown: {
+        type: Boolean,
+        required: true,
+      },
+      height: {
+        type: Number,
         required: true,
       },
     },

--- a/kolibri/core/assets/src/vue/app-bar/index.vue
+++ b/kolibri/core/assets/src/vue/app-bar/index.vue
@@ -6,7 +6,7 @@
       type="colored"
       textColor="white"
       class="app-bar"
-      @nav-icon-click="toggleDrawer">
+      @nav-icon-click="$emit('toggleSideNav')">
       <div slot="actions">
         <ui-icon-button
           icon="search"
@@ -40,11 +40,6 @@
       title: {
         type: String,
         required: true,
-      },
-    },
-    methods: {
-      toggleDrawer() {
-        console.log('toggleDrawer');
       },
     },
     components: {

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -1,8 +1,8 @@
 <template>
 
   <div>
-    <app-bar :title="topLevelPageName"/>
-    <nav-bar :topLevelPageName="topLevelPageName"/>
+    <app-bar @toggleSideNav="navShownMobile=!navShownMobile" :title="topLevelPageName"/>
+    <nav-bar @toggleSideNav="navShownMobile=!navShownMobile" :topLevelPageName="topLevelPageName" :navShownMobile="navShownMobile"/>
     <loading-spinner v-if="loading" class="loading-spinner-fixed"/>
     <div class="main-wrapper" v-scroll="onScroll" v-if="!loading">
       <error-box v-if="error"/>
@@ -59,6 +59,7 @@
     },
     data: () => ({
       scrolled: false,
+      navShownMobile: false,
     }),
     methods: {
       onScroll(e, position) {

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <app-bar @toggleSideNav="navShownMobile=!navShownMobile" :title="topLevelPageName"/>
+    <app-bar class='app-bar' @toggleSideNav="navShownMobile=!navShownMobile" :title="topLevelPageName"/>
     <nav-bar @toggleSideNav="navShownMobile=!navShownMobile" :topLevelPageName="topLevelPageName" :navShownMobile="navShownMobile"/>
     <loading-spinner v-if="loading" class="loading-spinner-fixed"/>
     <div class="main-wrapper" v-scroll="onScroll" v-if="!loading">
@@ -89,17 +89,21 @@
     overflow-y: scroll
     height: 100%
     width: 100%
-    padding-left: 100px
-    padding-right: 25px
     padding-bottom: 50px
     z-index: -2
+  .main-wrapper
+    padding-left: $nav-width + 25px
+    padding-right: 25px
     @media (max-width: $medium-breakpoint + 1)
       padding-left: 69px
       padding-right: 0
     @media screen and (max-width: $portrait-breakpoint)
       padding: 0 0.6em
       padding-bottom: 100px
-
+  .app-bar
+    padding-left: $nav-width
+    @media screen and (max-width: $portrait-breakpoint)
+      padding: 0
   .loading-spinner-fixed
     position: fixed
 

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <app-bar class='app-bar' @toggleSideNav="navShownMobile=!navShownMobile" :title="topLevelPageName"/>
+    <app-bar class="app-bar" @toggleSideNav="navShownMobile=!navShownMobile" :title="topLevelPageName"/>
     <nav-bar @toggleSideNav="navShownMobile=!navShownMobile" :topLevelPageName="topLevelPageName" :navShownMobile="navShownMobile"/>
     <loading-spinner v-if="loading" class="loading-spinner-fixed"/>
     <div class="main-wrapper" v-scroll="onScroll" v-if="!loading">

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -2,7 +2,7 @@
 
   <div>
     <app-bar
-      v-bind:style="{ paddingLeft: paddingForNav + 'px' }"
+      :style="{ paddingLeft: paddingForNav + 'px' }"
       @toggleSideNav="navShown=!navShown"
       :title="topLevelPageName"
       :navShown="navShown"
@@ -18,7 +18,7 @@
       :headerHeight="baseMaterialIncrement"
       :width="navWidth"/>
     <loading-spinner v-if="loading" class="loading-spinner-fixed"/>
-    <div class="main-wrapper" v-scroll="onScroll" v-if="!loading" v-bind:style="{ paddingLeft: paddingForNav + 'px' }">
+    <div class="main-wrapper" v-scroll="onScroll" v-if="!loading" :style="{ paddingLeft: paddingForNav + 'px' }">
       <error-box v-if="error"/>
       <slot name="above"/>
       <slot name="content"/>
@@ -72,7 +72,7 @@
       title(newVal, oldVal) {
         document.title = `${newVal} - Kolibri`;
       },
-      'windowSize.breakpoint': function (newVal, oldVal) {
+      'windowSize.breakpoint': function (newVal, oldVal) { // eslint-disable-line object-shorthand
         // Pop out the nav if transitioning from smaller viewport.
         if (oldVal < 5 & newVal > 4) {
           this.navShown = true;

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -2,13 +2,13 @@
   <div v-show="navShown">
     <div
       class='nav-wrapper'
-      v-bind:style="wrapperStyle">
-      <div class='header' v-bind:style="{ height: headerHeight + 'px', textAlign: !(mobile | tablet) ? 'center' : 'inherit' }">
+      :style="wrapperStyle">
+      <div class='header' :style="{ height: headerHeight + 'px', textAlign: !(mobile | tablet) ? 'center' : 'inherit' }">
         <button
           v-if="mobile | tablet"
           :aria-label="closeNav"
           class='close' @click="toggleNav"
-          v-bind:style="{ fontSize: headerHeight/2 + 'px' }">
+          :style="{ fontSize: headerHeight/2 + 'px' }">
           <ui-icon :icon="mobile ? 'arrow_back' : 'menu'"/>
         </button>
         <img
@@ -16,15 +16,15 @@
           v-if="mobile"
           src="../login-modal/icons/kolibri-logo.svg"
           alt=""
-          v-bind:style="{ width: headerHeight + 'px', height: headerHeight + 'px', marginRight: width/20 + 'px' }">
-        <p class='title' v-bind:style="{ fontSize: headerHeight/3 + 'px' }">Kolibri</p>
+          :style="{ width: headerHeight + 'px', height: headerHeight + 'px', marginRight: width/20 + 'px' }">
+        <p class='title' :style="{ fontSize: headerHeight/3 + 'px' }">Kolibri</p>
       </div>
       <img
         class='logo'
         v-if="!mobile"
         src="../login-modal/icons/kolibri-logo.svg"
         alt=""
-        v-bind:style="{ height: width/2.5 + 'px', width: width/2.5 + 'px' }">
+        :style="{ height: width/2.5 + 'px', width: width/2.5 + 'px' }">
       <ui-menu
         class='nav-main'
         :options="menuOptions"
@@ -32,14 +32,14 @@
         @select="navigate"
         role="navigation"
         :aria-label="ariaLabel"
-        v-bind:style="{ maxWidth: width + 'px' }">
+        :style="{ maxWidth: width + 'px' }">
       </ui-menu>
-      <div class='footer' v-bind:style="{ width: width + 'px' }">
+      <div class='footer' :style="{ width: width + 'px' }">
         <img
           class='logo'
           src="../login-modal/icons/kolibri-logo.svg"
           alt=""
-          v-bind:style="{ width: width/6 + 'px', height: width/6 + 'px', marginLeft: width/20 + 'px', marginRight: width/20 + 'px' }">
+          :style="{ width: width/6 + 'px', height: width/6 + 'px', marginLeft: width/20 + 'px', marginRight: width/20 + 'px' }">
         <div class='message-container'>
           <p class='message'>{{ footerMsg }}</p>
           <p class='message'><ui-icon icon='copyright'/> 2017 Learning Equality</p>

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -161,35 +161,112 @@
   @require '~kolibri.styles.definitions'
   @require '~kolibri.styles.navBarItem'
 
+  $headerheight = 60px
+  $footerheight = 100px
+
   .nav-wrapper
-    display: table
-    table-layout: fixed
     background: $core-bg-light
     font-weight: 300
     position: fixed
-    z-index: auto
-    @media screen and (min-width: $portrait-breakpoint + 1)
-      font-size: 1em
-      height: 100%
-      width: $nav-width
-    @media screen and (max-width: $portrait-breakpoint)
-      font-size: 0.8em
-      bottom: 0
-      width: 100%
-      min-width: 300px
+    z-index: 100
+    font-size: 1em
+    height: 100vh
+    width: $nav-width
+    overflow: auto
+    -webkit-overflow-scrolling: touch
 
   .nav-main
     background: $core-bg-light
-    height: 100vh
-    @media screen and (max-width: $portrait-breakpoint)
-      display: table-row
-      height: 56px
+    max-width: $nav-width
 
   a.active:focus svg
     fill: $core-bg-light
 
-  .nav-icon
-    width: 40px
-    height: 40px
+  .header
+    overflow: auto
+    overflow-y: hidden
+    background-color: $core-text-default
+    height: $headerheight
+    .logo, .title, .close
+      float: left
+    .title, .close
+      color: $core-bg-light
+    .close
+      font-size: ($headerheight / 2)
+      top: 50%
+      transform: translateY(-50%)
+      position: relative
+      margin-right: ($nav-width/20)
+      margin-left: ($nav-width/20)
+      border: none
+    .title
+      font-size: ($headerheight / 3)
+      font-weight: bold
+    .logo
+      width: $headerheight
+      height: @width
+      margin-right: ($nav-width/20)
 
+  .footer
+    bottom: 0
+    position: absolute
+    overflow: auto
+    overflow-y: hidden
+    background-color: $core-text-default
+    height: $footerheight
+    width: $nav-width
+    .logo, .message-container
+      top: 50%
+      transform: translateY(-50%)
+      position: relative
+    .logo
+      float: left
+      width: ($footerheight/2)
+      height: @width
+      margin-right: ($nav-width/20)
+      margin-left: ($nav-width/20)
+    .message-container
+      .message
+        color: $core-bg-light
+        font-size: ($footerheight/10)
+
+  .modal-overlay
+    position: fixed
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+    background: rgba(0, 0, 0, 0.7)
+    transition: opacity 0.3s ease
+    background-attachment: fixed
+    z-index: 10
+
+</style>
+
+<style lang="stylus">
+
+  @require '~kolibri.styles.coreTheme'
+
+  // Customize Keen UI Menu option
+  .nav-main
+    .ui-menu-option
+      margin: 5px 0px
+      &:not(.is-divider)
+        font-size: 1.2em
+        &.is-disabled
+          .ui-menu-option__icon
+            color: $core-action-normal
+            font-weight: bold
+          color: $core-action-normal
+          cursor: default
+          font-weight: bold
+          opacity: 1
+        .ui-menu-option__text
+          overflow: visible
+        .ui-menu-option__icon
+          font-size: 1.2em
+      &.is_divider
+        background-color: $core-text-annotation
+    &.ui-menu
+      border: none
 </style>

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -1,41 +1,23 @@
 <template>
-
-  <div class="nav-wrapper">
-    <nav class="nav-main" role="navigation" :aria-label="ariaLabel">
-      <nav-bar-item href="/learn/#/learn" :active="learnActive">
-        <mat-svg class="nav-icon" category="action" name="home"/>
-        <div class="label">{{ $tr('learn') }}</div>
-      </nav-bar-item>
-      <nav-bar-item href="/learn/#/explore" :active="exploreActive">
-        <mat-svg class="nav-icon" category="action" name="explore"/>
-        <div class="label">{{ $tr('explore') }}</div>
-      </nav-bar-item>
-      <nav-bar-item v-if="isCoachAdminOrSuperuser" href="/coach" :active="coachActive">
-        <mat-svg class="nav-icon" category="action" name="assessment"/>
-        <div class="label">{{ $tr('coach') }}</div>
-      </nav-bar-item>
-      <nav-bar-item v-if="loggedIn" href="/management" :active="profileActive">
-        <mat-svg class="nav-icon" category="social" name="people"/>
-        <div class="label">{{ $tr('profile') }}</div>
-      </nav-bar-item>
-      <nav-bar-item v-if="loggedIn">
-        <mat-svg class="nav-icon" category="social" name="people"/>
-        <div class="label">{{ $tr('logOut') }}</div>
-      </nav-bar-item>
-      <nav-bar-item v-else href="/signin">
-        <mat-svg class="nav-icon" category="social" name="people"/>
-        <div class="label">{{ $tr('signIn') }}</div>
-      </nav-bar-item>
-      <session-nav-widget/>
-      <div>
-        Kolibri Version: {{ version }}
+    <div
+      class='nav-wrapper'
+      v-bind:style="{minHeight: (menuOptions.length - 1)*50 + 173 + 'px'}">
+      <div class='header'>
+        <button :aria-label="closeNav" class='close' @click="toggleNav"><ui-icon icon='arrow_back'/></button>
+        <img class='logo' src="../login-modal/icons/kolibri-logo.svg" alt="">
+        <p class='title'>Kolibri</p>
       </div>
-    </nav>
-
-    <!-- log-in modal -->
-    <login-modal v-if="loginModalVisible"/>
-  </div>
-
+      <ui-menu
+        class='nav-main'
+        :options="menuOptions"
+        hasIcons
+        @select="navigate"
+        role="navigation"
+        :aria-label="ariaLabel">
+      </ui-menu>
+      <!-- log-in modal -->
+      <login-modal v-if="loginModalVisible"/>
+    </div>
 </template>
 
 
@@ -58,6 +40,8 @@
       signIn: 'Sign in',
       profile: 'Profile',
       logOut: 'Log out',
+      settings: 'Settings',
+      about: 'About',
     },
     props: {
       topLevelPageName: {
@@ -80,9 +64,6 @@
       learnActive() {
         return this.topLevelPageName === TopLevelPageNames.LEARN_LEARN;
       },
-      exploreActive() {
-        return this.topLevelPageName === TopLevelPageNames.LEARN_EXPLORE;
-      },
       coachActive() {
         return this.topLevelPageName === TopLevelPageNames.COACH;
       },
@@ -92,11 +73,74 @@
       profileActive() {
         return this.topLevelPageName === TopLevelPageNames.PROFILE;
       },
+      settingsActive() {
+        return this.topLevelPageName === TopLevelPageNames.SETTINGS;
+      },
+      aboutActive() {
+        return this.topLevelPageName === TopLevelPageNames.ABOUT;
+      },
+      menuOptions() {
+        let options = [
+          {
+            label: this.$tr('learn'),
+            disabled: this.learnActive,
+            icon: 'school',
+            href: '/learn/#/learn',
+          },
+        ];
+        if (this.isCoachAdminOrSuperuser) {
+          options.push({
+            label: this.$tr('coach'),
+            disabled: this.coachActive,
+            icon: 'assessment',
+            href: '/coach',
+          });
+        }
+        if (this.isAdminOrSuperuser) {
+          options.push({
+            label: this.$tr('manage'),
+            disabled: this.manageActive,
+            icon: 'people',
+            href: '/management',
+          });
+        }
+        options.push({
+            type: 'divider',
+        });
+        if (!this.isAdminOrSuperuser) {
+          options.push({
+            label: this.$tr('profile'),
+            disabled: this.profileActive,
+            icon: 'account_circle',
+            href: '/management',
+          });
+        }
+        options.push(...[
+          {
+            label: this.$tr('settings'),
+            disabled: this.settingsActive,
+            icon: 'settings',
+          },
+          {
+            label: this.$tr('about'),
+            disabled: this.aboutActive,
+            icon: 'error_outline',
+          },
+          {
+            label: this.loggedIn ? this.$tr('logOut') : this.$tr('signIn'),
+            icon: 'exit_to_app',
+          },
+        ]);
+
+        return options;
+      },
     },
     components: {
       'session-nav-widget': require('kolibri.coreVue.components.sessionNavWidget'),
       'nav-bar-item': require('kolibri.coreVue.components.navBarItem'),
       'login-modal': require('kolibri.coreVue.components.loginModal'),
+      'ui-menu': require('keen-ui/src/UiMenu'),
+      'ui-icon': require('keen-ui/src/UiIcon'),
     },
     vuex: {
       getters: {

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -67,21 +67,22 @@
           return values(TopLevelPageNames).includes(value);
         },
       },
+      navShownMobile: {
+        type: Boolean,
+        required: true,
+      }
     },
-    data: () => ({
-      shown: true,
-    }),
     methods: {
       navigate(option) {
         window.location.href = option.href;
       },
       toggleNav() {
-        this.shown = !this.shown;
+        this.$emit('toggleSideNav');
       },
     },
     computed: {
       navShown() {
-        return this.shown || !this.mobile;
+        return this.navShownMobile || !this.mobile;
       },
       mobile() {
         return true;

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -2,7 +2,7 @@
   <div v-show="navShown">
     <div
       class='nav-wrapper'
-      v-bind:style="{minHeight: (menuOptions.length - 1)*50 + 173 + 'px'}">
+      v-bind:style="wrapperStyle">
       <div class='header'>
         <button :aria-label="closeNav" class='close' @click="toggleNav"><ui-icon icon='arrow_back'/></button>
         <img class='logo' src="../login-modal/icons/kolibri-logo.svg" alt="">
@@ -81,6 +81,15 @@
       },
     },
     computed: {
+      wrapperStyle() {
+        let styles = {
+          minHeight: (this.menuOptions.length - 1)*50 + 173 + 'px',
+        };
+        if (this.mobile) {
+          styles['top'] = '0px';
+        }
+        return styles;
+      },
       navShown() {
         return this.navShownMobile || !this.mobile;
       },
@@ -203,7 +212,7 @@
     background: $core-bg-light
     font-weight: 300
     position: fixed
-    z-index: 100
+    z-index: 1001
     font-size: 1em
     height: 100vh
     width: $nav-width

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -1,4 +1,5 @@
 <template>
+  <div v-show="navShown">
     <div
       class='nav-wrapper'
       v-bind:style="{minHeight: (menuOptions.length - 1)*50 + 173 + 'px'}">
@@ -15,8 +16,19 @@
         role="navigation"
         :aria-label="ariaLabel">
       </ui-menu>
+      <div class='footer'>
+        <img class='logo' src="../login-modal/icons/kolibri-logo.svg" alt="">
+        <div class='message-container'>
+          <p class='message'>{{ footerMsg }}</p>
+          <p class='message'><ui-icon icon='copyright'/> 2017 Learning Equality</p>
+        </div>
+      </div>
       <!-- log-in modal -->
       <login-modal v-if="loginModalVisible"/>
+    </div>
+    <div v-if="mobile" class="modal-overlay"
+      @keydown.esc="toggleNav"
+      @click="toggleNav">
     </div>
 </template>
 
@@ -42,6 +54,8 @@
       logOut: 'Log out',
       settings: 'Settings',
       about: 'About',
+      closeNav: 'Close navigation',
+      poweredBy: 'Powered by Kolibri {version}',
     },
     props: {
       topLevelPageName: {
@@ -55,9 +69,29 @@
       },
     },
     data: () => ({
-      version: __version, // eslint-disable-line no-undef
+      shown: true,
     }),
+    methods: {
+      navigate(option) {
+        window.location.href = option.href;
+      },
+      toggleNav() {
+        this.shown = !this.shown;
+      },
+    },
     computed: {
+      navShown() {
+        return this.shown || !this.mobile;
+      },
+      mobile() {
+        return true;
+      },
+      footerMsg() {
+        return this.$tr('poweredBy', { version: __version }); // eslint-disable-line no-undef
+      },
+      closeNav() {
+        return this.$tr('closeNav');
+      },
       ariaLabel() {
         return this.$tr('navigationLabel');
       },

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -59,6 +59,7 @@
 
   const values = require('lodash.values');
   const getters = require('kolibri.coreVue.vuex.getters');
+  const actions = require('kolibri.coreVue.vuex.actions');
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
   const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
   const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
@@ -109,7 +110,11 @@
     },
     methods: {
       navigate(option) {
-        window.location.href = option.href;
+        if (option.href) {
+          window.location.href = option.href;
+        } else if (option.action) {
+          option.action();
+        }
       },
       toggleNav() {
         if (this.mobile | this.tablet) {
@@ -162,9 +167,6 @@
       profileActive() {
         return this.topLevelPageName === TopLevelPageNames.PROFILE;
       },
-      settingsActive() {
-        return this.topLevelPageName === TopLevelPageNames.SETTINGS;
-      },
       aboutActive() {
         return this.topLevelPageName === TopLevelPageNames.ABOUT;
       },
@@ -196,7 +198,7 @@
         options.push({
             type: 'divider',
         });
-        if (!this.isAdminOrSuperuser) {
+        if (this.loggedIn & !this.isAdminOrSuperuser) {
           options.push({
             label: this.$tr('profile'),
             disabled: this.profileActive,
@@ -206,11 +208,6 @@
         }
         options.push(...[
           {
-            label: this.$tr('settings'),
-            disabled: this.settingsActive,
-            icon: 'settings',
-          },
-          {
             label: this.$tr('about'),
             disabled: this.aboutActive,
             icon: 'error_outline',
@@ -218,6 +215,7 @@
           {
             label: this.loggedIn ? this.$tr('logOut') : this.$tr('signIn'),
             icon: 'exit_to_app',
+            action: this.loggedIn ? this.logout : this.showLoginModal,
           },
         ]);
 
@@ -232,6 +230,10 @@
       'ui-icon': require('keen-ui/src/UiIcon'),
     },
     vuex: {
+      actions: {
+        logout: actions.kolibriLogout,
+        showLoginModal: actions.showLoginModal,
+      },
       getters: {
         session: state => state.core.session,
         loggedIn: state => state.core.session.kind[0] !== UserKinds.ANONYMOUS,

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -293,7 +293,7 @@
 
 <style lang="stylus">
 
-  @require '~kolibri.styles.coreTheme'
+  @require '~kolibri.styles.definitions'
 
   // Customize Keen UI Menu option
   .nav-main

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -4,10 +4,11 @@
       class='nav-wrapper'
       v-bind:style="wrapperStyle">
       <div class='header'>
-        <button :aria-label="closeNav" class='close' @click="toggleNav"><ui-icon icon='arrow_back'/></button>
-        <img class='logo' src="../login-modal/icons/kolibri-logo.svg" alt="">
+        <button v-if="mobile" :aria-label="closeNav" class='close' @click="toggleNav"><ui-icon icon='arrow_back'/></button>
+        <img class='logo' v-if="mobile" src="../login-modal/icons/kolibri-logo.svg" alt="">
         <p class='title'>Kolibri</p>
       </div>
+      <img class='logo' v-if="!mobile" src="../login-modal/icons/kolibri-logo.svg" alt="">
       <ui-menu
         class='nav-main'
         :options="menuOptions"
@@ -85,16 +86,13 @@
         let styles = {
           minHeight: (this.menuOptions.length - 1)*50 + 173 + 'px',
         };
-        if (this.mobile) {
-          styles['top'] = '0px';
-        }
         return styles;
       },
       navShown() {
         return this.navShownMobile || !this.mobile;
       },
       mobile() {
-        return true;
+        return false;
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version }); // eslint-disable-line no-undef
@@ -205,10 +203,11 @@
   @require '~kolibri.styles.definitions'
   @require '~kolibri.styles.navBarItem'
 
-  $headerheight = 60px
+  $headerheight = 57px
   $footerheight = 100px
 
   .nav-wrapper
+    top: 0px
     background: $core-bg-light
     font-weight: 300
     position: fixed
@@ -218,6 +217,11 @@
     width: $nav-width
     overflow: auto
     -webkit-overflow-scrolling: touch
+    .logo
+      margin: auto
+      display: block
+      height: 125px
+      width: @height
 
   .nav-main
     background: $core-bg-light

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -3,22 +3,43 @@
     <div
       class='nav-wrapper'
       v-bind:style="wrapperStyle">
-      <div class='header'>
-        <button v-if="mobile" :aria-label="closeNav" class='close' @click="toggleNav"><ui-icon icon='arrow_back'/></button>
-        <img class='logo' v-if="mobile" src="../login-modal/icons/kolibri-logo.svg" alt="">
-        <p class='title'>Kolibri</p>
+      <div class='header' v-bind:style="{ height: headerHeight + 'px', textAlign: !(mobile | tablet) ? 'center' : 'inherit' }">
+        <button
+          v-if="mobile | tablet"
+          :aria-label="closeNav"
+          class='close' @click="toggleNav"
+          v-bind:style="{ fontSize: headerHeight/2 + 'px' }">
+          <ui-icon :icon="mobile ? 'arrow_back' : 'menu'"/>
+        </button>
+        <img
+          class='logo'
+          v-if="mobile"
+          src="../login-modal/icons/kolibri-logo.svg"
+          alt=""
+          v-bind:style="{ width: headerHeight + 'px', height: headerHeight + 'px', marginRight: width/20 + 'px' }">
+        <p class='title' v-bind:style="{ fontSize: headerHeight/3 + 'px' }">Kolibri</p>
       </div>
-      <img class='logo' v-if="!mobile" src="../login-modal/icons/kolibri-logo.svg" alt="">
+      <img
+        class='logo'
+        v-if="!mobile"
+        src="../login-modal/icons/kolibri-logo.svg"
+        alt=""
+        v-bind:style="{ height: width/2.5 + 'px', width: width/2.5 + 'px' }">
       <ui-menu
         class='nav-main'
         :options="menuOptions"
         hasIcons
         @select="navigate"
         role="navigation"
-        :aria-label="ariaLabel">
+        :aria-label="ariaLabel"
+        v-bind:style="{ maxWidth: width + 'px' }">
       </ui-menu>
-      <div class='footer'>
-        <img class='logo' src="../login-modal/icons/kolibri-logo.svg" alt="">
+      <div class='footer' v-bind:style="{ width: width + 'px' }">
+        <img
+          class='logo'
+          src="../login-modal/icons/kolibri-logo.svg"
+          alt=""
+          v-bind:style="{ width: width/6 + 'px', height: width/6 + 'px', marginLeft: width/20 + 'px', marginRight: width/20 + 'px' }">
         <div class='message-container'>
           <p class='message'>{{ footerMsg }}</p>
           <p class='message'><ui-icon icon='copyright'/> 2017 Learning Equality</p>
@@ -40,9 +61,14 @@
   const getters = require('kolibri.coreVue.vuex.getters');
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
   const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
-
+  const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
+  const responsiveElement = require('kolibri.coreVue.mixins.responsiveElement');
 
   module.exports = {
+    mixins: [
+      responsiveWindow,
+      responsiveElement,
+    ],
     $trNameSpace: 'navbar',
     $trs: {
       navigationLabel: 'Main user navigation',
@@ -68,31 +94,52 @@
           return values(TopLevelPageNames).includes(value);
         },
       },
-      navShownMobile: {
+      navShown: {
         type: Boolean,
         required: true,
-      }
+      },
+      headerHeight: {
+        type: Number,
+        required: true,
+      },
+      width: {
+        type: Number,
+        required: true,
+      },
     },
     methods: {
       navigate(option) {
         window.location.href = option.href;
       },
       toggleNav() {
-        this.$emit('toggleSideNav');
+        if (this.mobile | this.tablet) {
+          this.$emit('toggleSideNav');
+        }
       },
     },
     computed: {
-      wrapperStyle() {
-        let styles = {
-          minHeight: (this.menuOptions.length - 1)*50 + 173 + 'px',
+      closeStyle() {
+        return {
+          fontSize: headerHeight/2 + 'px',
+          marginLeft: this.width/20 + 'px',
+          marginRight: this.width/20 + 'px',
+
         };
-        return styles;
       },
-      navShown() {
-        return this.navShownMobile || !this.mobile;
+      wrapperStyle() {
+        return {
+          // Calculate min-height property by taking the number of options (minus the divider)
+          // multipying by 50 for each option, adding 173 for the divider and the footer,
+          // and finally adding this.width/2.5 for the non-mobile logo if needed.
+          minHeight: (this.menuOptions.length - 1)*50 + 173 + (!this.mobile ? this.width/2.5 : 0) + 'px',
+          width: this.width + 'px',
+        };
       },
       mobile() {
-        return false;
+        return this.windowSize.breakpoint < 2;
+      },
+      tablet() {
+        return (this.windowSize.breakpoint > 1) & (this.windowSize.breakpoint < 5);
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version }); // eslint-disable-line no-undef
@@ -203,7 +250,6 @@
   @require '~kolibri.styles.definitions'
   @require '~kolibri.styles.navBarItem'
 
-  $headerheight = 57px
   $footerheight = 100px
 
   .nav-wrapper
@@ -214,18 +260,15 @@
     z-index: 1001
     font-size: 1em
     height: 100vh
-    width: $nav-width
     overflow: auto
     -webkit-overflow-scrolling: touch
+    box-shadow: 2px 0 0px 0px rgba(0, 0, 0, 0.12)
     .logo
       margin: auto
       display: block
-      height: 125px
-      width: @height
 
   .nav-main
     background: $core-bg-light
-    max-width: $nav-width
 
   a.active:focus svg
     fill: $core-bg-light
@@ -234,26 +277,18 @@
     overflow: auto
     overflow-y: hidden
     background-color: $core-text-default
-    height: $headerheight
-    .logo, .title, .close
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2)
+    .logo, .close
       float: left
     .title, .close
       color: $core-bg-light
     .close
-      font-size: ($headerheight / 2)
       top: 50%
       transform: translateY(-50%)
       position: relative
-      margin-right: ($nav-width/20)
-      margin-left: ($nav-width/20)
       border: none
     .title
-      font-size: ($headerheight / 3)
       font-weight: bold
-    .logo
-      width: $headerheight
-      height: @width
-      margin-right: ($nav-width/20)
 
   .footer
     bottom: 0
@@ -262,17 +297,12 @@
     overflow-y: hidden
     background-color: $core-text-default
     height: $footerheight
-    width: $nav-width
     .logo, .message-container
       top: 50%
       transform: translateY(-50%)
       position: relative
     .logo
       float: left
-      width: ($footerheight/2)
-      height: @width
-      margin-right: ($nav-width/20)
-      margin-left: ($nav-width/20)
     .message-container
       .message
         color: $core-bg-light

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash.throttle": "4.1.1",
     "lodash.values": "4.3.0",
     "loglevel": "1.4.1",
+    "material-design-icons": "^3.0.1",
     "normalize.css": "5.0.0",
     "rest": "1.3.2",
     "screenfull": "3.0.2",


### PR DESCRIPTION
## Summary

Implements a side nav for Kolibri following designs detailed here: https://learningequality.gitbooks.io/design-iterations/content/quick-links.html

## Reviewer guidance

This is mostly complete, but needs integration with #901 to properly set environments via JS media queries.

Currently defaulting to 'non-mobile'.

## Screenshots (if appropriate)

Tablet/Desktop:
![image](https://cloud.githubusercontent.com/assets/1680573/22956925/eefcb5a4-f2d9-11e6-882f-0738f67f6894.png)
(The top 'Kolibri' won't centre align for the life of me, hints appreciated!)

Mobile:

![image](https://cloud.githubusercontent.com/assets/1680573/22956944/12c04122-f2da-11e6-8614-b79a993d43ca.png)
