### PR TITLE
Prevents iframe from overflowing

### DIFF
--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -186,6 +186,7 @@
 
   .content-wrapper
     height: 100%
+    overflow-x: scroll
 
   #spinner
     height: 160px


### PR DESCRIPTION
## Summary

* Prevents iframe from overflowing
* Addresses https://github.com/learningequality/kolibri/issues/1042

 ## Before
![bs_realios_mobile_iphone 5s-7 0 1](https://cloud.githubusercontent.com/assets/7193975/24318422/49aeaf2e-10c2-11e7-8677-fe1499a39c1d.jpg)

## After

![bs_realios_mobile_iphone 5s-7 0](https://cloud.githubusercontent.com/assets/7193975/24318424/4f5631fe-10c2-11e7-9859-24e35dd1de86.jpg)
