### PR TITLE
Adds validation to create account page

### DIFF
--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -215,7 +215,7 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
         validators=[
             validators.RegexValidator(
                 r'^\w+$',
-                _('Enter a valid username. This value may contain only letters and numbers.')
+                _('Enter a valid username. This value can contain only letters, numbers, and underscores.')
             ),
         ],
     )

--- a/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
@@ -35,7 +35,7 @@
           class="user-field"
           v-model="password"/>
         <core-textbox
-          :label="$tr('confirmPassword')"
+          :label="$tr('reEnterPassword')"
           :required="true"
           :invalid="passwordConfirmInvalid"
           :error="$tr('pwMismatchError')"
@@ -74,18 +74,18 @@
   export default {
     $trNameSpace: 'userCreateModal',
     $trs: {
-      addNewAccountTitle: 'Add New Account',
+      addNewAccountTitle: 'Add new account',
       name: 'Full name',
       username: 'Username',
       password: 'Password',
-      confirmPassword: 'Confirm Password',
+      reEnterPassword: 'Re-enter password',
       typeOfUser: 'Type of user',
       createAccount: 'Create Account',
       learner: 'Learner',
       coach: 'Coach',
       admin: 'Admin',
       usernameAlreadyExists: 'Username already exists',
-      usernameNotAlphaNum: 'Username can only contain letters and digits',
+      usernameNotAlphaNumUnderscore: 'Username can only contain letters, numbers, and underscores',
       pwMismatchError: 'Passwords do not match',
       unknownError: 'Whoops, something went wrong. Try again',
       loadingConfirmation: 'Loading...',
@@ -119,17 +119,19 @@
       usernameAlreadyExists() {
         return this.users.findIndex(user => user.username === this.username) !== -1;
       },
-      usernameIsAlphaNum() {
+      usernameIsAlphaNumUnderscore() {
         return /^\w+$/g.test(this.username);
       },
       usernameInvalid() {
-        return this.username !== '' && (this.usernameAlreadyExists || !this.usernameIsAlphaNum);
+        return (
+          this.username !== '' && (this.usernameAlreadyExists || !this.usernameIsAlphaNumUnderscore)
+        );
       },
       usernameInvalidMsg() {
         if (this.usernameAlreadyExists) {
           return this.$tr('usernameAlreadyExists');
-        } else if (!this.usernameIsAlphaNum) {
-          return this.$tr('usernameNotAlphaNum');
+        } else if (!this.usernameIsAlphaNumUnderscore) {
+          return this.$tr('usernameNotAlphaNumUnderscore');
         }
         return '';
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -42,7 +42,7 @@
             @blur="validatePassword()"
             :invalid="!!passwordError"
             :required="true"
-            :label="$tr('confirmPasswordInputLabel')"
+            :label="$tr('reEnterPasswordInputLabel')"
             type="password"
             v-model="passwordConfirm"
           />
@@ -112,7 +112,7 @@
       facilitySectionHeader: 'Facility',
       usernameInputLabel: 'Username',
       passwordInputLabel: 'Password',
-      confirmPasswordInputLabel: 'Confirm password',
+      reEnterPasswordInputLabel: 'Re-enter password',
       facilityInputLabel: 'Facility name',
       deviceOwnerDescription:
         'To use Kolibri, you first need to create a Device Owner. This account will be used to configure high-level settings for this installation, and create other administrator accounts',
@@ -120,7 +120,7 @@
         'You also need to create a Facility. This represents your school, training center, or other installation location',
       formSubmissionButton: 'Create and get started',
       usernameFieldEmptyErrorMessage: 'Username cannot be empty',
-      usernameCharacterErrorMessage: 'Username can only contain letters and digits',
+      usernameCharacterErrorMessage: 'Username can only contain letters, numbers, and underscores',
       passwordFieldEmptyErrorMessage: 'Password cannot be empty',
       passwordsMismatchErrorMessage: 'Passwords do not match',
       facilityFieldEmptyErrorMessage: 'Facility cannot be empty',

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -39,7 +39,7 @@
         :aria-label="$tr('username')"
         :maxlength="30"
         :invalid="!usernameIsValid"
-        :error="usernameIsInvalidText"
+        :error="usernameIsInvalidError"
         @input="resetSignUpState"
         v-model="username"
         autocomplete="username"
@@ -89,7 +89,7 @@
 
 <script>
 
-  import * as actions from '../../state/actions';
+  import { signUp, resetSignUpState } from '../../state/actions';
   import { PageNames } from '../../constants';
   import iconButton from 'kolibri.coreVue.components.iconButton';
   import uiAlert from 'keen-ui/src/UiAlert';
@@ -110,8 +110,8 @@
       reEnterPassword: 'Re-enter password',
       passwordMatchError: 'Passwords do not match',
       genericError: 'Something went wrong during sign up!',
-      usernameAlphaNum: 'Username can only contain letters, numbers, and underscores',
-      usernameAlreadyExists: 'An account with that username already exists',
+      usernameAlphaNumError: 'Username can only contain letters, numbers, and underscores',
+      usernameAlreadyExistsError: 'An account with that username already exists',
       logIn: 'Sign in',
       kolibri: 'Kolibri',
       finish: 'Finish',
@@ -167,11 +167,11 @@
       usernameIsValid() {
         return this.usernameIsAlphaNumUnderscore && this.usernameDoesNotExistYet;
       },
-      usernameIsInvalidText() {
+      usernameIsInvalidError() {
         if (!this.usernameIsAlphaNumUnderscore) {
-          return this.$tr('usernameAlphaNum');
+          return this.$tr('usernameAlphaNumError');
         } else if (!this.usernameDoesNotExistYet) {
-          return this.$tr('usernameAlreadyExists');
+          return this.$tr('usernameAlreadyExistsError');
         }
       },
       allFieldsPopulated() {
@@ -240,8 +240,8 @@
         facilities: state => state.core.facilities,
       },
       actions: {
-        signUpAction: actions.signUp,
-        resetSignUpState: actions.resetSignUpState,
+        signUpAction: signUp,
+        resetSignUpState: resetSignUpState,
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -17,16 +17,16 @@
     </ui-toolbar>
 
     <form class="signup-form" ref="form" @submit.prevent="signUp">
-      <ui-alert type="error" @dismiss="resetSignUpState" v-if="errorCode">
+      <ui-alert type="error" @dismiss="resetSignUpState" v-if="unknownError">
         {{errorMessage}}
       </ui-alert>
 
       <h1 class="signup-title">{{ $tr('createAccount') }}</h1>
 
       <core-textbox
-        :placeholder="$tr('enterName')"
         :label="$tr('name')"
         :aria-label="$tr('name')"
+        :maxlength="120"
         v-model="name"
         autocomplete="name"
         :autofocus="true"
@@ -35,10 +35,12 @@
         type="text" />
 
       <core-textbox
-        :placeholder="$tr('enterUsername')"
         :label="$tr('username')"
         :aria-label="$tr('username')"
-        :invalid="usernameError"
+        :maxlength="30"
+        :invalid="!usernameIsValid"
+        :error="usernameIsInvalidText"
+        @input="resetSignUpState"
         v-model="username"
         autocomplete="username"
         required
@@ -48,7 +50,6 @@
       <core-textbox
         id="password"
         type="password"
-        :placeholder="$tr('enterPassword')"
         :aria-label="$tr('password')"
         :label="$tr('password')"
         v-model="password"
@@ -58,9 +59,8 @@
       <core-textbox
         id="confirmed-password"
         type="password"
-        :placeholder="$tr('confirmPassword')"
-        :aria-label="$tr('confirmPassword')"
-        :label="$tr('confirmPassword')"
+        :aria-label="$tr('reEnterPassword')"
+        :label="$tr('reEnterPassword')"
         :invalid="!passwordsMatch"
         :error="passwordError "
         v-model="confirmed_password"
@@ -105,14 +105,13 @@
     $trs: {
       createAccount: 'Create an account',
       name: 'Full name',
-      enterName: 'Enter full name',
       username: 'Username',
-      enterUsername: 'Enter username',
       password: 'Password',
-      enterPassword: 'Enter password',
-      confirmPassword: 'Confirm password',
+      reEnterPassword: 'Re-enter password',
       passwordMatchError: 'Passwords do not match',
       genericError: 'Something went wrong during sign up!',
+      usernameAlphaNum: 'Username can only contain letters, numbers, and underscores',
+      usernameAlreadyExists: 'An account with that username already exists',
       logIn: 'Sign in',
       kolibri: 'Kolibri',
       finish: 'Finish',
@@ -153,8 +152,27 @@
         }
         return this.$tr('passwordMatchError');
       },
-      usernameError() {
-        return this.errorCode === 400;
+      usernameIsAlphaNumUnderscore() {
+        if (this.username === '') {
+          return true;
+        }
+        return /^\w+$/g.test(this.username);
+      },
+      usernameDoesNotExistYet() {
+        if (this.errorCode === 400) {
+          return false;
+        }
+        return true;
+      },
+      usernameIsValid() {
+        return this.usernameIsAlphaNumUnderscore && this.usernameDoesNotExistYet;
+      },
+      usernameIsInvalidText() {
+        if (!this.usernameIsAlphaNumUnderscore) {
+          return this.$tr('usernameAlphaNum');
+        } else if (!this.usernameDoesNotExistYet) {
+          return this.$tr('usernameAlreadyExists');
+        }
       },
       allFieldsPopulated() {
         return (
@@ -164,6 +182,12 @@
           this.confirmed_password &&
           !this.noFacilitySelected
         );
+      },
+      unknownError() {
+        if (this.errorCode) {
+          return this.errorCode !== 400;
+        }
+        return false;
       },
       errorMessage() {
         return this.backendErrorMessage || this.$tr('genericError');


### PR DESCRIPTION
* Addresses #1594 
* More accurate validation message for username
* `Confirm password` -> `Re-enter password` (Approved by @jtamiace) 
* Remove placeholders. Pattern we are going to add to style guide based on [UX research on placeholders](https://www.nngroup.com/articles/form-design-placeholders/)  (Approved by @jtamiace)

# Before
![127 0 0 1-8000-user 1](https://user-images.githubusercontent.com/7193975/27808182-02aa41be-5ffb-11e7-8ce1-1f088576447f.png)

# After
![127 0 0 1-8000-user 2](https://user-images.githubusercontent.com/7193975/27808183-02ac8320-5ffb-11e7-89a2-89c6b56083b8.png)