### PR TITLE
Login -> Sign in

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -223,16 +223,6 @@ function getCurrentSession(store) {
   .catch(error => { handleApiError(store, error); });
 }
 
-function showLoginModal(store, bool) {
-  store.dispatch('CORE_SET_LOGIN_MODAL_VISIBLE', true);
-  store.dispatch('CORE_SET_LOGIN_ERROR', null);
-}
-
-function cancelLoginModal(store, bool) {
-  store.dispatch('CORE_SET_LOGIN_MODAL_VISIBLE', false);
-  store.dispatch('CORE_SET_LOGIN_ERROR', null);
-}
-
 
 /**
  * Create models to store logging information
@@ -713,8 +703,6 @@ module.exports = {
   kolibriLogin,
   kolibriLogout,
   getCurrentSession,
-  showLoginModal,
-  cancelLoginModal,
   initContentSession,
   setChannelInfo,
   startTrackingProgress,

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -24,7 +24,6 @@ const initialState = {
       facility_id: undefined,
       kind: [UserKinds.ANONYMOUS],
     },
-    loginModalVisible: false,
     loginError: null,
     logging: baseLoggingState,
     totalProgress: null,
@@ -48,7 +47,6 @@ const initialState = {
 const mutations = {
   CORE_SET_SESSION(state, value) {
     state.core.session = value;
-    state.core.loginModalVisible = false;
   },
   // Makes settings for wrong credentials 401 error
   CORE_SET_LOGIN_ERROR(state, value) {
@@ -63,9 +61,6 @@ const mutations = {
       facility_id: undefined,
       kind: [UserKinds.ANONYMOUS],
     };
-  },
-  CORE_SET_LOGIN_MODAL_VISIBLE(state, value) {
-    state.core.loginModalVisible = value;
   },
   CORE_SET_PAGE_LOADING(state, value) {
     const update = { loading: value };

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -38,10 +38,10 @@
     $trNameSpace: 'coachRoot',
     $trs: {
       coachTitle: 'Coach',
-      logInPrompt: 'Did you forget to log in?',
-      logInCommand: 'You must be logged in as an Admin to view this page.',
-      superUserPrompt: 'Logged in as device owner',
-      superUserCommand: 'The coach tools cannot be used by a device owner. Please log in as an administrator or coach.',
+      logInPrompt: 'Did you forget to sign in?',
+      logInCommand: 'You must be signed in as an Admin to view this page.',
+      superUserPrompt: 'Signed in as device owner',
+      superUserCommand: 'The coach tools cannot be used by a device owner. Please sign in as an administrator or coach.',
     },
     components: {
       'top-nav': require('./top-nav'),

--- a/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
@@ -18,7 +18,7 @@
     $trs: {
       header: 'No content channels available',
       adminLink: 'Download content channels from the <a href="/management/#/content">Content Management</a> page',
-      notAdmin: 'You need to log in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
+      notAdmin: 'You need to sign in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
     },
     vuex: {
       getters: {

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -53,8 +53,8 @@
       start: 'Start',
       noExams: 'You have no exams assigned',
       assignedTo: 'You have { assigned } {assigned, plural, one {exam} other {exams} } assigned',
-      logInPrompt: 'Did you forget to log in?',
-      logInCommand: 'You must be logged in as a Learner to view this page.',
+      logInPrompt: 'Did you forget to sign in?',
+      logInCommand: 'You must be signed in as a Learner to view this page.',
     },
     components: {
       'page-header': require('../page-header'),

--- a/kolibri/plugins/management/assets/src/views/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/data-page/index.vue
@@ -60,7 +60,7 @@
       summaryHeading: 'Summary logs',
       summarySubHeading: 'Total time/progress for each piece of content',
       // info boxes
-      detailsInfo: 'When a user views content, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific piece of content. This includes anonymous usage, when no user is logged in.',
+      detailsInfo: 'When a user views content, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific piece of content. This includes anonymous usage, when no user is signed in.',
       summaryInfo: 'A user may visit the same piece of content multiple times. This file records the total time and progress each user has achieved for each piece of content, summarized across possibly more than one visit. Anonymous usage is not included.',
       // button
       download: 'Download',

--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
@@ -125,7 +125,7 @@
       currentFacilityHeader: 'Your current Facility',
       learnerCanDeleteAccount: 'Allow users to delete their account',
       learnerCanEditName: 'Allow users to edit their full name',
-      learnerCanEditPassword: 'Allow users to change their password when logged in',
+      learnerCanEditPassword: 'Allow users to change their password when signed in',
       learnerCanEditUsername: 'Allow users to edit their username',
       learnerCanSignUp: 'Allow users to sign-up on this device',
       pageDescription: 'Configure and change different Facility settings here.',

--- a/kolibri/plugins/management/assets/src/views/index.vue
+++ b/kolibri/plugins/management/assets/src/views/index.vue
@@ -41,8 +41,8 @@
     $trNameSpace: 'managementRoot',
     $trs: {
       managementTitle: 'Management',
-      logInPrompt: 'Did you forget to log in?',
-      logInCommand: 'You must be logged in as an Admin to view this page.',
+      logInPrompt: 'Did you forget to sign in?',
+      logInCommand: 'You must be signed in as an Admin to view this page.',
     },
     components: {
       'class-edit-page': require('./class-edit-page'),

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -73,7 +73,7 @@
       import: 'Import',
       export: 'Export',
       noChannels: 'No channels installed',
-      notAdmin: 'You need to log in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
+      notAdmin: 'You need to sign in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
     },
     components: {
       'icon-button': require('kolibri.coreVue.components.iconButton'),

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -30,7 +30,7 @@ class UserModule extends KolibriModule {
         },
         {
           name: PageNames.SIGN_UP,
-          path: '/signup',
+          path: '/create_account',
           handler: (toRoute, fromRoute) => {
             actions.showSignUp(store);
           },

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -53,7 +53,7 @@
     $trNameSpace: 'signInPage',
     $trs: {
       kolibri: 'Kolibri',
-      signIn: 'Log in',
+      signIn: 'Sign in',
       username: 'Username',
       enterUsername: 'Enter username',
       password: 'Password',

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -10,7 +10,7 @@
         {{ $tr('kolibri') }}
       </template>
       <div slot="actions">
-        <router-link id="login" :to="signInPage">
+        <router-link id="signin" :to="signInPage">
           <span>{{ $tr('logIn') }}</span>
         </router-link>
       </div>
@@ -95,7 +95,7 @@
       confirmPassword: 'Confirm password',
       passwordMatchError: 'Passwords do not match',
       genericError: 'Something went wrong during sign up!',
-      logIn: 'Log in',
+      logIn: 'Sign in',
       kolibri: 'Kolibri',
       finish: 'Finish',
     },
@@ -195,7 +195,7 @@
     display: inline-block
     margin-left: $logo-margin
 
-  #login
+  #signin
     margin-right: 1em
     color: white
     text-decoration: none


### PR DESCRIPTION
## Summary

* Addresses #1079 
* Replace all strings of 'log in' and 'logged in' with 'sign in' and 'signed in'
* Remove login modal dead code.
* Change sign up page url from `/signup` to `create_account`  