### PR TITLE
Fix modal title on import preview modal

### DIFF
--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/import-preview.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/import-preview.vue
@@ -1,7 +1,7 @@
 <template>
 
   <core-modal
-    :title="$tr('title')"
+    :title="modalTitle"
     :enableBgClickCancel="false"
     @cancel="cancel"
     @enter="submit"
@@ -72,6 +72,13 @@
       kButton,
     },
     computed: {
+      modalTitle() {
+        if (this.importSource === 'local') {
+          return this.$tr('localImportTitle');
+        } else {
+          return this.$tr('remoteImportTitle');
+        }
+      },
       localImportPrompt() {
         return this.$tr('localImportPrompt', {
           numChannels: this.channelList.length,
@@ -127,8 +134,7 @@
         'You are about to import {numChannels, number} {numChannels, plural, one {Channel} other {Channels}} on {driveName}',
       localImportTitle: 'Import from local drive',
       remoteImportPrompt: 'You are about to import 1 channel',
-      remoteImporttitle: 'Import from internet',
-      title: 'Import from local drive',
+      remoteImportTitle: 'Import from internet',
     },
   };
 


### PR DESCRIPTION
The import-preview modal uses the correct title

... when source is remote

![screen shot 2017-08-08 at 2 41 58 pm](https://user-images.githubusercontent.com/10248067/29096004-e2cb482a-7c47-11e7-922e-93ce9d4cd2bc.png)

... or local

![screen shot 2017-08-08 at 2 42 06 pm](https://user-images.githubusercontent.com/10248067/29096010-e8456556-7c47-11e7-9220-292128271494.png)
