### PR TITLE
Robustify frontend to missing assessment metadata

### DIFF
--- a/kolibri/core/assets/src/content/utils.js
+++ b/kolibri/core/assets/src/content/utils.js
@@ -1,0 +1,26 @@
+function validateAssessmentMetaData(data) {
+  // Data is coming from a serializer for a one to many key, so at least will return an empty array.
+  const assessmentMetaData = data.assessmentmetadata[0];
+  if (!assessmentMetaData) {
+    return {
+      assessment: false,
+    };
+  }
+  const assessmentIds = JSON.parse(assessmentMetaData.assessment_item_ids || '[]');
+  const masteryModel = JSON.parse(assessmentMetaData.mastery_model || '{}');
+  if (!assessmentIds.length || !Object.keys(masteryModel).length) {
+    return {
+      assessment: false,
+    };
+  }
+  return {
+    assessment: true,
+    assessmentIds,
+    masteryModel,
+    randomize: assessmentMetaData.randomize,
+  };
+}
+
+module.exports = {
+  validateAssessmentMetaData,
+};

--- a/kolibri/core/assets/src/content/utils.js
+++ b/kolibri/core/assets/src/content/utils.js
@@ -11,6 +11,7 @@ function validateAssessmentMetaData(data) {
   if (!assessmentIds.length || !Object.keys(masteryModel).length) {
     return {
       assessment: false,
+      assessmentIds: [],
     };
   }
   return {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -36,7 +36,7 @@ module.exports = {
       },
       seededshuffle: {
         module: require('seededshuffle'),
-      }
+      },
     },
     coreVue: {
       vuex: {
@@ -51,6 +51,9 @@ module.exports = {
         },
         store: {
           module: require('../state/store'),
+        },
+        mappers: {
+          module: require('../state/mappers'),
         },
       },
       components: {
@@ -138,9 +141,6 @@ module.exports = {
       },
       validateLinkObject: {
         module: require('../validateLinkObject'),
-      },
-      content: {
-        module: require('../content/utils'),
       },
     },
   },

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -139,6 +139,9 @@ module.exports = {
       validateLinkObject: {
         module: require('../validateLinkObject'),
       },
+      content: {
+        module: require('../content/utils'),
+      },
     },
   },
 };

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -10,10 +10,7 @@ function createQuestionList(questionSources) {
 
 function selectQuestionFromExercise(index, seed, contentNode) {
   const assessmentmetadata = validateAssessmentMetaData(contentNode);
-  if (assessmentmetadata.assessment) {
-    return seededShuffle.shuffle(assessmentmetadata.assessmentItemIds, seed, true)[index];
-  }
-  return null;
+  return seededShuffle.shuffle(assessmentmetadata.assessmentItemIds, seed, true)[index];
 }
 
 module.exports = {

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -1,5 +1,5 @@
 const seededShuffle = require('seededshuffle');
-const { validateAssessmentMetaData } = require('kolibri.utils.content');
+const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
 
 function createQuestionList(questionSources) {
   return questionSources.reduce((acc, val) =>
@@ -9,7 +9,7 @@ function createQuestionList(questionSources) {
 }
 
 function selectQuestionFromExercise(index, seed, contentNode) {
-  const assessmentmetadata = validateAssessmentMetaData(contentNode);
+  const assessmentmetadata = assessmentMetaDataState(contentNode);
   return seededShuffle.shuffle(assessmentmetadata.assessmentItemIds, seed, true)[index];
 }
 

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -1,4 +1,5 @@
 const seededShuffle = require('seededshuffle');
+const { validateAssessmentMetaData } = require('kolibri.utils.content');
 
 function createQuestionList(questionSources) {
   return questionSources.reduce((acc, val) =>
@@ -8,8 +9,11 @@ function createQuestionList(questionSources) {
 }
 
 function selectQuestionFromExercise(index, seed, contentNode) {
-  const assessmentItemIds = JSON.parse(contentNode.assessmentmetadata[0].assessment_item_ids);
-  return seededShuffle.shuffle(assessmentItemIds, seed, true)[index];
+  const assessmentmetadata = validateAssessmentMetaData(contentNode);
+  if (assessmentmetadata.assessment) {
+    return seededShuffle.shuffle(assessmentmetadata.assessmentItemIds, seed, true)[index];
+  }
+  return null;
 }
 
 module.exports = {

--- a/kolibri/core/assets/src/state/mappers.js
+++ b/kolibri/core/assets/src/state/mappers.js
@@ -1,11 +1,11 @@
 function assessmentMetaDataState(data) {
-  // Data is coming from a serializer for a one to many key, so at least will return an empty array.
   const blankState = {
     assessment: false,
     assessmentIds: [],
     masteryModel: null,
     randomize: false,
   };
+  // Data is from a serializer for a one to many key, so it will return a array of length 0 or 1
   const assessmentMetaData = data.assessmentmetadata[0];
   if (!assessmentMetaData) {
     return blankState;

--- a/kolibri/core/assets/src/state/mappers.js
+++ b/kolibri/core/assets/src/state/mappers.js
@@ -1,18 +1,19 @@
-function validateAssessmentMetaData(data) {
+function assessmentMetaDataState(data) {
   // Data is coming from a serializer for a one to many key, so at least will return an empty array.
+  const blankState = {
+    assessment: false,
+    assessmentIds: [],
+    masteryModel: null,
+    randomize: false,
+  };
   const assessmentMetaData = data.assessmentmetadata[0];
   if (!assessmentMetaData) {
-    return {
-      assessment: false,
-    };
+    return blankState;
   }
   const assessmentIds = JSON.parse(assessmentMetaData.assessment_item_ids || '[]');
   const masteryModel = JSON.parse(assessmentMetaData.mastery_model || '{}');
   if (!assessmentIds.length || !Object.keys(masteryModel).length) {
-    return {
-      assessment: false,
-      assessmentIds: [],
-    };
+    return blankState;
   }
   return {
     assessment: true,
@@ -23,5 +24,5 @@ function validateAssessmentMetaData(data) {
 }
 
 module.exports = {
-  validateAssessmentMetaData,
+  assessmentMetaDataState,
 };

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -7,6 +7,7 @@ const ContentNodeKinds = require('kolibri.coreVue.vuex.constants').ContentNodeKi
 const CollectionKinds = require('kolibri.coreVue.vuex.constants').CollectionKinds;
 const Constants = require('../../constants');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
+const { validateAssessmentMetaData } = require('kolibri.utils.content');
 
 const ClassroomResource = CoreApp.resources.ClassroomResource;
 const ChannelResource = CoreApp.resources.ChannelResource;
@@ -67,11 +68,11 @@ function _topicsState(topics) {
 }
 
 function _exerciseState(exercise) {
-  const numAssesments = (exercise.assessmentmetadata[0] || {}).number_of_assessments || 0;
+  const numAssessments = validateAssessmentMetaData(exercise).length;
   return {
     id: exercise.pk,
     title: exercise.title,
-    numAssesments,
+    numAssessments,
   };
 }
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -7,7 +7,7 @@ const ContentNodeKinds = require('kolibri.coreVue.vuex.constants').ContentNodeKi
 const CollectionKinds = require('kolibri.coreVue.vuex.constants').CollectionKinds;
 const Constants = require('../../constants');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
-const { validateAssessmentMetaData } = require('kolibri.utils.content');
+const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
 
 const ClassroomResource = CoreApp.resources.ClassroomResource;
 const ChannelResource = CoreApp.resources.ChannelResource;
@@ -68,7 +68,7 @@ function _topicsState(topics) {
 }
 
 function _exerciseState(exercise) {
-  const numAssessments = validateAssessmentMetaData(exercise).length;
+  const numAssessments = assessmentMetaDataState(exercise).length;
   return {
     id: exercise.pk,
     title: exercise.title,

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -67,10 +67,11 @@ function _topicsState(topics) {
 }
 
 function _exerciseState(exercise) {
+  const numAssesments = (exercise.assessmentmetadata[0] || {}).number_of_assessments || 0;
   return {
     id: exercise.pk,
     title: exercise.title,
-    numAssesments: exercise.assessmentmetadata[0].number_of_assessments,
+    numAssesments,
   };
 }
 

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -294,7 +294,7 @@ function _showExerciseDetailView(store, classId, userId, channelId, contentId,
       );
 
       const exerciseQuestions = parseJSONorUndefined(
-        exercise.assessmentmetadata[0].assessment_item_ids
+        (exercise.assessmentmetadata[0] || {}).assessment_item_ids || ''
       );
       // SECOND LOOP: Add their question number
       if (exerciseQuestions) {

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -1,6 +1,7 @@
 const coreApp = require('kolibri');
 const coreActions = require('kolibri.coreVue.vuex.actions');
 const coreGetters = require('kolibri.coreVue.vuex.getters');
+const { validateAssessmentMetaData } = require('kolibri.utils.content');
 
 const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const Constants = require('../../constants');
@@ -293,11 +294,9 @@ function _showExerciseDetailView(store, classId, userId, channelId, contentId,
           new Date(attemptLog2.end_timestamp) - new Date(attemptLog1.end_timestamp)
       );
 
-      const exerciseQuestions = parseJSONorUndefined(
-        (exercise.assessmentmetadata[0] || {}).assessment_item_ids || ''
-      );
+      const exerciseQuestions = validateAssessmentMetaData(exercise).assessmentIds;
       // SECOND LOOP: Add their question number
-      if (exerciseQuestions) {
+      if (exerciseQuestions && exerciseQuestions.length) {
         attemptLogs.forEach(
           attemptLog => {
             attemptLog.questionNumber = (exerciseQuestions.indexOf(attemptLog.item) + 1);

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -1,7 +1,7 @@
 const coreApp = require('kolibri');
 const coreActions = require('kolibri.coreVue.vuex.actions');
 const coreGetters = require('kolibri.coreVue.vuex.getters');
-const { validateAssessmentMetaData } = require('kolibri.utils.content');
+const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
 
 const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const Constants = require('../../constants');
@@ -294,7 +294,7 @@ function _showExerciseDetailView(store, classId, userId, channelId, contentId,
           new Date(attemptLog2.end_timestamp) - new Date(attemptLog1.end_timestamp)
       );
 
-      const exerciseQuestions = validateAssessmentMetaData(exercise).assessmentIds;
+      const exerciseQuestions = assessmentMetaDataState(exercise).assessmentIds;
       // SECOND LOOP: Add their question number
       if (exerciseQuestions && exerciseQuestions.length) {
         attemptLogs.forEach(

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/exercise-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/exercise-row.vue
@@ -52,9 +52,9 @@
     methods: {
       changeSelection() {
         if (this.isSelected) {
-          this.$emit('removeExercise', { id: this.exerciseId, title: this.exerciseTitle, numAssesments: this.exerciseNumAssesments });
+          this.$emit('removeExercise', { id: this.exerciseId, title: this.exerciseTitle, numAssessments: this.exerciseNumAssesments });
         } else {
-          this.$emit('addExercise', { id: this.exerciseId, title: this.exerciseTitle, numAssesments: this.exerciseNumAssesments });
+          this.$emit('addExercise', { id: this.exerciseId, title: this.exerciseTitle, numAssessments: this.exerciseNumAssesments });
         }
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -67,7 +67,7 @@
                 v-for="exercise in exercises"
                 :exerciseId="exercise.id"
                 :exerciseTitle="exercise.title"
-                :exerciseNumAssesments="exercise.numAssesments"
+                :exerciseNumAssesments="exercise.numAssessments"
                 :selectedExercises="selectedExercises"
                 @addExercise="handleAddExercise"
                 @removeExercise="handleRemoveExercise"/>
@@ -172,7 +172,7 @@
     },
     computed: {
       maxQuestionsFromSelection() {
-        return this.selectedExercises.reduce((sum, exercise) => sum + exercise.numAssesments, 0);
+        return this.selectedExercises.reduce((sum, exercise) => sum + exercise.numAssessments, 0);
       },
       titleInvalid() {
         return this.validateTitle ? !this.inputTitle : false;

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -14,7 +14,7 @@ const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const router = require('kolibri.coreVue.router');
 const seededShuffle = require('kolibri.lib.seededshuffle');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
-const { validateAssessmentMetaData } = require('kolibri.utils.content');
+const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
 
 /**
  * Vuex State Mappers
@@ -68,7 +68,7 @@ function _contentState(data) {
     license: data.license,
     license_owner: data.license_owner,
   };
-  Object.assign(state, validateAssessmentMetaData(data));
+  Object.assign(state, assessmentMetaDataState(data));
   return state;
 }
 

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -14,6 +14,7 @@ const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const router = require('kolibri.coreVue.router');
 const seededShuffle = require('kolibri.lib.seededshuffle');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
+const { validateAssessmentMetaData } = require('kolibri.utils.content');
 
 /**
  * Vuex State Mappers
@@ -42,29 +43,6 @@ function _topicState(data) {
   return state;
 }
 
-function _validateAssessmentMetaData(data) {
-  // Data is coming from a serializer for a one to many key, so at least will return an empty array.
-  const assessmentMetaData = data.assessmentmetadata[0];
-  if (!assessmentMetaData) {
-    return {
-      assessment: false,
-    };
-  }
-  const assessmentIds = JSON.parse(assessmentMetaData.assessment_item_ids || '[]');
-  const masteryModel = JSON.parse(assessmentMetaData.mastery_model || '{}');
-  if (!assessmentIds.length || !Object.keys(masteryModel).length) {
-    return {
-      assessment: false,
-    };
-  }
-  return {
-    assessment: true,
-    assessmentIds,
-    masteryModel,
-    randomize: assessmentMetaData.randomize,
-  };
-}
-
 function _contentState(data) {
   let progress;
   if (!data.progress_fraction) {
@@ -90,7 +68,7 @@ function _contentState(data) {
     license: data.license,
     license_owner: data.license_owner,
   };
-  Object.assign(state, _validateAssessmentMetaData(data));
+  Object.assign(state, validateAssessmentMetaData(data));
   return state;
 }
 

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -26,6 +26,7 @@
             <content-renderer
               class="content-renderer"
               ref="contentRenderer"
+              v-if="itemId"
               :id="content.id"
               :kind="content.kind"
               :files="content.files"
@@ -38,6 +39,9 @@
               :allowHints="false"
               :answerState="currentAttempt.answer"
               @interaction="saveAnswer"/>
+              <ui-alert v-else :dismissible="false" type="error">
+                {{ $tr('noItemId') }}
+              </ui-alert>
               <div class="question-navbutton-container">
                 <icon-button :disabled="questionNumber===0" @click="goToQuestion(questionNumber - 1)" :text="$tr('previousQuestion')"><mat-svg category="navigation" name="chevron_left"/></icon-button>
                 <icon-button :disabled="questionNumber===exam.questionCount-1" alignment="right" @click="goToQuestion(questionNumber + 1)" :text="$tr('nextQuestion')"><mat-svg category="navigation" name="chevron_right"/></icon-button>
@@ -75,6 +79,7 @@
       cancel: 'Cancel',
       areYouSure: 'Are you you want to submit your exam?',
       unanswered: 'You have {numLeft, number} {numLeft, plural, one {question} other {questions}} unanswered',
+      noItemId: 'This question has an error, please move on to the next question',
     },
     components: {
       'immersive-full-screen': require('kolibri.coreVue.components.immersiveFullScreen'),
@@ -82,6 +87,7 @@
       'icon-button': require('kolibri.coreVue.components.iconButton'),
       'answer-history': require('./answer-history'),
       'core-modal': require('kolibri.coreVue.components.coreModal'),
+      'ui-alert': require('keen-ui/src/UiAlert'),
     },
     data: () => ({
       submitModalOpen: false,


### PR DESCRIPTION
## Summary

Fixes #1309, and in the process should resolve #1238, resolve #1301, fix #1303, and close #1305.

Does this by using the same assessment meta data validation logic everywhere that we use assessment meta data in the app, by means of a core util function.