### PR TITLE
Upgrade perseus renderer to 0.3.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri-exercise-perseus-plugin==0.3.8
+kolibri-exercise-perseus-plugin==0.3.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri-exercise-perseus-plugin==0.3.7
+kolibri-exercise-perseus-plugin==0.3.8


### PR DESCRIPTION
## Summary

Adds in version that has KAS in order to fix https://github.com/learningequality/kolibri-exercise-perseus-plugin/issues/38