### PR TITLE
Backport make dist fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test-all:
 	tox
 
 assets: staticdeps
+	yarn install
 	yarn run build
 
 coverage:


### PR DESCRIPTION
Run yarn install before building frontend assets to ensure dependencies are met.

A bit ouch