### PR TITLE
Typo in the Deactivate Exam modal

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
@@ -30,7 +30,7 @@
   export default {
     $trNameSpace: 'deactivateExamModal',
     $trs: {
-      deactivateExam: 'Dectivate exam',
+      deactivateExam: 'Deactivate exam',
       areYouSure: 'Are you sure you want to deactivate <strong>{ examTitle }</strong>?',
       noLongerVisible: 'The exam will be no longer be visible to the following:',
       cancel: 'Cancel',


### PR DESCRIPTION
## Summary

Typo [reported by](https://crowdin.com/translate/kolibri/161/en-ptbr#8164) @fsrechia on Crowdin.
