### PR TITLE
points-slidein

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -134,7 +134,7 @@
     $trNameSpace: 'learnContent',
     $trs: {
       recommended: 'Recommended',
-      nextContent: 'Next item',
+      nextContent: 'Go to next item',
       author: 'Author',
       license: 'License',
       licenseDescription: 'License description',

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -83,16 +83,21 @@
       :header="recommendedText"
       :contents="recommended"/>
 
-    <content-points
-      v-if="progress >= 1 && wasIncomplete"
-      @close="closeModal"
-      :kind="content.next_content.kind"
-      :title="content.next_content.title">
+    <template v-if="progress >= 1 && wasIncomplete">
+      <points-popup
+        v-if="showPopup"
+        @close="markAsComplete"
+        :kind="content.next_content.kind"
+        :title="content.next_content.title">
+        <icon-button slot="nextItemBtn" @click="nextContentClicked" class="next-btn" :text="$tr('nextContent')" alignment="right">
+          <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
+        </icon-button>
+      </points-popup>
 
-      <icon-button slot="nextItemBtn" @click="nextContentClicked" class="next-btn" :text="$tr('nextContent')" alignment="right">
-        <mat-svg class="right-arrow" category="navigation" name="chevron_right"/>
-      </icon-button>
-    </content-points>
+      <transition v-else name="slidein" appear>
+        <points-slidein @close="markAsComplete"/>
+      </transition>
+    </template>
 
   </div>
 
@@ -118,16 +123,18 @@
   import downloadButton from 'kolibri.coreVue.components.downloadButton';
   import iconButton from 'kolibri.coreVue.components.iconButton';
   import assessmentWrapper from '../assessment-wrapper';
-  import contentPoints from '../content-points';
+  import pointsPopup from '../points-popup';
+  import pointsSlidein from '../points-slidein';
   import uiPopover from 'keen-ui/src/UiPopover';
   import uiIcon from 'keen-ui/src/UiIcon';
   import markdownIt from 'markdown-it';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     $trNameSpace: 'learnContent',
     $trs: {
       recommended: 'Recommended',
-      nextContent: 'Go to next item',
+      nextContent: 'Next item',
       author: 'Author',
       license: 'License',
       licenseDescription: 'License description',
@@ -181,6 +188,13 @@
         }
         return false;
       },
+      showPopup() {
+        return (
+          this.content.kind === ContentNodeKinds.EXERCISE ||
+          this.content.kind === ContentNodeKinds.VIDEO ||
+          this.content.kind === ContentNodeKinds.AUDIO
+        );
+      },
     },
     components: {
       pageHeader,
@@ -189,7 +203,8 @@
       downloadButton,
       iconButton,
       assessmentWrapper,
-      contentPoints,
+      pointsPopup,
+      pointsSlidein,
       uiPopover,
       uiIcon,
     },
@@ -207,7 +222,7 @@
         const summaryProgress = this.updateProgressAction(progressPercent, forceSave);
         updateContentNodeProgress(this.channelId, this.contentNodeId, summaryProgress);
       },
-      closeModal() {
+      markAsComplete() {
         this.wasIncomplete = false;
       },
       genRecLink(id, kind) {

--- a/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
@@ -8,7 +8,7 @@
 
 
     <div class="points-wrapper">
-      <h2>{{ $tr('pointsForCompletion') }}</h2>
+      <!-- <h2>{{ $tr('pointsForCompletion') }}</h2> -->
       <div class="points">
         <points-icon class="points-icon" :active="true"/>
         <span class="points-amount">{{ $tr('plusPoints', { maxPoints }) }}</span>
@@ -46,7 +46,7 @@
     $trNameSpace: 'pointsPopup',
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
-      niceWork: 'Great work!',
+      niceWork: 'Great work! Keep it up!',
       nextContent: 'Next Item',
       topic: 'Topic',
       exercise: 'Exercise',
@@ -55,7 +55,7 @@
       document: 'Document',
       html5: 'HTML5 app',
       item: 'Item',
-      close: 'Practice again',
+      close: 'Close',
       pointsForCompletion: 'Points for completion',
     },
     components: {

--- a/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
@@ -2,18 +2,24 @@
 
   <core-modal :title="$tr('niceWork')" @cancel="closePopover">
 
+    <div class="progress-icon">
+      <progress-icon :progress="1"/>
+    </div>
+
+
     <div class="points-wrapper">
+      <h2>{{ $tr('pointsForCompletion') }}</h2>
       <div class="points">
         <points-icon class="points-icon" :active="true"/>
-        <span class="plus-points">{{ $tr('plusPoints', { maxPoints }) }}</span>
+        <span class="points-amount">{{ $tr('plusPoints', { maxPoints }) }}</span>
       </div>
     </div>
 
     <div class="next-item-section">
       <h2 class="next-item-heading">{{ $tr('nextContent') }}</h2>
       <div>
-        <content-icon class="content-icon" :kind="kind"/>
-        <span>{{ title }}</span>
+        <content-icon class="nex-item-icon" :kind="kind"/>
+        <span class="next-item-title">{{ title }}</span>
       </div>
     </div>
 
@@ -33,13 +39,14 @@
   import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
+  import progressIcon from 'kolibri.coreVue.components.progressIcon';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import iconButton from 'kolibri.coreVue.components.iconButton';
   export default {
-    $trNameSpace: 'contentPoints',
+    $trNameSpace: 'pointsPopup',
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
-      niceWork: 'Great work! Keep it up!',
+      niceWork: 'Great work!',
       nextContent: 'Next Item',
       topic: 'Topic',
       exercise: 'Exercise',
@@ -48,11 +55,13 @@
       document: 'Document',
       html5: 'HTML5 app',
       item: 'Item',
-      close: 'Close',
+      close: 'Practice again',
+      pointsForCompletion: 'Points for completion',
     },
     components: {
       pointsIcon,
       contentIcon,
+      progressIcon,
       coreModal,
       iconButton,
     },
@@ -98,7 +107,7 @@
   @require '~kolibri.styles.definitions'
 
   .points-wrapper
-    margin: 2em
+    margin-bottom: 2em
     text-align: center
 
   .points
@@ -106,21 +115,20 @@
 
   .points-icon
     float: left
-    width: 30px
-    height: 30px
+    width: 20px
+    height: 20px
 
-  .plus-points
+  .points-amount
     padding-left: 5px
-    font-size: 1.5em
     font-weight: bold
     color: $core-status-correct
 
-  .content-icon
+  .nex-item-icon
     font-size: 1.5em
 
   .next-item-section
     text-align: center
-    padding: 0 2em 2em
+    margin-bottom: 2em
 
   .buttons
     text-align: center
@@ -131,5 +139,15 @@
 
   .close-button
     margin-right: 0.5em
+
+  .progress-icon
+    text-align: center
+    margin-bottom: 2em
+
+  .next-item-title
+    padding-left: 8px
+
+  h2
+    margin-top: 0
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
@@ -1,0 +1,102 @@
+<template>
+
+  <div class="points-slidein">
+    <div class="points">
+      <points-icon class="points-icon" :active="true"/>
+      <span class="points-amount">{{ $tr('plusPoints', { maxPoints }) }}</span>
+    </div>
+
+    <ui-icon-button
+      type="secondary"
+      color="default"
+      size="small"
+      icon="close"
+      :ariaLabel="$tr('dismiss')"
+      @click="$emit('close')"
+    />
+    </div>
+
+</template>
+
+
+<script>
+
+  import { contentPoints } from 'kolibri.coreVue.vuex.getters';
+  import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
+
+  export default {
+    $trNameSpace: 'pointsSlidein',
+    $trs: {
+      plusPoints: '+ { maxPoints, number } Points',
+      dismiss: 'Dismiss',
+    },
+    components: {
+      pointsIcon,
+      uiIconButton,
+    },
+
+    computed: {
+      maxPoints() {
+        return MaxPointsPerContent;
+      },
+    },
+    vuex: {
+      getters: { contentPoints },
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  $box-shadow = 0 2px 4px -1px rgba(0, 0, 0, 0.2),
+                0 4px 5px 0 rgba(0, 0, 0, 0.14),
+                0 1px 10px 0 rgba(0, 0, 0, 0.12)
+
+  .points-slidein
+    position: fixed
+    top: 84px
+    right: 24px
+    z-index: 24
+    padding: 8px
+    background-color: $core-bg-canvas
+    box-shadow: $box-shadow
+    animation-fill-mode: both
+    animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1)
+    animation-duration: 0.3s
+
+  .slidein-enter-active
+    animation-name: slidein
+
+  .slidein-leave-active
+    animation-name: slidein
+    animation-direction: reverse
+
+  @keyframes slidein
+    from
+      transform: translate3d(100%, 0, 0)
+      visibility: visible
+    to
+      transform: translate3d(0, 0, 0)
+
+  .points
+    display: inline-block
+    margin-left: 16px
+
+  .points-icon
+    float: left
+    width: 20px
+    height: 20px
+
+  .points-amount
+    margin-left: 8px
+    margin-right: 16px
+    font-weight: bold
+    color: $core-status-correct
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
@@ -11,7 +11,7 @@
       color="default"
       size="small"
       icon="close"
-      :ariaLabel="$tr('dismiss')"
+      :ariaLabel="$tr('close')"
       @click="$emit('close')"
     />
     </div>
@@ -30,7 +30,7 @@
     $trNameSpace: 'pointsSlidein',
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
-      dismiss: 'Dismiss',
+      close: 'Close',
     },
     components: {
       pointsIcon,


### PR DESCRIPTION
# Summary

* Addresses #1709 
* Adds a `points-slidein` component for pdfs & html5 apps
* Makes some minor changes to the points-popup (aka modal)

![okay](https://user-images.githubusercontent.com/7193975/29050173-17946f78-7b8f-11e7-8073-24c708372f53.gif)
