### PR TITLE
Upgrade perseus renderer to version compatible with import syntax

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.12
+kolibri_exercise_perseus_plugin==0.6.13
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e25b57b52656e2.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

0.6.12 version of perseus renderer fails to import the ContentRendererModule properly due to the shift to import syntax. 0.6.13 makes the minimal change to allow this, while still being backwards compatible with earlier versions of Kolibri that do not use import syntax.