### PR TITLE
Don't try to modify non-object options passed in with a cache buster.

### DIFF
--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -146,7 +146,8 @@ module.exports = class CoreApp {
 
   get client() {
     return (options) => {
-      if (!options.method || options.method === 'GET') {
+      if ((options && typeof options === 'object' && !Array.isArray(options)) &&
+        (!options.method || options.method === 'GET')) {
         if (!options.params) {
           options.params = {};
         }


### PR DESCRIPTION
Kolibri.client also sometimes gets used just with a string as the only parameter, which meant that the cache busting logic was trying to do something bad.

Make sure we have an object before we try to modify it like one.