### PR TITLE
Fix coach exam scores rendering as NaN

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -30,11 +30,17 @@
               </router-link>
             </th>
 
-            <td class="table-data" v-if="examTaker.progress === exam.question_count">{{ $tr('completed') }}</td>
-            <td class="table-data incomplete" v-else-if="examTaker.progress">
-              {{ $tr('incomplete', { num: examTaker.progress, outOf: exam.question_count }) }}
+            <td class="table-data">
+              <span v-if="examTaker.progress === exam.question_count">
+                {{ $tr('completed') }}
+              </span>
+              <span v-else-if="examTaker.progress !== undefined" class="incomplete">
+                {{ $tr('incomplete', { num: examTaker.progress, outOf: exam.question_count }) }}
+              </span>
+              <span v-else class="incomplete">
+                {{ $tr('notstarted') }}
+              </span>
             </td>
-            <td class="table-data incomplete" v-else>{{ $tr('notstarted') }}</td>
 
             <td class="table-data">
               <span v-if="examTaker.progress === undefined">&mdash;</span>

--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -6,7 +6,7 @@
       <h1>
         {{ $tr('examTakenby', { num: takenBy }) }}
       </h1>
-      <h1>
+      <h1 v-if="takenBy > 0">
         {{ $tr('averageScore', { num: averageScore }) }}
       </h1>
     </div>
@@ -57,6 +57,7 @@
 
   const constants = require('../../constants');
   const actions = require('../../state/actions/exam');
+  const sumBy = require('lodash/sumBy');
 
   module.exports = {
     computed: {
@@ -64,12 +65,14 @@
         return this.examTakers.length === 0;
       },
       averageScore() {
-        return Math.round(this.examTakers.reduce((acc, examTaker) => acc + examTaker.score, 0)
-          / this.takenBy);
+        const totalScores = sumBy(this.examsInProgress, 'score');
+        return (totalScores / this.takenBy) / this.exam.question_count;
+      },
+      examsInProgress() {
+        return this.examTakers.filter(examTaker => examTaker.progress !== undefined);
       },
       takenBy() {
-        return this.examTakers.reduce(
-          (acc, taker) => (acc + (taker.progress > 0 ? 1 : 0)), 0);
+        return this.examsInProgress.length;
       }
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -29,6 +29,7 @@
                 {{examTaker.name}}
               </router-link>
             </th>
+
             <td class="table-data" v-if="examTaker.progress === exam.question_count">{{ $tr('completed') }}</td>
             <td class="table-data incomplete" v-else-if="examTaker.progress">
               {{ $tr('incomplete', { num: examTaker.progress, outOf: exam.question_count }) }}

--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -34,7 +34,12 @@
               {{ $tr('incomplete', { num: examTaker.progress, outOf: exam.question_count }) }}
             </td>
             <td class="table-data incomplete" v-else>{{ $tr('notstarted') }}</td>
-            <td class="table-data">{{ $tr('scorePercentage', { num: examTaker.score/exam.question_count }) }}</td>
+
+            <td class="table-data">
+              <span v-if="examTaker.progress === undefined">&mdash;</span>
+              <span v-else>{{ $tr('scorePercentage', { num: examTaker.score / exam.question_count }) }}</span>
+            </td>
+
             <td class="table-data">{{ examTaker.group.name || $tr('ungrouped') }}</td>
           </tr>
         </tbody>

--- a/kolibri/plugins/coach/assets/test/views/exam-report-page.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/exam-report-page.spec.js
@@ -1,0 +1,86 @@
+/* eslint-env mocha */
+const Vue = require('vue-test');
+const assert = require('assert');
+const ExamReportPage = require('../../src/views/exam-report-page');
+
+function makeVm(options = {}) {
+  const Ctor = Vue.extend(ExamReportPage);
+  const components = {
+    'router-link': '<div></div>',
+  };
+  return new Ctor(Object.assign(options, { components })).$mount();
+}
+
+function getElements(vm) {
+  return {
+    headerStats: () => vm.$el.querySelectorAll('.header h1'),
+    tableRows: () => vm.$el.querySelectorAll('tbody > tr'),
+  };
+}
+
+function getTextInScoreColumn(tdEl) {
+  // in the second column
+  return tdEl.querySelectorAll('td')[1].innerText;
+}
+
+describe('exam report page', () => {
+  it('average score is not shown if no exams in progress', () => {
+    const vm = makeVm({
+      vuex: {
+        getters: {
+          examTakers: () => [
+            { progress: undefined, group: {}, score: undefined },
+            { progress: undefined, group: {}, score: undefined },
+          ],
+          classId: () => 'class_1',
+          exam: () => ({ question_count: 6 }),
+          channelId: () => 'channel_1',
+        }
+      }
+    });
+    const els = getElements(vm);
+    assert.equal(els.headerStats().length, 1);
+  });
+
+  it('average score is shown if at least one exam in progress', () => {
+    const vm = makeVm({
+      vuex: {
+        getters: {
+          examTakers: () => [
+            { progress: 6, group: {}, score: 3 },
+            { progress: 6, group: {}, score: 3 },
+            { progress: undefined, group: {}, score: undefined },
+          ],
+          classId: () => 'class_1',
+          exam: () => ({ question_count: 6 }),
+          channelId: () => 'channel_1',
+        }
+      }
+    });
+    const els = getElements(vm);
+    assert.equal(els.headerStats().length, 2);
+    // h1 text doesn't get formatted, so inspecting vm.averageScore directly
+    assert.equal(vm.averageScore, 0.5);
+  });
+
+  it('shows correct scores for exam takers', () => {
+    const vm = makeVm({
+      vuex: {
+        getters: {
+          examTakers: () => [
+            { progress: 6, group: {}, score: 3 },
+            { progress: undefined, group: {}, score: undefined },
+          ],
+          classId: () => 'class_1',
+          exam: () => ({ question_count: 6 }),
+          channelId: () => 'channel_1',
+        }
+      }
+    });
+    const els = getElements(vm);
+    // score isn't properly formatted
+    assert.equal(getTextInScoreColumn(els.tableRows()[0]), '{num, number, percent} ');
+    // emdash
+    assert.equal(getTextInScoreColumn(els.tableRows()[1]), '\u2014 ');
+  });
+});


### PR DESCRIPTION
Closes #1339 

Mixed progress:
<img width="1117" alt="screen shot 2017-04-26 at 5 59 20 pm" src="https://cloud.githubusercontent.com/assets/10248067/25458968/25d19182-2aaa-11e7-964c-8eb2d9d3084d.png">

No takers:
<img width="1125" alt="screen shot 2017-04-26 at 6 03 36 pm" src="https://cloud.githubusercontent.com/assets/10248067/25459122/b2457da4-2aaa-11e7-8042-db5dce0f39dd.png">

When running tests with complex `tr`s, the text does not render correctly, and LOG warnings appear in my console:

```
ERROR LOG: '[Vue Intl] Cannot format message: "examReportPage.scorePercentage", using message source as fallback.'
```

Is there a way to fix both of these issues?
