### PR TITLE
Dataset endpoint and anon permissions

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -5,9 +5,10 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.response import Response
 
-from .models import Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership, Role
+from .models import Classroom, DeviceOwner, Facility, FacilityDataset, FacilityUser, LearnerGroup, Membership, Role
 from .serializers import (
-    ClassroomSerializer, DeviceOwnerSerializer, FacilitySerializer, FacilityUserSerializer, LearnerGroupSerializer, MembershipSerializer, RoleSerializer
+    ClassroomSerializer, DeviceOwnerSerializer, FacilitySerializer, FacilityDatasetSerializer,
+    FacilityUserSerializer, LearnerGroupSerializer, MembershipSerializer, RoleSerializer
 )
 
 
@@ -61,6 +62,13 @@ class KolibriAuthPermissions(permissions.BasePermission):
             return request.user.can_delete(obj)
         else:
             return False
+
+
+class FacilityDatasetViewSet(viewsets.ModelViewSet):
+    permissions_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = FacilityDataset.objects.all()
+    serializer_class = FacilityDatasetSerializer
 
 
 class FacilityUserViewSet(viewsets.ModelViewSet):

--- a/kolibri/auth/api_urls.py
+++ b/kolibri/auth/api_urls.py
@@ -1,12 +1,13 @@
 from rest_framework import routers
 
 from .api import (
-    ClassroomViewSet, CurrentFacilityViewSet, DeviceOwnerViewSet, FacilityUserViewSet, FacilityViewSet, LearnerGroupViewSet, MembershipViewSet, RoleViewSet,
-    SessionViewSet, SignUpViewSet
+    ClassroomViewSet, CurrentFacilityViewSet, DeviceOwnerViewSet, FacilityDatasetViewSet, FacilityUserViewSet,
+    FacilityViewSet, LearnerGroupViewSet, MembershipViewSet, RoleViewSet, SessionViewSet, SignUpViewSet
 )
 
 router = routers.SimpleRouter()
 
+router.register(r'facilitydataset', FacilityDatasetViewSet)
 router.register(r'facilityuser', FacilityUserViewSet)
 router.register(r'deviceowner', DeviceOwnerViewSet)
 router.register(r'membership', MembershipViewSet)

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -44,7 +44,10 @@ from .errors import (
     UserIsNotFacilityUser, UserIsNotMemberError
 )
 from .filters import HierarchyRelationsFilter
-from .permissions.auth import AnybodyCanCreateIfNoDeviceOwner, AnybodyCanCreateIfNoFacility, CollectionSpecificRoleBasedPermissions
+from .permissions.auth import (
+    AnybodyCanCreateIfNoDeviceOwner, AnybodyCanCreateIfNoFacility, CollectionSpecificRoleBasedPermissions,
+    AnonUserCanReadFacilitiesThatAllowSignUps
+)
 from .permissions.base import BasePermissions, RoleBasedPermissions
 from .permissions.general import IsAdminForOwnFacility, IsFromSameFacility, IsOwn, IsSelf
 
@@ -604,7 +607,12 @@ class Collection(MPTTModel, AbstractFacilityDataModel):
     # Collection can be read by anybody from the facility; writing is only allowed by an admin for the collection.
     # Furthermore, no FacilityUser can create or delete a Facility. Permission to create a collection is governed
     # by roles in relation to the new collection's parent collection (see CollectionSpecificRoleBasedPermissions).
-    permissions = IsFromSameFacility(read_only=True) | CollectionSpecificRoleBasedPermissions() | AnybodyCanCreateIfNoFacility()
+    permissions = (
+        IsFromSameFacility(read_only=True) |
+        CollectionSpecificRoleBasedPermissions() |
+        AnybodyCanCreateIfNoFacility() |
+        AnonUserCanReadFacilitiesThatAllowSignUps()
+    )
 
     _KIND = None  # Should be overridden in subclasses to specify what "kind" they are
 

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -46,7 +46,7 @@ from .errors import (
 from .filters import HierarchyRelationsFilter
 from .permissions.auth import (
     AnybodyCanCreateIfNoDeviceOwner, AnybodyCanCreateIfNoFacility, CollectionSpecificRoleBasedPermissions,
-    AnonUserCanReadFacilitiesThatAllowSignUps
+    AnonUserCanReadFacilitiesThatAllowSignUps, IsAdminForOwnFacilityDataset
 )
 from .permissions.base import BasePermissions, RoleBasedPermissions
 from .permissions.general import IsAdminForOwnFacility, IsFromSameFacility, IsOwn, IsSelf
@@ -66,6 +66,8 @@ class FacilityDataset(models.Model):
     from ``AbstractFacilityDataModel``) foreign key onto, to indicate that they belong to this particular ``Facility``.
     """
 
+    permissions = IsAdminForOwnFacilityDataset()
+
     description = models.TextField(blank=True)
     location = models.CharField(max_length=200, blank=True)
 
@@ -82,6 +84,7 @@ class FacilityDataset(models.Model):
             return "FacilityDataset for {}".format(Facility.objects.get(id=facilities[0].id))
         else:
             return "FacilityDataset (no associated Facility)"
+
 
 class AbstractFacilityDataModel(models.Model):
     """

--- a/kolibri/auth/permissions/auth.py
+++ b/kolibri/auth/permissions/auth.py
@@ -81,10 +81,7 @@ class AnonUserCanReadFacilitiesThatAllowSignUps(DenyAll):
 
     def readable_by_user_filter(self, user, queryset):
         if isinstance(user, AnonymousUser):
-            obj = queryset.first()
-            if hasattr(obj, 'kind'):
-                if obj.kind == FACILITY:
-                    return queryset.filter(dataset__learner_can_sign_up=True)
+            return queryset.filter(dataset__learner_can_sign_up=True, kind=FACILITY)
         return queryset.none()
 
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from rest_framework import serializers
 
-from .models import Classroom, DeviceOwner, Facility, FacilityUser, LearnerGroup, Membership, Role
+from .models import Classroom, DeviceOwner, Facility, FacilityDataset, FacilityUser, LearnerGroup, Membership, Role
 
 class RoleSerializer(serializers.ModelSerializer):
 
@@ -73,6 +73,14 @@ class MembershipSerializer(serializers.ModelSerializer):
     class Meta:
         model = Membership
         exclude = ("dataset",)
+
+
+class FacilityDatasetSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = FacilityDataset
+        fields = ('id', 'learner_can_edit_username', 'learner_can_edit_name', 'learner_can_edit_password',
+                  'learner_can_sign_up', 'learner_can_delete_account', 'description', 'location')
 
 
 class FacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/auth/test/helpers.py
+++ b/kolibri/auth/test/helpers.py
@@ -4,7 +4,7 @@ Helper functions for use across the user/auth/permission-related tests.
 
 from ..models import FacilityUser, Facility, Classroom, LearnerGroup, FacilityDataset
 
-def create_dummy_facility_data(classroom_count=2, learnergroup_count=2):
+def create_dummy_facility_data(allow_sign_ups=False, classroom_count=2, learnergroup_count=2):
     """
     Helper to bootstrap facility data for use in role/permission scenarios (collections, users, and roles).
     This can be called multiple times to create parallel facilities/datasets in the same database, to test
@@ -19,7 +19,7 @@ def create_dummy_facility_data(classroom_count=2, learnergroup_count=2):
     data = {}
 
     # create the dataset object with which this data will be associated
-    dataset = data["dataset"] = FacilityDataset.objects.create()
+    dataset = data["dataset"] = FacilityDataset.objects.create(learner_can_sign_up=allow_sign_ups)
 
     # create the Collection hierarchy
     facility = data["facility"] = Facility.objects.create(dataset=dataset)


### PR DESCRIPTION
## Summary
Added endpoint for facility dataset. Permissions should only allow admins access for the facilitydataset that they belong to. Anonymous users can now read facilities that allow learner sign ups.

## TODO

- [x] Have tests been written for the new code?
