### PR TITLE
Requirements can now be overridden with `make dist REQUIREMENTS=other.txt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+REQUIREMENTS=requirements.txt
+
 .PHONY: help clean clean-pyc clean-build list test test-all coverage docs release sdist
 
 help:
@@ -64,7 +66,7 @@ release: clean assets
 	python setup.py bdist_wheel upload
 
 staticdeps: clean
-	pip install -t kolibri/dist -r requirements.txt
+	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 
 writeversion:


### PR DESCRIPTION
In order to build PEX files for Instant Schools, we need to run the makefile and tell it to look to the custom `requirements/vf.txt` file for dependencies.

After this tweak, it's possible to do so via:
`make clean && make dist REQUIREMENTS=requirements/vf.txt && make pex`