### PR TITLE
Use a file-based job storage SQLite DB again.

### DIFF
--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -15,6 +15,7 @@ import requests
 from django.core.management import call_command
 from django.http import Http404
 from django.utils.translation import ugettext as _
+from django.conf import settings
 from kolibri.content.models import ChannelMetadataCache
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.content.utils.paths import get_content_database_file_url
@@ -28,7 +29,7 @@ from .permissions import IsDeviceOwnerOnly
 
 logging = logger.getLogger(__name__)
 
-client = SimpleClient(app="kolibri")
+client = SimpleClient(app="kolibri", storage_path=settings.QUEUE_JOB_STORAGE_PATH)
 
 # all tasks are marked as remote imports for nwo
 TASKTYPE = "remoteimport"

--- a/kolibri/tasks/apps.py
+++ b/kolibri/tasks/apps.py
@@ -9,4 +9,5 @@ class KolibriTasksConfig(AppConfig):
     verbose_name = 'Kolibri Tasks'
 
     def ready(self):
-        pass
+        from kolibri.tasks.api import client
+        client.clear(force=True)


### PR DESCRIPTION
Avoids an error that @indirectlylit is getting.