### PR TITLE
Give tab and breadcrumb links a query param to fix bad links

### DIFF
--- a/kolibri/plugins/style_guide/assets/src/views/content/components/breadcrumbs.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/breadcrumbs.vue
@@ -123,8 +123,8 @@
     data: () => ({
     }),
     computed: {
-      topicsLink: function() { return { path: this.$route.path + '_' } },
-      decimalLink: function() { return { path: this.$route.path + '_' } },
+      topicsLink: function() { return { path: this.$route.path, query: { page: 'topics' } } },
+      decimalLink: function() { return { path: this.$route.path, query: { page: 'decimal' } } },
       decimalAddLink: function() { return { path: this.$route.path } },
     }
   };

--- a/kolibri/plugins/style_guide/assets/src/views/content/components/tabs.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/components/tabs.vue
@@ -152,10 +152,10 @@
     }),
     computed: {
       topicsLink: function() { return { path: this.$route.path } },
-      recentLink: function() { return { path: this.$route.path + 'foo' } },
-      learnersLink: function() { return { path: this.$route.path + 'foo' } },
-      groupsLink: function() { return { path: this.$route.path + 'foo' } },
-      examsLink: function() { return { path: this.$route.path + 'foo' } },
+      recentLink: function() { return { path: this.$route.path, query: { page: 'recent' } } },
+      learnersLink: function() { return { path: this.$route.path, query: { page: 'learners' } } },
+      groupsLink: function() { return { path: this.$route.path, query: { page: 'groups' } } },
+      examsLink: function() { return { path: this.$route.path, query: { page: 'exams' } } },
     },
     components: {
       // 'tabs': require('kolibri.coreVue.components.tabs'),


### PR DESCRIPTION
Addresses #1714 and #1715 

This gives the `router-link` elements' a `to` prop query parameter. This way, clicking the links does not go to an invalid route, nor does it take away their original inactive/active styling.