### PR TITLE
Class scoping API fix

### DIFF
--- a/kolibri/plugins/coach/utils/return_users.py
+++ b/kolibri/plugins/coach/utils/return_users.py
@@ -5,4 +5,4 @@ def get_members_or_user(collection_kind, collection_id):
     if 'user' == collection_kind:
         return FacilityUser.objects.filter(pk=collection_id)
     else:  # if not user, then it must be a collection
-        return Collection.objects.filter(kind=collection_kind).get(pk=collection_id).get_members()
+        return list(Collection.objects.filter(kind=collection_kind).get(pk=collection_id).get_members())


### PR DESCRIPTION
## Summary

Fixing the classroom error by evaluating `get_members` before passing it in as a filter argument, #1141 

As discussed in #1123 

## Addresses
#1123 