### PR TITLE
Add topic progress annotation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changes are ordered reverse-chronologically.
 ---
  - Update all user logging related timestamps to a custom datetime field that includes timezone info
  - Newly imported channels are given a 'last_updated' timestamp
+ - Add progress annotation for topics, lazily loaded to increase page load performance
 
 
 0.4

--- a/kolibri/content/api_urls.py
+++ b/kolibri/content/api_urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from .api import ChannelMetadataCacheViewSet, ContentNodeViewset, FileViewset
+from .api import ChannelMetadataCacheViewSet, ContentNodeProgressViewset, ContentNodeViewset, FileViewset
 
 router = routers.SimpleRouter()
 router.register('content', ChannelMetadataCacheViewSet, base_name="channel")
@@ -9,6 +9,7 @@ router.register('content', ChannelMetadataCacheViewSet, base_name="channel")
 content_router = routers.SimpleRouter()
 content_router.register(r'contentnode', ContentNodeViewset, base_name='contentnode')
 content_router.register(r'file', FileViewset, base_name='file')
+content_router.register(r'contentnodeprogress', ContentNodeProgressViewset, base_name='contentnodeprogress')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -16,6 +16,7 @@ from django.utils.text import get_valid_filename
 from jsonfield import JSONField
 from le_utils.constants import content_kinds, file_formats, format_presets
 from mptt.models import MPTTModel, TreeForeignKey
+from mptt.querysets import TreeQuerySet
 
 from kolibri.core.fields import DateTimeTzField
 from .content_db_router import get_active_content_database, get_content_database_connection
@@ -65,7 +66,7 @@ class UUIDField(models.CharField):
         return value
 
 
-class ContentQuerySet(models.QuerySet):
+class ContentQuerySet(TreeQuerySet):
     """
     Ensure proper database routing happens even when queryset is evaluated lazily outside of `using_content_database`.
     """
@@ -126,7 +127,7 @@ class ContentNode(MPTTModel, ContentDatabaseModel):
     objects = ContentQuerySet.as_manager()
 
     class Meta:
-        ordering = ('sort_order',)
+        ordering = ('lft',)
 
     def __str__(self):
         return self.title

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -90,7 +90,7 @@ class ContentNodeListSerializer(serializers.ListSerializer):
         iterable = data.all() if isinstance(data, Manager) else data
 
         return [
-            self.child.to_representation(item, progress_dict.get(item.content_id)) for item in iterable
+            self.child.to_representation(item, progress_fraction=progress_dict.get(item.content_id, 0)) for item in iterable
         ]
 
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -59,8 +59,10 @@ def get_summary_logs(content_ids, user):
 def get_topic_progress_fraction(topic, user):
     leaf_ids = topic.get_descendants(include_self=False).order_by().exclude(
         kind=content_kinds.TOPIC).values_list("content_id", flat=True)
-    return (get_summary_logs(leaf_ids, user).aggregate(Sum('progress')['progress__sum']) or 0)/(len(leaf_ids) or 1)
-
+    return round(
+        (get_summary_logs(leaf_ids, user).aggregate(Sum('progress'))['progress__sum'] or 0)/(len(leaf_ids) or 1),
+        4
+    )
 
 def get_content_progress_fraction(content, user):
     from kolibri.logger.models import ContentSummaryLog

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -292,8 +292,7 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(self._reverse_channel_url("file-detail", {'pk': "9f9438fe6b0d42dd8e913d7d04cfb2b1"}))
         self.assertEqual(response.data['preset'], 'High Resolution')
 
-    def test_contentnode_progress(self):
-
+    def _setup_contentnode_progress(self):
         # set up data for testing progress_fraction field on content node endpoint
         facility = Facility.objects.create(name="MyFac")
         user = FacilityUser.objects.create(username="learner", facility=facility)
@@ -313,6 +312,12 @@ class ContentNodeAPITestCase(APITestCase):
                 start_timestamp=datetime.datetime.now()
             )
 
+        return facility, root, c1, c2, c2c1, c2c3
+
+    def test_contentnode_progress(self):
+
+        facility, root, c1, c2, c2c1, c2c3 = self._setup_contentnode_progress()
+
         def assert_progress(node, progress):
             response = self.client.get(self._reverse_channel_url("contentnode-detail", {'pk': node.id}))
             self.assertEqual(response.data["progress_fraction"], progress)
@@ -331,6 +336,55 @@ class ContentNodeAPITestCase(APITestCase):
         # Topic so None
         assert_progress(c2, None)
         assert_progress(c2c1, 0.7)
+
+    def test_contentnode_progress_detail_endpoint(self):
+
+        facility, root, c1, c2, c2c1, c2c3 = self._setup_contentnode_progress()
+
+        def assert_progress(node, progress):
+            response = self.client.get(self._reverse_channel_url("contentnodeprogress-detail", {'pk': node.id}))
+            self.assertEqual(response.data["progress_fraction"], progress)
+
+        # check that there is no progress when not logged in
+        assert_progress(root, 0)
+        assert_progress(c1, 0)
+        assert_progress(c2, 0)
+        assert_progress(c2c1, 0)
+
+        # check that progress is calculated appropriately when user is logged in
+        self.client.login(username="learner", password="pass", facility=facility)
+
+        # The progress endpoint is used, so should report progress for topics
+        assert_progress(root, 0.3)
+        assert_progress(c1, 0)
+        assert_progress(c2, 0.4)
+        assert_progress(c2c1, 0.7)
+
+    def test_contentnode_progress_list_endpoint(self):
+
+        facility, root, c1, c2, c2c1, c2c3 = self._setup_contentnode_progress()
+
+        response = self.client.get(self._reverse_channel_url("contentnodeprogress-list"))
+
+        def get_progress_fraction(node):
+            return list(filter(lambda x: x['pk'] == node.pk, response.data))[0]['progress_fraction']
+
+        # check that there is no progress when not logged in
+        self.assertEqual(get_progress_fraction(root), 0)
+        self.assertEqual(get_progress_fraction(c1), 0)
+        self.assertEqual(get_progress_fraction(c2), 0)
+        self.assertEqual(get_progress_fraction(c2c1), 0)
+
+        # check that progress is calculated appropriately when user is logged in
+        self.client.login(username="learner", password="pass", facility=facility)
+
+        response = self.client.get(self._reverse_channel_url("contentnodeprogress-list"))
+
+        # The progress endpoint is used, so should report progress for topics
+        self.assertEqual(get_progress_fraction(root), 0.3)
+        self.assertEqual(get_progress_fraction(c1), 0)
+        self.assertEqual(get_progress_fraction(c2), 0.4)
+        self.assertEqual(get_progress_fraction(c2c1), 0.7)
 
     def tearDown(self):
         """

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -268,9 +268,9 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertTrue("pk" not in response.data)
 
     def test_contentnode_recommendations(self):
-        root_id = content.ContentNode.objects.get(title="root").id
-        response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"recommendations_for": root_id})
-        self.assertEqual(len(response.data), 4)
+        id = content.ContentNode.objects.get(title="c2c2").id
+        response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"recommendations_for": id})
+        self.assertEqual(len(response.data), 2)
 
     def test_channelmetadata_list(self):
         data = content.ChannelMetadata.objects.values()[0]

--- a/kolibri/core/assets/src/api-resources/contentNodeProgress.js
+++ b/kolibri/core/assets/src/api-resources/contentNodeProgress.js
@@ -1,0 +1,17 @@
+const Resource = require('../api-resource').Resource;
+
+class ContentNodeProgressResource extends Resource {
+  static resourceName() {
+    return 'contentnodeprogress';
+  }
+  static idKey() {
+    return 'pk';
+  }
+  static resourceIdentifiers() {
+    return [
+      'channel_id',
+    ];
+  }
+}
+
+module.exports = ContentNodeProgressResource;

--- a/kolibri/core/assets/src/api-resources/index.js
+++ b/kolibri/core/assets/src/api-resources/index.js
@@ -22,4 +22,5 @@ module.exports = {
   ExamAttemptLogResource: require('./examAttemptLog'),
   FacilityDatasetResource: require('./facilityDataset'),
   UserProgressResource: require('./userProgress'),
+  ContentNodeProgressResource: require('./contentNodeProgress'),
 };

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -1,4 +1,5 @@
 const ContentNodeResource = require('kolibri').resources.ContentNodeResource;
+const ContentNodeProgressResource = require('kolibri').resources.ContentNodeProgressResource;
 const SessionResource = require('kolibri').resources.SessionResource;
 const constants = require('../constants');
 const UserExamResource = require('kolibri').resources.UserExamResource;
@@ -33,27 +34,31 @@ function _crumbState(ancestors) {
   }));
 }
 
+function validateProgress(data) {
+  if (!data.progress_fraction) {
+    return 0.0;
+  } else if (data.progress_fraction > 1.0) {
+    return 1.0;
+  }
+  return data.progress_fraction;
+}
 
 function _topicState(data, ancestors = []) {
+  const progress = validateProgress(data);
   const state = {
     id: data.pk,
     title: data.title,
     description: data.description,
     breadcrumbs: _crumbState(ancestors),
     parent: data.parent,
+    kind: data.kind,
+    progress,
   };
   return state;
 }
 
 function _contentState(data, nextContent) {
-  let progress;
-  if (!data.progress_fraction) {
-    progress = 0.0;
-  } else if (data.progress_fraction > 1.0) {
-    progress = 1.0;
-  } else {
-    progress = data.progress_fraction;
-  }
+  const progress = validateProgress(data);
   const thumbnail = data.files.find(file => file.thumbnail && file.available) || {};
   const state = {
     id: data.pk,
@@ -79,13 +84,13 @@ function _contentState(data, nextContent) {
 
 
 function _collectionState(data) {
-  const topics = data
-    .filter((item) => item.kind === CoreConstants.ContentNodeKinds.TOPIC)
-    .map((item) => _topicState(item));
-  const contents = data
-    .filter((item) => item.kind !== CoreConstants.ContentNodeKinds.TOPIC)
-    .map((item) => _contentState(item));
-  return { topics, contents };
+  return data
+    .map((item) => {
+      if (item.kind === CoreConstants.ContentNodeKinds.TOPIC) {
+        return _topicState(item);
+      }
+      return _contentState(item);
+    });
 }
 
 function _examState(data) {
@@ -201,9 +206,19 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
       const pageState = {};
       pageState.topic = _topicState(topic, ancestors);
       const collection = _collectionState(children);
-      pageState.subtopics = collection.topics;
-      pageState.contents = collection.contents;
+      pageState.contents = collection;
       store.dispatch('SET_PAGE_STATE', pageState);
+      // Topics are expensive to compute progress for, so we lazily load progress for them.
+      const subtopicIds = collection.filter(
+        (item) => item.kind === CoreConstants.ContentNodeKinds.TOPIC).map(subtopic => subtopic.id);
+      if (subtopicIds.length) {
+        const topicProgressPromise = ContentNodeProgressResource.getCollection(channelPayload, {
+          ids: subtopicIds,
+        }).fetch();
+        topicProgressPromise.then(progressArray => {
+          store.dispatch('SET_TOPIC_PROGRESS', progressArray);
+        });
+      }
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
       if (isRoot) {

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -16,6 +16,7 @@ const seededShuffle = require('kolibri.lib.seededshuffle');
 const { createQuestionList, selectQuestionFromExercise } = require('kolibri.utils.exams');
 const { assessmentMetaDataState } = require('kolibri.coreVue.vuex.mappers');
 const { now } = require('kolibri.utils.serverClock');
+const uniqBy = require('lodash/uniqBy');
 
 /**
  * Vuex State Mappers
@@ -299,9 +300,12 @@ function showLearnChannel(store, channelId, cursor) {
         ([nextSteps, popular, resume, allContent]) => {
           const pageState = {
             recommendations: {
-              nextSteps: nextSteps.map(_contentState),
-              popular: popular.map(_contentState),
-              resume: resume.map(_contentState),
+              // Hard to guarantee this uniqueness on the database side, so
+              // do a uniqBy content_id here, to prevent confusing repeated
+              // content items.
+              nextSteps: uniqBy(nextSteps, 'content_id').map(_contentState),
+              popular: uniqBy(popular, 'content_id').map(_contentState),
+              resume: uniqBy(resume, 'content_id').map(_contentState),
             },
             all: {
               content: allContent.map(_contentState),

--- a/kolibri/plugins/learn/assets/src/state/store.js
+++ b/kolibri/plugins/learn/assets/src/state/store.js
@@ -42,6 +42,12 @@ const mutations = {
   },
   LEARN_SET_MEMBERSHIPS(state, memberships) {
     state.learnAppState.memberships = memberships;
+  },
+  SET_TOPIC_PROGRESS(state, progressArray) {
+    progressArray.forEach(progress => {
+      const topic = state.pageState.contents.find(subtopic => subtopic.id === progress.pk);
+      topic.progress = progress.progress_fraction;
+    });
   }
 };
 

--- a/kolibri/plugins/learn/assets/src/views/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/explore-page/index.vue
@@ -15,13 +15,6 @@
 
     <span class="visuallyhidden" v-if="subtopics.length">{{ $tr('navigate') }}</span>
 
-    <card-list v-if="subtopics.length">
-      <topic-list-item
-        v-for="topic in subtopics"
-        :title="topic.title"
-        :link="genTopicLink(topic.id)"/>
-    </card-list>
-
     <card-grid v-if="contents.length">
       <content-grid-item
         v-for="content in contents"
@@ -30,7 +23,7 @@
         :thumbnail="content.thumbnail"
         :kind="content.kind"
         :progress="content.progress"
-        :link="genContentLink(content.id)"/>
+        :link="genLink(content)"/>
     </card-grid>
 
   </div>
@@ -42,6 +35,7 @@
 
   const getCurrentChannelObject = require('kolibri.coreVue.vuex.getters').getCurrentChannelObject;
   const PageNames = require('../../constants').PageNames;
+  const ContentNodeKinds = require('kolibri.coreVue.vuex.constants').ContentNodeKinds;
 
   module.exports = {
     $trNameSpace: 'learnExplore',
@@ -60,25 +54,27 @@
       title() {
         return this.isRoot ? this.$tr('explore') : this.topic.title;
       },
+      subtopics() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.TOPIC);
+      },
     },
     methods: {
-      genTopicLink(id) {
+      genLink(node) {
+        if (node.kind !== ContentNodeKinds.TOPIC) {
+          return {
+            name: PageNames.EXPLORE_CONTENT,
+            params: { channel_id: this.channelId, id: node.id },
+          };
+        }
         return {
           name: PageNames.EXPLORE_TOPIC,
-          params: { channel_id: this.channelId, id },
-        };
-      },
-      genContentLink(id) {
-        return {
-          name: PageNames.EXPLORE_CONTENT,
-          params: { channel_id: this.channelId, id },
+          params: { channel_id: this.channelId, id: node.id },
         };
       },
     },
     vuex: {
       getters: {
         topic: state => state.pageState.topic,
-        subtopics: state => state.pageState.subtopics,
         contents: state => state.pageState.contents,
         isRoot: (state) => state.pageState.topic.id === getCurrentChannelObject(state).root_id,
         channelId: (state) => getCurrentChannelObject(state).id,


### PR DESCRIPTION
## Summary

Adds in lazily loadable topic annotation.

Makes recommendation endpoints more efficient along the way.

## TODO

- [x] Have tests been written for the new code?
- [x] Add an entry to CHANGELOG.rst

## Reviewer guidance

Most of the changes here are in the back end, the front end changes are relatively minor and benign.

Currently, this does not do any cache busting, so progress will not update after page navigation.

## Issues addressed

Fixes #1420 

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/26806140/3c86bf8c-4a04-11e7-9191-bac668e370d6.png)
