### PR TITLE
better loading spinner display when renderer is missing

### DIFF
--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -3,7 +3,7 @@
   <div>
     <div v-if="available" class="fill-height">
       <div class="content-wrapper">
-        <loading-spinner v-if="!currentViewClass"/>
+        <loading-spinner id="spinner" v-if="!currentViewClass"/>
         <div ref="container"></div>
       </div>
     </div>
@@ -233,5 +233,8 @@
 
   .content-wrapper
     height: 100%
+
+  #spinner
+    height: 160px
 
 </style>


### PR DESCRIPTION
fix issue #770
until we have a way to inform the front-end certain renderer is missing, this is a low risk way to handle it.
![screen shot 2017-02-15 at 3 32 33 pm](https://cloud.githubusercontent.com/assets/5577205/23000165/0d146ffe-f394-11e6-8a60-c952787c1d87.png)
