### PR TITLE
Add a max-width to the channel-switcher menu.

### DIFF
--- a/kolibri/core/assets/src/vue/channel-switcher/index.vue
+++ b/kolibri/core/assets/src/vue/channel-switcher/index.vue
@@ -98,6 +98,7 @@
   @require '~kolibri.styles.definitions'
 
   .channel-switcher-menu
+    max-width: 210px
     .ui-menu-option
         &.is-disabled
           color: $core-accent-color


### PR DESCRIPTION
## Summary

* Add a max-width to the channel-switcher to handle devices with a width of 320px and above. 
* Attempt to address https://github.com/learningequality/kolibri/issues/1044
* Can you think of a better solution?

## Before

![127 0 0 1-8000-learn- iphone 4 1](https://cloud.githubusercontent.com/assets/7193975/24063573/98dba160-0b1d-11e7-8622-46ffe31834a9.png)

## After

![127 0 0 1-8000-learn- iphone 4](https://cloud.githubusercontent.com/assets/7193975/24063556/89287496-0b1d-11e7-8d89-89a6529cec54.png)
