### PR TITLE
$tr namespaces

### DIFF
--- a/kolibri/plugins/coach/assets/src/vue/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/vue/groups-page/create-group-modal.vue
@@ -31,7 +31,7 @@
   const groupActions = require('../../group-actions');
 
   module.exports = {
-    $trNameSpace: 'confirm-enrollment-modal',
+    $trNameSpace: 'create-group-modal',
     $trs: {
       newLearnerGroup: 'New Learner Group',
       learnerGroupName: 'Learner Group Name',

--- a/kolibri/plugins/coach/assets/src/vue/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/vue/groups-page/delete-group-modal.vue
@@ -19,7 +19,7 @@
   const groupActions = require('../../group-actions');
 
   module.exports = {
-    $trNameSpace: 'confirm-enrollment-modal',
+    $trNameSpace: 'delete-group-modal',
     $trs: {
       deleteLearnerGroup: 'Delete Learner Group',
       areYouSure: 'Are you sure you want to delete <strong>{ groupName }</strong>?',

--- a/kolibri/plugins/coach/assets/src/vue/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/vue/groups-page/move-learners-modal.vue
@@ -38,7 +38,7 @@
   const groupActions = require('../../group-actions');
 
   module.exports = {
-    $trNameSpace: 'confirm-enrollment-modal',
+    $trNameSpace: 'move-learners-modal',
     $trs: {
       moveLearners: 'Move Learners',
       moveThe: 'Move the',

--- a/kolibri/plugins/coach/assets/src/vue/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/vue/groups-page/rename-group-modal.vue
@@ -29,7 +29,7 @@
   const groupActions = require('../../group-actions');
 
   module.exports = {
-    $trNameSpace: 'confirm-enrollment-modal',
+    $trNameSpace: 'rename-group-modal',
     $trs: {
       renameLearnerGroup: 'Rename Learner Group',
       learnerGroupName: 'Learner Group Name',


### PR DESCRIPTION
fixes current issue:

```
webpack: Compiling...
Kolibri: Duplicate translation id confirm-enrollment-modal.cancel found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/delete-group-modal.vue
Kolibri: Duplicate translation id confirm-enrollment-modal.ungrouped found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/move-learners-modal.vue
Kolibri: Duplicate translation id confirm-enrollment-modal.cancel found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/move-learners-modal.vue
Kolibri: Duplicate translation id confirm-enrollment-modal.learnerGroupName found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/rename-group-modal.vue
Kolibri: Duplicate translation id confirm-enrollment-modal.cancel found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/rename-group-modal.vue
Kolibri: Duplicate translation id confirm-enrollment-modal.save found in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/coach/assets/src/vue/groups-page/rename-group-modal.vue
```

