### PR TITLE
Set all client side set timestamps using a server time adjusted date object

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -142,6 +142,9 @@ module.exports = {
       validateLinkObject: {
         module: require('../validateLinkObject'),
       },
+      serverClock: {
+        module: require('../serverClock'),
+      },
     },
   },
 };

--- a/kolibri/core/assets/src/serverClock.js
+++ b/kolibri/core/assets/src/serverClock.js
@@ -4,7 +4,11 @@ const logging = require('kolibri.lib.logging').getLogger(__filename);
 let diff = 0;
 
 function setServerTime(time) {
-  diff = new Date(time) - new Date();
+  let clientTime = new Date();
+  if (window.performance && window.performance.timing) {
+    clientTime = window.performance.timing.requestStart;
+  }
+  diff = new Date(time) - clientTime;
   logging.debug(`Server time difference set to ${diff}`);
 }
 

--- a/kolibri/core/assets/src/serverClock.js
+++ b/kolibri/core/assets/src/serverClock.js
@@ -1,0 +1,18 @@
+const logging = require('kolibri.lib.logging').getLogger(__filename);
+
+// The currently known difference between server time and local clock time.
+let diff = 0;
+
+function setServerTime(time) {
+  diff = new Date(time) - new Date();
+  logging.debug(`Server time difference set to ${diff}`);
+}
+
+function now() {
+  return new Date(new Date().getTime() + diff);
+}
+
+module.exports = {
+  now,
+  setServerTime,
+};

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -7,6 +7,7 @@ const AttemptLoggingMap = require('../constants').AttemptLoggingMap;
 const InteractionTypes = require('../constants').InteractionTypes;
 const getDefaultChannelId = require('kolibri.coreVue.vuex.getters').getDefaultChannelId;
 const logging = require('kolibri.lib.logging').getLogger(__filename);
+const { now } = require('kolibri.utils.serverClock');
 
 const intervalTimer = require('../timer');
 
@@ -299,9 +300,9 @@ function initContentSession(store, channelId, contentId, contentKind) {
           /* If a summary model does not exist, create default state */
           store.dispatch('SET_LOGGING_SUMMARY_STATE', _contentSummaryLoggingState({
             pk: null,
-            start_timestamp: new Date(),
+            start_timestamp: now(),
             completion_timestamp: null,
-            end_timestamp: new Date(),
+            end_timestamp: now(),
             progress: 0,
             time_spent: 0,
             extra_fields: '{}',
@@ -331,8 +332,8 @@ function initContentSession(store, channelId, contentId, contentKind) {
   /* Set session log state to default */
   store.dispatch('SET_LOGGING_SESSION_STATE', _contentSessionLoggingState({
     pk: null,
-    start_timestamp: new Date(),
-    end_timestamp: new Date(),
+    start_timestamp: now(),
+    end_timestamp: now(),
     time_spent: 0,
     progress: 0,
     extra_fields: '{}',
@@ -463,7 +464,7 @@ function updateProgress(store, progressPercent, forceSave = false) {
   /* Mark completion time if 100% progress reached */
   const completedContent = originalProgress < 1 && summaryProgress === 1;
   if (completedContent) {
-    store.dispatch('SET_LOGGING_COMPLETION_TIME', new Date());
+    store.dispatch('SET_LOGGING_COMPLETION_TIME', now());
   }
 
   /* Save models if needed */
@@ -482,7 +483,7 @@ function updateExerciseProgress(store, progressPercent, forceSave = false) {
 
   /* Mark completion time if 100% progress reached */
   if (progressPercent === 1) {
-    store.dispatch('SET_LOGGING_COMPLETION_TIME', new Date());
+    store.dispatch('SET_LOGGING_COMPLETION_TIME', now());
   }
 
   /* Save models if needed */
@@ -508,7 +509,7 @@ function updateTimeSpent(store, forceSave = false) {
     sessionTime + summaryLog.time_spent_before_current_session : 0;
 
   /* Update the logging state with new timing information */
-  store.dispatch('SET_LOGGING_TIME', sessionTime, summaryTime, new Date());
+  store.dispatch('SET_LOGGING_TIME', sessionTime, summaryTime, now());
 
   /* Determine if time threshold has been met */
   const timeThresholdMet = sessionLog.time_spent -
@@ -576,7 +577,7 @@ function createMasteryLog(store, masteryLevel, masteryCriterion) {
   const masteryLogModel = coreApp.resources.MasteryLog.createModel({
     id: null,
     summarylog: store.state.core.logging.summary.id,
-    start_timestamp: new Date(),
+    start_timestamp: now(),
     completion_timestamp: null,
     end_timestamp: null,
     mastery_level: masteryLevel,
@@ -640,7 +641,7 @@ function createAttemptLog(store, itemId) {
     user: store.state.core.session.user_id,
     masterylog: store.state.core.logging.mastery.id || null,
     sessionlog: store.state.core.logging.session.id,
-    start_timestamp: new Date(),
+    start_timestamp: now(),
     completion_timestamp: null,
     end_timestamp: null,
     item: itemId,
@@ -672,7 +673,7 @@ function updateAttemptLogInteractionHistory(store, interaction) {
   }
   store.dispatch('UPDATE_LOGGING_ATTEMPT_INTERACTION_HISTORY', interaction);
   // Also update end timestamp on Mastery model.
-  store.dispatch('UPDATE_LOGGING_MASTERY', new Date());
+  store.dispatch('UPDATE_LOGGING_MASTERY', now());
 }
 
 /**
@@ -684,7 +685,7 @@ function initMasteryLog(store, masterySpacingTime, masteryCriterion) {
     // Either way, we need to create a new masterylog, with a masterylevel of 1!
     return createMasteryLog(store, 1, masteryCriterion);
   } else if (store.state.core.logging.mastery.complete &&
-    ((new Date() - new Date(store.state.core.logging.mastery.completion_timestamp)) >
+    ((now() - new Date(store.state.core.logging.mastery.completion_timestamp)) >
       masterySpacingTime)) {
     // The most recent masterylog is complete, and they completed it more than
     // masterySpacingTime time ago!

--- a/kolibri/core/assets/src/views/elapsed-time/index.vue
+++ b/kolibri/core/assets/src/views/elapsed-time/index.vue
@@ -12,6 +12,7 @@
 
   const parse = require('date-fns/parse');
   const differenceInSeconds = require('date-fns/difference_in_seconds');
+  const { now } = require('kolibri.utils.serverClock');
 
   const MINUTES_IN_DAY = 1440;
   const MINUTES_IN_MONTH = 43200;
@@ -39,12 +40,12 @@
     },
     props: ['date'],
     data: () => ({
-      now: new Date(),
+      now: now(),
       timer: null,
     }),
     mounted() {
       this.timer = setInterval(
-        () => { this.now = new Date(); },
+        () => { this.now = now(); },
         10000
       );
     },

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -51,6 +51,7 @@
   var languageCode = "{{ LANGUAGE_CODE }}";
 </script>
 {% webpack_asset 'default_frontend' %}
+{% kolibri_set_server_time %}
 <script type="text/javascript">
   {% cache 5000 js_urls %}
     {% js_reverse_inline %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -11,8 +11,10 @@ from six import iteritems
 
 from django import template
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.core.urlresolvers import reverse
 from django.utils.html import mark_safe
+from django.utils.timezone import now
 from kolibri.core.hooks import NavigationHook, UserNavigationHook
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIClient
@@ -47,6 +49,16 @@ def kolibri_main_navigation():
             "window._nav={0};"
             "</script>".format(json.dumps(init_data)))
     return mark_safe(html)
+
+
+@register.simple_tag()
+def kolibri_set_server_time():
+    html = ("<script type='text/javascript'>"
+            "{0}.utils.serverClock.setServerTime({1});"
+            "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
+                               json.dumps(now(), cls=DjangoJSONEncoder)))
+    return mark_safe(html)
+
 
 @register.simple_tag(takes_context=True)
 def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -7,6 +7,7 @@ const CoreConstants = require('kolibri.coreVue.vuex.constants');
 const Constants = require('../../constants');
 const ReportConstants = require('../../reportConstants');
 const { setClassState } = require('./main');
+const { now } = require('kolibri.utils.serverClock');
 
 const RecentReportResourceConstructor = require('../../apiResources/recentReport');
 const UserReportResourceConstructor = require('../../apiResources/userReport');
@@ -346,7 +347,7 @@ function showRecentItemsForChannel(store, classId, channelId) {
 
   Promise.all([channelPromise, setClassState(store, classId)]).then(
     ([channelData]) => {
-      const sevenDaysAgo = new Date();
+      const sevenDaysAgo = now();
       // this is being set by default in the backend
       // backend date data might be unreliable, though
       sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -15,6 +15,7 @@ const router = require('kolibri.coreVue.router');
 const seededShuffle = require('kolibri.lib.seededshuffle');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
 const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
+const { now } = require('kolibri.utils.serverClock');
 
 /**
  * Vuex State Mappers
@@ -634,7 +635,7 @@ function showExam(store, channelId, id, questionNumber) {
                 }
                 if (!attemptLogs[currentQuestion.contentId][itemId]) {
                   attemptLogs[currentQuestion.contentId][itemId] = {
-                    start_timestamp: new Date(),
+                    start_timestamp: now(),
                     completion_timestamp: null,
                     end_timestamp: null,
                     item: itemId,

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -61,6 +61,7 @@ oriented data synchronization.
   const InteractionTypes = require('kolibri.coreVue.vuex.constants').InteractionTypes;
   const MasteryModelGenerators = require('kolibri.coreVue.vuex.constants').MasteryModelGenerators;
   const seededShuffle = require('kolibri.lib.seededshuffle');
+  const { now } = require('kolibri.utils.serverClock');
 
   module.exports = {
     $trNameSpace: 'assessmentWrapper',
@@ -130,7 +131,7 @@ oriented data synchronization.
         simpleAnswer,
       }) {
         this.updateMasteryAttemptStateAction({
-          currentTime: new Date(),
+          currentTime: now(),
           correct,
           complete,
           firstAttempt,
@@ -142,7 +143,7 @@ oriented data synchronization.
       saveAttemptLogMasterLog() {
         this.saveAttemptLogAction().then(() => {
           if (this.canLogInteractions && this.success) {
-            this.setMasteryLogCompleteAction(new Date());
+            this.setMasteryLogCompleteAction(now());
             this.saveMasteryLogAction();
           }
         });

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -68,6 +68,7 @@
   const InteractionTypes = require('kolibri.coreVue.vuex.constants').InteractionTypes;
   const actions = require('../../state/actions');
   const isEqual = require('lodash/isEqual');
+  const { now } = require('kolibri.utils.serverClock');
 
   module.exports = {
     $trNameSpace: 'examPage',
@@ -124,9 +125,9 @@
           attempt.simple_answer = answer.simpleAnswer;
           attempt.correct = answer.correct;
           if (!attempt.completion_timestamp) {
-            attempt.completion_timestamp = new Date();
+            attempt.completion_timestamp = now();
           }
-          attempt.end_timestamp = new Date();
+          attempt.end_timestamp = now();
           attempt.interaction_history.push({
             type: InteractionTypes.answer,
             answer: answer.answerState,


### PR DESCRIPTION
## Summary

Initial fix for #1278 by reading the server time at pageload and setting an offset between that and client time.

Replaces all existing `new Date()` that are used for setting timestamps (I left others alone for now) with this `now()` function.

Should also fix #1363.