### PR TITLE
2 tiny improvements to (make assets and before_install in tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,7 @@ matrix:
 
 before_install:
   - git describe --tags
-  - pip install -U pip
-  - pip install codecov
-  - pip install tox
+  - pip install -U pip codecov tox
   - . $HOME/.nvm/nvm.sh
   - nvm install $TRAVIS_NODE_VERSION
   - nvm use $TRAVIS_NODE_VERSION

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ release: clean assets
 	@echo ""
 	@echo "Now run something like twine -s dist/* to upload all results in the dist/ folder"
 
-staticdeps: clean
+staticdeps:
+	rm -r kolibri/dist/* || true # remove everything
+	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 


### PR DESCRIPTION
## Summary

Had this dangling around.

Not doing a full clean in `staticdeps` means a lot to the speed of running `make assets` because it won't have to rebuild all the JS stuff.