### PR TITLE
Restore Topic page thumbnails

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-grid/index.vue
@@ -19,7 +19,7 @@
       v-show="selectedFilter.value === 'all' || selectedFilter.value === content.kind">
       <slot
         :title="content.title"
-        :thumbnail="content.thumnail"
+        :thumbnail="content.thumbnail"
         :kind="content.kind"
         :progress="content.progress"
         :id="content.id">


### PR DESCRIPTION
## Summary

Fix typo

Fixes #1783 

Before:
![image](https://user-images.githubusercontent.com/1680573/28050037-07518cda-65b0-11e7-8de0-25a57e435f68.png)

After:
![image](https://user-images.githubusercontent.com/1680573/28050051-17b40bde-65b0-11e7-9fb0-1ca5b2d12470.png)
