### PR TITLE
Add in missing translation files to the whl and pex files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include requirements.txt
 include kolibri/VERSION
 recursive-include requirements *.txt
 recursive-include kolibri/locale *.mo
+recursive-include kolibri/locale *.json
 recursive-include kolibri/auth *
 recursive-include kolibri/content *
 recursive-include kolibri/core *

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ makemessages: assets makedocsmessages
 	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*' --ignore 'docs/conf.py'
 
 compilemessages:
-	python -m kolibri manage compilemessages -- -l en > /dev/null
+	python -m kolibri manage compilemessages
 
 syncmessages: ensurecrowdinclient uploadmessages downloadmessages distributefrontendmessages
 


### PR DESCRIPTION
## Summary

1. mo files for other languages aren't getting included. Now we do.
2. We don't include json files. Now we do!

commits should be self contained.