### PR TITLE
Allow topics to have thumbnails

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -48,10 +48,12 @@ function validateProgress(data) {
 
 function _topicState(data, ancestors = []) {
   const progress = validateProgress(data);
+  const thumbnail = data.files.find(file => file.thumbnail && file.available) || {};
   const state = {
     id: data.pk,
     title: data.title,
     description: data.description,
+    thumbnail: thumbnail.storage_url,
     breadcrumbs: _crumbState(ancestors),
     parent: data.parent,
     kind: data.kind,


### PR DESCRIPTION
## Summary

Topics had their thumbnails filtered out, but they can have them. This enables that.

![image](https://user-images.githubusercontent.com/1680573/28101996-2c6b886e-6681-11e7-8336-1d5e0d5599d6.png)
