### PR TITLE
Travis dist upgrade + isolate KOLIBRI_HOME in tox envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: python
 
+dist: trusty
+
 services:
   - postgresql
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,6 @@ whitelist_externals =
     npm
 commands =
     yarn
-    # phantomjs doesn't seem to get invoked properly without this
-    npm install phantomjs-prebuilt@2.1.14
     # Node-sass gets mardy if we don't do this.
     npm rebuild node-sass
     yarn run coverage

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ usedevelop = True
 whitelist_externals=rm
 setenv =
     PYTHONPATH = {toxinidir}
-    KOLIBRI_HOME = {toxinidir}/kolibrihome_test
+    KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
 basepython =
     pythonbuild2.7: python2.7
@@ -31,12 +31,15 @@ commands =
     coverage run -p kolibri start
     coverage run -p kolibri stop
     py.test {posargs:--cov=kolibri --color=no}
-    rm -r {env:KOLIBRI_HOME}
+    # This is currently disabled because some process seems to be locking
+    # the directory:
+    # /bin/rm: cannot remove `/home/travis/build/learningequality/kolibri/.tox/py3.5/tmp/.kolibri': Directory not empty
+    # rm -rf {env:KOLIBRI_HOME}
 
 [testenv:postgres]
 setenv =
     PYTHONPATH = {toxinidir}
-    KOLIBRI_HOME = {toxinidir}/kolibrihome_test
+    KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.postgres_test
 basepython =
     postgres: python2.7
@@ -45,7 +48,7 @@ deps =
     -r{toxinidir}/requirements/postgres.txt
 commands =
     py.test {posargs:--cov=kolibri --color=no}
-    rm -r {env:KOLIBRI_HOME}
+    rm -rf {env:KOLIBRI_HOME}
 
 [testenv:pythonlint]
 deps =


### PR DESCRIPTION
## Summary

 - Upgrade to Trusty (Ubuntu 14.04) instead of Precise (Ubuntu 12.04)
 - Removes extra phantomjs npm install and uses the one from Travis instead
 - Cuts ~50% off combined runtime (from ~2h to ~1h)
 - Cuts ~31% off total runtime, down from 38m to 26m.
 - Isolates `KOLIBRI_HOME` from each tox env, which was causing random `/bin/rm: cannot remove '/home/travis/build/learningequality/kolibri/kolibrihome_test': Directory not empty`

## TODO

- [x] Test that things are working
- [x] Fix new Python 2.7 error regarding KOLIBRI_HOME deletion

## Reviewer guidance

Any thoughts here?
