### PR TITLE
Enable production environment for cherrypy.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -130,6 +130,8 @@ def run_server(port):
     from kolibri.deployment.default.wsgi import application
     cherrypy.tree.graft(application, "/")
 
+    cherrypy.config.update({"environment": "production"})
+
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
     serve_static_dir(
         settings.CONTENT_DATABASE_DIR, paths.get_content_database_url("/")


### PR DESCRIPTION
## Summary

Cherry-picking from #1628 to confirm if tests work (should be ported to 0.4.x as well)

@jamalex do you need anything else verified on this?

According to [this post](https://groups.google.com/forum/#!topic/cherrypy-users/6LNPDkFHi0U), the effects of production mode are:

```
{'checker.on': False,
 'engine.autoreload_on': False,
 'tools.log_headers.on': False,
 'request.show_tracebacks': False,
 'log.screen': False}
```