### PR TITLE
Add app bar titles to user page.

### DIFF
--- a/kolibri/plugins/user/assets/src/vue/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <core-base v-if="navBarNeeded" :topLevelPageName="topLevelPageName">
+  <core-base v-if="navBarNeeded" :topLevelPageName="topLevelPageName" :appBarTitle="appBarTitle">
     <component
       slot="content"
       class="user page"
@@ -25,6 +25,10 @@
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
 
   module.exports = {
+    $trNameSpace: 'user-root',
+    $trs: {
+      userProfileTitle: 'Profile',
+    },
     name: 'User-Plugin',
     components: {
       'core-base': require('kolibri.coreVue.components.coreBase'),
@@ -33,6 +37,12 @@
       'profile-page': require('./profile-page'),
     },
     computed: {
+      appBarTitle() {
+        if (this.pageName === PageNames.PROFILE) {
+          return this.$tr('userProfileTitle');
+        }
+        return null;
+      },
       topLevelPageName: () => TopLevelPageNames.USER,
       currentPage() {
         if (this.pageName === PageNames.SIGN_IN) {


### PR DESCRIPTION
## Summary

Adds app bar titles to the user page, to fix #981.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1680573/23385565/7c6785b0-fd05-11e6-8119-b65133dfc1b7.png)

