### PR TITLE
Set all language switcher modal contents to core-text-default.

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/index.vue
+++ b/kolibri/core/assets/src/views/language-switcher/index.vue
@@ -10,12 +10,12 @@
     </div>
     <core-modal
       v-if="showModal"
+      class="core-text"
       :title="$tr('changeLanguageModalHeader')"
       @cancel="closeModal">
       <p>{{ $tr('changeLanguageSubHeader') }}</p>
       <k-radio-button
         v-for="language in languageOptions"
-        class="choice"
         :key="language.code"
         :radiovalue="language.code"
         :value="selectedLanguage"
@@ -128,8 +128,8 @@
 
   @require '~kolibri.styles.definitions'
 
-  h1, p
-    color: black
+  .core-text
+    color: $core-text-default
 
   .choice
     color: $core-action-normal


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1680573/29332258-45cad06e-81b4-11e7-8c36-ec15f957faf9.png)
