### PR TITLE
Handle non-pytz tzinfo on datetimes by pretending it doesn't exist.

### DIFF
--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -24,8 +24,16 @@ def parse_timezonestamp(value):
     return value.astimezone(tz)
 
 def create_timezonestamp(value):
-    if value.tzinfo:
+    if value.tzinfo and hasattr(value.tzinfo, 'zone'):
+        # We have a pytz timezone, we can work with this
         tz = value.tzinfo.zone
+    elif value.tzinfo:
+        # Got some timezone data, but it's not a pytz timezone
+        # Let's just assume someone used dateutil parser on a UTC
+        # ISO format timestamp
+        # Fixes https://github.com/learningequality/kolibri/issues/1824
+        tz = pytz.utc
+        value = value.astimezone(tz)
     else:
         tz = timezone.get_current_timezone().zone
         value = timezone.make_aware(value, timezone.get_current_timezone())


### PR DESCRIPTION
## Summary

`dateutil.parser`'s `parse` function produces datetimes with `tzinfo` attributes with no `zone` information, which we currently use in `DatetimeTzField` with `pytz` in order to save timezone information in the database.

To address this, we detect when a non-pytz timezone object is the `tzinfo` attribute of a datetime, and we ignore it. This is safe for now, because the only time we do this is when doing database queries - never when saving data.

## Issues addressed

Fixes #1824

## Screenshots (if appropriate)

Before:

![image](https://user-images.githubusercontent.com/1680573/28096475-dbda40ac-665d-11e7-8014-0cfbdea8d30f.png)

After:

![image](https://user-images.githubusercontent.com/1680573/28096485-edfa06be-665d-11e7-8ae1-2e470b4de7ad.png)
