### PR TITLE
Extract compiled CSS into separate files.

### DIFF
--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -13,6 +13,7 @@ var base_config = require('./webpack.config.base');
 var _ = require('lodash');
 var extract$trs = require('./extract_$trs');
 var merge = require('webpack-merge');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 /**
  * Turn an object containing the vital information for a frontend plugin and return a bundle configuration for webpack.
@@ -91,6 +92,7 @@ var parseBundlePlugin = function(data, base_dir) {
   };
 
   bundle.plugins = bundle.plugins.concat([
+    new ExtractTextPlugin('[name]' + data.version + '.css'),
     // BundleTracker creates stats about our built files which we can then pass to Django to allow our template
     // tags to load the correct frontend files.
     new BundleTracker({

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -38,9 +38,6 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var production = process.env.NODE_ENV === 'production';
 var lint = process.env.LINT || production;
 
-// helps convert to older string syntax for vue-loader
-var combineLoaders = require('webpack-combine-loaders');
-
 var postCSSLoader = {
   loader: 'postcss-loader',
   options: { config: path.resolve(__dirname, '../../postcss.config.js') },
@@ -52,8 +49,7 @@ var cssLoader = {
 };
 
 // for stylus blocks in vue files.
-// note: vue-style-loader includes postcss processing
-var vueStylusLoaders = [cssLoader, 'stylus-loader'];
+var vueStylusLoaders = [cssLoader, postCSSLoader, 'stylus-loader'];
 if (lint) {
   vueStylusLoaders.push('stylint-loader');
 }
@@ -61,6 +57,7 @@ if (lint) {
 // for scss blocks in vue files (e.g. Keen-UI files)
 var vueSassLoaders = [
   cssLoader,
+  postCSSLoader,
   {
     loader: 'sass-loader',
     // prepends these variable override values to every parsed vue SASS block
@@ -80,12 +77,12 @@ var config = {
           loaders: {
             js: 'buble-loader',
             stylus: ExtractTextPlugin.extract({
-              fallback: 'style-loader',
-              use: combineLoaders(vueStylusLoaders),
+              allChunks: true,
+              use: vueStylusLoaders,
             }),
             scss: ExtractTextPlugin.extract({
-              fallback: 'style-loader',
-              use: combineLoaders(vueSassLoaders),
+              allChunks: true,
+              use: vueSassLoaders,
             }),
           },
           // handles <mat-svg/>, <ion-svg/>, <iconic-svg/>, and <file-svg/> svg inlining
@@ -100,21 +97,21 @@ var config = {
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
+          allChunks: true,
           use: [cssLoader, postCSSLoader],
         }),
       },
       {
         test: /\.styl$/,
         use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
+          allChunks: true,
           use: [cssLoader, postCSSLoader, 'stylus-loader'],
         }),
       },
       {
         test: /\.s[a|c]ss$/,
         use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
+          allChunks: true,
           use: [cssLoader, postCSSLoader, 'sass-loader'],
         }),
       },

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -33,6 +33,7 @@ var path = require('path');
 var webpack = require('webpack');
 var merge = require('webpack-merge');
 var PrettierFrontendPlugin = require('./prettier-frontend-webpack-plugin');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var production = process.env.NODE_ENV === 'production';
 var lint = process.env.LINT || production;
@@ -52,14 +53,13 @@ var cssLoader = {
 
 // for stylus blocks in vue files.
 // note: vue-style-loader includes postcss processing
-var vueStylusLoaders = ['vue-style-loader', cssLoader, 'stylus-loader'];
+var vueStylusLoaders = [cssLoader, 'stylus-loader'];
 if (lint) {
   vueStylusLoaders.push('stylint-loader');
 }
 
 // for scss blocks in vue files (e.g. Keen-UI files)
 var vueSassLoaders = [
-  'vue-style-loader', // includes postcss processing
   cssLoader,
   {
     loader: 'sass-loader',
@@ -79,8 +79,14 @@ var config = {
           preserveWhitespace: false,
           loaders: {
             js: 'buble-loader',
-            stylus: combineLoaders(vueStylusLoaders),
-            scss: combineLoaders(vueSassLoaders),
+            stylus: ExtractTextPlugin.extract({
+              fallback: 'style-loader',
+              use: combineLoaders(vueStylusLoaders),
+            }),
+            scss: ExtractTextPlugin.extract({
+              fallback: 'style-loader',
+              use: combineLoaders(vueSassLoaders),
+            }),
           },
           // handles <mat-svg/>, <ion-svg/>, <iconic-svg/>, and <file-svg/> svg inlining
           preLoaders: { html: 'svg-icon-inline-loader' },
@@ -93,15 +99,24 @@ var config = {
       },
       {
         test: /\.css$/,
-        use: ['style-loader', cssLoader, postCSSLoader],
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [cssLoader, postCSSLoader],
+        }),
       },
       {
         test: /\.styl$/,
-        use: ['style-loader', cssLoader, postCSSLoader, 'stylus-loader'],
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [cssLoader, postCSSLoader, 'stylus-loader'],
+        }),
       },
       {
         test: /\.s[a|c]ss$/,
-        use: ['style-loader', cssLoader, postCSSLoader, 'sass-loader'],
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [cssLoader, postCSSLoader, 'sass-loader'],
+        }),
       },
       {
         test: /\.(png|jpe?g|gif|svg)$/,

--- a/frontend_build/src/webpack.config.dev.js
+++ b/frontend_build/src/webpack.config.dev.js
@@ -9,7 +9,7 @@ var webpack = require('webpack');
 var bundles = require('./webpack.config.js');
 
 for (var i = 0; i < bundles.length; i++) {
-  bundles[i].devtool = '#cheap-module-eval-source-map';
+  bundles[i].devtool = '#source-map';
   bundles[i].plugins = bundles[i].plugins.concat([
     new webpack.DefinePlugin({
       'process.env': {

--- a/kolibri/core/assets/src/core-app/mediator.js
+++ b/kolibri/core/assets/src/core-app/mediator.js
@@ -242,12 +242,24 @@ export default class Mediator {
    */
   _scriptLoader(url) {
     return new Promise((resolve, reject) => {
-      const script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = url;
-      script.async = true;
-      script.addEventListener('load', resolve);
-      script.addEventListener('error', reject);
+      let script;
+      if (url.endsWith('js')) {
+        script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = url;
+        script.async = true;
+        script.addEventListener('load', resolve);
+        script.addEventListener('error', reject);
+      } else if (url.endsWith('css')) {
+        script = document.createElement('link');
+        script.rel = 'stylesheet';
+        script.type = 'text/css';
+        script.href = url;
+        // Can't detect loading for css, so just assume it worked.
+        resolve();
+      } else {
+        return resolve();
+      }
       global.document.body.appendChild(script);
     });
   }
@@ -451,6 +463,7 @@ export default class Mediator {
             }
           })
           .catch(error => {
+            logging.error(error);
             reject('Content renderer failed to load properly');
           });
       }

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -236,9 +236,13 @@ class WebpackBundleHook(hooks.KolibriHook):
 
     def js_and_css_tags(self):
         js_tag = '<script type="text/javascript" src="{url}"></script>'
-        for chunk in self.bundle:
+        css_tag = '<link type="text/css" href="{url}" rel="stylesheet"/>'
+        # Sorted to load css before js
+        for chunk in sorted(self.bundle, key=lambda x: x['name'].split('.')[-1]):
             if chunk['name'].endswith('.js'):
                 yield js_tag.format(url=chunk['url'])
+            elif chunk['name'].endswith('.css'):
+                yield css_tag.format(url=chunk['url'])
 
     def frontend_message_tag(self):
         if self.frontend_messages():
@@ -278,7 +282,7 @@ class WebpackBundleHook(hooks.KolibriHook):
 
         :returns: HTML of a script tag to insert into a page.
         """
-        urls = [chunk['url'] for chunk in self.bundle]
+        urls = [chunk['url'] for chunk in sorted(self.bundle, key=lambda x: x['name'].split('.')[-1])]
         tags = self.frontend_message_tag() +\
             ['<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"], {events}, {once});</script>'.format(
                 kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "css-loader": "0.25.0",
     "esprima": "2.7.2",
     "exports-loader": "0.6.3",
+    "extract-text-webpack-plugin": "^2.1.2",
     "fg-loadcss": "1.2.0",
     "file-loader": "0.9.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "webpack": "2.2.1",
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-bundle-tracker": "https://github.com/learningequality/webpack-bundle-tracker",
-    "webpack-combine-loaders": "^2.0.3",
     "webpack-dev-middleware": "^1.9.0",
     "webpack-dev-server": "2.3.0",
     "webpack-hot-middleware": "2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,6 +103,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -620,6 +626,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 change-case@3.0.x:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.0.1.tgz#ee5f5ad0415ad1ad9e8072cf49cd4cfa7660a554"
@@ -747,7 +761,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.3.0:
+color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -2073,6 +2087,10 @@ has-cors@1.1.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3898,6 +3916,14 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^6.0.1:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.5.tgz#efa34f745ca25bd3b3cbd15aa4e03112b8237f3c"
+  dependencies:
+    chalk "^2.0.1"
+    source-map "^0.5.6"
+    supports-color "^4.1.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -3986,10 +4012,6 @@ qs@6.2.0:
 qs@6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.1.tgz#801fee030e0b9450d6385adc48a4cc55b44aedfc"
 
 qs@~6.3.0:
   version "6.3.0"
@@ -4837,6 +4859,12 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0, supports-color@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.1.0.tgz#92cc14bb3dad8928ca5656c33e19a19f20af5c7a"
+  dependencies:
+    has-flag "^2.0.0"
+
 svg-icon-inline-loader@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/svg-icon-inline-loader/-/svg-icon-inline-loader-3.0.0.tgz#c7d08cec3081d18cc3637a6450d41310cf2bf07a"
@@ -5206,22 +5234,22 @@ vue-intl@2.0.0:
     intl-relativeformat "^1.3.0"
 
 "vue-loader@https://github.com/vuejs/vue-loader/":
-  version "12.2.1"
-  resolved "https://github.com/vuejs/vue-loader/#e2d998a07edb5dcb9daf0af5b8ae3d2fc99e361e"
+  version "13.0.0"
+  resolved "https://github.com/vuejs/vue-loader/#024a14e0f000b5a567986b9193a5957df2b5889e"
   dependencies:
     consolidate "^0.14.0"
     hash-sum "^1.0.2"
     js-beautify "^1.6.3"
     loader-utils "^1.1.0"
     lru-cache "^4.0.1"
-    postcss "^5.0.21"
+    postcss "^6.0.1"
     postcss-load-config "^1.1.0"
     postcss-selector-parser "^2.0.0"
     resolve "^1.3.3"
     source-map "^0.5.6"
     vue-hot-reload-api "^2.1.0"
     vue-style-loader "^3.0.0"
-    vue-template-es2015-compiler "^1.2.2"
+    vue-template-es2015-compiler "^1.5.3"
 
 vue-router@2.1.1:
   version "2.1.1"
@@ -5250,6 +5278,10 @@ vue-template-compiler@^2.3.3:
 vue-template-es2015-compiler@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.0.tgz#e4f672ab1718a3abf9171a080daefac31be117e1"
+
+vue-template-es2015-compiler@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.3.tgz#22787de4e37ebd9339b74223bc467d1adee30545"
 
 vue@^2.3.3:
   version "2.3.3"
@@ -5293,12 +5325,6 @@ webpack-bundle-size-analyzer@2.0.2:
   dependencies:
     mkdirp "^0.5.1"
     strip-ansi "^2.0.1"
-
-webpack-combine-loaders@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/webpack-combine-loaders/-/webpack-combine-loaders-2.0.3.tgz#53a14a748fe998349f46eb22f078be23d9fd73e0"
-  dependencies:
-    qs "^5.2.0"
 
 webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.9.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,15 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.0.tgz#c1735024c5da2ef75cc190713073d44f098bf486"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^0.1.0"
+    json-schema-traverse "^0.3.0"
+    json-stable-stringify "^1.0.1"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -1689,9 +1698,22 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-text-webpack-plugin@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz#756ef4efa8155c3681833fbc34da53b941746d6c"
+  dependencies:
+    async "^2.1.2"
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+    webpack-sources "^1.0.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-deep-equal@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -2650,6 +2672,10 @@ jshint@2.8.0:
 json-loader@0.5.4, json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -4333,6 +4359,12 @@ sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
+schema-utils@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
+  dependencies:
+    ajv "^5.0.0"
+
 screenfull@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-3.0.2.tgz#9fbcce07bad4c680a8f90f2bfc9c41788af55d0c"
@@ -4561,6 +4593,10 @@ sort-keys@^1.0.0:
 source-list-map@^0.1.4, source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
 source-map@0.1.x, source-map@^0.1.41:
   version "0.1.43"
@@ -5315,6 +5351,13 @@ webpack-sources@^0.1.4:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.4.tgz#ccc2c817e08e5fa393239412690bb481821393cd"
   dependencies:
     source-list-map "~0.1.7"
+    source-map "~0.5.3"
+
+webpack-sources@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"
+  dependencies:
+    source-list-map "^2.0.0"
     source-map "~0.5.3"
 
 webpack@*, webpack@2.2.1:


### PR DESCRIPTION
## Summary

Extract CSS from compiled JS.

Provides slight size savings, and prevent [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) by ensuring that CSS is always loaded before the JS that it provides styling for.