### PR TITLE
Try to fix undefined hints button

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.14
+kolibri_exercise_perseus_plugin==0.6.15b1
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e25b57b52656e2.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

Attempt to fix the difficult to usefully replicate #1811, by this change set: https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/100/commits/4c8493d4641838a847158dc990ad5b9ac4a9783b in perseus renderer.