### PR TITLE
Move channel sorting and empty state into channel-grid

### DIFF
--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -1,7 +1,11 @@
 <template>
 
   <div>
-    <table class="table">
+    <p class="core-text-alert" v-if="sortedChannels.length===0">
+      {{ $tr('emptyChannelListMessage') }}
+    </p>
+
+    <table v-else class="table">
 
       <thead class="table-header">
         <tr>
@@ -14,7 +18,7 @@
       </thead>
 
       <tbody class="table-body">
-        <tr v-for="(channel, idx) in channelList">
+        <tr v-for="(channel, idx) in sortedChannels">
           <td class="table-cell-title">
             {{ channel.title }}
           </td>
@@ -77,6 +81,7 @@
   const manageContentActions = require('../../state/manageContentActions');
   const { now } = require('kolibri.utils.serverClock');
   const map = require('lodash/map');
+  const orderBy = require('lodash/orderBy');
 
   module.exports = {
     data: () => ({
@@ -93,6 +98,13 @@
           return this.channelList[this.selectedChannelIdx].title;
         }
         return '';
+      },
+      sortedChannels() {
+        return orderBy(
+          this.channelList,
+          [channel => channel.title.toUpperCase()],
+          ['asc']
+        );
       },
     },
     components: {
@@ -144,6 +156,7 @@
     },
     $trNameSpace: 'channelsGrid',
     $trs: {
+      emptyChannelListMessage: 'No channels installed',
       deleteButtonLabel: 'Delete',
       lastUpdatedHeader: 'Last updated',
       nameHeader: 'Channel',

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -35,7 +35,6 @@
           </div>
         </div>
         <hr>
-        <p class="core-text-alert" v-if="!sortedChannels.length">{{$tr('noChannels')}}</p>
 
         <channels-grid />
 
@@ -53,7 +52,6 @@
   const isSuperuser = require('kolibri.coreVue.vuex.getters').isSuperuser;
   const actions = require('../../state/actions');
   const ContentWizardPages = require('../../constants').ContentWizardPages;
-  const orderBy = require('lodash/orderBy');
 
   module.exports = {
     $trNameSpace: 'manageContentState',
@@ -61,7 +59,6 @@
       title: 'My channels',
       import: 'Import',
       export: 'Export',
-      noChannels: 'No channels installed',
       notAdminHeader: 'You need to sign in as the Device Owner to manage content',
       notAdminDetails: 'The Device Owner is the account originally created in the Setup Wizard',
     },
@@ -89,13 +86,6 @@
       }
     },
     computed: {
-      sortedChannels() {
-        return orderBy(
-          this.channelList,
-          [channel => channel.title.toUpperCase()],
-          ['asc']
-        );
-      },
       wizardComponent() {
         switch (this.pageState.wizardState.page) {
           case ContentWizardPages.CHOOSE_IMPORT_SOURCE:
@@ -114,7 +104,6 @@
     vuex: {
       getters: {
         isSuperuser,
-        channelList: state => state.core.channels.list,
         pageState: state => state.pageState,
       },
       actions: {


### PR DESCRIPTION
This pulls in more behavior from `manage-content-page` that should have been encapsulated in `channel-grid`.