### PR TITLE
More kolibri optimization fixes

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -21,17 +21,22 @@ class KolibriCoreConfig(AppConfig):
         right now, but kept around as infrastructure if we ever want to add
         PRAGMAs in the future.
         """
-        # We don't have any per-connection pragmas, because they have negligible
-        # performance impacts. For reference, here's what we've tested:
-        # Only run the PRAGMAs if we're using SQLite
 
-        # Don't ensure that the OS has fully flushed
-        # our data to disk.
-        # cursor.execute("PRAGMA synchronous=OFF;")
+        if connection.vendor == "sqlite":
+            cursor = connection.cursor()
 
-        # Store cross-database JOINs in memory.
-        # cursor.execute("PRAGMA temp_store=MEMORY;")
-        pass
+            # Shorten the default WAL autocheckpoint from 1000 pages to 500
+            cursor.execute("PRAGMA wal_autocheckpoint=500;")
+
+            # We don't turn on the following pragmas, because they have negligible
+            # performance impact. For reference, here's what we've tested:
+
+            # Don't ensure that the OS has fully flushed
+            # our data to disk.
+            # cursor.execute("PRAGMA synchronous=OFF;")
+
+            # Store cross-database JOINs in memory.
+            # cursor.execute("PRAGMA temp_store=MEMORY;")
 
     @staticmethod
     def activate_pragmas_on_start():

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -129,7 +129,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         """
         for f in self._stats_file_content["files"]:
             filename = f['name']
-            if any(regex.match(filename) for regex in settings.IGNORE_PATTERNS):
+            if any(list(regex.match(filename) for regex in settings.IGNORE_PATTERNS)):
                 continue
             relpath = '{0}/{1}'.format(self.unique_slug, filename)
             if django_settings.DEBUG:


### PR DESCRIPTION
Add a couple of fixes due to the recent optimizations we did:

- Make WAL checkpointing more frequent, to avoid having a write transaction that's too long. 
- Turn a generator into a list, to avoid a race condition we had during testing.