### PR TITLE
Don’t show tab-links on content unavailable page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -37,7 +37,7 @@
       <a class="points-link" href="/user"><total-points/></a>
     </div>
 
-    <div v-if="!isSearchPage">
+    <div v-if="tabLinksAreVisible" class="tab-links">
       <tabs>
         <tab-link
           type="icon-and-title"
@@ -194,8 +194,11 @@
       searchPage() {
         return { name: PageNames.SEARCH_ROOT };
       },
-      isSearchPage() {
-        return this.pageName === PageNames.SEARCH;
+      tabLinksAreVisible() {
+        return (
+          this.pageName !== PageNames.CONTENT_UNAVAILABLE &&
+          this.pageName !== PageNames.SEARCH
+        );
       },
       recommendedLink() {
         return { name: PageNames.LEARN_CHANNEL, params: { channel_id: this.channelId } };

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -20,6 +20,7 @@ function makeVm(options) {
     components: {
       coreBase,
       'explore-page': '<div>Explore Page</div>',
+      'content-unavailable-page': '<div>Content Unavailable</div>',
     },
     router,
   });
@@ -29,6 +30,7 @@ function makeVm(options) {
 function getElements(vm) {
   return {
     examLink: () => vm.$el.querySelector('li[name="exam-link"]'),
+    tabLinks: () => vm.$el.querySelector('.tab-links'),
   };
 }
 
@@ -41,9 +43,19 @@ describe('learn index', () => {
   const setMemberships = (memberships) => {
     store.state.learnAppState.memberships = memberships;
   };
+  const setPageName = (pageName) => {
+    store.state.pageName = pageName;
+  };
 
   beforeEach(() => {
     store = makeStore();
+  });
+
+  it('there are no tabs if showing content unavailable page', () => {
+    setPageName('CONTENT_UNAVAILABLE');
+    const vm = makeVm({ store });
+    const { tabLinks } = getElements(vm);
+    assert(tabLinks() === null);
   });
 
   it('the exam tab is available if user is logged in and has memberships', () => {


### PR DESCRIPTION
addresses #1518 

This just hides the the tab links if the sub-page is 'content unavailable'. Based on the code, it it seems 'topics', 'exams', 'recommended', etc. are broken when there's no underlying channel anyway.