### PR TITLE
Bug fixes for release

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -2,6 +2,8 @@ const logging = require('kolibri.lib.logging').getLogger(__filename);
 const ConditionalPromise = require('./conditionalPromise');
 const find = require('lodash/find');
 const matches = require('lodash/matches');
+const isEqual = require('lodash/isEqual');
+const cloneDeep = require('./cloneDeep');
 
 
 /** Class representing a single API resource object */
@@ -98,7 +100,7 @@ class Model {
         if (this.synced) {
           // Model is synced with the server, so we can do dirty checking.
           Object.keys(attrs).forEach((key) => {
-            if (attrs[key] !== this.attributes[key]) {
+            if (!isEqual(attrs[key], this.attributes[key])) {
               payload[key] = attrs[key];
             }
           });
@@ -211,7 +213,7 @@ class Model {
         attributes[this.resource.idKey] = String(attributes[this.resource.idKey]);
       }
     }
-    Object.assign(this.attributes, attributes);
+    Object.assign(this.attributes, cloneDeep(attributes));
   }
 }
 

--- a/kolibri/core/assets/src/cloneDeep.js
+++ b/kolibri/core/assets/src/cloneDeep.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-use-before-define */
+const cloneArray = (array) => array.map(item => cloneDeep(item));
+
+const cloneObject = (object) => {
+  const clone = {};
+  Object.keys(object).forEach(key => { clone[key] = cloneDeep(object[key]); });
+  return clone;
+};
+
+/* eslint-enable no-use-before-define */
+
+const cloneDeep = (object) => {
+  if (Array.isArray(object)) {
+    // is an array
+    return cloneArray(object);
+  } else if (object && typeof object === 'object' && Object.keys(object).length) {
+    // is an object
+    return cloneObject(object);
+  }
+  // Do not bother converting other values.
+  return object;
+};
+
+module.exports = cloneDeep;

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -157,6 +157,7 @@ LANGUAGES = [
     ('es-es', 'Español'),
     ('fr-fr', 'Français, langue française'),
     ('pt-pt', 'Português'),
+    ('hi-in', 'हिंदी')
 ]
 
 LANGUAGE_CODE = conf.config.get("LANGUAGE_CODE") or "en-us"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.8
+kolibri_exercise_perseus_plugin==0.6.9
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/e964c9e3d8225fddd5fe086ec3fb0cf124fdd52c.zip#egg=morango
 requests-toolbelt==0.7.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,17 +3189,9 @@ lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
-lodash.random@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.random/-/lodash.random-3.2.0.tgz#96e24e763333199130d2c9e2fd57f91703cc262d"
-
 lodash.rest@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
-
-lodash.shuffle@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
 
 lodash.tail@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
## Summary

Adds Hindi to list of allowed languages.

Fixes an issue with setting objects on API Resource models whereby whole objects (including parts of Vuex state) would be copied in, and hence the dirty checking would flag no changes, as the objects had the same reference. Fixed this by first: Doing a deep comparison using lodash `isEqual`, and also cloning any passed in objects when data is set on the model.
This was primarily evidenced in exercises, where the updated interaction_history array was not being saved to the server, as the two Array objects (one in the Vuex state, one in the Resource Model) were actually the same Array object.

Updates the exercise renderer to properly include Hindi translations and add in fix by @DXCanas to make mathquill expression evaluation in perseus exercises work on Android 4.0.0. I made a slight tweak, and rather than using the whole npm babel-polyfill I used the version bundled in the Perseus git repo, which was considerably smaller. If tests show this is insufficient for compatibility, I can revert this change.