### PR TITLE
Fixes for exam behaviour and exam reports

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -490,7 +490,7 @@ function showExamReportDetailPage(
   ]).only(
     CoreActions.samePageCheckGenerator(store),
     ([examAttempts, exam, user, examLogs]) => {
-      const examLog = examLogs[0];
+      const examLog = examLogs[0] || {};
       const seed = exam.seed;
       const questionSources = JSON.parse(exam.question_sources);
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -526,6 +526,7 @@ function showExamReportDetailPage(
                   log.content_id === question.contentId) || {
                     interaction_history: '[]',
                     correct: false,
+                    noattempt: true,
                   };
                 return Object.assign({
                   questionNumber: index + 1,

--- a/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
@@ -13,7 +13,13 @@
           }"
         >
             <mat-svg
-              v-if="attemptLog.correct"
+              v-if="attemptLog.noattempt"
+              class="item svg-item svg-noattempt"
+              category="navigation"
+              name="cancel"
+            />
+            <mat-svg
+              v-else-if="attemptLog.correct"
               class="item svg-item svg-correct"
               category="action"
               name="check_circle"
@@ -25,7 +31,7 @@
               name="cancel"
             />
             <mat-svg
-              v-if="attemptLog.hinted"
+              v-else-if="attemptLog.hinted"
               class="item svg-item svg-hint"
               category="action"
               name="lightbulb_outline"
@@ -110,6 +116,9 @@
 
   .svg-correct
     fill: green
+
+  .svg-noattempt
+    fill: grey
 
   li
     clear: both

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
@@ -43,6 +43,19 @@
             :answerState="currentInteraction.answer"
             :extraFields="exercise.extra_fields"
             :assessment="true"/>
+          <content-renderer
+            v-else
+            class="content-renderer"
+            :id="exercise.pk"
+            :itemId="itemId"
+            :allowHints="false"
+            :kind="exercise.kind"
+            :files="exercise.files"
+            :contentId="exercise.content_id"
+            :channelId="channelId"
+            :available="exercise.available"
+            :extraFields="exercise.extra_fields"
+            :assessment="true"/>
         </div>
       </div>
     </template>

--- a/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-page/index.vue
@@ -25,9 +25,15 @@
         <tbody>
           <tr class="table-row" v-for="examTaker in examTakers">
             <th scope="row" class="table-text">
-              <router-link :to="examDetailPageLink(examTaker.id)" class="table-name">
+              <router-link
+                v-if="examTaker.progress !== undefined"
+                :to="examDetailPageLink(examTaker.id)"
+                class="table-name">
                 {{examTaker.name}}
               </router-link>
+              <span v-else class="table-name">
+                {{examTaker.name}}
+              </span>
             </th>
 
             <td class="table-data">

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -679,37 +679,40 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
     content_id: contentId,
     item: itemId,
   });
-  // If the above findModel returned no matching model, then we can do
-  // getModel to get the new model instead.
-  if (!examAttemptLogModel) {
-    examAttemptLogModel = ExamAttemptLogResource.getModel(
-      currentAttemptLog.id);
-  }
   const attributes = Object.assign({}, currentAttemptLog);
   attributes.interaction_history = JSON.stringify(attributes.interaction_history);
   attributes.answer = JSON.stringify(attributes.answer);
   attributes.user = store.state.core.session.user_id;
   attributes.examlog = store.state.examLog.id;
+  // If the above findModel returned no matching model, then we can do
+  // getModel to get the new model instead.
+  if (!examAttemptLogModel) {
+    examAttemptLogModel = ExamAttemptLogResource.createModel(
+      attributes);
+  }
   const promise = examAttemptLogModel.save(attributes);
-  return promise.then((newExamAttemptLog) => {
-    const log = Object.assign({}, newExamAttemptLog, {
-      answer: parseJSONorUndefined(newExamAttemptLog.answer),
-      interaction_history: parseJSONorUndefined(newExamAttemptLog.interaction_history) || [],
-    });
-    store.dispatch('SET_EXAM_ATTEMPT_LOGS', {
-      [contentId]: ({
-        [itemId]: log,
-      }),
-    });
-    const questionsAnswered = calcQuestionsAnswered(store.state.examAttemptLogs);
-    store.dispatch('SET_QUESTIONS_ANSWERED', questionsAnswered);
-    const examAttemptLogCollection = ExamAttemptLogResource.getCollection({
-      user: store.state.core.session.user_id,
-      exam: store.state.pageState.exam.id,
-    });
-    // Add this attempt log to the Collection for future caching.
-    examAttemptLogCollection.set(examAttemptLogModel);
-  });
+  return promise.then((newExamAttemptLog) =>
+    new Promise((resolve, reject) => {
+      const log = Object.assign({}, newExamAttemptLog, {
+        answer: parseJSONorUndefined(newExamAttemptLog.answer),
+        interaction_history: parseJSONorUndefined(newExamAttemptLog.interaction_history) || [],
+      });
+      store.dispatch('SET_EXAM_ATTEMPT_LOGS', {
+        [contentId]: ({
+          [itemId]: log,
+        }),
+      });
+      const questionsAnswered = calcQuestionsAnswered(store.state.examAttemptLogs);
+      store.dispatch('SET_QUESTIONS_ANSWERED', questionsAnswered);
+      const examAttemptLogCollection = ExamAttemptLogResource.getCollection({
+        user: store.state.core.session.user_id,
+        exam: store.state.pageState.exam.id,
+      });
+      // Add this attempt log to the Collection for future caching.
+      examAttemptLogCollection.set(examAttemptLogModel);
+      resolve();
+    })
+  );
 }
 
 function closeExam(store) {

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -667,6 +667,10 @@ function showExam(store, channelId, id, questionNumber) {
 }
 
 function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemptLog) {
+  // As soon as this has happened, we should clear any previous cache for the
+  // UserExamResource - as that data has now changed.
+  UserExamResource.clearCache();
+
   store.dispatch('SET_EXAM_ATTEMPT_LOGS', {
     [contentId]: ({
       [itemId]: currentAttemptLog,

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -67,6 +67,7 @@
   const PageNames = require('../../constants').PageNames;
   const InteractionTypes = require('kolibri.coreVue.vuex.constants').InteractionTypes;
   const actions = require('../../state/actions');
+  const isEqual = require('lodash/isEqual');
 
   module.exports = {
     $trNameSpace: 'examPage',
@@ -117,8 +118,8 @@
       },
       saveAnswer() {
         const answer = this.checkAnswer();
-        if (answer) {
-          const attempt = this.currentAttempt;
+        if (answer && !isEqual(answer.answerState, this.currentAttempt.answer)) {
+          const attempt = Object.assign({}, this.currentAttempt);
           attempt.answer = answer.answerState;
           attempt.simple_answer = answer.simpleAnswer;
           attempt.correct = answer.correct;


### PR DESCRIPTION
## Summary

Fixes #1246 - This was being caused by caching in the UserExamResource, fixed by clearing the cache as soon as any data is set to the server on the individual exam page.

Fixes #1343 - underlying cause was that the same server side model was being updated for each question, so only one question was being recorded on an exam.

Fixes #1387 - the same underlying cause as #1343 was responsible for this.

Fixes #1389 - was attempt to access `completion_timestamp` of exam log, when user had not started, the exam log was undefined. Fixes this, but also disables the link to the detail report page, as it is superfluous for users who have not started the exam yet.

Fixes #1392 - conditionally renders the content renderer without an answer if an attempt has not been made.

Fixes #1393 - marks unattempted questions with a grey incorrect sign if a question has not been attempted by the learner.