### PR TITLE
Test optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       env:
         - TOX_ENV=py2.7
         - TRAVIS_NODE_VERSION="6"
-    - python: "2.7"
+    - python: "3.5"
       env:
         - TOX_ENV=docs
         - TRAVIS_NODE_VERSION="6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
       env:
         - TOX_ENV=node6.x
         - TRAVIS_NODE_VERSION="6"
-    - python: "2.7"
+    - python: "3.5"
       env:
         - TOX_ENV=postgres
         - TRAVIS_NODE_VERSION="6"

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ setenv =
     KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.postgres_test
 basepython =
-    postgres: python2.7
+    postgres: python3.5
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/postgres.txt

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ basepython =
     py3.4: python3.4
     py3.5: python3.5
     pypy: pypy
-    docs: python2.7
+    docs: python3.5
     pythonlint: python2.7
     bdd: python2.7
     node6.x: python2.7
@@ -56,13 +56,12 @@ deps =
 commands =
     flake8 kolibri
 
-##### remove the link checker test because it causes random failures
-#[testenv:docs]
-#changedir=docs/
-#deps =
-#    -r{toxinidir}/requirements/docs.txt
-#commands =
-#    sphinx-build -b linkcheck ./ _build/
+[testenv:docs]
+changedir=docs/
+deps =
+    -r{toxinidir}/requirements/docs.txt
+commands =
+    sphinx-build ./ _build/
 
 [testenv:bdd]
 deps =


### PR DESCRIPTION
## Summary

Our docs build had previously been 'disabled' but had actually been turned into a replica of the Python2.7 tests (which are very slow). Have reenabled the docs build to make sure it doesn't error out, but removed the link checker which caused random failures.

Also switched the post gres test suite to Python3.5 as Python 3 tests take a quarter of the time of Python2 tests.

Fixes #1775 