### PR TITLE
pass channel ID to content node resource

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -548,7 +548,7 @@ class Resource {
       }
     });
     if (missingParams.length > 0) {
-      throw TypeError('Missing required resourceIds for: ', missingParams);
+      throw TypeError(`Missing required resourceIds for: ${missingParams}`);
     }
     return filteredParams;
   }

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -187,7 +187,7 @@ function showExploreContent(store, channelId, id) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.EXPLORE_CONTENT);
 
-  const contentPromise = ContentNodeResource.getModel(id).fetch();
+  const contentPromise = ContentNodeResource.getModel(id, { channel_id: channelId }).fetch();
   const channelsPromise = coreActions.setChannelInfo(store, channelId);
   ConditionalPromise.all([contentPromise, channelsPromise]).only(
     samePageCheckGenerator(store),


### PR DESCRIPTION

In current develop, trying to navigate to a content item throws an error:

```
Uncaught (in promise) TypeError: Missing required resourceIds
```

It's referring to the `channel_id` on a content node. This PR passes that ID and fixes the error reporting.

