### PR TITLE
Build kolibri windows installer in kolibri branch release-v0.3.x

### DIFF
--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -12,7 +12,7 @@ make writeversion
 
 # Clone kolibri windows installer base in develop branch.
 cd $KOLIBRI_DOCKER_PATH \
-    && git clone https://github.com/learningequality/kolibri-installers.git \
+    && git clone https://github.com/learningequality/kolibri-installer-windows.git \
     && cd kolibri-installers \
     && git checkout develop
 

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PARENT_PATH=$(pwd)
+KOLIBRI_DOCKER_PATH="$PARENT_PATH/windows_installer_docker_build"
+KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installers/windows"
+
+mkdir dist
+buildkite-agent artifact download 'dist/*.whl' dist/
+make writeversion
+
+# Clone kolibri windows installer base in develop branch.
+cd $KOLIBRI_DOCKER_PATH \
+    && git clone https://github.com/learningequality/kolibri-installers.git \
+    && cd kolibri-installers \
+    && git checkout develop
+
+# Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.
+cd $PARENT_PATH
+cp $PARENT_PATH/dist/*.whl $KOLIBRI_WINDOWS_PATH
+
+# Build kolibri windows installer docker image.
+cd $KOLIBRI_DOCKER_PATH
+KOLBIRI_VERSION=$(cat $PARENT_PATH/kolibri/VERSION)
+DOCKER_BUILD_CMD="docker build -t $KOLBIRI_VERSION-build ."
+$DOCKER_BUILD_CMD
+if [ $? -ne 0 ]; then
+    echo ".. Abort!  Error running $DOCKER_BUILD_CMD."
+    exit 1
+fi
+
+INSTALLER_PATH="$KOLIBRI_DOCKER_PATH/installer"
+rm -rf $INSTALLER_PATH
+mkdir $INSTALLER_PATH
+
+# Run kolibri windows installer docker image.
+DOCKER_RUN_CMD="docker run -v $INSTALLER_PATH:/installer/ $KOLBIRI_VERSION-build"
+$DOCKER_RUN_CMD
+if [ $? -ne 0 ]; then
+    echo ".. Abort!  Error running $DOCKER_RUN_CMD."
+    exit 1
+fi
+
+# Upload built kolibri windows installer at buildkite artifact. 
+cd $KOLIBRI_DOCKER_PATH
+buildkite-agent artifact upload './installer/*.exe'

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 PARENT_PATH=$(pwd)
 KOLIBRI_DOCKER_PATH="$PARENT_PATH/windows_installer_docker_build"
-KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installers/windows"
+KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installer-windows/windows"
 
 mkdir dist
 buildkite-agent artifact download 'dist/*.whl' dist/
@@ -13,7 +13,7 @@ make writeversion
 # Clone kolibri windows installer base in develop branch.
 cd $KOLIBRI_DOCKER_PATH \
     && git clone https://github.com/learningequality/kolibri-installer-windows.git \
-    && cd kolibri-installers \
+    && cd kolibri-installer-windows \
     && git checkout develop
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,3 +11,8 @@ steps:
 
   - label: Build the pex file
     command: mkdir -p dist && .buildkite/build_pex.sh
+
+  - wait
+
+  - label: Build kolibri windows installer
+    command: .buildkite/build_windows_installer.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,5 @@ steps:
   - label: Build the pex file
     command: mkdir -p dist && .buildkite/build_pex.sh
 
-  - wait
-
   - label: Build kolibri windows installer
     command: .buildkite/build_windows_installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ RUN apt-get install -y python2.7 python3.6 python-pip git nodejs yarn gettext py
 COPY . /kolibri
 
 VOLUME /kolibridist/  # for mounting the whl files into other docker containers
-CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt && yarn install && make dist && cp /kolibri/dist/* /kolibridist/
+CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt \
+	&& yarn install \
+	&& make make dist REQUIREMENTS=requirements/vf.txt dist \
+	&& cp /kolibri/dist/* /kolibridist/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ VOLUME /kolibridist/  # for mounting the whl files into other docker containers
 CMD cd /kolibri && pip install -r requirements/dev.txt \
 	&& pip install -r requirements/vf.txt \
 	&& pip install -r requirements/build.txt \
+	&& python -m kolibri plugin kolibri-instant-schools-plugin enable \
 	&& yarn install \
-	&& make dist \
+	&& make dist REQUIREMENTS=requirements/vf.txt \
 	&& cp /kolibri/dist/* /kolibridist/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get install -y python2.7 python3.6 python-pip git nodejs yarn gettext py
 COPY . /kolibri
 
 VOLUME /kolibridist/  # for mounting the whl files into other docker containers
-CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt \
+CMD cd /kolibri && pip install -r requirements/dev.txt \
+	&& pip install -r requirements/vf.txt \
+	&& pip install -r requirements/build.txt \
 	&& yarn install \
 	&& make dist \
 	&& cp /kolibri/dist/* /kolibridist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ VOLUME /kolibridist/  # for mounting the whl files into other docker containers
 CMD cd /kolibri && pip install -r requirements/dev.txt \
 	&& pip install -r requirements/vf.txt \
 	&& pip install -r requirements/build.txt \
-	&& python -m kolibri plugin kolibri-instant-schools-plugin enable \
+	&& python -m kolibri plugin kolibri_instant_schools_plugin enable \
 	&& yarn install \
 	&& make dist REQUIREMENTS=requirements/vf.txt \
 	&& cp /kolibri/dist/* /kolibridist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ COPY . /kolibri
 VOLUME /kolibridist/  # for mounting the whl files into other docker containers
 CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt \
 	&& yarn install \
-	&& make make dist REQUIREMENTS=requirements/vf.txt dist \
+	&& make dist REQUIREMENTS=requirements/vf.txt dist \
 	&& cp /kolibri/dist/* /kolibridist/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ COPY . /kolibri
 VOLUME /kolibridist/  # for mounting the whl files into other docker containers
 CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt \
 	&& yarn install \
-	&& make dist REQUIREMENTS=requirements/vf.txt dist \
+	&& make dist \
 	&& cp /kolibri/dist/* /kolibridist/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 REQUIREMENTS=requirements.txt
-VF_REQUIREMENTS="requirements/vf.txt"
 
 .PHONY: help clean clean-pyc clean-build list test test-all coverage docs release sdist
 
@@ -67,7 +66,6 @@ release: clean assets
 	python setup.py bdist_wheel upload
 
 staticdeps: clean
-	pip install -t kolibri/dist -r $(VF_REQUIREMENTS)
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ release: clean assets
 	python setup.py bdist_wheel upload
 
 staticdeps: clean
-	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	pip install -t kolibri/dist -r $(VF_REQUIREMENTS)
+	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 
 writeversion:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REQUIREMENTS=requirements.txt
+VF_REQUIREMENTS="requirements/vf.txt"
 
 .PHONY: help clean clean-pyc clean-build list test test-all coverage docs release sdist
 
@@ -67,6 +68,7 @@ release: clean assets
 
 staticdeps: clean
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
+	pip install -t kolibri/dist -r $(VF_REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 
 writeversion:

--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Build kolibri windows installer.
 RUN mkdir /installer/
-RUN cd /kolibri/kolibri-installers/windows \
+RUN cd /kolibri/kolibri-installer-windows/windows \
     && WHL_FILE=$(find ./ -name \*.whl) \
     && WHL_FILE=$(basename $WHL_FILE) \
     && WHL_FILE=${WHL_FILE:8} \
@@ -23,4 +23,4 @@ RUN cd /kolibri/kolibri-installers/windows \
     && export KOLIBRI_BUILD_VERSION=$WHL_FILE_VERSION \
     && wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss
 
-CMD cp /kolibri/kolibri-installers/windows/*.exe /installer/
+CMD cp /kolibri/kolibri-installer-windows/windows/*.exe /installer/

--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:xenial
+
+RUN apt-get -y update 
+
+# Install wine and related packages
+RUN dpkg --add-architecture i386 
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sudo software-properties-common
+
+RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update \
+    && apt-get install -y wine1.8
+
+COPY ./ /kolibri
+
+SHELL ["/bin/bash", "-c"]
+
+# Build kolibri windows installer.
+RUN mkdir /installer/
+RUN cd /kolibri/kolibri-installers/windows \
+    && WHL_FILE=$(find ./ -name \*.whl) \
+    && WHL_FILE=$(basename $WHL_FILE) \
+    && WHL_FILE=${WHL_FILE:8} \
+    && WHL_FILE_VERSION=${WHL_FILE:0:(${#WHL_FILEs}-21)} \
+    && export KOLIBRI_BUILD_VERSION=$WHL_FILE_VERSION \
+    && wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss
+
+CMD cp /kolibri/kolibri-installers/windows/*.exe /installer/


### PR DESCRIPTION
## Summary

This will build kolibri windows installer in kolibri branch release-v0.3.x.
The same changes at this [PR](https://github.com/learningequality/kolibri/pull/1215)




/cc @aronasorman 