### PR TITLE
Cleaned up version of fixes for #1818

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.db.models import Q, Sum
 from django.db.models.aggregates import Count
 from kolibri.content import models, serializers
-from kolibri.content.content_db_router import get_active_content_database
+from kolibri.content.content_db_router import get_active_content_database, using_content_database
 from kolibri.logger.models import ContentSessionLog, ContentSummaryLog
 from le_utils.constants import content_kinds
 from rest_framework import filters, pagination, viewsets
@@ -359,10 +359,11 @@ class FileViewset(viewsets.ModelViewSet):
 
 class ChannelFileSummaryViewSet(viewsets.ViewSet):
     def list(self, request, **kwargs):
-        file_summary = models.File.objects.aggregate(
-            total_files=Count('pk'),
-            total_file_size=Sum('file_size')
-        )
-        file_summary['channel_id'] = get_active_content_database()
-        # Need to wrap in an array to be fetchable as a Collection on client
-        return Response([file_summary])
+        with using_content_database(kwargs['channel_id']):
+            file_summary = models.File.objects.aggregate(
+                total_files=Count('pk'),
+                total_file_size=Sum('file_size')
+            )
+            file_summary['channel_id'] = get_active_content_database()
+            # Need to wrap in an array to be fetchable as a Collection on client
+            return Response([file_summary])

--- a/kolibri/content/middleware.py
+++ b/kolibri/content/middleware.py
@@ -9,9 +9,12 @@ class ContentDBRoutingMiddleware(object):
     """
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        request.PREVIOUSLY_ACTIVE_CONTENT_DATABASE = get_active_content_database(return_none_if_not_set=True)
-        if "channel_id" in view_kwargs:
-            set_active_content_database(view_kwargs["channel_id"])
+        if view_func.__name__ == 'TasksViewSet':
+            pass  # Fix #1818.1: skip get_active_content_database for Task workers to avoid locking DB
+        else:
+            request.PREVIOUSLY_ACTIVE_CONTENT_DATABASE = get_active_content_database(return_none_if_not_set=True)
+            if "channel_id" in view_kwargs:
+                set_active_content_database(view_kwargs["channel_id"])
 
     def process_response(self, request, response):
         set_active_content_database(getattr(request, "PREVIOUSLY_ACTIVE_CONTENT_DATABASE", None))

--- a/kolibri/content/utils/annotation.py
+++ b/kolibri/content/utils/annotation.py
@@ -32,3 +32,7 @@ def update_channel_metadata_cache():
         if ch_metadata_obj.last_updated is None:
             ch_metadata_obj.last_updated = local_now()
             ch_metadata_obj.save()
+
+    # Fix #1818.1 content database files get locked (this is called on startup)
+    from django.db import connections
+    connections.close_all()

--- a/kolibri/content/utils/channels.py
+++ b/kolibri/content/utils/channels.py
@@ -53,9 +53,15 @@ def enumerate_content_database_file_paths(content_database_dir):
 def read_channel_metadata_from_db_file(channeldbpath):
     # import here to avoid circular imports whenever kolibri.content.models imports utils too
     from kolibri.content.models import ChannelMetadata
-
     with using_content_database(channeldbpath):
-        return ChannelMetadata.objects.first()
+        channel_metadata = ChannelMetadata.objects.first()
+
+    # FIX for #1818.2: DB file on removable media remains locked after import
+    from django.db import connections
+    connections.close_all()
+
+    return channel_metadata
+
 
 def get_channels_for_data_folder(datafolder):
     channels = []

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -143,7 +143,11 @@ class TasksViewSet(viewsets.ViewSet):
 
 
 def _networkimport(channel_id, update_progress=None):
-    call_command("importchannel", "network", channel_id)
+    call_command(
+        "importchannel",
+        "network",
+        channel_id,
+        update_progress=update_progress)
     call_command(
         "importcontent",
         "network",
@@ -154,8 +158,14 @@ def _networkimport(channel_id, update_progress=None):
 def _localimport(drive_id, update_progress=None):
     drives = get_mounted_drives_with_channel_info()
     drive = drives[drive_id]
+    # copy channel's db file then copy all the content files from sorage dir
     for channel in drive.metadata["channels"]:
-        call_command("importchannel", "local", channel["id"], drive.datafolder)
+        call_command(
+            "importchannel",
+            "local",
+            channel["id"],
+            drive.datafolder,
+            update_progress=update_progress)
         call_command(
             "importcontent",
             "local",
@@ -168,7 +178,11 @@ def _localexport(drive_id, update_progress=None):
     drives = get_mounted_drives_with_channel_info()
     drive = drives[drive_id]
     for channel in ChannelMetadataCache.objects.all():
-        call_command("exportchannel", channel.id, drive.datafolder)
+        call_command(
+            "exportchannel",
+            channel.id,
+            drive.datafolder,
+            update_progress=update_progress)
         call_command(
             "exportcontent",
             channel.id,

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -14,6 +14,7 @@ except AppRegistryNotReady:
 import requests
 from django.core.management import call_command
 from django.http import Http404
+from django.db import connections
 from django.utils.translation import ugettext as _
 from kolibri.content.models import ChannelMetadataCache
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
@@ -153,7 +154,7 @@ def _networkimport(channel_id, update_progress=None):
         "network",
         channel_id,
         update_progress=update_progress)
-
+    connections.close_all()  # close all DB connections (FIX for #1818)
 
 def _localimport(drive_id, update_progress=None):
     drives = get_mounted_drives_with_channel_info()
@@ -172,6 +173,7 @@ def _localimport(drive_id, update_progress=None):
             channel["id"],
             drive.datafolder,
             update_progress=update_progress)
+    connections.close_all()  # close all DB connections (FIX for #1818)
 
 
 def _localexport(drive_id, update_progress=None):
@@ -188,6 +190,7 @@ def _localexport(drive_id, update_progress=None):
             channel.id,
             drive.datafolder,
             update_progress=update_progress)
+    connections.close_all()  # close all DB connections (FIX for #1818)
 
 
 def _job_to_response(job):


### PR DESCRIPTION
## Summary

This PR contains four commits that address three separate but related issues around sqlite file locking.

  - Fix for #1818 part2: DB on USB media being locked after import (all platforms)
  - Fix for #1818 part1: DB file in `C:\Users\IEUser\.kolibri\content\databases\` does not get deleted when removing channel (Windows only issue)
  - A fix to `ChannelFileSummaryViewSet` which was throwing ContentModelUsedOutsideDBContext  (I don't fully understand how this worked before? how did the API calls know which DB to connect to?)
  - A small fix enabling `update_progress` (see below)

## Reviewer guidance

@aronasorman Please take a look at the second commit. I added `update_progress=update_progress` to the importchannel task because without it, there an endless stream of progress updates get posted. It seems when we don't use `update_progress`, there is nobody to handle/acknowledge these updates so they keep getting posted.

```
INFO     {'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
INFO:kolibri.tasks.api:{'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
[03/Aug/2017 11:51:43] "GET /api/tasks/?1501775503004=1501775503004 HTTP/1.1" 200 137
DEBUG:barbequeue.worker.backends.base:Worker message queue currently empty.
DEBUG:root:No job to schedule right now.
DEBUG:barbequeue.worker.backends.base:Worker message queue currently empty.
DEBUG:root:No job to schedule right now.
INFO     job is truthy
INFO:kolibri.tasks.api:job is truthy
INFO     {'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
INFO:kolibri.tasks.api:{'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
[03/Aug/2017 11:51:44] "GET /api/tasks/?1501775504006=1501775504006 HTTP/1.1" 200 137
DEBUG:root:No job to schedule right now.
DEBUG:barbequeue.worker.backends.base:Worker message queue currently empty.
INFO     job is truthy
INFO:kolibri.tasks.api:job is truthy
INFO     {'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
INFO:kolibri.tasks.api:{'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
[03/Aug/2017 11:51:45] "GET /api/tasks/?1501775505004=1501775505004 HTTP/1.1" 200 137
DEBUG:root:No job to schedule right now.
DEBUG:barbequeue.worker.backends.base:Worker message queue currently empty.
INFO     job is truthy
INFO:kolibri.tasks.api:job is truthy
INFO     {'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
INFO:kolibri.tasks.api:{'status': 'COMPLETED', 'exception': 'None', 'traceback': '', 'percentage': 1.0, 'type': 'remoteimport', 'id': '5b4da7a7b0a44ab8857cc51613abaf2a'}
[03/Aug/2017 11:51:46] "GET /api/tasks/?1501775506005=1501775506005 HTTP/1.1" 200 137
```

Have you tested bbq Tasks without progress reporting? This might need a fix in upstrem bbq code base, because it's likely we'll want to schedule this type of tasks.

@radinamatic Could you please test the .exe from this PR on Window7 ? If you have time, otherwise I can test next week.


## Testing protocol

For second part:
  - Import one or more channels from USB stick
  - Confirm that USB can be "Safely removed" after import

For first part:
  - Remove all channels
  - Confirm the directory `C:\Users\IEUser\.kolibri\content\databases\` is empty


## Issues addressed

#1818 


