### PR TITLE
move facility_id to be in user mgmt page state

### DIFF
--- a/kolibri/plugins/management/assets/src/actions.js
+++ b/kolibri/plugins/management/assets/src/actions.js
@@ -105,7 +105,7 @@ function assignUserRole(user, kind) {
  */
 function createUser(store, stateUserData) {
   const userData = {
-    facility: stateUserData.facility_id,
+    facility: store.pageState.facility_id,
     username: stateUserData.username,
     full_name: stateUserData.full_name,
     password: stateUserData.password,
@@ -158,9 +158,6 @@ function updateUser(store, stateUser) {
   }
   if (stateUser.password && stateUser.password !== savedUser.password) {
     changedValues.password = stateUser.password;
-  }
-  if (stateUser.facility && stateUser.facility !== savedUser.facility) {
-    changedValues.facility = stateUser.facility;
   }
 
   if (stateUser.kind && stateUser.kind !== _userState(savedUser).kind) {
@@ -240,12 +237,10 @@ function showUserPage(store) {
   ConditionalPromise.all(promises).only(
     samePageCheckGenerator(store),
     ([facilityId, users]) => {
-      store.dispatch('SET_FACILITY', facilityId[0]); // for mvp, we assume only one facility exists
-
       const pageState = {
         users: users.map(_userState),
+        facility_id: facilityId[0],
       };
-
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);

--- a/kolibri/plugins/management/assets/src/state/store.js
+++ b/kolibri/plugins/management/assets/src/state/store.js
@@ -27,7 +27,6 @@ Content import/export page:
 const initialState = {
   pageName: constants.PageNames.USER_MGMT_PAGE,
   pageState: {},
-  facility: undefined,
 };
 
 const mutations = {
@@ -47,9 +46,6 @@ const mutations = {
   },
   DELETE_USER(state, id) {
     state.pageState.users = state.pageState.users.filter(user => user.id !== id);
-  },
-  SET_FACILITY(state, id) {
-    state.facility = id;
   },
   SET_PAGE_NAME(state, name) {
     state.pageName = name;

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -120,7 +120,6 @@
         const newUser = {
           username: this.username,
           full_name: this.full_name,
-          facility_id: this.facility,
           kind: this.kind,
         };
 
@@ -161,9 +160,6 @@
       },
     },
     vuex: {
-      getters: {
-        facility: state => state.facility,
-      },
       actions: {
         createUser: actions.createUser,
       },

--- a/kolibri/plugins/user/assets/src/actions.js
+++ b/kolibri/plugins/user/assets/src/actions.js
@@ -41,9 +41,7 @@ function editProfile(store, edits, session) {
   // }
 
   // check to see if anything's changed and conditionally add last requirement
-  if (Object.keys(changedValues).length) {
-    changedValues.facility = session.facility_id;
-  } else {
+  if (!Object.keys(changedValues).length) {
     return;
   }
 


### PR DESCRIPTION

Previously it was global in the management state which wasn't quite correct.

Also removed unnecessary checks when updating users, because you can't change the facility ID of a user