### PR TITLE
Run yarn install before building frontend assets to ensure dependencies are met.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test-all:
 	tox
 
 assets: staticdeps
+	yarn install
 	yarn run build
 
 coverage:


### PR DESCRIPTION
## Summary

Make our make commands work without any preamble by ensuring all dependencies are installed for appropriate commands.