### PR TITLE
Remove dependency links from setup.py-based installations and builds

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,8 +9,8 @@ django-mptt==0.8.5
 djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
-https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
 iceqube==0.0.2
+cherrypy==11.0.0
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5


### PR DESCRIPTION
## Summary

One way of enforcing not having dependency links for our distributed app, is to move everything from `requirements/base.txt` back to `setup.py`.

`parse_requirements` simply strips off all dependency links and leaves what comes after `#egg=<dist_name>`

## TODO

- [x] Wait for Iceqube to be on PyPi
- [ ] Wait for Morango to be on PyPi
- [ ] Move all production/dist requirements to setup.py

## Traceback

On a clean virtualenv, you can see the problem by installing through setup.py:

1. CherryPy is installed as 10.2.2 (the latest) and not from the github source specified in the dependency link
1. Barbequeue can't be found despite the dependency link

```
$ pip install -e .

Collecting cherrypy (from kolibri==0.4.0b10.dev396)
  Downloading CherryPy-10.2.2-py2.py3-none-any.whl (435kB)
    100% |████████████████████████████████| 440kB 1.5MB/s 
Collecting barbequeue (from kolibri==0.4.0b10.dev396)
  Could not find a version that satisfies the requirement barbequeue (from kolibri==0.4.0b10.dev396) (from versions: )
No matching distribution found for barbequeue (from kolibri==0.4.0b10.dev396)
```