### PR TITLE
Delete channel content sqlite3 with contentmetadata model

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -31,10 +31,10 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
         return models.ChannelMetadataCache.objects.all()
 
     def destroy(self, request, pk=None):
-        '''
-        Destroys the ChannelMetadata object and also the sqlite3 files on the
-        filesystem.
-        '''
+        """
+        Destroys the ChannelMetadata object and its associated sqlite3 file on
+        the filesystem.
+        """
         super(ChannelMetadataCacheViewSet, self).destroy(request)
 
         if self.delete_content_db_file(pk):
@@ -45,10 +45,8 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
         return Response(response_msg)
 
     def delete_content_db_file(self, channel_id):
-        db_path = get_content_database_file_path(channel_id)
-
         try:
-            os.remove(db_path)
+            os.remove(get_content_database_file_path(channel_id))
             return True
         except OSError:
             return False

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -17,9 +17,11 @@ from .permissions import OnlyDeviceOwnerCanDelete
 from .utils.search import fuzz
 from .utils.paths import get_content_database_file_path
 
+
 def _join_with_logical_operator(lst, operator):
     op = ") {operator} (".format(operator=operator)
     return "(({items}))".format(items=op.join(lst))
+
 
 class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
     permission_classes = (OnlyDeviceOwnerCanDelete,)
@@ -30,7 +32,8 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, pk=None):
         '''
-        Destroys the ChannelMetadata object and also the sqlite3 files on the filesystem.
+        Destroys the ChannelMetadata object and also the sqlite3 files on the
+        filesystem.
         '''
         super(ChannelMetadataCacheViewSet, self).destroy(request)
 

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -13,6 +13,7 @@ from rest_framework import filters, pagination, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
+from .permissions import OnlyDeviceOwnerCanDelete
 from .utils.search import fuzz
 from .utils.paths import get_content_database_file_path
 
@@ -21,6 +22,7 @@ def _join_with_logical_operator(lst, operator):
     return "(({items}))".format(items=op.join(lst))
 
 class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
+    permission_classes = (OnlyDeviceOwnerCanDelete,)
     serializer_class = serializers.ChannelMetadataCacheSerializer
 
     def get_queryset(self):
@@ -45,7 +47,7 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
         try:
             os.remove(db_path)
             return True
-        except OSError, e:
+        except OSError:
             return False
 
 

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -42,10 +42,10 @@ class ChannelMetadataCacheViewSet(viewsets.ModelViewSet):
     def delete_content_db_file(self, channel_id):
         db_path = get_content_database_file_path(channel_id)
 
-        if os.path.isfile(db_path):
+        try:
             os.remove(db_path)
             return True
-        else:
+        except OSError, e:
             return False
 
 

--- a/kolibri/content/permissions.py
+++ b/kolibri/content/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class OnlyDeviceOwnerCanDelete(BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+
+        if request.method == 'DELETE':
+            return request.user.is_superuser

--- a/kolibri/content/permissions.py
+++ b/kolibri/content/permissions.py
@@ -9,3 +9,5 @@ class OnlyDeviceOwnerCanDelete(BasePermission):
 
         if request.method == 'DELETE':
             return request.user.is_superuser
+
+        return False

--- a/kolibri/content/utils/paths.py
+++ b/kolibri/content/utils/paths.py
@@ -28,7 +28,7 @@ def get_content_folder_path(datafolder):
 def get_content_database_folder_path(datafolder=None):
     """
     Returns the path to the content sqlite databases
-    ($HOME/.kolibri/content/databases on POSIX systems)
+    ($HOME/.kolibri/content/databases on POSIX systems, by default)
     """
     return os.path.join(
         get_content_folder_path(datafolder),
@@ -38,7 +38,7 @@ def get_content_database_folder_path(datafolder=None):
 def get_content_database_file_path(channel_id, datafolder=None):
     """
     Given a channel_id, returns the path to the sqlite3 file
-    ($HOME/.kolibri/content/databases/<channel_id>.sqlite3 on POSIX systems)
+    ($HOME/.kolibri/content/databases/<channel_id>.sqlite3 on POSIX systems, by default)
     """
     return os.path.join(
         get_content_database_folder_path(datafolder),

--- a/kolibri/content/utils/paths.py
+++ b/kolibri/content/utils/paths.py
@@ -26,12 +26,20 @@ def get_content_folder_path(datafolder):
     )
 
 def get_content_database_folder_path(datafolder=None):
+    """
+    Returns the path to the content sqlite databases
+    ($HOME/.kolibri/content/databases on POSIX systems)
+    """
     return os.path.join(
         get_content_folder_path(datafolder),
         "databases",
     ) if datafolder else settings.CONTENT_DATABASE_DIR
 
 def get_content_database_file_path(channel_id, datafolder=None):
+    """
+    Given a channel_id, returns the path to the sqlite3 file
+    ($HOME/.kolibri/content/databases/<channel_id>.sqlite3 on POSIX systems)
+    """
     return os.path.join(
         get_content_database_folder_path(datafolder),
         "{}.sqlite3".format(channel_id),


### PR DESCRIPTION
Implements #1495.

When the `ContentMetadataCache` object is deleted via

```
DELETE :8000/api/content/8b4d3e6d3d4842ba8ea658335b5dd252/
```

The corresponding `.sqlite3` file is also deleted from the file system, but not the actual contents (pictures, mp3s, etc.).