### PR TITLE
bring back facility coaches, and temporarily disable class coaches

### DIFF
--- a/kolibri/core/assets/src/state/getters.js
+++ b/kolibri/core/assets/src/state/getters.js
@@ -26,6 +26,9 @@ function isLearner(state) {
   return state.core.session.kind[0] === UserKinds.LEARNER;
 }
 
+function currentFacilityId(state) {
+  return state.core.session.facility_id;
+}
 
 /*
  * Returns the 'default' channel ID:
@@ -60,4 +63,5 @@ module.exports = {
   isLearner,
   getDefaultChannelId,
   getCurrentChannelObject,
+  currentFacilityId,
 };

--- a/kolibri/plugins/management/assets/src/state/actions.js
+++ b/kolibri/plugins/management/assets/src/state/actions.js
@@ -49,9 +49,10 @@ function _classState(data) {
  * This mostly duplicates _userState below, but searches Roles array for an exact match
  * on the classId, and not for any Role object.
  */
-function _userStateForClassEditPage(classId, apiUserData) {
+function _userStateForClassEditPage(facilityId, classId, apiUserData) {
   const matchingRole = apiUserData.roles.find((r) => (
-      String(r.collection) === classId ||
+      String(r.collection) === String(classId) ||
+      String(r.collection) === String(facilityId) ||
       r.kind === UserKinds.ADMIN ||
       r.kind === UserKinds.SUPERUSER
     )
@@ -239,10 +240,12 @@ function showClassEditPage(store, classId) {
     ClassroomResource.getModel(classId).fetch(),
   ];
 
+  const facilityId = getters.currentFacilityId(store.state);
+
   const transformResults = ([facilityUsers, classroom]) => ({
     modalShown: false,
     classes: [classroom],
-    classUsers: facilityUsers.map(_userStateForClassEditPage.bind(null, classId)),
+    classUsers: facilityUsers.map(_userStateForClassEditPage.bind(null, facilityId, classId)),
   });
 
   ConditionalPromise.all(promises).only(

--- a/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
@@ -60,7 +60,9 @@
         <tr>
           <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
           <th class="col-header table-username" scope="col"> {{$tr('username')}} </th>
-          <th class="col-header" scope="col"> {{$tr('role')}} </th>
+          <th class="col-header" scope="col">
+            <span class="visuallyhidden">{{ $tr('role') }}</span>
+          </th>
           <th class="col-header" scope="col"></th>
         </tr>
       </thead>
@@ -82,12 +84,15 @@
 
           <!-- Logic for role tags -->
           <td class="table-cell table-role">
+            <user-role :role="user.kind" :omitLearner="true" />
+            <!--
             <role-switcher
-              class="user-role"
+              class="user-role-switcher"
               :currentRole="user.kind"
               @click-add-coach="addCoachRoleToUser(user)"
               @click-remove-coach="removeCoachRoleFromUser(user)"
             />
+            -->
           </td>
 
           <!-- Edit field -->
@@ -140,6 +145,7 @@
       'role-switcher': require('./role-switcher'),
       'user-remove-modal': require('./user-remove-modal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
+      'user-role': require('../user-role'),
     },
     data: () => ({
       searchFilter: '',
@@ -326,7 +332,7 @@
   .table-cell
     color: $core-text-default
 
-  .user-role
+  .user-role-switcher
     display: table-cell
     height: 1.5rem
     margin: 5px 0

--- a/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
@@ -58,11 +58,11 @@
       <!-- Table Headers -->
       <thead v-if="usersMatchFilter">
         <tr>
-          <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
           <th class="col-header table-username" scope="col"> {{$tr('username')}} </th>
           <th class="col-header" scope="col">
             <span class="visuallyhidden">{{ $tr('role') }}</span>
           </th>
+          <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
           <th class="col-header" scope="col"></th>
         </tr>
       </thead>
@@ -70,17 +70,10 @@
       <!-- Table body -->
       <tbody v-if="usersMatchFilter">
         <tr v-for="user in visibleUsers">
-          <!-- Full Name field -->
-          <th scope="row" class="table-cell full-name">
-            <span class="table-name">
-              {{user.full_name}}
-            </span>
-          </th>
-
           <!-- Username field -->
-          <td class="table-cell table-username">
+          <th class="table-cell table-username" scope="col">
             {{user.username}}
-          </td>
+          </th>
 
           <!-- Logic for role tags -->
           <td class="table-cell table-role">
@@ -93,6 +86,13 @@
               @click-remove-coach="removeCoachRoleFromUser(user)"
             />
             -->
+          </td>
+
+          <!-- Full Name field -->
+          <td scope="row" class="table-cell full-name">
+            <span class="table-name">
+              {{user.full_name}}
+            </span>
           </td>
 
           <!-- Edit field -->

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -67,11 +67,11 @@
         <thead>
         <tr>
           <th></th>
-          <th>{{ $tr('name') }}</th>
           <th>{{ $tr('username') }}</th>
           <th>
             <span class="visuallyhidden">{{ $tr('role') }}</span>
           </th>
+          <th>{{ $tr('name') }}</th>
         </tr>
         </thead>
 
@@ -79,11 +79,11 @@
         <tr v-for="learner in visibleFilteredUsers" :class="isSelected(learner.id) ? 'selectedrow' : ''"
             @click="toggleSelection(learner.id)">
           <td class="col-checkbox"><input type="checkbox" :id="learner.id" :value="learner.id" v-model="selectedUsers"></td>
-          <td><strong>{{ learner.full_name }}</strong></td>
-          <td>{{ learner.username }}</td>
+          <th scope="col">{{ learner.username }}</th>
           <td class="col-role">
             <user-role :role="learner.kind" :omitLearner="true" />
           </td>
+          <td><strong>{{ learner.full_name }}</strong></td>
         </tr>
         </tbody>
       </table>
@@ -362,9 +362,6 @@
 
   .col-checkbox
     width: 24px
-
-  .col-role
-    width: 100px
 
   .results-text
     font-size: 0.9375rem

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -69,6 +69,9 @@
           <th></th>
           <th>{{ $tr('name') }}</th>
           <th>{{ $tr('username') }}</th>
+          <th>
+            <span class="visuallyhidden">{{ $tr('role') }}</span>
+          </th>
         </tr>
         </thead>
 
@@ -76,8 +79,11 @@
         <tr v-for="learner in visibleFilteredUsers" :class="isSelected(learner.id) ? 'selectedrow' : ''"
             @click="toggleSelection(learner.id)">
           <td class="col-checkbox"><input type="checkbox" :id="learner.id" :value="learner.id" v-model="selectedUsers"></td>
-          <td class="col-name"><strong>{{ learner.full_name }}</strong></td>
-          <td class="col-username">{{ learner.username }}</td>
+          <td><strong>{{ learner.full_name }}</strong></td>
+          <td>{{ learner.username }}</td>
+          <td class="col-role">
+            <user-role :role="learner.kind" :omitLearner="true" />
+          </td>
         </tr>
         </tbody>
       </table>
@@ -157,6 +163,7 @@
       numLearners: '{count, number, integer} {count, plural, one {User} other {Users}}',
       name: 'Name',
       username: 'Username',
+      role: 'Role',
       selectedUsers: 'Only show selected users',
       noUsersExist: 'No users exist',
       noUsersSelected: 'No users are selected',
@@ -174,6 +181,7 @@
       'user-create-modal': require('../user-page/user-create-modal'),
       'confirm-enrollment-modal': require('./confirm-enrollment-modal'),
       'ui-switch': require('keen-ui/src/UiSwitch'),
+      'user-role': require('../user-role'),
     },
     data: () => ({
       filterInput: '',
@@ -353,10 +361,10 @@
     background-color: $core-bg-canvas
 
   .col-checkbox
-    width: 10%
+    width: 24px
 
-  .col-name, .col-username
-    width: 45%
+  .col-role
+    width: 100px
 
   .results-text
     font-size: 0.9375rem

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -151,7 +151,7 @@
     $trNameSpace: 'managementClassEnroll',
     $trs: {
       backToClassDetails: 'Back to class details',
-      enrollSelectedUsers: 'Review selected users',
+      enrollSelectedUsers: 'Enroll selected users',
       selectLearners: 'Choose users to enroll in',
       showingAllUnassigned: 'Showing all users not assigned to this class',
       searchForUser: 'Search for a user',

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
@@ -26,10 +26,8 @@
         <thead class="table-header">
           <tr>
             <th scope="col" class="table-text">{{ $tr('className') }}</th>
-            <th scope="col" class="table-data">{{ $tr('learners') }}</th>
-            <th scope="col" class="table-data">{{ $tr('coaches') }}</th>
-            <th scope="col" class="table-data">{{ $tr('admins') }}</th>
-            <th scope="col"></th>
+            <th scope="col" class="table-data">{{ $tr('members') }}</th>
+            <th scope="col">{{ $tr('actions') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -39,9 +37,9 @@
                 {{classModel.name}}
               </router-link>
             </th>
-            <td class="table-data">{{ classModel.learner_count }}</td>
-            <td class="table-data">{{ classModel.coach_count }}</td>
-            <td class="table-data">{{ classModel.admin_count }}</td>
+            <td class="table-data">
+              {{ classModel.learner_count + classModel.coach_count + classModel.admin_count }}
+            </td>
             <td class="table-btn">
               <button class="delete-class-button" @click="openDeleteClassModal(classModel)">
                 {{ $tr('deleteClass') }}
@@ -118,9 +116,8 @@
       // table info
       className: 'Class Name',
       classes: 'Users',
-      learners: 'Learners',
-      coaches: 'Coaches',
-      admins: 'Admins',
+      members: 'Members',
+      actions: 'Actions',
       noClassesExist: 'No Classes Exist.',
     },
   };
@@ -147,6 +144,7 @@
 
   .table-text
     text-align: left
+    width: 100%
 
   .table-data
     text-align: center

--- a/kolibri/plugins/management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/index.vue
@@ -60,11 +60,11 @@
       <!-- Table Headers -->
       <thead v-if="usersMatchFilter">
         <tr>
-          <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
+          <th class="col-header table-username" scope="col"> {{$tr('username')}} </th>
           <th class="col-header" scope="col">
             <span class="visuallyhidden">{{ $tr('kind') }}</span>
           </th>
-          <th class="col-header table-username" scope="col"> {{$tr('username')}} </th>
+          <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
           <th class="col-header" scope="col"> {{$tr('edit')}} </th>
         </tr>
       </thead>
@@ -72,11 +72,9 @@
       <!-- Table body -->
       <tbody v-if="usersMatchFilter">
         <tr v-for="user in visibleUsers">
-          <!-- Full Name field -->
-          <th scope="row" class="table-cell">
-            <span class="table-name">
-              {{user.full_name}}
-            </span>
+          <!-- Username field -->
+          <th class="table-cell table-username" scope="col">
+            {{user.username}}
           </th>
 
           <!-- Logic for role tags -->
@@ -84,9 +82,11 @@
             <user-role :role="user.kind" :omitLearner="true" />
           </td>
 
-          <!-- Username field -->
-          <td class="table-cell table-username">
-            {{user.username}}
+          <!-- Full Name field -->
+          <td scope="row" class="table-cell">
+            <span class="table-name">
+              {{user.full_name}}
+            </span>
           </td>
 
           <!-- Edit field -->

--- a/kolibri/plugins/management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/index.vue
@@ -62,9 +62,7 @@
         <tr>
           <th class="col-header" scope="col"> {{$tr('fullName')}} </th>
           <th class="col-header" scope="col">
-            <span class="role-header" aria-hidden="true">
-              {{$tr('kind')}}
-            </span>
+            <span class="visuallyhidden">{{ $tr('kind') }}</span>
           </th>
           <th class="col-header table-username" scope="col"> {{$tr('username')}} </th>
           <th class="col-header" scope="col"> {{$tr('edit')}} </th>
@@ -83,9 +81,7 @@
 
           <!-- Logic for role tags -->
           <td class="table-cell table-role">
-            <span v-if="user.kind !== LEARNER" class="user-role">
-              {{ user.kind === ADMIN ? $tr('admin') : $tr('coach') }}
-            </span>
+            <user-role :role="user.kind" :omitLearner="true" />
           </td>
 
           <!-- Username field -->
@@ -125,6 +121,7 @@
       'user-create-modal': require('./user-create-modal'),
       'user-edit-modal': require('./user-edit-modal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
+      'user-role': require('../user-role'),
     },
     // Has to be a funcion due to vue's treatment of data
     data: () => ({
@@ -211,13 +208,10 @@
       learners: 'Learners',
       // edit button text
       addNew: 'Add New',
-      // user tags
-      admin: 'Admin',
-      coach: 'Coach',
       // table info
       fullName: 'Full Name',
       users: 'Users',
-      kind: 'Kind',
+      kind: 'Role',
       username: 'Username',
       edit: 'Edit',
       // search-related error messages
@@ -295,17 +289,6 @@
     font-weight: normal // compensates for <th> cells
     padding-bottom: $row-padding
     color: $core-text-default
-
-  .user-role
-    background-color: $core-text-annotation
-    color: $core-bg-light
-    padding-left: 1em
-    padding-right: 1em
-    border-radius: 40px
-    font-size: 0.875em
-    display: inline-block
-    text-transform: capitalize
-    white-space: nowrap
 
   .searchbar .icon
     display: inline-block

--- a/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
@@ -46,6 +46,7 @@
           <label for="user-kind"><span class="visuallyhidden">{{$tr('userKind')}}</span></label>
           <select @focus="clearStatus" v-model="kind" id="user-kind">
             <option :value="LEARNER"> {{$tr('learner')}} </option>
+            <option :value="COACH"> {{$tr('coach')}} </option>
             <option :value="ADMIN"> {{$tr('admin')}} </option>
           </select>
         </div>

--- a/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
@@ -30,8 +30,8 @@
           <label for="user-role"><span class="visuallyhidden">{{$tr('userKind')}}</span></label>
           <select v-model="kind_new" id="user-role">
             <option :value="LEARNER"> {{$tr('learner')}} </option>
-            <option :value="ADMIN"> {{$tr('admin')}} </option>
             <option :value="COACH"> {{$tr('coach')}} </option>
+            <option :value="ADMIN"> {{$tr('admin')}} </option>
           </select>
         </div>
 

--- a/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
@@ -31,6 +31,7 @@
           <select v-model="kind_new" id="user-role">
             <option :value="LEARNER"> {{$tr('learner')}} </option>
             <option :value="ADMIN"> {{$tr('admin')}} </option>
+            <option :value="COACH"> {{$tr('coach')}} </option>
           </select>
         </div>
 

--- a/kolibri/plugins/management/assets/src/views/user-role/index.vue
+++ b/kolibri/plugins/management/assets/src/views/user-role/index.vue
@@ -32,7 +32,7 @@
     },
     computed: {
       text() {
-        if (this.role === UserKinds.LEARNER && !this.omitLearner) {
+        if (this.role === UserKinds.LEARNER) {
           return this.$tr('learner');
         } else if (this.role === UserKinds.COACH) {
           return this.$tr('coach');

--- a/kolibri/plugins/management/assets/src/views/user-role/index.vue
+++ b/kolibri/plugins/management/assets/src/views/user-role/index.vue
@@ -1,0 +1,67 @@
+<template>
+
+  <span class="user-role" v-if="!hidden">{{ text }}</span>
+
+</template>
+
+
+<script>
+
+  const UserKinds = require('kolibri.coreVue.vuex.constants').UserKinds;
+  const values = require('lodash/values');
+
+  module.exports = {
+    $trNameSpace: 'roleText',
+    $trs: {
+      admin: 'Admin',
+      coach: 'Coach',
+      learner: 'Learner',
+    },
+    props: {
+      role: {
+        type: String,
+        required: true,
+        validator(value) {
+          return values(UserKinds).includes(value);
+        },
+      },
+      omitLearner: {
+        type: Boolean,
+        default: false,
+      }
+    },
+    computed: {
+      text() {
+        if (this.role === UserKinds.LEARNER && !this.omitLearner) {
+          return this.$tr('learner');
+        } else if (this.role === UserKinds.COACH) {
+          return this.$tr('coach');
+        } else if (this.role === UserKinds.ADMIN) {
+          return this.$tr('admin');
+        }
+        return '';
+      },
+      hidden() {
+        return this.role === UserKinds.LEARNER && this.omitLearner;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  .user-role
+    background-color: $core-text-annotation
+    color: $core-bg-light
+    padding-left: 1em
+    padding-right: 1em
+    border-radius: 0.5em
+    font-size: small
+    display: inline-block
+    white-space: nowrap
+
+</style>


### PR DESCRIPTION

In our current implementation, we added functionality to elevate a Learner to Coach status on a per-class basis, and removed the ability to create facility-wide coaches.

However, our class coach UI has a few issues (both bugs and design). e.g...

* The UI currently shows class coaches as facility coaches. This is because the API simply aggregates a list of all roles (#1280)
* All classes are shown to a coach of a single class (#1281)
* Many users were confused that they could not create a Coach during user management, and that they had to add a user to a class first.

Short-term proposal for 0.4.x (Nalanda): simply revert back to the old functionality. Only facility-wide coaches, no class coaches.

----

This PR also makes user lists more consistent across class enrollment, roster listing, and facility roster listing:

* consistent role display
* make column order always [username, role, full name].

----

cc @jonboiser sorry I commented out the coach/learner switcher. However I believe we'll want to bring this back once @khangmach and @jtamiace have worked a bit more on the UX.


