### PR TITLE
Updates perseus renderer.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.11
+kolibri_exercise_perseus_plugin==0.6.12
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/5132d16623ee05ba19a4be106af0c1f83eb5e74d.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

Brings in latest updates to perseus renderer, by bringing in perseus renderer v0.6.12

## Issues addressed

Fixes #1738 (by making a work around for a breaking bug in Perseus itself when serializing hint states with `replace: true` - see https://github.com/Khan/perseus/issues/101 for details).

Fixes #1740 (main issue is resolved by content updates, but additional problem with missing `KhanUtil` global is also fixed)

Fixes #1744 (by properly adding the `$_` global variable that gets called for translation)

Attempts to fix #1756 (by making the margin on the `#workarea` div conditional on the `isMobile` computed property).