### PR TITLE
Reset the job queue during kolibri restart...

### DIFF
--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -13,7 +13,6 @@ except AppRegistryNotReady:
 
 import requests
 from django.core.management import call_command
-from django.conf import settings
 from django.http import Http404
 from django.utils.translation import ugettext as _
 from kolibri.content.models import ChannelMetadataCache

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -29,15 +29,14 @@ from .permissions import IsDeviceOwnerOnly
 
 logging = logger.getLogger(__name__)
 
-client = SimpleClient(
-    app="kolibri", storage_path=settings.QUEUE_JOB_STORAGE_PATH)
+client = SimpleClient(app="kolibri")
 
 # all tasks are marked as remote imports for nwo
 TASKTYPE = "remoteimport"
 
 
 class TasksViewSet(viewsets.ViewSet):
-    permission_classes = (IsDeviceOwnerOnly, )
+    permission_classes = (IsDeviceOwnerOnly,)
 
     def list(self, request):
         jobs_response = [_job_to_response(j) for j in client.all_jobs()]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://github.com/learningequality/barbequeue/archive/b2bf9.zip#egg=barbequeue
+https://github.com/learningequality/barbequeue/archive/e4f32.zip#egg=barbequeue
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5


### PR DESCRIPTION
By having the job storage live in memory. Fixes #1720. Also upgrades our BBQ version to include the latest hacks and optimizations.