### PR TITLE
WIP filtering classes to only those for which a coach has write access

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -26,7 +26,12 @@ class KolibriAuthPermissionsFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         if request.method == "GET" and request.resolver_match.url_name.endswith("-list"):
             # only filter down the queryset in the case of the list view being requested
-            return request.user.filter_readable(queryset)
+            # return request.user.filter_readable(queryset)
+
+            # TESTING ONLY
+            writable = request.user.filter_writable(queryset)
+            print("TEST WRITABLE", writable)
+            return writable
         else:
             # otherwise, return the full queryset, as permission checks will happen object-by-object
             # (and filtering here then leads to 404's instead of the more correct 403's)

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -329,7 +329,7 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
         :param queryset: A ``QuerySet`` instance that the filtering should be applied to.
         :return: Filtered ``QuerySet`` including only elements that are readable by this user.
         """
-        raise NotImplementedError("Subclasses of KolibriAbstractBaseUser must override the `can_delete` method.")
+        raise NotImplementedError("Subclasses of KolibriAbstractBaseUser must override the `filter_readable` method.")
 
 
 class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):

--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -331,6 +331,15 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
         """
         raise NotImplementedError("Subclasses of KolibriAbstractBaseUser must override the `filter_readable` method.")
 
+    def filter_writable(self, queryset):
+        """
+        Filters a queryset down to only the elements that this user should have permission to update.
+
+        :param queryset: A ``QuerySet`` instance that the filtering should be applied to.
+        :return: Filtered ``QuerySet`` including only elements that are writable by this user.
+        """
+        raise NotImplementedError("Subclasses of KolibriAbstractBaseUser must override the `filter_writable` method.")
+
 
 class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
     """
@@ -387,6 +396,13 @@ class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
         # check the object permissions, if available, just in case permissions are granted to anon users
         if _has_permissions_class(queryset.model):
             return queryset.model.permissions.readable_by_user_filter(self, queryset).distinct()
+        else:
+            return queryset.none()
+
+    def filter_writable(self, queryset):
+        # check the object permissions, if available, just in case permissions are granted to anon users
+        if _has_permissions_class(queryset.model):
+            return queryset.model.permissions.writable_by_user_filter(self, queryset).distinct()
         else:
             return queryset.none()
 
@@ -510,6 +526,12 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
         else:
             return queryset.none()
 
+    def filter_writable(self, queryset):
+        if _has_permissions_class(queryset.model):
+            return queryset.model.permissions.writable_by_user_filter(self, queryset).distinct()
+        else:
+            return queryset.none()
+
     def __str__(self):
         return '"{user}"@"{facility}"'.format(user=self.full_name or self.username, facility=self.facility)
 
@@ -581,6 +603,9 @@ class DeviceOwner(KolibriAbstractBaseUser):
         return True
 
     def filter_readable(self, queryset):
+        return queryset
+
+    def filter_writable(self, queryset):
         return queryset
 
     def __str__(self):

--- a/kolibri/auth/permissions/auth.py
+++ b/kolibri/auth/permissions/auth.py
@@ -120,11 +120,17 @@ class IsAdminForOwnFacilityDataset(BasePermissions):
     def user_can_delete_object(self, user, obj):
         return False
 
-    def readable_by_user_filter(self, user, queryset):
+    def _filter(self, user, queryset):
         if self._user_is_admin_for_related_facility(user):
             return queryset.filter(id=user.dataset_id)
         else:
             return queryset.none()
+
+    def readable_by_user_filter(self, user, queryset):
+        return self._filter(user, queryset)
+
+    def writable_by_user_filter(self, user, queryset):
+        return self._filter(user, queryset)
 
 
 class CoachesCanManageGroupsForTheirClasses(BasePermissions):
@@ -145,6 +151,9 @@ class CoachesCanManageGroupsForTheirClasses(BasePermissions):
         return self._user_is_coach_for_classroom(user, obj)
 
     def readable_by_user_filter(self, user, queryset):
+        return queryset.none()
+
+    def writable_by_user_filter(self, user, queryset):
         return queryset.none()
 
 
@@ -176,4 +185,7 @@ class CoachesCanManageMembershipsForTheirGroups(BasePermissions):
         return self._user_should_be_able_to_manage(user, obj)
 
     def readable_by_user_filter(self, user, queryset):
+        return queryset.none()
+
+    def writable_by_user_filter(self, user, queryset):
         return queryset.none()

--- a/kolibri/logger/permissions.py
+++ b/kolibri/logger/permissions.py
@@ -26,3 +26,6 @@ class AnyoneCanWriteAnonymousLogs(BasePermissions):
 
     def readable_by_user_filter(self, user, queryset):
         return queryset.none()
+
+    def writable_by_user_filter(self, user, queryset):
+        return queryset.none()


### PR DESCRIPTION

Trying to filter classes to only those for which a class coach (not facility coach) has write access (re #1281).

I might be on the wrong track here, but it seems like we need:

* a new `writable` filter on users and permissions, which I've tried to add
* an update to `KolibriAuthPermissionsFilter` which allows the desired permission to be passed (`read`, `write`, `delete`?)
* an update to the resource layer for passing in this permission

Right now my `user.filter_writable` function is not working as expected - it always returns an empty list. I'm guessing that I don't quite understand how `RoleBasedPermissions` works and that querying for `role_kind == can_be_updated_by` isn't doing what I expected.
