### PR TITLE
Make 'next question' button disappear as soon as it is clicked

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -31,13 +31,27 @@ oriented data synchronization.
         @sessionInitialized="sessionInitialized"
         @itemError="handleItemError"/>
     </div>
+
     <div class="button-drawer">
-      <icon-button @click="checkAnswer" v-show="!complete" class="question-btn" :class="{shaking: shake}" id="check-answer-button" :text="$tr('check')"></icon-button>
+      <icon-button
+        @click="checkAnswer"
+        v-show="!complete"
+        class="question-btn"
+        :class="{shaking: shake}"
+        id="check-answer-button"
+        :text="$tr('check')"
+      />
       <transition name="delay">
-        <icon-button @click="nextQuestion" v-show="complete" class="question-btn next-question-button" :text="$tr('correct')"></icon-button>
+        <icon-button
+          @click="nextQuestion"
+          v-show="complete"
+          class="question-btn next-question-button"
+          :text="$tr('correct')"
+        >
       </transition>
       <slot/>
     </div>
+
     <div id="attemptprogress-container">
       <exercise-attempts
         class="attemptprogress"
@@ -58,8 +72,8 @@ oriented data synchronization.
 
   const getters = require('kolibri.coreVue.vuex.getters');
   const actions = require('kolibri.coreVue.vuex.actions');
-  const InteractionTypes = require('kolibri.coreVue.vuex.constants').InteractionTypes;
-  const MasteryModelGenerators = require('kolibri.coreVue.vuex.constants').MasteryModelGenerators;
+  const { InteractionTypes } = require('kolibri.coreVue.vuex.constants');
+  const { MasteryModelGenerators } = require('kolibri.coreVue.vuex.constants');
   const seededShuffle = require('kolibri.lib.seededshuffle');
 
   module.exports = {
@@ -220,9 +234,9 @@ oriented data synchronization.
       nextQuestion() {
         // Consistently get the next item in the sequence depending on how many previous
         // attempts have been made.
+        this.complete = false;
         this.shake = false;
         this.firstAttempt = true;
-        this.complete = false;
         this.correct = 0;
         this.itemError = false;
         this.setItemId();

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -47,7 +47,7 @@ oriented data synchronization.
           v-show="complete"
           class="question-btn next-question-button"
           :text="$tr('correct')"
-        >
+        />
       </transition>
       <slot/>
     </div>
@@ -436,6 +436,9 @@ oriented data synchronization.
 
   .delay-enter
     background-color: $core-action-normal
+
+  .delay-leave-active
+    display: none
 
   // checkAnswer btn animation
   .shaking


### PR DESCRIPTION
#1167 

It seems that the 'next question' button was flashing because it didn't have a 'delay-leave-active' class defined, so it just defaulted to its base class which showed it as a green button. I added the 'leave-active' class so that it would disappear immediately.

![kapture 2017-05-01 at 12 55 51](https://cloud.githubusercontent.com/assets/10248067/25586610/0de3d900-2e6e-11e7-97d1-5e4043dbef70.gif)

