### PR TITLE
Show version number on login page

### DIFF
--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -38,6 +38,7 @@
           <icon-button id="guest-access-button" :text="$tr('accessAsGuest')" :primary="false"/>
         </a>
       </div>
+      <p class="login-text version">{{ versionMsg }}</p>
     </div>
   </div>
 
@@ -63,6 +64,7 @@
       accessAsGuest: 'Access as guest',
       signInError: 'Incorrect username or password',
       resetPassword: 'Reset your password',
+      poweredBy: 'Kolibri {version}',
     },
     components: {
       'icon-button': require('kolibri.coreVue.components.iconButton'),
@@ -76,6 +78,9 @@
     computed: {
       signUp() {
         return { name: PageNames.SIGN_UP };
+      },
+      versionMsg() {
+        return this.$tr('poweredBy', { version: __version }); // eslint-disable-line no-undef
       },
     },
     methods: {
@@ -207,6 +212,10 @@
     background-color: $login-text
     margin: auto
     margin-top: 16px
+
+  .version
+    text-align: center
+    font-size: 0.8em
 
   .no-account
     text-align: center


### PR DESCRIPTION
This makes the version number visible on the sign-in page, below the login form. Is the placement/formatting/etc okay?

Related issue: https://github.com/learningequality/kolibri/issues/1095

Screenshot:
![screenshot](https://i.imgur.com/QvABl8P.png)
