### PR TITLE
Gets exam preview within exams page working

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -14,7 +14,7 @@
         :tabindex="0"
         role="dialog"
         aria-labelledby="modal-title"
-        :style="{ maxWidth: maxWidth }">
+        :style="{ width: width, height: height }">
 
         <div class="top-buttons" @keydown.enter.stop>
           <button :aria-label="$tr('goBack')" @click="emitBackEvent" class="header-btn btn-back" v-if="enableBackBtn">
@@ -82,10 +82,15 @@
         type: Boolean,
         default: false,
       },
-      // Specifies a max-width for the modal
-      maxWidth: {
+      // Specifies a custom width for the modal
+      width: {
         type: String,
-        default: '380px',
+        required: false,
+      },
+      // Specifies a custom height for the modal
+      height: {
+        type: String,
+        required: false,
       },
     },
     mounted() {
@@ -166,9 +171,9 @@
     top: 50%
     left: 50%
     transform: translate(-50%, -50%)
-    width: 60%
     background: #fff
-    max-height: 80%
+    max-width: 100%
+    max-height: 100%
     overflow-y: auto
     border-radius: $radius
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33)

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -94,11 +94,10 @@
 
     <preview-new-exam-modal
       v-if="showPreviewNewExamModal"
-      :examTitle="inputTitle"
+      :examChannelId="currentChannel.id"
+      :examQuestionSources="questionSources"
+      :examSeed="seed"
       :examNumQuestions="inputNumQuestions"
-      :channelId="currentChannel.id"
-      :questionSources="questionSources"
-      :seed="seed"
       @randomize="seed = generateRandomSeed()"/>
 
     <ui-snackbar-container

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -98,7 +98,8 @@
       :examQuestionSources="questionSources"
       :examSeed="seed"
       :examNumQuestions="inputNumQuestions"
-      @randomize="seed = generateRandomSeed()"/>
+      @randomize="seed = generateRandomSeed()"
+      @removeExercise="handleRemoveExercise"/>
 
     <ui-snackbar-container
       class="snackbar-container"

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -98,8 +98,7 @@
       :examQuestionSources="questionSources"
       :examSeed="seed"
       :examNumQuestions="inputNumQuestions"
-      @randomize="seed = generateRandomSeed()"
-      @removeExercise="handleRemoveExercise"/>
+      @randomize="seed = generateRandomSeed()"/>
 
     <ui-snackbar-container
       class="snackbar-container"

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -83,11 +83,11 @@
     <div class="footer">
       <p>{{ $tr('selected', { count: selectedExercises.length }) }}</p>
       <p class="validation-error">{{ validationError }}</p>
-      <!--
+
       <icon-button :text="$tr('preview')" @click="preview">
         <mat-svg category="action" name="visibility"/>
       </icon-button>
-      -->
+
       <br>
       <icon-button :text="$tr('finish')" :primary="true" @click="finish"/>
     </div>
@@ -96,7 +96,8 @@
       v-if="showPreviewNewExamModal"
       :examTitle="inputTitle"
       :examNumQuestions="inputNumQuestions"
-      :selectedExercises="selectedExercises"
+      :channelId="currentChannel.id"
+      :questionSources="questionSources"
       :seed="seed"
       @randomize="seed = generateRandomSeed()"/>
 

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
@@ -5,8 +5,7 @@
     :examQuestionSources="examQuestionSources"
     :examSeed="examSeed"
     :examNumQuestions="examNumQuestions"
-    :examCreation="true"
-    @removeExercise="emitRemoval">
+    :examCreation="true">
     <icon-button slot="randomize-button" :text="$tr('randomize')" @click="$emit('randomize')"/>
   </preview-exam-modal>
 
@@ -20,7 +19,7 @@
   module.exports = {
     $trNameSpace: 'previewNewExamModal',
     $trs: {
-      randomize: 'Randomize',
+      randomize: 'Randomize questions',
     },
     components: {
       'preview-exam-modal': require('../exams-page/preview-exam-modal'),
@@ -47,9 +46,6 @@
     methods: {
       close() {
         this.displayExamModal(false);
-      },
-      emitRemoval(exercise) {
-        this.$emit('removeExercise', exercise);
       },
     },
     vuex: {

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
@@ -1,13 +1,8 @@
 <template>
 
-  <core-modal :title="$tr('previewExam')" @cancel="close">
-    <h2>{{ examTitle }}</h2>
-    <div>
-      {{$tr('questions', { count: examNumQuestions }) }}
-      <icon-button :text="$tr('randomize')" @click="$emit('randomize')"/>
-    </div>
-    {{ selectedExercises }}
-  </core-modal>
+  <preview-exam-modal :exam="exam">
+    <icon-button slot="randomize-button" :text="$tr('randomize')" @click="$emit('randomize')"/>
+  </preview-exam-modal>
 
 </template>
 
@@ -24,7 +19,7 @@
       questions: '{count, number, integer} {count, plural, one {question} other {questions}}'
     },
     components: {
-      'core-modal': require('kolibri.coreVue.components.coreModal'),
+      'preview-exam-modal': require('../exams-page/preview-exam-modal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     props: {
@@ -32,17 +27,31 @@
         type: String,
         required: true,
       },
+      channelId: {
+        type: String,
+        required: true,
+      },
       examNumQuestions: {
         type: Number,
         required: true,
       },
-      selectedExercises: {
+      questionSources: {
         type: Array,
         required: true,
       },
       seed: {
         type: Number,
         required: true,
+      }
+    },
+    computed: {
+      exam() {
+        return {
+          questionCount: this.examNumQuestions,
+          channelId: this.channelId,
+          seed: this.seed,
+          questionSources: this.questionSources,
+        };
       }
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
@@ -4,7 +4,9 @@
     :examChannelId="examChannelId"
     :examQuestionSources="examQuestionSources"
     :examSeed="examSeed"
-    :examNumQuestions="examNumQuestions">
+    :examNumQuestions="examNumQuestions"
+    :examCreation="true"
+    @removeExercise="emitRemoval">
     <icon-button slot="randomize-button" :text="$tr('randomize')" @click="$emit('randomize')"/>
   </preview-exam-modal>
 
@@ -45,6 +47,9 @@
     methods: {
       close() {
         this.displayExamModal(false);
+      },
+      emitRemoval(exercise) {
+        this.$emit('removeExercise', exercise);
       },
     },
     vuex: {

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/preview-new-exam-modal.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <preview-exam-modal :exam="exam">
+  <preview-exam-modal
+    :examChannelId="examChannelId"
+    :examQuestionSources="examQuestionSources"
+    :examSeed="examSeed"
+    :examNumQuestions="examNumQuestions">
     <icon-button slot="randomize-button" :text="$tr('randomize')" @click="$emit('randomize')"/>
   </preview-exam-modal>
 
@@ -14,45 +18,29 @@
   module.exports = {
     $trNameSpace: 'previewNewExamModal',
     $trs: {
-      previewExam: 'Preview exam exercises',
       randomize: 'Randomize',
-      questions: '{count, number, integer} {count, plural, one {question} other {questions}}'
     },
     components: {
       'preview-exam-modal': require('../exams-page/preview-exam-modal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     props: {
-      examTitle: {
+      examChannelId: {
         type: String,
         required: true,
       },
-      channelId: {
-        type: String,
+      examQuestionSources: {
+        type: Array,
+        required: true,
+      },
+      examSeed: {
+        type: Number,
         required: true,
       },
       examNumQuestions: {
         type: Number,
         required: true,
       },
-      questionSources: {
-        type: Array,
-        required: true,
-      },
-      seed: {
-        type: Number,
-        required: true,
-      }
-    },
-    computed: {
-      exam() {
-        return {
-          questionCount: this.examNumQuestions,
-          channelId: this.channelId,
-          seed: this.seed,
-          questionSources: this.questionSources,
-        };
-      }
     },
     methods: {
       close() {

--- a/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
@@ -78,7 +78,10 @@
     />
     <preview-exam-modal
       v-if="showPreviewExamModal"
-      :exam="selectedExam"
+      :examChannelId="selectedExam.channelId"
+      :examQuestionSources="JSON.parse(selectedExam.questionSources)"
+      :examSeed="selectedExam.seed"
+      :examNumQuestions="selectedExam.questionCount"
     />
     <rename-exam-modal
       v-if="showRenameExamModal"

--- a/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <core-modal :title="$tr('preview')" @cancel="close" maxWidth="100%">
+  <core-modal :title="$tr('preview')" @cancel="close" width="100%" height="100%">
     <ui-progress-linear v-show="loading"/>
     <div class="exam-preview-container" v-show="!loading">
       <div>
@@ -10,22 +10,14 @@
       <div class="pure-g">
         <div class="question-selector pure-u-1-3">
           <div v-for="(exercise, exerciseIndex) in examQuestionSources">
-            <h2 v-if="examCreation">
-              {{$tr('exercise', { num: exerciseIndex + 1 })}}
-              <ui-icon-button
-              icon="remove_circle_outline"
-              size="small"
-              type="secondary"
-              :ariaLabel="$tr('removeExercise')"
-              @click="removeExercise(exercise)"/>
-              </h2>
+            <h2 v-if="examCreation">{{$tr('exercise', { num: exerciseIndex + 1 })}}</h2>
             <ol class="question-list">
               <li v-for="(question, questionIndex) in questions.filter(q => q.contentId === exercise.exercise_id)">
                 <ui-button
-                  @click="goToQuestion(question.itemId)"
-                  :type="isSelected(question.itemId) ? 'primary' : 'secondary'">
-                    <span v-if="examCreation">{{ $tr('question', { num: questionIndex + 1 }) }}</span>
-                    <span v-else>{{ $tr('question', { num: getQuestionIndex(question.itemId) + 1 }) }}</span>
+                  @click="goToQuestion(question.itemId, exercise.exercise_id)"
+                  :type="isSelected(question.itemId, exercise.exercise_id) ? 'primary' : 'secondary'">
+                    <span v-if="!examCreation">{{ $tr('question', { num: questionIndex + 1 }) }}</span>
+                    <span v-else>{{ $tr('question', { num: getQuestionIndex(question.itemId, exercise.exercise_id) + 1 }) }}</span>
                 </ui-button>
               </li>
             </ol>
@@ -68,14 +60,12 @@
       question: 'Question { num }',
       numQuestions: '{ num } questions',
       exercise: 'Exercise { num }',
-      removeExercise: 'Remove exercise',
     },
     components: {
       'core-modal': require('kolibri.coreVue.components.coreModal'),
       'content-renderer': require('kolibri.coreVue.components.contentRenderer'),
       'ui-button': require('keen-ui/src/UiButton'),
       'ui-progress-linear': require('keen-ui/src/UiProgressLinear'),
-      'ui-icon-button': require('keen-ui/src/UiIconButton'),
     },
     props: {
       examChannelId: {
@@ -128,20 +118,16 @@
       },
     },
     methods: {
-      isSelected(questionItemId) {
-        if (this.currentQuestion.itemId === questionItemId) {
-          return true;
-        }
-        return false;
+      isSelected(questionItemId, exerciseId) {
+        return (this.currentQuestion.itemId === questionItemId)
+          && (this.currentQuestion.contentId === exerciseId);
       },
-      getQuestionIndex(questionItemId) {
-        return this.questions.findIndex(question => question.itemId === questionItemId);
+      getQuestionIndex(questionItemId, exerciseId) {
+        return this.questions.findIndex(
+          question => (question.itemId === questionItemId) && (question.contentId === exerciseId));
       },
-      goToQuestion(questionItemId) {
-        this.currentQuestionIndex = this.getQuestionIndex(questionItemId);
-      },
-      removeExercise(exercise) {
-        this.$emit('removeExercise', { id: exercise.exercise_id, title: '' });
+      goToQuestion(questionItemId, exerciseId) {
+        this.currentQuestionIndex = this.getQuestionIndex(questionItemId, exerciseId);
       },
       close() {
         this.displayExamModal(false);
@@ -171,7 +157,6 @@
   @require '~kolibri.styles.definitions'
 
   .question-selector
-    max-height: 300px
     overflow-y: scroll
     border: 2px black
 

--- a/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
@@ -10,13 +10,22 @@
       <div class="pure-g">
         <div class="question-selector pure-u-1-3">
           <div v-for="(exercise, exerciseIndex) in examQuestionSources">
-            <h2>{{$tr('exercise', { num: exerciseIndex + 1 })}}</h2>
+            <h2 v-if="examCreation">
+              {{$tr('exercise', { num: exerciseIndex + 1 })}}
+              <ui-icon-button
+              icon="remove_circle_outline"
+              size="small"
+              type="secondary"
+              :ariaLabel="$tr('removeExercise')"
+              @click="removeExercise(exercise)"/>
+              </h2>
             <ol class="question-list">
               <li v-for="(question, questionIndex) in questions.filter(q => q.contentId === exercise.exercise_id)">
                 <ui-button
                   @click="goToQuestion(question.itemId)"
                   :type="isSelected(question.itemId) ? 'primary' : 'secondary'">
-                    {{ $tr('question', { num: questionIndex + 1 }) }}
+                    <span v-if="examCreation">{{ $tr('question', { num: questionIndex + 1 }) }}</span>
+                    <span v-else>{{ $tr('question', { num: getQuestionIndex(question.itemId) + 1 }) }}</span>
                 </ui-button>
               </li>
             </ol>
@@ -54,17 +63,19 @@
   module.exports = {
     $trNameSpace: 'previewExamModal',
     $trs: {
-      preview: 'Preview Exam Exercises',
+      preview: 'Preview exam',
       close: 'Close',
       question: 'Question { num }',
       numQuestions: '{ num } questions',
       exercise: 'Exercise { num }',
+      removeExercise: 'Remove exercise',
     },
     components: {
       'core-modal': require('kolibri.coreVue.components.coreModal'),
       'content-renderer': require('kolibri.coreVue.components.contentRenderer'),
       'ui-button': require('keen-ui/src/UiButton'),
       'ui-progress-linear': require('keen-ui/src/UiProgressLinear'),
+      'ui-icon-button': require('keen-ui/src/UiIconButton'),
     },
     props: {
       examChannelId: {
@@ -83,6 +94,10 @@
         type: Number,
         required: true,
       },
+      examCreation: {
+        type: Boolean,
+        default: false,
+      }
     },
     data: () => ({
       currentQuestionIndex: 0,
@@ -119,9 +134,14 @@
         }
         return false;
       },
+      getQuestionIndex(questionItemId) {
+        return this.questions.findIndex(question => question.itemId === questionItemId);
+      },
       goToQuestion(questionItemId) {
-        this.currentQuestionIndex = this.questions.findIndex(
-          question => question.itemId === questionItemId);
+        this.currentQuestionIndex = this.getQuestionIndex(questionItemId);
+      },
+      removeExercise(exercise) {
+        this.$emit('removeExercise', { id: exercise.exercise_id, title: '' });
       },
       close() {
         this.displayExamModal(false);
@@ -157,6 +177,7 @@
 
   ol
     padding: 0
+    margin: 0
 
   li
     list-style-type: none

--- a/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
@@ -5,6 +5,7 @@
     <div class="exam-preview-container" v-show="!loading">
       <div>
         <strong>{{ $tr('numQuestions', { num: exam.questionCount })}}</strong>
+        <slot name="randomize-button"/>
       </div>
       <div class="pure-g">
         <div class="question-selector pure-u-1-3">
@@ -81,6 +82,9 @@
         return this.exam.seed;
       },
       questionSources() {
+        if (typeof this.exam.questionSources === 'object') {
+          return this.exam.questionSources;
+        }
         try {
           return JSON.parse(this.exam.questionSources);
         } catch (e) {


### PR DESCRIPTION
## Summary

* Gets exam preview within exams page working
* Gets exam preview within exams creation page working
* Cleaned up a bit
* Replaced the collapsible with buttons
* TODO: Make question list the only scrollable part. send help

## Exam preview from exam page

![exam_preview](https://cloud.githubusercontent.com/assets/7193975/25197734/d68dd67c-24f9-11e7-8d88-f4628f2413a6.gif)

## Exam preview from exam creation page

![exam_preview_creation](https://cloud.githubusercontent.com/assets/7193975/25197732/d405801c-24f9-11e7-9fd1-9f65aa5d5cfc.gif)

