### PR TITLE
Hide Breadcrumbs to Reduce Title Repetition

### DIFF
--- a/kolibri/core/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/core/assets/src/views/breadcrumbs/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div v-if="crumbs.length > 1">
     <nav class="breadcrumbs">
       <div v-show="collapsedCrumbs.length" class="breadcrumbs-dropdown-wrapper">
         <ui-icon-button :has-dropdown="true" icon="expand_more" size="small">


### PR DESCRIPTION
## Summary

Hides breadcrumbs if there's only 1 item (top level). Fixes #1838 Titleception.