### PR TITLE
cleanup navbar sizing

### DIFF
--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -95,7 +95,7 @@
         return this.mobile ? 56 : 64;
       },
       navWidth() {
-        return this.navShown ? this.headerHeight * 5 : 0;
+        return this.navShown ? this.headerHeight * 4 : 0;
       },
       appBarStyle() {
         return { paddingLeft: `${this.navWidth + PADDING}px` };

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -3,7 +3,7 @@
   <div :class="`gutter-${windowSize.gutterWidth}`">
     <app-bar
       class="app-bar"
-      :style="navStyle"
+      :style="appBarStyle"
       @toggleSideNav="navShown=!navShown"
       :title="appBarTitle"
       :navShown="navShown"
@@ -34,6 +34,8 @@
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
   const values = require('lodash.values');
   const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
+
+  const PADDING = 32;
 
   module.exports = {
     mixins: [responsiveWindow],
@@ -93,23 +95,13 @@
         return this.mobile ? 56 : 64;
       },
       navWidth() {
-        return 270;
+        return this.navShown ? this.headerHeight * 5 : 0;
       },
-      navPadding() {
-        const PADDING = 32;
-        if (this.mobile || !this.navShown) {
-          return PADDING;
-        }
-        return this.navWidth + PADDING;
-      },
-      navStyle() {
-        if (this.navShown) {
-          return { paddingLeft: `${this.navPadding}px` };
-        }
-        return '';
+      appBarStyle() {
+        return { paddingLeft: `${this.navWidth + PADDING}px` };
       },
       contentStyle() {
-        return { left: `${this.navPadding}px`, top: `${this.headerHeight}px` };
+        return { left: `${this.navWidth}px`, top: `${this.headerHeight}px` };
       },
     },
     mounted() {
@@ -147,6 +139,6 @@
     right: 0
     bottom: 0
     padding-bottom: 40px
-    padding-right: 32px
+    padding: 32px
 
 </style>

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -35,7 +35,7 @@
   const values = require('lodash.values');
   const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
 
-  const PADDING = 32;
+  const PADDING = 16;
 
   module.exports = {
     mixins: [responsiveWindow],

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -419,5 +419,6 @@
         background-color: $core-text-annotation
     &.ui-menu
       border: none
+      max-width: 320px
 
 </style>

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -24,7 +24,7 @@
         -->
         <img
           class="header-logo"
-          v-if="mobile"
+          v-if="mobile || tablet"
           src="./instant.png"
           alt="instant-schools-logo">
         <span class="title">{{ $tr('instant') }}</span>
@@ -335,7 +335,7 @@
     z-index: 1003
     top: 0
     left: 0
-    font-size: 18px
+    font-size: 14px
     text-transform: uppercase
     overflow: auto
     overflow-y: hidden
@@ -402,11 +402,10 @@
     .ui-menu-option
       margin: 5px 0
       &:not(.is-divider)
-        font-size: 1.2em
+        font-size: 14px
         &.is-disabled
           .ui-menu-option__icon
             color: $core-accent-color
-            font-weight: bold
           color: $core-accent-color
           cursor: default
           font-weight: bold


### PR DESCRIPTION
* addresses #962 
* addresses style tech debt here mentioned here: https://github.com/learningequality/kolibri/pull/959#discussion_r102336923
* make fonts and width smaller, trying to get [closer to specs](https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs)
* make top logo shown in mobile or tablet views


I’m not sure about the font sizing but I think it looks a little better. The spacing around the logo on top looks a little weird because the ‘collapse’ button is pretty large in comparison

Before:

![image](https://cloud.githubusercontent.com/assets/2367265/23196610/8b81c244-f86f-11e6-8d9c-7b3dbc33ad10.png)


After:

![image](https://cloud.githubusercontent.com/assets/2367265/23196595/778989ac-f86f-11e6-90d6-41826f752c20.png)
