### PR TITLE
Signup Fix

### DIFF
--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -67,7 +67,7 @@
         autocomplete="new-password"
         required />
 
-      <icon-button :disabled="canSubmit" id="submit" :primary="true" :text="$tr('finish')" type="submit" />
+      <icon-button :disabled="busy" id="submit" :primary="true" :text="$tr('finish')" type="submit" />
 
     </form>
 
@@ -113,7 +113,6 @@
       username: '',
       password: '',
       confirmed_password: '',
-      termsAgreement: false,
     }),
     computed: {
       signInPage() {
@@ -136,10 +135,7 @@
         return this.errorCode === 400;
       },
       allFieldsPopulated() {
-        return !(this.name && this.username && this.password && this.confirmed_password);
-      },
-      canSubmit() {
-        return !this.termsAgreement || this.allFieldsPopulated || !this.passwordsMatch || this.busy;
+        return this.name && this.username && this.password && this.confirmed_password;
       },
       errorMessage() {
         return this.backendErrorMessage || this.$tr('genericError');
@@ -147,11 +143,18 @@
     },
     methods: {
       signUp() {
-        this.signUpAction({
-          full_name: this.name,
-          username: this.username,
-          password: this.password,
-        });
+        const canSubmit =
+          this.allFieldsPopulated &&
+          this.passwordsMatch &&
+          !this.busy;
+
+        if (canSubmit) {
+          this.signUpAction({
+            full_name: this.name,
+            username: this.username,
+            password: this.password,
+          });
+        }
       },
     },
     vuex: {


### PR DESCRIPTION
Changing UI to match behavior from vf. Must have gotten lost somewhere, because these changes were merged at some point.

Fixes #1327? Allows users to sign up now, but the `id` error shown comes from a core action. We don't need that data to sign up. 