### PR TITLE
Auth message

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -111,6 +111,9 @@ module.exports = {
         pointsIcon: {
           module: require('../views/points-icon'),
         },
+        authMessage: {
+          module: require('../views/auth-message'),
+        },
       },
       router: {
         module: require('../router'),

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -1,0 +1,50 @@
+<template>
+
+  <div class="LoginMessage">
+    <h1>{{ $tr('loginPrompt') }}</h1>
+    <p id="login-command">
+      {{ loginCommand }}
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+    props: {
+      // 'role' or 'learner'
+      authorizedRole: {
+        type: String,
+        required: true,
+        validator(role) {
+          return role === 'admin' || role === 'learner';
+        },
+      },
+    },
+    computed: {
+      loginCommand() {
+        return `${this.$tr('commandStart')} ${this.$tr(this.authorizedRole)} ${this.$tr('commandEnd')}`;
+      }
+    },
+    $trNameSpace: 'authMessage',
+    $trs: {
+      loginPrompt: 'Did you forget to sign in?',
+      admin: 'an Admin',
+      learner: 'a Learner',
+      commandStart: 'You must be signed in as',
+      commandEnd: 'to view this page.'
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  .LoginMessage
+    text-align: center
+    margin-top: 200px
+
+</style>

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -14,13 +14,18 @@
 
 <script>
 
+  const userRoles = [
+    'admin',
+    'admin_or_coach',
+    'learner',
+  ];
+
   module.exports = {
     props: {
-      // 'role' or 'learner'
       authorizedRole: {
         type: String,
         validator(role) {
-          return role === 'admin' || role === 'learner';
+          return userRoles.includes(role);
         },
       },
       header: { type: String },
@@ -35,6 +40,7 @@
     $trs: {
       loginPrompt: 'Did you forget to sign in?',
       admin: 'an Admin',
+      admin_or_coach: 'an Admin or Coach',
       learner: 'a Learner',
       commandStart: 'You must be signed in as',
       commandEnd: 'to view this page.'

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -2,7 +2,7 @@
 
   <div class="auth-message">
     <h1>
-      {{ header || $tr('loginPrompt') }}
+      {{ header }}
     </h1>
     <p>
       {{ details || defaultDetails }}
@@ -16,8 +16,10 @@
 
   const userRoles = [
     'admin',
-    'admin_or_coach',
+    'adminOrCoach',
+    'deviceOwner',
     'learner',
+    'registeredUser'
   ];
 
   module.exports = {
@@ -27,23 +29,30 @@
         validator(role) {
           return userRoles.includes(role);
         },
+        default: 'registeredUser',
       },
-      header: { type: String },
+      header: {
+        type: String,
+        default() {
+          return this.$tr('forgetToSignIn');
+        },
+      },
       details: { type: String },
     },
     computed: {
       defaultDetails() {
-        return `${this.$tr('commandStart')} ${this.$tr(this.authorizedRole)} ${this.$tr('commandEnd')}`;
+        return this.$tr('mustBeSignedInAsRole', { role: this.$tr(this.authorizedRole) });
       }
     },
     $trNameSpace: 'authMessage',
     $trs: {
-      loginPrompt: 'Did you forget to sign in?',
       admin: 'an Admin',
-      admin_or_coach: 'an Admin or Coach',
+      adminOrCoach: 'an Admin or Coach',
+      deviceOwner: 'a Device Owner',
+      forgetToSignIn: 'Did you forget to sign in?',
       learner: 'a Learner',
-      commandStart: 'You must be signed in as',
-      commandEnd: 'to view this page.'
+      mustBeSignedInAsRole: 'You must be signed in as {role} to view this page',
+      registeredUser: 'a Registered User',
     },
   };
 

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -1,7 +1,9 @@
 <template>
 
   <div class="LoginMessage">
-    <h1>{{ $tr('loginPrompt') }}</h1>
+    <h1 id="login-prompt">
+      {{ loginPrompt }}
+    </h1>
     <p id="login-command">
       {{ loginCommand }}
     </p>
@@ -17,14 +19,21 @@
       // 'role' or 'learner'
       authorizedRole: {
         type: String,
-        required: true,
         validator(role) {
           return role === 'admin' || role === 'learner';
         },
       },
+      prompt: { type: String },
+      command: { type: String },
     },
     computed: {
+      loginPrompt() {
+        return this.prompt || this.$tr('loginPrompt');
+      },
       loginCommand() {
+        if (this.command) {
+          return this.command;
+        }
         return `${this.$tr('commandStart')} ${this.$tr(this.authorizedRole)} ${this.$tr('commandEnd')}`;
       }
     },

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -54,6 +54,5 @@
 
   .LoginMessage
     text-align: center
-    margin-top: 200px
 
 </style>

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -1,11 +1,11 @@
 <template>
 
-  <div class="LoginMessage">
-    <h1 id="login-prompt">
-      {{ loginPrompt }}
+  <div class="AuthorizationMsg">
+    <h1>
+      {{ header || $tr('loginPrompt') }}
     </h1>
-    <p id="login-command">
-      {{ loginCommand }}
+    <p>
+      {{ details || defaultDetails }}
     </p>
   </div>
 
@@ -23,17 +23,11 @@
           return role === 'admin' || role === 'learner';
         },
       },
-      prompt: { type: String },
-      command: { type: String },
+      header: { type: String },
+      details: { type: String },
     },
     computed: {
-      loginPrompt() {
-        return this.prompt || this.$tr('loginPrompt');
-      },
-      loginCommand() {
-        if (this.command) {
-          return this.command;
-        }
+      defaultDetails() {
         return `${this.$tr('commandStart')} ${this.$tr(this.authorizedRole)} ${this.$tr('commandEnd')}`;
       }
     },
@@ -52,7 +46,7 @@
 
 <style lang="stylus" scoped>
 
-  .LoginMessage
+  .AuthorizationMsg
     text-align: center
 
 </style>

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="AuthMessage">
+  <div class="auth-message">
     <h1>
       {{ header || $tr('loginPrompt') }}
     </h1>
@@ -52,7 +52,7 @@
 
 <style lang="stylus" scoped>
 
-  .AuthMessage
+  .auth-message
     text-align: center
 
 </style>

--- a/kolibri/core/assets/src/views/auth-message.vue
+++ b/kolibri/core/assets/src/views/auth-message.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="AuthorizationMsg">
+  <div class="AuthMessage">
     <h1>
       {{ header || $tr('loginPrompt') }}
     </h1>
@@ -52,7 +52,7 @@
 
 <style lang="stylus" scoped>
 
-  .AuthorizationMsg
+  .AuthMessage
     text-align: center
 
 </style>

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -16,16 +16,25 @@ function getElements(vm) {
 }
 
 describe('auth message component', () => {
+  it('shows the correct details when there are no props', () => {
+    const vm = makeVm({ propsData: {} });
+    const { headerText, detailsText } = getElements(vm);
+    assert.equal(headerText(), 'Did you forget to sign in?');
+    assert.equal(detailsText(), 'You must be signed in as a Registered User to view this page');
+  });
+
   it('shows the correct details when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
-    const { detailsText } = getElements(vm);
-    assert.equal(detailsText(), 'You must be signed in as a Learner to view this page.');
+    const { headerText, detailsText } = getElements(vm);
+    assert.equal(headerText(), 'Did you forget to sign in?');
+    assert.equal(detailsText(), 'You must be signed in as a Learner to view this page');
   });
 
   it('shows the correct details when authorized role is "admin"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'admin' } });
-    const { detailsText } = getElements(vm);
-    assert.equal(detailsText(), 'You must be signed in as an Admin to view this page.');
+    const { headerText, detailsText } = getElements(vm);
+    assert.equal(headerText(), 'Did you forget to sign in?');
+    assert.equal(detailsText(), 'You must be signed in as an Admin to view this page');
   });
 
   it('shows correct text when both texts manually provided as prop', () => {

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -10,8 +10,8 @@ function makeVm(options) {
 
 function getElements(vm) {
   return {
-    headerText: () => vm.$el.querySelector('.AuthMessage h1').innerText.trim(),
-    detailsText: () => vm.$el.querySelector('.AuthMessage p').innerText.trim(),
+    headerText: () => vm.$el.querySelector('.auth-message h1').innerText.trim(),
+    detailsText: () => vm.$el.querySelector('.auth-message p').innerText.trim(),
   };
 }
 

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -15,7 +15,7 @@ function getElements(vm) {
   };
 }
 
-describe.only('auth message component', () => {
+describe('auth message component', () => {
   it('shows the right command when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
     const { loginCommand } = getElements(vm);

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -11,10 +11,11 @@ function makeVm(options) {
 function getElements(vm) {
   return {
     loginCommand: () => vm.$el.querySelector('#login-command').innerText.trim(),
+    loginPrompt: () => vm.$el.querySelector('#login-prompt').innerText.trim(),
   };
 }
 
-describe('auth message component', () => {
+describe.only('auth message component', () => {
   it('shows the right command when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
     const { loginCommand } = getElements(vm);
@@ -31,5 +32,19 @@ describe('auth message component', () => {
       loginCommand(),
       'You must be signed in as an Admin to view this page.'
     );
+  });
+
+  it('shows right text when manually provided as prop', () => {
+    const vm = makeVm({
+      propsData: {
+        prompt: 'Signed in as device owner',
+        command: 'Cannot be used by device owner',
+      },
+    });
+
+    const { loginCommand, loginPrompt } = getElements(vm);
+
+    assert.equal(loginPrompt(), 'Signed in as device owner');
+    assert.equal(loginCommand(), 'Cannot be used by device owner');
   });
 });

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+const Vue = require('vue-test');
+const assert = require('assert');
+const AuthMessage = require('../../src/views/auth-message.vue');
+
+function makeVm(options) {
+  const Ctor = Vue.extend(AuthMessage);
+  return new Ctor(options).$mount();
+}
+
+function getElements(vm) {
+  return {
+    loginCommand: () => vm.$el.querySelector('#login-command').innerText.trim(),
+  };
+}
+
+describe('auth message component', () => {
+  it('shows the right command when authorized role is "learner"', () => {
+    const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
+    const { loginCommand } = getElements(vm);
+    assert.equal(
+      loginCommand(),
+      'You must be signed in as a Learner to view this page.'
+    );
+  });
+
+  it('shows the right command when authorized role is "admin"', () => {
+    const vm = makeVm({ propsData: { authorizedRole: 'admin' } });
+    const { loginCommand } = getElements(vm);
+    assert.equal(
+      loginCommand(),
+      'You must be signed in as an Admin to view this page.'
+    );
+  });
+});

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -10,41 +10,48 @@ function makeVm(options) {
 
 function getElements(vm) {
   return {
-    loginCommand: () => vm.$el.querySelector('#login-command').innerText.trim(),
-    loginPrompt: () => vm.$el.querySelector('#login-prompt').innerText.trim(),
+    headerText: () => vm.$el.querySelector('.AuthorizationMsg h1').innerText.trim(),
+    detailsText: () => vm.$el.querySelector('.AuthorizationMsg p').innerText.trim(),
   };
 }
 
-describe('auth message component', () => {
+describe.only('auth message component', () => {
   it('shows the right command when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
-    const { loginCommand } = getElements(vm);
-    assert.equal(
-      loginCommand(),
-      'You must be signed in as a Learner to view this page.'
-    );
+    const { detailsText } = getElements(vm);
+    assert.equal(detailsText(), 'You must be signed in as a Learner to view this page.');
   });
 
   it('shows the right command when authorized role is "admin"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'admin' } });
-    const { loginCommand } = getElements(vm);
-    assert.equal(
-      loginCommand(),
-      'You must be signed in as an Admin to view this page.'
-    );
+    const { detailsText } = getElements(vm);
+    assert.equal(detailsText(), 'You must be signed in as an Admin to view this page.');
   });
 
-  it('shows right text when manually provided as prop', () => {
+  it('shows right text when both texts manually provided as prop', () => {
     const vm = makeVm({
       propsData: {
-        prompt: 'Signed in as device owner',
-        command: 'Cannot be used by device owner',
+        header: 'Signed in as device owner',
+        details: 'Cannot be used by device owner',
       },
     });
 
-    const { loginCommand, loginPrompt } = getElements(vm);
+    const { headerText, detailsText } = getElements(vm);
 
-    assert.equal(loginPrompt(), 'Signed in as device owner');
-    assert.equal(loginCommand(), 'Cannot be used by device owner');
+    assert.equal(headerText(), 'Signed in as device owner');
+    assert.equal(detailsText(), 'Cannot be used by device owner');
+  });
+
+  it('shows right text when one text manually provided as prop', () => {
+    const vm = makeVm({
+      propsData: {
+        details: 'Must be device owner to manage content',
+      },
+    });
+
+    const { headerText, detailsText } = getElements(vm);
+
+    assert.equal(headerText(), 'Did you forget to sign in?');
+    assert.equal(detailsText(), 'Must be device owner to manage content');
   });
 });

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -15,7 +15,7 @@ function getElements(vm) {
   };
 }
 
-describe.only('auth message component', () => {
+describe('auth message component', () => {
   it('shows the right command when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
     const { detailsText } = getElements(vm);

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -10,25 +10,25 @@ function makeVm(options) {
 
 function getElements(vm) {
   return {
-    headerText: () => vm.$el.querySelector('.AuthorizationMsg h1').innerText.trim(),
-    detailsText: () => vm.$el.querySelector('.AuthorizationMsg p').innerText.trim(),
+    headerText: () => vm.$el.querySelector('.AuthMessage h1').innerText.trim(),
+    detailsText: () => vm.$el.querySelector('.AuthMessage p').innerText.trim(),
   };
 }
 
 describe('auth message component', () => {
-  it('shows the right command when authorized role is "learner"', () => {
+  it('shows the correct details when authorized role is "learner"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'learner' } });
     const { detailsText } = getElements(vm);
     assert.equal(detailsText(), 'You must be signed in as a Learner to view this page.');
   });
 
-  it('shows the right command when authorized role is "admin"', () => {
+  it('shows the correct details when authorized role is "admin"', () => {
     const vm = makeVm({ propsData: { authorizedRole: 'admin' } });
     const { detailsText } = getElements(vm);
     assert.equal(detailsText(), 'You must be signed in as an Admin to view this page.');
   });
 
-  it('shows right text when both texts manually provided as prop', () => {
+  it('shows correct text when both texts manually provided as prop', () => {
     const vm = makeVm({
       propsData: {
         header: 'Signed in as device owner',
@@ -42,7 +42,7 @@ describe('auth message component', () => {
     assert.equal(detailsText(), 'Cannot be used by device owner');
   });
 
-  it('shows right text when one text manually provided as prop', () => {
+  it('shows correct text when one text manually provided as prop', () => {
     const vm = makeVm({
       propsData: {
         details: 'Must be device owner to manage content',

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -13,8 +13,8 @@
       </div>
       <auth-message
         v-else-if="isSuperuser"
-        :prompt="$tr('superUserPrompt')"
-        :command="$tr('superUserCommand')"
+        :header="$tr('superUserPrompt')"
+        :details="$tr('superUserCommand')"
       />
       <auth-message v-else authorizedRole="admin" />
     </div>

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -16,7 +16,7 @@
         :header="$tr('superUserPrompt')"
         :details="$tr('superUserCommand')"
       />
-      <auth-message v-else authorizedRole="admin_or_coach" />
+      <auth-message v-else authorizedRole="adminOrCoach" />
     </div>
 
   </core-base>

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -16,7 +16,7 @@
         :header="$tr('superUserPrompt')"
         :details="$tr('superUserCommand')"
       />
-      <auth-message v-else authorizedRole="admin" />
+      <auth-message v-else authorizedRole="admin_or_coach" />
     </div>
 
   </core-base>

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -11,14 +11,12 @@
       <div v-if="isCoach || isAdmin">
         <component :is="currentPage"/>
       </div>
-      <div v-else-if="isSuperuser">
-        <h1>{{ $tr('superUserPrompt') }}</h1>
-        <p>{{ $tr('superUserCommand') }}</p>
-      </div>
-      <div v-else class="login-message">
-        <h1>{{ $tr('logInPrompt') }}</h1>
-        <p>{{ $tr('logInCommand') }}</p>
-      </div>
+      <auth-message
+        v-else-if="isSuperuser"
+        :prompt="$tr('superUserPrompt')"
+        :command="$tr('superUserCommand')"
+      />
+      <auth-message v-else authorizedRole="admin" />
     </div>
 
   </core-base>
@@ -37,12 +35,11 @@
     $trNameSpace: 'coachRoot',
     $trs: {
       coachTitle: 'Coach',
-      logInPrompt: 'Did you forget to sign in?',
-      logInCommand: 'You must be signed in as an Admin to view this page.',
       superUserPrompt: 'Signed in as device owner',
       superUserCommand: 'The coach tools cannot be used by a device owner. Please sign in as an administrator or coach.',
     },
     components: {
+      'auth-message': require('kolibri.coreVue.components.authMessage'),
       'top-nav': require('./top-nav'),
       'class-list-page': require('./class-list-page'),
       'exams-page': require('./exams-page'),
@@ -128,9 +125,5 @@
   .content
     background-color: $core-bg-light
     padding: 1em
-
-  .login-message
-    text-align: center
-    margin-top: 200px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -1,10 +1,7 @@
 <template>
 
   <div>
-    <div v-if="!isUserLoggedIn" class="login-message">
-      <h1>{{ $tr('logInPrompt') }}</h1>
-      <p>{{ $tr('logInCommand') }}</p>
-    </div>
+    <auth-message v-if="!isUserLoggedIn" authorizedRole="learner" />
 
     <div v-else>
       <page-header :title="$tr('examName')"></page-header>
@@ -53,10 +50,9 @@
       start: 'Start',
       noExams: 'You have no exams assigned',
       assignedTo: 'You have { assigned } {assigned, plural, one {exam} other {exams} } assigned',
-      logInPrompt: 'Did you forget to sign in?',
-      logInCommand: 'You must be signed in as a Learner to view this page.',
     },
     components: {
+      'auth-message': require('kolibri.coreVue.components.authMessage'),
       'page-header': require('../page-header'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
@@ -88,10 +84,6 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
-
-  .login-message
-    text-align: center
-    margin-top: 200px
 
   .exams-assigned
     margin-top: 0

--- a/kolibri/plugins/management/assets/src/views/index.vue
+++ b/kolibri/plugins/management/assets/src/views/index.vue
@@ -9,10 +9,7 @@
       <component class="manage-content page" :is="currentPage"/>
     </div>
 
-    <div v-else class="login-message">
-      <h1>{{ $tr('logInPrompt') }}</h1>
-      <p>{{ $tr('logInCommand') }}</p>
-    </div>
+    <auth-message v-else authorizedRole="admin" />
 
   </core-base>
 
@@ -41,10 +38,9 @@
     $trNameSpace: 'managementRoot',
     $trs: {
       managementTitle: 'Management',
-      logInPrompt: 'Did you forget to sign in?',
-      logInCommand: 'You must be signed in as an Admin to view this page.',
     },
     components: {
+      'auth-message': require('kolibri.coreVue.components.authMessage'),
       'class-edit-page': require('./class-edit-page'),
       'class-enroll-page': require('./class-enroll-page'),
       'core-base': require('kolibri.coreVue.components.coreBase'),
@@ -92,9 +88,5 @@
     background-color: $core-bg-light
     margin-top: 1em
     border-radius: $radius
-
-  .login-message
-    text-align: center
-    margin-top: 200px
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -49,10 +49,7 @@
         </table>
       </div>
     </template>
-    <template v-else>
-      {{ $tr('notAdmin') }}
-    </template>
-
+    <auth-message v-else :command="$tr('notAdmin')" />
 
   </div>
 
@@ -76,6 +73,7 @@
       notAdmin: 'You need to sign in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
     },
     components: {
+      'auth-message': require('kolibri.coreVue.components.authMessage'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
       'task-status': require('./task-status'),
       'wizard-import-source': require('./wizard-import-source'),

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -49,7 +49,7 @@
         </table>
       </div>
     </template>
-    <auth-message v-else :command="$tr('notAdmin')" />
+    <auth-message v-else :details="$tr('notAdmin')" />
 
   </div>
 

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -49,7 +49,7 @@
         </table>
       </div>
     </template>
-    <auth-message v-else :details="$tr('notAdmin')" />
+    <auth-message v-else :header="$tr('notAdminHeader')" :details="$tr('notAdminDetails')" />
 
   </div>
 
@@ -70,7 +70,8 @@
       import: 'Import',
       export: 'Export',
       noChannels: 'No channels installed',
-      notAdmin: 'You need to sign in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
+      notAdminHeader: 'You need to sign in as the Device Owner to manage content',
+      notAdminDetails: 'The Device Owner is the account originally created in the Setup Wizard',
     },
     components: {
       'auth-message': require('kolibri.coreVue.components.authMessage'),


### PR DESCRIPTION
Fixes #1365 

This adds an `auth-message` ("Authorization Message") component that replaces the HTML that has been copy-pasted in different places.

## Simple case

Default header and details message following a formula

http://github.com/jonboiser/kolibri/blob/c79358241d4cce5c21a0a4a66a9379efa467f6ac/kolibri/plugins/coach/assets/src/views/index.vue#L19
```
<auth-message v-else authorizedRole="admin_or_coach" />
```

<img width="500" alt="screen shot 2017-05-11 at 1 23 38 pm" src="https://cloud.githubusercontent.com/assets/10248067/25962774/123fe458-364d-11e7-9b42-da687b69beb7.png">

## Override the default message
http://github.com/jonboiser/kolibri/blob/c79358241d4cce5c21a0a4a66a9379efa467f6ac/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue#L52

```
<auth-message v-else :header="$tr('notAdminHeader')" :details="$tr('notAdminDetails')" />
```

<img width="500" alt="screen shot 2017-05-11 at 1 13 28 pm" src="https://cloud.githubusercontent.com/assets/10248067/25962932/8e9b2148-364d-11e7-9a15-265a932b61f7.png">

