### PR TITLE
Changes to content icons

### DIFF
--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -19,7 +19,6 @@ $core-text-default = #3A3A3A
 $core-text-annotation = #686868
 $core-text-disabled = #DFDFDF
 
-$core-text-info = #11568e
 $core-bg-warning = #fff3e1
 
 $core-text-error = #b93329
@@ -27,7 +26,7 @@ $core-bg-error = #fee9e7
 
 /* Content type colors */
 $core-content-topic = #262626
-$core-content-exercise = #33A369
+$core-content-exercise = #0eafaf
 $core-content-video = #3938A5
 $core-content-audio = #E65997
 $core-content-document = #ED2828

--- a/kolibri/core/assets/src/views/content-icon/index.vue
+++ b/kolibri/core/assets/src/views/content-icon/index.vue
@@ -4,8 +4,8 @@
     <ui-icon>
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.CHANNEL)"
-        category="action"
-        name="view_module"
+        category="navigation"
+        name="apps"
         :class="[colorClass]"/>
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.TOPIC)"
@@ -25,12 +25,12 @@
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.DOCUMENT)"
         category="action"
-        name="description"
+        name="book"
         :class="[colorClass]"/>
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.EXERCISE)"
-        category="toggle"
-        name="star"
+        category="action"
+        name="assignment"
         :class="[colorClass]"/>
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.HTML5)"

--- a/kolibri/plugins/coach/assets/src/views/top-nav/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/top-nav/index.vue
@@ -28,7 +28,7 @@
     <tab-link
       type="icon-and-title"
       :title="$tr('exams')"
-      icon="assignments"
+      icon="assignment_late"
       :link="examsLink"
     />
   </tabs>

--- a/kolibri/plugins/learn/assets/src/views/channel-switcher/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/channel-switcher/index.vue
@@ -7,7 +7,7 @@
     :displayDisabledAsSelected="true"
     type="primary"
     color="primary"
-    icon="view_module"
+    icon="apps"
     @select="emitSelection"
   />
 

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -11,7 +11,7 @@
       <p v-if="activeExams" class="exams-assigned">{{ $tr('assignedTo', { assigned: activeExams }) }}</p>
       <p v-else class="exams-assigned">{{ $tr('noExams') }}</p>
       <div class="exam-row" v-for="exam in exams">
-        <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment"/>
+        <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment_late"/>
         <h2 class="exam-title">{{ exam.title }}</h2>
         <div class="exam-details" v-if="exam.closed || !exam.active">
           <p class="answer-count">{{ $tr('howManyCorrect', { score: exam.score, outOf: exam.questionCount })}}</p>

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -8,7 +8,7 @@
     <template>
       <div class="container">
         <div class="exam-status-container">
-          <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment"/>
+          <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment_late"/>
           <h1 class="exam-title">{{ exam.title }}</h1>
           <div class="exam-status">
             <p class="questions-answered">{{ $tr('questionsAnswered', { numAnswered: questionsAnswered, numTotal: exam.questionCount }) }}</p>

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -56,7 +56,7 @@
           v-if="isUserLoggedIn && userHasMemberships"
           type="icon-and-title"
           :title="$tr('exams')"
-          icon="assignments"
+          icon="assignment_late"
           :link="examsLink"
         />
       </tabs>

--- a/kolibri/plugins/learn/assets/src/views/search-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page/index.vue
@@ -25,7 +25,7 @@
         <tab-button
           type="icon-and-title"
           :title="$tr('exercises', { num: exercises.length } )"
-          icon="star"
+          icon="assignment"
           :selected="filter === contentNodeKinds.EXERCISE"
           @click="filter = contentNodeKinds.EXERCISE"
         />
@@ -46,7 +46,7 @@
         <tab-button
           type="icon-and-title"
           :title="$tr('documents', { num: documents.length } )"
-          icon="description"
+          icon="book"
           :selected="filter === contentNodeKinds.DOCUMENT"
           @click="filter = contentNodeKinds.DOCUMENT"
         />


### PR DESCRIPTION
## Summary

1. Changes the icon for exercises from `star` to `assignment`, since the star is already used to symbolize 'mastered'.
2. Changes the icon for documents from `description` to `book`.
3. Changes the color of the exercise icon background so it is not too similar to the color that is used to symbolize `complete`.
4. Changes the icon for exams.

### Before

![image](https://cloud.githubusercontent.com/assets/7193975/26653404/debd100e-4607-11e7-940a-df83f932fedf.png)


### After

![image](https://cloud.githubusercontent.com/assets/7193975/26653318/9b369102-4607-11e7-8f38-30b5ce9f21da.png)