### PR TITLE
adds class titles to each coach page

### DIFF
--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -22,11 +22,9 @@
       <loading-spinner v-if="loading" class="align-to-parent"/>
       <template v-else>
         <error-box v-if="error"/>
-        <slot name="tabs"/>
-        <slot name="content"/>
+        <slot/>
       </template>
     </div>
-    <slot name="extra"/>
   </div>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/state/actions/main.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/main.js
@@ -8,6 +8,14 @@ const ClassroomResource = coreApp.resources.ClassroomResource;
 // ================================
 // CLASS LIST ACTIONS
 
+
+function _classState(classData) {
+  return {
+    id: classData.id,
+    name: classData.name,
+    memberCount: classData.learner_count,
+  };
+}
 function showClassListPage(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.CLASS_LIST);
@@ -15,7 +23,7 @@ function showClassListPage(store) {
   classCollection.fetch().then(
     (classes) => {
       const pageState = {
-        classes,
+        classes: classes.map(_classState),
       };
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);

--- a/kolibri/plugins/coach/assets/src/state/actions/main.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/main.js
@@ -16,16 +16,22 @@ function _classState(classData) {
     memberCount: classData.learner_count,
   };
 }
+
+function setClassState(store, classId = null) {
+  const classCollection = ClassroomResource.getCollection();
+  return classCollection.fetch().then(
+    classes => {
+      store.dispatch('SET_CLASS_INFO', classId, classes.map(_classState));
+    }
+  );
+}
+
 function showClassListPage(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.CLASS_LIST);
-  const classCollection = ClassroomResource.getCollection();
-  classCollection.fetch().then(
-    (classes) => {
-      const pageState = {
-        classes: classes.map(_classState),
-      };
-      store.dispatch('SET_PAGE_STATE', pageState);
+  setClassState(store).then(
+    classes => {
+      store.dispatch('SET_PAGE_STATE', {});
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
       store.dispatch('CORE_SET_TITLE', 'Coach - Classes'); // Follow Naming Scheme
@@ -43,6 +49,7 @@ function setSelectedAttemptLogIndex(store, index) {
 
 
 module.exports = {
+  setClassState,
   showClassListPage,
   setSelectedAttemptLogIndex,
 };

--- a/kolibri/plugins/coach/assets/src/state/getters/main.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/main.js
@@ -1,6 +1,14 @@
 const Constants = require('../../constants');
 
 
+function className(state) {
+  const cls = state.classList.find(thisClass => thisClass.id === state.classId);
+  if (cls) {
+    return cls.name;
+  }
+  return '';
+}
+
 function isRecentPage(state) {
   return Constants.RecentReports.includes(state.pageName);
 }
@@ -15,6 +23,7 @@ function isLearnerPage(state) {
 
 
 module.exports = {
+  className,
   isRecentPage,
   isTopicPage,
   isLearnerPage,

--- a/kolibri/plugins/coach/assets/src/state/store.js
+++ b/kolibri/plugins/coach/assets/src/state/store.js
@@ -5,6 +5,8 @@ const coreStore = require('kolibri.coreVue.vuex.store');
 const initialState = {
   pageName: '',
   pageState: {},
+  classId: null,
+  classList: [],
 };
 
 const mutations = {
@@ -16,6 +18,10 @@ const mutations = {
   SET_PAGE_NAME(state, pageName) {
     state.pageName = pageName;
   },
+  SET_CLASS_INFO(state, classId, classList) {
+    state.classId = classId;
+    state.classList = classList;
+  },
 
   // report
   SET_REPORT_SORTING(state, sortColumn, sortOrder) {
@@ -23,7 +29,6 @@ const mutations = {
     Vue.set(state.pageState, 'sortOrder', sortOrder);
   },
   SET_REPORT_PROPERTIES(state, options) {
-    Vue.set(state.pageState, 'classId', options.classId);
     Vue.set(state.pageState, 'channelId', options.channelId);
     Vue.set(state.pageState, 'contentScope', options.contentScope);
     Vue.set(state.pageState, 'contentScopeId', options.contentScopeId);

--- a/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
@@ -70,7 +70,7 @@
     },
     $trNameSpace: 'coachClassListPage',
     $trs: {
-      myClasses: 'My classes',
+      myClasses: 'All classes',
       pageDescription: 'View learner progress and performance',
       className: 'Class name',
       tableCaption: 'List of classes',

--- a/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
@@ -12,7 +12,6 @@
           <tr>
             <th scope="col" class="table-text">{{ $tr('className') }}</th>
             <th scope="col" class="table-data">{{ $tr('members') }}</th>
-            <th scope="col" class="table-data">{{ $tr('groups') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -22,8 +21,7 @@
                 {{ cl.name }}
               </router-link>
             </th>
-            <td class="table-data">{{ cl.learner_count }}</td>
-            <td class="table-data">{{ cl.admin_count }}</td>
+            <td class="table-data">{{ cl.memberCount }}</td>
           </tr>
         </tbody>
       </table>
@@ -77,7 +75,6 @@
       className: 'Class name',
       tableCaption: 'List of classes',
       members: 'Members',
-      groups: 'Groups',
       noClassesExist: 'No Classes Exist.',
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page/index.vue
@@ -65,7 +65,7 @@
     },
     vuex: {
       getters: {
-        classes: state => state.pageState.classes,
+        classes: state => state.classList,
       },
     },
     $trNameSpace: 'coachClassListPage',

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -124,6 +124,7 @@
 <script>
 
   const ExamActions = require('../../state/actions/exam');
+  const className = require('../../state/getters/main').className;
   const ExamModals = require('../../examConstants').Modals;
   const CollectionKinds = require('kolibri.coreVue.vuex.constants').CollectionKinds;
   const shuffle = require('lodash/shuffle');
@@ -337,12 +338,12 @@
       finish() {
         if (this.checkAllValid() === true) {
           const classCollection = {
-            id: this.currentClass.id,
-            name: this.currentClass.name,
+            id: this.classId,
+            name: this.className,
             kind: CollectionKinds.CLASSROOM
           };
           const examObj = {
-            classId: this.currentClass.id,
+            classId: this.classId,
             channelId: this.currentChannel.id,
             title: this.inputTitle,
             numQuestions: this.inputNumQuestions,
@@ -386,7 +387,8 @@
     },
     vuex: {
       getters: {
-        currentClass: state => state.pageState.currentClass,
+        classId: state => state.classId,
+        className,
         currentChannel: state => state.pageState.currentChannel,
         topic: state => state.pageState.topic,
         subtopics: state => state.pageState.subtopics,

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
@@ -103,7 +103,7 @@
     vuex: {
       getters: {
         channelId: state => state.pageState.channelId,
-        classId: state => state.pageState.classId,
+        classId: state => state.classId,
         examAttempts: state => state.pageState.examAttempts,
         exam: state => state.pageState.exam,
         userName: state => state.pageState.user.full_name,

--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -98,7 +98,7 @@
     vuex: {
       getters: {
         examTakers: state => state.pageState.examTakers,
-        classId: state => state.pageState.classId,
+        classId: state => state.classId,
         exam: state => state.pageState.exam,
         channelId: state => state.pageState.channelId,
       },

--- a/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h1>{{ currentClass.name }} {{ $tr('exams') }}</h1>
+    <h1>{{ className }} {{ $tr('exams') }}</h1>
     <ui-radio-group
       :name="$tr('examFilter')"
       :label="$tr('show')"
@@ -34,8 +34,8 @@
           :examTitle="exam.title"
           :examActive="exam.active"
           :examVisibility="exam.visibility"
-          :classId="currentClass.id"
-          :className="currentClass.name"
+          :classId="classId"
+          :className="className"
           :classGroups="[]"
           @changeExamVisibility="openChangeExamVisibilityModal"
           @activateExam="openActivateExamModal"
@@ -50,7 +50,7 @@
     <p v-else class="center-text"><strong>{{ $tr('noExams') }}</strong></p>
     <create-exam-modal
       v-if="showCreateExamModal"
-      :classId="currentClass.id"
+      :classId="classId"
       :channels="sortedChannels"
     />
     <activate-exam-modal
@@ -58,22 +58,22 @@
       :examId="selectedExam.id"
       :examTitle="selectedExam.title"
       :examVisibility="selectedExam.visibility"
-      :classId="currentClass.id"
+      :classId="classId"
     />
     <deactivate-exam-modal
       v-if="showDeactivateExamModal"
       :examId="selectedExam.id"
       :examTitle="selectedExam.title"
       :examVisibility="selectedExam.visibility"
-      :classId="currentClass.id"
+      :classId="classId"
     />
     <change-exam-visibility-modal
       v-if="showChangeExamVisibilityModal"
       :examId="selectedExam.id"
       :examTitle="selectedExam.title"
       :examVisibility="selectedExam.visibility"
-      :classId="currentClass.id"
-      :className="currentClass.name"
+      :classId="classId"
+      :className="className"
       :classGroups="currentClassGroups"
     />
     <preview-exam-modal
@@ -87,14 +87,14 @@
       v-if="showRenameExamModal"
       :examId="selectedExam.id"
       :examTitle="selectedExam.title"
-      :classId="currentClass.id"
+      :classId="classId"
       :exams="sortedExams"
     />
     <delete-exam-modal
       v-if="showDeleteExamModal"
       :examId="selectedExam.id"
       :examTitle="selectedExam.title"
-      :classId="currentClass.id"
+      :classId="classId"
     />
   </div>
 
@@ -103,6 +103,7 @@
 
 <script>
 
+  const className = require('../../state/getters/main').className;
   const ExamActions = require('../../state/actions/exam');
   const ExamModals = require('../../examConstants').Modals;
   const PageNames = require('../../constants').PageNames;
@@ -227,7 +228,7 @@
       routeToExamReport({ id, channelId }) {
         this.$router.push({
           name: PageNames.EXAM_REPORT,
-          params: { classId: this.currentClass.id, examId: id, channelId }
+          params: { classId: this.classId, examId: id, channelId }
         });
       },
       openRenameExamModal(examId) {
@@ -244,7 +245,8 @@
         displayExamModal: ExamActions.displayExamModal,
       },
       getters: {
-        currentClass: state => state.pageState.currentClass,
+        classId: state => state.classId,
+        className,
         currentClassGroups: state => state.pageState.currentClassGroups,
         exams: state => state.pageState.exams,
         channels: state => state.pageState.channels,

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -52,10 +52,6 @@
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     props: {
-      classId: {
-        type: String,
-        required: true,
-      },
       groups: {
         type: Array,
         required: true,
@@ -74,7 +70,7 @@
     methods: {
       callCreateGroup() {
         if (!this.duplicateName) {
-          this.createGroup(this.classId, this.groupNameInput);
+          this.createGroup(this.groupNameInput);
         }
       },
       close() {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -8,7 +8,7 @@
       @click="close" />
     <icon-button :text="$tr('deleteGroup')"
       :primary="true"
-      @click="deleteGroup(classId, groupId)" />
+      @click="deleteGroup(groupId)" />
   </core-modal>
 
 </template>
@@ -34,10 +34,6 @@
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     props: {
-      classId: {
-        type: String,
-        required: true,
-      },
       groupName: {
         type: String,
         required: true,

--- a/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
@@ -1,7 +1,6 @@
 <template>
 
   <div>
-    <h1>{{ className }} - {{ $tr('groups') }}</h1>
     <div class="btn">
       <icon-button
         :text="$tr('newGroup')"
@@ -13,17 +12,14 @@
     </div>
 
     <create-group-modal v-if="showCreateGroupModal"
-      :classId="classId"
       :groups="sortedGroups" />
 
     <rename-group-modal v-if="showRenameGroupModal"
-      :classId="classId"
       :groupName="selectedGroup.name"
       :groupId="selectedGroup.id"
       :groups="sortedGroups" />
 
     <delete-group-modal v-if="showDeleteGroupModal"
-      :classId="classId"
       :groupName="selectedGroup.name"
       :groupId="selectedGroup.id" />
 
@@ -137,8 +133,6 @@
     },
     vuex: {
       getters: {
-        className: state => state.pageState.class.name,
-        classId: state => state.pageState.class.id,
         classUsers: state => state.pageState.classUsers,
         groups: state => state.pageState.groups,
         groupModalShown: state => state.pageState.groupModalShown,

--- a/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
@@ -50,10 +50,6 @@
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     props: {
-      classId: {
-        type: String,
-        required: true,
-      },
       groupName: {
         type: String,
         required: true,
@@ -83,7 +79,7 @@
     methods: {
       callRenameGroup() {
         if (!this.duplicateName) {
-          this.renameGroup(this.classId, this.groupId, this.groupNameInput);
+          this.renameGroup(this.groupId, this.groupNameInput);
         }
       },
       close() {

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -2,10 +2,12 @@
 
   <core-base :topLevelPageName="topLevelPageName" :appBarTitle="$tr('coachTitle')">
 
-
-    <top-nav v-if="showTopNav"/>
-
     <div class="content">
+      <template v-if="showTopNav">
+        <h1>{{ className }}</h1>
+        <top-nav/>
+      </template>
+
       <div v-if="isCoach || isAdmin">
         <component :is="currentPage"/>
       </div>
@@ -27,6 +29,7 @@
 <script>
 
   const store = require('../state/store');
+  const className = require('../state/getters/main').className;
   const Constants = require('../constants');
   const coreGetters = require('kolibri.coreVue.vuex.getters');
   const TopLevelPageNames = require('kolibri.coreVue.vuex.constants').TopLevelPageNames;
@@ -91,6 +94,7 @@
     vuex: {
       getters: {
         pageName: state => state.pageName,
+        className,
         isSuperuser: coreGetters.isSuperuser,
         isAdmin: coreGetters.isAdmin,
         isCoach: coreGetters.isCoach,

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -2,9 +2,10 @@
 
   <core-base :topLevelPageName="topLevelPageName" :appBarTitle="$tr('coachTitle')">
 
-    <top-nav v-if="showTopNav" slot="tabs"/>
 
-    <div slot="content" class="content">
+    <top-nav v-if="showTopNav"/>
+
+    <div class="content">
       <div v-if="isCoach || isAdmin">
         <component :is="currentPage"/>
       </div>

--- a/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
@@ -41,7 +41,7 @@
             title: this.$tr('channels'),
             vlink: {
               name: CoachConstants.PageNames.RECENT_CHANNELS,
-              params: { classId: this.pageState.classId },
+              params: { classId: this.classId },
             },
           },
           { title: this.channelTitle }
@@ -56,7 +56,7 @@
             title: this.$tr('channels'),
             vlink: {
               name: CoachConstants.PageNames.RECENT_CHANNELS,
-              params: { classId: this.pageState.classId },
+              params: { classId: this.classId },
             },
           },
           {
@@ -64,7 +64,7 @@
             vlink: {
               name: CoachConstants.PageNames.RECENT_ITEMS_FOR_CHANNEL,
               params: {
-                classId: this.pageState.classId,
+                classId: this.classId,
                 channelId: this.pageState.channelId,
               },
             },
@@ -79,7 +79,7 @@
             title: this.$tr('channels'),
             vlink: {
               name: CoachConstants.PageNames.TOPIC_CHANNELS,
-              params: { classId: this.pageState.classId },
+              params: { classId: this.classId },
             },
           },
           // links to each ancestor
@@ -90,7 +90,7 @@
               breadcrumb.vlink = {
                 name: CoachConstants.PageNames.TOPIC_ITEM_LIST,
                 params: {
-                  classId: this.pageState.classId,
+                  classId: this.classId,
                   channelId: this.pageState.channelId,
                   topicId: item.id,
                 },
@@ -100,7 +100,7 @@
               breadcrumb.vlink = {
                 name: CoachConstants.PageNames.TOPIC_CHANNEL_ROOT,
                 params: {
-                  classId: this.pageState.classId,
+                  classId: this.classId,
                   channelId: this.pageState.channelId,
                 },
               };
@@ -115,6 +115,7 @@
     vuex: {
       getters: {
         channels: state => state.core.channels.list,
+        classId: state => state.classId,
         pageName: state => state.pageName,
         pageState: state => state.pageState,
         isTopicPage: coachGetters.isTopicPage,

--- a/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
@@ -73,7 +73,7 @@
       getters: {
         channels: state => state.core.channels.list,
         lastActive: state => state.pageState.lastActive,
-        classId: state => state.pageState.classId,
+        classId: state => state.classId,
         pageName: state => state.pageName,
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -76,7 +76,7 @@
           return {
             name: CoachConstants.PageNames.TOPIC_ITEM_LIST,
             params: {
-              classId: this.pageState.classId,
+              classId: this.classId,
               channelId: this.pageState.channelId,
               topicId: row.id,
             }
@@ -85,7 +85,7 @@
         return {
           name: CoachConstants.PageNames.TOPIC_LEARNERS_FOR_ITEM,
           params: {
-            classId: this.pageState.classId,
+            classId: this.classId,
             channelId: this.pageState.channelId,
             contentId: row.id,
           }
@@ -94,6 +94,7 @@
     },
     vuex: {
       getters: {
+        classId: state => state.classId,
         pageState: state => state.pageState,
         exerciseCount: reportGetters.exerciseCount,
         contentCount: reportGetters.contentCount,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -135,7 +135,7 @@
         attemptLogs: state => state.pageState.attemptLogs,
         currentInteraction: state => state.pageState.currentInteraction,
         currentInteractionHistory: state => state.pageState.currentInteractionHistory,
-        classId: state => state.pageState.classId,
+        classId: state => state.classId,
         contentId: state => state.pageState.exercise.pk,
         channelId: state => state.pageState.channelId,
         user: state => state.pageState.user,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
@@ -79,7 +79,7 @@
           return {
             name: targetName,
             params: {
-              classId: this.pageState.classId,
+              classId: this.classId,
               userId: row.id,
               channelId: this.pageState.channelId,
               contentId: this.pageState.contentScopeSummary.contentId,
@@ -91,6 +91,7 @@
     },
     vuex: {
       getters: {
+        classId: state => state.classId,
         pageState: state => state.pageState,
         pageName: state => state.pageName,
         exerciseCount: reportGetters.exerciseCount,

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -102,7 +102,7 @@
         return {
           name: CoachConstants.PageNames.RECENT_LEARNERS_FOR_ITEM,
           params: {
-            classId: this.pageState.classId,
+            classId: this.classId,
             channelId: this.pageState.channelId,
             contentId: row.id,
           }
@@ -111,6 +111,7 @@
     },
     vuex: {
       getters: {
+        classId: state => state.classId,
         pageState: state => state.pageState,
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/top-nav/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/top-nav/index.vue
@@ -88,7 +88,7 @@
     vuex: {
       getters: {
         pageName: state => state.pageName,
-        classId: state => state.pageState.classId,
+        classId: state => state.classId,
         isRecentPage: coachGetters.isRecentPage,
         isTopicPage: coachGetters.isTopicPage,
         isLearnerPage: coachGetters.isLearnerPage,

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -12,10 +12,10 @@
       </router-link>
       <a class="points-link" href="/user"><total-points/></a>
     </div>
-    <div slot="tabs" v-if="!isSearchPage">
+    <div v-if="!isSearchPage">
       <tabs :items="learnTabs" type="icon-and-text" @tabclicked="handleTabClick"/>
     </div>
-    <div slot="content">
+    <div>
       <breadcrumbs/>
       <component :is="currentPage"/>
     </div>

--- a/kolibri/plugins/management/assets/src/state/actions.js
+++ b/kolibri/plugins/management/assets/src/state/actions.js
@@ -38,9 +38,9 @@ function _classState(data) {
     id: data.id,
     name: data.name,
     parent: data.parent,
-    learner_count: data.learner_count,
-    coach_count: data.coach_count,
-    admin_count: data.admin_count,
+    memberCount: data.learner_count,
+    coachCount: data.coach_count,
+    adminCount: data.admin_count,
   };
 }
 

--- a/kolibri/plugins/management/assets/src/views/index.vue
+++ b/kolibri/plugins/management/assets/src/views/index.vue
@@ -2,14 +2,14 @@
 
   <core-base :topLevelPageName="topLevelPageName" :appBarTitle="$tr('managementTitle')">
 
-    <div v-if="isAdmin || isSuperuser" slot="content">
+    <div v-if="isAdmin || isSuperuser">
       <div class="manage-content">
         <top-nav/>
       </div>
       <component class="manage-content page" :is="currentPage"/>
     </div>
 
-    <div v-else slot="content" class="login-message">
+    <div v-else class="login-message">
       <h1>{{ $tr('logInPrompt') }}</h1>
       <p>{{ $tr('logInCommand') }}</p>
     </div>

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
@@ -38,7 +38,7 @@
               </router-link>
             </th>
             <td class="table-data">
-              {{ classModel.learner_count + classModel.coach_count + classModel.admin_count }}
+              {{ classModel.memberCount }}
             </td>
             <td class="table-btn">
               <button class="delete-class-button" @click="openDeleteClassModal(classModel)">

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -1,19 +1,9 @@
 <template>
 
   <core-base v-if="navBarNeeded" :topLevelPageName="topLevelPageName" :appBarTitle="appBarTitle">
-    <component
-      slot="content"
-      class="user page"
-      :is="currentPage"
-    />
+    <component :is="currentPage"/>
   </core-base>
-
-  <component
-    v-else
-    slot="content"
-    class="user page"
-    :is="currentPage"
-    />
+  <component v-else :is="currentPage"/>
 
 </template>
 


### PR DESCRIPTION

In preparation to potentially doing a full class-list switcher, as spec'd in the mockups.

This PR moves all class-related state out of pageState and to the top-level, so it's shared across pages.

![image](https://cloud.githubusercontent.com/assets/2367265/25470552/9127c794-2ad7-11e7-92c3-53a368e5ed4c.png)
