### PR TITLE
Removes dateCreated from Exams

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -110,21 +110,18 @@ function showExamsPage(store, classId) {
         id: '1',
         title: 'UNIT 1 Exam',
         active: false,
-        dateCreated: 'March 15, 2017 03:24:00',
         visibility: { class: false, groups: [{ id: '1', name: 'groupA' }, { id: '2', name: 'groupA' }] },
       },
       {
         id: '2',
         title: 'UNIT 1 Quiz',
         active: true,
-        dateCreated: 'March 21, 2017 03:24:00',
         visibility: { class: false, groups: [{ id: '1', name: 'groupA' }] },
       },
       {
         id: '3',
         title: 'UNIT 2',
         active: true,
-        dateCreated: 'March 22, 2017 03:24:00',
         visibility: { class: true, groups: [{ id: '1', name: 'groupA' }, { id: '2', name: 'groupA' }] },
       }];
 

--- a/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
@@ -8,12 +8,8 @@
         :class="examActive ? 'icon-active' : 'icon-inactive'"
       />
     </td>
-    <td class="col-title">
-      <strong>{{ examTitle }}</strong>
-        <span v-if="examActive">{{ $tr('active') }}</span>
-        <span v-else>{{ $tr('inactive') }}</span>
-        {{ ` - ${$tr('createdOn')} ${examDate}` }}
-    </td>
+
+    <td class="col-title"><strong>{{ examTitle }}</strong></td>
 
     <td class="col-visibility"><strong>{{ visibilityString }}</strong> |
       <ui-button
@@ -65,9 +61,6 @@
   module.exports = {
     $trNameSpace: 'examRow',
     $trs: {
-      active: 'Active',
-      inactive: 'Inactive',
-      createdOn: 'Created on',
       change: 'Change',
       activate: 'Activate',
       deactivate: 'Deactivate',
@@ -95,10 +88,6 @@
       },
       examActive: {
         type: Boolean,
-        required: true,
-      },
-      examDate: {
-        type: String,
         required: true,
       },
       examVisibility: {

--- a/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
@@ -33,7 +33,6 @@
           :examId="exam.id"
           :examTitle="exam.title"
           :examActive="exam.active"
-          :examDate="exam.dateCreated"
           :examVisibility="exam.visibility"
           :classId="currentClass.id"
           :className="currentClass.name"


### PR DESCRIPTION
## Summary

* Removes `dateCreated` from Exams.
* Removes 'active' and 'inactive' per [updated mockups](https://projects.invisionapp.com/share/7D8ZDY4EN#/screens/222425504) 
