### PR TITLE
Fix channel deletion bug

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   root: true,
-  extends: 'airbnb/base',
   // required to lint *.vue files
   plugins: [
     'html'

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -80,7 +80,7 @@
       },
       selectedChannelTitle() {
         if (this.channelIsSelected) {
-          return this.channelList[this.selectedChannelIdx].title;
+          return this.sortedChannels[this.selectedChannelIdx].title;
         }
         return '';
       },
@@ -105,7 +105,7 @@
     methods: {
       handleDeleteChannel() {
         if (this.selectedChannelIdx !== null) {
-          const channelId = this.channelList[this.selectedChannelIdx].id;
+          const channelId = this.sortedChannels[this.selectedChannelIdx].id;
           this.selectedChannelIdx = null;
           this.deleteChannel(channelId)
             .then(() => {

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/channels-grid.vue
@@ -37,7 +37,7 @@
           </td>
           <td>
             <button
-              @click="selectedChannelIdx=idx"
+              @click="selectedChannelId=channel.id"
               class="delete-button"
             >
               {{ $tr('deleteButtonLabel') }}
@@ -52,7 +52,7 @@
       v-if="channelIsSelected"
       :channelTitle="selectedChannelTitle"
       @confirm="handleDeleteChannel()"
-      @cancel="selectedChannelIdx=null"
+      @cancel="selectedChannelId=null"
     />
   </div>
 
@@ -65,22 +65,24 @@
   import * as manageContentActions from '../../state/manageContentActions';
   import map from 'lodash/map';
   import orderBy from 'lodash/orderBy';
+  import find from 'lodash/find';
   import uiButton from 'keen-ui/src/UiButton';
   import uiProgressCircular from 'keen-ui/src/UiProgressCircular';
   import deleteChannelModal from './delete-channel-modal';
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
   export default {
     data: () => ({
-      selectedChannelIdx: null,
+      selectedChannelId: null,
       notification: null,
     }),
     computed: {
       channelIsSelected() {
-        return this.selectedChannelIdx !== null;
+        return this.selectedChannelId !== null;
       },
       selectedChannelTitle() {
         if (this.channelIsSelected) {
-          return this.sortedChannels[this.selectedChannelIdx].title;
+          const channel = find(this.channelList, { id: this.selectedChannelId });
+          return channel.title;
         }
         return '';
       },
@@ -104,9 +106,9 @@
     },
     methods: {
       handleDeleteChannel() {
-        if (this.selectedChannelIdx !== null) {
-          const channelId = this.sortedChannels[this.selectedChannelIdx].id;
-          this.selectedChannelIdx = null;
+        if (this.selectedChannelId !== null) {
+          const channelId = this.selectedChannelId;
+          this.selectedChannelId = null;
           this.deleteChannel(channelId)
             .then(() => {
               this.$emit('deletesuccess');


### PR DESCRIPTION
Addresses #1813 

Root cause was that the list of channels is presented in alphabetical order, whereas the logic that chose which channel to display in modal and delete was assuming original (non-sorted) order. This patch passes the channel id (instead of the item's index) directly as data to be used for the modal+delete logic.

How to test:

1. Install at least two channels. The first should have a title that is "higher" than the other in alphabetical order (e.g. "Portion Control" first, then "KA Testing")
2. Attempt to delete either channel and confirm that the correct title appears in the modal, plus the correct channel gets deleted.