### PR TITLE
Prevent multiline comments in vue files from being weirdly indented.

### DIFF
--- a/frontend_build/src/prettier-frontend.js
+++ b/frontend_build/src/prettier-frontend.js
@@ -29,7 +29,8 @@ function prettierFrontend({ file, write, encoding = 'utf-8', prettierOptions }) 
         } else if (vueComponent && vueComponent.script) {
           const start = vueComponent.script.start;
           const end = vueComponent.script.end;
-          let formattedJs = prettier.format(source.slice(start, end), options);
+          const code = source.slice(start, end).replace(/(\n)  /g, '$1');
+          let formattedJs = prettier.format(code, options);
           // Ensure that the beginning and end of the JS has two newlines to fit our
           // Component linting conventions
           // Ensure it is indented by two spaces

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -121,9 +121,10 @@
       noRendererAvailable: false,
     }),
     methods: {
-      // Check the Kolibri core app for a content renderer module that is able to
-      // handle the rendering of the current content node. This is the entrance point for changes
-      // in the props,so any change in the props will trigger this function first.
+      /* Check the Kolibri core app for a content renderer module that is able to
+       * handle the rendering of the current content node. This is the entrance point for changes
+       * in the props,so any change in the props will trigger this function first.
+       */
       updateRendererComponent() {
         // Assume we will find a renderer until we find out otherwise.
         this.noRendererAvailable = false;


### PR DESCRIPTION
## Summary

Removes two space indent from vue component script blocks before running prettier on them.

Fixes #1800 