### PR TITLE
Don't generate cache keys from the 'query' property of Querysets.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -204,7 +204,6 @@ class ContentNodeViewset(viewsets.ModelViewSet):
         if cache.get(cache_key) is not None:
             return Response(cache.get(cache_key))
 
-        # Call prefetch_related None to not retrieve the unnecessary prefetches set on the queryset
         ancestors = list(self.get_object().get_ancestors().values('pk', 'title'))
 
         cache.set(cache_key, ancestors, 60 * 10)


### PR DESCRIPTION
## Summary

Only generate cache keys for parent contentnode queries.
Don't fetch progress fractions for topic content nodes.