### PR TITLE
Remove Last-Modified from response. Not needed.

### DIFF
--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -1,11 +1,9 @@
-import datetime
 import mimetypes
 import os
 import zipfile
 
 from django.http import Http404, HttpResponse
 from django.http.response import FileResponse, HttpResponseNotModified
-from django.utils.http import http_date
 from django.views.generic.base import View
 from le_utils.constants import exercises
 
@@ -60,10 +58,6 @@ class ZipContentView(View):
                 content_with_path = content.replace(str_to_be_replaced, zipcontent)
                 response = HttpResponse(content_with_path, content_type=content_type)
                 file_size = len(content_with_path)
-
-        # set the last-modified header to the date marked on the embedded file
-        if info.date_time:
-            response["Last-Modified"] = http_date(float(datetime.datetime(*info.date_time).strftime("%s")))
 
         # cache these resources forever; this is safe due to the MD5-naming used on content files
         response["Expires"] = "Sun, 17-Jan-2038 19:14:07 GMT"


### PR DESCRIPTION
cherrypick b6d6e5c9df7203e861edd74cba494d092548d9f3

supersedes #1093