### PR TITLE
Carousel initial animation fix

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-card-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-carousel/index.vue
@@ -110,6 +110,8 @@
       return {
         contentSetStart: 0,
         leftToRight: false,
+        // tracks whether the carousel has been interacted with
+        interacted: false,
       };
     },
     watch: {
@@ -119,6 +121,12 @@
         const newIndexTooLarge = this.contentSetEnd >= this.contents.length;
         const newIndexTooSmall = newStartIndex < 0;
         const enoughContentForASet = this.contents.length >= this.contentSetSize;
+
+        // turns animation on in case this is the first time it's been updated
+        if (!this.interacted) {
+          this.interacted = true;
+        }
+
         if (nextSet && newIndexTooLarge && enoughContentForASet) {
           this.contentSetStart = this.contents.length - this.contentSetSize;
         } else if (previousSet && newIndexTooSmall) {
@@ -179,7 +187,10 @@
         const gutters = (this.contentSetSize - 1) * gutterWidth;
         const carouselContainerOffset = cards + gutters;
         const sign = this.leftToRight ? -1 : 1;
-        el.style.left = `${sign * carouselContainerOffset + originalPosition}px`;
+
+        if (this.interacted) {
+          el.style.left = `${sign * carouselContainerOffset + originalPosition}px`;
+        }
       },
       slide(el) {
         const originalPosition = parseInt(el.style.left, 10);
@@ -187,7 +198,10 @@
         const gutters = (this.contentSetSize - 1) * gutterWidth;
         const carouselContainerOffset = cards + gutters;
         const sign = this.leftToRight ? 1 : -1;
-        el.style.left = `${sign * carouselContainerOffset + originalPosition}px`;
+
+        if (this.interacted) {
+          el.style.left = `${sign * carouselContainerOffset + originalPosition}px`;
+        }
       },
       isInThisSet(index) {
         return this.contentSetStart <= index && index <= this.contentSetEnd;

--- a/kolibri/plugins/learn/assets/src/views/content-card-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-carousel/index.vue
@@ -108,13 +108,16 @@
     },
     data() {
       return {
+        // flag marks holds the index (in contents array, prop) of first item in carousel
         contentSetStart: 0,
+        // flag that marks when the slide animation will be going start at left
         leftToRight: false,
         // tracks whether the carousel has been interacted with
         interacted: false,
       };
     },
     watch: {
+      // ensures that indeces in contentSetStart/End are within bounds of the contents
       contentSetStart(newStartIndex, oldStartIndex) {
         const nextSet = newStartIndex > oldStartIndex;
         const previousSet = newStartIndex < oldStartIndex;
@@ -133,6 +136,7 @@
           this.contentSetStart = 0;
         }
       },
+      // ensures that carousel correctly readjusts # of cards if resize occurs at end of contents
       contentSetSize(newSetSize, oldSetSize) {
         const addingCards = newSetSize > oldSetSize;
         const removingCards = oldSetSize > newSetSize;
@@ -182,6 +186,8 @@
         return { left: `${cardOffset + gutterOffset}px` };
       },
       setStartPosition(el) {
+        // sets the initial spot from which cards will be sliding into place from
+        // direction depends on `leftToRight`
         const originalPosition = parseInt(el.style.left, 10);
         const cards = this.contentSetSize * contentCardWidth;
         const gutters = (this.contentSetSize - 1) * gutterWidth;
@@ -193,6 +199,8 @@
         }
       },
       slide(el) {
+        // moves cards from their starting point by their offset
+        // direction depends on `leftToRight`
         const originalPosition = parseInt(el.style.left, 10);
         const cards = this.contentSetSize * contentCardWidth;
         const gutters = (this.contentSetSize - 1) * gutterWidth;


### PR DESCRIPTION
## Summary

Fixes #1638

Stops fly-in on pageload, only starts animating once the content set has been changed (which translates to user input).