### PR TITLE
Restore Ctrl-C handler when Transfer closes

### DIFF
--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -45,7 +45,7 @@ class Transfer(object):
         self.finalized = False
         self.closed = False
 
-        signal.signal(signal.SIGINT, self._kill_gracefully)
+        self._old_sigint_handler = signal.signal(signal.SIGINT, self._kill_gracefully)
         signal.signal(signal.SIGTERM, self._kill_gracefully)
 
         assert not os.path.isdir(dest), "dest must include the target filename, not just directory path"
@@ -124,6 +124,7 @@ class Transfer(object):
     def close(self):
         self.dest_file_obj.close()
         self.closed = True
+        signal.signal(signal.SIGINT, self._old_sigint_handler)
 
 
 class FileDownload(Transfer):


### PR DESCRIPTION
Addreses #828 

Adds an extra step to`Transfer.close`, restoring whatever the old handler for `SIGINT` was.

In manual test, it seems to fix the original issue.