### PR TITLE
i18n additions in support of Perseus i18nization

### DIFF
--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -140,6 +140,9 @@ var parseBundlePlugin = function(data, base_dir) {
   bundle.output = {
     path: outputPath,
     filename: '[name]-' + data.version + '.js',
+    // Need to define this in order for chunks to be named
+    // Without this chunks from different bundles will likely have colliding names
+    chunkFilename: '[name]-' + data.version + '.js',
     publicPath: publicPath,
     library: library,
   };

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -12,21 +12,6 @@
  *  and used as a template, with additional plugin-specific
  *  modifications made on top.
  */
-var path = require('path');
-
-/*
- * This is a filthy hack. Do as I say, not as I do.
- * Taken from: https://gist.github.com/branneman/8048520#6-the-hack
- * This forces the NODE_PATH environment variable to include the main
- * kolibri node_modules folder, so that even plugins being built outside
- * of the kolibri folder will have access to all installed loaders, etc.
- * Doing it here, rather than at command invocation, allows us to do this
- * in a cross platform way, and also to avoid having to prepend it to all
- * our commands that end up invoking webpack.
- */
-
-process.env.NODE_PATH = path.resolve(path.join(__dirname, '..', '..', 'node_modules'));
-require('module').Module._initPaths();
 
 var fs = require('fs');
 var path = require('path');
@@ -142,6 +127,7 @@ var config = {
   plugins: [],
   resolve: {
     extensions: ['.js', '.vue', '.styl'],
+    alias: {},
   },
   node: {
     __filename: true,

--- a/frontend_build/src/webpack.config.prod.js
+++ b/frontend_build/src/webpack.config.prod.js
@@ -22,8 +22,10 @@ for (var i = 0; i < bundles.length; i++) {
         warnings: false,
       },
     }),
-    // optimize module ids by occurence count
-    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.LoaderOptionsPlugin({
+      minimize: true,
+      debug: false,
+    }),
   ]);
 }
 

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -258,7 +258,7 @@ class ContentNodeViewset(viewsets.ModelViewSet):
             'assessmentmetadata',
             'files',
             'files__local_file'
-        ).select_related('license')
+        ).select_related('license', 'lang')
 
     def get_queryset(self, prefetch=True):
         queryset = models.ContentNode.objects.filter(available=True)

--- a/kolibri/content/hooks.py
+++ b/kolibri/content/hooks.py
@@ -82,7 +82,7 @@ class ContentRendererHook(WebpackBundleHook):
 
         :returns: HTML of a script tag to insert into a page.
         """
-        urls = [chunk['url'] for chunk in self.sorted_chunks()]
+        urls = [chunk['url'] for chunk in self.bundle]
         tags = self.frontend_message_tag() +\
             ['<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(
                 kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -30,7 +30,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 class LowerCaseField(serializers.CharField):
 
     def to_representation(self, obj):
-        return super(LowerCaseField, self).to_representation(self, obj).lower()
+        return super(LowerCaseField, self).to_representation(obj).lower()
 
 
 class LanguageSerializer(serializers.ModelSerializer):

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.db.models import Manager, Sum
 from django.db.models.aggregates import Count
 from django.db.models.query import RawQuerySet
-from kolibri.content.models import AssessmentMetaData, ChannelMetadata, ContentNode, File
+from kolibri.content.models import AssessmentMetaData, ChannelMetadata, ContentNode, File, Language
 from le_utils.constants import content_kinds
 from rest_framework import serializers
 
@@ -27,12 +27,29 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
         fields = ('root', 'id', 'name', 'description', 'author', 'last_updated')
 
 
+class LowerCaseField(serializers.CharField):
+
+    def to_representation(self, obj):
+        return super(LowerCaseField, self).to_representation(self, obj).lower()
+
+
+class LanguageSerializer(serializers.ModelSerializer):
+    id = LowerCaseField(max_length=14)
+    lang_code = LowerCaseField(max_length=3)
+    lang_subcode = LowerCaseField(max_length=10)
+
+    class Meta:
+        model = Language
+        fields = ('id', 'lang_code', 'lang_subcode', 'lang_name', 'lang_direction')
+
+
 class FileSerializer(serializers.ModelSerializer):
     storage_url = serializers.SerializerMethodField()
     preset = serializers.SerializerMethodField()
     download_url = serializers.SerializerMethodField()
     extension = serializers.SerializerMethodField()
     file_size = serializers.SerializerMethodField()
+    lang = LanguageSerializer()
 
     def get_storage_url(self, target_node):
         return target_node.get_storage_url()
@@ -182,6 +199,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
     assessmentmetadata = AssessmentMetaDataSerializer(read_only=True, allow_null=True, many=True)
     license = serializers.StringRelatedField(many=False)
     license_description = serializers.SerializerMethodField()
+    lang = LanguageSerializer()
 
     def __init__(self, *args, **kwargs):
         # Instantiate the superclass normally
@@ -219,7 +237,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         fields = (
             'pk', 'content_id', 'title', 'description', 'kind', 'available', 'sort_order', 'license_owner',
             'license', 'license_description', 'files', 'parent', 'author',
-            'assessmentmetadata',
+            'assessmentmetadata', 'lang',
         )
 
         list_serializer_class = ContentNodeListSerializer

--- a/kolibri/core/assets/src/content_renderer_module.js
+++ b/kolibri/core/assets/src/content_renderer_module.js
@@ -7,4 +7,7 @@ export default class ContentRenderer extends KolibriModule {
   get contentTypes() {
     return null;
   }
+  loadDirectionalCSS(direction) {
+    return this.Kolibri.loadDirectionalCSS(this, direction);
+  }
 }

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -30,6 +30,8 @@ const publicMethods = [
   'registerLanguageAssets',
   'registerContentRenderer',
   'retrieveContentRenderer',
+  'loadDirectionalCSS',
+  'scriptLoader',
 ];
 
 /**

--- a/kolibri/core/assets/src/kolibri_module.js
+++ b/kolibri/core/assets/src/kolibri_module.js
@@ -82,4 +82,7 @@ export default class KolibriModule {
   emit(...args) {
     coreApp.emit(...args);
   }
+  get Kolibri() {
+    return coreApp;
+  }
 }

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -178,9 +178,13 @@ export function setUpIntl() {
     if (!Object.prototype.hasOwnProperty.call(global, 'Intl')) {
       Promise.all([
         new Promise(resolve => {
-          require.ensure([], require => {
-            resolve(() => require('intl'));
-          });
+          require.ensure(
+            ['intl'],
+            require => {
+              resolve(() => require('intl'));
+            },
+            'intl'
+          );
         }),
         importIntlLocale(global.languageCode),
       ]).then(
@@ -200,11 +204,15 @@ export function setUpIntl() {
         }
       );
     } else if (global.languageCode === 'rt-lft') {
-      require.ensure([], () => {
-        toFakeRTL = require('./mirrorText').toFakeRTL;
-        setUpVueIntl();
-        resolve();
-      });
+      require.ensure(
+        ['./mirrorText'],
+        require => {
+          toFakeRTL = require('./mirrorText').default;
+          setUpVueIntl();
+          resolve();
+        },
+        'fakeRtl'
+      );
     } else {
       setUpVueIntl();
       resolve();

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -30,17 +30,31 @@ function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
 
 const defaultLocale = 'en';
 
+export const languageDirections = {
+  LTR: 'ltr',
+  RTL: 'rtl',
+};
+
 export const availableLanguages = {
   en: {
     code: 'en',
     name: 'English',
+    langDir: languageDirections.LTR,
   },
 };
 
 export let currentLanguage = defaultLocale;
 
 // Default to ltr
-export let languageDirection = 'ltr';
+export let languageDirection = languageDirections.LTR;
+
+export const getLangDir = lang_code => {
+  return (availableLanguages[lang_code] || {}).langDir || languageDirections.LTR;
+};
+
+export const isRtl = lang_code => {
+  return getLangDir(lang_code) === languageDirections.RTL;
+};
 
 export const languageDensities = {
   englishLike: 'english_like',

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -28,19 +28,25 @@ function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
   return formatter(message, args);
 }
 
-const defaultLocale = 'en';
-
 export const languageDirections = {
   LTR: 'ltr',
   RTL: 'rtl',
 };
 
+const defaultLocale = 'en';
+
+export const defaultLanguage = {
+  id: 'en',
+  lang_name: 'English',
+  lang_direction: languageDirections.LTR,
+};
+
+export const languageValidator = language => {
+  return ['id', 'lang_name', 'lang_direction'].reduce((valid, key) => valid && language[key], true);
+};
+
 export const availableLanguages = {
-  en: {
-    code: 'en',
-    name: 'English',
-    langDir: languageDirections.LTR,
-  },
+  en: defaultLanguage,
 };
 
 export let currentLanguage = defaultLocale;
@@ -48,12 +54,16 @@ export let currentLanguage = defaultLocale;
 // Default to ltr
 export let languageDirection = languageDirections.LTR;
 
-export const getLangDir = lang_code => {
-  return (availableLanguages[lang_code] || {}).langDir || languageDirections.LTR;
+export const getContentLangDir = language => {
+  return (language || {}).lang_direction || languageDirections.LTR;
 };
 
-export const isRtl = lang_code => {
-  return getLangDir(lang_code) === languageDirections.RTL;
+export const getLangDir = id => {
+  return (availableLanguages[id] || {}).lang_direction || languageDirections.LTR;
+};
+
+export const isRtl = id => {
+  return getLangDir(id) === languageDirections.RTL;
 };
 
 export const languageDensities = {
@@ -89,10 +99,14 @@ const languageDensityMapping = {
   zh: languageDensities.dense,
 };
 
-function setLanguageDensity(lang_code) {
-  const shortCode = lang_code.split('-')[0].toLowerCase();
+function languageIdToCode(id) {
+  return id.split('-')[0].toLowerCase();
+}
+
+function setLanguageDensity(id) {
+  const langCode = languageIdToCode(id);
   // Set the exported languageDensity in JS
-  languageDensity = languageDensityMapping[shortCode] || languageDensities.englishLike;
+  languageDensity = languageDensityMapping[langCode] || languageDensities.englishLike;
   // Set the body class for global typography
   global.document.body.classList.add(`language-${languageDensity}`);
 }

--- a/kolibri/core/assets/src/utils/import-intl-locale.js
+++ b/kolibri/core/assets/src/utils/import-intl-locale.js
@@ -2,27 +2,43 @@ module.exports = (locale, callback) => {
   switch (locale) {
     case 'fr-FR':
       return new Promise(resolve => {
-        require.ensure([], require => {
-          resolve(() => require('intl/locale-data/jsonp/fr-FR.js'));
-        });
+        require.ensure(
+          ['intl/locale-data/jsonp/fr-FR.js'],
+          require => {
+            resolve(() => require('intl/locale-data/jsonp/fr-FR.js'));
+          },
+          'fr-FR'
+        );
       });
     case 'pt-PT':
       return new Promise(resolve => {
-        require.ensure([], require => {
-          resolve(() => require('intl/locale-data/jsonp/pt-PT.js'));
-        });
+        require.ensure(
+          ['intl/locale-data/jsonp/pt-PT.js'],
+          require => {
+            resolve(() => require('intl/locale-data/jsonp/pt-PT.js'));
+          },
+          'pt-PT'
+        );
       });
     case 'sw-TZ':
       return new Promise(resolve => {
-        require.ensure([], require => {
-          resolve(() => require('intl/locale-data/jsonp/sw-TZ.js'));
-        });
+        require.ensure(
+          ['intl/locale-data/jsonp/sw-TZ.js'],
+          require => {
+            resolve(() => require('intl/locale-data/jsonp/sw-TZ.js'));
+          },
+          'sw-SW'
+        );
       });
     case 'es-ES':
       return new Promise(resolve => {
-        require.ensure([], require => {
-          resolve(() => require('intl/locale-data/jsonp/es-ES.js'));
-        });
+        require.ensure(
+          ['intl/locale-data/jsonp/es-ES.js'],
+          require => {
+            resolve(() => require('intl/locale-data/jsonp/es-ES.js'));
+          },
+          'es-ES'
+        );
       });
     case 'es-MX':
       return new Promise(resolve => {
@@ -32,9 +48,13 @@ module.exports = (locale, callback) => {
       });
     default:
       return new Promise(resolve => {
-        require.ensure([], require => {
-          resolve(() => require('intl/locale-data/jsonp/en.js'));
-        });
+        require.ensure(
+          ['intl/locale-data/jsonp/en.js'],
+          require => {
+            resolve(() => require('intl/locale-data/jsonp/en.js'));
+          },
+          'en'
+        );
       });
   }
 };

--- a/kolibri/core/assets/src/utils/mirrorText.js
+++ b/kolibri/core/assets/src/utils/mirrorText.js
@@ -258,6 +258,6 @@ function toPseudoText(text, messageParser) {
   return result;
 }
 
-export function toFakeRTL(text) {
+export default function toFakeRTL(text) {
   return toPseudoText(text, IntlMessageFormatParser);
 }

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -22,6 +22,7 @@
         :allowHints="allowHints"
         :supplementaryFiles="supplementaryFiles"
         :thumbnailFiles="thumbnailFiles"
+        :interactive="interactive"
         ref="contentView"
         />
       </div>
@@ -85,6 +86,12 @@
       initSession: {
         type: Function,
         default: () => Promise.resolve(),
+      },
+      // Allow content renderers to display in a static mode
+      // where user interaction is not allowed
+      interactive: {
+        type: Boolean,
+        default: true,
       },
     },
     components: {

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -23,6 +23,7 @@
         :supplementaryFiles="supplementaryFiles"
         :thumbnailFiles="thumbnailFiles"
         :interactive="interactive"
+        :lang="lang"
         ref="contentView"
         />
       </div>
@@ -42,6 +43,7 @@
   const logging = logger.getLogger(__filename);
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';
   import uiAlert from 'keen-ui/src/UiAlert';
+  import { defaultLanguage, languageValidator } from 'kolibri.utils.i18n';
   export default {
     name: 'contentRender',
     $trs: {
@@ -92,6 +94,11 @@
       interactive: {
         type: Boolean,
         default: true,
+      },
+      lang: {
+        type: Object,
+        default: () => defaultLanguage,
+        validator: languageValidator,
       },
     },
     components: {

--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -3,8 +3,8 @@
   <div>
     <div v-if="footer" class="page-footer">
       <ul class="language-list">
-        <li v-for="language in languageOptions" :class="selectedLanguage===language.code ? 'selected item' : 'choice item'" @click="setAndSwitchLanguage(language.code)">
-          {{ language.name }}
+        <li v-for="language in languageOptions" :class="selectedLanguage===language.id ? 'selected item' : 'choice item'" @click="setAndSwitchLanguage(language.id)">
+          {{ language.lang_name }}
         </li>
       </ul>
     </div>
@@ -16,10 +16,10 @@
       <p>{{ $tr('changeLanguageSubHeader') }}</p>
       <k-radio-button
         v-for="language in languageOptions"
-        :key="language.code"
-        :radiovalue="language.code"
+        :key="language.id"
+        :radiovalue="language.id"
         :value="selectedLanguage"
-        :label="language.name"
+        :label="language.lang_name"
         v-model="selectedLanguage"
       />
       <div class="footer">
@@ -69,7 +69,7 @@
           .map(key => availableLanguages[key]);
       },
       currentLanguageName() {
-        return availableLanguages[currentLanguage].name;
+        return availableLanguages[currentLanguage].lang_name;
       },
       showModal() {
         return this.modalOpen || this.internalModalOpen;

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -13,7 +13,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.core.urlresolvers import reverse
 from django.utils.html import mark_safe
 from django.utils.timezone import now
-from django.utils.translation import get_language, get_language_bidi
+from django.utils.translation import get_language, get_language_bidi, get_language_info
 from django_js_reverse.js_reverse_settings import JS_GLOBAL_OBJECT_NAME, JS_VAR_NAME
 from django_js_reverse.templatetags.js_reverse import js_reverse_inline
 from kolibri.core.hooks import NavigationHook, UserNavigationHook
@@ -35,7 +35,12 @@ def kolibri_language_globals(context):
     """.format(
         lang_code=get_language(),
         lang_dir=lang_dir,
-        languages=json.dumps({code: {'code': code, 'name': name} for code, name in settings.LANGUAGES}),
+        languages=json.dumps({code: {
+            # Format to match the schema of the content Language model
+            'id': code,
+            'lang_name': name,
+            'lang_direction': get_language_info(code)['bidi']
+        } for code, name in settings.LANGUAGES}),
     )
     return mark_safe(js)
 

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
@@ -42,6 +42,7 @@
             :available="exercise.available"
             :answerState="currentInteraction.answer"
             :extraFields="exercise.extra_fields"
+            :interactive="false"
             :assessment="true"/>
           <content-renderer
             v-else
@@ -55,6 +56,7 @@
             :channelId="channelId"
             :available="exercise.available"
             :extraFields="exercise.extra_fields"
+            :interactive="false"
             :assessment="true"/>
         </div>
       </div>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -38,6 +38,7 @@
             :channelId="channelId"
             :available="exercise.available"
             :answerState="currentInteraction.answer"
+            :interactive="false"
             :extraFields="exercise.extra_fields"/>
         </div>
       </div>

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -81,6 +81,7 @@ function contentState(data, nextContent, ancestors = []) {
     license_description: data.license_description,
     license_owner: data.license_owner,
     parent: data.parent,
+    lang: data.lang,
   };
   Object.assign(state, assessmentMetaDataState(data));
   return state;

--- a/kolibri/plugins/setup_wizard/assets/src/state/actions.js
+++ b/kolibri/plugins/setup_wizard/assets/src/state/actions.js
@@ -1,12 +1,12 @@
 import { DeviceProvisionResource } from 'kolibri.resources';
 import { kolibriLogin, handleApiError } from 'kolibri.coreVue.vuex.actions';
 
-export function provisionDevice(store, superuser, facility, preset, language_code) {
+export function provisionDevice(store, superuser, facility, preset, language_id) {
   const DeviceProvisionModel = DeviceProvisionResource.createModel({
     superuser,
     facility,
     preset,
-    language_code,
+    language_id,
   });
   const deviceProvisionPromise = DeviceProvisionModel.save();
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.11
-kolibri_exercise_perseus_plugin==0.6.16
+kolibri_exercise_perseus_plugin==0.7.0
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e25b57b52656e2.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

Most of these changes are build related that I have put in, so that the i18nization of the perseus render is made possible.

Also adds the `interactive` prop which allows signalling that an otherwise interactive content item should be rendered uninteractively.

Note that this now also includes an upgrade for the perseus renderer, with the following diff: https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v0.6.16...v0.7.0