### PR TITLE
Video player buttons fix

### DIFF
--- a/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
+++ b/kolibri/plugins/video_mp4_render/assets/src/views/index.vue
@@ -296,6 +296,11 @@
   $video-player-font-size = 12px
 
 
+  /* Hide control bar when playing & inactive */
+  .vjs-has-started.vjs-playing.vjs-user-inactive
+    .vjs-control-bar
+      visibility: hidden
+
 
   /*** CUSTOM VIDEOJS SKIN ***/
   .custom-skin


### PR DESCRIPTION
# Description

There was an issue where the buttons were still clickable even if not visible. This resulted in unintentional clicks. 

# Before

![before](https://user-images.githubusercontent.com/7193975/28131677-808c1a26-66ef-11e7-9aab-9ab9750441d2.gif)

# After

![after](https://user-images.githubusercontent.com/7193975/28131686-83b872da-66ef-11e7-8513-58205ad34aed.gif)
