### PR TITLE
Move points out of app-bar.

### DIFF
--- a/kolibri/core/assets/src/views/dropdown-menu/index.vue
+++ b/kolibri/core/assets/src/views/dropdown-menu/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <span v-if="windowSize.breakpoint > 0">
+    <span v-if="windowSize.breakpoint > 2">
       <ui-button
         :ariaLabel="name"
         :type="type"

--- a/kolibri/core/assets/src/views/tabs/index.vue
+++ b/kolibri/core/assets/src/views/tabs/index.vue
@@ -21,7 +21,6 @@
   @require '~kolibri.styles.definitions'
 
   .tabs
-    background-color: white
     white-space: nowrap
     overflow-x: auto
     overflow-y: hidden

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -215,7 +215,8 @@
         );
       },
       pointsAreVisible() {
-        return this.pageName !== PageNames.SEARCH;
+        return this.windowSize.breakpoint > 0 &&
+          this.pageName !== PageNames.SEARCH;
       },
       recommendedLink() {
         return { name: PageNames.LEARN_CHANNEL, params: { channel_id: this.channelId } };
@@ -300,12 +301,7 @@
     vertical-align: middle
 
   .points-wrapper
-    text-align: right
-    margin-bottom: 1em
+    margin-top: -70px
     float: right
-
-  .tab-links, .points-wrapper
-    display: inline-block
-    vertical-align: middle
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -11,7 +11,8 @@
           :placeholder="$tr('search')"
           v-model="searchQuery"
           class="search-input"
-          :style="searchInputStyle" >
+          :style="searchInputStyle"
+        >
         <ui-icon-button
           :ariaLabel="$tr('clear')"
           icon="clear"

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -10,7 +10,8 @@
           type="search"
           :placeholder="$tr('search')"
           v-model="searchQuery"
-          class="search-input">
+          class="search-input"
+          :style="searchInputStyle" >
         <ui-icon-button
           :ariaLabel="$tr('clear')"
           icon="clear"
@@ -34,7 +35,6 @@
 
       <channel-switcher @switch="switchChannel"/>
 
-      <a class="points-link" href="/user"><total-points/></a>
     </div>
 
     <div v-if="tabLinksAreVisible" class="tab-links">
@@ -62,6 +62,10 @@
       </tabs>
     </div>
 
+    <div v-if="pointsAreVisible" class="points-wrapper">
+      <a class="points-link" href="/user"><total-points/></a>
+    </div>
+
     <div>
       <breadcrumbs/>
       <component :is="currentPage"/>
@@ -79,8 +83,10 @@
   const { PageNames, PageModes } = require('../constants');
   const { TopLevelPageNames } = require('kolibri.coreVue.vuex.constants');
   const { isUserLoggedIn } = require('kolibri.coreVue.vuex.getters');
+  const ResponsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
 
   module.exports = {
+    mixins: [ResponsiveWindow],
     $trNameSpace: 'learn',
     $trs: {
       learnTitle: 'Learn',
@@ -156,6 +162,14 @@
       },
     },
     computed: {
+      searchInputStyle() {
+        if (this.windowSize.breakpoint === 0) {
+          return { width: '40px' };
+        } else if (this.windowSize.breakpoint === 1) {
+          return { width: '150px' };
+        }
+        return {};
+      },
       topLevelPageName() {
         return TopLevelPageNames.LEARN;
       },
@@ -200,6 +214,9 @@
           this.pageName !== PageNames.SEARCH
         );
       },
+      pointsAreVisible() {
+        return this.pageName !== PageNames.SEARCH;
+      },
       recommendedLink() {
         return { name: PageNames.LEARN_CHANNEL, params: { channel_id: this.channelId } };
       },
@@ -240,16 +257,19 @@
     margin: auto
 
   .points-link
-    color: inherit
+    display: inline-block
+    text-decoration: none
 
   .search-box
     display: inline-block
+    margin-left: 0.5em
     background-color: white
 
   .search-input
     background-color: white
     color: $core-text-default
     border: none
+    width: 150px
     height: 36px
     padding: 0
     padding-left: 0.5em
@@ -277,6 +297,15 @@
   .search-submit-button-wrapper
     display: inline-block
     background-color: $core-action-dark
+    vertical-align: middle
+
+  .points-wrapper
+    text-align: right
+    margin-bottom: 1em
+    float: right
+
+  .tab-links, .points-wrapper
+    display: inline-block
     vertical-align: middle
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/total-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points/index.vue
@@ -1,11 +1,11 @@
 <template>
 
   <div v-if="isUserLoggedIn && !isSuperuser" class="points" ref="points">
-    <div class="circle in-points">
-      <points-icon class="icon" :active="true"/>
+    <points-icon class="icon" :active="true"/>
+    <div class="description">
+      <div class="description-value">{{ $formatNumber(totalPoints) }}</div>
     </div>
-    <span class="total in-points">{{ $formatNumber(totalPoints) }}</span>
-    <ui-tooltip trigger="points" :position="'bottom right'" :openOn="'hover focus'">{{ $tr('totalPoints', { points: totalPoints }) }}</ui-tooltip>
+    <ui-tooltip trigger="points" :position="'bottom right'" :openOn="'hover focus'">{{ $tr('pointsTooltip', { points: totalPoints }) }}</ui-tooltip>
   </div>
 
 </template>
@@ -19,7 +19,8 @@
   module.exports = {
     $trNameSpace: 'totalPoints',
     $trs: {
-      totalPoints: 'You have earned { points, number } points!',
+      totalPoints: 'Total points',
+      pointsTooltip: 'You have earned { points, number } points!',
     },
     components: {
       'points-icon': require('kolibri.coreVue.components.pointsIcon'),
@@ -52,25 +53,19 @@
   @require '~kolibri.styles.definitions'
 
   .points
-    display: inline-block
     font-weight: bold
-    .in-points
-      display: inline-block
-
-  .circle
-    border-radius: 50%
-    width: 25px
-    height: 25px
-    background-color: white
+    font-size: small
 
   .icon
-    position: relative
-    top: 2.5px
-    left: 2.5px
+    display: inline-block
     width: 20px
     height: 20px
 
-  .total
-    padding-left: 5px
+  .description
+    display: inline-block
+    padding-left: 0.25em
+
+  .description-value
+    font-size: x-large
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/total-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points/index.vue
@@ -19,7 +19,6 @@
   module.exports = {
     $trNameSpace: 'totalPoints',
     $trs: {
-      totalPoints: 'Total points',
       pointsTooltip: 'You have earned { points, number } points!',
     },
     components: {


### PR DESCRIPTION
## Summary

* Moves points out of app-bar. Not visible on search page as discussed. Hides on smaller screens.
* Removes white background of tabs as discussed.
* Attempts to make app-bar contents more responsive.
* Addresses #1574 

## Before

![127 0 0 1-8000-learn- 2](https://user-images.githubusercontent.com/7193975/26843623-b3cc1d16-4aa5-11e7-82a8-118d0c999ded.png)

![127 0 0 1-8000-learn- 3](https://user-images.githubusercontent.com/7193975/26843617-b00a0cf6-4aa5-11e7-8836-be4bb3842ae8.png)

## After

![127 0 0 1-8000-learn- 1](https://user-images.githubusercontent.com/7193975/26843634-b8d3d40c-4aa5-11e7-9efb-dfc184d36958.png)

![127 0 0 1-8000-learn-](https://user-images.githubusercontent.com/7193975/26843635-b8daf35e-4aa5-11e7-9da1-346a598dadfc.png)
