### PR TITLE
Port of kolibri

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -37,7 +37,7 @@ Supported by Foundation for Learning Equality
 www.learningequality.org
 
 Usage:
-  kolibri start [--foreground --watch] [options] [-- DJANGO_OPTIONS ...]
+  kolibri start [--foreground --watch] [--port=<port>] [options] [-- DJANGO_OPTIONS ...]
   kolibri stop [options] [-- DJANGO_OPTIONS ...]
   kolibri restart [options] [-- DJANGO_OPTIONS ...]
   kolibri status [options]
@@ -293,5 +293,6 @@ def main(args=None):
         return
 
     if arguments['start']:
-        server.start()
+        port = int(arguments['--port'] or 8080)
+        server.start(port=port)
         return

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -1,33 +1,34 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from . import server
 
+import importlib  # noqa
+import logging  # noqa
 # Do this before importing anything else, we need to add bundled requirements
 # from the distributed version in case it exists before importing anything
 # else.
 # TODO: Do we want to manage the path at an even more fundametal place like
 # kolibri.__init__ !? Load order will still matter...
 import os  # noqa
+import signal  # noqa
 import sys  # noqa
+from logging import config as logging_config  # noqa
+
+import django  # noqa
+from django.core.management import call_command  # noqa
+from docopt import docopt  # noqa
+
 import kolibri  # noqa
 from kolibri import dist as kolibri_dist  # noqa
 
+from . import server
+
 # Setup path in case we are running with dependencies bundled into Kolibri
-sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
-
-import django  # noqa
-import importlib  # noqa
-import logging  # noqa
-import signal  # noqa
-
-from docopt import docopt  # noqa
-from logging import config as logging_config  # noqa
-from django.core.management import call_command  # noqa
+sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))
+            ] + sys.path
 
 # Force python2 to interpret every string as unicode.
 if sys.version[0] == '2':
     reload(sys)
     sys.setdefaultencoding('utf8')
-
 
 USAGE = """
 Kolibri
@@ -96,12 +97,14 @@ Auto-generated usage instructions from ``kolibri -h``::
 
 """.format(usage="\n".join(map(lambda x: "    " + x, USAGE.split("\n"))))
 
-
 # Set default env
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
-os.environ.setdefault("KOLIBRI_HOME", os.path.join(os.path.expanduser("~"), ".kolibri"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
+)
+os.environ.setdefault(
+    "KOLIBRI_HOME", os.path.join(os.path.expanduser("~"), ".kolibri")
+)
 os.environ.setdefault("KOLIBRI_LISTEN_PORT", "8008")
-
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +126,9 @@ def _first_run():
     found.
     """
     if os.path.exists(VERSION_FILE):
-        logger.error("_first_run() called, but Kolibri is already initialized.")
+        logger.error(
+            "_first_run() called, but Kolibri is already initialized."
+        )
         return
     logger.info("Kolibri running for the first time.")
     logger.info(
@@ -206,13 +211,21 @@ def plugin(plugin_name, **args):
 
     # Try to load kolibri_plugin from given plugin module identifier
     try:
-        plugin_module = importlib.import_module(plugin_name + ".kolibri_plugin")
+        plugin_module = importlib.import_module(
+            plugin_name + ".kolibri_plugin"
+        )
         for obj in plugin_module.__dict__.values():
-            if type(obj) == type and obj is not KolibriPluginBase and issubclass(obj, KolibriPluginBase):
+            if type(obj
+                    ) == type and obj is not KolibriPluginBase and issubclass(
+                        obj, KolibriPluginBase
+                    ):
                 plugin_classes.append(obj)
     except ImportError as e:
         if e.message.startswith("No module named"):
-            raise PluginDoesNotExist("Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?".format(plugin_name))
+            raise PluginDoesNotExist(
+                "Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?".
+                format(plugin_name)
+            )
         else:
             raise
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -199,6 +199,15 @@ def manage(cmd, args=[]):
     execute_from_command_line(argv=argv)
 
 
+def _is_plugin(obj):
+    from kolibri.plugins.base import KolibriPluginBase  # NOQA
+
+    return (
+        isinstance(obj, type) and obj is not KolibriPluginBase and
+        issubclass(obj, KolibriPluginBase)
+    )
+
+
 def plugin(plugin_name, **args):
     """
     Receives a plugin identifier and tries to load its main class. Calls class
@@ -207,18 +216,13 @@ def plugin(plugin_name, **args):
     from kolibri.utils import conf
     plugin_classes = []
 
-    from kolibri.plugins.base import KolibriPluginBase  # NOQA
-
     # Try to load kolibri_plugin from given plugin module identifier
     try:
         plugin_module = importlib.import_module(
             plugin_name + ".kolibri_plugin"
         )
         for obj in plugin_module.__dict__.values():
-            if type(obj
-                    ) == type and obj is not KolibriPluginBase and issubclass(
-                        obj, KolibriPluginBase
-                    ):
+            if _is_plugin(obj):
                 plugin_classes.append(obj)
     except ImportError as e:
         if e.message.startswith("No module named"):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -21,7 +21,9 @@ def start_background_workers():
     p.start()
 
 
-def start():
+def start(port=None):
+
+    server_port = port or 8080
 
     # TODO(aronasorman): move to install/plugin-enabling scripts, and remove from here
     call_command("collectstatic", interactive=False)
@@ -37,17 +39,22 @@ def start():
     from kolibri.content.utils.annotation import update_channel_metadata_cache
     update_channel_metadata_cache()
 
-    run_server()
+    run_server(port=server_port)
 
-def run_server():
+
+def run_server(port):
 
     # Mount the application
     from kolibri.deployment.default.wsgi import application
     cherrypy.tree.graft(application, "/")
 
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
-    serve_static_dir(settings.CONTENT_DATABASE_DIR, paths.get_content_database_url("/"))
-    serve_static_dir(settings.CONTENT_STORAGE_DIR, paths.get_content_storage_url("/"))
+    serve_static_dir(
+        settings.CONTENT_DATABASE_DIR, paths.get_content_database_url("/")
+    )
+    serve_static_dir(
+        settings.CONTENT_STORAGE_DIR, paths.get_content_storage_url("/")
+    )
 
     # Unsubscribe the default server
     cherrypy.server.unsubscribe()
@@ -55,9 +62,9 @@ def run_server():
     # Instantiate a new server object
     server = cherrypy._cpserver.Server()
 
-    # Configure the server settings
+    # Configure the server
     server.socket_host = "0.0.0.0"
-    server.socket_port = 8080
+    server.socket_port = port
     server.thread_pool = 30
 
     # Subscribe this server
@@ -66,6 +73,7 @@ def run_server():
     # Start the server engine (Option 1 *and* 2)
     cherrypy.engine.start()
     cherrypy.engine.block()
+
 
 def serve_static_dir(root, url):
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -6,11 +6,12 @@ import platform
 import cherrypy
 from django.conf import settings
 from django.core.management import call_command
+
 from kolibri.content.utils import paths
 
 
 def start_background_workers():
-    p = multiprocessing.Process(target=call_command, args=("qcluster",))
+    p = multiprocessing.Process(target=call_command, args=("qcluster", ))
 
     # note: atexit normally only runs when python exits normally, aka doesn't
     # exit through a signal. However, this function gets run because cherrypy


### PR DESCRIPTION
Add a `--port=<port>` option to Kolibri's cli. Sample call:

```
python -m kolibri start --port=8090
```

Other changes are due to automatic linting.