### PR TITLE
Override xframe options to enable iframes to load in chrome.

### DIFF
--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -75,6 +75,10 @@ class ZipContentView(View):
         # allow all origins so that content can be read from within zips within sandboxed iframes
         response["Access-Control-Allow-Origin"] = "*"
 
+        # Newer versions of Chrome block iframes from loading
+        # solution is to override xframe options with any string (https://stackoverflow.com/a/6767901)
+        response['X-Frame-Options'] = "GOFORIT"
+
         return response
 
 


### PR DESCRIPTION
## Summary

Newer versions of chrome don't allow plix iframes to load. We override the xframe options to allow the iframes to be loaded properly. 