### PR TITLE
Get pex files exported as artifacts on buildkite

### DIFF
--- a/.buildkite/build_pex.sh
+++ b/.buildkite/build_pex.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+pip install pex                 # pex is really the only thing we need here.
 buildkite-agent artifact download 'dist/*.whl' dist/
 make pex
 buildkite-agent artifact upload 'dist/*.pex'

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ dist: writeversion staticdeps assets compilemessages
 	ls -l dist
 
 pex:
-	pex dist/*.whl --disable-cache -o dist/`python setup.py --fullname`.pex -m kolibri --python-shebang=/usr/bin/python
+	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`unzip -p $$whlfile kolibri/VERSION`.pex -m kolibri --python-shebang=/usr/bin/python; done
 
 makedocsmessages:
 	make -C docs/ gettext


### PR DESCRIPTION
## Summary

Find the right magic text to get pex to build on servers that only have the whl file. Useful for agents that may not have built the whl file themselves.

