### PR TITLE
Enable sortOrder rule for stylint.

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -90,7 +90,10 @@
     "expect": "never",
     "error": true
   },
-  "sortOrder": false,
+  "sortOrder": {
+    "expect": "grouped",
+    "error": true
+  },
   "stackedProperties": {
     "expect": "never",
     "error": true

--- a/kolibri/core/assets/src/styles/definitions.styl
+++ b/kolibri/core/assets/src/styles/definitions.styl
@@ -25,8 +25,8 @@ clearfix()
   zoom: 1
   &:after
   &:before
-    content: ''
     display: table
+    content: ''
   &:after
     clear: both
 

--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -36,8 +36,8 @@ html
 
 html, body
   height:100%
-  color: $core-text-default
   background-color: $core-bg-canvas
+  color: $core-text-default
   letter-spacing: 0.01em
 
 // https://purecss.io/grids/#using-grids-with-custom-fonts
@@ -78,34 +78,34 @@ svg:not(:root)
 button
   // structure (from https://github.com/yahoo/pure/blob/master/src/buttons/css/buttons-core.css)
   display: inline-block
-  zoom: 1
-  line-height: normal
-  white-space: nowrap
   vertical-align: middle
   text-align: center
+  white-space: nowrap
+  line-height: normal
   cursor: pointer
+  zoom: 1
   user-select: none
 
   // style
-  font-size: 0.9em
-  color: $core-action-normal
-  background-color: transparent
-  border-radius: 4px
   border-width: 2px
   border-style: solid
   border-color: $core-action-normal
+  border-radius: 4px
+  background-color: transparent
+  color: $core-action-normal
+  font-size: 0.9em
   transition: border-color $core-time ease-out, color $core-time ease-out
 
   &:hover
-    color: $core-action-dark
     border-color: $core-action-dark
+    color: $core-action-dark
 
   &:focus
     outline: $core-action-light 2px solid
 
   &:disabled
-    color: $core-text-disabled
     border-color: $core-text-disabled
+    color: $core-text-disabled
     cursor: not-allowed
 
 
@@ -116,14 +116,14 @@ button::-moz-focus-inner
   border: none
 
 .visuallyhidden
-  border: none
-  clip: rect(0 0 0 0)
-  height: 1px
-  margin: -1px
-  overflow: hidden
-  padding: 0
   position: absolute
+  overflow: hidden
+  clip: rect(0 0 0 0)
+  margin: -1px
+  padding: 0
   width: 1px
+  height: 1px
+  border: none
 
 .core-text-alert
   color: $core-text-error
@@ -135,9 +135,9 @@ button::-moz-focus-inner
 // from http://google.github.io/material-design-icons/
 
 @font-face
-  font-family: 'Material Icons'
-  font-style: normal
   font-weight: 400
+  font-style: normal
+  font-family: 'Material Icons'
   src: local('Material Icons'),
 local('MaterialIcons-Regular'),
 url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'),
@@ -145,16 +145,16 @@ url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Re
 url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype')
 
 .material-icons
-  font-family: 'Material Icons'
+  display: inline-block
+  white-space: nowrap
+  word-wrap: normal
+  letter-spacing: normal
+  text-transform: none
   font-weight: normal
   font-style: normal
   font-size: 24px /* Preferred icon size */
-  display: inline-block
+  font-family: 'Material Icons'
   line-height: 1
-  text-transform: none
-  letter-spacing: normal
-  word-wrap: normal
-  white-space: nowrap
   direction: ltr
 
   /* Support for all WebKit browsers. */

--- a/kolibri/core/assets/src/vue/channel-switcher/index.vue
+++ b/kolibri/core/assets/src/vue/channel-switcher/index.vue
@@ -100,9 +100,9 @@
   .channel-switcher-menu
     .ui-menu-option
         &.is-disabled
+          background-color: rgba(0, 0, 0, 0.05)
           color: $core-accent-color
           font-weight: bold
           opacity: 1
-          background-color: rgba(0, 0, 0, 0.05)
 
 </style>

--- a/kolibri/core/assets/src/vue/content-renderer/download-button.vue
+++ b/kolibri/core/assets/src/vue/content-renderer/download-button.vue
@@ -142,13 +142,13 @@
   @require '~kolibri.styles.definitions'
 
   .dropdown
-    display: inline-block
     position: relative
+    display: inline-block
 
   .dropdown-button
-    padding: 0.5em
     margin-top: 1em
     margin-bottom: 1em
+    padding: 0.5em
     font-size: smaller
 
   .dropdown-button-text
@@ -161,32 +161,32 @@
       content: '\25b2'
 
   .dropdown-items
-    background-color: white
-    list-style: none
-    padding: 0
+    position: absolute
     margin: 0
     margin-top: -0.8em
-    position: absolute
+    padding: 0
+    background-color: white
+    list-style: none
 
   .dropdown-item
-    padding: 0
-    margin: 0
-    width: 100%
     position: relative
     display: block
+    margin: 0
+    padding: 0
+    width: 100%
 
   .dropdown-item-link
-    padding: 0.5em
-    margin: 0
-    width: 100%
     display: block
+    margin: 0
+    padding: 0.5em
+    width: 100%
     text-decoration: none
     white-space: nowrap
     font-size: smaller
     &:focus
       background-color: $core-action-light
     &:hover
-      background-color: $core-action-light
       outline: $core-action-light 2px solid
+      background-color: $core-action-light
 
 </style>

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -125,23 +125,22 @@
     position: fixed
 
   .app-bar
-    height: 64px
-    z-index: 50
-    width: 100%
     position: absolute
     top: 0
     left: 0
+    z-index: 50
+    width: 100%
+    height: 64px
 
   .app-bar-actions
     display: inline-block
 
   .content-container
     position: absolute
-    overflow-y: auto
-    overflow-x: hidden
     right: 0
     bottom: 0
-    padding-bottom: 40px
+    overflow-x: hidden
+    overflow-y: auto
     padding: 32px
 
 </style>

--- a/kolibri/core/assets/src/vue/core-modal/index.vue
+++ b/kolibri/core/assets/src/vue/core-modal/index.vue
@@ -148,44 +148,44 @@
     position: fixed
     top: 0
     left: 0
+    z-index: 70
     width: 100%
     height: 100%
     background: rgba(0, 0, 0, 0.7)
-    transition: opacity 0.3s ease
     background-attachment: fixed
-    z-index: 70
+    transition: opacity 0.3s ease
 
   .modal
     position: absolute
     top: 50%
     left: 50%
     transform: translate(-50%, -50%)
-    width: 60%
-    background: #fff
-    max-width: 380px
-    max-height: 80%
     overflow-y: auto
-    border-radius: $radius
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33)
     margin: 0 auto
     padding: 15px 30px
+    max-width: 380px
+    max-height: 80%
+    width: 60%
+    border-radius: $radius
+    background: #fff
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33)
 
     &:focus
       outline: none
 
     @media (max-width: $portrait-breakpoint)
-      width: 85%
       top: 45%
+      width: 85%
 
   .top-buttons
     position: relative
-    height: 20px
     margin-bottom: 25px
+    height: 20px
 
   .header-btn
-    color: $core-text-default
-    border: none
     position: absolute
+    border: none
+    color: $core-text-default
 
   .btn-back
     left: -10px

--- a/kolibri/core/assets/src/vue/error-box/index.vue
+++ b/kolibri/core/assets/src/vue/error-box/index.vue
@@ -48,11 +48,11 @@
   @require '~kolibri.styles.definitions'
 
   .error-box-wrapper
-    padding: 10px
-    margin-top: 50px
     position: relative
-    background-color: $core-bg-error
+    margin-top: 50px
+    padding: 10px
     border: 1px solid $core-text-error
+    background-color: $core-bg-error
     color: $core-text-error
 
   .hidden
@@ -60,19 +60,19 @@
 
   .close-button
     position: absolute
-    right: 5px
     top: 5px
+    right: 5px
     border: none
 
   .error-box
-    max-height: 300px
-    padding: 5px
-    margin-top: 10px
     overflow: auto
-    font-family: monospace
-    font-size: 10px
+    margin-top: 10px
+    padding: 5px
+    max-height: 300px
     border: 1px solid black
     background-color: white
     color: black
+    font-size: 10px
+    font-family: monospace
 
 </style>

--- a/kolibri/core/assets/src/vue/exercise-attempts/index.vue
+++ b/kolibri/core/assets/src/vue/exercise-attempts/index.vue
@@ -102,12 +102,12 @@
     white-space: nowrap
 
   .answer
-    width: $size
-    height: 20px
+    position: absolute
     display: inline-block
     margin: $margin
+    width: $size
+    height: 20px
     text-align: center
-    position: absolute
     transition: all 0.5s ease-in-out
 
     // try to improve performance - http://stackoverflow.com/a/10133679
@@ -119,9 +119,9 @@
 
   .placeholder
     display: inline-block
-    height: $size
-    width: $size
     margin: $margin
+    width: $size
+    height: $size
     border-bottom: 1px solid $core-text-annotation
     transition: border-bottom 0.1s linear
 

--- a/kolibri/core/assets/src/vue/icon-button/index.vue
+++ b/kolibri/core/assets/src/vue/icon-button/index.vue
@@ -64,9 +64,9 @@
 <style lang="stylus" scoped>
 
   .icon-margin
-    margin-left: -0.25rem
-    margin-right: 0.375rem
     margin-top: -0.125rem
+    margin-right: 0.375rem
+    margin-left: -0.25rem
 
 </style>
 

--- a/kolibri/core/assets/src/vue/loading-spinner/index.vue
+++ b/kolibri/core/assets/src/vue/loading-spinner/index.vue
@@ -40,17 +40,17 @@
 <style lang="stylus" scoped>
 
   .loading-spinner-wrapper
+    position: relative
     width: 100%
     height: 100%
-    position: relative
 
   .loading-spinner
-    width: 125px
-    height: 125px
     position: absolute
     top: 50%
     left: 50%
     transform: translate(-50%, -50%)
+    width: 125px
+    height: 125px
     background: url('loading-spinner.gif') no-repeat center
     background-size: contain
 

--- a/kolibri/core/assets/src/vue/nav-bar/index.vue
+++ b/kolibri/core/assets/src/vue/nav-bar/index.vue
@@ -251,22 +251,22 @@
   $footerheight = 152px
 
   .nav-wrapper
-    top: 0
-    background: $core-bg-light
-    font-weight: 300
     position: fixed
-    z-index: 70
-    font-size: 1em
-    height: 100%
+    top: 0
     overflow: auto
     -webkit-overflow-scrolling: touch
+    z-index: 70
+    height: 100%
+    background: $core-bg-light
     box-shadow: 2px 0 0 0 rgba(0, 0, 0, 0.12)
+    font-weight: 300
+    font-size: 1em
     .header-logo
-      font-size: 3em
       margin-right: 0.25em
+      font-size: 3em
     .logo
-      margin: auto
       display: inline-block
+      margin: auto
 
   .nav-main
     background: $core-bg-light
@@ -276,46 +276,46 @@
 
   .header
     position: absolute
-    z-index: 1003
     top: 0
     left: 0
-    font-size: 14px
-    text-transform: uppercase
+    z-index: 1003
     overflow: auto
     overflow-y: hidden
+    text-transform: uppercase
     background-color: $core-text-default
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2)
+    font-size: 14px
     .close
       float: left
     .title, .close
       color: $core-bg-light
     .close
+      position: relative
       top: 50%
       transform: translateY(-50%)
-      position: relative
       border: none
     .title
-      font-weight: bold
       vertical-align: middle
+      font-weight: bold
 
   .scrollable-nav
     position: absolute
-    z-index: 1002
     top: 0
     left: 0
+    z-index: 1002
+    overflow: auto
     padding-bottom: $footerheight + 16
     height: 100%
-    overflow: auto
 
   .footer
     position: absolute
-    z-index: 1003
     bottom: 0
     left: 0
+    z-index: 1003
     overflow: hidden
-    background-color: $core-text-default
     padding-top: 1em
     padding-bottom: 1em
+    background-color: $core-text-default
     .logo
       float: left
     .message-container
@@ -327,12 +327,12 @@
     position: fixed
     top: 0
     left: 0
+    z-index: 60
     width: 100%
     height: 100%
     background: rgba(0, 0, 0, 0.7)
-    transition: opacity 0.3s ease
     background-attachment: fixed
-    z-index: 60
+    transition: opacity 0.3s ease
 
 </style>
 
@@ -351,9 +351,9 @@
           .ui-menu-option__icon
             color: $core-accent-color
           color: $core-accent-color
-          cursor: default
           font-weight: bold
           opacity: 1
+          cursor: default
         .ui-menu-option__text
           overflow: visible
         .ui-menu-option__icon
@@ -361,7 +361,7 @@
       &.is_divider
         background-color: $core-text-annotation
     &.ui-menu
-      border: none
       max-width: 320px
+      border: none
 
 </style>

--- a/kolibri/core/assets/src/vue/progress-bar/index.vue
+++ b/kolibri/core/assets/src/vue/progress-bar/index.vue
@@ -50,31 +50,31 @@
 
   .wrapper
     position: relative
-    white-space: nowrap
     padding-right: 40px
+    white-space: nowrap
 
   .progress-bar-wrapper
-    display: inline-block
     position: relative
-    width: 100%
-    max-width: 125px
-    height: 1.2em
-    background-color: #E0E0E0
-    border-radius: 15px
+    display: inline-block
     float: left
-    margin-right: 5px
     overflow: hidden
+    margin-right: 5px
+    max-width: 125px
+    width: 100%
+    height: 1.2em
+    border-radius: 15px
+    background-color: #E0E0E0
 
   .progress-bar-complete
-    height: 100%
     width: 0
+    height: 100%
     background-color: $core-action-normal
     transition: width, $core-time, ease
 
   .progress-bar-text
-    display: inline-block
     position: relative
     right: 0
+    display: inline-block
     width: 30px
     text-align: left
 

--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/index.vue
@@ -203,11 +203,11 @@
 
   .play-button
     margin-right: 2%
-    background: none
     width: 44px
     height: 50px
     border: none
     border-radius: 0
+    background: none
 
   .audio-button
     margin: 5% 2% 0 0
@@ -221,8 +221,8 @@
 
   #current-time, #total-time
     display: inline-block
-    font-size: 20px
     margin: 1%
+    font-size: 20px
 
   // hacky solution for CSS differences between Chrome and Firefox
   @-moz-document url-prefix()
@@ -244,46 +244,46 @@
   /* Chrome, Safari, Opera **********/
   input[type=range]::-webkit-slider-runnable-track
     display: inline-block
-    background: lightgray
-    border-radius: 15px
     height: 15px
+    border-radius: 15px
+    background: lightgray
     animate: 0.2s
 
   input[type=range]::-webkit-slider-thumb
+    position: relative
+    bottom: 12px
     -webkit-appearance: none
     width: 40px
     height: 40px
     border-radius: 50%
     background: $core-action-normal
-    position: relative
-    bottom: 12px
 
   /* Firefox ***********/
   input[type=range]::-moz-range-track
     display: inline-block
-    background: lightgray
-    border-radius: 15px
     height: 15px
+    border-radius: 15px
+    background: lightgray
     animate: 0.2s
 
   input[type=range]::-moz-range-thumb
     width: 40px
     height: 40px
+    border: none
     border-radius: 50%
     background: $core-action-normal
-    border: none
 
   /* IE/Edge **********/
   input[type=range]::-ms-track
+    height: 20px
     border: 8px solid transparent
     background: transparent
     color: transparent
-    height: 20px
 
   input[type=range]::-ms-thumb
-    border: none
-    height: 25px
     width: 25px
+    height: 25px
+    border: none
     border-radius: 50%
     background: $core-action-normal
 

--- a/kolibri/plugins/coach/assets/src/vue/class-list-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/vue/class-list-page/index.vue
@@ -108,9 +108,9 @@
   $row-padding = 1.5em
   .status-group
     display: inline-table
+    margin-left: 30px
     width: 100%
     text-align: center
-    margin-left: 30px
   .status-header
     vertical-align: middle
   .status-body
@@ -119,25 +119,25 @@
     float: right
     margin-top: -48px
   input[type='search']
-    display: inline-block
-    box-sizing: border-box
     position: relative
     top: 0
     left: 10px
-    height: 100%
+    display: inline-block
+    clear: both
+    box-sizing: border-box
     width: 85%
+    height: 100%
     border-color: transparent
     background-color: transparent
-    clear: both
   .header h1
     display: inline-block
     margin-bottom: 0
   #description
     margin-bottom: 40px
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
   tr
     text-align: left
   .roster
@@ -147,30 +147,30 @@
     text-align: inherit
   .col-header
     padding-bottom: (1.2 * $row-padding)
+    width: 28%
     color: $core-text-annotation
     font-weight: normal
     font-size: 80%
-    width: 28%
   .table-cell
-    font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
+    font-weight: normal // compensates for <th> cells
   .delete-class-button
-    color: red
-    width: 110px
-    padding: 8px
-    cursor: pointer
-    margin-right: 4px
     float: right
+    margin-right: 4px
+    padding: 8px
+    width: 110px
+    color: red
+    cursor: pointer
   .create-class-button
     width: 100%
   .table-name
-    $line-height = 1em
-    line-height: $line-height
-    max-height: ($line-height * 2)
     display: inline-block
     padding-right: 1em
+    $line-height = 1em
+    max-height: ($line-height * 2)
     font-weight: bold
+    line-height: $line-height
   .role-header
     display: none
   @media print
@@ -187,9 +187,9 @@
       display: none
     .table-name
       overflow: hidden
+      width: 100px
       text-overflow: ellipsis
       white-space: nowrap
-      width: 100px
     .col-header
       width: 50%
 

--- a/kolibri/plugins/coach/assets/src/vue/index.vue
+++ b/kolibri/plugins/coach/assets/src/vue/index.vue
@@ -101,7 +101,7 @@
   @require '~kolibri.styles.definitions'
 
   .login-message
-    text-align: center
     margin-top: 200px
+    text-align: center
 
 </style>

--- a/kolibri/plugins/coach/assets/src/vue/recent-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/vue/recent-page/index.vue
@@ -93,9 +93,9 @@
     $row-padding = 1.5em
   .status-group
     display: inline-table
+    margin-left: 30px
     width: 100%
     text-align: center
-    margin-left: 30px
   .status-header
     vertical-align: middle
   .status-body
@@ -104,25 +104,27 @@
     float: right
     margin-top: -48px
   input[type='search']
-    display: inline-block
-    box-sizing: border-box
     position: relative
     top: 0
     left: 10px
-    height: 100%
+    display: inline-block
+    clear: both
     width: 85%
+    height: 100%
     border-color: transparent
     background-color: transparent
-    clear: both
+
+    box-sizing: border-box
   .header h1
     display: inline-block
     margin-bottom: 0
   #description
     margin-bottom: 40px
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
+
   tr
     text-align: left
   .roster
@@ -132,30 +134,30 @@
     text-align: inherit
   .col-header
     padding-bottom: (1.2 * $row-padding)
+    width: 28%
     color: $core-text-annotation
     font-weight: normal
     font-size: 80%
-    width: 28%
   .table-cell
-    font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
+    font-weight: normal // compensates for <th> cells
   .delete-class-button
-    color: red
-    width: 110px
-    padding: 8px
-    cursor: pointer
-    margin-right: 4px
     float: right
+    margin-right: 4px
+    padding: 8px
+    width: 110px
+    color: red
+    cursor: pointer
   .create-class-button
     width: 100%
   .table-name
-    $line-height = 1em
-    line-height: $line-height
-    max-height: ($line-height * 2)
     display: inline-block
     padding-right: 1em
+    $line-height = 1em
+    max-height: ($line-height * 2)
     font-weight: bold
+    line-height: $line-height
   .role-header
     display: none
   @media print
@@ -172,9 +174,9 @@
       display: none
     .table-name
       overflow: hidden
+      width: 100px
       text-overflow: ellipsis
       white-space: nowrap
-      width: 100px
     .col-header
       width: 50%
 

--- a/kolibri/plugins/coach/assets/src/vue/top-nav/index.vue
+++ b/kolibri/plugins/coach/assets/src/vue/top-nav/index.vue
@@ -93,15 +93,15 @@
   .top
     position: relative
     padding: 1em 2em
-    background: $core-bg-light
     border-radius: $radius
+    background: $core-bg-light
   .top a
     padding: 0.6em 2em
-    text-decoration: none
     color: $core-text-annotation
+    text-decoration: none
   .top .active
+    border-bottom: 0.3em $core-action-normal solid
     color: $core-text-default
     cursor: default
-    border-bottom: 0.3em $core-action-normal solid
 
 </style>

--- a/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/vue/index.vue
@@ -74,14 +74,14 @@
 
   .container
     position: relative
-    height: 100vh
-    max-height: calc(100vh - 24em)
     min-height: 400px
+    max-height: calc(100vh - 24em)
+    height: 100vh
     &:fullscreen
-      width: 100%
-      height: 100%
       min-height: inherit
       max-height: inherit
+      width: 100%
+      height: 100%
 
   .pdfcontainer
     height: 100%

--- a/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/vue/index.vue
@@ -75,18 +75,18 @@
 
   .container
     position: relative
-    text-align: center
-    height: 100vh
-    max-height: calc(100vh - 24em)
     min-height: 400px
+    max-height: calc(100vh - 24em)
+    height: 100vh
+    text-align: center
     &:fullscreen
-      width: 100%
-      height: 100%
       min-height: inherit
       max-height: inherit
+      width: 100%
+      height: 100%
 
   .sandbox
-    height: 100%
     width: 100%
+    height: 100%
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/breadcrumbs/index.vue
@@ -124,22 +124,22 @@
   @require '../learn.styl'
 
   .middle-breadcrumb::before
-    content: '>'
-    margin-left: 0.5em
     margin-right: 0.5em
+    margin-left: 0.5em
     color: $core-text-annotation
+    content: '>'
 
   .middle-breadcrumb, .first-breadcrumb
-    vertical-align: middle
-    font-size: 0.9em
-    font-weight: 300
-    max-width: 140px
-    white-space: nowrap
     overflow: hidden
+    max-width: 140px
+    vertical-align: middle
     text-overflow: ellipsis
+    white-space: nowrap
+    font-weight: 300
+    font-size: 0.9em
     a
-      color: $core-text-annotation
       display: inline-block
+      color: $core-text-annotation
 
   .landscape
     @media screen and (max-width: $portrait-breakpoint)

--- a/kolibri/plugins/learn/assets/src/vue/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-grid/grid-item/index.vue
@@ -61,37 +61,37 @@
   $thumb-width = 100px
 
   .card
+    overflow: hidden
     width: $card-width
     height: $card-height
-    overflow: hidden
-    background-color: $core-bg-light
     border-radius: $radius
+    background-color: $core-bg-light
 
   .card-thumbnail
-    height: 122px
     position: relative
+    height: 122px
 
   .text
     -webkit-line-clamp: 3 // Enhance Chrome, doesn't work on other browsers
     -webkit-box-orient: vertical // Enhance Chrome, doesn't work on other browsers
-    width: auto
-    max-height: 68px
-    margin-left: 35px
     overflow: hidden
+    margin-left: 35px
+    max-height: 68px
+    width: auto
+    color: $core-text-default
+    text-overflow: ellipsis
     font-size: 0.9rem
     line-height: 1.2rem
-    text-overflow: ellipsis
-    color: $core-text-default
 
   .content-icon
     position: absolute
-    left: 10px
     top: 10px
+    left: 10px
     font-size: 1.5em
 
   .card-content
-    padding: 10px
     position: relative
+    padding: 10px
 
   a
     text-decoration: none

--- a/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/card-list/list-item/index.vue
@@ -39,24 +39,24 @@
   @require '../../learn.styl'
 
   .list-item
-    background-color: $core-bg-light
-    border-radius: $radius
     display: block
-    text-decoration: none
-    padding-right: 0.5em
-    padding-left: 0.5em
-    padding-top: 0.5em
-    padding-bottom: 0.5em
     margin-bottom: 1em
+    padding-top: 0.5em
+    padding-right: 0.5em
+    padding-bottom: 0.5em
+    padding-left: 0.5em
+    border-radius: $radius
+    background-color: $core-bg-light
+    text-decoration: none
 
   h2
     display: inline-block
-    font-size: 0.9em
     color: $core-text-default
+    font-size: 0.9em
 
   .topic-icon
-    font-size: 1.5em
     padding-right: 0.25em
     padding-left: 0.25em
+    font-size: 1.5em
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-grid-item/index.vue
@@ -75,18 +75,18 @@
   @require '~kolibri.styles.definitions'
 
   .thumbnail
+    position: relative
     width: 100%
     height: 100%
-    background-size: cover
-    background-position: center
     background-color: black
+    background-position: center
+    background-size: cover
     text-align: center
-    position: relative
 
   .thumbnail:before
-    content: ''
     display: inline-block
-    vertical-align: middle
     height: 100%
+    content: ''
+    vertical-align: middle
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/content-page/index.vue
@@ -156,13 +156,13 @@
     margin-top: 4em
 
   .next-btn
-    background-color: #4A8DDC
-    border-color: #4A8DDC
-    color: $core-bg-light
     position: relative
     top: -62px
     left: 150px
     z-index: 10
+    border-color: #4A8DDC
+    background-color: #4A8DDC
+    color: $core-bg-light
     @media screen and (max-width: $medium-breakpoint)
       top: -10px
       left: 0
@@ -188,8 +188,8 @@
     line-height: 1.5em
 
   .download-button-left-align
-    vertical-align: top
     margin-right: 1.5em
+    vertical-align: top
 
 </style>
 

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -104,7 +104,7 @@
   @require '~kolibri.styles.definitions'
 
   .button-wrapper
-    text-align: center
     margin-top: 1em
+    text-align: center
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/page-header/index.vue
@@ -68,8 +68,8 @@
 <style lang="stylus" scoped>
 
   .extra-nav
-    font-size: 12px
     min-height: 16px
+    font-size: 12px
 
   .title
     display: inline-block

--- a/kolibri/plugins/management/assets/src/vue/class-edit-page/class-rename-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/class-edit-page/class-rename-modal.vue
@@ -127,18 +127,18 @@
     select
       width: 100%
       height: 40px
-      font-weight: bold
       background-color: transparent
+      font-weight: bold
 
   .add-form
-    width: 300px
-    margin: 0 auto
     display: block
+    margin: 0 auto
     padding: 5px 10px
-    letter-spacing: 0.08em
+    width: 300px
+    height: 30px
     border: none
     border-bottom: 1px solid $core-text-default
-    height: 30px
+    letter-spacing: 0.08em
     &:focus
       outline: none
       border-bottom: 3px solid $core-action-normal

--- a/kolibri/plugins/management/assets/src/vue/class-edit-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/class-edit-page/index.vue
@@ -236,9 +236,9 @@
     margin-left: 5px
 
   .toolbar:after
-    content: ''
     display: table
     clear: both
+    content: ''
 
   .enroll-user-button
     width: 100%
@@ -247,24 +247,24 @@
     float: right
 
   input[type='search']
-    display: inline-block
-    box-sizing: border-box
     position: relative
     top: 0
     left: 10px
-    height: 100%
+    display: inline-block
+    clear: both
+    box-sizing: border-box
     width: 85%
+    height: 100%
     border-color: transparent
     background-color: transparent
-    clear: both
 
   .header h1
     display: inline-block
 
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
 
   tr
     text-align: left
@@ -286,65 +286,65 @@
     vertical-align: middle
 
   .remove-user-btn
+    margin-right: 4px
+    padding: 8px
+    width: 90px
     color: $core-action-normal
     font-weight: bold
-    width: 90px
-    padding: 8px
     cursor: pointer
-    margin-right: 4px
 
   .col-header
     padding-bottom: (1.2 * $row-padding)
+    width: 30%
     color: $core-text-annotation
     font-weight: normal
     font-size: 80%
-    width: 30%
 
   .table-cell
     color: $core-text-default
 
   .user-role
-    background-color: $core-text-annotation
-    color: $core-bg-light
-    padding-left: 1em
-    padding-right: 1em
-    border-radius: 40px
-    font-size: 0.875em
     display: inline-block
     text-transform: capitalize
+    padding-right: 1em
+    padding-left: 1em
+    border-radius: 40px
+    background-color: $core-text-annotation
+    color: $core-bg-light
     white-space: nowrap
+    font-size: 0.875em
 
   .searchbar .icon
+    position: relative
+    top: 5px
+    left: 5px
     display: inline-block
     float: left
-    position: relative
     fill: $core-text-annotation
-    left: 5px
-    top: 5px
 
   .searchbar
-    border-radius: 5px
-    padding: inherit
-    border: 1px solid #c0c0c0
-    width: 300px
-    height: $toolbar-height
     float: left
     margin-left: 5px
+    padding: inherit
+    width: 300px
+    height: $toolbar-height
+    border: 1px solid #c0c0c0
+    border-radius: 5px
 
   @media screen and (min-width: $portrait-breakpoint + 1)
     .searchbar
-      font-size: 0.9em
       min-width: 170px
       width: 45%
+      font-size: 0.9em
     #search-field
       width: 80%
 
   .table-name
-    $line-height = 1em
-    line-height: $line-height
-    max-height: ($line-height * 2)
     display: inline-block
     padding-right: 1em
+    $line-height = 1em
+    max-height: ($line-height * 2)
+    line-height: $line-height
 
   @media print
     .toolbar
@@ -360,17 +360,17 @@
     .create
       margin-top: -78px
     .searchbar
-      font-size: 0.9em
-      width: 100%
-      margin-top: 5px
       float: right
+      margin-top: 5px
+      width: 100%
+      font-size: 0.9em
     .table-username
       display: none
     .table-name
       overflow: hidden
+      width: 100px
       text-overflow: ellipsis
       white-space: nowrap
-      width: 100px
     .col-header
       width: 50%
 

--- a/kolibri/plugins/management/assets/src/vue/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/class-enroll-page/index.vue
@@ -324,8 +324,8 @@
     position: relative
 
   .pagination
-    text-align:center
     padding: 2em
+    text-align:center
 
   .search-box
     max-width: 400px

--- a/kolibri/plugins/management/assets/src/vue/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/data-page/index.vue
@@ -96,12 +96,12 @@
   @require '~kolibri.styles.definitions'
 
   .infobox
-    background-color: $core-bg-warning
-    border-radius: $radius
-    font-size: 0.8em
-    padding: 8px
-    margin-left: -8px
     margin-right: 8px
+    margin-left: -8px
+    padding: 8px
+    border-radius: $radius
+    background-color: $core-bg-warning
+    font-size: 0.8em
 
   form
     display: inline

--- a/kolibri/plugins/management/assets/src/vue/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/index.vue
@@ -90,19 +90,19 @@
   .manage-content
     width: 100%
     @media screen and (max-width: $medium-breakpoint)
-        width: 90%
-        margin-left: auto
         margin-right: auto
+        margin-left: auto
+        width: 90%
 
   .page
+    margin-top: 1em
     padding: 1em 2em
     padding-bottom: 3em
-    background-color: $core-bg-light
-    margin-top: 1em
     border-radius: $radius
+    background-color: $core-bg-light
 
   .login-message
-    text-align: center
     margin-top: 200px
+    text-align: center
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/manage-class-page/class-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-class-page/class-create-modal.vue
@@ -123,18 +123,18 @@
     select
       width: 100%
       height: 40px
-      font-weight: bold
       background-color: transparent
+      font-weight: bold
 
   .add-form
-    width: 300px
-    margin: 0 auto
     display: block
+    margin: 0 auto
     padding: 5px 10px
-    letter-spacing: 0.08em
+    width: 300px
+    height: 30px
     border: none
     border-bottom: 1px solid $core-text-default
-    height: 30px
+    letter-spacing: 0.08em
     &:focus
       outline: none
       border-bottom: 3px solid $core-action-normal

--- a/kolibri/plugins/management/assets/src/vue/manage-class-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-class-page/index.vue
@@ -169,9 +169,9 @@
 
   .status-group
     display: inline-table
+    margin-left: 30px
     width: 100%
     text-align: center
-    margin-left: 30px
 
   .status-header
     vertical-align: middle
@@ -184,24 +184,24 @@
     margin-top: -48px
 
   input[type='search']
-    display: inline-block
-    box-sizing: border-box
     position: relative
     top: 0
     left: 10px
-    height: 100%
+    display: inline-block
+    clear: both
+    box-sizing: border-box
     width: 85%
+    height: 100%
     border-color: transparent
     background-color: transparent
-    clear: both
 
   .header h1
     display: inline-block
 
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
 
   tr
     text-align: left
@@ -215,34 +215,34 @@
 
   .col-header
     padding-bottom: (1.2 * $row-padding)
+    width: 28%
     color: $core-text-annotation
     font-weight: normal
     font-size: 80%
-    width: 28%
 
   .table-cell
-    font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
+    font-weight: normal // compensates for <th> cells
 
   .delete-class-button
-    color: red
-    width: 110px
-    padding: 8px
-    cursor: pointer
-    margin-right: 4px
     float: right
+    margin-right: 4px
+    padding: 8px
+    width: 110px
+    color: red
+    cursor: pointer
 
   .create-class-button
     width: 100%
 
   .table-name
-    $line-height = 1em
-    line-height: $line-height
-    max-height: ($line-height * 2)
     display: inline-block
     padding-right: 1em
+    $line-height = 1em
+    max-height: ($line-height * 2)
     font-weight: bold
+    line-height: $line-height
 
   .role-header
     display: none
@@ -262,9 +262,9 @@
       display: none
     .table-name
       overflow: hidden
+      width: 100px
       text-overflow: ellipsis
       white-space: nowrap
-      width: 100px
     .col-header
       width: 50%
 

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/index.vue
@@ -137,9 +137,9 @@
   $toolbar-height = 36px
 
   .main
+    margin-top: 2em
     padding: 1em 2em
     padding-bottom: 3em
-    margin-top: 2em
     width: 100%
     border-radius: 4px
 
@@ -153,9 +153,9 @@
     margin-top: 1em
 
   .table-title:after
-    content: ''
     display: table
     clear: both
+    content: ''
 
   .page-title
     float: left
@@ -168,9 +168,9 @@
     width: 100%
 
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
 
   tr
     text-align: left
@@ -195,9 +195,9 @@
     width: 10%
 
   .table-cell
-    font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
+    font-weight: normal // compensates for <th> cells
 
   .channel-name
     font-weight: 700

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/task-status.vue
@@ -129,7 +129,7 @@
     border-radius: 50px
 
   progress[value]::-webkit-progress-value
-    background-color: $core-action-normal
     border-radius: 50px
+    background-color: $core-action-normal
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-export.vue
@@ -198,9 +198,9 @@
   $min-height = 200px
 
   .main
-    text-align: left
     margin: 3em 0
     min-height: $min-height
+    text-align: left
 
   h2
     font-size: 1em

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-local.vue
@@ -166,9 +166,9 @@
   $min-height = 200px
 
   .main
-    text-align: left
     margin: 3em 0
     min-height: $min-height
+    text-align: left
 
   h2
     font-size: 1em

--- a/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-source.vue
+++ b/kolibri/plugins/management/assets/src/vue/manage-content-page/wizard-import-source.vue
@@ -55,13 +55,13 @@
   @require '~kolibri.styles.definitions'
 
   .main
-    text-align: center
     margin-bottom: 4em 0
+    text-align: center
 
   .large-icon-button
+    margin: 3px
     width: 150px
     height: 120px
-    margin: 3px
 
   .lg-button-wrapper
     margin: 4em 0
@@ -70,12 +70,12 @@
     margin-bottom: 2em
 
   .text-only-buttons
-    height: 36px
+    margin: 1em
     padding-right: 2em
     padding-left: 2em
-    margin: 1em
-    color: $core-text-annotation
+    height: 36px
     border: 1px $core-text-annotation solid
+    color: $core-text-annotation
 
   .icon
     width: 50px

--- a/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/top-nav/index.vue
@@ -86,17 +86,17 @@
   .top
     position: relative
     padding: 1em 2em
-    background: $core-bg-light
     border-radius: $radius
+    background: $core-bg-light
 
   .top a
     padding: 0.6em 2em
-    text-decoration: none
     color: $core-text-annotation
+    text-decoration: none
 
   .top .active
+    border-bottom: 0.3em $core-action-normal solid
     color: $core-text-default
     cursor: default
-    border-bottom: 0.3em $core-action-normal solid
 
 </style>

--- a/kolibri/plugins/management/assets/src/vue/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/index.vue
@@ -239,40 +239,40 @@
   $toolbar-height = 36px
 
   .toolbar:after
-    content: ''
     display: table
     clear: both
+    content: ''
 
   // Toolbar Styling
   .create
     float: right
 
   input[type='search']
-    display: inline-block
-    box-sizing: border-box
     position: relative
     top: 0
     left: 10px
-    height: 100%
+    display: inline-block
+    clear: both
+    box-sizing: border-box
     width: 85%
+    height: 100%
     border-color: transparent
     background-color: transparent
-    clear: both
 
   #type-filter
     float: left
-    background-color: $core-bg-light
-    border-color: $core-action-light
     height: $toolbar-height
+    border-color: $core-action-light
+    background-color: $core-bg-light
     cursor: pointer
 
   .header h1
     display: inline-block
 
   hr
-    background-color: $core-text-annotation
     height: 1px
     border: none
+    background-color: $core-text-annotation
 
   tr
     text-align: left
@@ -286,43 +286,43 @@
 
   .col-header
     padding-bottom: (1.2 * $row-padding)
+    width: 30%
     color: $core-text-annotation
     font-weight: normal
     font-size: 80%
-    width: 30%
 
   .table-cell
-    font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
+    font-weight: normal // compensates for <th> cells
 
   .user-role
+    display: inline-block
+    padding-right: 1em
+    padding-left: 1em
+    border-radius: 40px
     background-color: $core-text-annotation
     color: $core-bg-light
-    padding-left: 1em
-    padding-right: 1em
-    border-radius: 40px
-    font-size: 0.875em
-    display: inline-block
     text-transform: capitalize
     white-space: nowrap
+    font-size: 0.875em
 
   .searchbar .icon
+    position: relative
+    top: 5px
+    left: 5px
     display: inline-block
     float: left
-    position: relative
     fill: $core-text-annotation
-    left: 5px
-    top: 5px
 
   .searchbar
-    border-radius: 5px
-    padding: inherit
-    border: 1px solid #c0c0c0
-    width: 300px
-    height: $toolbar-height
     float: left
     margin-left: 5px
+    padding: inherit
+    width: 300px
+    height: $toolbar-height
+    border: 1px solid #c0c0c0
+    border-radius: 5px
 
   .edit-user-button
     border: none
@@ -338,18 +338,18 @@
 
   @media screen and (min-width: $portrait-breakpoint + 1)
     .searchbar
-      font-size: 0.9em
       min-width: 170px
       width: 45%
+      font-size: 0.9em
     #search-field
       width: 80%
 
   .table-name
-    $line-height = 1em
-    line-height: $line-height
-    max-height: ($line-height * 2)
     display: inline-block
     padding-right: 1em
+    $line-height = 1em
+    max-height: ($line-height * 2)
+    line-height: $line-height
 
   .role-header
     display: none
@@ -368,17 +368,17 @@
     .create
       margin-top: -78px
     .searchbar
-      font-size: 0.9em
-      width: 100%
-      margin-top: 5px
       float: right
+      margin-top: 5px
+      width: 100%
+      font-size: 0.9em
     .table-username
       display: none
     .table-name
       overflow: hidden
+      width: 100px
       text-overflow: ellipsis
       white-space: nowrap
-      width: 100px
     .col-header
       width: 50%
 

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -195,8 +195,8 @@
     select
       width: 100%
       height: 40px
-      font-weight: bold
       background-color: transparent
+      font-weight: bold
 
   .header
     text-align: center
@@ -212,8 +212,8 @@
 
   .secondary
     &:hover
-      color: #ffffff
       background-color: $core-action-dark
+      color: #ffffff
       svg
         fill: #ffffff
 

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-edit-modal.vue
@@ -321,8 +321,8 @@
       -webkit-appearance: menulist-button
       width: 100%
       height: 40px
-      font-weight: bold
       background-color: transparent
+      font-weight: bold
     p
       text-align: center
 

--- a/kolibri/plugins/setup_wizard/assets/src/vue/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/vue/index.vue
@@ -115,32 +115,32 @@
     height: 100%
   .wrapper
     position: absolute
-    max-height: 100%
     top: 50%
     left: 50%
     transform: translate(-50%, -50%)
+    max-height: 100%
   .container
-    background: #fff
-    width: 100%
-    max-width: 430px
-    min-width: 320px
-    border-radius: $radius
     margin: 0 auto
     padding: 20px 30px
+    min-width: 320px
+    max-width: 430px
+    width: 100%
+    border-radius: $radius
+    background: #fff
   h1
     font-size: 18px
   h2.title
-    font-size: 14px
     font-weight: bold
-  .inputlabel
     font-size: 14px
-    color: $core-action-normal
+  .inputlabel
+    display: inline-block
     margin-top: 8px
     margin-bottom: 4px
-    display: inline-block
+    color: $core-action-normal
+    font-size: 14px
   .description
-    font-size: 12px
     color: $core-text-annotation
+    font-size: 12px
   .btn-wrapper
     width: 100%
     text-align: center
@@ -148,13 +148,13 @@
     background-color: $core-action-normal
     color: white
   input
+    padding: 6px
     width: 100%
     border-width: 2px
     border-style: solid
-    border-radius: $radius
-    padding: 6px
-    background-color: $core-bg-canvas
     border-color: $core-action-light
+    border-radius: $radius
+    background-color: $core-bg-canvas
   input:focus
     background-color: #DAEFE5
   .input-error
@@ -164,14 +164,14 @@
   .error-message
     color: $core-text-error
   .logo
-    height: 40%
-    width: 40%
-    max-height: 160px
+    display: block
+    margin-right: auto
+    margin-left: auto
+    min-width: 100px
     min-height: 100px
     max-width: 160px
-    min-width: 100px
-    display: block
-    margin-left: auto
-    margin-right: auto
+    max-height: 160px
+    width: 40%
+    height: 40%
 
 </style>

--- a/kolibri/plugins/user/assets/src/vue/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/profile-page/index.vue
@@ -118,23 +118,23 @@
   $iphone-width = 320
 
   .content
-    padding-top: $vertical-page-margin
-    margin-left: auto
-    margin-right: auto
     overflow-y: auto
+    margin-right: auto
+    margin-left: auto
+    padding-top: $vertical-page-margin
     width: ($iphone-width - 20)px
 
   #submit
-    margin-left: auto
-    margin-right: auto
     display: block
     margin-top: $vertical-page-margin
+    margin-right: auto
+    margin-left: auto
     width: 98%
 
   .advanced-option
-    color: $core-action-light
-    width: 100%
     display: inline-block
+    width: 100%
+    color: $core-action-light
     font-size: 0.9em
 
 </style>

--- a/kolibri/plugins/user/assets/src/vue/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/sign-in-page/index.vue
@@ -121,9 +121,9 @@
         background-color: $login-red
 
         &#guest-access-button
+          border: 2px solid $core-action-normal
           background-color: transparent
           color: $login-text
-          border: 2px solid $core-action-normal
 
 </style>
 
@@ -134,14 +134,14 @@
   $login-text = #D8D8D8
 
   .login
-    background-color: $login-overlay
+    overflow-x: hidden
+    overflow-y: auto
     height: 100%
-    // Fallback for older browers.
     background: $core-bg-canvas
     background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center fixed
+    background-color: $login-overlay
+    // Fallback for older browers.
     background-size: cover
-    overflow-y: auto
-    overflow-x: hidden
 
   #login-container
     display: block
@@ -152,25 +152,25 @@
     display: block
     margin: auto
     margin-top: 34px
+    min-width: 60px
+    max-width: 120px
     width: 30%
     height: auto
-    max-width: 120px
-    min-width: 60px
 
   .login-text
     color: $login-text
 
   .title
+    text-align: center
+    letter-spacing: 0.1em
     font-weight: 100
     font-size: 1.3em
-    letter-spacing: 0.1em
-    text-align: center
 
   #login-form
-    width: 70%
-    max-width: 300px
     margin: auto
     margin-top: 30px
+    max-width: 300px
+    width: 70%
 
   #password
     margin-top: 30px
@@ -189,26 +189,26 @@
     text-align: center
 
   .group-btn
-    padding: 5px
     display: inline-block
+    padding: 5px
     text-decoration: none
 
   #password-reset
     display: block
-    text-align: center
     margin: auto
     margin-top: 26px
-    font-size: 0.8em
     color: $login-text
+    text-align: center
     text-decoration: underline
+    font-size: 0.8em
 
   #divid-line
+    margin: auto
+    margin-top: 16px
     width: 412px
     height: 1px
     background-color: $core-text-annotation
     background-color: $login-text
-    margin: auto
-    margin-top: 16px
 
   .no-account
     text-align: center

--- a/kolibri/plugins/user/assets/src/vue/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/vue/sign-up-page/index.vue
@@ -180,16 +180,16 @@
 
   // component, highest level
   #signup-page
+    overflow-y: auto
     width: 100%
     height: 100%
-    overflow-y: auto
 
   // Action Bar
   #logo
-    // 1.63 * font height
-    height: $logo-size
     display: inline-block
     margin-left: $logo-margin
+    // 1.63 * font height
+    height: $logo-size
 
   #login
     margin-right: 1em
@@ -202,31 +202,30 @@
 
   .signup-form
     margin-top: $vertical-page-margin
-    margin-left: auto
     margin-right: auto
+    margin-left: auto
     width: ($iphone-5-width - 20)px
 
   .terms
+    overflow-y: scroll
+    margin-bottom: 1em
+    padding: 0.5em
+    height: 6em
     background-color: $core-bg-light
     color: $core-text-annotation
-    height: 6em
-    overflow-y: scroll
-    padding: 0.5em
-    margin-bottom: 1em
     p
       margin-top: 0
 
   #submit
-    width: 90%
     display: block
-    margin-left: auto
-    margin-right: auto
-
     margin-top: $vertical-page-margin
+    margin-right: auto
     margin-bottom: $vertical-page-margin
+    margin-left: auto
+    width: 90%
 
   .app-bar-icon
-    font-size: 2.5em
     margin-left: 0.25em
+    font-size: 2.5em
 
 </style>

--- a/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/vue/index.vue
@@ -221,10 +221,10 @@
 
   // Containers
   .wrapper
-    width: 854px
-    height: 480px
     max-width: 100%
     max-height: 480px
+    width: 854px
+    height: 480px
 
   .fill-space
     width: 100%
@@ -251,10 +251,10 @@
 
   // Video Player
   .video-js
+    color: white
+    font-weight: bold
     font-size: $video-player-font-size
     font-family: $core-font
-    font-weight: bold
-    color: white
 
     // Responsiveness
     @media screen and (max-width: 840px)
@@ -268,10 +268,10 @@
       top: 50%
       left: 50%
       transform: translate(-50%, -50%)
-      height: 2em
       width: 2em
-      border-radius: 50%
+      height: 2em
       border: none
+      border-radius: 50%
       background-color: $video-player-color
 
     .vjs-big-play-button:before
@@ -289,11 +289,11 @@
     // Seek Bar
     .vjs-progress-control
       position: absolute
-      left: 0
-      right: 0
-      width: auto
       top: -3em
+      right: 0
+      left: 0
       visibility: inherit
+      width: auto
       opacity: inherit
 
       &:hover
@@ -306,10 +306,10 @@
           font-size: calc(1em - 2px)
 
     .vjs-progress-holder
-      margin-left: 7px
-      margin-right: 7px
-      font-size: 1em
       margin-top: auto
+      margin-right: 7px
+      margin-left: 7px
+      font-size: 1em
 
     .vjs-load-progress
       background: $grey


### PR DESCRIPTION
## Summary

* Enable sortOrder rule for stylint.
* It had to be done.
* TODO:
  * Update perseus renderer and vf user plugin.
* Notes:
  * Unrecognized properties are ignored. Can be placed anywhere.
  * New lines end order test. See: https://github.com/SimenB/stylint/issues/399 

Example
Before:
```css
  .searchbar
    border-radius: 5px
    padding: inherit
    border: 1px solid #c0c0c0
    width: 300px
    height: $toolbar-height
    float: left
    margin-left: 5px
```
After
```css
  .searchbar
    float: left
    margin-left: 5px
    padding: inherit
    width: 300px
    height: $toolbar-height
    border: 1px solid #c0c0c0
    border-radius: 5px
```