### PR TITLE
Hides fullscreen buttons if fullscreen is not allowed

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -3,7 +3,7 @@
   <div ref="container" class="container" allowfullscreen>
     <icon-button
       class="btn"
-      v-if="supportsPDFs"
+      v-if="fullscreenAllowed && supportsPDFs"
       :text="isFullScreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
       @click="toggleFullScreen"
       :primary="true">
@@ -32,6 +32,7 @@
     data: () => ({
       supportsPDFs: PDFobject.supportsPDFs,
       timeout: null,
+      fullscreenAllowed: ScreenFull.enabled,
       isFullScreen: false,
     }),
 

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -3,6 +3,7 @@
   <div ref="container" class="container" allowfullscreen>
     <icon-button
       class="btn"
+      v-if="fullscreenAllowed"
       :text="isFullScreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
       @click="toggleFullScreen"
       :primary="true">
@@ -30,6 +31,7 @@
       },
     },
     data: () => ({
+      fullscreenAllowed: ScreenFull.enabled,
       isFullScreen: false,
     }),
     computed: {


### PR DESCRIPTION
## Summary

* Hides fullscreen buttons if fullscreen is not allowed
* Partially addresses https://github.com/learningequality/kolibri/issues/977 since the fullscreen buttons should have not been visible since there is no support for fullscreen on iOS Safari . 