### PR TITLE
Points overlay rework

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -222,7 +222,7 @@ class ContentNodeViewset(viewsets.ModelViewSet):
         next_item = models.ContentNode.objects.filter(tree_id=this_item.tree_id, lft__gt=this_item.rght).order_by("lft").first()
         if not next_item:
             next_item = this_item.get_root()
-        return Response({'kind': next_item.kind, 'id': next_item.id})
+        return Response({'kind': next_item.kind, 'id': next_item.id, 'title': next_item.title})
 
 
 class FileViewset(viewsets.ModelViewSet):

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
@@ -101,8 +101,8 @@
     vuex: {
       getters: {
         pageMode: getters.pageMode,
-        topicCrumbs: state => state.pageState.topic.breadcrumbs,
-        contentCrumbs: state => state.pageState.content.breadcrumbs,
+        topicCrumbs: state => (state.pageState.topic || {}).breadcrumbs || [],
+        contentCrumbs: state => (state.pageState.content || {}).breadcrumbs || [],
         topicParent: state => state.pageState.topic.parent,
         contentParent: state => state.pageState.content.parent,
         pageName: state => state.pageName,

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -3,9 +3,6 @@
   <div>
 
     <page-header :title="content.title">
-      <content-points
-        slot="end-header"
-        :showPopover="progress >= 1 && wasIncomplete"/>
     </page-header>
 
     <content-renderer
@@ -24,7 +21,7 @@
       :available="content.available"
       :extraFields="content.extra_fields"
       :initSession="initSession">
-      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn" :text="$tr('nextContent')" alignment="right">
+      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
         <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
       </icon-button>
     </content-renderer>
@@ -45,7 +42,7 @@
       :available="content.available"
       :extraFields="content.extra_fields"
       :initSession="initSession">
-      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn" :text="$tr('nextContent')" alignment="right">
+      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
         <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
       </icon-button>
     </assessment-wrapper>
@@ -86,6 +83,17 @@
       :title="recommendedText"
       :contents="recommended"/>
 
+    <content-points
+      v-if="progress >= 1 && wasIncomplete"
+      @close="closeModal"
+      :kind="content.next_content.kind"
+      :title="content.next_content.title">
+
+      <icon-button slot="nextItemBtn" @click="nextContentClicked" class="next-btn" :text="$tr('nextContent')" alignment="right">
+        <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
+      </icon-button>
+    </content-points>
+
   </div>
 
 </template>
@@ -125,10 +133,7 @@
         return false;
       },
       showNextBtn() {
-        if (this.content && this.nextContentLink) {
-          return this.content.kind === ContentNodeKinds.EXERCISE;
-        }
-        return false;
+        return (this.content && this.nextContentLink);
       },
       recommendedText() {
         return this.$tr('recommended');
@@ -179,6 +184,9 @@
       updateProgress(progressPercent, forceSave = false) {
         const summaryProgress = this.updateProgressAction(progressPercent, forceSave);
         updateContentNodeProgress(this.channelId, this.contentNodeId, summaryProgress);
+      },
+      closeModal() {
+        this.wasIncomplete = false;
       },
     },
     beforeDestroy() {
@@ -233,14 +241,15 @@
     background-color: #4A8DDC
     border-color: #4A8DDC
     color: $core-bg-light
-    float: right
-    margin-right: 1.5em
     &:hover
       &:not(.is-disabled)
         background-color: #336db1
 
   .next-btn:hover svg
     fill: $core-bg-light
+
+  .right
+    float: right
 
   .right-arrow
     fill: $core-bg-light

--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -1,29 +1,35 @@
 <template>
 
-  <div>
-    <transition name="popup">
-      <div v-if="popoverShown" class="popover-container">
-        <div class="popover">
-          <div class="content">
-            <div class="topline">
+  <transition name="popup">
+    <div class="popover-container">
+      <div class="popover">
+        <div class="content">
+          <span class="encourage">{{ $tr('niceWork') }}</span>
+          <div class="points-wrapper">
+            <div class="points">
               <points-icon class="popover-icon" :active="true"/>
               <span class="plus-points">{{ $tr('plusPoints', { maxPoints }) }}</span>
             </div>
-            <span class="encourage">{{ $tr('niceWork') }}</span>
           </div>
-          <ui-close-button
-              size="small"
-              @click="closePopover"
-              class="close"
-          ></ui-close-button>
+          <div class="description">
+            <div class="item-wrapper">
+              <p class="next-item">{{ $tr('nextContent') }}</p>
+              <div class="content-name">
+                <content-icon class="content-icon" :kind="kind"/>
+                <p>{{ title }}</p>
+              </div>
+            </div>
+          </div>
+          <slot name="nextItemBtn"/>
         </div>
+        <ui-close-button
+            size="small"
+            @click="closePopover"
+            class="close"
+        ></ui-close-button>
       </div>
-    </transition>
-    <div class="points" :style="style">
-      <points-icon class="in-points icon" :active="active"/>
-      <span class="count in-points">{{ $formatNumber(maxPoints) }}</span>
     </div>
-  </div>
+  </transition>
 
 </template>
 
@@ -38,10 +44,12 @@
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
       niceWork: 'Nice work. Keep it up!',
+      nextContent: 'Next item',
     },
     components: {
       'points-icon': require('kolibri.coreVue.components.pointsIcon'),
       'ui-close-button': require('keen-ui/src/UiCloseButton'),
+      'content-icon': require('kolibri.coreVue.components.contentIcon'),
     },
     vuex: {
       getters: {
@@ -49,46 +57,22 @@
       },
     },
     props: {
-      showPopover: {
-        type: Boolean,
-        default: false,
+      kind: {
+        type: String,
+      },
+      title: {
+        type: String,
       },
     },
-    watch: {
-      popoverShown: 'popOverSetTime',
-    },
-    data: () => ({
-      internalPopoverShown: true,
-    }),
     computed: {
       maxPoints() {
         return MaxPointsPerContent;
       },
-      active() {
-        return this.contentPoints === this.maxPoints;
-      },
-      style() {
-        if (this.active) {
-          return {};
-        }
-        return {
-          color: 'grey',
-          boxShadow: 'inset 1px 1px 3px 1px #b3b3b3',
-        };
-      },
-      popoverShown() {
-        return this.showPopover && this.internalPopoverShown;
-      },
     },
     methods: {
       closePopover() {
-        this.internalPopoverShown = false;
+        this.$emit('close');
       },
-      popOverSetTime(newVal, oldVal) {
-        if (newVal === true && oldVal !== true) {
-          setTimeout(this.closePopover, 5000);
-        }
-      }
     },
   };
 
@@ -99,30 +83,11 @@
 
   @require '~kolibri.styles.definitions'
 
-  .points
-    display: inline-block
-    font-weight: bold
-    background-color: #EEEEEE
-    color: $core-accent-color
-    padding: 10px
-
-    .in-points
-      display: table-cell
-      vertical-align: middle
-
-  .icon
-    width: 30px
-    height: 30px
-
-  .count
-    padding-left: 5px
-    font-size: 25px
-
   .popover-container
-    position: absolute
+    position: fixed
     height: 0
-    right: 5%
-    top: 15%
+    left: 10%
+    top: 10%
 
   .popover
     background-color: $core-bg-canvas
@@ -132,8 +97,8 @@
 
   .popover-icon
     float: left
-    width: 20px
-    height: 20px
+    width: 30px
+    height: 30px
 
   .plus-points
     padding-left: 5px
@@ -141,18 +106,24 @@
     font-weight: bold
     color: $core-correct-color
 
-  .topline
-    padding-bottom: 5px
-    clearfix()
+  .points-wrapper
+    margin: 2em
+    text-align: center
+
+  .points
+    display: inline-block
 
   .encourage
-    color: $core-text-annotation
-    font-size: 0.9em
+    color: $core-correct-color
+    font-size: 1.5em
     font-weight: bold
+    margin: auto 3em
 
   .content
     display: inline-table
     margin-right: 10px
+    padding-top: 0.5em
+    text-align: center
 
   .close
     float: right
@@ -168,5 +139,27 @@
   .popup-leave-active
     top: 5%
     opacity: 0
+
+  .content-icon
+    float: left
+    font-size: 1.5em
+    line-height: 0
+    margin-right: 0.5em
+
+  .item-wrapper
+    text-align: left
+    display: inline-block
+
+  .next-item
+    color: $core-accent-color
+    font-weight: bold
+    font-size: 0.9em
+
+  .content-name
+    color: $core-text-annotation
+    font-size: 0.9em
+
+  .description
+    width: 400px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -84,14 +84,13 @@
   @require '~kolibri.styles.definitions'
 
   .popover-container
-    position: fixed
+    position: absolute
     height: 0
     left: 10%
-    top: 10%
+    top: 50%
 
   .popover
     background-color: $core-bg-canvas
-    border-left: $core-correct-color solid 3px
     padding: 10px 15px 5px
     box-shadow: grey 2px 2px 5px 1px
 
@@ -148,7 +147,7 @@
 
   .item-wrapper
     text-align: left
-    display: inline-block
+    margin-left: 1em
 
   .next-item
     color: $core-accent-color

--- a/kolibri/plugins/learn/assets/src/views/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header/index.vue
@@ -24,7 +24,6 @@
 
   module.exports = {
     components: {
-      'content-icon': require('kolibri.coreVue.components.contentIcon'),
       'progress-icon': require('kolibri.coreVue.components.progressIcon'),
     },
     props: {


### PR DESCRIPTION
## Summary

Gets rid of the points display per content, and reworks the overlay that appears once completed in order to more heavily indicate to the user that they have finished.

MMVP implementation of this design https://cloud.githubusercontent.com/assets/25045166/26118317/4fdd576c-3a1e-11e7-9e5f-1d519045ea6e.png by @khangmach.

Currently optimized for display on 7" tablets as a priority for 0.4.x - will need more responsive design implementation going forwards, and can be updated to properly implement the design for 0.6.x.

Fixes #1478
Fixes #1471

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/26178285/360b62a8-3b12-11e7-8081-3d3149815917.png)

