### PR TITLE
Fix exam rendering, prevent exam from rendering if it is completely malformed

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -10,7 +10,7 @@ function createQuestionList(questionSources) {
 
 function selectQuestionFromExercise(index, seed, contentNode) {
   const assessmentmetadata = assessmentMetaDataState(contentNode);
-  return seededShuffle.shuffle(assessmentmetadata.assessmentItemIds, seed, true)[index];
+  return seededShuffle.shuffle(assessmentmetadata.assessmentIds, seed, true)[index];
 }
 
 module.exports = {

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -601,49 +601,54 @@ function showExam(store, channelId, id, questionNumber) {
                 contentId: question.contentId
               }));
 
-              const itemId = questions[questionNumber].itemId;
+              if (questions.every(question => !question.itemId)) {
+                // Exam is drawing solely on malformed exercise data, best to quit now
+                coreActions.handleError(store, `This exam has no valid questions`);
+              } else {
+                const itemId = questions[questionNumber].itemId;
 
-              const currentQuestion = questions[questionNumber];
+                const currentQuestion = questions[questionNumber];
 
-              const questionsAnswered = Math.max(store.state.pageState.questionsAnswered || 0,
-                calcQuestionsAnswered(attemptLogs));
+                const questionsAnswered = Math.max(store.state.pageState.questionsAnswered || 0,
+                  calcQuestionsAnswered(attemptLogs));
 
-              const pageState = {
-                exam: _examState(exam),
-                itemId,
-                questions,
-                currentQuestion,
-                questionNumber,
-                content: _contentState(contentNodeMap[questions[questionNumber].contentId]),
-                channelId,
-                questionsAnswered,
-              };
-              if (!attemptLogs[currentQuestion.contentId]) {
-                attemptLogs[currentQuestion.contentId] = {};
-              }
-              if (!attemptLogs[currentQuestion.contentId][itemId]) {
-                attemptLogs[currentQuestion.contentId][itemId] = {
-                  start_timestamp: new Date(),
-                  completion_timestamp: null,
-                  end_timestamp: null,
-                  item: itemId,
-                  complete: false,
-                  time_spent: 0,
-                  correct: 0,
-                  answer: undefined,
-                  simple_answer: '',
-                  interaction_history: [],
-                  hinted: false,
-                  channel_id: channelId,
-                  content_id: currentQuestion.contentId,
+                const pageState = {
+                  exam: _examState(exam),
+                  itemId,
+                  questions,
+                  currentQuestion,
+                  questionNumber,
+                  content: _contentState(contentNodeMap[questions[questionNumber].contentId]),
+                  channelId,
+                  questionsAnswered,
                 };
+                if (!attemptLogs[currentQuestion.contentId]) {
+                  attemptLogs[currentQuestion.contentId] = {};
+                }
+                if (!attemptLogs[currentQuestion.contentId][itemId]) {
+                  attemptLogs[currentQuestion.contentId][itemId] = {
+                    start_timestamp: new Date(),
+                    completion_timestamp: null,
+                    end_timestamp: null,
+                    item: itemId,
+                    complete: false,
+                    time_spent: 0,
+                    correct: 0,
+                    answer: undefined,
+                    simple_answer: '',
+                    interaction_history: [],
+                    hinted: false,
+                    channel_id: channelId,
+                    content_id: currentQuestion.contentId,
+                  };
+                }
+                pageState.currentAttempt = attemptLogs[currentQuestion.contentId][itemId];
+                store.dispatch('SET_EXAM_ATTEMPT_LOGS', attemptLogs);
+                store.dispatch('SET_PAGE_STATE', pageState);
+                store.dispatch('CORE_SET_PAGE_LOADING', false);
+                store.dispatch('CORE_SET_ERROR', null);
+                store.dispatch('CORE_SET_TITLE', `${pageState.exam.title} - ${currentChannel.title}`);
               }
-              pageState.currentAttempt = attemptLogs[currentQuestion.contentId][itemId];
-              store.dispatch('SET_EXAM_ATTEMPT_LOGS', attemptLogs);
-              store.dispatch('SET_PAGE_STATE', pageState);
-              store.dispatch('CORE_SET_PAGE_LOADING', false);
-              store.dispatch('CORE_SET_ERROR', null);
-              store.dispatch('CORE_SET_TITLE', `${pageState.exam.title} - ${currentChannel.title}`);
             },
             error => { coreActions.handleApiError(store, error); }
           );

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -110,7 +110,10 @@
     },
     methods: {
       checkAnswer() {
-        return this.$refs.contentRenderer.checkAnswer();
+        if (this.$refs.contentRenderer) {
+          return this.$refs.contentRenderer.checkAnswer();
+        }
+        return null;
       },
       saveAnswer() {
         const answer = this.checkAnswer();


### PR DESCRIPTION
## Summary

Fixes a severe bug (caused by an incorrect property name) that stops all exams rendering for learners.

Also just shows an error if *none* of the questions in an exam are capable of being rendered.

refs #1301 