### PR TITLE
Setup wizard progress indicators

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/state/actions.js
+++ b/kolibri/plugins/setup_wizard/assets/src/state/actions.js
@@ -1,5 +1,5 @@
 import { DeviceOwnerResource, FacilityResource } from 'kolibri.resources';
-import * as coreActions from 'kolibri.coreVue.vuex.actions';
+import { kolibriLogin, handleApiError } from 'kolibri.coreVue.vuex.actions';
 
 function createDeviceOwnerAndFacility(store, deviceownerpayload, facilitypayload) {
   const DeviceOwnerModel = DeviceOwnerResource.createModel(deviceownerpayload);
@@ -7,12 +7,16 @@ function createDeviceOwnerAndFacility(store, deviceownerpayload, facilitypayload
   const FacilityModel = FacilityResource.createModel(facilitypayload);
   const facilityPromise = FacilityModel.save();
   const promises = [deviceOwnerPromise, facilityPromise];
+
+  store.dispatch('SET_SUBMITTED_STATE', true);
+
   Promise.all(promises).then(
     responses => {
-      coreActions.kolibriLogin(store, deviceownerpayload, true);
+      kolibriLogin(store, deviceownerpayload, true);
     },
     error => {
-      coreActions.handleApiError(store, error);
+      store.dispatch('SET_SUBMITTED_STATE', false);
+      handleApiError(store, error);
     }
   );
 }

--- a/kolibri/plugins/setup_wizard/assets/src/state/store.js
+++ b/kolibri/plugins/setup_wizard/assets/src/state/store.js
@@ -1,12 +1,23 @@
 import Vuex from 'kolibri.lib.vuex';
-import * as coreStore from 'kolibri.coreVue.vuex.store';
+import {
+  initialState as coreInitialState,
+  mutations as coreMutations,
+} from 'kolibri.coreVue.vuex.store';
 
-const initialState = {};
-const mutations = {};
+const initialState = {
+  pageState: {
+    submitted: false,
+  },
+};
+const mutations = {
+  SET_SUBMITTED_STATE(state, submittedFlag) {
+    state.pageState.submitted = submittedFlag;
+  },
+};
 
 // assigns core state and mutations
-Object.assign(initialState, coreStore.initialState);
-Object.assign(mutations, coreStore.mutations);
+Object.assign(initialState, coreInitialState);
+Object.assign(mutations, coreMutations);
 
 const store = new Vuex.Store({
   state: initialState,

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -8,21 +8,13 @@
       <form @submit.prevent="submitSetupForm" novalidate class="container">
         <h1>{{ $tr('formHeader') }}</h1>
 
-        <ui-alert @dismiss="clearGlobalError()" type="error" v-if="globalError">
-          {{ globalError }}
-        </ui-alert>
 
-        <ui-alert type="info" remove-icon="true" :dismissible="false" v-if="submitted">
-          {{ $tr('setupProgressFeedback') }}
-        </ui-alert>
+        <fieldset :disabled="submitted" class="setup-owner">
 
-        <section class="setup-owner">
-
-          <header>
-            <h2 class="title">{{ $tr('deviceOwnerSectionHeader') }}</h2>
-            <p class="description">{{ $tr('deviceOwnerDescription') }}</p>
-          </header>
-
+          <legend class="title">
+            {{ $tr('deviceOwnerSectionHeader') }}
+          </legend>
+          <p class="description">{{ $tr('deviceOwnerDescription') }}</p>
 
           <core-textbox
             @focus="firstUsernameFieldVisit || visitUsername()"
@@ -55,13 +47,13 @@
             v-model="passwordConfirm"
           />
 
-        </section>
-        <section class="setup-facility">
+        </fieldset>
+        <fieldset :disabled="submitted" class="setup-facility">
 
-          <header>
-            <h2 class="title">{{ $tr('facilitySectionHeader') }}</h2>
-            <p class="description">{{ $tr('facilityDescription') }}</p>
-          </header>
+          <legend class="title">
+            {{ $tr('facilitySectionHeader') }}
+          </legend>
+          <p class="description">{{ $tr('facilityDescription') }}</p>
 
           <core-textbox
             @focus="firstFacilityFieldVisit || visitFacility()"
@@ -74,11 +66,29 @@
             :enforceMaxlength="true"
             v-model="facility"
           />
-        </section>
+        </fieldset>
 
-        <section class="setup-submission">
-          <icon-button :loading="submitted" :text="$tr('formSubmissionButton')" type="submit"/>
-        </section>
+
+        <div class="setup-submission">
+          <ui-alert
+            class="setup-submission-alert"
+            type="error"
+            @dismiss="clearGlobalError()"
+            v-if="globalError">
+            {{ globalError }}
+          </ui-alert>
+
+          <ui-alert
+            class="setup-submission-alert"
+            type="info"
+            :dismissible="false"
+            :remove-icon="true"
+            v-if="submitted">
+            {{ $tr('setupProgressFeedback') }}
+          </ui-alert>
+
+          <icon-button :disabled="submitted" :text="$tr('formSubmissionButton')" type="submit"/>
+        </div>
       </form>
 
     </div>
@@ -178,6 +188,7 @@
     methods: {
       submitSetupForm() {
         this.globalError = '';
+
         if (this.canSubmit) {
           const deviceOwnerPayload = {
             password: this.password,
@@ -186,6 +197,21 @@
           const facilityPayload = { name: this.facility };
           this.createDeviceOwnerAndFacility(deviceOwnerPayload, facilityPayload);
         } else {
+          if (this.firstUsernameFieldVisit) {
+            this.visitUsername();
+            this.validateUsername();
+          }
+
+          if (this.firstPasswordFieldsVisit) {
+            this.visitPassword();
+            this.validatePassword();
+          }
+
+          if (this.firstFacilityFieldVisit) {
+            this.visitFacility();
+            this.validateFacility();
+          }
+
           this.globalError = this.$tr('cannotSubmitPageError');
         }
       },
@@ -245,7 +271,14 @@
     width: 100%
     height: 100%
 
+    &-owner, &-facility
+      // fighting pureCSS
+      border: none
+      margin: 0
+      padding: 0
+
     &-submission
+      margin-top: 16px
       text-align: center
 
   .wrapper
@@ -264,7 +297,7 @@
     padding: 20px 30px
   h1
     font-size: 18px
-  h2.title
+  .title
     font-size: 14px
     font-weight: bold
   .description

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -12,6 +12,10 @@
           {{ globalError }}
         </ui-alert>
 
+        <ui-alert type="info" remove-icon="true" :dismissible="false" v-if="submitted">
+          {{ $tr('setupProgressFeedback') }}
+        </ui-alert>
+
         <section class="setup-owner">
 
           <header>
@@ -73,7 +77,7 @@
         </section>
 
         <section class="setup-submission">
-          <icon-button :text="$tr('formSubmissionButton')" type="submit"/>
+          <icon-button :loading="submitted" :text="$tr('formSubmissionButton')" type="submit"/>
         </section>
       </form>
 
@@ -85,7 +89,7 @@
 
 <script>
 
-  import * as actions from '../state/actions';
+  import { createDeviceOwnerAndFacility } from '../state/actions';
   import store from '../state/store';
   import coreTextbox from 'kolibri.coreVue.components.textbox';
   import iconButton from 'kolibri.coreVue.components.iconButton';
@@ -112,7 +116,9 @@
       facilityFieldEmptyErrorMessage: 'Facility cannot be empty',
       cannotSubmitPageError: 'Please resolve all of the errors shown',
       genericPageError: 'Something went wrong',
+      setupProgressFeedback: 'Setting up your device...',
     },
+    name: 'setupWizard',
     data() {
       return {
         username: '',
@@ -161,7 +167,12 @@
         );
       },
       canSubmit() {
-        return this.passwordFieldsMatch && this.usernameValidityCheck && this.allFieldsPopulated;
+        return (
+          !this.submitted &&
+          this.passwordFieldsMatch &&
+          this.usernameValidityCheck &&
+          this.allFieldsPopulated
+        );
       },
     },
     methods: {
@@ -212,7 +223,10 @@
     },
     vuex: {
       actions: {
-        createDeviceOwnerAndFacility: actions.createDeviceOwnerAndFacility,
+        createDeviceOwnerAndFacility,
+      },
+      getters: {
+        submitted: state => state.pageState.submitted,
       },
     },
     store,


### PR DESCRIPTION
## Summary

Prevents repeated user submissions for new device owner + facility and notifies user that it's in progress. Needed now due to longer facility setup time. Found by @laurenlichtman, requested by @jamalex 

## Screenshots (if appropriate)

![newsubmissionindicators](https://user-images.githubusercontent.com/9877852/27607999-a7da291c-5b3a-11e7-89c5-89657952f25a.gif)
