### PR TITLE
Updated permissions for datasets.

### DIFF
--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -25,6 +25,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging as logger
 
+from six import string_types
+
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -36,7 +38,6 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from kolibri.core.errors import KolibriValidationError
 from mptt.models import MPTTModel, TreeForeignKey
-from six import string_types
 
 from .constants import collection_kinds, role_kinds
 from .errors import (
@@ -45,8 +46,8 @@ from .errors import (
 )
 from .filters import HierarchyRelationsFilter
 from .permissions.auth import (
-    AnybodyCanCreateIfNoDeviceOwner, AnybodyCanCreateIfNoFacility, CollectionSpecificRoleBasedPermissions,
-    AnonUserCanReadFacilitiesThatAllowSignUps, IsAdminForOwnFacilityDataset, CoachesCanManageGroupsForTheirClasses, CoachesCanManageMembershipsForTheirGroups
+    AnonUserCanReadFacilitiesThatAllowSignUps, AnybodyCanCreateIfNoDeviceOwner, AnybodyCanCreateIfNoFacility, CoachesCanManageGroupsForTheirClasses,
+    CoachesCanManageMembershipsForTheirGroups, CollectionSpecificRoleBasedPermissions, IsAdminOrUserForOwnFacilityDataset
 )
 from .permissions.base import BasePermissions, RoleBasedPermissions
 from .permissions.general import IsAdminForOwnFacility, IsFromSameFacility, IsOwn, IsSelf
@@ -67,7 +68,7 @@ class FacilityDataset(models.Model):
     to indicate that they belong to this particular ``Facility``.
     """
 
-    permissions = IsAdminForOwnFacilityDataset()
+    permissions = IsAdminOrUserForOwnFacilityDataset()
 
     description = models.TextField(blank=True)
     location = models.CharField(max_length=200, blank=True)

--- a/kolibri/auth/permissions/auth.py
+++ b/kolibri/auth/permissions/auth.py
@@ -85,10 +85,13 @@ class AnonUserCanReadFacilitiesThatAllowSignUps(DenyAll):
         return queryset.none()
 
 
-class IsAdminForOwnFacilityDataset(BasePermissions):
+class IsAdminOrUserForOwnFacilityDataset(BasePermissions):
     """
-    Permission class that allows access to dataset settings if they are admin for facility.
+    Permission class that allows access to dataset settings if they are admin or user for facility.
     """
+
+    def _facility_dataset_is_same(self, user, obj):
+        return hasattr(user, "dataset") and user.dataset_id == obj.id
 
     def _user_is_admin_for_related_facility(self, user, obj=None):
 
@@ -112,7 +115,7 @@ class IsAdminForOwnFacilityDataset(BasePermissions):
         return self._user_is_admin_for_related_facility(user, obj)
 
     def user_can_read_object(self, user, obj):
-        return self._user_is_admin_for_related_facility(user, obj)
+        return self._facility_dataset_is_same(user, obj)
 
     def user_can_update_object(self, user, obj):
         return self._user_is_admin_for_related_facility(user, obj)
@@ -121,10 +124,9 @@ class IsAdminForOwnFacilityDataset(BasePermissions):
         return False
 
     def readable_by_user_filter(self, user, queryset):
-        if self._user_is_admin_for_related_facility(user):
-            return queryset.filter(id=user.dataset_id)
-        else:
+        if isinstance(user, AnonymousUser):
             return queryset.none()
+        return queryset.filter(id=user.dataset_id)
 
 
 class CoachesCanManageGroupsForTheirClasses(BasePermissions):

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -377,7 +377,6 @@ class FacilityDatasetAPITestCase(APITestCase):
     def setUp(self):
         self.device_owner = DeviceOwnerFactory.create()
         self.facility = FacilityFactory.create()
-        FacilityFactory.create(name='extra')
         self.admin = FacilityUserFactory.create(facility=self.facility)
         self.user = FacilityUserFactory.create(facility=self.facility)
         self.facility.add_admin(self.admin)
@@ -385,7 +384,7 @@ class FacilityDatasetAPITestCase(APITestCase):
     def test_return_dataset_that_user_is_an_admin_for(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse('facilitydataset-list'))
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data), len(models.FacilityDataset.objects.all()))
         self.assertEqual(self.admin.dataset_id, response.data[0]['id'])
 
     def test_return_all_datasets_for_device_owner(self):
@@ -393,7 +392,7 @@ class FacilityDatasetAPITestCase(APITestCase):
         response = self.client.get(reverse('facilitydataset-list'))
         self.assertEqual(len(response.data), len(models.FacilityDataset.objects.all()))
 
-    def test_return_nothing_for_facility_user(self):
+    def test_return_dataset_for_facility_user(self):
         self.client.login(username=self.user.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse('facilitydataset-list'))
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data), len(models.FacilityDataset.objects.all()))

--- a/kolibri/auth/test/test_permissions.py
+++ b/kolibri/auth/test/test_permissions.py
@@ -71,12 +71,16 @@ class FacilityDatasetPermissionsTestCase(TestCase):
         self.assertFalse(self.data1["classroom_coaches"][0].can_create(FacilityDataset, new_facility_dataset))
         self.assertFalse(self.data1["learners_one_group"][0][0].can_create(FacilityDataset, new_facility_dataset))
         self.assertFalse(self.data1["unattached_users"][0].can_create(FacilityDataset, new_facility_dataset))
-        self.assertFalse(self.data1["unattached_users"][0].can_create(FacilityDataset, new_facility_dataset))
 
-    def test_anon_users_cannot_read_facility_dataset(self):
-        """ KolibriAnonymousUser cannot read Facility objects """
-        self.assertFalse(self.anon_user.can_read(self.data1["dataset"]))
-        self.assertNotIn(self.data1["dataset"], self.anon_user.filter_readable(FacilityDataset.objects.all()))
+    def test_facility_users_can_read_own_facility_dataset(self):
+        """ FacilityUsers can read own FacilityDatasets. """
+        own_dataset = self.data1["dataset"]
+        self.assertTrue(self.data1["facility_admin"].can_read(own_dataset))
+        self.assertTrue(self.data1["classroom_coaches"][0].can_read(own_dataset))
+        self.assertTrue(self.data1["learners_one_group"][0][0].can_read(own_dataset))
+        self.assertTrue(self.data1["unattached_users"][0].can_read(own_dataset))
+        self.assertFalse(self.anon_user.can_read(own_dataset))
+        self.assertNotIn(own_dataset, self.anon_user.filter_readable(FacilityDataset.objects.all()))
 
     def test_only_facility_admins_can_update_own_facility_dataset(self):
         """ The only FacilityUser who can update a FacilityDataset is a facility admin for that FacilityDataset """
@@ -135,7 +139,6 @@ class FacilityPermissionsTestCase(TestCase):
         self.assertFalse(self.data1["facility_admin"].can_create(Facility, new_facility_data))
         self.assertFalse(self.data1["classroom_coaches"][0].can_create(Facility, new_facility_data))
         self.assertFalse(self.data1["learners_one_group"][0][0].can_create(Facility, new_facility_data))
-        self.assertFalse(self.data1["unattached_users"][0].can_create(Facility, new_facility_data))
         self.assertFalse(self.data1["unattached_users"][0].can_create(Facility, new_facility_data))
 
     def test_facility_users_can_read_own_facility(self):


### PR DESCRIPTION
## Summary

`FacilityUsers` can read `FacilityDataset` if they have the same `dataset_id`. Only admins with same `dataset_id` can update or create. No user can delete a `FacilityDataset`.

## TODO

- [X] Have tests been written for the new code?