### PR TITLE
Do not apply a left offset if drawer is temporary.

### DIFF
--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -101,7 +101,11 @@
         return { paddingLeft: `${this.navWidth + PADDING}px` };
       },
       contentStyle() {
-        return { left: `${this.navWidth}px`, top: `${this.headerHeight}px` };
+        const style = { top: `${this.headerHeight}px` };
+        if (!this.mobile) {
+          style.left = `${this.navWidth}px`;
+        }
+        return style;
       },
     },
     mounted() {


### PR DESCRIPTION
## Summary

Do not apply a left offset if drawer is temporary.

## Issues addressed

A left offset was being applied even on mobile.

## Before

![image](https://cloud.githubusercontent.com/assets/7193975/23389709/b14824ba-fd1e-11e6-9204-59b490f5a21b.png)

## After

![image](https://cloud.githubusercontent.com/assets/7193975/23389692/9e60fc00-fd1e-11e6-9bde-ed0131afed84.png)
