### PR TITLE
Use default Travis containers again (they are updated to Trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 services:
   - postgresql
 
-sudo: false
-
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
## Summary

In #1689 I upgraded to the beta group of Travis, which is putting a warning in all our builds. Now, Travis has put the new containers live:

https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch

If this passes tests, it should be fine.. might just have a read of the test logs and get back with a final confirmation.