### PR TITLE
2 + 3 again

### DIFF
--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -15,7 +15,6 @@ import requests
 from django.core.management import call_command
 from django.http import Http404
 from django.utils.translation import ugettext as _
-from django.conf import settings
 from kolibri.content.models import ChannelMetadataCache
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.content.utils.paths import get_content_database_file_url
@@ -23,13 +22,12 @@ from rest_framework import serializers, viewsets
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
 from barbequeue.common.classes import State
-from barbequeue.client import SimpleClient
 
 from .permissions import IsDeviceOwnerOnly
+from .apps import client
+
 
 logging = logger.getLogger(__name__)
-
-client = SimpleClient(app="kolibri", storage_path=settings.QUEUE_JOB_STORAGE_PATH)
 
 # all tasks are marked as remote imports for nwo
 TASKTYPE = "remoteimport"

--- a/kolibri/tasks/apps.py
+++ b/kolibri/tasks/apps.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.apps import AppConfig
+from django.conf import settings
+
+from barbequeue.client import SimpleClient
+
+client = None
 
 
 class KolibriTasksConfig(AppConfig):
@@ -9,5 +14,6 @@ class KolibriTasksConfig(AppConfig):
     verbose_name = 'Kolibri Tasks'
 
     def ready(self):
-        from kolibri.tasks.api import client
+        global client
+        client = SimpleClient(app="kolibri", storage_path=settings.QUEUE_JOB_STORAGE_PATH)
         client.clear(force=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://github.com/learningequality/barbequeue/archive/d135b.zip#egg=barbequeue
+https://github.com/learningequality/barbequeue/archive/d655b.zip#egg=barbequeue
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5


### PR DESCRIPTION
Fixes the daemonization issue in https://github.com/learningequality/kolibri/issues/1786. We do this by making sure we only start the BBQ machinery when we actually start Django, not when we just load the tasks/api.py module.

Also fixes the python-2-and-python-3-from-a-single-pex issue.