### PR TITLE
Basic implementation of the sidenav for the style guide UI

### DIFF
--- a/kolibri/plugins/style_guide/assets/src/app.js
+++ b/kolibri/plugins/style_guide/assets/src/app.js
@@ -1,6 +1,9 @@
 const KolibriModule = require('kolibri_module');
 const Vue = require('kolibri.lib.vue');
 const RootVue = require('./views');
+const VueRouter = require('vue-router');
+const router = require('kolibri.coreVue.router');
+const {navigationMenuRoutes} = require('./views/shell/navigation-menu');
 
 class StyleGuideModule extends KolibriModule {
   ready() {
@@ -8,6 +11,7 @@ class StyleGuideModule extends KolibriModule {
       el: 'rootvue',
       name: 'StyleGuideRoot',
       render: createElement => createElement(RootVue),
+      router: router.init(navigationMenuRoutes)
     });
   }
 }

--- a/kolibri/plugins/style_guide/assets/src/app.js
+++ b/kolibri/plugins/style_guide/assets/src/app.js
@@ -1,9 +1,8 @@
 const KolibriModule = require('kolibri_module');
 const Vue = require('kolibri.lib.vue');
 const RootVue = require('./views');
-const VueRouter = require('vue-router');
 const router = require('kolibri.coreVue.router');
-const {navigationMenuRoutes} = require('./views/shell/navigation-menu');
+const { navigationMenuRoutes } = require('./views/shell/navigation-menu');
 
 class StyleGuideModule extends KolibriModule {
   ready() {

--- a/kolibri/plugins/style_guide/assets/src/views/content/button.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/button.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    Button
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+</style>

--- a/kolibri/plugins/style_guide/assets/src/views/content/tab.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/tab.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    Tab
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+</style>

--- a/kolibri/plugins/style_guide/assets/src/views/content/typography.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/typography.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    Typography
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+</style>

--- a/kolibri/plugins/style_guide/assets/src/views/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/index.vue
@@ -12,7 +12,7 @@
 
   module.exports = {
     components: {
-      'sidenav': require('./shell/sidenav'),
+      sidenav: require('./shell/sidenav'),
     }
   };
 
@@ -23,7 +23,7 @@
 
   @require '~kolibri.styles.definitions'
 
-  sidenav-width = 10em;
+  $sidenav-width = 10em
 
   page-section()
     position: absolute
@@ -36,10 +36,10 @@
   .sidenav
     page-section()
     right: initial
-    width: sidenav-width
+    width: $sidenav-width
 
   .content
     page-section()
-    left: sidenav-width
+    left: $sidenav-width
 
 </style>

--- a/kolibri/plugins/style_guide/assets/src/views/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/index.vue
@@ -1,9 +1,8 @@
 <template>
 
   <div>
-
-    <h1>Style Guide</h1>
-
+    <sidenav class="sidenav"></sidenav>
+    <router-view class="content"></router-view>
   </div>
 
 </template>
@@ -11,7 +10,11 @@
 
 <script>
 
-  module.exports = {};
+  module.exports = {
+    components: {
+      'sidenav': require('./shell/sidenav'),
+    }
+  };
 
 </script>
 
@@ -19,5 +22,24 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
+
+  sidenav-width = 10em;
+
+  page-section()
+    position: absolute
+    top: 0
+    bottom: 0
+    left: 0
+    right: 0
+    overflow-y: auto
+
+  .sidenav
+    page-section()
+    right: initial
+    width: sidenav-width
+
+  .content
+    page-section()
+    left: sidenav-width
 
 </style>

--- a/kolibri/plugins/style_guide/assets/src/views/shell/navigation-menu.js
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/navigation-menu.js
@@ -43,4 +43,4 @@ const navigationMenuRoutes = _.flatten(
     navigationMenu.map(menuSection =>
         menuSection.sectionLinks.map(link => link.linkRoute)));
 
-module.exports = {navigationMenu, navigationMenuRoutes};
+module.exports = { navigationMenu, navigationMenuRoutes };

--- a/kolibri/plugins/style_guide/assets/src/views/shell/navigation-menu.js
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/navigation-menu.js
@@ -1,0 +1,46 @@
+const _ = require('lodash');
+
+// This data structure contains the navigational links pointing to all the
+// content pages in the style guide.
+// Notes: This is view-agnostic; it doesn't make assumption on how it will be
+// rendered (whether it's a side-nav or a horizontal menu).
+const navigationMenu = [
+  {
+    sectionHeading: 'Styles',
+    sectionLinks: [
+      {
+        linkLabel: 'Typography',
+        linkRoute: {
+          path: '/typograhy',
+          component: require('../content/typography')
+        }
+      },
+    ]
+  },
+  {
+    sectionHeading: 'Components',
+    sectionLinks: [
+      {
+        linkLabel: 'Button',
+        linkRoute: {
+          path: '/button',
+          component: require('../content/button')
+        }
+      },
+      {
+        linkLabel: 'Tab',
+        linkRoute: {
+          path: '/tab',
+          component: require('../content/tab')
+        }
+      }
+    ]
+  }
+];
+
+// Extract the routes from the sideNavMenu so they can be added to VueRouter.
+const navigationMenuRoutes = _.flatten(
+    navigationMenu.map(menuSection =>
+        menuSection.sectionLinks.map(link => link.linkRoute)));
+
+module.exports = {navigationMenu, navigationMenuRoutes};

--- a/kolibri/plugins/style_guide/assets/src/views/shell/sidenav.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/sidenav.vue
@@ -1,0 +1,42 @@
+<template>
+
+  <nav class="sidenav">
+
+    <template v-for="menuSection in navigationMenu">
+      <h1>{{ menuSection.sectionHeading }}</h1>
+      <ul>
+        <li v-for="sectionLink in menuSection.sectionLinks">
+          <router-link :to="sectionLink.linkRoute">
+            {{ sectionLink.linkLabel }}
+          </router-link>
+        </li>
+      </ul>
+    </template>
+
+  </nav>
+
+</template>
+
+
+<script>
+  const {navigationMenu} = require('./navigation-menu.js');
+
+  module.exports = {
+    data() {
+      return {
+        navigationMenu
+      }
+    }
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  .sidenav
+    border-right: 1px solid black;
+
+</style>

--- a/kolibri/plugins/style_guide/assets/src/views/shell/sidenav.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/sidenav.vue
@@ -19,13 +19,14 @@
 
 
 <script>
-  const {navigationMenu} = require('./navigation-menu.js');
+
+  const { navigationMenu } = require('./navigation-menu.js');
 
   module.exports = {
     data() {
       return {
         navigationMenu
-      }
+      };
     }
   };
 
@@ -37,6 +38,6 @@
   @require '~kolibri.styles.definitions'
 
   .sidenav
-    border-right: 1px solid black;
+    border-right: 1px solid black
 
 </style>


### PR DESCRIPTION
## Summary

This is the initial sidenav for the style guide UI, including the basic view and routes.

Some skeleton routes have been set up to showcase/test the sidenav functionality, but they are subject to change once we have actual content for the style guide.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1924154/26702686/f585f8d6-46da-11e7-9c45-af521e12d70b.png)

