### PR TITLE
Refactor test to pull shared stuff from closure instead of 'this'

### DIFF
--- a/kolibri/core/assets/test/vue.progress-bar.js
+++ b/kolibri/core/assets/test/vue.progress-bar.js
@@ -1,10 +1,9 @@
 /* eslint-env mocha */
-
 const Vue = require('vue-test');
+const assert = require('assert');
 const progressBar = require('../src/views/progress-bar');
 
 const ProgressBarComponent = Vue.extend(progressBar);
-const assert = require('assert');
 
 describe('progressBar Component', () => {
   describe('`percent` computed property', () => {
@@ -17,7 +16,7 @@ describe('progressBar Component', () => {
       }).$mount();
     });
     it('should give 0 percent for progress of < 0', () => {
-      vm.progress = -1.0;
+      vm.progress = -0.0000000001;
       assert.equal(vm.percent, 0);
     });
     it('should give 10 percent for progress of 0.1', () => {
@@ -29,7 +28,7 @@ describe('progressBar Component', () => {
       assert.equal(vm.percent, 100);
     });
     it('should give 100 percent for progress of > 1.0', () => {
-      vm.progress = 70.0;
+      vm.progress = 1.0000000001;
       assert.equal(vm.percent, 100);
     });
   });

--- a/kolibri/core/assets/test/vue.progress-bar.js
+++ b/kolibri/core/assets/test/vue.progress-bar.js
@@ -1,7 +1,4 @@
 /* eslint-env mocha */
-// The following two rules are disabled so that we can use anonymous functions with mocha
-// This allows the test instance to be properly referenced with `this`
-/* eslint prefer-arrow-callback: "off", func-names: "off" */
 
 const Vue = require('vue-test');
 const progressBar = require('../src/views/progress-bar');
@@ -9,32 +6,31 @@ const progressBar = require('../src/views/progress-bar');
 const ProgressBarComponent = Vue.extend(progressBar);
 const assert = require('assert');
 
-describe('progressBar Component', function () {
-  describe('computed property', function () {
-    describe('percent', function () {
-      beforeEach(function () {
-        this.vm = new ProgressBarComponent({
-          propsData: {
-            progress: 0,
-          },
-        }).$mount();
-      });
-      it('should give 0 percent for progress of < 0', function () {
-        this.vm.progress = -1.0;
-        assert.equal(this.vm.percent, 0);
-      });
-      it('should give 10 percent for progress of 0.1', function () {
-        this.vm.progress = 0.1;
-        assert.equal(this.vm.percent, 10);
-      });
-      it('should give 100 percent for progress of 1.0', function () {
-        this.vm.progress = 1.0;
-        assert.equal(this.vm.percent, 100);
-      });
-      it('should give 100 percent for progress of > 1.0', function () {
-        this.vm.progress = 70.0;
-        assert.equal(this.vm.percent, 100);
-      });
+describe('progressBar Component', () => {
+  describe('`percent` computed property', () => {
+    let vm;
+    beforeEach(() => {
+      vm = new ProgressBarComponent({
+        propsData: {
+          progress: 0,
+        },
+      }).$mount();
+    });
+    it('should give 0 percent for progress of < 0', () => {
+      vm.progress = -1.0;
+      assert.equal(vm.percent, 0);
+    });
+    it('should give 10 percent for progress of 0.1', () => {
+      vm.progress = 0.1;
+      assert.equal(vm.percent, 10);
+    });
+    it('should give 100 percent for progress of 1.0', () => {
+      vm.progress = 1.0;
+      assert.equal(vm.percent, 100);
+    });
+    it('should give 100 percent for progress of > 1.0', () => {
+      vm.progress = 70.0;
+      assert.equal(vm.percent, 100);
     });
   });
 });


### PR DESCRIPTION
I wanted to do this on the smallest test for illustrative purposes.

Instead of attaching shared symbols to `this`, it might be better to just put it in the closure of the `describe` block.

Some benefits:

1. The linter can actually find 'no-undefined' and 'no-shadowing' violations
1. If something is actually a constant, no need to setup/teardown in beforeEach
1. Can use arrow functions again
1. Less typing