### PR TITLE
Upgrade to fixed 0.8.0 release of django-q

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,55 +18,55 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=pythonbuild2.7
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "3.4"
       env:
         - TOX_ENV=pythonbuild3.4
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=pythonbuild3.5
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=licenses
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=py2.7
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=docs
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=bdd
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "3.4"
       env:
         - TOX_ENV=py3.4
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=py3.5
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
-        - TOX_ENV=node4.x
-        - TRAVIS_NODE_VERSION="4"
+        - TOX_ENV=node6.x
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=postgres
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=npmbuild
-        - TRAVIS_NODE_VERSION="4"
+        - TRAVIS_NODE_VERSION="6"
 
 before_install:
   - pip install -U pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,32 @@ Release Notes
 Changes are ordered reverse-chronologically.
 
 
+0.4.4
+-----
+
+ - Fix for Python 3 compatibility in Whl, Windows and Pex builds #1797
+
+
+0.4.3
+-----
+
+ - Speed improvements for content recommendation #1798
+
+
+0.4.2
+-----  
+
+ - Fixes for morango database migrations 
+
+
+0.4.1
+-----
+
+ - Makes usernames for login case insensitive #1733 
+ - Fixes various issues with exercise rendering #1757 
+ - Removes wrong CLI usage instructions #1742
+
+
 0.4
 ---
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://github.com/fle-internal/django-q/archive/934d557d77ded18c4a73a702905a6f8fe932f97b.zip#egg=django-q
+https://github.com/fle-internal/django-q/archive/0e319c1c8e0471b9319b001500b2c82eadca7ec5.zip#egg=django-q
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node4.x, docs, bdd, node, postgres, pythonbuild{2.7, 3.4, 3.5}
+envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node6.x, docs, bdd, node, postgres, pythonbuild{2.7, 3.4, 3.5}
 
 [testenv]
 usedevelop = True
@@ -20,7 +20,7 @@ basepython =
     docs: python2.7
     pythonlint: python2.7
     bdd: python2.7
-    node4.x: python2.7
+    node6.x: python2.7
     npmbuild: python2.7
 deps =
     -r{toxinidir}/requirements/test.txt
@@ -74,7 +74,7 @@ commands =
     npm rebuild node-sass
     yarn run coverage
 
-[testenv:node4.x]
+[testenv:node6.x]
 whitelist_externals = {[node_base]whitelist_externals}
 commands = {[node_base]commands}
 


### PR DESCRIPTION
## Summary

I created a fix for django-q and submitted an upstream PR: `https://github.com/Koed00/django-q/pull/247`

Is it risky to upgrade django-q? I believe that it contains valuable fixes @jayoshih @aronasorman 

Quoting release notes:

 - Adds support for Django 1.11 and Python 3.6
 - Updates all dependencies to latest versions
 - Merges several long over due pull requests

## TODO

- [x] New dependencies (if any) added to requirements file
- [x] Add an entry to CHANGELOG.rst

## Reviewer guidance

Just wanna have someone scream out if 0.8.0 is too risky.. otherwise I see testing it for 0.4.x the same effort as testing for later releases, so we might as well get it in here instead of having our only stable release branch remain with a botched release flow.

## Issues addressed

#1797 
