### PR TITLE
Autoremove configured plugins when they do not exist

### DIFF
--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -1,0 +1,35 @@
+"""
+Compatibility layer for Python 2+3
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import sys
+
+
+def module_exists(module_path):
+    """
+    Determines if a module exists without loading it (Python 3)
+    In Python 2, the module will be loaded
+    """
+    if sys.version_info >= (3, 4):
+        from importlib.util import find_spec
+        try:
+            if "." in module_path:
+                find_spec(module_path)
+                return True
+            else:
+                return find_spec(module_path) is not None
+        except ImportError:
+            return False
+    elif sys.version_info < (3,):
+        from imp import find_module
+        try:
+            if "." in module_path:
+                __import__(module_path)
+            else:
+                find_module(module_path)
+            return True
+        except ImportError:
+            return False
+    else:
+        raise NotImplementedError("No compatibility with Python 3.0 and 3.2")

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 import logging
 import os
+from kolibri.utils.compat import module_exists
 
 logger = logging.getLogger(__name__)
 
@@ -84,3 +85,30 @@ else:
     # Open up the config file and overwrite defaults
     with open(conf_file, 'r') as kolibri_conf_file:
         config.update(json.load(kolibri_conf_file))
+
+
+def autoremove_unavailable_plugins():
+    """
+    Sanitize INSTALLED_APPS - something that should be done separately for all
+    build in plugins, but we should not auto-remove plugins that are actually
+    configured by the user or some other kind of hard dependency that should
+    make execution stop if not loadable.
+    """
+    global config
+    changed = False
+    for module_path in config['INSTALLED_APPS']:
+        if not module_exists(module_path):
+            config['INSTALLED_APPS'].remove(module_path)
+            logger.error(
+                (
+                    "Plugin {mod} not found and disabled. To re-enable it, run:\n"
+                    "   $ kolibri plugin {mod} enable"
+                ).format(mod=module_path)
+            )
+            changed = True
+
+    if changed:
+        save()
+
+
+autoremove_unavailable_plugins()

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -23,6 +23,28 @@ def conf():
     conf.save()
 
 
+def test_bogus_plugin_autoremove(conf):
+    """
+    Checks that a plugin is auto-removed when it cannot be imported
+    """
+    plugin_name = "giraffe.horse"
+    conf.config["INSTALLED_APPS"].append(plugin_name)
+    conf.save()
+    conf.autoremove_unavailable_plugins()
+    assert plugin_name not in conf.config["INSTALLED_APPS"]
+
+
+def test_bogus_plugin_autoremove_no_path(conf):
+    """
+    Checks that a plugin without a dotted path is also auto-removed
+    """
+    plugin_name = "giraffehorse"
+    conf.config["INSTALLED_APPS"].append(plugin_name)
+    conf.save()
+    conf.autoremove_unavailable_plugins()
+    assert plugin_name not in conf.config["INSTALLED_APPS"]
+
+
 def test_bogus_plugin_disable(conf):
     installed_apps_before = conf.config["INSTALLED_APPS"][:]
     cli.plugin("i_do_not_exist", disable=True)


### PR DESCRIPTION
## Summary

Automatically removes an entry from INSTALLED_APPS in config. This should be made more sensible later so we distinguish between built in plugins that may change their paths during an upgrade and something that was configured by the user and should throw an exception.

## TODO

- [x] Have tests been written for the new code?

## Reviewer guidance

This seems plausible, right? Not sure if we need the Python 3.2 compatible code, though?

## Issues addressed

Fixes #1859
