### PR TITLE
Use pk not content_id to get content node to update progress fraction.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -267,7 +267,7 @@ oriented data synchronization.
       },
       updateExerciseProgressMethod() {
         this.updateExerciseProgress(this.exerciseProgress);
-        updateContentNodeProgress(this.channelId, this.contentId, this.exerciseProgress);
+        updateContentNodeProgress(this.channelId, this.id, this.exerciseProgress);
       },
       sessionInitialized() {
         // Once the session is initialized we can initialize the mastery log,


### PR DESCRIPTION
## Summary

Fixes #1680 by getting the right model and updating it in the assessment wrapper.