### PR TITLE
Add external plugins' locale folders to LOCALE_PATHS.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -17,8 +17,9 @@ import platform
 
 # import kolibri, so we can get the path to the module.
 import kolibri
+# we load other utilities related to i18n
 # This is essential! We load the kolibri conf INSIDE the Django conf
-from kolibri.utils import conf
+from kolibri.utils import conf, i18n
 
 KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
 
@@ -63,6 +64,13 @@ INSTALLED_APPS = [
     'rest_framework',
     'django_js_reverse',
 ] + conf.config['INSTALLED_APPS']
+
+# Add in the external plugins' locale paths. Our frontend messages depends
+# specifically on the value of LOCALE_PATHS to find its catalog files.
+LOCALE_PATHS += [
+    i18n.get_installed_app_locale_path(app) for app in INSTALLED_APPS
+    if i18n.is_external_plugin(app)
+]
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -1,0 +1,30 @@
+import importlib
+import os
+
+EXTERNAL_PLUGINS_PREFIX = "kolibri_"
+
+
+def is_external_plugin(appname):
+    '''
+    Returns true when the given app is an external plugin.
+
+    Implementation note: does a simple check on the name to see if it's
+    prefixed with "kolibri_". If so, we think it's a plugin.
+    '''
+
+    return appname.startswith(EXTERNAL_PLUGINS_PREFIX)
+
+
+def get_installed_app_locale_path(appname):
+    """
+    Load the app given by appname and return its locale folder path, if it exists.
+
+    Note that the module is imported to determine its location.
+    """
+
+    m = importlib.import_module(appname)
+    module_path = os.path.dirname(m.__file__)
+    module_locale_path = os.path.join(module_path, "locale")
+
+    if os.path.isdir(module_locale_path):
+        return module_locale_path


### PR DESCRIPTION
Fixes #1138. `LOCALE_PATHS` is used by our frontend messages system to find its catalog files. 

![screen shot 2017-03-27 at 17 14 43](https://cloud.githubusercontent.com/assets/191955/24383881/b08df6e2-1314-11e7-87a0-d68f83742348.png)
