### PR TITLE
Fix html 5 apps not being progress-tracked

### DIFF
--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -47,7 +47,7 @@
         this.isFullScreen = ScreenFull.isFullscreen;
       },
     },
-    ready() {
+    mounted() {
       this.$emit('startTracking');
       const self = this;
       this.timeout = setTimeout(() => {


### PR DESCRIPTION
Fixes #1525 

The tracking was being added to a non-existent lifecycle hook `ready`. Changed to `mounted`.

