### PR TITLE
Stricter build steps

### DIFF
--- a/.buildkite/build_pex.sh
+++ b/.buildkite/build_pex.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/.buildkite/build_pex.sh
+++ b/.buildkite/build_pex.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -euo pipefail
+
 pip install pex                 # pex is really the only thing we need here.
 buildkite-agent artifact download 'dist/*.whl' dist/
 make pex

--- a/.buildkite/build_whl.sh
+++ b/.buildkite/build_whl.sh
@@ -1,4 +1,6 @@
-l#!/usr/bin/env bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 make dockerenvdist
 buildkite-agent artifact upload 'dist/*.whl'


### PR DESCRIPTION
## Summary

Make sure we error out when a step inside the build scripts fail. Also change one of the script's default interpreter to bash.