### PR TITLE
Learner exam and exercise bug fixes

### DIFF
--- a/docs/dev/frontend.rst
+++ b/docs/dev/frontend.rst
@@ -118,6 +118,8 @@ Content Renderers
 A special kind of Kolibri Module is dedicated to rendering particular content types. All content renderers should extend the ``ContentRendererModule`` class found in `kolibri/core/assets/src/content_renderer_module.js`. In addition, rather than subclassing the ``WebpackBundleHook`` class, content renderers should be defined in the Python code using the ``ContentRendererHook`` class defined in ``kolibri.content.hooks``. In addition to the standard options for the ``WebpackBundleHook``, the ``ContentRendererHook`` also accepts a json file defining the content types that it renders::
 
 .. automodule:: kolibri.content.hooks
+    :members:
+    :noindex:
 
 The ``ContentRendererModule`` class has one required property ``getRendererComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``defaultFile`` and ``files`` props, defining the files associated with the piece of content.
 
@@ -138,7 +140,7 @@ In order to log data about users viewing content, the component should emit ``st
   this.$emit('stopTracking');
   this.$emit('updateProgress', 0.25);
 
-For content that has assessment functionality two additional props will be passed: ``itemId`` and ``answerState``. ``itemId`` is a unique identifier for that content for a particular question in the assessment, ``answerState`` is passed to prefill an answer (one that has been previously given on an exam, or for a coach to preview a learner's given answers). The answer renderer should also define a ``checkAnswer`` method in its component methods, this method should return an object with the following keys: ``correct``, ``answerState``, and ``simpleAnswer`` - describing the correctness, an object describing the answer that can be used to reconstruct it within the renderer, and a simple, human readable answer. If no valid answer is given, ``null`` should be returned. In addition to the base content renderer events, assessment items can also emit a ``hintTaken`` event to indicate that the user has taken a hint in the assessment, and an ``itemError`` event to indicate that there has been an error in rendering the requested question corresponding to the ``itemId``.
+For content that has assessment functionality two additional props will be passed: ``itemId`` and ``answerState``. ``itemId`` is a unique identifier for that content for a particular question in the assessment, ``answerState`` is passed to prefill an answer (one that has been previously given on an exam, or for a coach to preview a learner's given answers). The answer renderer should also define a ``checkAnswer`` method in its component methods, this method should return an object with the following keys: ``correct``, ``answerState``, and ``simpleAnswer`` - describing the correctness, an object describing the answer that can be used to reconstruct it within the renderer, and a simple, human readable answer. If no valid answer is given, ``null`` should be returned. In addition to the base content renderer events, assessment items can also emit a ``hintTaken`` event to indicate that the user has taken a hint in the assessment, an ``itemError`` event to indicate that there has been an error in rendering the requested question corresponding to the ``itemId``, and an ``interaction`` event that indicates a user has interacted with the assessment.
 
 .. code-block:: javascript
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -202,9 +202,8 @@ class UserExamSerializer(serializers.ModelSerializer):
         if isinstance(self.context['request'].user, FacilityUser):
             try:
                 # Try to add the score from the user's ExamLog attempts.
-                output['score'] = sum(
-                    obj.exam.examlogs.get(user=self.context['request'].user).attemptlogs.values_list(
-                        'correct', flat=True))
+                output['score'] = obj.exam.examlogs.get(user=self.context['request'].user).attemptlogs.aggregate(
+                    Sum('correct')).get('correct__sum')
                 output['answer_count'] = obj.exam.examlogs.get(user=self.context['request'].user).attemptlogs.count()
                 output['closed'] = obj.exam.examlogs.get(user=self.context['request'].user).closed
             except ExamLog.DoesNotExist:

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -195,7 +195,6 @@
 
   .content-wrapper
     height: 100%
-    overflow-x: scroll
 
   #spinner
     height: 160px

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -14,6 +14,7 @@
         @answerGiven="answerGiven"
         @hintTaken="hintTaken"
         @itemError="itemError"
+        @interaction="interaction"
         :files="availableFiles"
         :defaultFile="defaultFile"
         :itemId="itemId"
@@ -147,6 +148,9 @@
       },
       itemError(...args) {
         this.$emit('itemError', ...args);
+      },
+      interaction(...args) {
+        this.$emit('interaction', ...args);
       },
       wrappedStartTracking() {
         // Assume that as soon as we have started tracking data for this content item,

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -173,9 +173,14 @@ describe('Resource', function () {
       this.resource.addModel(new Resources.Model(this.modelData, {}, this.resource));
       assert.ok(!spy.called);
     });
-    it('should not add a model to the cache if no id', function () {
+    it('should add a model to the cache if no id', function () {
       this.resource.addModel(new Resources.Model({ data: 'data' }, {}, this.resource));
-      assert.deepEqual({}, this.resource.models);
+      assert.equal(1, Object.keys(this.resource.models).length);
+    });
+    it('should not return the added model from the cache if no id', function () {
+      this.resource.addModel(new Resources.Model({ data: 'data' }, {}, this.resource));
+      const model = this.resource.getModel(undefined);
+      assert.ok(!model.attributes.data);
     });
     it('should add a model to the cache if it has an id', function () {
       const model = this.resource.addModel(new Resources.Model({ id: 'test' }, {}, this.resource));

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -83,6 +83,8 @@
     height: 100vh
     max-height: calc(100vh - 24em)
     min-height: 400px
+    overflow-x: auto
+    -webkit-overflow-scrolling: touch
     &:fullscreen
       width: 100%
       height: 100%

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -84,7 +84,6 @@
     max-height: calc(100vh - 24em)
     min-height: 400px
     overflow-x: auto
-    -webkit-overflow-scrolling: touch
     &:fullscreen
       width: 100%
       height: 100%

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -683,10 +683,15 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
       [itemId]: currentAttemptLog,
     }),
   });
+  // If a save has already been fired for this particular attempt log,
+  // it may not have an id yet, so we can look for it by its uniquely
+  // identifying fields, contentId and itemId.
   let examAttemptLogModel = ExamAttemptLogResource.findModel({
     content_id: contentId,
     item: itemId,
   });
+  // If the above findModel returned no matching model, then we can do
+  // getModel to get the new model instead.
   if (!examAttemptLogModel) {
     examAttemptLogModel = ExamAttemptLogResource.getModel(
       currentAttemptLog.id);

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -661,6 +661,7 @@ function showExam(store, channelId, id, questionNumber) {
                   content_id: currentQuestion.contentId,
                 };
               }
+              pageState.currentAttempt = attemptLogs[currentQuestion.contentId][itemId];
               store.dispatch('SET_EXAM_ATTEMPT_LOGS', attemptLogs);
               store.dispatch('SET_PAGE_STATE', pageState);
               store.dispatch('CORE_SET_PAGE_LOADING', false);
@@ -682,8 +683,14 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
       [itemId]: currentAttemptLog,
     }),
   });
-  const examAttemptLogModel = ExamAttemptLogResource.getModel(
-    currentAttemptLog.id);
+  let examAttemptLogModel = ExamAttemptLogResource.findModel({
+    content_id: contentId,
+    item: itemId,
+  });
+  if (!examAttemptLogModel) {
+    examAttemptLogModel = ExamAttemptLogResource.getModel(
+      currentAttemptLog.id);
+  }
   const attributes = Object.assign({}, currentAttemptLog);
   attributes.interaction_history = JSON.stringify(attributes.interaction_history);
   attributes.answer = JSON.stringify(attributes.answer);

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -132,9 +132,7 @@
       },
       submitExam() {
         if (!this.submitModalOpen) {
-          this.saveAnswer().then(() => {
-            this.toggleModal();
-          });
+          this.saveAnswer().then(this.toggleModal);
         }
       },
       toggleModal() {

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -33,7 +33,8 @@
               :itemId="itemId"
               :assessment="true"
               :allowHints="false"
-              :answerState="currentAttempt.answer"/>
+              :answerState="currentAttempt.answer"
+              @interaction="saveAnswer"/>
               <div class="question-navbutton-container">
                 <icon-button :disabled="questionNumber===0" @click="goToQuestion(questionNumber - 1)" :text="$tr('previousQuestion')"><mat-svg category="navigation" name="chevron_left"/></icon-button>
                 <icon-button :disabled="questionNumber===exam.questionCount-1" alignment="right" @click="goToQuestion(questionNumber + 1)" :text="$tr('nextQuestion')"><mat-svg category="navigation" name="chevron_right"/></icon-button>
@@ -90,8 +91,7 @@
         itemId: state => state.pageState.itemId,
         questionNumber: state => state.pageState.questionNumber,
         attemptLogs: state => state.examAttemptLogs,
-        currentAttempt: state =>
-          state.examAttemptLogs[state.pageState.content.id][state.pageState.itemId],
+        currentAttempt: state => state.pageState.currentAttempt,
         questionsAnswered: state => state.pageState.questionsAnswered,
       },
       actions: {
@@ -100,8 +100,11 @@
       },
     },
     methods: {
-      goToQuestion(questionNumber) {
-        const answer = this.$refs.contentRenderer.checkAnswer();
+      checkAnswer() {
+        return this.$refs.contentRenderer.checkAnswer();
+      },
+      saveAnswer() {
+        const answer = this.checkAnswer();
         if (answer) {
           const attempt = this.currentAttempt;
           attempt.answer = answer.answerState;
@@ -116,8 +119,12 @@
             answer: answer.answerState,
             correct: answer.correct,
           });
-          this.setAndSaveCurrentExamAttemptLog(this.content.id, this.itemId, attempt);
+          return this.setAndSaveCurrentExamAttemptLog(this.content.id, this.itemId, attempt);
         }
+        return Promise.resolve();
+      },
+      goToQuestion(questionNumber) {
+        this.saveAnswer();
         this.$router.push({
           name: PageNames.EXAM,
           params: { channel_id: this.channelId, id: this.exam.id, questionNumber },

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -42,7 +42,7 @@
           </div>
         </div>
       </div>
-      <core-modal v-if="submitModalOpen" :title="$tr('submitExam')" @cancel="toggleModal">
+      <core-modal v-if="submitModalOpen" :title="$tr('submitExam')" @cancel="submitExam">
         <p>{{ $tr('areYouSure') }}</p>
         <p v-if="questionsUnanswered">{{ $tr('unanswered', { numLeft: questionsUnanswered } )}}</p>
         <icon-button :text="$tr('cancel')" @click="toggleModal"/>
@@ -122,6 +122,13 @@
           name: PageNames.EXAM,
           params: { channel_id: this.channelId, id: this.exam.id, questionNumber },
         });
+      },
+      submitExam() {
+        if (!this.submitModalOpen) {
+          this.saveAnswer().then(() => {
+            this.toggleModal();
+          });
+        }
       },
       toggleModal() {
         this.submitModalOpen = !this.submitModalOpen;

--- a/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
@@ -217,6 +217,8 @@
     height: 480px
     max-width: 100%
     max-height: 480px
+    overflow: auto
+    -webkit-overflow-scrolling: touch
 
   .fill-space
     width: 100%

--- a/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
@@ -217,8 +217,7 @@
     height: 480px
     max-width: 100%
     max-height: 480px
-    overflow: auto
-    -webkit-overflow-scrolling: touch
+    overflow-x: auto
 
   .fill-space
     width: 100%

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.2
+kolibri_exercise_perseus_plugin==0.6.3


### PR DESCRIPTION
## Summary

Fixes #1229, #1242, #1246, #1247.

Some of the above also require an update from this PR: https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/66 which further fixes: #1239, #1240.

Put a WIP label here, to flag that it needs the updated perseus build before merge.

Additional note, that attemptlog saving is currently still broken, but will be fixed in @DXCanas's next PR, so don't be alarmed by that!

Finally, it makes a small tweak to how we address content scrolling, as previously it was adding a scrollbar to Perseus items, which was unnecessary and caused an ugly visual flow. Have moved the relevant fixes inside HTML5 and video renderer plugins.