### PR TITLE
Replaces copyright icon with copyright symbol

### DIFF
--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -35,7 +35,7 @@
         <div class="message-container">
           <p class="message">{{ footerMsg }}</p>
           <p class="message">
-            <ui-icon icon="copyright"/>
+            ©
             {{ $tr('learningEqualityCopyright') }}
           </p>
         </div>

--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -34,10 +34,7 @@
           :style="{ width: width/6 + 'px', height: width/6 + 'px', marginLeft: width/20 + 'px', marginRight: width/20 + 'px' }"/>
         <div class="message-container">
           <p class="message">{{ footerMsg }}</p>
-          <p class="message">
-            ©
-            {{ $tr('learningEqualityCopyright') }}
-          </p>
+          <p class="message">{{ $tr('learningEqualityCopyright') }}</p>
         </div>
       </div>
     </div>
@@ -77,7 +74,7 @@
       about: 'About',
       closeNav: 'Close navigation',
       poweredBy: 'Kolibri {version}',
-      learningEqualityCopyright: '2017 Learning Equality',
+      learningEqualityCopyright: '© 2017 Learning Equality',
     },
     props: {
       topLevelPageName: {


### PR DESCRIPTION
## Summary

* Replaces copyright icon with copyright symbol
* Icon was not necessary. 
* TODO: Do the same to the VF plugin :disappointed: 

## Before
![before](https://cloud.githubusercontent.com/assets/7193975/24312445/dece5e92-1095-11e7-8fee-817eec9d6705.png)

## After
![after](https://cloud.githubusercontent.com/assets/7193975/24312451/e5757b72-1095-11e7-8234-239a1e2ba717.png)
