### PR TITLE
Replaces drawer left arrow icon with menu icon

### DIFF
--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -12,7 +12,7 @@
           type="secondary"
           color="white"
           size="large"
-          icon="keyboard_arrow_left"
+          icon="menu"
           :aria-label="closeNav"/>
         <ui-icon class="header-logo"><logo/></ui-icon>
         <span class="title">Kolibri</span>


### PR DESCRIPTION
## Summary

* Replaces drawer left arrow icon with menu icon
* Somewhat addresses https://github.com/learningequality/kolibri/issues/953
* TODO: Do the same to VF plugin
 
## Before
![before](https://cloud.githubusercontent.com/assets/7193975/24312157/866487aa-1094-11e7-9804-ec5036f262d6.gif)

## After
![afer](https://cloud.githubusercontent.com/assets/7193975/24312164/899a7dda-1094-11e7-8837-a2c5484c103c.gif)
