### PR TITLE
Uniqueify by content_id for ContentNodes in coach reports.

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -1,7 +1,7 @@
 import datetime
 from dateutil.parser import parse
 
-from django.db.models import Q
+from django.db.models import Min, Q
 from django.utils import timezone
 
 from kolibri.auth.constants import role_kinds
@@ -98,4 +98,6 @@ class RecentReportViewSet(viewsets.ModelViewSet):
             Q(progress__gt=0) | Q(masterylogs__in=attempted_mastery_logs),
             user__in=get_members_or_user(self.kwargs['collection_kind'], self.kwargs['collection_id']),
             end_timestamp__gte=datetime_cutoff).values_list('content_id')
-        return ContentNode.objects.filter(content_id__in=recent_content_items)
+        return ContentNode.objects.filter(pk__in=ContentNode.objects.filter(
+            content_id__in=recent_content_items).values('content_id').annotate(pk=Min('pk')).values_list(
+            'pk', flat=True))

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -99,9 +99,10 @@ class RecentReportViewSet(viewsets.ModelViewSet):
             user__in=get_members_or_user(self.kwargs['collection_kind'], self.kwargs['collection_id']),
             end_timestamp__gte=datetime_cutoff).values_list('content_id')
         # note from rtibbles:
-        # Possibly a horrible hack to ensure that we only return unique content_id'ed ContentNodes
-        # from the coach recent report endpoint.
+        # As good as either I or jamalex could come up with to ensure that we only return
+        # unique content_id'ed ContentNodes from the coach recent report endpoint.
         # Would have loved to use distinct('content_id'), but unfortunately DISTINCT ON is Postgresql only
-        return ContentNode.objects.filter(pk__in=ContentNode.objects.filter(
-            content_id__in=recent_content_items).values('content_id').annotate(pk=Min('pk')).values_list(
-            'pk', flat=True))
+        pks_with_unique_content_ids = ContentNode.objects.filter(
+            content_id__in=recent_content_items).values('content_id').annotate(
+            pk=Min('pk')).values_list('pk', flat=True)
+        return ContentNode.objects.filter(pk__in=pks_with_unique_content_ids)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -98,6 +98,10 @@ class RecentReportViewSet(viewsets.ModelViewSet):
             Q(progress__gt=0) | Q(masterylogs__in=attempted_mastery_logs),
             user__in=get_members_or_user(self.kwargs['collection_kind'], self.kwargs['collection_id']),
             end_timestamp__gte=datetime_cutoff).values_list('content_id')
+        # note from rtibbles:
+        # Possibly a horrible hack to ensure that we only return unique content_id'ed ContentNodes
+        # from the coach recent report endpoint.
+        # Would have loved to use distinct('content_id'), but unfortunately DISTINCT ON is Postgresql only
         return ContentNode.objects.filter(pk__in=ContentNode.objects.filter(
             content_id__in=recent_content_items).values('content_id').annotate(pk=Min('pk')).values_list(
             'pk', flat=True))


### PR DESCRIPTION
## Summary

Fixes #1295 

What seems like a horrible hack to ensure that we only return unique `content_id`ed ContentNodes from the coach recent report endpoint.

Would appreciate any feedback to make this more efficient/less hacky @jamalex @ralphiee22. Would have loved to use `distinct('content_id')`, but unfortunately `DISTINCT ON` is Postgresql only.