### PR TITLE
Learn search page: Replace tab filters with select filters

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
@@ -52,7 +52,7 @@
     $trNameSpace: 'contentCardGrid',
     $trs: {
       display: 'Display',
-      all: 'All content ({ count, number })',
+      all: 'All content ({ num, number })',
       topics: 'Topics ({ count, number })',
       exercises: 'Exercises ({ count, number })',
       videos: 'Videos ({ count, number })',

--- a/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
@@ -6,7 +6,17 @@
       <span v-if="subheader"> {{subheader}} </span>
     </header>
 
-    <span v-for="content in contents" class="content-card">
+    <ui-select
+      v-if="filter"
+      :label="$tr('display')"
+      :options="filterOptions"
+      v-model="selectedFilter"
+      class="filter"
+    />
+
+    <span
+      v-for="content in contents" class="content-card"
+      v-show="selectedFilter.value === 'all' || selectedFilter.value === content.kind">
       <slot
         :title="content.title"
         :thumbnail="content.thumnail"
@@ -32,8 +42,28 @@
 <script>
 
   import validateLinkObject from 'kolibri.utils.validateLinkObject';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import some from 'lodash/some';
+  import forEach from 'lodash/forEach';
+  import uiSelect from 'keen-ui/src/UiSelect';
   import contentCard from '../content-card';
+
   export default {
+    $trNameSpace: 'contentCardGrid',
+    $trs: {
+      display: 'Display',
+      all: 'All content ({ count, number })',
+      topics: 'Topics ({ count, number })',
+      exercises: 'Exercises ({ count, number })',
+      videos: 'Videos ({ count, number })',
+      audio: 'Audio ({ count, number })',
+      documents: 'Documents ({ count, number })',
+      html5: 'HTML5 Apps ({ count, number })',
+    },
+    components: {
+      contentCard,
+      uiSelect,
+    },
     props: {
       contents: {
         type: Array,
@@ -55,8 +85,65 @@
         default: () => {},
         required: false,
       },
+      filter: {
+        type: Boolean,
+        default: true,
+      },
     },
-    components: { contentCard },
+    data: () => ({ selectedFilter: '' }),
+    computed: {
+      topics() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.TOPIC);
+      },
+      exercises() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.EXERCISE);
+      },
+      videos() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.VIDEO);
+      },
+      audio() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.AUDIO);
+      },
+      documents() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.DOCUMENT);
+      },
+      html5() {
+        return this.contents.filter(content => content.kind === ContentNodeKinds.HTML5);
+      },
+      filterOptions() {
+        const options = [
+          {
+            label: this.$tr('all', { count: this.contents.length }),
+            value: 'all',
+          },
+        ];
+        const kindLabelsMap = {
+          [ContentNodeKinds.TOPIC]: this.$tr('topics', { count: this.topics.length }),
+          [ContentNodeKinds.EXERCISE]: this.$tr('exercises', { count: this.exercises.length }),
+          [ContentNodeKinds.VIDEO]: this.$tr('videos', { count: this.videos.length }),
+          [ContentNodeKinds.AUDIO]: this.$tr('audio', { count: this.audio.length }),
+          [ContentNodeKinds.DOCUMENT]: this.$tr('documents', { count: this.documents.length }),
+          [ContentNodeKinds.HTML5]: this.$tr('html5', { count: this.html5.length }),
+        };
+        forEach(kindLabelsMap, (value, key) => {
+          if (this.contentsContain(key)) {
+            options.push({
+              label: value,
+              value: key,
+            });
+          }
+        });
+        return options;
+      },
+    },
+    methods: {
+      contentsContain(kind) {
+        return some(this.contents, content => content.kind === kind);
+      },
+    },
+    mounted() {
+      this.selectedFilter = this.filterOptions[0];
+    },
     vuex: { getters: { channelId: state => state.core.channels.currentId } },
   };
 
@@ -70,5 +157,9 @@
   .content-card
     display: inline-block
     margin: 10px
+
+  .filter
+    width: 200px
+    margin-top: 2em
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
@@ -53,12 +53,12 @@
     $trs: {
       display: 'Display',
       all: 'All content ({ num, number })',
-      topics: 'Topics ({ count, number })',
-      exercises: 'Exercises ({ count, number })',
-      videos: 'Videos ({ count, number })',
-      audio: 'Audio ({ count, number })',
-      documents: 'Documents ({ count, number })',
-      html5: 'HTML5 Apps ({ count, number })',
+      topics: 'Topics ({ num, number })',
+      exercises: 'Exercises ({ num, number })',
+      videos: 'Videos ({ num, number })',
+      audio: 'Audio ({ num, number })',
+      documents: 'Documents ({ num, number })',
+      html5: 'HTML5 Apps ({ num, number })',
     },
     components: {
       contentCard,
@@ -113,17 +113,17 @@
       filterOptions() {
         const options = [
           {
-            label: this.$tr('all', { count: this.contents.length }),
+            label: this.$tr('all', { num: this.contents.length }),
             value: 'all',
           },
         ];
         const kindLabelsMap = {
-          [ContentNodeKinds.TOPIC]: this.$tr('topics', { count: this.topics.length }),
-          [ContentNodeKinds.EXERCISE]: this.$tr('exercises', { count: this.exercises.length }),
-          [ContentNodeKinds.VIDEO]: this.$tr('videos', { count: this.videos.length }),
-          [ContentNodeKinds.AUDIO]: this.$tr('audio', { count: this.audio.length }),
-          [ContentNodeKinds.DOCUMENT]: this.$tr('documents', { count: this.documents.length }),
-          [ContentNodeKinds.HTML5]: this.$tr('html5', { count: this.html5.length }),
+          [ContentNodeKinds.TOPIC]: this.$tr('topics', { num: this.topics.length }),
+          [ContentNodeKinds.EXERCISE]: this.$tr('exercises', { num: this.exercises.length }),
+          [ContentNodeKinds.VIDEO]: this.$tr('videos', { num: this.videos.length }),
+          [ContentNodeKinds.AUDIO]: this.$tr('audio', { num: this.audio.length }),
+          [ContentNodeKinds.DOCUMENT]: this.$tr('documents', { num: this.documents.length }),
+          [ContentNodeKinds.HTML5]: this.$tr('html5', { num: this.html5.length }),
         };
         forEach(kindLabelsMap, (value, key) => {
           if (this.contentsContain(key)) {

--- a/kolibri/plugins/learn/assets/src/views/explore-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/explore-page/index.vue
@@ -13,20 +13,10 @@
       {{ topic.description }}
     </p>
 
-    <ui-select
-      :label="$tr('display')"
-      :options="filterOptions"
-      v-model="selectedFilter"
-      class="filter"
-    />
-
-    <span class="visuallyhidden" v-if="subtopics.length">{{ $tr('navigate') }}</span>
-
     <content-card-grid :contents="contents" v-if="contents.length">
 
       <template scope="content">
         <content-card
-          v-show="selectedFilter.value === 'all' || selectedFilter.value === content.kind"
           :key="content.id"
           :title="content.title"
           :thumbnail="content.thumbnail"
@@ -52,65 +42,23 @@
   import pageHeader from '../page-header';
   import contentCard from '../content-card';
   import contentCardGrid from '../content-card-grid';
-  import uiSelect from 'keen-ui/src/UiSelect';
   export default {
     $trNameSpace: 'learnExplore',
     $trs: {
       explore: 'Topics',
       navigate: 'Navigate content using headings',
-      all: 'All content',
-      topics: 'Topics',
-      exercises: 'Exercises',
-      videos: 'Videos',
-      audio: 'Audio',
-      documents: 'Documents',
-      html5: 'HTML5 Apps',
-      display: 'Display',
     },
     components: {
       pageHeader,
       contentCard,
       contentCardGrid,
-      uiSelect,
     },
-    data: () => ({ selectedFilter: '' }),
     computed: {
-      filterOptions() {
-        const options = [
-          {
-            label: this.$tr('all'),
-            value: 'all',
-          },
-        ];
-        const kindLabelsMap = {
-          [ContentNodeKinds.TOPIC]: this.$tr('topics'),
-          [ContentNodeKinds.EXERCISE]: this.$tr('exercises'),
-          [ContentNodeKinds.VIDEO]: this.$tr('videos'),
-          [ContentNodeKinds.AUDIO]: this.$tr('audio'),
-          [ContentNodeKinds.DOCUMENT]: this.$tr('documents'),
-          [ContentNodeKinds.HTML5]: this.$tr('html5'),
-        };
-        forEach(kindLabelsMap, (value, key) => {
-          if (this.contentsContain(key)) {
-            options.push({
-              label: value,
-              value: key,
-            });
-          }
-        });
-        return options;
-      },
       title() {
         return this.isRoot ? this.$tr('explore') : this.topic.title;
       },
-      subtopics() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.TOPIC);
-      },
     },
     methods: {
-      contentsContain(kind) {
-        return some(this.contents, content => content.kind === kind);
-      },
       genLink(node) {
         if (node.kind === ContentNodeKinds.TOPIC) {
           return {
@@ -123,9 +71,6 @@
           params: { channel_id: this.channelId, id: node.id },
         };
       },
-    },
-    mounted() {
-      this.selectedFilter = this.filterOptions[0];
     },
     vuex: {
       getters: {
@@ -146,9 +91,5 @@
     margin-top: 1em
     margin-bottom: 1em
     line-height: 1.5em
-
-  .filter
-    width: 200px
-    margin-top: 2em
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/search-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page/index.vue
@@ -12,64 +12,11 @@
       <h1 class="search-results">{{ $tr('showingResultsFor', { searchTerm }) }}</h1>
       <p class="search-channel">{{ $tr('withinChannel', { channelName }) }}</p>
 
-      <tabs>
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('all', { num: contents.length } )"
-          icon="layers"
-          @click="filter = 'all'"
-          :selected="filter === 'all'"
-        />
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('topics', { num: topics.length } )"
-          icon="folder"
-          :selected="filter === contentNodeKinds.TOPIC"
-          @click="filter = contentNodeKinds.TOPIC"
-        />
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('exercises', { num: exercises.length } )"
-          icon="assignment"
-          :selected="filter === contentNodeKinds.EXERCISE"
-          @click="filter = contentNodeKinds.EXERCISE"
-        />
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('videos', { num: videos.length } )"
-          icon="ondemand_video"
-          :selected="filter === contentNodeKinds.VIDEO"
-          @click="filter = contentNodeKinds.VIDEO"
-        />
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('audio', { num: audio.length } )"
-          icon="audiotrack"
-          :selected="filter === contentNodeKinds.AUDIO"
-          @click="filter = contentNodeKinds.AUDIO"
-        />
-        <tab-button
-          type="icon-and-title"
-          :title="$tr('documents', { num: documents.length } )"
-          icon="book"
-          :selected="filter === contentNodeKinds.DOCUMENT"
-          @click="filter = contentNodeKinds.DOCUMENT"
-        />
-        <tab-button
-          type="icon-and-title"
-          icon="widgets"
-          :title="$tr('html5', { num: html5.length } )"
-          :selected="filter === contentNodeKinds.HTML5"
-          @click="filter = contentNodeKinds.HTML5"
-        />
-      </tabs>
+      <p v-if="contents.length === 0">{{ $tr('noResultsMsg', { searchTerm }) }}</p>
 
-      <p v-if="filteredResults.length === 0">{{ noResultsMsg }}</p>
-
-      <content-card-grid v-else :contents="filteredResults">
+      <content-card-grid v-else :contents="contents">
         <template scope="content">
           <content-card
-            v-show="filter === 'all' || filter === content.kind"
             :key="content.id"
             :title="content.title"
             :thumbnail="content.thumbnail"
@@ -91,98 +38,22 @@
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { PageNames } from '../../constants';
-  import { getCurrentChannelObject as GetCurrentChannelObject } from 'kolibri.coreVue.vuex.getters';
+  import { getCurrentChannelObject } from 'kolibri.coreVue.vuex.getters';
   import contentCard from '../content-card';
   import contentCardGrid from '../content-card-grid';
   import searchBox from '../search-box';
-  import tabs from 'kolibri.coreVue.components.tabs';
-  import tabButton from 'kolibri.coreVue.components.tabButton';
   export default {
     $trNameSpace: 'learnSearch',
     $trs: {
       noSearch: 'Search by typing something in the search box above',
       showingResultsFor: 'Search results for "{searchTerm}"',
       withinChannel: 'Within {channelName}',
-      all: 'All ({ num, number })',
-      content: 'Content',
-      exercises: 'Exercises ({ num, number })',
-      videos: 'Videos ({ num, number })',
-      audio: 'Audio ({ num, number })',
-      topics: 'Topics ({ num, number })',
-      documents: 'Documents ({ num, number })',
-      html5: 'HTML5 apps ({ num, number })',
-      noContent: 'No content matches "{searchTerm}"',
-      noExercises: 'No exercises match "{searchTerm}"',
-      noVideos: 'No videos match "{searchTerm}"',
-      noAudio: 'No audio matches "{searchTerm}"',
-      noTopics: 'No topics match "{searchTerm}"',
-      noDocuments: 'No documents match "{searchTerm}"',
-      noHtml5: 'No HTML5 apps match "{searchTerm}"',
+      noResultsMsg: 'No results for "{searchTerm}"',
     },
     components: {
       contentCard,
       contentCardGrid,
-      tabs,
-      tabButton,
       searchBox,
-    },
-    data() {
-      return { filter: 'all' };
-    },
-    computed: {
-      contentNodeKinds() {
-        return ContentNodeKinds;
-      },
-      topics() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.TOPIC);
-      },
-      exercises() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.EXERCISE);
-      },
-      videos() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.VIDEO);
-      },
-      audio() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.AUDIO);
-      },
-      documents() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.DOCUMENT);
-      },
-      html5() {
-        return this.contents.filter(content => content.kind === ContentNodeKinds.HTML5);
-      },
-      filteredResults() {
-        if (this.filter === ContentNodeKinds.TOPIC) {
-          return this.topics;
-        } else if (this.filter === ContentNodeKinds.EXERCISE) {
-          return this.exercises;
-        } else if (this.filter === ContentNodeKinds.VIDEO) {
-          return this.videos;
-        } else if (this.filter === ContentNodeKinds.AUDIO) {
-          return this.audio;
-        } else if (this.filter === ContentNodeKinds.DOCUMENT) {
-          return this.documents;
-        } else if (this.filter === ContentNodeKinds.HTML5) {
-          return this.html5;
-        }
-        return this.contents;
-      },
-      noResultsMsg() {
-        if (this.filter === ContentNodeKinds.TOPIC) {
-          return this.$tr('noTopics', { searchTerm: this.searchTerm });
-        } else if (this.filter === ContentNodeKinds.EXERCISE) {
-          return this.$tr('noExercises', { searchTerm: this.searchTerm });
-        } else if (this.filter === ContentNodeKinds.VIDEO) {
-          return this.$tr('noVideos', { searchTerm: this.searchTerm });
-        } else if (this.filter === ContentNodeKinds.AUDIO) {
-          return this.$tr('noAudio', { searchTerm: this.searchTerm });
-        } else if (this.filter === ContentNodeKinds.DOCUMENT) {
-          return this.$tr('noDocuments', { searchTerm: this.searchTerm });
-        } else if (this.filter === ContentNodeKinds.HTML5) {
-          return this.$tr('noHtml5', { searchTerm: this.searchTerm });
-        }
-        return this.$tr('noContent', { searchTerm: this.searchTerm });
-      },
     },
     methods: {
       genLink(content) {
@@ -209,7 +80,7 @@
         contents: state => state.pageState.contents,
         searchTerm: state => state.pageState.searchTerm,
         channelId: state => state.core.channels.currentId,
-        channelName: state => GetCurrentChannelObject(state).title,
+        channelName: state => getCurrentChannelObject(state).title,
       },
     },
   };


### PR DESCRIPTION
# Description

* Learn search page: Replace tab filters with select filters. 
* Adds filter to `content-card-grid`.

# Before

![127 0 0 1-8000-learn- 6](https://user-images.githubusercontent.com/7193975/27811697-d7ee3dd6-601d-11e7-8c90-06848fe4f5fd.png)

# After

![127 0 0 1-8000-learn- 5](https://user-images.githubusercontent.com/7193975/27811678-c28e67d6-601d-11e7-834b-973d51947f78.png) 