### PR TITLE
Language switcher

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -40,6 +40,7 @@ import kNavbar from '../views/k-navbar';
 import kNavbarButton from '../views/k-navbar/button';
 import kNavbarLink from '../views/k-navbar/link';
 import logo from '../views/logo';
+import languageSwitcher from '../views/language-switcher';
 import immersiveFullScreen from '../views/immersive-full-screen';
 import elapsedTime from '../views/elapsed-time';
 import pointsIcon from '../views/points-icon';
@@ -104,6 +105,7 @@ export default {
       kBreadcrumbs,
       kCheckbox,
       kRadioButton,
+      languageSwitcher,
     },
     router,
     mixins: {

--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -29,7 +29,6 @@ html
   font-size: 100%
   text-size-adjust: 100%
   box-sizing: border-box
-  overflow-y: scroll
   // from normalize v5
   line-height: 1.15
 

--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -28,9 +28,8 @@ html
   // https://davidwalsh.name/html5-boilerplate
   font-size: 100%
   text-size-adjust: 100%
-  overflow: hidden
   box-sizing: border-box
-
+  overflow-y: scroll
   // from normalize v5
   line-height: 1.15
 

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -10,7 +10,6 @@
     <div slot="actions">
       <slot name="app-bar-actions"/>
       <ui-button
-        v-if="isUserLoggedIn"
         icon="person"
         type="primary"
         color="primary"

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -34,7 +34,7 @@
           @select="optionSelected"
         />
       </ui-button>
-      <language-switcher v-if="showLanguageModal" @close="showLanguageModal=false"/>
+      <language-switcher :modalOpen="showLanguageModal" @close="showLanguageModal=false"/>
     </div>
   </ui-toolbar>
 

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -10,7 +10,6 @@
         :navShown="navShown"
         :height="headerHeight">
         <div slot="app-bar-actions" class="app-bar-actions">
-          <language-switcher/>
           <slot name="app-bar-actions"/>
         </div>
       </app-bar>
@@ -50,7 +49,6 @@
   import sideNav from 'kolibri.coreVue.components.sideNav';
   import errorBox from './error-box';
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';
-  import languageSwitcher from './language-switcher';
   import Vue from 'kolibri.lib.vue';
 
   export default {
@@ -83,7 +81,6 @@
       sideNav,
       errorBox,
       loadingSpinner,
-      languageSwitcher,
     },
     vuex: {
       getters: {

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -157,7 +157,6 @@
 
   .content-container
     position: absolute
-    overflow-y: scroll
     overflow-x: hidden
     right: 0
     bottom: 0

--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -2,22 +2,28 @@
 
   <div>
     <div v-if="footer" class="page-footer">
-      <div class="lang-container" :style="isMobile ? { width: '40%' } : {}">
-        <p class="prompt" v-if="!isMobile">{{ $tr('changeLanguagePrompt') }}</p>
-        <p v-for="language in footerLanguageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="setAndSwitchLanguage(language)">
-          {{ language.name }}
-        </p>
+      <div>
+        <ul class="language-list">
+          <li v-for="language in languageOptions" :class="selectedLanguage===language.code ? 'selected item' : 'choice item'" @click="setAndSwitchLanguage(language.code)">
+            {{ language.name }}
+          </li>
+        </ul>
       </div>
-      <k-button style="margin-top: 0" :text="$tr('moreLanguageButtonText')" :raised="false" @click="setModalOpen"/>
     </div>
     <core-modal
       v-if="showModal"
       :title="$tr('changeLanguageModalHeader')"
       @cancel="closeModal">
       <p>{{ $tr('changeLanguageSubHeader') }}</p>
-      <p v-for="language in languageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="selectedLanguage=language">
-        {{ language.name }}
-      </p>
+      <k-radio-button
+        v-for="language in languageOptions"
+        class="choice"
+        :key="language.code"
+        :radiovalue="language.code"
+        :value="selectedLanguage"
+        :label="language.name"
+        v-model="selectedLanguage"
+      />
       <div class="footer">
         <k-button :text="$tr('cancelButtonText')" :raised="false" :disabled="disabled" @click="closeModal"/>
         <k-button :text="$tr('confirmButtonText')" :primary="true" :disabled="disabled" @click="switchLanguage"/>
@@ -32,18 +38,15 @@
 
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import { httpClient } from 'kolibri.client';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
-  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   export default {
     name: 'languageSwitcherModalDialog',
-    mixins: [responsiveWindow],
-    components: { coreModal, kButton },
+    components: { coreModal, kButton, kRadioButton },
     $trs: {
       changeLanguageModalHeader: 'Change language',
       changeLanguageSubHeader: 'Select the language you want to view Kolibri in',
-      changeLanguagePrompt: 'Select language:',
-      moreLanguageButtonText: 'More languages',
       cancelButtonText: 'Cancel',
       confirmButtonText: 'Confirm',
     },
@@ -67,21 +70,11 @@
           })
           .map(key => availableLanguages[key]);
       },
-      footerLanguageOptions() {
-        if (this.isMobile) {
-          return this.languageOptions.filter(lang => lang.code !== currentLanguage).slice(0, 3);
-        }
-        return this.languageOptions.slice(0, 6);
-      },
       currentLanguageName() {
         return availableLanguages[currentLanguage].name;
       },
       showModal() {
-        console.log(this.internalModalOpen);
         return this.modalOpen || this.internalModalOpen;
-      },
-      isMobile() {
-        return this.windowSize.breakpoint <= 1;
       },
     },
     props: {
@@ -96,7 +89,7 @@
     },
     data: () => ({
       disabled: false,
-      selectedLanguage: availableLanguages[currentLanguage],
+      selectedLanguage: currentLanguage,
       internalModalOpen: false,
     }),
     methods: {
@@ -104,7 +97,7 @@
         this.disabled = true;
         const path = this.Kolibri.urls['kolibri:set_language']();
         const entity = {
-          language: this.selectedLanguage.code,
+          language: this.selectedLanguage,
         };
         httpClient({
           path,
@@ -113,8 +106,8 @@
           global.location.reload(true);
         });
       },
-      setAndSwitchLanguage(language) {
-        this.selectedLanguage = language;
+      setAndSwitchLanguage(languageCode) {
+        this.selectedLanguage = languageCode;
         this.switchLanguage();
       },
       closeModal() {
@@ -138,33 +131,31 @@
   h1, p
     color: black
 
-  .more-button
-    float: left
+  .choice
+    color: $core-action-normal
 
   .selected
     font-weight: bold
-
-  .choice
-    color: $core-action-normal
-    text-decoration: underline $core-action-normal
-    cursor: pointer
-
 
   .page-footer
     padding-left: 32px
     padding-top: 16px
     padding-bottom: 16px
-    .lang-container
-      display: inline-block
-      p
-        float: left
-        padding-left: 10px
-        margin: 0
     button
       float: right
       position: absolute
 
   .prompt
     padding-right: 16px
+
+  .language-list
+    list-style: none
+    margin: 0
+    padding: 0
+
+  .item
+    display: inline-block
+    padding-top: 6px
+    padding-right: 20px
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -2,13 +2,11 @@
 
   <div>
     <div v-if="footer" class="page-footer">
-      <div>
-        <ul class="language-list">
-          <li v-for="language in languageOptions" :class="selectedLanguage===language.code ? 'selected item' : 'choice item'" @click="setAndSwitchLanguage(language.code)">
-            {{ language.name }}
-          </li>
-        </ul>
-      </div>
+      <ul class="language-list">
+        <li v-for="language in languageOptions" :class="selectedLanguage===language.code ? 'selected item' : 'choice item'" @click="setAndSwitchLanguage(language.code)">
+          {{ language.name }}
+        </li>
+      </ul>
     </div>
     <core-modal
       v-if="showModal"
@@ -107,8 +105,10 @@
         });
       },
       setAndSwitchLanguage(languageCode) {
-        this.selectedLanguage = languageCode;
-        this.switchLanguage();
+        if (languageCode != this.selectedLanguage) {
+          this.selectedLanguage = languageCode;
+          this.switchLanguage();
+        }
       },
       closeModal() {
         this.internalModalOpen = false;
@@ -141,6 +141,7 @@
     padding-left: 32px
     padding-top: 16px
     padding-bottom: 16px
+    text-align: center
     button
       float: right
       position: absolute
@@ -152,10 +153,14 @@
     list-style: none
     margin: 0
     padding: 0
+    text-align: initial
+    display: inline-block
 
   .item
     display: inline-block
     padding-top: 6px
     padding-right: 20px
+    &.choice
+      cursor: pointer
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -1,15 +1,29 @@
 <template>
 
-  <core-modal :title="$tr('changeLanguageModalHeader')" @cancel="$emit('close')">
-    <p>{{ $tr('changeLanguageSubHeader') }}</p>
-    <p v-for="language in languageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="selectedLanguage=language">
-      {{ language.name }}
-    </p>
-    <div class="footer">
-      <k-button :text="$tr('cancelButtonText')" :raised="false" :disabled="disabled" @click="$emit('close')"/>
-      <k-button :text="$tr('confirmButtonText')" :primary="true" :disabled="disabled" @click="switchLanguage"/>
+  <div>
+    <div class="page-footer">
+      <div class="lang-container">
+        <p class="prompt" v-if="!isMobile">{{ $tr('changeLanguagePrompt') }}</p>
+        <p v-for="language in footerLanguageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="setAndSwitchLanguage(language)">
+          {{ language.name }}
+        </p>
+      </div>
+      <k-button style="margin-top: 0" :text="$tr('moreLanguageButtonText')" :raised="false" @click="setModalOpen"/>
     </div>
-  </core-modal>
+    <core-modal
+      v-if="showModal"
+      :title="$tr('changeLanguageModalHeader')"
+      @cancel="closeModal">
+      <p>{{ $tr('changeLanguageSubHeader') }}</p>
+      <p v-for="language in languageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="selectedLanguage=language">
+        {{ language.name }}
+      </p>
+      <div class="footer">
+        <k-button :text="$tr('cancelButtonText')" :raised="false" :disabled="disabled" @click="closeModal"/>
+        <k-button :text="$tr('confirmButtonText')" :primary="true" :disabled="disabled" @click="switchLanguage"/>
+      </div>
+    </core-modal>
+  </div>
 
 </template>
 
@@ -20,12 +34,16 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import { httpClient } from 'kolibri.client';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   export default {
     name: 'languageSwitcherModalDialog',
+    mixins: [responsiveWindow],
     components: { coreModal, kButton },
     $trs: {
       changeLanguageModalHeader: 'Change language',
       changeLanguageSubHeader: 'Select the language you want to view Kolibri in',
+      changeLanguagePrompt: 'Select language:',
+      moreLanguageButtonText: 'More languages',
       cancelButtonText: 'Cancel',
       confirmButtonText: 'Confirm',
     },
@@ -33,23 +51,53 @@
       languageOptions() {
         return Object.keys(availableLanguages)
           .sort((a, b) => {
-            if (a === currentLanguage || a[0] > b[0]) {
+            if (a === currentLanguage) {
               return -1;
             }
-            if (b === currentLanguage || b[0] > a[0]) {
+            if (b === currentLanguage) {
+              return 1;
+            }
+            if (a[0] < b[0]) {
+              return -1;
+            }
+            if (b[0] < a[0]) {
               return 1;
             }
             return 0;
           })
           .map(key => availableLanguages[key]);
       },
+      footerLanguageOptions() {
+        if (this.isMobile) {
+          return this.languageOptions.filter(lang => lang.code !== currentLanguage).slice(0, 3);
+        }
+        return this.languageOptions.slice(0, 6);
+      },
       currentLanguageName() {
         return availableLanguages[currentLanguage].name;
+      },
+      showModal() {
+        console.log(this.internalModalOpen);
+        return this.modalOpen || this.internalModalOpen;
+      },
+      isMobile() {
+        return this.windowSize.breakpoint <= 1;
+      },
+    },
+    props: {
+      footer: {
+        type: Boolean,
+        default: false,
+      },
+      modalOpen: {
+        type: Boolean,
+        default: false,
       },
     },
     data: () => ({
       disabled: false,
       selectedLanguage: availableLanguages[currentLanguage],
+      internalModalOpen: false,
     }),
     methods: {
       switchLanguage() {
@@ -65,6 +113,18 @@
           global.location.reload(true);
         });
       },
+      setAndSwitchLanguage(language) {
+        this.selectedLanguage = language;
+        this.switchLanguage();
+      },
+      closeModal() {
+        this.internalModalOpen = false;
+        this.$emit('close');
+      },
+      setModalOpen() {
+        console.log('setting open');
+        this.internalModalOpen = true;
+      },
     },
   };
 
@@ -78,6 +138,9 @@
   h1, p
     color: black
 
+  .more-button
+    float: left
+
   .selected
     font-weight: bold
 
@@ -85,5 +148,24 @@
     color: $core-action-normal
     text-decoration: underline $core-action-normal
     cursor: pointer
+
+
+  .page-footer
+    padding-left: 32px
+    padding-top: 16px
+    padding-bottom: 16px
+    .lang-container
+      display: inline-block
+      width: 40%
+      p
+        float: left
+        padding-left: 10px
+        margin: 0
+    button
+      float: right
+      position: absolute
+
+  .prompt
+    padding-right: 16px
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -1,8 +1,8 @@
 <template>
 
   <div>
-    <div class="page-footer">
-      <div class="lang-container">
+    <div v-if="footer" class="page-footer">
+      <div class="lang-container" :style="isMobile ? { width: '40%' } : {}">
         <p class="prompt" v-if="!isMobile">{{ $tr('changeLanguagePrompt') }}</p>
         <p v-for="language in footerLanguageOptions" :class="selectedLanguage.code===language.code ? 'selected' : 'choice'" @click="setAndSwitchLanguage(language)">
           {{ language.name }}
@@ -156,7 +156,6 @@
     padding-bottom: 16px
     .lang-container
       display: inline-block
-      width: 40%
       p
         float: left
         padding-left: 10px

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -33,10 +33,12 @@ return the module.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.conf.urls.static import static
 from kolibri.content.utils import paths
 from kolibri.plugins.registry import get_urls as plugin_urls
+
+from .views import set_language
 
 app_name = 'kolibri'
 
@@ -46,4 +48,4 @@ urlpatterns = plugin_urls()
 urlpatterns += static(paths.get_content_storage_url("/"), document_root=settings.CONTENT_STORAGE_DIR)
 urlpatterns += static(paths.get_content_database_url("/"), document_root=settings.CONTENT_DATABASE_DIR)
 
-urlpatterns += [url(r'^i18n/', include('django.conf.urls.i18n'))]
+urlpatterns += [url(r'^i18n/setlang/$', set_language, name='set_language')]

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -1,0 +1,39 @@
+from django import http
+from django.conf import settings
+from django.core.urlresolvers import translate_url
+from django.utils.http import is_safe_url
+from django.utils.translation import LANGUAGE_SESSION_KEY, check_for_language
+from django.views.i18n import LANGUAGE_QUERY_PARAMETER
+
+
+# Modified from django.views.i18n
+def set_language(request):
+    """
+    Redirect to a given url while setting the chosen language in the
+    session or cookie. The url and the language code need to be
+    specified in the request parameters.
+    Since this view changes how the user will see the rest of the site, it must
+    only be accessed as a POST request. If called as a GET request, it will
+    redirect to the page in the request (the 'next' parameter) without changing
+    any state.
+    """
+    next = request.POST.get('next', request.GET.get('next'))
+    if not is_safe_url(url=next, host=request.get_host()):
+        next = request.META.get('HTTP_REFERER')
+        if not is_safe_url(url=next, host=request.get_host()):
+            next = '/'
+    response = http.HttpResponseRedirect(next)
+    if request.method == 'POST':
+        lang_code = request.POST.get(LANGUAGE_QUERY_PARAMETER)
+        if lang_code and check_for_language(lang_code):
+            next_trans = translate_url(next, lang_code)
+            if next_trans != next:
+                response = http.HttpResponseRedirect(next_trans)
+            if hasattr(request, 'session'):
+                request.session[LANGUAGE_SESSION_KEY] = lang_code
+            # Always set cookie
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang_code,
+                                max_age=settings.LANGUAGE_COOKIE_AGE,
+                                path=settings.LANGUAGE_COOKIE_PATH,
+                                domain=settings.LANGUAGE_COOKIE_DOMAIN)
+    return response

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -1,8 +1,12 @@
 <template>
 
-  <core-base :navBarNeeded="navBarNeeded" :topLevelPageName="topLevelPageName" :appBarTitle="appBarTitle">
-    <component :is="currentPage"/>
-  </core-base>
+  <div>
+    <core-base :navBarNeeded="navBarNeeded" :topLevelPageName="topLevelPageName" :appBarTitle="appBarTitle">
+      <component v-if="navBarNeeded" :is="currentPage"/>
+    </core-base>
+    <component v-if="!navBarNeeded" :is="currentPage"/>
+    <language-switcher v-if="!navBarNeeded" :footer="true"/>
+  </div>
 
 </template>
 
@@ -16,6 +20,7 @@
   import signInPage from './sign-in-page';
   import signUpPage from './sign-up-page';
   import profilePage from './profile-page';
+  import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
   export default {
     $trs: { userProfileTitle: 'Profile' },
     name: 'userPlugin',
@@ -24,6 +29,7 @@
       signInPage,
       signUpPage,
       profilePage,
+      languageSwitcher,
     },
     computed: {
       appBarTitle() {

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -4,8 +4,10 @@
     <core-base :navBarNeeded="navBarNeeded" :topLevelPageName="topLevelPageName" :appBarTitle="appBarTitle">
       <component v-if="navBarNeeded" :is="currentPage"/>
     </core-base>
-    <component v-if="!navBarNeeded" :is="currentPage"/>
-    <language-switcher v-if="!navBarNeeded" :footer="true"/>
+    <div v-if="!navBarNeeded" class="full-page">
+      <component :is="currentPage"/>
+      <language-switcher :footer="true"/>
+    </div>
   </div>
 
 </template>
@@ -71,5 +73,11 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
+
+  .full-page
+    position: absolute
+    top: 0
+    height: 100%
+    width: 100%
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -257,8 +257,7 @@
     background: $core-bg-canvas
     background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center fixed
     background-size: cover
-    overflow-y: auto
-    overflow-x: hidden
+    overflow: hidden
 
   #login-container
     display: block


### PR DESCRIPTION
## Summary

Implements a language switcher following design of @khangmach - moves language switcher out of the app bar, and implements it as an option in the used drop down.

In addition, it adds a footer to the login and sign up pages (where no app bar is present) showing six languages, and a more languages button to prompt the same modal.

## Screenshots

Mobile footer:

![image](https://user-images.githubusercontent.com/1680573/29149043-49622c32-7d26-11e7-98e3-19e6f6435420.png)

Desktop footer:

![image](https://user-images.githubusercontent.com/1680573/29149116-bc4f73b2-7d26-11e7-9271-550e419dd2dd.png)

Drop down:

![image](https://user-images.githubusercontent.com/1680573/29149092-9e6b00b4-7d26-11e7-9af3-9c8d62f8d478.png)


Modal:

![image](https://user-images.githubusercontent.com/1680573/29149108-a733089a-7d26-11e7-9907-2805ee8d8c89.png)
