### PR TITLE
Always register translation strings before loading their associated JS scripts.

### DIFF
--- a/kolibri/content/hooks.py
+++ b/kolibri/content/hooks.py
@@ -83,11 +83,11 @@ class ContentRendererHook(WebpackBundleHook):
         :returns: HTML of a script tag to insert into a page.
         """
         urls = [chunk['url'] for chunk in self.bundle]
-        tags = ['<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(
-            kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
-            bundle=self.unique_slug,
-            urls='","'.join(urls),
-            content_types=json.dumps(self._content_type_json),
-        )]
-        tags += self.frontend_message_tag()
+        tags = self.frontend_message_tag() +\
+            ['<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(
+                kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
+                bundle=self.unique_slug,
+                urls='","'.join(urls),
+                content_types=json.dumps(self._content_type_json),
+            )]
         return mark_safe('\n'.join(tags))

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -259,7 +259,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         :param bundle_data: The data returned from
         :return: HTML of script tags for insertion into a page.
         """
-        tags = list(self.js_and_css_tags()) + self.frontend_message_tag()
+        tags = self.frontend_message_tag() + list(self.js_and_css_tags())
 
         return mark_safe('\n'.join(tags))
 
@@ -279,14 +279,14 @@ class WebpackBundleHook(hooks.KolibriHook):
         :returns: HTML of a script tag to insert into a page.
         """
         urls = [chunk['url'] for chunk in self.bundle]
-        tags = ['<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"], {events}, {once});</script>'.format(
-            kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
-            bundle=self.unique_slug,
-            urls='","'.join(urls),
-            events=json.dumps(self.events),
-            once=json.dumps(self.once),
-        )]
-        tags += self.frontend_message_tag()
+        tags = self.frontend_message_tag() +\
+            ['<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"], {events}, {once});</script>'.format(
+                kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
+                bundle=self.unique_slug,
+                urls='","'.join(urls),
+                events=json.dumps(self.events),
+                once=json.dumps(self.once),
+            )]
         return mark_safe('\n'.join(tags))
 
     class Meta:


### PR DESCRIPTION
## Summary

Fixes #1085.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/24066342/ed60153e-0b2e-11e7-8b8c-f5a97a127b56.png)
