### PR TITLE
Adds tooltips to progress icons

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -168,7 +168,7 @@
     background: rgba(0, 0, 0, 0.7)
     transition: opacity 0.3s ease
     background-attachment: fixed
-    z-index: 25
+    z-index: 24
 
   .modal
     position: absolute

--- a/kolibri/core/assets/src/views/immersive-full-screen/index.vue
+++ b/kolibri/core/assets/src/views/immersive-full-screen/index.vue
@@ -46,7 +46,7 @@
   .whole-page
     left: 0
     top: 0
-    z-index: 100
+    z-index: 24
     width: 100%
     height: 100%
     position: fixed

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <span>
+  <span ref="progress-icon">
     <ui-icon
       v-if="isInProgress"
       ariaLabel="$tr('inProgress')"
@@ -13,6 +13,9 @@
       icon="check"
       class="completed"
     />
+    <ui-tooltip trigger="progress-icon">
+      {{ isInProgress ? $tr('inProgress') : $tr('completed') }}
+    </ui-tooltip>
   </span>
 
 </template>
@@ -45,6 +48,7 @@
     },
     components: {
       'ui-icon': require('keen-ui/src/UiIcon'),
+      'ui-tooltip': require('keen-ui/src/UiTooltip'),
     },
   };
 
@@ -56,6 +60,8 @@
   .inprogress, .completed
     border-radius: 50%
     color: white
+    cursor: default
+
 
   .inprogress
     background-color: #2196f3

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -3,13 +3,13 @@
   <span ref="progress-icon">
     <ui-icon
       v-if="isInProgress"
-      ariaLabel="$tr('inProgress')"
+      :ariaLabel="$tr('inProgress')"
       icon="schedule"
       class="inprogress"
     />
     <ui-icon
       v-else-if="isCompleted"
-      ariaLabel="$tr('completed')"
+      :ariaLabel="$tr('completed')"
       icon="check"
       class="completed"
     />

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -400,7 +400,7 @@ oriented data synchronization.
       height: 60px
       width: 100%
       border-radius: 0
-      bottom: $nav-portrait-height
+      bottom: 0
       border-bottom: thin solid $core-text-annotation
       border-top: thin solid $core-text-annotation
       z-index: 10


### PR DESCRIPTION
## Summary

* Adds tooltips to progress icons by making use of the `ui-tooltip`
* Addresses #1448 
![tooltip](https://cloud.githubusercontent.com/assets/7193975/25820837/97760bf6-33e7-11e7-8734-9fc78cad64e4.gif)

