### PR TITLE
Remove extra outline for a.tab elements

### DIFF
--- a/kolibri/core/assets/src/views/tab-items.styl
+++ b/kolibri/core/assets/src/views/tab-items.styl
@@ -21,6 +21,7 @@
     &:hover, &:focus
       background-color: $core-action-light
       color: $core-action-normal
+      outline: none
 
   .router-link-active, .tab-selected
     border-bottom-style: solid


### PR DESCRIPTION
This removes the tab elements from getting an extra outline when active and hovered:

## Before
![outline before](https://user-images.githubusercontent.com/10248067/27056735-42a75e92-4f7e-11e7-8b35-e818290373ce.gif)

## After
![outline-after](https://user-images.githubusercontent.com/10248067/27056752-4e347574-4f7e-11e7-8367-7fa0388e348d.gif)
