### PR TITLE
Make all renderers findable, and make better errors when they are not found.

### DIFF
--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -427,7 +427,8 @@ module.exports = class Mediator {
       if (!kolibriModuleName) {
         // Our content renderer registry does not have a renderer for this content kind/extension.
         reject(
-          `No registered content renderer available for kind: ${kind} with file extension: ${extension}`);
+          `No registered content renderer available for kind: ${kind} with file extension: ${extension}`
+        );
       } else if (this._kolibriModuleRegistry[kolibriModuleName]) {
         // There is a named renderer for this kind/extension combination, and it is already loaded.
         resolve(this._kolibriModuleRegistry[kolibriModuleName].rendererComponent);

--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -426,7 +426,8 @@ module.exports = class Mediator {
       const kolibriModuleName = (this._contentRendererRegistry[kind] || {})[extension];
       if (!kolibriModuleName) {
         // Our content renderer registry does not have a renderer for this content kind/extension.
-        reject('No registered content renderer available');
+        reject(
+          `No registered content renderer available for kind: ${kind} with file extension: ${extension}`);
       } else if (this._kolibriModuleRegistry[kolibriModuleName]) {
         // There is a named renderer for this kind/extension combination, and it is already loaded.
         resolve(this._kolibriModuleRegistry[kolibriModuleName].rendererComponent);

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -1,9 +1,9 @@
 <template>
 
   <div>
-    <div v-if="noRendererAvailable">
-      {{ $tr('contentNotAvailable') }}
-    </div>
+    <ui-alert v-if="noRendererAvailable" :dismissible="false" type="error">
+        {{ $tr('rendererNotAvailable') }}
+    </ui-alert>
     <div v-else-if="available" class="fill-height">
       <div class="content-wrapper">
         <loading-spinner id="spinner" v-if="!currentViewClass"/>
@@ -27,7 +27,7 @@
     $trNameSpace: 'contentRender',
     $trs: {
       msgNotAvailable: 'This content is not available',
-      contentNotAvailable: 'Kolibri is unable to render this content',
+      rendererNotAvailable: 'Kolibri is unable to render this content',
     },
     props: {
       id: {
@@ -61,6 +61,7 @@
     },
     components: {
       'loading-spinner': require('kolibri.coreVue.components.loadingSpinner'),
+      'ui-alert': require('keen-ui/src/UiAlert'),
     },
     computed: {
       extension() {

--- a/kolibri/core/assets/src/vue/content-renderer/index.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <ui-alert v-if="noRendererAvailable" :dismissible="false" type="error">
-        {{ $tr('rendererNotAvailable') }}
+      {{ $tr('rendererNotAvailable') }}
     </ui-alert>
     <div v-else-if="available" class="fill-height">
       <div class="content-wrapper">

--- a/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
+++ b/kolibri/plugins/audio_mp3_render/kolibri_plugin.py
@@ -8,7 +8,7 @@ class AudioMP3RenderPlugin(KolibriPluginBase):
     pass
 
 
-class AudioMP3RenderAsset(content_hooks.WebpackBundleHook):
+class AudioMP3RenderAsset(content_hooks.ContentRendererHook):
     unique_slug = "audio_mp3_render_module"
     src_file = "assets/src/module.js"
     content_types_file = "assets/src/content_types.json"

--- a/kolibri/plugins/document_pdf_render/kolibri_plugin.py
+++ b/kolibri/plugins/document_pdf_render/kolibri_plugin.py
@@ -8,7 +8,7 @@ class DocumentPDFRenderPlugin(KolibriPluginBase):
     pass
 
 
-class DocumentPDFRenderAsset(content_hooks.WebpackBundleHook):
+class DocumentPDFRenderAsset(content_hooks.ContentRendererHook):
     unique_slug = "document_pdf_render_module"
     src_file = "assets/src/module.js"
     content_types_file = "assets/src/content_types.json"

--- a/kolibri/plugins/html5_app_renderer/kolibri_plugin.py
+++ b/kolibri/plugins/html5_app_renderer/kolibri_plugin.py
@@ -8,7 +8,7 @@ class HTML5AppPlugin(KolibriPluginBase):
     pass
 
 
-class HTML5AppAsset(content_hooks.WebpackBundleHook):
+class HTML5AppAsset(content_hooks.ContentRendererHook):
     unique_slug = "html5_app_renderer_module"
     src_file = "assets/src/module.js"
     content_types_file = "assets/src/content_types.json"


### PR DESCRIPTION
## Summary

Fix some poor code I had previously committed, and make UI for errors better.

Fixes #1003 

## Screenshots

With HTML5 renderer explicitly disabled:

![image](https://cloud.githubusercontent.com/assets/1680573/23567952/6b7dd528-000d-11e7-9ab9-ac04990dfdb7.png)

Enabled:

![image](https://cloud.githubusercontent.com/assets/1680573/23568009/9d6cf0c8-000d-11e7-9a2b-d5c614ba7d9e.png)

