### PR TITLE
Guard against updateTime being called after unmount

### DIFF
--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -97,13 +97,6 @@ var config = {
         test: /\.styl$/,
         use: [ 'style-loader', cssLoader, postCSSLoader, 'stylus-loader' ]
       },
-      // Only used by unit test environment for mp3 plugin. Let's try to remove eventually.
-      {
-        test: /html5media\/dist\/api\/1\.1\.8\/html5media/,
-        use: [{
-          loader: "imports-loader?this=>window"
-        }],
-      },
       {
         test: /\.s[a|c]ss$/,
         use: [ 'style-loader', cssLoader, postCSSLoader, 'sass-loader' ]

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -97,6 +97,7 @@ var config = {
         test: /\.styl$/,
         use: [ 'style-loader', cssLoader, postCSSLoader, 'stylus-loader' ]
       },
+      // Only used by unit test environment for mp3 plugin. Let's try to remove eventually.
       {
         test: /html5media\/dist\/api\/1\.1\.8\/html5media/,
         use: [{

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -98,6 +98,12 @@ var config = {
         use: [ 'style-loader', cssLoader, postCSSLoader, 'stylus-loader' ]
       },
       {
+        test: /html5media\/dist\/api\/1\.1\.8\/html5media/,
+        use: [{
+          loader: "imports-loader?this=>window"
+        }],
+      },
+      {
         test: /\.s[a|c]ss$/,
         use: [ 'style-loader', cssLoader, postCSSLoader, 'sass-loader' ]
       },

--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -1,24 +1,24 @@
 // Karma configuration
-var RewirePlugin = require("rewire-webpack");
-var _ = require("lodash");
-var webpack_config = _.clone(require("../frontend_build/src/webpack.config.base"));
-var path = require('path');
-var webpack = require('webpack');
+const RewirePlugin = require('rewire-webpack');
+const _ = require('lodash');
+const webpack_config = _.clone(require('../frontend_build/src/webpack.config.base'));
+const path = require('path');
+const webpack = require('webpack');
 
 webpack_config.plugins.push(new RewirePlugin());
 webpack_config.plugins.push(
   new webpack.DefinePlugin({
-    __coreAPISpec: "{}"
+    __coreAPISpec: '{}'
   })
 );
 webpack_config.devtool = '#inline-source-map';
-var aliases = require('../frontend_build/src/apiSpecExportTools').coreAliases();
-aliases['kolibri'] = path.resolve(__dirname, './kolibriGlobalMock');
+const aliases = require('../frontend_build/src/apiSpecExportTools').coreAliases();
+aliases.kolibri = path.resolve(__dirname, './kolibriGlobalMock');
 aliases['vue-test'] = path.resolve(__dirname, './vueLocal');
 
 webpack_config.resolve.alias = aliases;
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -34,7 +34,7 @@ module.exports = function(config) {
       { pattern: './node_modules/core-js/client/core.js', watched: false },
       './node_modules/phantomjs-polyfill-find/find-polyfill.js',
       'kolibri/**/assets/test/**/*.js',
-      {pattern: 'kolibri/**/assets/src/**/*.js', included: false} // load these, but not in the browser, just for linting
+      { pattern: 'kolibri/**/assets/src/**/*.js', included: false } // load these, but not in the browser, just for linting
     ],
 
     // list of files to exclude
@@ -74,7 +74,7 @@ module.exports = function(config) {
 
     webpackMiddleware: {
       // suppress all webpack building information to make test logs more readable.
-       noInfo: true
+      noInfo: true
     },
 
     eslint: {

--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -12,6 +12,15 @@ webpack_config.plugins.push(
   })
 );
 webpack_config.devtool = '#inline-source-map';
+
+// html5media plugin requires this
+webpack_config.module.rules.push({
+  test: /html5media\/dist\/api\/1\.1\.8\/html5media/,
+  use: [{
+    loader: 'imports-loader?this=>window',
+  }],
+});
+
 const aliases = require('../frontend_build/src/apiSpecExportTools').coreAliases();
 aliases.kolibri = path.resolve(__dirname, './kolibriGlobalMock');
 aliases['vue-test'] = path.resolve(__dirname, './vueLocal');

--- a/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
@@ -155,7 +155,7 @@
         this.$refs.audio.currentTime = sum;
       },
 
-      updateTime(e) {
+      updateTime() {
         // guard against the function being called after component is unmounted
         if (this.$refs.audio === undefined) return;
         this.displayTime = this.$refs.audio.currentTime;

--- a/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
@@ -155,7 +155,9 @@
         this.$refs.audio.currentTime = sum;
       },
 
-      updateTime() {
+      updateTime(e) {
+        // guard against the function being called after component is unmounted
+        if (this.$refs.audio === undefined) return;
         this.displayTime = this.$refs.audio.currentTime;
         if (this.displayTime - this.lastUpdateTime >= 5) {
           this.recordProgress();

--- a/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
+++ b/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
@@ -1,0 +1,27 @@
+/* eslint-env mocha */
+const Vue = require('vue-test');
+const sinon = require('sinon');
+const audioRenderer = require('../../src/views/index.vue');
+
+function makeVm(propsData) {
+  const Ctor = Vue.extend(audioRenderer);
+  return new Ctor({ propsData }).$mount();
+}
+
+describe('audio mp3 render component', () => {
+  describe('timeUpdate', () => {
+    it('does not error out if <audio> is undefined', () => {
+      // regression test for https://github.com/learningequality/kolibri/issues/1276
+      const vm = makeVm({ defaultFile: '' });
+      const audioEl = vm.$el.querySelector('#audio');
+      try {
+        // unmount the vm to simulate original situation
+        vm.$destroy();
+        // then dispatch an event
+        audioEl.dispatchEvent(new Event('timeupdate'));
+      } catch (err) {
+        sinon.assert.fail('No exceptions were expected');
+      }
+    });
+  });
+});

--- a/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
+++ b/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 const Vue = require('vue-test');
 const sinon = require('sinon');
+const simulant = require('simulant');
 const audioRenderer = require('../../src/views/index.vue');
 
 function makeVm(propsData) {
@@ -10,18 +11,18 @@ function makeVm(propsData) {
 
 describe('audio mp3 render component', () => {
   describe('timeUpdate', () => {
-    it('does not error out if <audio> is undefined', () => {
+    it('does not error out if <audio> dispatches event after unmount', () => {
       // regression test for https://github.com/learningequality/kolibri/issues/1276
       const vm = makeVm({ defaultFile: '' });
       const audioEl = vm.$el.querySelector('#audio');
-      try {
-        // unmount the vm to simulate original situation
-        vm.$destroy();
-        // then dispatch an event
-        audioEl.dispatchEvent(new Event('timeupdate'));
-      } catch (err) {
-        sinon.assert.fail('No exceptions were expected');
-      }
+      const updateTimeSpy = sinon.spy(vm, 'updateTime');
+      // unmount the vm to simulate original situation
+      vm.$destroy();
+      // then dispatch timeupdate event immediately after
+      simulant.fire(audioEl, 'timeupdate');
+      Vue.nextTick(() => {
+        sinon.assert.called(updateTimeSpy);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #1276 

The error is caused by the `audio` element firing off an event that is handled after the `<audio>` is destroyed. Tried pausing `audio` at `beforeDestroy`, but that didn't seem to work.

So the simplest solution seemed to be to just put a guard inside `updateTime`.

I tried to write a test for this, but got this error trying to run it:
```
TypeError: undefined is not an object (evaluating 'window.navigator.userAgent')
  at webpack:///kolibri/plugins/audio_mp3_render/~/html5media/dist/api/1.1.8/html5media.js:213:0
```
`window.navigator.userAgent` is fine, so I wonder if it has something to do with how webpack config is working in test environment.