### PR TITLE
Add more specific assertions to the data validation specs for api-resource.js.

### DIFF
--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -49,9 +49,10 @@ describe('ResourceManager', function () {
     it('should throw a TypeError if the resource name is already registered', function () {
       function mockClass() {}
       mockClass.resourceName = () => this.mockClassName;
-      this.resourceManager._resources[this.mockClassName] = {};
-      assert.throws(() => this.resourceManager.registerResource(this.mockName, mockClass),
-        /been registered/);
+      // try to register the resource twice
+      const register = () => this.resourceManager.registerResource(this.mockName, mockClass);
+      register();
+      assert.throws(register, /been registered/);
     });
     describe('when successfully registering', function () {
       beforeEach(function () {

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -32,7 +32,7 @@ describe('ResourceManager', function () {
       assert.deepEqual(this.resourceManager._resources, {});
     });
   });
-  describe.only('registerResource method', function () {
+  describe('registerResource method', function () {
     it('should throw a TypeError if no className is passed', function () {
       assert.throws(this.resourceManager.registerResource, /className/);
     });
@@ -47,10 +47,9 @@ describe('ResourceManager', function () {
         /resource name/);
     });
     it('should throw a TypeError if the resource name is already registered', function () {
-      const mockClass = {
-        resourceName: sinon.stub().returns(this.mockClassName),
-      };
-      this.resourceManager._resources.test = {};
+      function mockClass() {}
+      mockClass.resourceName = () => this.mockClassName;
+      this.resourceManager._resources[this.mockClassName] = {};
       assert.throws(() => this.resourceManager.registerResource(this.mockName, mockClass),
         /been registered/);
     });

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -32,19 +32,19 @@ describe('ResourceManager', function () {
       assert.deepEqual(this.resourceManager._resources, {});
     });
   });
-  describe('registerResource method', function () {
+  describe.only('registerResource method', function () {
     it('should throw a TypeError if no className is passed', function () {
-      assert.throws(this.resourceManager.registerResource, TypeError);
+      assert.throws(this.resourceManager.registerResource, /className/);
     });
     it('should throw a TypeError if no ResourceClass is passed', function () {
-      assert.throws(() => this.resourceManager.registerResource(this.mockName), TypeError);
+      assert.throws(() => this.resourceManager.registerResource(this.mockName), /ResourceClass/);
     });
     it('should throw a TypeError if the ResourceClass does not have a name', function () {
       const mockClass = {
         resourceName: sinon.spy(),
       };
       assert.throws(() => this.resourceManager.registerResource(this.mockName, mockClass),
-        TypeError);
+        /resource name/);
     });
     it('should throw a TypeError if the resource name is already registered', function () {
       const mockClass = {
@@ -52,7 +52,7 @@ describe('ResourceManager', function () {
       };
       this.resourceManager._resources.test = {};
       assert.throws(() => this.resourceManager.registerResource(this.mockName, mockClass),
-        TypeError);
+        /been registered/);
     });
     describe('when successfully registering', function () {
       beforeEach(function () {

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -33,20 +33,20 @@ describe('ResourceManager', function () {
     });
   });
   describe('registerResource method', function () {
-    it('should throw a TypeError if no className is passed', function () {
+    it('should throw a "must specify a className" Error if none is passed', function () {
       assert.throws(this.resourceManager.registerResource, /className/);
     });
-    it('should throw a TypeError if no ResourceClass is passed', function () {
+    it('should throw a "must specify ResourceClass" Error if none is passed', function () {
       assert.throws(() => this.resourceManager.registerResource(this.mockName), /ResourceClass/);
     });
-    it('should throw a TypeError if the ResourceClass does not have a name', function () {
+    it('should throw a "must have [...] resource name" Error if ResourceClass does not one', function () {
       const mockClass = {
         resourceName: sinon.spy(),
       };
       assert.throws(() => this.resourceManager.registerResource(this.mockName, mockClass),
         /resource name/);
     });
-    it('should throw a TypeError if the resource name is already registered', function () {
+    it('should throw a "already been registered" Error if the resource name is already registered', function () {
       function mockClass() {}
       mockClass.resourceName = () => this.mockClassName;
       // try to register the resource twice


### PR DESCRIPTION
Add more specific assertions to the data validation specs for api-resource.js

This refactoring uncovered a test that was failing for unintended reasons, so I fixed that too, and also refactored it to not use a private method in the implementation.