### PR TITLE
Set default language through a command line argument

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -43,7 +43,6 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -135,7 +134,6 @@ if not os.path.exists(CONTENT_STORAGE_DIR):
 # Base default URL for downloading content from an online server
 CENTRAL_CONTENT_DOWNLOAD_BASE_URL = "https://contentworkshop.learningequality.org"
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 
@@ -145,7 +143,7 @@ LANGUAGES = [
     ('es-es', 'Español'),
 ]
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = conf.config.get("LANGUAGE_CODE") or "en-us"
 
 TIME_ZONE = 'UTC'
 
@@ -183,13 +181,11 @@ Q_CLUSTER = {
     "sync": platform.system() == "Windows",
 }
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(KOLIBRI_HOME, "static")
-
 
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
 # https://docs.djangoproject.com/en/1.9/topics/logging/
@@ -291,11 +287,9 @@ REST_FRAMEWORK = {
     ),
 }
 
-
 # System warnings to disable
 # see https://docs.djangoproject.com/en/1.9/ref/settings/#silenced-system-checks
 SILENCED_SYSTEM_CHECKS = ["auth.W004"]
-
 
 # Configuration for Django JS Reverse
 # https://github.com/ierror/django-js-reverse#options

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -253,9 +253,19 @@ def set_default_language(lang):
     """
 
     from kolibri.utils import conf
+    from django.conf import settings
 
-    conf.config['LANGUAGE_CODE'] = lang
-    conf.save()
+    valid_languages = [l[0] for l in settings.LANGUAGES]
+
+    if lang in valid_languages:
+        conf.config['LANGUAGE_CODE'] = lang
+        conf.save()
+    else:
+        msg = "Invalid language code {langcode}. Must be one of: {validlangs}".format(
+            langcode=lang, validlangs=valid_languages
+        )
+
+        logging.warning(msg)
 
 
 def main(args=None):

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -46,6 +46,7 @@ Usage:
   kolibri manage [options] COMMAND [-- DJANGO_OPTIONS ...]
   kolibri diagnose [options]
   kolibri plugin [options] PLUGIN (enable | disable)
+  kolibri language setdefault <langcode>
   kolibri plugin --list
   kolibri -h | --help
   kolibri --version
@@ -245,6 +246,18 @@ def plugin(plugin_name, **args):
     conf.save()
 
 
+def set_default_language(lang):
+    """
+    Set the default language for this installation of Kolibri. Any running
+    instance of Kolibri needs to be restarted in order for this change to work.
+    """
+
+    from kolibri.utils import conf
+
+    conf.config['LANGUAGE_CODE'] = lang
+    conf.save()
+
+
 def main(args=None):
     """
     Kolibri's main function. Parses arguments and calls utility functions.
@@ -301,3 +314,6 @@ def main(args=None):
         port = int(arguments['--port'] or 8080)
         server.start(port=port)
         return
+
+    if arguments['language'] and arguments['setdefault']:
+        set_default_language(arguments['<langcode>'])


### PR DESCRIPTION
## Summary

This adds a new command line argument in Kolibri:

```
kolibri language setdefault <langcode>
```

That sets the default language for the current installation. It does this by adding a `LANGUAGE_CODE` field on `kolibri_settings.json` (the `conf` file).

![screen shot 2017-03-10 at 11 53 55](https://cloud.githubusercontent.com/assets/191955/23810957/b34d60d2-0588-11e7-9cba-6eeb7a96f22c.png)
