### PR TITLE
Drawer Change: Remove Big Logo

### DIFF
--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -302,14 +302,6 @@
       margin: auto
       display: inline-block
 
-  .logo-large-wrapper
-    text-align: center
-
-  .logo-large
-    width: 50%
-    margin-top: 1em
-    margin-bottom: 1em
-
   .nav-main
     background: $core-bg-light
 

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -17,31 +17,17 @@
         <!--
         <img
           class="header-logo"
-          v-if="mobile"
           src="../login-modal/icons/kolibri-logo.svg"
           alt="kolibri-logo">
         <span class="title" >Kolibri</span>
         -->
         <img
           class="header-logo"
-          v-if="mobile || tablet"
           src="./instant.png"
           alt="instant-schools-logo">
         <span class="title">{{ $tr('instant') }}</span>
       </div>
       <div class="scrollable-nav" :style="{ width: width + 'px', paddingTop: `${headerHeight + 16}px` }">
-        <div class="logo-large-wrapper">
-          <img
-            src="./instant.png"
-            v-if="!mobile && !tablet"
-            class="logo-large">
-          <!--
-          <file-svg
-            src="../login-modal/icons/kolibri-logo.svg"
-            v-if="!mobile"
-            class="logo-large"/>
-          -->
-        </div>
         <ui-menu
           class="nav-main"
           :options="menuOptions"


### PR DESCRIPTION
## Summary

Keep the logo in the header of the drawer in all screen sizes as recommended by @khangmach 

### Before

![127 0 0 1-8000-learn- 2](https://cloud.githubusercontent.com/assets/7193975/23238092/3589b620-f915-11e6-9043-ebc4d4612c98.png)

### After

![127 0 0 1-8000-learn- 3](https://cloud.githubusercontent.com/assets/7193975/23238093/3598eac8-f915-11e6-8a1e-8b5a7aa0b4a9.png)