### PR TITLE
Updates perseus renderer version to be compatible with new content renderer API.

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -154,7 +154,7 @@ class WebpackBundleHook(hooks.KolibriHook):
                 "name": self.unique_slug,
                 "src_file": self.src_file,
                 "static_dir": self._static_dir,
-                "plugin_path": os.path.dirname(self._build_path),
+                "plugin_path": self._module_file_path,
                 "stats_file": self._stats_file,
                 "events": self.events,
                 "once": self.once,
@@ -207,7 +207,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         """
         Returns the path of the class inheriting this classmethod.
         """
-        return os.path.join(*self.__module__.split(".")[:-1])
+        return os.path.dirname(self._build_path)
 
     def frontend_message_file(self, lang_code):
         message_file_name = "{name}-messages.json".format(name=self.unique_slug)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.4.4
+kolibri_exercise_perseus_plugin==0.5.0


### PR DESCRIPTION
Also fixes module_file_path property so that it returns a useable file path.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/23770429/d4f5c434-04c7-11e7-8659-056821928be7.png)

