### PR TITLE
Fix mimetypes for windows for zip file endpoint.

### DIFF
--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -9,6 +9,9 @@ from le_utils.constants import exercises
 
 from .utils.paths import get_content_storage_file_path
 
+# Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
+# https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
+mimetypes.init([])
 
 class ZipContentView(View):
 


### PR DESCRIPTION
## Summary

Side step known and unfixed bug in Python `mimetypes` package for Windows.

https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/