### PR TITLE
Fix Next Content Button

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -101,11 +101,16 @@
 
 <script>
 
-  import * as Constants from '../../constants';
-  import * as getters from '../../state/getters';
+  import {
+    initSessionAction,
+    updateProgressAction,
+    startTracking,
+    stopTracking,
+  } from 'kolibri.coreVue.vuex.actions';
+  import { PageNames } from '../../constants';
+  import { pageMode } from '../../state/getters';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import * as coreGetters from 'kolibri.coreVue.vuex.getters';
-  import * as actions from 'kolibri.coreVue.vuex.actions';
+  import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { updateContentNodeProgress } from '../../state/actions';
   import pageHeader from '../page-header';
   import contentCardCarousel from '../content-card-carousel';
@@ -117,6 +122,7 @@
   import uiPopover from 'keen-ui/src/UiPopover';
   import uiIcon from 'keen-ui/src/UiIcon';
   import markdownIt from 'markdown-it';
+
   export default {
     $trNameSpace: 'learnContent',
     $trs: {
@@ -158,12 +164,12 @@
         if (nextContent) {
           if (nextContent.kind === 'topic') {
             return {
-              name: Constants.PageNames.EXPLORE_TOPIC,
+              name: PageNames.EXPLORE_TOPIC,
               params: { channel_id: this.channelId, id: nextContent.id },
             };
           }
           return {
-            name: Constants.PageNames.EXPLORE_CONTENT,
+            name: PageNames.EXPLORE_CONTENT,
             params: { channel_id: this.channelId, id: nextContent.id },
           };
         }
@@ -207,12 +213,12 @@
       genRecLink(id, kind) {
         if (kind === 'topic') {
           return {
-            name: Constants.PageNames.EXPLORE_TOPIC,
+            name: PageNames.EXPLORE_TOPIC,
             params: { channel_id: this.channelId, id },
           };
         }
         return {
-          name: Constants.PageNames.LEARN_CONTENT,
+          name: PageNames.LEARN_CONTENT,
           params: { channel_id: this.channelId, id },
         };
       },
@@ -222,7 +228,6 @@
     },
     vuex: {
       getters: {
-        pageMode: getters.pageMode,
         searchOpen: state => state.searchOpen,
         content: state => state.pageState.content,
         contentId: state => state.pageState.content.content_id,
@@ -232,13 +237,14 @@
         recommended: state => state.pageState.recommended,
         summaryProgress: state => state.core.logging.summary.progress,
         sessionProgress: state => state.core.logging.session.progress,
-        isSuperuser: coreGetters.isSuperuser,
+        pageMode,
+        isSuperuser,
       },
       actions: {
-        initSessionAction: actions.initContentSession,
-        updateProgressAction: actions.updateProgress,
-        startTracking: actions.startTrackingProgress,
-        stopTracking: actions.stopTrackingProgress,
+        initSessionAction,
+        updateProgressAction,
+        startTracking,
+        stopTracking,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -79,7 +79,7 @@
 
     <content-card-carousel
       v-if="showRecommended"
-      :gen-link="genLink"
+      :gen-link="genRecLink"
       :header="recommendedText"
       :contents="recommended"/>
 
@@ -155,7 +155,7 @@
       },
       nextContentLink() {
         if (this.content.next_content) {
-          return this.genLink(this.content.next_content.id, this.content.next_content.kind);
+          return this.genNextLink(this.content.next_content.id, this.content.next_content.kind);
         }
         return null;
       },
@@ -194,7 +194,7 @@
       closeModal() {
         this.wasIncomplete = false;
       },
-      genLink(id, kind) {
+      genRecLink(id, kind) {
         if (kind === 'topic') {
           return {
             name: Constants.PageNames.EXPLORE_TOPIC,
@@ -203,6 +203,18 @@
         }
         return {
           name: Constants.PageNames.LEARN_CONTENT,
+          params: { channel_id: this.channelId, id },
+        };
+      },
+      genNextLink(id, kind) {
+        if (kind === 'topic') {
+          return {
+            name: Constants.PageNames.EXPLORE_TOPIC,
+            params: { channel_id: this.channelId, id },
+          };
+        }
+        return {
+          name: Constants.PageNames.EXPLORE_CONTENT,
           params: { channel_id: this.channelId, id },
         };
       },

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -21,7 +21,7 @@
       :available="content.available"
       :extraFields="content.extra_fields"
       :initSession="initSession">
-      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
+      <icon-button @click="nextContentClicked" v-if="showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
         <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
       </icon-button>
     </content-renderer>
@@ -42,7 +42,7 @@
       :available="content.available"
       :extraFields="content.extra_fields"
       :initSession="initSession">
-      <icon-button @click="nextContentClicked" v-if="progress >= 1 && showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
+      <icon-button @click="nextContentClicked" v-if="showNextBtn" class="next-btn right" :text="$tr('nextContent')" alignment="right">
         <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
       </icon-button>
     </assessment-wrapper>
@@ -142,7 +142,7 @@
         }
       },
       showNextBtn() {
-        return this.content && this.nextContentLink;
+        return this.progress >= 1 && this.content && this.nextContentLink;
       },
       recommendedText() {
         return this.$tr('recommended');
@@ -154,8 +154,18 @@
         return this.sessionProgress;
       },
       nextContentLink() {
-        if (this.content.next_content) {
-          return this.genNextLink(this.content.next_content.id, this.content.next_content.kind);
+        const nextContent = this.content.next_content;
+        if (nextContent) {
+          if (nextContent.kind === 'topic') {
+            return {
+              name: Constants.PageNames.EXPLORE_TOPIC,
+              params: { channel_id: this.channelId, id: nextContent.id },
+            };
+          }
+          return {
+            name: Constants.PageNames.EXPLORE_CONTENT,
+            params: { channel_id: this.channelId, id: nextContent.id },
+          };
         }
         return null;
       },
@@ -203,18 +213,6 @@
         }
         return {
           name: Constants.PageNames.LEARN_CONTENT,
-          params: { channel_id: this.channelId, id },
-        };
-      },
-      genNextLink(id, kind) {
-        if (kind === 'topic') {
-          return {
-            name: Constants.PageNames.EXPLORE_TOPIC,
-            params: { channel_id: this.channelId, id },
-          };
-        }
-        return {
-          name: Constants.PageNames.EXPLORE_CONTENT,
           params: { channel_id: this.channelId, id },
         };
       },


### PR DESCRIPTION
## Summary

Fixes #1854 

New behavior: when arrived at a page from the "recommended" carousel down below, you will have a breakcrumb that led there from "recommended", as described in the issue.

If you click on the next button, breadcrumbs show the proper hierarchy from topic tree:
![nextbuttondemo](https://user-images.githubusercontent.com/9877852/28294746-fba3fa42-6b10-11e7-9c9d-c221a8a752f9.gif)
