### PR TITLE
Fixes for exam log saving

### DIFF
--- a/kolibri/logger/serializers.py
+++ b/kolibri/logger/serializers.py
@@ -31,7 +31,7 @@ class ExamLogSerializer(serializers.ModelSerializer):
         # This has changed, set the completion timestamp
         if validated_data.get('closed') and not instance.closed:
             instance.completion_timestamp = now()
-        return instance
+        return super(ExamLogSerializer, self).update(instance, validated_data)
 
 class MasteryLogSerializer(serializers.ModelSerializer):
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -485,7 +485,8 @@ function showExamReportDetailPage(
   const userPromise = FacilityUserResource.getModel(userId).fetch();
   ConditionalPromise.all([attemptLogPromise, examPromise, userPromise, examLogPromise]).only(
     CoreActions.samePageCheckGenerator(store),
-    ([examAttempts, exam, user, examLog]) => {
+    ([examAttempts, exam, user, examLogs]) => {
+      const examLog = examLogs[0];
       const seed = exam.seed;
       const questionSources = JSON.parse(exam.question_sources);
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -68,7 +68,7 @@ function _topicsState(topics) {
 }
 
 function _exerciseState(exercise) {
-  const numAssessments = assessmentMetaDataState(exercise).length;
+  const numAssessments = assessmentMetaDataState(exercise).assessmentIds.length;
   return {
     id: exercise.pk,
     title: exercise.title,

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
@@ -10,8 +10,8 @@
           :contentName="exam.title"
           :userName="userName"
           :questions="examAttempts"
-          :completionTimeStamp="completionTimeStamp"
-          :completed="exam.closed"/>
+          :completionTimestamp="new Date(completionTimestamp)"
+          :completed="closed"/>
       </div>
       <div class="details-container">
         <div class="attempt-log-container">
@@ -24,7 +24,7 @@
         <div class="exercise-container">
           <interaction-list
             :interactions="currentInteractionHistory"
-            :attemptNumber="questionNumber"
+            :attemptNumber="currentAttempt.questionNumber"
             :selectedInteractionIndex="selectedInteractionIndex"
             @select="navigateToInteraction"
           />
@@ -115,7 +115,8 @@
         questionNumber: state => state.pageState.questionNumber,
         exercise: state => state.pageState.exercise,
         itemId: state => state.pageState.itemId,
-        completionTimeStamp: state => state.pageState.examLog.completion_timestamp,
+        completionTimestamp: state => state.pageState.examLog.completion_timestamp,
+        closed: state => state.pageState.examLog.closed,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/page-status.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/page-status.vue
@@ -19,12 +19,18 @@
     </div>
     <div class="column pure-u-1-4">
       <div class="inner-column">
-        <div>
-          <progress-icon class="svg-icon" :progress="progress"/>
-          <strong v-if="completed"> {{ $tr('completed') }} </strong>
-          <p v-else> {{ $tr('inProgress') }} </p>
-        </div>
-        <p v-if="completed">{{ $tr('date', { date }) }}</p>
+        <progress-icon class="svg-icon" :progress="progress"/>
+        <span v-if="completed">
+          <strong> {{ $tr('completed') }} </strong>
+          <br />
+          <elapsed-time :date="completionTimestamp"/>
+        </span>
+        <span v-else-if="completed !== null">
+          <strong> {{ $tr('inProgress') }} </strong>
+        </span>
+        <span v-else>
+          <strong> {{ $tr('notStarted') }} </strong>
+        </span>
       </div>
     </div>
   </div>
@@ -43,9 +49,11 @@
       completed: 'Completed',
       date: 'on { completed, date, medium }',
       inProgress: 'In progress',
+      notStarted: 'Not started',
     },
     components: {
       'progress-icon': require('kolibri.coreVue.components.progressIcon'),
+      'elapsed-time': require('kolibri.coreVue.components.elapsedTime'),
     },
     props: {
       userName: {
@@ -74,7 +82,7 @@
       progress() {
         // Either return in completed or in progress
         return this.completed ? 1 : 0.1;
-      }
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
@@ -48,7 +48,7 @@
     $trNameSpace: 'coachExercisePageStatus',
     $trs: {
       statusMastered: 'Mastered',
-      statusInProgress: 'In Progress',
+      statusInProgress: 'In progress',
       requirementsMOfN: 'Mastery: {m ,number} out of {n, number} correct',
       attemptDateIndicator: 'on { date }',
       notStarted: 'Not started',

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -706,7 +706,7 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
 }
 
 function closeExam(store) {
-  const examLog = store.state.examLog;
+  const examLog = Object.assign({}, store.state.examLog);
   examLog.closed = true;
   return ExamLogResource.getModel(examLog.id).save(examLog).catch(
     error => { coreActions.handleApiError(store, error); });

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -684,7 +684,7 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
   attributes.user = store.state.core.session.user_id;
   attributes.examlog = store.state.examLog.id;
   const promise = examAttemptLogModel.save(attributes);
-  promise.then((newExamAttemptLog) => {
+  return promise.then((newExamAttemptLog) => {
     const log = Object.assign({}, newExamAttemptLog, {
       answer: parseJSONorUndefined(newExamAttemptLog.answer),
       interaction_history: parseJSONorUndefined(newExamAttemptLog.interaction_history) || [],

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -136,10 +136,11 @@
         return Promise.resolve();
       },
       goToQuestion(questionNumber) {
-        this.saveAnswer();
-        this.$router.push({
-          name: PageNames.EXAM,
-          params: { channel_id: this.channelId, id: this.exam.id, questionNumber },
+        this.saveAnswer().then(() => {
+          this.$router.push({
+            name: PageNames.EXAM,
+            params: { channel_id: this.channelId, id: this.exam.id, questionNumber },
+          });
         });
       },
       submitExam() {


### PR DESCRIPTION
## Summary

Updates ExamLogSerializer to properly update the model.
Updates frontend to properly parse exam data for reports.
Waits for API attempt update before navigation on learner exam page.

Fixes #1246, resolves #1340, and closes #1343.