### PR TITLE
Refactor Import/Export wizard flows to use state machine

### DIFF
--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -58,7 +58,9 @@ function addChannelFileSummaries(store, channelIds) {
 }
 
 /**
- * State machine for the Import wizards
+ * State machine for the Import wizards.
+ * Only handles forward, back, and cancel transitions.
+ *
  * @param store - vuex store object
  * @param {string} transition - 'forward', 'back', or 'cancel'
  * @param {Object} params - data needed to execute transition
@@ -77,6 +79,21 @@ function transitionToWizardStage(store, transition, params) {
     }
     if (transition === FORWARD && params.source === 'network') {
       return actions.showImportNetworkWizard(store);
+    }
+    if (transition === CANCEL) {
+      return actions.cancelImportExportWizard(store);
+    }
+  }
+
+  // At Local Import Wizard
+  if (wizardPage === ContentWizardPages.IMPORT_LOCAL) {
+    if (transition === BACKWARD) {
+      return actions.startImportWizard(store);
+    }
+    // Now: Start downloading immediately
+    // Later: Preview of imported channels
+    if (transition === FORWARD) {
+      return actions.triggerLocalContentImportTask(store, params.driveId);
     }
     if (transition === CANCEL) {
       return actions.cancelImportExportWizard(store);

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -1,5 +1,7 @@
 /* eslint-disable prefer-arrow-callback */
 const { ChannelResource, FileSummaryResource } = require('kolibri').resources;
+const { ContentWizardPages } = require('../constants');
+const actions = require('./actions');
 
 const namespace = 'MANAGE_CONTENT';
 
@@ -55,8 +57,38 @@ function addChannelFileSummaries(store, channelIds) {
   });
 }
 
+/**
+ * State machine for the Import wizards
+ * @param store - vuex store object
+ * @param {string} transition - 'forward', 'back', or 'cancel'
+ * @param {Object} params - data needed to execute transition
+ * @returns {undefined}
+ */
+function transitionToWizardStage(store, transition, params) {
+  const wizardPage = store.state.pageState.wizardState.page;
+  const FORWARD = 'forward';
+  const BACKWARD = 'backward';
+  const CANCEL = 'cancel';
+
+  // At Choose Source Wizard
+  if (wizardPage === ContentWizardPages.CHOOSE_IMPORT_SOURCE) {
+    if (transition === FORWARD && params.source === 'local') {
+      return actions.showImportLocalWizard(store);
+    }
+    if (transition === FORWARD && params.source === 'network') {
+      return actions.showImportNetworkWizard(store);
+    }
+    if (transition === CANCEL) {
+      return actions.cancelImportExportWizard(store);
+    }
+  }
+
+  return undefined;
+}
+
 module.exports = {
   actionTypes,
   addChannelFileSummaries,
   deleteChannel,
+  transitionToWizardStage,
 };

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -66,7 +66,7 @@ function addChannelFileSummaries(store, channelIds) {
  * @param {Object} params - data needed to execute transition
  * @returns {undefined}
  */
-function transitionToWizardStage(store, transition, params) {
+function transitionWizardPage(store, transition, params) {
   const wizardPage = store.state.pageState.wizardState.page;
   const FORWARD = 'forward';
   const BACKWARD = 'backward';
@@ -121,5 +121,5 @@ module.exports = {
   actionTypes,
   addChannelFileSummaries,
   deleteChannel,
-  transitionToWizardStage,
+  transitionWizardPage,
 };

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -72,6 +72,10 @@ function transitionToWizardStage(store, transition, params) {
   const BACKWARD = 'backward';
   const CANCEL = 'cancel';
 
+  if (transition === CANCEL) {
+    return actions.cancelImportExportWizard(store);
+  }
+
   // At Choose Source Wizard
   if (wizardPage === ContentWizardPages.CHOOSE_IMPORT_SOURCE) {
     // Now: Shows list of local drives
@@ -83,9 +87,6 @@ function transitionToWizardStage(store, transition, params) {
     // Later: Same
     if (transition === FORWARD && params.source === 'network') {
       return actions.showImportNetworkWizard(store);
-    }
-    if (transition === CANCEL) {
-      return actions.cancelImportExportWizard(store);
     }
   }
 
@@ -99,9 +100,6 @@ function transitionToWizardStage(store, transition, params) {
     if (transition === FORWARD) {
       return actions.triggerLocalContentImportTask(store, params.driveId);
     }
-    if (transition === CANCEL) {
-      return actions.cancelImportExportWizard(store);
-    }
   }
 
   // At Network Import Wizard
@@ -113,9 +111,6 @@ function transitionToWizardStage(store, transition, params) {
     // Later: Show preview of imported channels
     if (transition === FORWARD) {
       return actions.triggerRemoteContentImportTask(store, params.contentId);
-    }
-    if (transition === CANCEL) {
-      return actions.cancelImportExportWizard(store);
     }
   }
 

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -58,11 +58,11 @@ function addChannelFileSummaries(store, channelIds) {
 }
 
 /**
- * State machine for the Import wizards.
+ * State machine for the Import/Export wizards.
  * Only handles forward, back, and cancel transitions.
  *
  * @param store - vuex store object
- * @param {string} transition - 'forward', 'back', or 'cancel'
+ * @param {string} transition - 'forward', 'backward', or 'cancel'
  * @param {Object} params - data needed to execute transition
  * @returns {undefined}
  */
@@ -111,6 +111,15 @@ function transitionWizardPage(store, transition, params) {
     // Later: Show preview of imported channels
     if (transition === FORWARD) {
       return actions.triggerRemoteContentImportTask(store, params.contentId);
+    }
+  }
+
+  // At Export Wizard
+  if (wizardPage === ContentWizardPages.EXPORT) {
+    // Now: Start exporting immediately
+    // Later: Show preview of exported channels
+    if (transition === FORWARD) {
+      return actions.triggerLocalContentExportTask(store, params.driveId);
     }
   }
 

--- a/kolibri/plugins/management/assets/src/state/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/state/manageContentActions.js
@@ -74,9 +74,13 @@ function transitionToWizardStage(store, transition, params) {
 
   // At Choose Source Wizard
   if (wizardPage === ContentWizardPages.CHOOSE_IMPORT_SOURCE) {
+    // Now: Shows list of local drives
+    // Later: `source` is driveId, and next screen is preview of imported channels
     if (transition === FORWARD && params.source === 'local') {
       return actions.showImportLocalWizard(store);
     }
+    // Now: Show text box to get channelId
+    // Later: Same
     if (transition === FORWARD && params.source === 'network') {
       return actions.showImportNetworkWizard(store);
     }
@@ -91,9 +95,24 @@ function transitionToWizardStage(store, transition, params) {
       return actions.startImportWizard(store);
     }
     // Now: Start downloading immediately
-    // Later: Preview of imported channels
+    // Later: Show preview of imported channels
     if (transition === FORWARD) {
       return actions.triggerLocalContentImportTask(store, params.driveId);
+    }
+    if (transition === CANCEL) {
+      return actions.cancelImportExportWizard(store);
+    }
+  }
+
+  // At Network Import Wizard
+  if (wizardPage === ContentWizardPages.IMPORT_NETWORK) {
+    if (transition === BACKWARD) {
+      return actions.startImportWizard(store);
+    }
+    // Now: Start downloading immediately
+    // Later: Show preview of imported channels
+    if (transition === FORWARD) {
+      return actions.triggerRemoteContentImportTask(store, params.contentId);
     }
     if (transition === CANCEL) {
       return actions.cancelImportExportWizard(store);

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
@@ -48,6 +48,7 @@
 <script>
 
   const actions = require('../../state/actions');
+  const bytesForHumans = require('./bytesForHumans');
 
   module.exports = {
     $trNameSpace: 'wizardExport',
@@ -82,7 +83,7 @@
     },
     methods: {
       formatEnabledMsg(drive) {
-        return `${this.$tr('available')} ${this.bytesForHumans(drive.freespace)}`;
+        return `${this.$tr('available')} ${bytesForHumans(drive.freespace)}`;
       },
       driveIsEnabled(drive) {
         return drive.writable;
@@ -96,37 +97,6 @@
         if (!this.wizardState.busy) {
           this.cancelImportExportWizard();
         }
-      },
-      bytesForHumans(bytes) {
-        // breaking down byte counts in terms of larger sizes
-        const kilobyte = 1024;
-        const megabyte = kilobyte ** 2;
-        const gigabyte = kilobyte ** 3;
-
-        function kilobyteCalc(byteCount) {
-          const kilos = Math.floor(byteCount / kilobyte);
-          return `${kilos} KB`;
-        }
-        function megabyteCalc(byteCount) {
-          const megs = Math.floor(byteCount / megabyte);
-          return `${megs} MB`;
-        }
-        function gigabyteCalc(byteCount) {
-          const gigs = Math.floor(byteCount / gigabyte);
-          return `${gigs} GB`;
-        }
-        function chooseSize(byteCount) {
-          if (byteCount > gigabyte) {
-            return gigabyteCalc(byteCount);
-          } else if (byteCount > megabyte) {
-            return megabyteCalc(byteCount);
-          } else if (byteCount > kilobyte) {
-            return kilobyteCalc(byteCount);
-          }
-          return `${bytes} B`;
-        }
-
-        return chooseSize(bytes);
       },
       selectDriveByID(driveID) {
         this.selectedDrive = driveID;

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-export.vue
@@ -48,6 +48,7 @@
 <script>
 
   const actions = require('../../state/actions');
+  const manageContentActions = require('../../state/manageContentActions');
   const bytesForHumans = require('./bytesForHumans');
 
   module.exports = {
@@ -90,12 +91,12 @@
       },
       submit() {
         if (this.canSubmit) {
-          this.triggerLocalContentExportTask(this.selectedDrive);
+          this.transitionWizardPage('forward', { driveId: this.selectedDrive });
         }
       },
       cancel() {
         if (!this.wizardState.busy) {
-          this.cancelImportExportWizard();
+          this.transitionWizardPage('cancel');
         }
       },
       selectDriveByID(driveID) {
@@ -107,10 +108,8 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
-        startImportWizard: actions.startImportWizard,
+        transitionWizardPage: manageContentActions.transitionWizardPage,
         updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
-        cancelImportExportWizard: actions.cancelImportExportWizard,
-        triggerLocalContentExportTask: actions.triggerLocalContentExportTask,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
@@ -7,7 +7,7 @@
     :enableBackBtn="true"
     @cancel="cancel"
     @enter="submit"
-    @back="startImportWizard"
+    @back="goBack"
   >
     <div class="main">
       <template v-if="!drivesLoading">
@@ -52,6 +52,7 @@
 <script>
 
   const actions = require('../../state/actions');
+  const manageContentActions = require('../../state/manageContentActions');
 
   module.exports = {
     $trNameSpace: 'wizardLocalImport',
@@ -85,12 +86,15 @@
     },
     methods: {
       driveIsEnabled: (drive) => drive.metadata.channels.length > 0,
+      goBack() {
+        this.transitionToWizardStage('backward');
+      },
       submit() {
-        this.triggerLocalContentImportTask(this.selectedDrive);
+        this.transitionToWizardStage('forward', { driveId: this.selectedDrive });
       },
       cancel() {
         if (!this.wizardState.busy) {
-          this.cancelImportExportWizard();
+          this.transitionToWizardStage('cancel');
         }
       },
     },
@@ -99,10 +103,8 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
-        startImportWizard: actions.startImportWizard,
+        transitionToWizardStage: manageContentActions.transitionToWizardStage,
         updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
-        cancelImportExportWizard: actions.cancelImportExportWizard,
-        triggerLocalContentImportTask: actions.triggerLocalContentImportTask,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-local.vue
@@ -87,14 +87,14 @@
     methods: {
       driveIsEnabled: (drive) => drive.metadata.channels.length > 0,
       goBack() {
-        this.transitionToWizardStage('backward');
+        this.transitionWizardPage('backward');
       },
       submit() {
-        this.transitionToWizardStage('forward', { driveId: this.selectedDrive });
+        this.transitionWizardPage('forward', { driveId: this.selectedDrive });
       },
       cancel() {
         if (!this.wizardState.busy) {
-          this.transitionToWizardStage('cancel');
+          this.transitionWizardPage('cancel');
         }
       },
     },
@@ -103,7 +103,7 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
-        transitionToWizardStage: manageContentActions.transitionToWizardStage,
+        transitionWizardPage: manageContentActions.transitionWizardPage,
         updateWizardLocalDriveList: actions.updateWizardLocalDriveList,
       },
     },

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-network.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-network.vue
@@ -61,15 +61,15 @@
     },
     methods: {
       goBack() {
-        this.transitionToWizardStage('backward');
+        this.transitionWizardPage('backward');
       },
       submit() {
         if (this.canSubmit) {
-          this.transitionToWizardStage('forward', { contentId: this.contentId });
+          this.transitionWizardPage('forward', { contentId: this.contentId });
         }
       },
       cancel() {
-        this.transitionToWizardStage('cancel');
+        this.transitionWizardPage('cancel');
       },
     },
     vuex: {
@@ -77,7 +77,7 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
-        transitionToWizardStage: manageContentActions.transitionToWizardStage,
+        transitionWizardPage: manageContentActions.transitionWizardPage,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-network.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-network.vue
@@ -7,7 +7,7 @@
     :enableBackBtn="true"
     @cancel="cancel"
     @enter="submit"
-    @back="startImportWizard"
+    @back="goBack"
   >
     <div class="main">
       <core-textbox :label="$tr('enterContentChannel')" v-model="contentId" :disabled="wizardState.busy"/>
@@ -33,7 +33,7 @@
 
 <script>
 
-  const actions = require('../../state/actions');
+  const manageContentActions = require('../../state/manageContentActions');
 
   module.exports = {
     $trNameSpace: 'wizardImportNetwork',
@@ -60,13 +60,16 @@
       },
     },
     methods: {
+      goBack() {
+        this.transitionToWizardStage('backward');
+      },
       submit() {
         if (this.canSubmit) {
-          this.triggerRemoteContentImportTask(this.contentId);
+          this.transitionToWizardStage('forward', { contentId: this.contentId });
         }
       },
       cancel() {
-        this.cancelImportExportWizard();
+        this.transitionToWizardStage('cancel');
       },
     },
     vuex: {
@@ -74,9 +77,7 @@
         wizardState: (state) => state.pageState.wizardState,
       },
       actions: {
-        startImportWizard: actions.startImportWizard,
-        triggerRemoteContentImportTask: actions.triggerRemoteContentImportTask,
-        cancelImportExportWizard: actions.cancelImportExportWizard,
+        transitionToWizardStage: manageContentActions.transitionToWizardStage,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
@@ -1,20 +1,27 @@
 <template>
 
-  <core-modal
-    :title="$tr('title')"
-    @cancel="cancelImportExportWizard"
-  >
+  <core-modal :title="$tr('title')" @cancel="cancel">
     <div class="main">
       <div class="lg-button-wrapper">
-        <icon-button class="large-icon-button" :text="$tr('internet')" :showTextBelowIcon="true" @click="showImportNetworkWizard">
+        <icon-button
+          class="large-icon-button"
+          :text="$tr('internet')"
+          :showTextBelowIcon="true"
+          @click="goForward('local')"
+        >
           <mat-svg class="icon" category="action" name="language"/>
         </icon-button>
-        <icon-button class="large-icon-button" :text="$tr('localDrives')" :showTextBelowIcon="true" @click="showImportLocalWizard">
+        <icon-button
+          class="large-icon-button"
+          :text="$tr('localDrives')"
+          :showTextBelowIcon="true"
+          @click="goForward('network')"
+        >
           <mat-svg class="icon" category="device" name="storage"/>
         </icon-button>
       </div>
       <icon-button
-        @click="cancelImportExportWizard"
+        @click="cancel"
         :text="$tr('cancel')"/>
     </div>
   </core-modal>
@@ -24,7 +31,7 @@
 
 <script>
 
-  const actions = require('../../state/actions');
+  const manageContentActions = require('../../state/manageContentActions');
 
   module.exports = {
     $trNameSpace: 'wizardImportSource',
@@ -34,15 +41,21 @@
       localDrives: 'Local Drives',
       cancel: 'Cancel',
     },
+    methods: {
+      goForward(source) {
+        return this.transitionToWizardStage('forward', { source });
+      },
+      cancel() {
+        return this.transitionToWizardStage('cancel');
+      }
+    },
     components: {
       'core-modal': require('kolibri.coreVue.components.coreModal'),
       'icon-button': require('kolibri.coreVue.components.iconButton'),
     },
     vuex: {
       actions: {
-        showImportNetworkWizard: actions.showImportNetworkWizard,
-        showImportLocalWizard: actions.showImportLocalWizard,
-        cancelImportExportWizard: actions.cancelImportExportWizard,
+        transitionToWizardStage: manageContentActions.transitionToWizardStage,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
@@ -43,10 +43,10 @@
     },
     methods: {
       goForward(source) {
-        return this.transitionToWizardStage('forward', { source });
+        return this.transitionWizardPage('forward', { source });
       },
       cancel() {
-        return this.transitionToWizardStage('cancel');
+        return this.transitionWizardPage('cancel');
       }
     },
     components: {
@@ -55,7 +55,7 @@
     },
     vuex: {
       actions: {
-        transitionToWizardStage: manageContentActions.transitionToWizardStage,
+        transitionWizardPage: manageContentActions.transitionWizardPage,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizard-import-source.vue
@@ -7,7 +7,7 @@
           class="large-icon-button"
           :text="$tr('internet')"
           :showTextBelowIcon="true"
-          @click="goForward('local')"
+          @click="goForward('network')"
         >
           <mat-svg class="icon" category="action" name="language"/>
         </icon-button>
@@ -15,7 +15,7 @@
           class="large-icon-button"
           :text="$tr('localDrives')"
           :showTextBelowIcon="true"
-          @click="goForward('network')"
+          @click="goForward('local')"
         >
           <mat-svg class="icon" category="device" name="storage"/>
         </icon-button>


### PR DESCRIPTION
This moves the wizard flow logic for import/export wizards to a vuex action `transitionWizardPage` which implements a state machine, instead of putting that logic inside the various wizard components.

This is to make it simpler to implement #1616 and #1617 later on, which effectively change the 'backward' and 'forward' transitions at different parts in the workflow. This would only involve inserting a new state (for previewing imported/exported channels) and changing the other state transitions in one place.