### PR TITLE
Patching up errors caused my #1140

### DIFF
--- a/kolibri/plugins/coach/serializers.py
+++ b/kolibri/plugins/coach/serializers.py
@@ -142,4 +142,4 @@ class ContentSummarySerializer(ContentReportSerializer):
 
     def get_num_users(self, target_node):
         kwargs = self.context['view'].kwargs
-        return get_members_or_user(kwargs['collection_kind'], kwargs['collection_id']).count()
+        return len(get_members_or_user(kwargs['collection_kind'], kwargs['collection_id']))


### PR DESCRIPTION
#1140 changed the return value of `get_members_or_user`, caused some issues with counting # of users. This patches that. Came across bug, assisted by @indirectlylit 