### PR TITLE
Replace auto with scroll

### DIFF
--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -136,7 +136,7 @@
 
   .content-container
     position: absolute
-    overflow-y: auto
+    overflow-y: scroll
     overflow-x: hidden
     right: 0
     bottom: 0


### PR DESCRIPTION
## Summary

* Replace `auto` with `scroll`
* Addresses https://github.com/learningequality/kolibri/issues/1103