### PR TITLE
Only set user id on attempt log if user is a facility user.

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -622,9 +622,10 @@ function saveAttemptLog(store) {
 }
 
 function createAttemptLog(store, itemId) {
+  const user = getters.isFacilityUser(store.state) ? getters.currentUserId(store.state) : null;
   const attemptLogModel = AttemptLogResource.createModel({
     id: null,
-    user: store.state.core.session.user_id,
+    user,
     masterylog: store.state.core.logging.mastery.id || null,
     sessionlog: store.state.core.logging.session.id,
     start_timestamp: now(),


### PR DESCRIPTION
## Summary

Currently we just unconditionally set the user_id on an attempt log, but if the logged in user is a device owner, this will cause a 400, as it cannot find a facility user with that pk.

This PR fixes that by setting the user_id to null if a device owner is logged in.

## Issues addressed

Fixes #1789 

## Screenshots (if appropriate)

Before

![image](https://user-images.githubusercontent.com/1680573/28095817-6ddef718-6659-11e7-956e-7f7ddb3cb711.png)

After

![image](https://user-images.githubusercontent.com/1680573/28095829-8777cd3a-6659-11e7-8140-83d6c6ee6992.png)
