### PR TITLE
Fix some async vue tests

### DIFF
--- a/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/views/index.vue
@@ -32,7 +32,7 @@
     <audio
       id="audio"
       ref="audio"
-      @timeupdate="updateTime"
+      @timeupdate="updateTime()"
       @loadedmetadata="setTotalTime"
       @ended="endPlay"
       :src="defaultFile.storage_url"

--- a/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
+++ b/kolibri/plugins/audio_mp3_render/assets/test/views/audio-mp3-render.spec.js
@@ -20,7 +20,8 @@ describe('audio mp3 render component', () => {
       vm.$destroy();
       // then dispatch timeupdate event immediately after
       simulant.fire(audioEl, 'timeupdate');
-      Vue.nextTick(() => {
+      return Vue.nextTick()
+      .then(() => {
         sinon.assert.called(updateTimeSpy);
       });
     });

--- a/kolibri/plugins/management/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/management/assets/test/views/facility-config-page.spec.js
@@ -34,12 +34,6 @@ function getElements(wrapper) {
   };
 }
 
-function promisifyNextTick() {
-  return new Promise((resolve) => {
-    Vue.nextTick(() => { resolve(); });
-  });
-}
-
 describe('facility config page view', () => {
   it('clicking checkboxes dispatches a modify action', () => {
     const wrapper = makeWrapper();
@@ -58,7 +52,7 @@ describe('facility config page view', () => {
     const saveActionStub = sinon.stub(wrapper, 'saveFacilityConfig');
     const { saveButton } = getElements(wrapper);
     simulant.fire(saveButton(), 'click');
-    return promisifyNextTick()
+    return Vue.nextTick()
     .then(() => {
       sinon.assert.calledOnce(saveActionStub);
       saveActionStub.restore();
@@ -78,7 +72,7 @@ describe('facility config page view', () => {
     const { resetButton, cancelResetButton } = getElements(wrapper);
     assert.equal(wrapper.showModal, false);
     simulant.fire(resetButton(), 'click');
-    return promisifyNextTick()
+    return Vue.nextTick()
     .then(() => {
       assert.equal(wrapper.showModal, true);
       simulant.fire(cancelResetButton(), 'click');
@@ -91,10 +85,10 @@ describe('facility config page view', () => {
     const resetActionStub = sinon.stub(wrapper, 'resetFacilityConfig');
     const { resetButton, confirmResetButton } = getElements(wrapper);
     simulant.fire(resetButton(), 'click');
-    return promisifyNextTick()
+    return Vue.nextTick()
     .then(() => {
       simulant.fire(confirmResetButton(), 'click');
-      return promisifyNextTick();
+      return Vue.nextTick();
     })
     .then(() => {
       assert.equal(wrapper.showModal, false);


### PR DESCRIPTION
1. Got rid of an unnecessary `promisifyNextTick` helper, because it happens that `Vue.nextTick()` already returns a promise if you don't provide it callback argument.
1. Fixed the mp3 render spec to also return a Promise after finding out it was swallowing an error.
1. Fixed the source of the error, where `@timeupdate=updateTime` instead of `@timeupdate=updateTime()` 