### PR TITLE
[WIP] frontend_build fix to call kolibri in the correct development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ release: clean assets
 	@echo ""
 	@echo "Now run something like twine -s dist/* to upload all results in the dist/ folder"
 
-staticdeps: clean
+staticdeps:
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ release: clean assets
 	@echo "Now run something like twine -s dist/* to upload all results in the dist/ folder"
 
 staticdeps:
+	rm -r kolibri/dist/* || true # remove everything
+	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 

--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -7,7 +7,7 @@ module.exports = function() {
   var webpack_json_tempfile = temp.openSync({ suffix: '.json' }).path;
 
   // Run the script below to extract the relevant information about the plugin configuration from the Python code.
-  execSync('python -m kolibri manage webpack_json -- --outputfile ' + webpack_json_tempfile);
+  execSync("kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
 
   var result = fs.readFileSync(webpack_json_tempfile);
 

--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -13,7 +13,11 @@ module.exports = function() {
   // You can debug it like this:
   //     execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" which python >&2 && exit 1", {env: process.env});
   // ..hence, we have manipulated the path in the shell command to remove Node's unwanted manipulation
-  execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" python -m kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
+  if (process.platform !== 'win32') {
+    execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" python -m kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
+  } else {
+    execSync('python -m kolibri manage webpack_json -- --outputfile ' + webpack_json_tempfile);
+  }
 
   var result = fs.readFileSync(webpack_json_tempfile);
 

--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -7,7 +7,13 @@ module.exports = function() {
   var webpack_json_tempfile = temp.openSync({ suffix: '.json' }).path;
 
   // Run the script below to extract the relevant information about the plugin configuration from the Python code.
-  execSync("python -m kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
+
+  // For reasons unknown, there is an extra /usr/bin injected into PATH while running execSync, which
+  // by-passes the virtualenv!
+  // You can debug it like this:
+  //     execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" which python >&2 && exit 1", {env: process.env});
+  // ..hence, we have manipulated the path in the shell command to remove Node's unwanted manipulation
+  execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" python -m kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
 
   var result = fs.readFileSync(webpack_json_tempfile);
 

--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -7,7 +7,7 @@ module.exports = function() {
   var webpack_json_tempfile = temp.openSync({ suffix: '.json' }).path;
 
   // Run the script below to extract the relevant information about the plugin configuration from the Python code.
-  execSync("kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
+  execSync("python -m kolibri manage webpack_json --outputfile " + webpack_json_tempfile, {env: process.env});
 
   var result = fs.readFileSync(webpack_json_tempfile);
 


### PR DESCRIPTION
## Summary

I don't think others are having this issue? But I can't run `tox -e node4x` or `make assets`.



This fixes the problem by passing the environment that for instance virtualenv sets.

```
node --version
v4.8.3

make assets

...

Error: Command failed: python -m kolibri manage webpack_json -- --outputfile /tmp/117520-20009-z9d7hh.json
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/media/archive/code/kolibri/kolibri/__main__.py", line 7, in <module>
    from kolibri.utils.cli import main
  File "kolibri/utils/cli.py", line 32, in <module>
    from docopt import docopt  # noqa
ImportError: No module named docopt
```

## Reviewer guidance

Not presuming this breaks anything, but please try out in a different node environment


## TODO

- [ ] Figure out how we can reliably call `execSync` and have the virtualenv available to the `kolibri` command that's called.