### PR TITLE
Add 'drive-list' component and refactor wizards

### DIFF
--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
@@ -10,44 +10,14 @@
     <div class="main">
       <template v-if="!drivesLoading">
         <div class="modal-message">
-          <h2 class="core-text-alert" v-if="noDrives">
-            <mat-svg class="error-svg" category="alert" name="error_outline"/>
-            {{$tr('noDrivesDetected')}}
-          </h2>
-          <template v-else>
-            <h2>{{$tr('drivesFound')}}</h2>
-            <div class="drive-list">
-              <div class="enabled drive-names" v-for="(drive, index) in writableDrives"
-                @click="selectDriveByID(drive.id)">
-                <input
-                  type="radio"
-                  :id="'drive-'+index"
-                  :value="drive.id"
-                  v-model="selectedDrive"
-                  name="drive-select"
-                >
-                <label :for="'drive-'+index">
-                  {{drive.name}}
-                  <br>
-                  <span class="drive-detail">
-                    {{$tr('available')}} {{bytesForHumans(drive.freespace)}}
-                  </span>
-                </label>
-              </div>
-              <div class="disabled drive-names" v-for="(drive, index) in unwritableDrives">
-                <input
-                  type="radio"
-                  disabled
-                  :id="'disabled-drive-'+index"
-                >
-                <label :for="'disabled-drive-'+index">
-                  {{drive.name}}
-                  <br>
-                  <span class="drive-detail">{{$tr('notWritable')}}</span>
-                </label>
-              </div>
-            </div>
-          </template>
+          <drive-list
+            :value="selectedDrive"
+            :drives="wizardState.driveList"
+            :enabledDrivePred="driveIsEnabled"
+            :disabledMsg="$tr('notWritable')"
+            :enabledMsg="formatEnabledMsg"
+            @change="(driveId) => selectedDrive = driveId"
+          />
         </div>
         <div class="refresh-btn-wrapper">
           <icon-button @click="updateWizardLocalDriveList" :disabled="wizardState.busy" :text="$tr('refresh')">
@@ -84,8 +54,6 @@
     $trs: {
       title: 'Export to a Local Drive',
       available: 'Available Storage:',
-      noDrivesDetected: 'No drives were detected:',
-      drivesFound: 'Drives detected:',
       notWritable: 'Not writable',
       cancel: 'Cancel',
       export: 'Export',
@@ -95,44 +63,33 @@
       'core-modal': require('kolibri.coreVue.components.coreModal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
       'loading-spinner': require('kolibri.coreVue.components.loadingSpinner'),
+      'drive-list': require('./wizards/drive-list'),
     },
     data: () => ({
-      selectedDrive: undefined, // used when there's more than one option
+      selectedDrive: '',
     }),
     computed: {
-      noDrives() {
-        return !Array.isArray(this.wizardState.driveList);
-      },
-      driveToUse() {
-        if (this.writableDrives.length === 1) {
-          return this.writableDrives[0].id;
-        }
-        return this.selectedDrive;
-      },
       drivesLoading() {
         return this.wizardState.driveList === null;
       },
-      writableDrives() {
-        return this.wizardState.driveList.filter(
-          (drive) => drive.writable
-        );
-      },
-      unwritableDrives() {
-        return this.wizardState.driveList.filter(
-          (drive) => !drive.writable
-        );
-      },
       canSubmit() {
-        if (this.drivesLoading || this.wizardState.busy) {
-          return false;
-        }
-        return Boolean(this.driveToUse);
+        return (
+          !this.drivesLoading &&
+          !this.wizardState.busy &&
+          this.selectedDrive !== ''
+        );
       },
     },
     methods: {
+      formatEnabledMsg(drive) {
+        return `${this.$tr('available')} ${this.bytesForHumans(drive.freespace)}`;
+      },
+      driveIsEnabled(drive) {
+        return drive.writable;
+      },
       submit() {
         if (this.canSubmit) {
-          this.triggerLocalContentExportTask(this.driveToUse);
+          this.triggerLocalContentExportTask(this.selectedDrive);
         }
       },
       cancel() {
@@ -207,31 +164,6 @@
 
   .modal-message
     margin: 2em 0
-
-  .error-svg
-    margin-right: 0.2em
-    margin-bottom: -6px
-
-  .drive-names
-    padding: 0.6em
-    border: 1px $core-bg-canvas solid
-    label
-      display: inline-table
-      font-size: 0.9em
-    &.disabled
-      color: $core-text-disabled
-    &.enabled
-      &:hover
-        background-color: $core-bg-canvas
-      &, label
-        cursor: pointer
-
-  .drive-list:not(first-child)
-    border-top: none
-
-  .drive-detail
-    color: $core-text-annotation
-    font-size: 0.7em
 
   .button-wrapper
     margin: 1em 0

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
@@ -11,43 +11,13 @@
   >
     <div class="main">
       <template v-if="!drivesLoading">
-        <div class="modal-message">
-          <h2 class="core-text-alert" v-if="noDrives">
-            <mat-svg class="error-svg" category="alert" name="error_outline"/>
-            {{$tr('noDrivesDetected')}}
-          </h2>
-          <template v-else>
-            <h2>{{$tr('drivesFound')}}</h2>
-            <div class="drive-list">
-              <div class="enabled drive-names" v-for="(drive, index) in drivesWithData"
-                @click="selectDriveByID(drive.id)">
-                <input
-                  type="radio"
-                  :id="'drive-'+index"
-                  :value="drive.id"
-                  v-model="selectedDrive"
-                  name="drive-select"
-                >
-                <label :for="'drive-'+index">
-                  {{drive.name}}
-                  <br>
-                </label>
-              </div>
-              <div class="disabled drive-names" v-for="(drive, index) in drivesWithoutData">
-                <input
-                  type="radio"
-                  disabled
-                  :id="'disabled-drive-'+index"
-                >
-                <label :for="'disabled-drive-'+index">
-                  {{drive.name}}
-                  <br>
-                  <span class="drive-detail">{{$tr('incompatible')}}</span>
-                </label>
-              </div>
-            </div>
-          </template>
-        </div>
+        <drive-list
+          :value="selectedDrive"
+          :drives="wizardState.driveList"
+          :enabledDrivePred="driveIsEnabled"
+          :disabledMsg="$tr('incompatible')"
+          @change="(driveId) => selectedDrive = driveId"
+        />
         <div class="refresh-btn-wrapper">
           <icon-button
             :text="$tr('refresh')"
@@ -85,8 +55,6 @@
     $trNameSpace: 'wizardLocalImport',
     $trs: {
       title: 'Import from a Local Drive',
-      noDrivesDetected: 'No drives were detected',
-      drivesFound: 'Drives detected:',
       incompatible: 'No content available',
       refresh: 'Refresh',
       cancel: 'Cancel',
@@ -96,51 +64,32 @@
       'core-modal': require('kolibri.coreVue.components.coreModal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
       'loading-spinner': require('kolibri.coreVue.components.loadingSpinner'),
+      'drive-list': require('./wizards/drive-list'),
     },
     data: () => ({
-      selectedDrive: undefined, // used when there's more than one option
+      selectedDrive: '',
     }),
     computed: {
-      noDrives() {
-        return !Array.isArray(this.wizardState.driveList);
-      },
-      driveToUse() {
-        if (this.drivesWithData.length === 1) {
-          return this.drivesWithData[0].id;
-        }
-        return this.selectedDrive;
-      },
       drivesLoading() {
         return this.wizardState.driveList === null;
       },
-      drivesWithData() {
-        return this.wizardState.driveList.filter(
-          (drive) => drive.metadata.channels.length
-        );
-      },
-      drivesWithoutData() {
-        return this.wizardState.driveList.filter(
-          (drive) => !drive.metadata.channels.length
-        );
-      },
       canSubmit() {
-        if (this.drivesLoading || this.wizardState.busy) {
-          return false;
-        }
-        return Boolean(this.driveToUse);
+        return (
+          !this.drivesLoading &&
+          this.selectedDrive !== '' &&
+          !this.wizardState.busy
+        );
       },
     },
     methods: {
+      driveIsEnabled: (drive) => drive.metadata.channels.length > 0,
       submit() {
-        this.triggerLocalContentImportTask(this.driveToUse);
+        this.triggerLocalContentImportTask(this.selectedDrive);
       },
       cancel() {
         if (!this.wizardState.busy) {
           this.cancelImportExportWizard();
         }
-      },
-      selectDriveByID(driveID) {
-        this.selectedDrive = driveID;
       },
     },
     vuex: {
@@ -179,28 +128,6 @@
   .error-svg
     margin-right: 0.2em
     margin-bottom: -6px
-
-  .drive-names
-    padding: 0.6em
-    border: 1px $core-bg-canvas solid
-    label
-      display: inline-table
-      font-size: 0.9em
-    &.disabled
-      color: $core-text-disabled
-    &.enabled
-      &:hover
-        background-color: $core-bg-canvas
-      &, label
-        cursor: pointer
-
-  .drive-list:not(first-child)
-    border-top: none
-
-  .drive-detail
-    color: $core-text-annotation
-    font-size: 0.7em
-
 
   .button-wrapper
     margin: 1em 0

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
@@ -11,13 +11,15 @@
   >
     <div class="main">
       <template v-if="!drivesLoading">
-        <drive-list
-          :value="selectedDrive"
-          :drives="wizardState.driveList"
-          :enabledDrivePred="driveIsEnabled"
-          :disabledMsg="$tr('incompatible')"
-          @change="(driveId) => selectedDrive = driveId"
-        />
+        <div class="modal-message">
+          <drive-list
+            :value="selectedDrive"
+            :drives="wizardState.driveList"
+            :enabledDrivePred="driveIsEnabled"
+            :disabledMsg="$tr('incompatible')"
+            @change="(driveId) => selectedDrive = driveId"
+          />
+        </div>
         <div class="refresh-btn-wrapper">
           <icon-button
             :text="$tr('refresh')"
@@ -124,10 +126,6 @@
 
   .modal-message
     margin: 2em 0
-
-  .error-svg
-    margin-right: 0.2em
-    margin-bottom: -6px
 
   .button-wrapper
     margin: 1em 0

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/drive-list.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/drive-list.vue
@@ -89,6 +89,10 @@
 
   @require '~kolibri.styles.definitions'
 
+  .error-svg
+    margin-right: 0.2em
+    margin-bottom: -6px
+
   h2
     font-size: 1em
 
@@ -97,7 +101,7 @@
       border-top: none
 
   .drive-list-item
-    padding: 0.6em
+    padding: 1em 0.6em
     font-size: 0.9em
     border: 1px $core-bg-canvas solid
     &-detail

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/drive-list.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/drive-list.vue
@@ -1,0 +1,118 @@
+<template>
+
+  <div class="drive-list">
+    <div v-if="drives.length === 0">
+      <h2 class="core-text-alert">
+        <mat-svg class="error-svg" category="alert" name="error_outline"/>
+        {{ $tr('noDrivesDetected') }}
+      </h2>
+    </div>
+
+    <div v-else>
+      <h2>{{ $tr('drivesFound') }}</h2>
+      <div
+        :name="'drive-'+index"
+        @click="$emit('change', drive.id)"
+        class="drive-list-item drive-list-item-enabled"
+        v-for="(drive, index) in enabledDrives"
+      >
+        <ui-radio
+          :id="'drive-'+index"
+          :trueValue="drive.id"
+          v-model="selectedDrive"
+        >
+          <div class="drive-name">{{ drive.name }}</div>
+          <div v-if="enabledMsg" class="drive-list-item-detail">
+            {{ enabledMsg(drive) }}
+          </div>
+        </ui-radio>
+      </div>
+
+      <div class="drive-list-item drive-list-item-disabled" v-for="(drive, index) in disabledDrives">
+        <ui-radio
+          :id="'disabled-drive-'+index"
+          :trueValue="drive.id"
+          disabled
+          v-model="selectedDrive"
+        >
+          <div>{{ drive.name }}</div>
+          <div class="drive-list-item-detail">
+            {{ disabledMsg }}
+          </div>
+        </ui-radio>
+      </div>
+
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+    components: {
+      UiRadio: require('keen-ui/src/UiRadio'),
+    },
+    props: {
+      value: { type: String, required: true },
+      drives: { type: Array, required: true },
+      // function that partitions drive list in to enabled/disabled
+      enabledDrivePred: { type: Function, required: true },
+      // function that creates a message for enabled drives, takes the drive object as argument
+      enabledMsg: { type: Function },
+      // hard-coded string for disabled drives
+      disabledMsg: { type: String, required: true },
+    },
+    computed: {
+      selectedDrive() {
+        return this.value;
+      },
+      enabledDrives() {
+        return this.drives.filter(drive => this.enabledDrivePred(drive));
+      },
+      disabledDrives() {
+        return this.drives.filter(drive => !this.enabledDrivePred(drive));
+      },
+    },
+    $trNameSpace: 'wizardDriveList',
+    $trs: {
+      drivesFound: 'Drives found:',
+      noDrivesDetected: 'No drives were detected',
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  h2
+    font-size: 1em
+
+  .drive-list
+    &:not(first-child)
+      border-top: none
+
+  .drive-list-item
+    padding: 0.6em
+    font-size: 0.9em
+    border: 1px $core-bg-canvas solid
+    &-detail
+      color: $core-text-annotation
+      font-size: 0.7em
+    &-disabled
+      color: $core-text-disabled
+    &-enabled
+      cursor: pointer
+      &:hover
+        background-color: $core-bg-canvas
+
+  .drive-name
+    font-size: 0.9em
+    & > label
+      cursor: pointer
+
+</style>


### PR DESCRIPTION
This introduces a `drive-list` component that de-duplicates the code in the 'local import' and 'export' wizards that shows the (un)available drives. It's part of the import-export reworking that can be merged in separately without affecting the rest of the app.