### PR TITLE
Update channel list and notify user when channel imported successfully

### DIFF
--- a/kolibri/plugins/management/assets/src/constants.js
+++ b/kolibri/plugins/management/assets/src/constants.js
@@ -52,9 +52,12 @@ const defaultFacilityConfig = {
 };
 
 const notificationTypes = {
-  PAGELOAD_FAILURE: 'pageload_failure',
-  SAVE_FAILURE: 'save_failure',
-  SAVE_SUCCESS: 'save_success',
+  PAGELOAD_FAILURE: 'PAGELOAD_FAILURE',
+  SAVE_FAILURE: 'SAVE_FAILURE',
+  SAVE_SUCCESS: 'SAVE_SUCCESS',
+  CHANNEL_DELETE_SUCCESS: 'CHANNEL_DELETE_SUCCESS',
+  CHANNEL_DELETE_FAILURE: 'CHANNEL_DELETE_FAILURE',
+  CHANNEL_IMPORT_SUCCESS: 'CHANNEL_IMPORT_SUCCESS',
 };
 
 module.exports = {

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -8,6 +8,15 @@ const actionTypes = {
 };
 
 /**
+ * Force-refresh the ChannelResource Collection
+ *
+ * @param store
+ */
+function refreshChannelList(store) {
+  return ChannelResource.getCollection().fetch({}, true);
+}
+
+/**
  * Delete a Channel from the device
  *
  * @param store - vuex store object
@@ -16,11 +25,7 @@ const actionTypes = {
  */
 function deleteChannel(store, channelId) {
   return ChannelResource.getModel(channelId).delete()
-  .then(function onSuccess(msg) {
-    // Bust the cache of ChannelResource. Page state should be updated
-    // on next poll.
-    ChannelResource.getCollection().fetch({}, true);
-  });
+  .then(refreshChannelList);
 }
 
 /**
@@ -59,4 +64,5 @@ module.exports = {
   actionTypes,
   addChannelFileSummaries,
   deleteChannel,
+  refreshChannelList,
 };

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -10,7 +10,7 @@ const actionTypes = {
 /**
  * Force-refresh the ChannelResource Collection
  *
- * @param store
+ * @param {Object} store - vuex store object
  */
 function refreshChannelList(store) {
   return ChannelResource.getCollection().fetch({}, true);
@@ -19,7 +19,7 @@ function refreshChannelList(store) {
 /**
  * Delete a Channel from the device
  *
- * @param store - vuex store object
+ * @param {Object} store - vuex store object
  * @param {string} channelId - a valid channel UUID
  * @returns {Promise}
  */
@@ -31,7 +31,7 @@ function deleteChannel(store, channelId) {
 /**
  * Request and hydrate pageState with file summary info for single channel
  *
- * @param store - vuex store object
+ * @param {Object} store - vuex store object
  * @param {string} channelId - channel UUID
  * @returns {Promise}
  */
@@ -50,7 +50,7 @@ function addChannelFileSummary(store, channelId) {
  * Hydrate the manage content pageState with file summary info for all channels.
  * Requests for individual channels are non-blocking.
  *
- * @param store - vuex store object
+ * @param {Object} store - vuex store object
  * @param {Array<String>} channelIds - an array of channelIds
  * @return {undefined}
  */

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -54,28 +54,6 @@
       @confirm="handleDeleteChannel()"
       @cancel="selectedChannelIdx=null"
     />
-
-    <ui-alert
-      v-if="notification==='deleteSuccess'"
-      @dismiss="notification=null"
-      type="success"
-    >
-      {{ $tr('deleteSuccessNotification') }}
-    </ui-alert>
-    <ui-alert
-      v-if="notification==='deleteFailure'"
-      @dismiss="notification=null"
-      type="error"
-    >
-      {{ $tr('deleteFailureNotification') }}
-    </ui-alert>
-    <ui-alert
-      v-if="notification==='importSuccess'"
-      @dismiss="notification=null"
-      type="success"
-    >
-      {{ $tr('successfulImportNotification') }}
-    </ui-alert>
   </div>
 
 </template>
@@ -115,7 +93,6 @@
       },
     },
     components: {
-      'ui-alert': require('keen-ui/src/UiAlert'),
       'ui-button': require('keen-ui/src/UiButton'),
       'ui-progress-circular': require('keen-ui/src/UiProgressCircular'),
       'delete-channel-modal': require('./delete-channel-modal'),
@@ -136,10 +113,10 @@
           this.selectedChannelIdx = null;
           this.deleteChannel(channelId)
           .then(() => {
-            this.notification = 'deleteSuccess';
+            this.$emit('deletesuccess');
           })
           .catch(() => {
-            this.notification = 'deleteFailure';
+            this.$emit('deletefailure');
           });
         }
       },
@@ -174,9 +151,6 @@
       nameHeader: 'Channel',
       numContentsHeader: '# Contents',
       sizeHeader: 'Size',
-      deleteFailureNotification: 'There was a problem deleting this channel',
-      deleteSuccessNotification: 'The channel has been removed from this device',
-      successfulImportNotification: 'A channel has been added to this device',
     }
   };
 

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -33,7 +33,7 @@
             {{ totalSizeOfFilesInChannel(channel.id) }}
           </td>
           <td>
-            {{ lastUpdatedDate(channel) }}
+            <elapsed-time :date="channel.last_updated" />
           </td>
           <td>
             <button
@@ -61,17 +61,14 @@
 
 <script>
 
-  const distanceInWords = require('date-fns/distance_in_words');
   const bytesForHumans = require('./bytesForHumans');
   const manageContentActions = require('../../state/manageContentActions');
-  const { now } = require('kolibri.utils.serverClock');
   const map = require('lodash/map');
   const orderBy = require('lodash/orderBy');
 
   module.exports = {
     data: () => ({
       selectedChannelIdx: null,
-      currentTime: null,
       notification: null,
     }),
     computed: {
@@ -96,9 +93,9 @@
       'ui-button': require('keen-ui/src/UiButton'),
       'ui-progress-circular': require('keen-ui/src/UiProgressCircular'),
       'delete-channel-modal': require('./delete-channel-modal'),
+      'elapsed-time': require('kolibri.coreVue.components.elapsedTime'),
     },
     mounted() {
-      this.currentTime = now();
       this.addChannelFileSummaries(map(this.channelList, 'id'));
     },
     watch: {
@@ -127,9 +124,6 @@
       totalSizeOfFilesInChannel(channelId) {
         const channel = this.channelFileSummaries[channelId];
         return this.channelFileSummaries[channelId] ? bytesForHumans(channel.totalFileSizeInBytes) : '';
-      },
-      lastUpdatedDate(channel) {
-        return distanceInWords(this.currentTime, channel.last_updated, { addSuffix: true });
       },
     },
     vuex: {

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -65,6 +65,13 @@
     >
       {{ $tr('deleteFailureNotification') }}
     </ui-alert>
+    <ui-alert
+      v-if="notification==='importSuccess'"
+      @dismiss="notification=null"
+      type="success"
+    >
+      {{ $tr('successfulImportNotification') }}
+    </ui-alert>
   </div>
 
 </template>
@@ -104,6 +111,11 @@
     mounted() {
       this.currentTime = now();
       this.addChannelFileSummaries(map(this.channelList, 'id'));
+    },
+    watch: {
+      channelList(val, newVal) {
+        this.addChannelFileSummaries(map(newVal, 'id'));
+      }
     },
     methods: {
       handleDeleteChannel() {
@@ -151,6 +163,7 @@
       sizeHeader: 'Size',
       deleteFailureNotification: 'There was a problem deleting this channel',
       deleteSuccessNotification: 'The channel has been removed from this device',
+      successfulImportNotification: 'A channel has been added to this device',
     }
   };
 

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -27,7 +27,7 @@
             <icon-button
               :text="$tr('import')"
               class="button"
-              @click="startImportWizard"
+              @click="openWizard('import')"
               :primary="true">
               <mat-svg category="content" name="add"/>
             </icon-button>
@@ -35,7 +35,7 @@
               :text="$tr('export')"
               class="button"
               :primary="true"
-              @click="startExportWizard">
+              @click="openWizard('export')">
               <ion-svg name="ios-upload-outline"/>
             </icon-button>
           </div>
@@ -94,6 +94,15 @@
       if (this.isSuperuser) {
         clearInterval(this.intervalId);
       }
+    },
+    methods: {
+      openWizard(action) {
+        this.notification = null;
+        if (action === 'import') {
+          return this.startImportWizard();
+        }
+        return this.startExportWizard();
+      },
     },
     computed: {
       notificationTypes: () => notificationTypes,

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -11,6 +11,7 @@
           :status="pageState.taskList[0].status"
           :percentage="pageState.taskList[0].percentage"
           :id="pageState.taskList[0].id"
+          @importsuccess="handleSuccessfulImport"
         />
       </div>
 
@@ -37,7 +38,7 @@
         <hr>
         <p class="core-text-alert" v-if="!sortedChannels.length">{{$tr('noChannels')}}</p>
 
-        <channels-grid />
+        <channels-grid ref="channelGrid" />
 
       </div>
     </template>
@@ -86,6 +87,11 @@
     destroyed() {
       if (this.isSuperuser) {
         clearInterval(this.intervalId);
+      }
+    },
+    methods: {
+      handleSuccessfulImport() {
+        this.$refs.channelGrid.notification = 'importSuccess';
       }
     },
     computed: {

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -11,7 +11,7 @@
           :status="pageState.taskList[0].status"
           :percentage="pageState.taskList[0].percentage"
           :id="pageState.taskList[0].id"
-          @importsuccess="notification='importsuccess'"
+          @importsuccess="notification=notificationTypes.CHANNEL_IMPORT_SUCCESS"
         />
       </div>
 
@@ -38,8 +38,8 @@
         <hr>
 
         <channels-grid
-          @deletefailure="notification='deletefailure'"
-          @deletesuccess="notification='deletesuccess'"
+          @deletesuccess="notification=notificationTypes.CHANNEL_DELETE_SUCCESS"
+          @deletefailure="notification=notificationTypes.CHANNEL_DELETE_FAILURE"
         />
 
         <notifications
@@ -59,7 +59,7 @@
 
   const isSuperuser = require('kolibri.coreVue.vuex.getters').isSuperuser;
   const actions = require('../../state/actions');
-  const ContentWizardPages = require('../../constants').ContentWizardPages;
+  const { ContentWizardPages, notificationTypes } = require('../../constants');
 
   module.exports = {
     $trNameSpace: 'manageContentState',
@@ -96,6 +96,7 @@
       }
     },
     computed: {
+      notificationTypes: () => notificationTypes,
       wizardComponent() {
         switch (this.pageState.wizardState.page) {
           case ContentWizardPages.CHOOSE_IMPORT_SOURCE:

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -15,6 +15,11 @@
         />
       </div>
 
+      <notifications
+        v-bind="{notification}"
+        @dismiss="notification=null"
+      />
+
       <div class="main light-bg">
         <div class="table-title">
           <h1 class="page-title">{{$tr('title')}}</h1>
@@ -40,11 +45,6 @@
         <channels-grid
           @deletesuccess="notification=notificationTypes.CHANNEL_DELETE_SUCCESS"
           @deletefailure="notification=notificationTypes.CHANNEL_DELETE_FAILURE"
-        />
-
-        <notifications
-          v-bind="{notification}"
-          @dismiss="notification=null"
         />
       </div>
     </template>

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/index.vue
@@ -11,7 +11,7 @@
           :status="pageState.taskList[0].status"
           :percentage="pageState.taskList[0].percentage"
           :id="pageState.taskList[0].id"
-          @importsuccess="handleSuccessfulImport"
+          @importsuccess="notification='importsuccess'"
         />
       </div>
 
@@ -37,8 +37,15 @@
         </div>
         <hr>
 
-        <channels-grid ref="channelGrid" />
+        <channels-grid
+          @deletefailure="notification='deletefailure'"
+          @deletesuccess="notification='deletesuccess'"
+        />
 
+        <notifications
+          v-bind="{notification}"
+          @dismiss="notification=null"
+        />
       </div>
     </template>
     <auth-message v-else :header="$tr('notAdminHeader')" :details="$tr('notAdminDetails')" />
@@ -67,6 +74,7 @@
       'auth-message': require('kolibri.coreVue.components.authMessage'),
       'channels-grid': require('./channels-grid'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
+      'notifications': require('./manage-content-notifications'),
       'task-status': require('./task-status'),
       'wizard-import-source': require('./wizard-import-source'),
       'wizard-import-network': require('./wizard-import-network'),
@@ -75,6 +83,7 @@
     },
     data: () => ({
       intervalId: undefined,
+      notification: null,
     }),
     mounted() {
       if (this.isSuperuser) {
@@ -84,11 +93,6 @@
     destroyed() {
       if (this.isSuperuser) {
         clearInterval(this.intervalId);
-      }
-    },
-    methods: {
-      handleSuccessfulImport() {
-        this.$refs.channelGrid.notification = 'importSuccess';
       }
     },
     computed: {

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/manage-content-notifications.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/manage-content-notifications.vue
@@ -1,0 +1,57 @@
+<template>
+
+  <div>
+    <ui-alert
+      type="success"
+      v-if="notification==='deletesuccess'"
+      @dismiss="dismiss()"
+    >
+      {{ $tr('deleteSuccessNotification') }}
+    </ui-alert>
+
+    <ui-alert
+      type="error"
+      v-if="notification==='deletefailure'"
+      @dismiss="dismiss()"
+    >
+      {{ $tr('deleteFailureNotification') }}
+    </ui-alert>
+
+    <ui-alert
+      type="success"
+      v-if="notification==='importsuccess'"
+      @dismiss="dismiss()"
+    >
+      {{ $tr('successfulImportNotification') }}
+    </ui-alert>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+    props: {
+      notification: {
+        type: String,
+        required: false,
+      },
+    },
+    components: {
+      'ui-alert': require('keen-ui/src/UiAlert'),
+    },
+    methods: {
+      dismiss() {
+        this.$emit('dismiss');
+      }
+    },
+    $trNameSpace: 'manageContentPageNotifications',
+    $trs: {
+      deleteFailureNotification: 'There was a problem deleting this channel',
+      deleteSuccessNotification: 'The channel has been removed from this device',
+      successfulImportNotification: 'A channel has been added to this device',
+    },
+  };
+
+</script>

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/manage-content-notifications.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/manage-content-notifications.vue
@@ -3,7 +3,7 @@
   <div>
     <ui-alert
       type="success"
-      v-if="notification==='deletesuccess'"
+      v-if="notification===notificationTypes.CHANNEL_DELETE_SUCCESS"
       @dismiss="dismiss()"
     >
       {{ $tr('deleteSuccessNotification') }}
@@ -11,7 +11,7 @@
 
     <ui-alert
       type="error"
-      v-if="notification==='deletefailure'"
+      v-if="notification===notificationTypes.CHANNEL_DELETE_FAILURE"
       @dismiss="dismiss()"
     >
       {{ $tr('deleteFailureNotification') }}
@@ -19,7 +19,7 @@
 
     <ui-alert
       type="success"
-      v-if="notification==='importsuccess'"
+      v-if="notification===notificationTypes.CHANNEL_IMPORT_SUCCESS"
       @dismiss="dismiss()"
     >
       {{ $tr('successfulImportNotification') }}
@@ -31,6 +31,8 @@
 
 <script>
 
+  const { notificationTypes } = require('../../constants');
+
   module.exports = {
     props: {
       notification: {
@@ -40,6 +42,9 @@
     },
     components: {
       'ui-alert': require('keen-ui/src/UiAlert'),
+    },
+    computed: {
+      notificationTypes: () => notificationTypes,
     },
     methods: {
       dismiss() {

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/task-status.vue
@@ -75,6 +75,7 @@
     methods: {
       clearTaskHandler() {
         if (this.statusSuccess) {
+          this.$emit('importsuccess');
           this.refreshChannelList();
         }
         this.clearTask(this.id);

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/task-status.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/task-status.vue
@@ -13,6 +13,7 @@
 
 <script>
 
+  const manageContentActions = require('../../state/manageContentActions');
   const actions = require('../../state/actions');
   const logging = require('kolibri.lib.logging');
   const constants = require('../../constants');
@@ -73,6 +74,9 @@
     },
     methods: {
       clearTaskHandler() {
+        if (this.statusSuccess) {
+          this.refreshChannelList();
+        }
         this.clearTask(this.id);
       },
     },
@@ -97,6 +101,7 @@
     vuex: {
       actions: {
         clearTask: actions.clearTask,
+        refreshChannelList: manageContentActions.refreshChannelList,
       },
     },
   };

--- a/kolibri/plugins/management/assets/test/state/facilityConfigPageActions.spec.js
+++ b/kolibri/plugins/management/assets/test/state/facilityConfigPageActions.spec.js
@@ -79,7 +79,7 @@ describe('facility config page actions', () => {
       const expectedPageState = {
         facilityName: '',
         settings: null,
-        notification: 'pageload_failure',
+        notification: 'PAGELOAD_FAILURE',
       };
       it('when fetching Facility fails', () => {
         FacilityStub.__getModelFetchReturns('incomprehensible error', true);

--- a/kolibri/plugins/management/assets/test/state/facilityConfigPageActions.spec.js
+++ b/kolibri/plugins/management/assets/test/state/facilityConfigPageActions.spec.js
@@ -130,7 +130,7 @@ describe('facility config page actions', () => {
       .then(() => {
         sinon.assert.calledWith(DatasetStub.getModel, 1000);
         sinon.assert.calledWith(saveStub, sinon.match(expectedRequest));
-        sinon.assert.calledWith(storeMock.dispatch, 'CONFIG_PAGE_NOTIFY', 'save_success');
+        sinon.assert.calledWith(storeMock.dispatch, 'CONFIG_PAGE_NOTIFY', 'SAVE_SUCCESS');
       });
     });
 
@@ -139,7 +139,7 @@ describe('facility config page actions', () => {
       return actions.saveFacilityConfig(storeMock)
       .then(() => {
         sinon.assert.called(saveStub);
-        sinon.assert.calledWith(storeMock.dispatch, 'CONFIG_PAGE_NOTIFY', 'save_failure');
+        sinon.assert.calledWith(storeMock.dispatch, 'CONFIG_PAGE_NOTIFY', 'SAVE_FAILURE');
         sinon.assert.calledWith(storeMock.dispatch, 'CONFIG_PAGE_UNDO_SETTINGS_CHANGE');
       });
     });


### PR DESCRIPTION
Addresses #769 

When an import successfully finished and the user closes the 'task status' widget, then the new channel appears in the channel list along with a notification.

![success notification](https://user-images.githubusercontent.com/10248067/27060762-db6a5d54-4f93-11e7-8ebb-8d38e0473fc1.gif)

![screen shot 2017-06-13 at 4 05 52 pm](https://user-images.githubusercontent.com/10248067/27108505-6bc6b8ca-5052-11e7-93ff-9e7bee361597.png)
