### PR TITLE
fork ui-menu and make active items clickable

### DIFF
--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -196,13 +196,6 @@
             href: '/user',
           });
         }
-        /*
-         options.push({
-         label: this.$tr('about'),
-         disabled: this.aboutActive,
-         icon: 'error_outline',
-         });
-         */
         if (this.isUserLoggedIn) {
           options.push({
             label: this.$tr('signOut'),

--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -164,7 +164,7 @@
         const options = [
           {
             label: this.$tr('learn'),
-            disabled: this.learnActive,
+            active: this.learnActive,
             icon: 'school',
             href: '/learn',
           },
@@ -172,7 +172,7 @@
         if (this.isCoachAdminOrSuperuser) {
           options.push({
             label: this.$tr('coach'),
-            disabled: this.coachActive,
+            active: this.coachActive,
             icon: 'assessment',
             href: '/coach',
           });
@@ -180,7 +180,7 @@
         if (this.isAdminOrSuperuser) {
           options.push({
             label: this.$tr('manage'),
-            disabled: this.manageActive,
+            active: this.manageActive,
             icon: 'people',
             href: '/management',
           });
@@ -191,7 +191,7 @@
         if (this.isUserLoggedIn && !this.isAdminOrSuperuser) {
           options.push({
             label: this.$tr('profile'),
-            disabled: this.profileActive,
+            active: this.profileActive,
             icon: 'account_circle',
             href: '/user',
           });
@@ -336,11 +336,10 @@
       margin: 5px 0
       &:not(.is-divider)
         font-size: 14px
-        &.is-disabled
+        &.is-active
           .ui-menu-option-icon
             color: $core-accent-color
           color: $core-accent-color
-          cursor: default
           font-weight: bold
           opacity: 1
         .ui-menu-option-text

--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -213,7 +213,7 @@
       },
     },
     components: {
-      'ui-menu': require('keen-ui/src/UiMenu'),
+      'ui-menu': require('./keen-menu-port'),
       'ui-icon': require('keen-ui/src/UiIcon'),
       'ui-icon-button': require('keen-ui/src/UiIconButton'),
       'logo': require('kolibri.coreVue.components.logo'),
@@ -337,15 +337,15 @@
       &:not(.is-divider)
         font-size: 14px
         &.is-disabled
-          .ui-menu-option__icon
+          .ui-menu-option-icon
             color: $core-accent-color
           color: $core-accent-color
           cursor: default
           font-weight: bold
           opacity: 1
-        .ui-menu-option__text
+        .ui-menu-option-text
           overflow: visible
-        .ui-menu-option__icon
+        .ui-menu-option-icon
           font-size: 1.2em
       &.is_divider
         background-color: $core-text-annotation

--- a/kolibri/core/assets/src/views/nav-bar/keen-menu-port/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/keen-menu-port/index.vue
@@ -4,6 +4,7 @@
     <menu-option
       :disable-ripple="disableRipple"
       :disabled="option[keys.disabled]"
+      :active="Boolean(option.active)"
       :icon-props="iconProps || option[keys.iconProps]"
       :icon="hasIcons ? option[keys.icon] : null"
       :label="option[keys.type] === 'divider' ? null : option[keys.label] || option"

--- a/kolibri/core/assets/src/views/nav-bar/keen-menu-port/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/keen-menu-port/index.vue
@@ -1,0 +1,154 @@
+<template>
+
+  <ul class="ui-menu" role="menu" :class="classes">
+    <menu-option
+      :disable-ripple="disableRipple"
+      :disabled="option[keys.disabled]"
+      :icon-props="iconProps || option[keys.iconProps]"
+      :icon="hasIcons ? option[keys.icon] : null"
+      :label="option[keys.type] === 'divider' ? null : option[keys.label] || option"
+      :secondary-text="hasSecondaryText ? option[keys.secondaryText] : null"
+      :type="option[keys.type]"
+
+      @click.native="selectOption(option)"
+      @keydown.enter.native.prevent="selectOption(option)"
+      @keydown.esc.native.esc="closeMenu"
+
+      v-for="option in options"
+    >
+      <slot name="option" :option="option"></slot>
+    </menu-option>
+
+    <div
+      class="ui-menu-focus-redirector"
+      tabindex="0"
+
+      @focus="redirectFocus"
+
+      v-if="containFocus"
+    ></div>
+  </ul>
+
+</template>
+
+
+<script>
+
+  import config from 'keen-ui/src/config';
+
+  import UiMenuOption from './menu-option.vue';
+
+  export default {
+    name: 'ui-menu',
+
+    props: {
+      options: {
+        type: Array,
+        default() {
+          return [];
+        }
+      },
+      hasIcons: {
+        type: Boolean,
+        default: false
+      },
+      iconProps: Object,
+      hasSecondaryText: {
+        type: Boolean,
+        default: false
+      },
+      containFocus: {
+        type: Boolean,
+        default: false
+      },
+      keys: {
+        type: Object,
+        default() {
+          return config.data.UiMenu.keys;
+        }
+      },
+      disableRipple: {
+        type: Boolean,
+        default: config.data.disableRipple
+      },
+      raised: {
+        type: Boolean,
+        default: false
+      }
+    },
+
+    computed: {
+      classes() {
+        return {
+          'is-raised': this.raised,
+          'has-icons': this.hasIcons,
+          'has-secondary-text': this.hasSecondaryText,
+        };
+      },
+    },
+
+    methods: {
+      selectOption(option) {
+        if (option.disabled || option.type === 'divider') {
+          return;
+        }
+
+        this.$emit('select', option);
+        this.closeMenu();
+      },
+
+      closeMenu() {
+        this.$emit('close');
+      },
+
+      redirectFocus(e) {
+        e.stopPropagation();
+        this.$el.querySelector('.ui-menu-option').focus();
+      }
+    },
+
+    components: {
+      'menu-option': UiMenuOption,
+    },
+  };
+
+</script>
+
+
+<style lang="scss">
+
+  @import '~keen-ui/src/styles/imports';
+
+  .ui-menu {
+      background-color: white;
+      border: rem-calc(1px) solid rgba(black, 0.08);
+      font-family: $font-stack;
+      list-style: none;
+      margin: 0;
+      max-height: 100vh;
+      max-width: rem-calc(272px);
+      min-width: rem-calc(168px);
+      outline: none;
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding: rem-calc(4px 0);
+
+      &.is-raised {
+          border: none;
+          box-shadow: 0 2px 4px -1px rgba(black, 0.2),
+                      0 4px 5px 0 rgba(black, 0.14),
+                      0 1px 10px 0 rgba(black, 0.12);
+      }
+
+      &.has-secondary-text {
+          min-width: rem-calc(240px);
+          max-width: rem-calc(304px);
+      }
+  }
+
+  .ui-menu-focus-redirector {
+      position: absolute;
+      opacity: 0;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/nav-bar/keen-menu-port/menu-option.vue
+++ b/kolibri/core/assets/src/views/nav-bar/keen-menu-port/menu-option.vue
@@ -1,0 +1,163 @@
+<template>
+
+  <li
+    class="ui-menu-option"
+    ref="menuOption"
+    role="menu-item"
+
+    :class="classes"
+    :tabindex="(isDivider || disabled) ? null : '0'"
+  >
+    <slot v-if="!isDivider">
+      <div class="ui-menu-option-content">
+        <ui-icon
+          class="ui-menu-option-icon"
+
+          :icon-set="iconProps.iconSet"
+          :icon="icon"
+          :remove-text="iconProps.removeText"
+          :use-svg="iconProps.useSvg"
+
+          v-if="icon"
+        ></ui-icon>
+
+        <div class="ui-menu-option-text">{{ label }}</div>
+
+        <div class="ui-menu-option-secondary-text" v-if="secondaryText">
+          {{ secondaryText }}
+        </div>
+      </div>
+    </slot>
+
+    <ui-ripple-ink
+      trigger="menuOption"
+      v-if="!disabled && !isDivider && !disableRipple"
+    ></ui-ripple-ink>
+  </li>
+
+</template>
+
+
+<script>
+
+  import config from 'keen-ui/src/config';
+
+  import UiIcon from 'keen-ui/src/UiIcon.vue';
+  import UiRippleInk from 'keen-ui/src/UiRippleInk.vue';
+
+  export default {
+    name: 'ui-menu-option',
+
+    props: {
+      type: String,
+      label: String,
+      icon: String,
+      iconProps: {
+        type: Object,
+        default() {
+          return {};
+        }
+      },
+      secondaryText: String,
+      disableRipple: {
+        type: Boolean,
+        default: config.data.disableRipple
+      },
+      disabled: {
+        type: Boolean,
+        default: false
+      }
+    },
+
+    computed: {
+      classes() {
+        return {
+          'is-divider': this.isDivider,
+          'is-disabled': this.disabled
+        };
+      },
+
+      isDivider() {
+        return this.type === 'divider';
+      }
+    },
+
+    components: {
+      UiIcon,
+      UiRippleInk
+    }
+  };
+
+</script>
+
+
+<style lang="scss">
+
+  @import '~keen-ui/src/styles/imports';
+
+  .ui-menu-option {
+      display: block;
+      font-family: $font-stack;
+      position: relative;
+      user-select: none;
+      width: 100%;
+
+      &.is-divider {
+          background-color: rgba(black, 0.08);
+          display: block;
+          height: rem-calc(1px);
+          margin: rem-calc(6px 0);
+          padding: 0;
+      }
+
+      &:not(.is-divider) {
+          color: $primary-text-color;
+          cursor: pointer;
+          font-size: $ui-dropdown-item-font-size;
+          font-weight: normal;
+          min-height: rem-calc(40px);
+          outline: none;
+
+          &:hover:not(.is-disabled),
+          body[modality="keyboard"] &:focus {
+              background-color: #EEEEEE; // rgba(black, 0.1);
+          }
+
+          &.is-disabled {
+              color: $secondary-text-color;
+              cursor: default;
+              opacity: 0.5;
+
+              .ui-menu-option-secondary-text {
+                  color: $secondary-text-color;
+              }
+          }
+      }
+  }
+
+  .ui-menu-option-content {
+      align-items: center;
+      display: flex;
+      height: rem-calc(40px);
+      padding: rem-calc(0 16px);
+  }
+
+  .ui-menu-option-icon {
+      color: $secondary-text-color;
+      font-size: rem-calc(18px);
+      margin-right: rem-calc(16px);
+  }
+
+  .ui-menu-option-text {
+      @include text-truncation;
+      flex-grow: 1;
+  }
+
+  .ui-menu-option-secondary-text {
+      color: $hint-text-color;
+      flex-shrink: 0;
+      font-size: rem-calc(13px);
+      margin-left: rem-calc(4px);
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/nav-bar/keen-menu-port/menu-option.vue
+++ b/kolibri/core/assets/src/views/nav-bar/keen-menu-port/menu-option.vue
@@ -66,14 +66,19 @@
       disabled: {
         type: Boolean,
         default: false
-      }
+      },
+      active: {
+        type: Boolean,
+        default: false,
+      },
     },
 
     computed: {
       classes() {
         return {
           'is-divider': this.isDivider,
-          'is-disabled': this.disabled
+          'is-disabled': this.disabled,
+          'is-active': this.active
         };
       },
 


### PR DESCRIPTION
Copies code from ui-menu into our code-base, and adds a new 'active' option.

Shorter-term, this provides a way to get back to the root level of the coach app after selecting a class, which is not currently possible with the state of the UI.

Longer-term, this also allows us greater control over this component and allows us to remove some unscoped files.

fixes #1160