### PR TITLE
Return user in response when signing up.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -140,7 +140,7 @@ class SignUpViewSet(viewsets.ViewSet):
             serialized_user.save()
             authenticated_user = authenticate(username=kwargs['username'], password=kwargs['password'], facility=kwargs['facility'])
             login(request, authenticated_user)
-            return Response(status=status.HTTP_201_CREATED)
+            return Response(serialized_user.data, status=status.HTTP_201_CREATED)
         else:
             # grab error if related to username
             error = serialized_user.errors.get('username', None)

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 from .models import Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership, Role
@@ -36,7 +37,7 @@ class FacilityUserSerializer(serializers.ModelSerializer):
 
     def validate_username(self, value):
         if FacilityUser.objects.filter(username__iexact=value).exists() | DeviceOwner.objects.filter(username__iexact=value).exists():
-            raise serializers.ValidationError('An account with that username already exists.')
+            raise serializers.ValidationError(_('An account with that username already exists.'))
         return value
 
 
@@ -64,7 +65,7 @@ class DeviceOwnerSerializer(serializers.ModelSerializer):
 
     def validate_username(self, value):
         if FacilityUser.objects.filter(username__iexact=value).exists() | DeviceOwner.objects.filter(username__iexact=value).exists():
-            raise serializers.ValidationError('An account with that username already exists.')
+            raise serializers.ValidationError(_('An account with that username already exists.'))
         return value
 
 

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -321,7 +321,7 @@ class LoginLogoutTestCase(APITestCase):
         self.assertTrue(response.data['kind'][0], 'anonymous')
 
 
-class SignUpTestCase(APITestCase):
+class AnonSignUpTestCase(APITestCase):
 
     def setUp(self):
         self.device_owner = DeviceOwnerFactory.create()
@@ -331,6 +331,12 @@ class SignUpTestCase(APITestCase):
         response = self.client.post(reverse('signup-list'), data={"username": "user", "password": DUMMY_PASSWORD})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(models.FacilityUser.objects.all())
+
+    def test_anon_sign_up_returns_user(self):
+        full_name = "Bob Lee"
+        response = self.client.post(reverse('signup-list'), data={"full_name": full_name, "username": "user", "password": DUMMY_PASSWORD})
+        self.assertEqual(response.data['username'], 'user')
+        self.assertEqual(response.data['full_name'], full_name)
 
     def test_create_user_with_same_username_fails(self):
         FacilityUserFactory.create(username='bob')


### PR DESCRIPTION
## Summary

Return the user data along with the response for signing up a user. Also, added translation wrapping on error messages for user creation validation. 