### PR TITLE
CLI help strings and django argument simplification

### DIFF
--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -168,7 +168,7 @@ Now you should be able to access the server at ``http://127.0.0.1:8000/``.
   Now you can simply use your server's IP from another device in the local network through the port 8000, for example ``http://192.168.1.38:8000/``.
 
 
-In addition to the docs displayed above, you can also run:
+More advanced examples of the ``devserver`` command:
 
 .. code-block:: bash
 

--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -168,6 +168,23 @@ Now you should be able to access the server at ``http://127.0.0.1:8000/``.
   Now you can simply use your server's IP from another device in the local network through the port 8000, for example ``http://192.168.1.38:8000/``.
 
 
+In addition to the docs displayed above, you can also run:
+
+.. code-block:: bash
+
+  # runs the dev server and rebuild client assets when files change
+  kolibri manage devserver --debug -- --webpack
+
+  # runs the dev server and re-run client-side tests when files changes
+  kolibri manage devserver --debug -- --karma
+
+  # runs the dev server and also spawns the qcluster task queue in the background
+  kolibri manage devserver --debug -- --qcluster
+
+  # runs all of the above
+  kolibri manage devserver --debug -- --webpack --karma --qcluster
+
+
 Running the Production Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -26,6 +26,8 @@ user interface tests.
 To run a subset of tests::
 
      $ py.test test/test_kolibri.py
+     $ # ...or with a tox environment
+     $ tox -e 3.5 test/test_kolibri.py
 
 
 JS unit tests

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -1,27 +1,6 @@
 The ``kolibri`` command
 =======================
 
-In addition to the docs displayed below, there are some special forms of the ``kolibri`` command:
-
-.. code-block:: bash
-
-  # runs the dev server and rebuild client assets when files change
-  kolibri manage devserver --debug -- --webpack
-
-  # runs the dev server and re-run client-side tests when files changes
-  kolibri manage devserver --debug -- --karma
-
-  # runs the dev server and also spawns the qcluster task queue in the background
-  kolibri manage devserver --debug -- --qcluster
-
-  # runs all of the above
-  kolibri manage devserver --debug -- --webpack --karma --qcluster
-
-
-.. note::
-
-  The commands above reload the Python code on changes, but they do *not* run python tests.
-
 .. automodule:: kolibri.utils.cli
   :undoc-members:
   :show-inheritance:

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -45,8 +45,8 @@ Usage:
   kolibri stop [options]
   kolibri restart [options]
   kolibri status [options]
-  kolibri shell [options] [-- DJANGO_OPTIONS ...]
-  kolibri manage [options] COMMAND [-- DJANGO_OPTIONS ...]
+  kolibri shell [options]
+  kolibri manage [options] COMMAND [DJANGO_OPTIONS ...]
   kolibri diagnose [options]
   kolibri plugin [options] PLUGIN (enable | disable)
   kolibri language setdefault <langcode>
@@ -60,9 +60,9 @@ Options:
   --debug               Output debug messages (for development)
   COMMAND               The name of any available django manage command. For
                         help, type `kolibri manage help`
-  DJANGO_OPTIONS        All options are passed on to the django manage command.
-                        Notice that all django options must appear *last* and
-                        should not be mixed with other options.
+  DJANGO_OPTIONS        Command options are passed on to the django manage
+                        command. Notice that all django options must appear
+                        *last* and should not be mixed with other options.
 
 Examples:
   kolibri start             Start Kolibri
@@ -286,7 +286,10 @@ def main(args=None):
     # Split out the parts of the argument list that we pass on to Django
     # and don't feed to docopt.
     if '--' in args:
-        # Include "manage COMMAND" for docopt parsing, but split out the rest
+        # At the moment, we keep this for backwards-compatibility and in case there
+        # is a real case of having to force the parsing of DJANGO_OPTIONS to a
+        # specific location. Example:
+        # kolibri manage commandname --non-django-arg -- --django-arg
         pivot = args.index('--')
         args, django_args = args[:pivot], args[pivot + 1:]
     elif 'manage' in args:

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -268,20 +268,16 @@ def set_default_language(lang):
         logging.warning(msg)
 
 
-def main(args=None):
+def parse_args(args=None):
     """
-    Kolibri's main function. Parses arguments and calls utility functions.
-    Utility functions should be callable for unit testing purposes, but remember
-    to use main() for integration tests in order to test the argument API.
-    """
+    Parses arguments by invoking docopt. Arguments for django management
+    commands are split out before returning.
 
-    # ensure that Django is set up before we do anything else
-    django.setup()
+    :returns: (parsed_arguments, raw_django_ars)
+    """
 
     if not args:
         args = sys.argv[1:]
-
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     # Split out the parts of the argument list that we pass on to Django
     # and don't feed to docopt.
@@ -307,7 +303,22 @@ def main(args=None):
     if args:
         docopt_kwargs['argv'] = args
 
-    arguments = docopt(USAGE, **docopt_kwargs)
+    return docopt(USAGE, **docopt_kwargs), django_args
+
+
+def main(args=None):
+    """
+    Kolibri's main function. Parses arguments and calls utility functions.
+    Utility functions should be callable for unit testing purposes, but remember
+    to use main() for integration tests in order to test the argument API.
+    """
+
+    # ensure that Django is set up before we do anything else
+    django.setup()
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    arguments, django_args = parse_args(args)
 
     debug = arguments['--debug']
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -57,8 +57,6 @@ Options:
   COMMAND               The name of any available django manage command. For
                         help, type `kolibri manage help`
   --debug               Output debug messages (for development)
-  --port=<arg>          Use a non-default port on which to start the HTTP server
-                        or to query an existing server (stop/status)
   DJANGO_OPTIONS        All options are passed on to the django manage command.
                         Notice that all django options must appear *last* and
                         should not be mixed with other options.

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -61,8 +61,7 @@ Options:
                         or to query an existing server (stop/status)
   DJANGO_OPTIONS        All options are passed on to the django manage command.
                         Notice that all django options must appear *last* and
-                        should not be mixed with other options. Only long-name
-                        options ('--long-name') are supported.
+                        should not be mixed with other options.
 
 Examples:
   kolibri start             Start Kolibri

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -46,7 +46,8 @@ Usage:
   kolibri restart [options]
   kolibri status [options]
   kolibri shell [options]
-  kolibri manage [options] COMMAND [DJANGO_OPTIONS ...]
+  kolibri manage COMMAND [DJANGO_OPTIONS ...]
+  kolibri manage COMMAND [options] [-- DJANGO_OPTIONS ...]
   kolibri diagnose [options]
   kolibri plugin [options] PLUGIN (enable | disable)
   kolibri language setdefault <langcode>

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -38,9 +38,9 @@ Supported by Foundation for Learning Equality
 www.learningequality.org
 
 Usage:
-  kolibri start [--foreground --watch] [--port=<port>] [options] [-- DJANGO_OPTIONS ...]
-  kolibri stop [options] [-- DJANGO_OPTIONS ...]
-  kolibri restart [options] [-- DJANGO_OPTIONS ...]
+  kolibri start [--foreground --watch] [--port=<port>] [options]
+  kolibri stop [options]
+  kolibri restart [options]
   kolibri status [options]
   kolibri shell [options] [-- DJANGO_OPTIONS ...]
   kolibri manage [options] COMMAND [-- DJANGO_OPTIONS ...]

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-from kolibri.utils.cli import main
+from kolibri.utils import cli
 
 from .base import KolibriTestBase
 
@@ -18,4 +18,34 @@ class TestKolibriCLI(KolibriTestBase):
         logger.debug("This is a unit test in the main Kolibri app space")
         # Test the -h
         with self.assertRaises(SystemExit):
-            main("-h")
+            cli.main("-h")
+        with self.assertRaises(SystemExit):
+            cli.main("--version")
+
+    def test_parsing(self):
+        test_patterns = (
+            (['start'], {'start': True}, []),
+            (['stop'], {'stop': True}, []),
+            (['shell'], {'shell': True}, []),
+            (['manage', 'shell'], {'manage': True, 'COMMAND': 'shell'}, []),
+            (['manage', 'help'], {'manage': True, 'COMMAND': 'help'}, []),
+            (['manage', 'blah'], {'manage': True, 'COMMAND': 'blah'}, []),
+            (
+                ['manage', 'blah', '--debug', '--', '--django-arg'],
+                {'manage': True, 'COMMAND': 'blah', '--debug': True},
+                ['--django-arg']
+            ),
+            (
+                ['manage', 'blah', '--django-arg'],
+                {'manage': True, 'COMMAND': 'blah'},
+                ['--django-arg']
+            ),
+        )
+
+        for p, docopt_expected, django_expected in test_patterns:
+            docopt, django = cli.parse_args(p)
+
+            for k, v in docopt_expected.items():
+                assert docopt[k] == v
+
+            assert django == django_expected

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -4,9 +4,6 @@ Tests for `kolibri` module.
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-import os
-import shutil
-import tempfile
 
 from kolibri.utils.cli import main
 
@@ -17,19 +14,8 @@ logger = logging.getLogger(__name__)
 
 class TestKolibriCLI(KolibriTestBase):
 
-    @classmethod
-    def setup_class(cls):
-        os.environ["KOLIBRI_HOME"] = tempfile.mkdtemp()
-
     def test_cli(self):
         logger.debug("This is a unit test in the main Kolibri app space")
         # Test the -h
         with self.assertRaises(SystemExit):
             main("-h")
-
-    @classmethod
-    def teardown_class(cls):
-        try:
-            shutil.rmtree(os.environ["KOLIBRI_HOME"])
-        except WindowsError as e:
-            logger.debug("Couldn't delete temporary file because\n\t" + str(e))

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
     # Enable the plugins to ensure the configuration is read without error
     kolibri plugin kolibri.plugins.learn enable
     kolibri plugin kolibri.plugins.management enable
-    py.test --cov=kolibri --color=no {posargs}
+    py.test {posargs:--cov=kolibri --color=no}
     rm -r {env:KOLIBRI_HOME}
 
 [testenv:postgres]


### PR DESCRIPTION
## Summary

NB! I'll improve tests for the CLI as well, they're really absent :/

This should once and for all make our CLI nice and clean.

There was a bunch of inaccuracies in the help text as well.

Backwards incompatibility: None. Using `--` is still optional.

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file
- [x] Add an entry to CHANGELOG.rst
- [x] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

Let me know if you spot something I didn't :)

## Issues addressed

#1556
