### PR TITLE
Add missing component core-base.

### DIFF
--- a/kolibri/plugins/user/assets/src/vue/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/index.vue
@@ -27,6 +27,7 @@
   module.exports = {
     name: 'User-Plugin',
     components: {
+      'core-base': require('kolibri.coreVue.components.coreBase'),
       'sign-in-page': require('./sign-in-page'),
       'sign-up-page': require('./sign-up-page'),
       'profile-page': require('./profile-page'),


### PR DESCRIPTION
## Summary

User plugin was missing component `core-base`.