### PR TITLE
Reinstates All content section on Learn page

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -218,13 +218,26 @@ class OptionalPageNumberPagination(pagination.PageNumberPagination):
 class AllContentCursorPagination(pagination.CursorPagination):
     page_size = 10
     ordering = 'lft'
+    cursor_query_param = 'cursor'
 
     def get_paginated_response(self, data):
+        """
+        By default the get_paginated_response method of the CursorPagination class returns the url link
+        to the next and previous queries of they exist.
+        For Kolibri this is not very helpful, as we construct our URLs on the client side rather than
+        directly querying passed in URLs.
+        Instead, return the cursor value that points to the next and previous items, so that they can be put
+        in a GET parameter in future queries.
+        """
         if self.has_next:
+            # The CursorPagination class has no internal methods to just return the cursor value, only
+            # the url of the next and previous, so we have to generate the URL, parse it, and then
+            # extract the cursor parameter from it to return in the Response.
             next_item = parse_qs(urlparse(self.get_next_link()).query).get(self.cursor_query_param)
         else:
             next_item = None
         if self.has_previous:
+            # Similarly to next, we have to create the previous link and then parse it to get the cursor value
             prev_item = parse_qs(urlparse(self.get_previous_link()).query).get(self.cursor_query_param)
         else:
             prev_item = None

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -279,6 +279,8 @@ class Collection {
               this.pageCount = Math.ceil(response.entity.count / this.pageSize);
               this.hasNext = Boolean(response.entity.next);
               this.hasPrev = Boolean(response.entity.previous);
+              this.next = response.entity.next;
+              this.previous = response.entity.previous;
               // Mark that the fetch has completed.
               this.synced = true;
             } else {

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -87,12 +87,22 @@ class ContentNodeResource extends Resource {
     }
     return promise;
   }
+  /*
+   * Method to return a collection that queries the all_content list endpoint.
+   * @param resourceIds {Object} the resource ids required for this resource.
+   * @param getParams {Object} any getParams for query - most likely the a cursor
+   * key to query a different page of the all content endpoint by cursor reference.
+   * @return {Collection} returns a collection that will fetch from the all content endpoint.
+   */
   getAllContentCollection(resourceIds = {}, getParams = {}) {
     const filteredResourceIds = this.filterAndCheckResourceIds(resourceIds);
     let collection;
+    // Create a unique cache key so that this collection can be retrieved again with caching.
     const key = this.cacheKey(getParams, { allContent: true }, filteredResourceIds);
     if (!this.collections[key]) {
       collection = this.createCollection(filteredResourceIds, getParams, []);
+      // Edit the url of the collection so that it fetches from the all_content endpoint,
+      // rather than the regular endpoint.
       collection.url = (...args) => this.urls[`${this.name}_all_content`](...args);
     } else {
       collection = this.collections[key];

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -87,6 +87,18 @@ class ContentNodeResource extends Resource {
     }
     return promise;
   }
+  getAllContentCollection(resourceIds = {}, getParams = {}) {
+    const filteredResourceIds = this.filterAndCheckResourceIds(resourceIds);
+    let collection;
+    const key = this.cacheKey(getParams, { allContent: true }, filteredResourceIds);
+    if (!this.collections[key]) {
+      collection = this.createCollection(filteredResourceIds, getParams, []);
+      collection.url = (...args) => this.urls[`${this.name}_all_content`](...args);
+    } else {
+      collection = this.collections[key];
+    }
+    return collection;
+  }
 }
 
 module.exports = ContentNodeResource;

--- a/kolibri/core/assets/src/state/getters.js
+++ b/kolibri/core/assets/src/state/getters.js
@@ -60,9 +60,13 @@ function getDefaultChannelId(channelList) {
   return null;
 }
 
+function getCurrentChannelId(state) {
+  return state.core.channels.currentId;
+}
+
 /* return the current channel object, according to vuex state */
 function getCurrentChannelObject(state) {
-  return state.core.channels.list.find(channel => channel.id === state.core.channels.currentId);
+  return state.core.channels.list.find(channel => channel.id === getCurrentChannelId(state));
 }
 
 function totalPoints(state) {
@@ -82,6 +86,7 @@ module.exports = {
   isCoach,
   isLearner,
   getDefaultChannelId,
+  getCurrentChannelId,
   getCurrentChannelObject,
   currentFacilityId,
   totalPoints,

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -79,8 +79,8 @@ class LearnModule extends KolibriModule {
           name: PageNames.LEARN_CHANNEL,
           path: '/:channel_id/recommended',
           handler: (toRoute, fromRoute) => {
-            const page = toRoute.query.page ? Number(toRoute.query.page) : 1;
-            actions.showLearnChannel(store, toRoute.params.channel_id, page);
+            const cursor = toRoute.query.cursor;
+            actions.showLearnChannel(store, toRoute.params.channel_id, cursor);
           },
         },
         {

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -303,8 +303,9 @@ function showLearnChannel(store, channelId, cursor) {
               resume: resume.map(_contentState),
             },
             all: {
-              content: allContent,
-              pageCount: 1,
+              content: allContent.map(_contentState),
+              next: allContentCollection.next,
+              previous: allContentCollection.previous,
             },
           };
           store.dispatch('SET_PAGE_STATE', pageState);

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -263,7 +263,8 @@ function showLearnChannel(store, channelId, cursor) {
   // Special case for when only the page number changes:
   // Don't set the 'page loading' boolean, to prevent flash and loss of keyboard focus.
   const state = store.state;
-  if (state.pageName !== PageNames.LEARN_CHANNEL || state.currentChannel !== channelId) {
+  if (state.pageName !== PageNames.LEARN_CHANNEL ||
+    coreGetters.getCurrentChannelId(state) !== channelId) {
     store.dispatch('CORE_SET_PAGE_LOADING', true);
   }
   store.dispatch('SET_PAGE_NAME', PageNames.LEARN_CHANNEL);

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -259,7 +259,7 @@ function showExploreContent(store, channelId, id) {
 }
 
 
-function showLearnChannel(store, channelId, page = 1) {
+function showLearnChannel(store, channelId, cursor) {
   // Special case for when only the page number changes:
   // Don't set the 'page loading' boolean, to prevent flash and loss of keyboard focus.
   const state = store.state;
@@ -288,11 +288,14 @@ function showLearnChannel(store, channelId, page = 1) {
         channelPayload, resumePayload).fetch() : Promise.resolve([]);
       const popularPromise = ContentNodeResource.getCollection(
         channelPayload, popularPayload).fetch();
+      const allContentCollection = ContentNodeResource.getAllContentCollection(
+        channelPayload, { cursor });
+      const allContentPromise = allContentCollection.fetch();
       ConditionalPromise.all(
-        [nextStepsPromise, popularPromise, resumePromise]
+        [nextStepsPromise, popularPromise, resumePromise, allContentPromise]
       ).only(
         samePageCheckGenerator(store),
-        ([nextSteps, popular, resume]) => {
+        ([nextSteps, popular, resume, allContent]) => {
           const pageState = {
             recommendations: {
               nextSteps: nextSteps.map(_contentState),
@@ -300,9 +303,8 @@ function showLearnChannel(store, channelId, page = 1) {
               resume: resume.map(_contentState),
             },
             all: {
-              content: [],
+              content: allContent,
               pageCount: 1,
-              page,
             },
           };
           store.dispatch('SET_PAGE_STATE', pageState);

--- a/kolibri/plugins/learn/assets/src/views/learn-page/allcontent.vue
+++ b/kolibri/plugins/learn/assets/src/views/learn-page/allcontent.vue
@@ -47,24 +47,24 @@
         return this.all.content.slice(0, nCols);
       },
       hasNext() {
-        return this.all.page < this.all.pageCount;
+        return Boolean(this.all.next);
       },
       nextPageLink() {
         return {
           name: PageNames.LEARN_CHANNEL,
           channel_id: this.currentChannel,
-          query: { page: this.all.page + 1 },
+          query: { cursor: this.all.next },
           replace: true,
         };
       },
       hasPrev() {
-        return this.all.page > 1;
+        return Boolean(this.all.previous);
       },
       prevPageLink() {
         return {
           name: PageNames.LEARN_CHANNEL,
           channel_id: this.currentChannel,
-          query: { page: this.all.page - 1 },
+          query: { cursor: this.all.previous },
           replace: true,
         };
       },


### PR DESCRIPTION
## Summary

Due to performance issues, the **All content** section of the learn page was removed, as loading a large channel using page limited pagination was exceptionally slow.

This reinstates the All content section of the learn page, and uses cursor based pagination instead, which seems to be somewhat quicker, even on large channels.

As a flyby, it also fixes the flash issue when paging between pages of the all content, because we were checking the incorrect part of the state for the channel id.

## Issues addressed

Fixes #1474.

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/26700119/0a80c298-46d1-11e7-887e-0c13494a4a30.png)

![image](https://cloud.githubusercontent.com/assets/1680573/26700128/156df982-46d1-11e7-93e0-5882626ca563.png)

