### PR TITLE
Hinting fixes

### DIFF
--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -155,8 +155,6 @@ const mutations = {
       state.core.logging.attempt.completion_timestamp = null;
       state.core.logging.attempt.complete = false;
     }
-    state.core.logging.attempt.correct = correct;
-    state.core.logging.attempt.hinted = hinted;
     state.core.logging.attempt.end_timestamp = currentTime;
     let starttime = state.core.logging.attempt.start_timestamp;
     if (typeof starttime === 'string') {
@@ -164,8 +162,15 @@ const mutations = {
     }
     state.core.logging.attempt.time_spent = currentTime - starttime;
     if (firstAttempt) {
+      // Can only get it correct on the first try.
+      state.core.logging.attempt.correct = correct;
+      state.core.logging.attempt.hinted = hinted;
       state.core.logging.attempt.answer = JSON.stringify(answerState);
       state.core.logging.attempt.simple_answer = simpleAnswer;
+    } else if (state.core.logging.attempt.correct < 1) {
+      // Only set hinted if attempt has not already been marked as correct
+      // and set it to true if now true, but leave as true if false.
+      state.core.logging.attempt.hinted = state.core.logging.attempt.hinted || hinted;
     }
   },
   SET_EMPTY_LOGGING_STATE(state) {

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -47,7 +47,7 @@ oriented data synchronization.
         :log="recentAttempts"
       />
       <p class="message">{{ $tr('goal', {count: totalCorrectRequiredM}) }}</p>
-      <p id="try-again" v-if="!correct && !firstAttempt">{{ $tr('tryAgain') }}</p>
+      <p id="try-again" v-if="correct < 1 && !firstAttempt">{{ $tr('tryAgain') }}</p>
     </div>
   </div>
 
@@ -117,7 +117,7 @@ oriented data synchronization.
       shake: false,
       firstAttempt: true,
       complete: false,
-      correct: true,
+      correct: 0,
       itemError: false,
     }),
     methods: {
@@ -125,7 +125,7 @@ oriented data synchronization.
         correct,
         complete,
         firstAttempt = false,
-        hinted = false,
+        hinted,
         answerState,
         simpleAnswer,
       }) {
@@ -154,8 +154,9 @@ oriented data synchronization.
         }
       },
       answerGiven({ correct, answerState, simpleAnswer }) {
+        correct = Number(correct); // eslint-disable-line no-param-reassign
         this.correct = correct;
-        if (!correct) {
+        if (correct < 1) {
           if (!this.shake) {
             setTimeout(() => {
               this.shake = false;
@@ -168,7 +169,7 @@ oriented data synchronization.
           answer: answerState,
           correct,
         });
-        this.complete = correct;
+        this.complete = correct === 1;
         if (this.firstAttempt) {
           this.updateAttemptLogMasteryLog({
             correct,
@@ -222,7 +223,7 @@ oriented data synchronization.
         this.shake = false;
         this.firstAttempt = true;
         this.complete = false;
-        this.correct = true;
+        this.correct = 0;
         this.itemError = false;
         this.setItemId();
         this.createAttemptLog();
@@ -258,7 +259,7 @@ oriented data synchronization.
         this.complete = true;
         if (this.firstAttempt) {
           this.updateAttemptLogMasteryLog({
-            correct: true,
+            correct: 1,
             complete: this.complete,
             firstAttempt: true,
           });

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -196,7 +196,9 @@ oriented data synchronization.
             correct: 0,
             complete: false,
             firstAttempt: true,
-            hinted: true
+            hinted: true,
+            answerState,
+            simpleAnswer: '',
           });
           this.firstAttempt = false;
         }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,4 +15,4 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.4
+kolibri_exercise_perseus_plugin==0.6.5


### PR DESCRIPTION
## Summary

Fixes various bugs related to hinting functionality. Fixes #1298, resolves #1299, and closes #1300.

Does this by preventing attempts from being set as 'unhinted' after a hint has been taken, and also prevents attempts being set as correct after the first attempt.

Updates the Perseus Renderer to reset hint state when a new question is loaded.

It also ensures that an answer and simpleanswer are set on the attempt log when the user gets a hint as their first interaction.

Finally, it corrects all front end usage of 'correct' to represent answers as a float between 0 and 1, rather than Booleans.