### PR TITLE
Temporarily hides unimplemented settings from facility config page

### DIFF
--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
@@ -76,8 +76,8 @@
   const settingsList = [
     'learnerCanEditUsername',
     'learnerCanEditName',
-    'learnerCanEditPassword',
-    'learnerCanDeleteAccount',
+    // 'learnerCanEditPassword',
+    // 'learnerCanDeleteAccount',
     'learnerCanSignUp',
   ];
 


### PR DESCRIPTION
## Summary

* Temporarily hides unimplemented settings from facility config page.
* Addresses #1415 

![image](https://cloud.githubusercontent.com/assets/7193975/25644554/fcf968e6-2f5b-11e7-9d28-4e2e6156559e.png)
