### PR TITLE
Change 'Learn/Explore' to 'Recommended/Topics'.

### DIFF
--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -85,13 +85,11 @@
     $trs: {
       navigationLabel: 'Main user navigation',
       learn: 'Learn',
-      explore: 'Explore',
       manage: 'Manage',
       coach: 'Coach',
       signIn: 'Sign in',
       profile: 'Profile',
       logOut: 'Log out',
-      settings: 'Settings',
       about: 'About',
       closeNav: 'Close navigation',
       poweredBy: 'Powered by Kolibri {version}',
@@ -156,7 +154,7 @@
         return this.windowSize.breakpoint < 2;
       },
       tablet() {
-        return (this.windowSize.breakpoint > 1) & (this.windowSize.breakpoint < 5);
+        return (this.windowSize.breakpoint > 1) && (this.windowSize.breakpoint < 5);
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version }); // eslint-disable-line no-undef
@@ -168,7 +166,8 @@
         return this.$tr('navigationLabel');
       },
       learnActive() {
-        return this.topLevelPageName === TopLevelPageNames.LEARN_LEARN;
+        return (this.topLevelPageName === TopLevelPageNames.LEARN_LEARN) ||
+        (this.topLevelPageName === TopLevelPageNames.LEARN_EXPLORE);
       },
       coachActive() {
         return this.topLevelPageName === TopLevelPageNames.COACH;
@@ -188,7 +187,7 @@
             label: this.$tr('learn'),
             disabled: this.learnActive,
             icon: 'school',
-            href: '/learn/#/learn',
+            href: '/learn',
           },
         ];
         if (this.isCoachAdminOrSuperuser) {

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -15,42 +15,42 @@ class LearnModule extends KolibriModule {
       const routes = [
         {
           name: PageNames.EXPLORE_ROOT,
-          path: '/explore',
+          path: '/topics',
           handler: (toRoute, fromRoute) => {
             actions.redirectToExploreChannel(store);
           },
         },
         {
           name: PageNames.EXPLORE_CHANNEL,
-          path: '/explore/:channel_id',
+          path: '/topics/:channel_id',
           handler: (toRoute, fromRoute) => {
             actions.showExploreChannel(store, toRoute.params.channel_id);
           },
         },
         {
           name: PageNames.EXPLORE_TOPIC,
-          path: '/explore/:channel_id/topic/:id',
+          path: '/topics/:channel_id/topic/:id',
           handler: (toRoute, fromRoute) => {
             actions.showExploreTopic(store, toRoute.params.channel_id, toRoute.params.id);
           },
         },
         {
           name: PageNames.EXPLORE_CONTENT,
-          path: '/explore/:channel_id/content/:id',
+          path: '/topics/:channel_id/content/:id',
           handler: (toRoute, fromRoute) => {
             actions.showExploreContent(store, toRoute.params.channel_id, toRoute.params.id);
           },
         },
         {
           name: PageNames.LEARN_ROOT,
-          path: '/learn',
+          path: '/recommended',
           handler: (toRoute, fromRoute) => {
             actions.redirectToLearnChannel(store);
           },
         },
         {
           name: PageNames.LEARN_CHANNEL,
-          path: '/learn/:channel_id',
+          path: '/recommended/:channel_id',
           handler: (toRoute, fromRoute) => {
             const page = toRoute.query.page ? Number(toRoute.query.page) : 1;
             actions.showLearnChannel(store, toRoute.params.channel_id, page);
@@ -58,7 +58,7 @@ class LearnModule extends KolibriModule {
         },
         {
           name: PageNames.LEARN_CONTENT,
-          path: '/learn/:channel_id/content/:id',
+          path: '/recommended/:channel_id/content/:id',
           handler: (toRoute, fromRoute) => {
             actions.showLearnContent(store, toRoute.params.channel_id, toRoute.params.id);
           },
@@ -79,7 +79,7 @@ class LearnModule extends KolibriModule {
         },
         {
           path: '/',
-          redirect: '/explore',
+          redirect: '/recommended',
         },
       ];
 

--- a/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
@@ -55,7 +55,7 @@
   module.exports = {
     $trNameSpace: 'learn',
     $trs: {
-      explore: 'Explore',
+      explore: 'Topics',
       youAreHere: 'You are here:',
       back: 'Back to previous topic',
     },

--- a/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/explore-page/index.vue
@@ -46,7 +46,7 @@
   module.exports = {
     $trNameSpace: 'learnExplore',
     $trs: {
-      explore: 'Explore',
+      explore: 'Topics',
       navigate: 'You can navigate groups of content through headings.',
     },
     components: {

--- a/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/learn-page/index.vue
@@ -24,7 +24,7 @@
   module.exports = {
     $trNameSpace: 'learnIndex',
     $trs: {
-      learnName: 'Learn',
+      learnName: 'Recommended',
     },
     components: {
       'page-header': require('../page-header'),


### PR DESCRIPTION
## Summary

Quick, purely cosmetic, change of frontend strings so that the user never has to know of our Learn/Explore past.