### PR TITLE
Release upload and status API build artifact

### DIFF
--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -130,7 +130,7 @@ def create_github_status(report_url):
         "description": "Kolibri Buildkite assets",
         "context": "buildkite/kolibri/assets"
     }
-    r = session.post(url, data=payload, headers=headers)
+    r = session.post(url, json=payload, headers=headers)
     if r.status_code == 201:
         logging.info('Successfully created Github status(%s).' % url)
     else:

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -46,42 +46,46 @@ INSTALLER_DIR = os.path.join(PROJECT_PATH, "installer")
 
 headers = {'Authorization': 'token %s' % ACCESS_TOKEN}
 
+INSTALLER_CAT = 'Installers'
+
+PYTHON_PKG_CAT = 'Python packages'
+
 # Manifest of files, keyed by extension
 file_manifest = {
     'exe': {
         'extension': 'exe',
         'description': 'Windows Installer',
-        'category': 'installer',
+        'category': INSTALLER_CAT,
         'content_type': 'application/x-ms-dos-executable',
     },
     'pex': {
         'extension': 'pex',
         'description': 'Pex file',
-        'category': 'Python package',
+        'category': PYTHON_PKG_CAT,
         'content_type': 'application/octet-stream',
     },
     'whl': {
         'extension': 'whl',
         'description': 'Whl file',
-        'category': 'Python package',
+        'category': PYTHON_PKG_CAT,
         'content_type': 'application/zip',
     },
     'zip': {
         'extension': 'zip',
         'description': 'Zip file',
-        'category': 'Python package',
+        'category': PYTHON_PKG_CAT,
         'content_type': 'application/zip',
     },
     'gz': {
         'extension': 'gz',
         'description': 'Tar file',
-        'category': 'Python package',
+        'category': PYTHON_PKG_CAT,
         'content_type': 'application/gzip',
     },
     'apk': {
         'extension': 'apk',
         'description': 'Android Installer',
-        'category': 'installer',
+        'category': INSTALLER_CAT,
         'content_type': 'application/vnd.android.package-archive',
     },
 }

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -186,6 +186,8 @@ def upload_artifacts():
 
     blob.upload_from_string(html, content_type='text/html')
 
+    blob.make_public()
+
     create_github_status(blob.media_link)
 
     if TAG:

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -141,7 +141,9 @@ def collect_local_artifacts():
     def create_artifact_data(artifact_dir):
         for artifact in listdir(artifact_dir):
             filename, file_extension = os.path.splitext(artifact)
-            if file_extension in artifacts_dict:
+            # Remove leading '.'
+            file_extension = file_extension[1:]
+            if file_extension in file_manifest:
                 data = {"name": artifact,
                         "file_location": "%s/%s" % (artifact_dir, artifact)}
                 data.update(file_manifest[file_extension])

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -188,7 +188,7 @@ def upload_artifacts():
 
     blob.make_public()
 
-    create_github_status(blob.media_link)
+    create_github_status(blob.public_url)
 
     if TAG:
         # Building from a tag, this is probably a release!

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -98,6 +98,9 @@ file_order = [
 session = requests.Session()
 
 def create_status_report_html(artifacts):
+    """
+    Create html page to list build artifacts for linking from github status.
+    """
     html = "<html>\n<body>\n<h1>Build Artifacts</h1>\n"
     current_heading = None
     for ext in file_order:
@@ -112,6 +115,10 @@ def create_status_report_html(artifacts):
     return html
 
 def create_github_status(report_url):
+    """
+    Create a github status with a link to the report URL,
+    only do this once buildkite has been successful, so only report success here.
+    """
     url = 'https://api.github.com/repos/{owner}/{repo}/statuses/{commit}'.format(
         owner=REPO_OWNER,
         repo=REPO_NAME,


### PR DESCRIPTION
## Summary

Not really sure how to test this locally, so creating a PR to test things out.
This PR adds release uploading when a tag has been created, and also switches the normal asset linking to use the Github status API.

## TODO

- [ ] Have tests been written for the new code?
- [x] Has documentation been written/updated?