### PR TITLE
Center text, increase z-index of points popover.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -7,8 +7,7 @@
           <ui-close-button
               size="small"
               @click="closePopover"
-              class="close"
-          ></ui-close-button>
+              class="close"/>
           <span class="encourage">{{ $tr('niceWork') }}</span>
           <div class="points-wrapper">
             <div class="points">
@@ -88,7 +87,7 @@
     height: 0
     left: 10%
     top: 50%
-    z-index: 1000
+    z-index: 24
 
   .popover
     background-color: $core-bg-canvas

--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -4,6 +4,11 @@
     <div class="popover-container">
       <div class="popover">
         <div class="content">
+          <ui-close-button
+              size="small"
+              @click="closePopover"
+              class="close"
+          ></ui-close-button>
           <span class="encourage">{{ $tr('niceWork') }}</span>
           <div class="points-wrapper">
             <div class="points">
@@ -22,11 +27,6 @@
           </div>
           <slot name="nextItemBtn"/>
         </div>
-        <ui-close-button
-            size="small"
-            @click="closePopover"
-            class="close"
-        ></ui-close-button>
       </div>
     </div>
   </transition>
@@ -88,6 +88,7 @@
     height: 0
     left: 10%
     top: 50%
+    z-index: 1000
 
   .popover
     background-color: $core-bg-canvas
@@ -125,8 +126,9 @@
     text-align: center
 
   .close
-    float: right
-    display: inline-table
+    position: absolute
+    right: 10px
+    top: 10px
 
   .popup-enter-active, .popup-leave-active
     transition: all 0.3s ease

--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -114,7 +114,7 @@
     display: inline-block
 
   .encourage
-    color: $core-correct-color
+    color: $core-text-default
     font-size: 1.5em
     font-weight: bold
     margin: auto 3em


### PR DESCRIPTION
## Summary

Small stylistic improvements to points popover as suggested in https://github.com/learningequality/kolibri/issues/1471#issuecomment-302317017

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/26214019/cdf2c820-3baf-11e7-8caf-4d6a8f60f3c5.png)
