### PR TITLE
Fix user type counter in ClassroomSerializer

### DIFF
--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -80,13 +80,17 @@ class ClassroomSerializer(serializers.ModelSerializer):
     admin_count = serializers.SerializerMethodField()
 
     def get_learner_count(self, target_node):
-        return target_node.get_members().count()
+        n_members = target_node.get_members().count()
+        n_coaches = self.get_coach_count(target_node)
+        n_admin = self.get_admin_count(target_node)
+        # the intersection of coaches and admins should be empty, so this shouldn't double count
+        return n_members - n_coaches - n_admin
 
     def get_coach_count(self, target_node):
         return Role.objects.filter(collection=target_node, kind=role_kinds.COACH).count()
 
     def get_admin_count(self, target_node):
-        return Role.objects.filter(collection=target_node, kind=role_kinds.ADMIN).count()
+        return target_node.get_members().filter(roles__kind=role_kinds.ADMIN).count()
 
     class Meta:
         model = Classroom


### PR DESCRIPTION
Fixes #1190 

1. Changed formula for counting non-coach learners
2. Changed formula for counting admins

Before (see `pageState.classes` entry on right)
<img width="1200" alt="screen shot 2017-04-25 at 12 34 01 pm" src="https://cloud.githubusercontent.com/assets/10248067/25396784/e26fdc92-29b3-11e7-91eb-564efb7390f2.png">

AFter
<img width="1200" alt="screen shot 2017-04-25 at 12 33 38 pm" src="https://cloud.githubusercontent.com/assets/10248067/25396789/ea447c20-29b3-11e7-9072-837d8dda54f4.png">
