### PR TITLE
Redesigns the grid-item, aka card, & adds color consistency throughout app.

### DIFF
--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -36,7 +36,10 @@ $core-content-document = #ED2828
 $core-content-html5 = #FF8B41
 
 /* Status colors */
-$core-status-progress = #42BCE3
+$core-status-progress = #2196f3
 $core-status-mastered = #E7B92C
-$core-status-correct = #228225
+$core-status-correct = #4caf50
 $core-status-wrong = #DF4D4F
+
+
+$core-grey = #E0E0E0

--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -12,8 +12,6 @@ $core-action-dark = #72486f
 
 $core-accent-color = #996189
 
-$core-correct-color = #0BB120
-
 $core-bg-light = #FFFFFF
 $core-bg-canvas = #F9F9F9
 
@@ -37,7 +35,7 @@ $core-content-html5 = #FF8B41
 
 /* Status colors */
 $core-status-progress = #2196f3
-$core-status-mastered = #E7B92C
+$core-status-mastered = #ffc107
 $core-status-correct = #4caf50
 $core-status-wrong = #DF4D4F
 

--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -26,3 +26,17 @@ $core-bg-warning = #fff3e1
 
 $core-text-error = #b93329
 $core-bg-error = #fee9e7
+
+/* Content type colors */
+$core-content-topic = #262626
+$core-content-exercise = #33A369
+$core-content-video = #3938A5
+$core-content-audio = #E65997
+$core-content-document = #ED2828
+$core-content-html5 = #FF8B41
+
+/* Status colors */
+$core-status-progress = #42BCE3
+$core-status-mastered = #E7B92C
+$core-status-correct = #228225
+$core-status-wrong = #DF4D4F

--- a/kolibri/core/assets/src/views/error-box/index.vue
+++ b/kolibri/core/assets/src/views/error-box/index.vue
@@ -73,6 +73,6 @@
     font-size: 10px
     border: 1px solid black
     background-color: white
-    color: black
+    color: $core-text-default
 
 </style>

--- a/kolibri/core/assets/src/views/progress-bar/index.vue
+++ b/kolibri/core/assets/src/views/progress-bar/index.vue
@@ -64,7 +64,7 @@
     width: 100%
     max-width: 125px
     height: 1.2em
-    background-color: #E0E0E0
+    background-color: $core-grey
     border-radius: 15px
     float: left
     margin-right: 5px

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -57,6 +57,8 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.definitions'
+
   .inprogress, .completed
     border-radius: 50%
     color: white

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -64,9 +64,9 @@
 
 
   .inprogress
-    background-color: #2196f3
+    background-color: $core-status-progress
 
   .completed
-    background-color: #4caf50
+    background-color: $core-status-correct
 
 </style>

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -10,7 +10,7 @@
     <ui-icon
       v-else-if="isCompleted"
       :ariaLabel="$tr('completed')"
-      icon="check"
+      icon="star"
       class="completed"
     />
     <ui-tooltip trigger="progress-icon">
@@ -69,6 +69,6 @@
     background-color: $core-status-progress
 
   .completed
-    background-color: $core-status-correct
+    background-color: $core-status-mastered
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
@@ -109,16 +109,16 @@
     width: 32px
 
   .svg-hint
-    fill: grey
+    fill: $core-text-annotation
 
   .svg-wrong
-    fill: red
+    fill: $core-status-wrong
 
   .svg-correct
-    fill: green
+    fill: $core-status-correct
 
   .svg-noattempt
-    fill: grey
+    fill: $core-text-annotation
 
   li
     clear: both

--- a/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
@@ -163,7 +163,7 @@
     color: $core-action-normal
 
   .icon-inactive
-    color: #9e9e9e
+    color: $core-grey
 
   .col-visibility, .col-action
     text-align: right
@@ -175,6 +175,6 @@
     height: 10px
     width: 10px
     border-radius: 50%
-    background-color: #4caf50
+    background-color: $core-status-correct
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
@@ -163,7 +163,7 @@
     color: $core-action-normal
 
   .icon-inactive
-    color: $core-grey
+    color: $core-text-annotation
 
   .col-visibility, .col-action
     text-align: right

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -189,11 +189,11 @@
     tr
       cursor: pointer
       &:hover
-        background-color: #f1f1f1
+        background-color: $core-grey
 
   thead
     .col-name, .col-username
-      color: #686868
+      color: $core-text-annotation
       font-size: small
 
   .selectedrow

--- a/kolibri/plugins/coach/assets/src/views/interaction-list/interaction-item.vue
+++ b/kolibri/plugins/coach/assets/src/views/interaction-list/interaction-item.vue
@@ -78,12 +78,12 @@
     padding: 2px
 
   .svg-hint
-    fill: grey
+    fill: $core-text-annotation
 
   .svg-wrong
-    fill: red
+    fill: $core-status-wrong
 
   .svg-correct
-    fill: green
+    fill: $core-status-correct
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
@@ -151,7 +151,7 @@
     margin-top: 10px
 
   .in-progress
-    color: #ADADAD
+    color: $core-grey
 
   .svg-item
     display: inline-block

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -397,7 +397,7 @@ oriented data synchronization.
   @require '~kolibri.styles.definitions'
 
   .message
-    color: grey
+    color: $core-text-annotation
     padding: 16px
     font-size: 14px
     @media screen and (max-width: $portrait-breakpoint)
@@ -436,7 +436,7 @@ oriented data synchronization.
       left: 0
 
   #try-again
-    color: #DF0F0F
+    color: $core-text-error
     font-size: 14px
     font-weight: bold
     padding: 16px
@@ -452,14 +452,14 @@ oriented data synchronization.
     background-color: $core-action-normal
 
   .next-question-button
-    background-color: #43A047
+    background-color: $core-status-correct
     &:hover
       &:not(.is-disabled)
         background-color: #2a7d2e
 
   // next-question-button transition effect
   .delay-enter-active
-    background-color: #43A047
+    background-color: $core-status-correct
     transition: background-color 1s
 
   .delay-enter

--- a/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
@@ -3,6 +3,7 @@
   <router-link :to="link" class="card">
 
     <div class="card-thumbnail" :style="backgroundImg">
+      <content-icon v-if="!thumbnail" :kind="kind" class="card-thumbnail-backup"/>
       <div class="card-progress-icon-wrapper">
         <progress-icon :progress="progress"/>
       </div>
@@ -70,7 +71,10 @@
         return this.progress > 0 && this.progress < 1.0;
       },
       backgroundImg() {
-        return { backgroundImage: `url('${this.thumbnail}')` };
+        if (this.thumbnail) {
+          return { backgroundImage: `url('${this.thumbnail}')` };
+        }
+        return {};
       },
       backgroundClass() {
         if (this.kind === 'exercise') {
@@ -128,7 +132,15 @@
     height: $card-thumbnail-height
     background-size: cover
     background-position: center
-    background-color: black
+    background-color: $core-grey
+
+  .card-thumbnail-backup
+    position: absolute
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%)
+    color: $core-text-annotation
+    font-size: ($card-thumbnail-height / 2)
 
   .card-progress-icon-wrapper
     position: absolute

--- a/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
@@ -178,7 +178,7 @@
   .card-progress-bar-wrapper
     position: absolute
     bottom: 0
-    background-color: #e0e0e0
+    background-color: $core-grey
     width: 100%
     height: 5px
 

--- a/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
@@ -7,13 +7,21 @@
         <progress-icon :progress="progress"/>
       </div>
 
-      <div class="card-content-icon-background" :style="contentIconBackground"></div>
+      <div class="card-content-icon-background" :class="backgroundClass"></div>
       <div class="card-content-icon-wrapper">
         <content-icon :kind="kind" class="card-content-icon"/>
       </div>
+
+      <div class="card-progress-bar-wrapper">
+        <div
+          class="card-progress-bar"
+          :style="{ width: `${progress * 100}%` }"
+          :class="{ 'card-progress-bar-mastered': mastered, 'card-progress-bar-progress': inProgress }">
+        </div>
+      </div>
     </div>
 
-    <div class="card-content">
+    <div class="card-text">
       <h3 class="card-title">{{ title }}</h3>
       <h4 class="card-subtitle"></h4>
     </div>
@@ -55,25 +63,28 @@
       },
     },
     computed: {
+      mastered() {
+        return this.progress === 1.0;
+      },
+      inProgress() {
+        return this.progress > 0 && this.progress < 1.0;
+      },
       backgroundImg() {
         return { backgroundImage: `url('${this.thumbnail}')` };
       },
-      contentIconBackground() {
-        let color = '#262626';
-        if (this.kind === 'topics') {
-          color = '#ffca28';
-        } else if (this.kind === 'exercise') {
-          color = '#33A369';
+      backgroundClass() {
+        if (this.kind === 'exercise') {
+          return 'card-content-icon-background-exercise';
         } else if (this.kind === 'video') {
-          color = '#3938A5';
+          return 'card-content-icon-background-video';
         } else if (this.kind === 'audio') {
-          color = '#E65997';
+          return 'card-content-icon-background-audio';
         } else if (this.kind === 'document') {
-          color = '#ED2828';
+          return 'card-content-icon-background-document';
         } else if (this.kind === 'html5') {
-          color = '#FF8B41';
+          return 'card-content-icon-background-html5';
         }
-        return { borderColor: `${color} transparent transparent transparent` };
+        return '';
       },
     },
     components: {
@@ -93,8 +104,8 @@
   $card-height = $card-width
   $card-thumbnail-ratio = (9 / 16)
   $card-thumbnail-height = $card-width * $card-thumbnail-ratio
-  $card-content-height = $card-height - $card-thumbnail-height
-  $card-content-padding = ($card-width / (320 / 24))
+  $card-text-height = $card-height - $card-thumbnail-height
+  $card-text-padding = ($card-width / (320 / 24))
   $card-elevation-resting = 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12)
   $card-elevation-raised = 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2)
 
@@ -134,6 +145,25 @@
     height: 0
     border-style: solid
     border-width: 3.5em 3.5em 0 0
+    border-top-color: $core-content-topic
+    border-right-color: transparent
+    border-bottom-color: transparent
+    border-left-color: transparent
+
+  .card-content-icon-background-exercise
+    border-top-color: $core-content-exercise
+
+  .card-content-icon-background-video
+    border-top-color: $core-content-video
+
+  .card-content-icon-background-audio
+    border-top-color: $core-content-audio
+
+  .card-content-icon-background-document
+    border-top-color: $core-content-document
+
+  .card-content-icon-background-html5
+    border-top-color: $core-content-html5
 
   .card-content-icon-wrapper
     position: absolute
@@ -145,9 +175,25 @@
   .card-content-icon
     font-size: 1.25em
 
-  .card-content
-    padding: $card-content-padding
-    height: $card-content-height
+  .card-progress-bar-wrapper
+    position: absolute
+    bottom: 0
+    background-color: #e0e0e0
+    width: 100%
+    height: 5px
+
+  .card-progress-bar
+    height: 100%
+
+  .card-progress-bar-mastered
+    background-color: $core-status-mastered
+
+  .card-progress-bar-progress
+    background-color: $core-status-progress
+
+  .card-text
+    padding: $card-text-padding
+    height: $card-text-height
     color: $core-text-default
 
   .card-title, .card-subtitle

--- a/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/card-grid/grid-item/index.vue
@@ -1,22 +1,21 @@
 <template>
 
-  <router-link :to="link" class="link-block">
-    <div class="wrapper">
-      <div class="card-thumbnail">
-        <slot/>
-        <div class="progress-icon-wrapper">
-          <progress-icon :progress="progress"/>
-        </div>
+  <router-link :to="link" class="card">
+
+    <div class="card-thumbnail" :style="backgroundImg">
+      <div class="card-progress-icon-wrapper">
+        <progress-icon :progress="progress"/>
       </div>
-      <div class="card-content">
-        <div class="text">
-          <content-icon
-          class="content-icon"
-          v-if="kind"
-          :kind="kind"/>
-          {{ title }}
-        </div>
+
+      <div class="card-content-icon-background" :style="contentIconBackground"></div>
+      <div class="card-content-icon-wrapper">
+        <content-icon :kind="kind" class="card-content-icon"/>
       </div>
+    </div>
+
+    <div class="card-content">
+      <h3 class="card-title">{{ title }}</h3>
+      <h4 class="card-subtitle"></h4>
     </div>
   </router-link>
 
@@ -28,14 +27,14 @@
   const validateLinkObject = require('kolibri.utils.validateLinkObject');
 
   module.exports = {
-    components: {
-      'content-icon': require('kolibri.coreVue.components.contentIcon'),
-      'progress-icon': require('kolibri.coreVue.components.progressIcon'),
-    },
     props: {
       title: {
         type: String,
         required: true,
+      },
+      subtitle: {
+        type: String,
+        required: false,
       },
       kind: {
         type: String,
@@ -50,6 +49,36 @@
         required: true,
         validator: validateLinkObject,
       },
+      thumbnail: {
+        type: String,
+        required: false,
+      },
+    },
+    computed: {
+      backgroundImg() {
+        return { backgroundImage: `url('${this.thumbnail}')` };
+      },
+      contentIconBackground() {
+        let color = '#262626';
+        if (this.kind === 'topics') {
+          color = '#ffca28';
+        } else if (this.kind === 'exercise') {
+          color = '#33A369';
+        } else if (this.kind === 'video') {
+          color = '#3938A5';
+        } else if (this.kind === 'audio') {
+          color = '#E65997';
+        } else if (this.kind === 'document') {
+          color = '#ED2828';
+        } else if (this.kind === 'html5') {
+          color = '#FF8B41';
+        }
+        return { borderColor: `${color} transparent transparent transparent` };
+      },
+    },
+    components: {
+      'content-icon': require('kolibri.coreVue.components.contentIcon'),
+      'progress-icon': require('kolibri.coreVue.components.progressIcon'),
     },
   };
 
@@ -59,57 +88,80 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
-  @require '../../learn.styl'
 
-  $thumb-width = 100px
-
-  .card
-    width: $card-width
-    height: $card-height
-    overflow: hidden
-    background-color: $core-bg-light
-    border-radius: $radius
-
-  .card-thumbnail
-    height: 122px
-    position: relative
-
-  .text
-    -webkit-line-clamp: 3 // Enhance Chrome, doesn't work on other browsers
-    -webkit-box-orient: vertical // Enhance Chrome, doesn't work on other browsers
-    width: auto
-    max-height: 68px
-    margin-left: 35px
-    overflow: hidden
-    font-size: 0.9rem
-    line-height: 1.2rem
-    text-overflow: ellipsis
-    color: $core-text-default
-
-  .content-icon
-    position: absolute
-    left: 10px
-    top: 10px
-    font-size: 1.5em
-
-  .card-content
-    padding: 10px
-    position: relative
+  $card-width = 210px
+  $card-height = $card-width
+  $card-thumbnail-ratio = (9 / 16)
+  $card-thumbnail-height = $card-width * $card-thumbnail-ratio
+  $card-content-height = $card-height - $card-thumbnail-height
+  $card-content-padding = ($card-width / (320 / 24))
+  $card-elevation-resting = 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12)
+  $card-elevation-raised = 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2)
 
   a
     text-decoration: none
 
-  .progress-icon-wrapper
+  .card
+    display: inline-block
+    width: $card-width
+    height: $card-height
+    border-radius: 2px
+    background-color: $core-bg-light
+    box-shadow: $card-elevation-resting
+    &:hover, &:focus
+      box-shadow: $card-elevation-raised
+
+  .card-thumbnail
+    position: relative
+    width: $card-width
+    height: $card-thumbnail-height
+    background-size: cover
+    background-position: center
+    background-color: black
+
+  .card-progress-icon-wrapper
     position: absolute
     top: 0.25em
     right: 0.25em
     width: 1.5em
     height: 1.5em
 
-  .wrapper
-    background-color: $core-bg-light
+  .card-content-icon-background
+    position: absolute
+    top: 0
+    left: 0
+    width: 0
+    height: 0
+    border-style: solid
+    border-width: 3.5em 3.5em 0 0
 
-  .link-block
-    display: block
+  .card-content-icon-wrapper
+    position: absolute
+    top: 0
+    left: 0
+    padding: 0.25em
+    color: white
+
+  .card-content-icon
+    font-size: 1.25em
+
+  .card-content
+    padding: $card-content-padding
+    height: $card-content-height
+    color: $core-text-default
+
+  .card-title, .card-subtitle
+    margin: 0
+
+  .card-title
+    overflow: hidden
+    line-height: ($card-width / (320 / 32))
+    height: ($card-width / (320 / 64))
+    font-size: ($card-width / (320 / 24))
+
+  .card-subtitle
+    padding-top: ($card-width / (320 / 16))
+    font-size: ($card-width / (320 / 14))
+    color: $core-text-annotation
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-grid-item/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-grid-item/index.vue
@@ -1,8 +1,7 @@
 <template>
 
   <div :class="sizeClass">
-    <grid-item :link="link" :title="title" :kind="kind" :progress="progress">
-      <div class="thumbnail" :style="{ 'background-image': thumb }"></div>
+    <grid-item :link="link" :title="title" :kind="kind" :progress="progress" :thumbnail="thumbnail">
     </grid-item>
   </div>
 
@@ -28,6 +27,7 @@
       },
       thumbnail: {
         type: String,
+        required: false,
       },
       kind: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -239,7 +239,7 @@
 
   .next-btn
     background-color: #4A8DDC
-    border-color: #4A8DDC
+    border: none
     color: $core-bg-light
     &:hover
       &:not(.is-disabled)

--- a/kolibri/plugins/learn/assets/src/views/content-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-points/index.vue
@@ -103,7 +103,7 @@
     padding-left: 5px
     font-size: 1.5em
     font-weight: bold
-    color: $core-correct-color
+    color: $core-status-correct
 
   .points-wrapper
     margin: 2em

--- a/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
@@ -94,6 +94,6 @@
     cursor: pointer
 
   .selected
-    background-color: #EDEDED
+    background-color: $core-grey
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/search-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page/index.vue
@@ -38,6 +38,13 @@
         />
         <tab-button
           type="icon-and-title"
+          :title="$tr('audio', { num: audio.length } )"
+          icon="audiotrack"
+          :selected="filter === contentNodeKinds.AUDIO"
+          @click="filter = contentNodeKinds.AUDIO"
+        />
+        <tab-button
+          type="icon-and-title"
           :title="$tr('documents', { num: documents.length } )"
           icon="description"
           :selected="filter === contentNodeKinds.DOCUMENT"
@@ -93,12 +100,14 @@
       content: 'Content',
       exercises: 'Exercises ({ num, number })',
       videos: 'Videos ({ num, number })',
+      audio: 'Audio ({ num, number })',
       topics: 'Topics ({ num, number })',
       documents: 'Documents ({ num, number })',
       html5: 'HTML5 apps ({ num, number })',
       noContent: 'No content matches "{searchTerm}"',
       noExercises: 'No exercises match "{searchTerm}"',
       noVideos: 'No videos match "{searchTerm}"',
+      noAudio: 'No audio matches "{searchTerm}"',
       noTopics: 'No topics match "{searchTerm}"',
       noDocuments: 'No documents match "{searchTerm}"',
       noHtml5: 'No HTML5 apps match "{searchTerm}"',
@@ -131,6 +140,9 @@
       videos() {
         return this.contents.filter(content => content.kind === ContentNodeKinds.VIDEO);
       },
+      audio() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.AUDIO);
+      },
       documents() {
         return this.contents.filter(content => content.kind === ContentNodeKinds.DOCUMENT);
       },
@@ -144,6 +156,8 @@
           return this.exercises;
         } else if (this.filter === ContentNodeKinds.VIDEO) {
           return this.videos;
+        } else if (this.filter === ContentNodeKinds.AUDIO) {
+          return this.audio;
         } else if (this.filter === ContentNodeKinds.DOCUMENT) {
           return this.documents;
         } else if (this.filter === ContentNodeKinds.HTML5) {
@@ -161,6 +175,8 @@
           return this.$tr('noExercises', { searchTerm: this.searchTerm });
         } else if (this.filter === ContentNodeKinds.VIDEO) {
           return this.$tr('noVideos', { searchTerm: this.searchTerm });
+        } else if (this.filter === ContentNodeKinds.AUDIO) {
+          return this.$tr('noAudio', { searchTerm: this.searchTerm });
         } else if (this.filter === ContentNodeKinds.DOCUMENT) {
           return this.$tr('noDocuments', { searchTerm: this.searchTerm });
         } else if (this.filter === ContentNodeKinds.HTML5) {

--- a/kolibri/plugins/learn/assets/src/views/search-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page/index.vue
@@ -123,7 +123,7 @@
         return !this.topics.length && !this.contents.length;
       },
       all() {
-        return this.contents.concat(this.topics);
+        return this.topics.concat(this.contents);
       },
       exercises() {
         return this.contents.filter(content => content.kind === ContentNodeKinds.EXERCISE);

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -375,7 +375,7 @@
 
 
   thead
-    color: #686868
+    color: $core-text-annotation
     font-size: small
 
   tbody

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/index.vue
@@ -171,7 +171,7 @@
     right: 0
 
   .delete-class-button
-    color: red
+    color: $core-text-error
     border: none
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
@@ -339,6 +339,6 @@
     word-break: keep-all
 
   .error
-    color: red
+    color: $core-text-error
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -197,7 +197,7 @@
     height: 2em
 
   .points-num
-    color: #1EB204
+    color: $core-status-correct
     font-size: 3em
     font-weight: bold
 

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -210,6 +210,6 @@
     text-align: center
 
   .sign-in-error
-    color: red
+    color: $core-text-error
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -131,6 +131,8 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.definitions'
+
   $login-overlay = #201A21
   $login-text = #D8D8D8
 


### PR DESCRIPTION
## Summary

* Redesigns the grid-item, aka card
* Adds missing tab for audio within search page
* Adds new colors to definitions and attempts to make use of colors throughout app more consistent.
* **TODOS NOT part of this PR**
  * Also use cards for topics
  * Do not separate topics from contents to keep order.



![pasted_image_at_2017_05_18_02_50_pm_1024](https://cloud.githubusercontent.com/assets/7193975/26225462/24a3aeec-3bdc-11e7-89dc-b2648372e920.png)
