### PR TITLE
Fix issue where user is logged out when refreshing on content management page

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -202,10 +202,9 @@ function kolibriLogout(store) {
 function getCurrentSession(store) {
   const coreApp = require('kolibri');
   const { SessionResource, FacilityResource } = coreApp.resources;
-  const id = 'current';
-  const sessionModel = SessionResource.getModel(id);
-  const sessionPromise = sessionModel.fetch({});
-  return sessionPromise.then((session) => {
+  const sessionPromise = SessionResource.getModel('current').fetch()._promise;
+  return sessionPromise
+  .then((session) => {
     if (!session.facility_id) {
       // device owners users aren't associated with a facility, so just choose one
       logging.info('No facilty ID set on session. Fetching facility list...');
@@ -220,7 +219,8 @@ function getCurrentSession(store) {
     logging.info('Session set.');
     store.dispatch('CORE_SET_SESSION', _sessionState(session));
     return null;
-  }).catch(error => { handleApiError(store, error); });
+  })
+  .catch(error => { handleApiError(store, error); });
 }
 
 function showLoginModal(store, bool) {


### PR DESCRIPTION
Fixes the bug described in #1320 where refreshing at `/management/content` logs out the user.

The root cause was that when loading the `management/content` page from a refresh, `state.core.session.kind` equals "anonymous". This happen because when evaluating

http://github.com/jonboiser/kolibri/blob/33fdb6b3eb02ef80e9f5900992f2306d8f18e5cb/kolibri/plugins/management/assets/src/app.js#L15

Then `.then` callback is evaluated eagerly, before this line is executed

http://github.com/jonboiser/kolibri/blob/33fdb6b3eb02ef80e9f5900992f2306d8f18e5cb/kolibri/core/assets/src/state/actions.js#L216,

in which is where `session.kind` is set in the state to 'admin' or 'superuser'

To fix this, I unwrap the ConditionalPromise using `._promise` to get normal chaining semantics back.

I tried to write  a test for this, but realized that I had been mocking Resource responses with normal Promises instead of Conditional Promises, so couldn't write a failing test from the original code.