### PR TITLE
user-type handling

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -1,6 +1,6 @@
 
 const cookiejs = require('js-cookie');
-const UserKinds = require('../constants').UserKinds;
+const getters = require('kolibri.coreVue.vuex.getters');
 const MasteryLoggingMap = require('../constants').MasteryLoggingMap;
 const AttemptLoggingMap = require('../constants').AttemptLoggingMap;
 const InteractionTypes = require('../constants').InteractionTypes;
@@ -75,7 +75,7 @@ function _contentSessionModel(store) {
     progress: sessionLog.progress || 0,
     extra_fields: sessionLog.extra_fields,
   };
-  if (store.state.core.session.kind[0] !== UserKinds.SUPERUSER) {
+  if (!getters.isSuperuser(store.state)) {
     mapping.user = store.state.core.session.user_id;
   }
   return mapping;
@@ -170,7 +170,7 @@ function kolibriLogin(store, sessionPayload) {
   return sessionPromise.then((session) => {
     store.dispatch('CORE_SET_SESSION', _sessionState(session));
     /* Very hacky solution to redirect an admin or superuser to Manage tab on login*/
-    if (session.kind[0] === UserKinds.SUPERUSER || session.kind[0] === UserKinds.ADMIN) {
+    if (getters.isSuperuser(store.state) || getters.isAdmin(store.state)) {
       const manageURL = coreApp.urls['kolibri:managementplugin:management']();
       window.location.href = window.location.origin + manageURL;
     } else {
@@ -236,8 +236,7 @@ function initContentSession(store, channelId, contentId, contentKind) {
   const promises = [];
 
   /* Create summary log iff user exists */
-  if (store.state.core.session.user_id &&
-    store.state.core.session.kind[0] !== UserKinds.SUPERUSER) {
+  if (store.state.core.session.user_id && !getters.isSuperuser(store.state)) {
      /* Fetch collection matching content and user */
     const summaryCollection = ContentSummaryLogResource.getCollection({
       content_id: contentId,
@@ -311,7 +310,7 @@ function initContentSession(store, channelId, contentId, contentKind) {
     kind: contentKind,
   }, _contentSessionModel(store));
 
-  if (store.state.core.session.kind[0] === UserKinds.SUPERUSER) {
+  if (getters.isSuperuser(store.state)) {
     // treat deviceOwner as anonymous user.
     sessionData.user = null;
   }

--- a/kolibri/core/assets/src/state/getters.js
+++ b/kolibri/core/assets/src/state/getters.js
@@ -22,6 +22,11 @@ function isCoach(state) {
 }
 
 
+function isLearner(state) {
+  return state.core.session.kind[0] === UserKinds.LEARNER;
+}
+
+
 /*
  * Returns the 'default' channel ID:
  * - if there are channels and they match the cookie, return that
@@ -52,6 +57,7 @@ module.exports = {
   isSuperuser,
   isAdmin,
   isCoach,
+  isLearner,
   getDefaultChannelId,
   getCurrentChannelObject,
 };

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -10,6 +10,7 @@
     :style="{ height: height + 'px' }">
     <div slot="actions">
       <slot name="app-bar-actions"/>
+      <span v-if="isSuperuser" class="superuser">{{ $tr('superuser') }}</span>
       <ui-icon-button
         v-if="isUserLoggedIn"
         icon="person"
@@ -57,6 +58,7 @@
       editProfile: 'Edit Profile',
       signOut: 'Sign Out',
       signIn: 'Sign In',
+      superuser: 'Signed in as a Device Owner',
       learnerDetails: '{username} (Learner)',
       coachDetails: '{username} (Coach)',
       adminDetails: '{username} (Admin)',
@@ -141,6 +143,14 @@
   };
 
 </script>
+
+
+<style lang="stylus" scoped>
+
+  .superuser
+    font-size: smaller
+
+</style>
 
 
 <style lang="stylus">

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -16,6 +16,7 @@
         type="secondary"
         color="white"
         :ariaLabel="$tr('account')"
+        :title="userTooltip"
         has-dropdown
         ref="accountButton">
         <ui-menu
@@ -44,6 +45,10 @@
 
   const kolibriLogout = require('kolibri.coreVue.vuex.actions').kolibriLogout;
   const isUserLoggedIn = require('kolibri.coreVue.vuex.getters').isUserLoggedIn;
+  const isSuperuser = require('kolibri.coreVue.vuex.getters').isSuperuser;
+  const isAdmin = require('kolibri.coreVue.vuex.getters').isAdmin;
+  const isCoach = require('kolibri.coreVue.vuex.getters').isCoach;
+  const isLearner = require('kolibri.coreVue.vuex.getters').isUserLoggedIn;
 
   module.exports = {
     $trNameSpace: 'appBar',
@@ -52,6 +57,10 @@
       editProfile: 'Edit Profile',
       signOut: 'Sign Out',
       signIn: 'Sign In',
+      learnerDetails: '{username} (Learner)',
+      coachDetails: '{username} (Coach)',
+      adminDetails: '{username} (Admin)',
+      superuserDetails: '{username} (Device Owner)',
     },
     props: {
       title: {
@@ -74,6 +83,21 @@
       'ui-button': require('keen-ui/src/UiButton'),
     },
     computed: {
+      userTooltip() {
+        if (this.isSuperuser) {
+          return this.$tr('superuserDetails', { username: this.username });
+        }
+        if (this.isAdmin) {
+          return this.$tr('adminDetails', { username: this.username });
+        }
+        if (this.isCoach) {
+          return this.$tr('coachDetails', { username: this.username });
+        }
+        if (this.isLearner) {
+          return this.$tr('learnerDetails', { username: this.username });
+        }
+        return '';
+      },
       accountMenuOptions() {
         return [
           {
@@ -106,7 +130,12 @@
         kolibriLogout,
       },
       getters: {
+        username: state => state.core.session.username,
         isUserLoggedIn,
+        isSuperuser,
+        isAdmin,
+        isCoach,
+        isLearner,
       },
     },
   };

--- a/kolibri/core/assets/src/views/nav-bar/index.vue
+++ b/kolibri/core/assets/src/views/nav-bar/index.vue
@@ -169,7 +169,7 @@
             href: '/learn',
           },
         ];
-        if (this.isAdmin || this.isCoach) {
+        if (this.isAdmin || this.isSuperuser || this.isCoach) {
           options.push({
             label: this.$tr('coach'),
             active: this.coachActive,

--- a/kolibri/plugins/coach/assets/src/state/actions/group.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/group.js
@@ -70,7 +70,6 @@ function showGroupsPage(store, classId) {
           });
 
           const pageState = {
-            facilityId: facility[0],
             class: _classState(classModel),
             classUsers: _usersState(classUsers),
             groups,

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -557,8 +557,7 @@ function showExam(store, channelId, id, questionNumber) {
 
         const attemptLogs = {};
 
-        if (store.state.core.session.user_id &&
-          store.state.core.session.kind[0] !== CoreConstants.UserKinds.SUPERUSER) {
+        if (store.state.core.session.user_id && !coreGetters.isSuperuser(store.state)) {
           if (examLogs.length > 0 && examLogs.some(log => !log.closed)) {
             store.dispatch('SET_EXAM_LOG', _examLoggingState(examLogs.find(log => !log.closed)));
           } else {

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -56,9 +56,9 @@ oriented data synchronization.
 
 <script>
 
+  const getters = require('kolibri.coreVue.vuex.getters');
   const actions = require('kolibri.coreVue.vuex.actions');
   const InteractionTypes = require('kolibri.coreVue.vuex.constants').InteractionTypes;
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
   const MasteryModelGenerators = require('kolibri.coreVue.vuex.constants').MasteryModelGenerators;
   const seededShuffle = require('kolibri.lib.seededshuffle');
 
@@ -141,7 +141,7 @@ oriented data synchronization.
       },
       saveAttemptLogMasterLog() {
         this.saveAttemptLogAction().then(() => {
-          if (this.isFacilityUser && this.success) {
+          if (this.canLogInteractions && this.success) {
             this.setMasteryLogCompleteAction(new Date());
             this.saveMasteryLogAction();
           }
@@ -239,7 +239,7 @@ oriented data synchronization.
       sessionInitialized() {
         // Once the session is initialized we can initialize the mastery log,
         // as the required data will be available.
-        if (this.isFacilityUser) {
+        if (this.canLogInteractions) {
           this.initMasteryLog();
         } else {
           // if userKind is anonymous user or deviceOwner.
@@ -268,9 +268,8 @@ oriented data synchronization.
       },
     },
     computed: {
-      isFacilityUser() {
-        return !(this.userkind.includes(UserKinds.SUPERUSER) ||
-          this.userkind.includes(UserKinds.ANONYMOUS));
+      canLogInteractions() {
+        return !this.isSuperuser;
       },
       recentAttempts() {
         if (!this.pastattempts) {
@@ -330,7 +329,7 @@ oriented data synchronization.
         updateExerciseProgress: actions.updateExerciseProgress,
       },
       getters: {
-        userkind: (state) => state.core.session.kind,
+        isSuperuser: getters.isSuperuser,
         totalattempts: (state) => state.core.logging.mastery.totalattempts,
         pastattempts: (state) => state.core.logging.mastery.pastattempts,
         userid: (state) => state.core.session.user_id,

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -74,7 +74,7 @@
   const Constants = require('../../constants');
   const getters = require('../../state/getters');
   const ContentNodeKinds = require('kolibri.coreVue.vuex.constants').ContentNodeKinds;
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
+  const coreGetters = require('kolibri.coreVue.vuex.getters');
 
   module.exports = {
     $trNameSpace: 'learnContent',
@@ -106,7 +106,7 @@
         return this.$tr('recommended');
       },
       progress() {
-        if (this.userkind.includes(UserKinds.LEARNER)) {
+        if (this.isLearner) {
           return this.summaryProgress;
         }
         return this.sessionProgress;
@@ -158,7 +158,8 @@
 
         summaryProgress: (state) => state.core.logging.summary.progress,
         sessionProgress: (state) => state.core.logging.session.progress,
-        userkind: (state) => state.core.session.kind,
+
+        isLearner: coreGetters.isLearner,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
@@ -18,7 +18,7 @@
     $trs: {
       header: 'No content channels available',
       adminLink: 'Download content channels from the <a href="/management/#/content">Content Management</a> page',
-      notAdmin: 'You need to log in as an administrator to manage content',
+      notAdmin: 'You need to log in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
     },
     vuex: {
       getters: {

--- a/kolibri/plugins/management/assets/src/state/actions.js
+++ b/kolibri/plugins/management/assets/src/state/actions.js
@@ -1,5 +1,6 @@
 const coreApp = require('kolibri');
 const logging = require('kolibri.lib.logging');
+const getters = require('kolibri.coreVue.vuex.getters');
 
 const ClassroomResource = coreApp.resources.ClassroomResource;
 const FacilityResource = coreApp.resources.FacilityResource;
@@ -507,6 +508,12 @@ function showUserPage(store) {
 
 function showContentPage(store) {
   preparePage(store.dispatch, { name: PageNames.CONTENT_MGMT_PAGE, title: _managePageTitle('Content') });
+
+  if (!getters.isSuperuser(store.state)) {
+    store.dispatch('CORE_SET_PAGE_LOADING', false);
+    return;
+  }
+
   const taskCollectionPromise = TaskResource.getCollection().fetch();
   taskCollectionPromise.only(
     samePageCheckGenerator(store),

--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
@@ -129,7 +129,7 @@
       learnerCanEditUsername: 'Allow users to edit their username',
       learnerCanSignUp: 'Allow users to sign-up on this device',
       pageDescription: 'Configure and change different Facility settings here.',
-      pageHeader: 'Facilities Configuration',
+      pageHeader: 'Facility Configuration',
       resetToDefaultSettings: 'Reset to default settings',
       saveChanges: 'Save changes',
       settingsHeader: 'Facility Settings',

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/class-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/class-create-modal.vue
@@ -82,11 +82,7 @@
         if (!this.name) {
           this.errorMessage = 'Must provide class name to create new class!';
         } else {
-          const newClass = {
-            name: this.name,
-            facilityId: this.facilityId,
-          };
-          this.createClass(newClass);
+          this.createClass(this.name);
         }
       },
       close() {
@@ -94,9 +90,6 @@
       },
     },
     vuex: {
-      getters: {
-        facilityId: state => state.pageState.facility.id,
-      },
       actions: {
         createClass: actions.createClass,
         displayModal: actions.displayModal,

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
@@ -3,9 +3,7 @@
   <div>
 
     <div class="header">
-      <h1>
-        {{ $tr('allClasses', { name: facilityName }) }}
-      </h1>
+      <h1>{{ $tr('allClasses') }}</h1>
 
       <icon-button
         class="create-btn"
@@ -106,7 +104,6 @@
       getters: {
         modalShown: state => state.pageState.modalShown,
         classes: state => state.pageState.classes,
-        facilityName: state => state.pageState.facility.name,
       },
       actions: {
         displayModal: actions.displayModal,
@@ -114,7 +111,7 @@
     },
     $trNameSpace: 'classPage',
     $trs: {
-      allClasses: 'All Classes in {name}',
+      allClasses: 'All Classes',
       // button text
       addNew: 'Add New Class',
       deleteClass: 'Delete Class',

--- a/kolibri/plugins/management/assets/src/views/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/views/top-nav/index.vue
@@ -14,7 +14,7 @@
       <router-link :to="dataLink" :class="{active: dataActive}" @click.native="blur">
         {{$tr('data')}}
       </router-link>
-      <router-link :to="contentLink" :class="{active: contentActive}" @click.native="blur" v-if="isDeviceOwner">
+      <router-link :to="contentLink" :class="{active: contentActive}" @click.native="blur">
         {{$tr('content')}}
       </router-link>
     </div>
@@ -25,7 +25,6 @@
 
 <script>
 
-  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
   const { PageNames } = require('../../constants');
 
   const linkify = (name) => ({ name });
@@ -84,7 +83,6 @@
     },
     vuex: {
       getters: {
-        isDeviceOwner: state => state.core.session.kind[0] === UserKinds.SUPERUSER,
         pageName: state => state.pageName,
       },
     },

--- a/kolibri/plugins/management/assets/src/views/top-nav/index.vue
+++ b/kolibri/plugins/management/assets/src/views/top-nav/index.vue
@@ -41,7 +41,7 @@
       classes: 'Classes',
       content: 'Content',
       data: 'Data',
-      facilities: 'Facilities',
+      facilities: 'Facility',
       users: 'Users',
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -43,7 +43,7 @@
     $trNameSpace: 'setupWizard',
     $trs: {
       header: 'Create device owner and facility',
-      deviceOwner: 'Device owner',
+      deviceOwner: 'Device Owner',
       deviceOwnerDescription: 'To use Kolibri, you first need to create a Device Owner. This account will be used to configure high-level settings for this installation, and create other administrator accounts',
       username: 'Username',
       password: 'Password',

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -18,6 +18,11 @@
         id="username"
         type="text" />
 
+      <p v-if="isLearner" class="type">{{ $tr('isLearner') }}</p>
+      <p v-if="isCoach" class="type">{{ $tr('isCoach') }}</p>
+      <p v-if="isAdmin" class="type">{{ $tr('isAdmin') }}</p>
+      <p v-if="isSuperuser" class="type">{{ $tr('isSuperuser') }}</p>
+
       <core-textbox
         v-if="hasPrivilege('name')"
         class="input-field"
@@ -43,6 +48,7 @@
 <script>
 
   const actions = require('../../state/actions');
+  const getters = require('kolibri.coreVue.vuex.getters');
   const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
 
   module.exports = {
@@ -53,7 +59,11 @@
       success: 'Profile details updated!',
       username: 'Username',
       name: 'Name',
-      updateProfile: 'Update',
+      updateProfile: 'Update profile',
+      isLearner: '(you are a Learner)',
+      isCoach: '(you are a Coach)',
+      isAdmin: '(you are an Admin)',
+      isSuperuser: '(you are a Device Owner)',
     },
     components: {
       'icon-button': require('kolibri.coreVue.components.iconButton'),
@@ -96,6 +106,10 @@
         success: state => state.pageState.success,
         busy: state => state.pageState.busy,
         backendErrorMessage: state => state.pageState.errorMessage,
+        isSuperuser: getters.isSuperuser,
+        isAdmin: getters.isAdmin,
+        isCoach: getters.isCoach,
+        isLearner: getters.isLearner,
       },
       actions: {
         editProfile: actions.editProfile,
@@ -136,5 +150,9 @@
     width: 100%
     display: inline-block
     font-size: 0.9em
+
+  .type
+    text-align: right
+    font-size: smaller
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -24,7 +24,7 @@
       <p v-if="isSuperuser" class="type">{{ $tr('isSuperuser') }}</p>
 
       <core-textbox
-        v-if="hasPrivilege('name')"
+        v-if="hasPrivilege('name') && !isSuperuser"
         class="input-field"
         :disabled="busy"
         :label="$tr('name')"
@@ -34,6 +34,7 @@
         type="text" />
 
       <icon-button
+        v-if="!isSuperuser"
         :disabled="busy"
         :primary="true"
         :text="$tr('updateProfile')"


### PR DESCRIPTION
A small set of updates to make it more clear what type of user is logged in.

## Manage content tab for non-superusers

![image](https://cloud.githubusercontent.com/assets/2367265/25259824/455cf50c-25fd-11e7-96df-22d5941c4a6e.png)

## User profile for all users

![image](https://cloud.githubusercontent.com/assets/2367265/25259836/5982c70a-25fd-11e7-9226-3e23b8fe6a2f.png)

## Hide user profile editing functionality for superusers

![image](https://cloud.githubusercontent.com/assets/2367265/25259860/752a9456-25fd-11e7-9fd3-dce7a9fde70a.png)

## Tooltip for all users

![image](https://cloud.githubusercontent.com/assets/2367265/25259842/68611aec-25fd-11e7-96ef-c885bb3a6b2d.png)

## Loud warning for superusers

![image](https://cloud.githubusercontent.com/assets/2367265/25259897/ae3fadc6-25fd-11e7-96fa-7496091c1769.png)


