### PR TITLE
Reinstates video subtitles

### DIFF
--- a/docs/dev/frontend.rst
+++ b/docs/dev/frontend.rst
@@ -121,7 +121,7 @@ A special kind of Kolibri Module is dedicated to rendering particular content ty
     :members:
     :noindex:
 
-The ``ContentRendererModule`` class has one required property ``getRendererComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``defaultFile`` and ``files`` props, defining the files associated with the piece of content.
+The ``ContentRendererModule`` class has one required property ``getRendererComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``defaultFile``, ``files``, ``supplementaryFiles``, and ``thumbnailFiles`` props, defining the files associated with the piece of content.
 
 .. code-block:: javascript
 

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -20,6 +20,8 @@
         :itemId="itemId"
         :answerState="answerState"
         :allowHints="allowHints"
+        :supplementaryFiles="supplementaryFiles"
+        :thumbnailFiles="thumbnailFiles"
         ref="contentView"
         />
       </div>
@@ -106,6 +108,12 @@
       defaultFile() {
         return this.availableFiles &&
           this.availableFiles.length ? this.availableFiles[0] : undefined;
+      },
+      supplementaryFiles() {
+        return this.files.filter(file => file.supplementary && file.available);
+      },
+      thumbnailFiles() {
+        return this.files.filter(file => file.thumbnail && file.available);
       },
     },
     created() {

--- a/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
@@ -44,6 +44,12 @@
         type: Array,
         required: true,
       },
+      supplementaryFiles: {
+        type: Array,
+      },
+      thumbnailFiles: {
+        type: Array,
+      },
     },
 
     data: () => ({
@@ -56,8 +62,8 @@
     computed: {
       posterSource() {
         const posterFileExtensions = ['png', 'jpg'];
-        const posterArray =
-          this.files.filter(file => posterFileExtensions.some(ext => ext === file.extension));
+        const posterArray = this.thumbnailFiles.filter(
+          file => posterFileExtensions.some(ext => ext === file.extension));
         if (posterArray.length === 0) {
           return '';
         }
@@ -71,7 +77,8 @@
 
       trackSources() {
         const trackFileExtensions = ['vtt'];
-        return this.files.filter(file => trackFileExtensions.some(ext => ext === file.extension));
+        return this.supplementaryFiles.filter(
+          file => trackFileExtensions.some(ext => ext === file.extension));
       },
     },
 


### PR DESCRIPTION
## Summary

Video subtitles was relying on the passed in `files` field, which only passes in non-thumbnail, and non-supplementary files that are currently available.

As such pass in thumbnail and supplementary files through additional props in order to allow them to be used for the basis for captionining.