### PR TITLE
Don't redundantly reset session state when user logs out

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -152,6 +152,10 @@ function handleApiError(store, errorObject) {
   handleError(store, JSON.stringify(errorObject, null, '\t'));
 }
 
+function refreshBrowser(url) {
+  window.location.href = url || window.location.origin;
+}
+
 function kolibriLogin(store, sessionPayload) {
   const coreApp = require('kolibri');
   const SessionResource = coreApp.resources.SessionResource;
@@ -162,9 +166,9 @@ function kolibriLogin(store, sessionPayload) {
     /* Very hacky solution to redirect an admin or superuser to Manage tab on login*/
     if (getters.isSuperuser(store.state) || getters.isAdmin(store.state)) {
       const manageURL = coreApp.urls['kolibri:managementplugin:management']();
-      window.location.href = window.location.origin + manageURL;
+      refreshBrowser(window.location.origin + manageURL);
     } else {
-      window.location.href = window.location.origin;
+      refreshBrowser();
     }
   }).catch(error => {
     if (error.status.code === 401) {
@@ -181,9 +185,8 @@ function kolibriLogout(store) {
   const sessionModel = SessionResource.getModel('current');
   const logoutPromise = sessionModel.delete();
   return logoutPromise.then((response) => {
-    store.dispatch('CORE_CLEAR_SESSION');
     /* Very hacky solution to redirect a user back to Learn tab on logout*/
-    window.location.href = window.location.origin;
+    refreshBrowser();
     coreApp.resources.clearCaches();
   }).catch(error => { handleApiError(store, error); });
 }

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -108,14 +108,9 @@ describe('Vuex store/actions for core module', () => {
         },
         clearCaches: clearCachesSpy,
       };
-      // fake a session
-      store.state.core.session.id = '123';
-      store.state.core.session.username = 'l_organa';
 
       coreActions.kolibriLogout(store)
         .then(() => {
-          assert.equal(store.state.core.session.id, undefined);
-          assert.equal(store.state.core.session.username, '');
           sinon.assert.calledWith(getModelStub, 'current');
           sinon.assert.calledOnce(clearCachesSpy);
         })


### PR DESCRIPTION
Addresses #1408 

The unexpected 'premature logout' seen in the original post is due to dispatching `CORE_CLEAR_SESSION` In the `kolibriLogout` action. However, in the same action, the entire browser is refreshed, which basically has the same effect as resetting the `session` (and every other part) of the store.

Here, I just get rid of the dispatch. When the user clicks logout, nothing happens to the app bar or sidebar, and the browser just refreshes itself.