### PR TITLE
Improve the component API parsing.

### DIFF
--- a/kolibri/plugins/style_guide/assets/src/views/content/component_api.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/component_api.vue
@@ -2,8 +2,11 @@
 
   <div>
 
-    <p><b>Name:</b> {{ api.name }}</p>
-    <p><b>Description:</b> {{ api.description }}</p>
+    <h3>Require Path</h3>
+    <p>{{ requirePath }}</p>
+
+    <h3>Description</h3>
+    <p>{{ api.description ? api.description : '-' }}</p>
 
     <template v-if="api.props.length">
       <h3>Props</h3>
@@ -18,9 +21,9 @@
         <tr v-for="prop in api.props">
           <td>{{ prop.name }}</td>
           <td>{{ parseType(prop.value.type) }}</td>
-          <td>{{ prop.value.required }}</td>
+          <td>{{ prop.value.required ? 'true' : 'false' }}</td>
           <td>{{ prop.value.default ? prop.value.default : '-' }}</td>
-          <td>{{ prop.description }}</td>
+          <td>{{ prop.description ? prop.description : '-' }}</td>
         </tr>
       </table>
     </template>
@@ -30,15 +33,13 @@
       <table>
         <tr>
           <th>Name</th>
-          <th>Type</th>
           <th>Default</th>
           <th>Description</th>
         </tr>
         <tr v-for="event in api.events">
           <td>{{ event.name }}</td>
-          <td>{{ event.type }}</td>
           <td>{{ event.default ? event.default : '-' }}</td>
-          <td>{{ event.description }}</td>
+          <td>{{ event.description ? event.description : '-' }}</td>
         </tr>
       </table>
     </template>
@@ -52,21 +53,7 @@
         </tr>
         <tr v-for="slot in api.slots">
           <td>{{ slot.name }}</td>
-          <td>{{ slot.description }}</td>
-        </tr>
-      </table>
-    </template>
-
-    <template v-if="api.methods.length">
-      <h3>Methods</h3>
-      <table>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-        </tr>
-        <tr v-for="method in api.methods">
-          <td>{{ method.name }}</td>
-          <td>{{ method.description }}</td>
+          <td>{{ slot.description ? slot.description : '-' }}</td>
         </tr>
       </table>
     </template>
@@ -78,11 +65,26 @@
 
 <script>
 
+  /**
+   * The programming API for the specific component: its require path, its description,
+   * and tables storing a list of its props, events, and slots.
+   */
   module.exports = {
     props: {
+      /*
+       * A JSON object returned from the vue-loader when parsing the specific component file.
+       * Should correspond to require('!vue-loader!path/to/component/file').
+       */
       api: {
-        type: Object,
+        type: Object
       },
+      /*
+       * The path of the component to be used in a require statement if a developer
+       * wished to use that require statement.
+       */
+      requirePath: {
+        type: String
+      }
     },
     methods: {
       parseType(type) {
@@ -110,15 +112,21 @@
 
 <style lang="stylus" scoped>
 
-  table, th, td
+  table,
+  th,
+  td
     border: 1px solid darkgray
     border-collapse: collapse
 
-  th, td
+  th,
+  td
     padding: 0.6em
 
   th
     background: #e0e0e0
     text-align: left
+
+  h4
+    font-weight: bold
 
 </style>

--- a/kolibri/plugins/style_guide/assets/src/views/content/component_api.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/component_api.vue
@@ -25,7 +25,7 @@
       </table>
     </template>
 
-    <template v-if="api.props.length">
+    <template v-if="api.events.length">
       <h3>Emitted events</h3>
       <table>
         <tr>
@@ -43,7 +43,7 @@
       </table>
     </template>
 
-    <template v-if="api.props.length">
+    <template v-if="api.slots.length">
       <h3>Slots</h3>
       <table>
         <tr>
@@ -57,7 +57,7 @@
       </table>
     </template>
 
-    <template v-if="api.props.length">
+    <template v-if="api.methods.length">
       <h3>Methods</h3>
       <table>
         <tr>

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/buttons.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/buttons.vue
@@ -209,7 +209,7 @@
 
   module.exports = {
     components: {
-      'component-api': require('../component_api'),
+      'component-api': require('../../shell/component_api'),
       'table-of-contents': require('../../shell/table-of-contents'),
     },
     data: () => ({

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/buttons.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/buttons.vue
@@ -142,7 +142,7 @@
     <vuep class="code-examples" :template="codeExamplesTemplate"></vuep>
 
     <h2 id="api">API</h2>
-    <component-api :api="api"></component-api>
+    <component-api :api="api" :requirePath="requirePath"></component-api>
 
   </div>
 
@@ -207,8 +207,6 @@
 </style>
 `;
 
-  const api = require('!vue-doc!keen-ui/src/UiButton'); // eslint-disable-line
-
   module.exports = {
     components: {
       'component-api': require('../component_api'),
@@ -216,7 +214,8 @@
     },
     data: () => ({
       codeExamplesTemplate,
-      api
+      api: require('!vue-doc!keen-ui/src/UiButton'), // eslint-disable-line
+      requirePath: 'keen-ui/src/UiButton'
     })
   };
 

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
@@ -128,7 +128,6 @@
   const api = require('!vue-doc!keen-ui/src/UiCheckbox'); // eslint-disable-line
 
   module.exports = {
-<<<<<<< HEAD
     components: {
       'component-api': require('../component_api'),
       'table-of-contents': require('../../shell/table-of-contents'),
@@ -137,12 +136,6 @@
       codeExamplesTemplate,
       api
     })
-=======
-    data: () => ({ codeExamplesTemplate }),
-    components: {
-      'table-of-contents': require('../../shell/table-of-contents'),
-    },
->>>>>>> chao/add_toc_and_fix_bugs
   };
 
 </script>

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
@@ -66,7 +66,7 @@
     <vuep class="code-examples" :template="codeExamplesTemplate"></vuep>
 
     <h2 id="api">API</h2>
-    <component-api :api="api"></component-api>
+    <component-api :api="api" :requirePath="requirePath"></component-api>
 
   </div>
 
@@ -125,8 +125,6 @@
 </style>
 `;
 
-  const api = require('!vue-doc!keen-ui/src/UiCheckbox'); // eslint-disable-line
-
   module.exports = {
     components: {
       'component-api': require('../component_api'),
@@ -134,7 +132,8 @@
     },
     data: () => ({
       codeExamplesTemplate,
-      api
+      api: require('!vue-doc!keen-ui/src/UiCheckbox'), // eslint-disable-line
+      requirePath: 'keen-ui/src/UiCheckbox'
     })
   };
 

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/checkboxes.vue
@@ -127,7 +127,7 @@
 
   module.exports = {
     components: {
-      'component-api': require('../component_api'),
+      'component-api': require('../../shell/component_api'),
       'table-of-contents': require('../../shell/table-of-contents'),
     },
     data: () => ({

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/radio_buttons.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/radio_buttons.vue
@@ -130,7 +130,7 @@
 
   module.exports = {
     components: {
-      'component-api': require('../component_api'),
+      'component-api': require('../../shell/component_api'),
       'table-of-contents': require('../../shell/table-of-contents'),
     },
     data: () => ({

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/radio_buttons.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/radio_buttons.vue
@@ -71,7 +71,7 @@
     <vuep class="code-examples" :template="codeExamplesTemplate"></vuep>
 
     <h2 id="api">API</h2>
-    <component-api :api="api"></component-api>
+    <component-api :api="api" :requirePath="requirePath"></component-api>
 
   </div>
 
@@ -128,8 +128,6 @@
 </style>
 `;
 
-  const api = require('!vue-doc!keen-ui/src/UiRadio'); // eslint-disable-line
-
   module.exports = {
     components: {
       'component-api': require('../component_api'),
@@ -137,7 +135,8 @@
     },
     data: () => ({
       codeExamplesTemplate,
-      api
+      api: require('!vue-doc!keen-ui/src/UiRadio'), // eslint-disable-line
+      requirePath: 'keen-ui/src/UiRadio'
     })
   };
 

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/text_fields.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/text_fields.vue
@@ -7,7 +7,7 @@
     <vuep :template="codeExamplesTemplate"></vuep>
 
     <h2>API</h2>
-    <component-api :api="api"></component-api>
+    <component-api :api="api" :requirePath="requirePath"></component-api>
   </div>
 
 </template>
@@ -40,8 +40,6 @@
 </${script}>
 `;
 
-  const api = require('!vue-doc!kolibri.coreVue.components.textbox'); // eslint-disable-line
-
   module.exports = {
     components: {
       'component-api': require('../component_api'),
@@ -49,7 +47,8 @@
     },
     data: () => ({
       codeExamplesTemplate,
-      api
+      api: require('!vue-doc!kolibri.coreVue.components.textbox'), // eslint-disable-line
+      requirePath: 'kolibri.coreVue.components.textbox'
     })
   };
 

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/text_fields.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/text_fields.vue
@@ -42,7 +42,7 @@
 
   module.exports = {
     components: {
-      'component-api': require('../component_api'),
+      'component-api': require('../../shell/component_api'),
       'table-of-contents': require('../../shell/table-of-contents'),
     },
     data: () => ({

--- a/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
@@ -73,7 +73,7 @@
     props: {
       /*
        * A JSON object returned from the vue-loader when parsing the specific component file.
-       * Should correspond to require('!vue-loader!path/to/component/file').
+       * Should correspond to the output of require('!vue-loader!path/to/component/file').
        */
       api: {
         type: Object

--- a/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
@@ -21,7 +21,7 @@
         <tr v-for="prop in api.props">
           <td>{{ prop.name }}</td>
           <td>{{ parsePropType(prop.value.type) }}</td>
-          <td>{{ prop.value.required ? 'true' : 'false' }}</td>
+          <td>{{ parsePropRequired(prop.value.required) }}</td>
           <td>{{ parsePropDefault(prop.value.type, prop.value.default) }}</td>
           <td>{{ prop.description ? prop.description : '-' }}</td>
         </tr>
@@ -103,6 +103,15 @@
           return arrayDescription;
         }
         return propType;
+      },
+      parsePropRequired(propRequired) {
+        if (!propRequired) {
+          return 'false';
+        }
+        if (propRequired === true) {
+          return 'true';
+        }
+        return escodegen.generate(propRequired);
       },
       parsePropDefault(propType, propDefault) {
         if (!propDefault) {

--- a/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/component_api.vue
@@ -20,9 +20,9 @@
         </tr>
         <tr v-for="prop in api.props">
           <td>{{ prop.name }}</td>
-          <td>{{ parseType(prop.value.type) }}</td>
+          <td>{{ parsePropType(prop.value.type) }}</td>
           <td>{{ prop.value.required ? 'true' : 'false' }}</td>
-          <td>{{ prop.value.default ? prop.value.default : '-' }}</td>
+          <td>{{ parsePropDefault(prop.value.type, prop.value.default) }}</td>
           <td>{{ prop.description ? prop.description : '-' }}</td>
         </tr>
       </table>
@@ -33,12 +33,10 @@
       <table>
         <tr>
           <th>Name</th>
-          <th>Default</th>
           <th>Description</th>
         </tr>
         <tr v-for="event in api.events">
           <td>{{ event.name }}</td>
-          <td>{{ event.default ? event.default : '-' }}</td>
           <td>{{ event.description ? event.description : '-' }}</td>
         </tr>
       </table>
@@ -65,6 +63,8 @@
 
 <script>
 
+  const escodegen = require('escodegen');
+
   /**
    * The programming API for the specific component: its require path, its description,
    * and tables storing a list of its props, events, and slots.
@@ -87,22 +87,34 @@
       }
     },
     methods: {
-      parseType(type) {
-        if (!type) {
+      parsePropType(propType) {
+        if (!propType) {
           return 'null';
         }
-        if (type.type === 'ArrayExpression') {
-          let arrayType = '[';
-          type.elements.forEach((element, index) => {
+        if (propType.type === 'ArrayExpression') {
+          let arrayDescription = '[';
+          propType.elements.forEach((element, index) => {
             if (index !== 0) {
-              arrayType += ', ';
+              arrayDescription += ', ';
             }
-            arrayType += type.elements[index].name;
+            arrayDescription += propType.elements[index].name;
           });
-          arrayType += ']';
-          return arrayType;
+          arrayDescription += ']';
+          return arrayDescription;
         }
-        return type;
+        return propType;
+      },
+      parsePropDefault(propType, propDefault) {
+        if (!propDefault) {
+          return '-';
+        }
+        if (propType === 'String') {
+          return JSON.stringify(propDefault);
+        }
+        if (propDefault.type) {
+          return escodegen.generate(propDefault);
+        }
+        return propDefault;
       }
     }
   };

--- a/kolibri/plugins/style_guide/package.json
+++ b/kolibri/plugins/style_guide/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@vuedoc/parser": "https://github.com/learningequality/parser",
     "codemirror": "^5.26.0",
+    "escodegen": "^1.8.1",
     "vuep": "^0.7.0"
   }
 }

--- a/kolibri/plugins/style_guide/package.json
+++ b/kolibri/plugins/style_guide/package.json
@@ -3,7 +3,7 @@
   "description": "Kolibri's living style guide",
   "private": true,
   "dependencies": {
-    "@vuedoc/parser": "https://github.com/learningequality/parser",
+    "@vuedoc/parser": "https://github.com/learningequality/vuedoc-parser",
     "codemirror": "^5.26.0",
     "escodegen": "^1.8.1",
     "vuep": "^0.7.0"

--- a/kolibri/plugins/style_guide/yarn.lock
+++ b/kolibri/plugins/style_guide/yarn.lock
@@ -24,6 +24,10 @@ acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -70,6 +74,10 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -109,12 +117,39 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+escodegen@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+  dependencies:
+    esprima "^2.7.1"
+    estraverse "^1.9.1"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.2.0"
+
 espree@^3.4.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
+
+esprima@^2.7.1:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+estraverse@^1.9.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
+
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
 htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
@@ -134,6 +169,13 @@ inherits@^2.0.1, inherits@~2.0.1:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 lodash.assignin@^4.0.9:
   version "4.2.0"
@@ -189,6 +231,21 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
+optionator@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -213,11 +270,23 @@ simple-assign@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
 
+source-map@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+  dependencies:
+    amdefine ">=0.0.4"
+
 string_decoder@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
   dependencies:
     safe-buffer "~5.0.1"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -228,3 +297,7 @@ vuep@^0.7.0:
   resolved "https://registry.yarnpkg.com/vuep/-/vuep-0.7.0.tgz#b28f86b7fe098e65740e878c85615411dd7b3cbb"
   dependencies:
     simple-assign "^0.1.0"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"

--- a/kolibri/plugins/style_guide/yarn.lock
+++ b/kolibri/plugins/style_guide/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@vuedoc/parser@https://github.com/learningequality/parser":
+"@vuedoc/parser@https://github.com/learningequality/vuedoc-parser":
   version "0.3.4"
-  resolved "https://github.com/learningequality/parser#ba1e6781fec80e00a88e5e3f2aae9d8b01f38044"
+  resolved "https://github.com/learningequality/vuedoc-parser#ba1e6781fec80e00a88e5e3f2aae9d8b01f38044"
   dependencies:
     cheerio "^0.22.0"
     espree "^3.4.2"


### PR DESCRIPTION
## Summary

- Refactor the code for the API parsing. 
- Use Escodegen to unparse the output when the **default** or **required** values of a component are expressions, in order to properly display the expressions.
- Reflect changing the name of LE's fork of the vuedoc parser from parser to vuedoc-parser.

## Screenshots

<img width="958" alt="screen shot 2017-06-13 at 5 07 00 pm" src="https://user-images.githubusercontent.com/4418405/27110112-cf706e62-505b-11e7-8997-052d05ff482d.png">

<img width="950" alt="screen shot 2017-06-13 at 5 07 31 pm" src="https://user-images.githubusercontent.com/4418405/27110114-d20ca000-505b-11e7-97fc-d028860b0d6e.png">