### PR TITLE
Re enable default plugins on version change.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -200,6 +200,14 @@ def update():
 
     logger.info("Running update routines for new version...")
 
+    # Need to do this here, before we run any Django management commands that
+    # import settings. Otherwise the updated configuration will not be used
+    # during this runtime.
+
+    from kolibri.utils.conf import enable_default_plugins
+
+    enable_default_plugins()
+
     call_command("collectstatic", interactive=False)
 
     from kolibri.core.settings import SKIP_AUTO_DATABASE_MIGRATION
@@ -209,10 +217,6 @@ def update():
 
     with open(VERSION_FILE, "w") as f:
         f.write(kolibri.__version__)
-
-    from kolibri.utils.conf import enable_default_plugins
-
-    enable_default_plugins()
 
 
 update.called = False

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -39,7 +39,7 @@ from .system import become_daemon  # noqa
 # ...we need to (re)move it /benjaoming
 # Force python2 to interpret every string as unicode.
 if sys.version[0] == '2':
-    reload(sys)
+    reload(sys)  # noqa
     sys.setdefaultencoding('utf8')
 
 USAGE = """
@@ -209,6 +209,10 @@ def update():
 
     with open(VERSION_FILE, "w") as f:
         f.write(kolibri.__version__)
+
+    from kolibri.utils.conf import enable_default_plugins
+
+    enable_default_plugins()
 
 
 update.called = False

--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -14,11 +14,7 @@ def module_exists(module_path):
     if sys.version_info >= (3, 4):
         from importlib.util import find_spec
         try:
-            if "." in module_path:
-                find_spec(module_path)
-                return True
-            else:
-                return find_spec(module_path) is not None
+            return find_spec(module_path) is not None
         except ImportError:
             return False
     elif sys.version_info < (3,):

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 import logging
 import os
+
 from kolibri.utils.compat import module_exists
 
 logger = logging.getLogger(__name__)
@@ -38,8 +39,7 @@ if not os.path.exists(KOLIBRI_HOME):
 #: Set defaults before updating the dict
 config = {}
 
-#: Everything in this list is added to django.conf.settings.INSTALLED_APPS
-config['INSTALLED_APPS'] = [
+DEFAULT_PLUGINS = [
     # Note from Devon -
     # Temporarily adding these here to get things working for most devs.
     # It's not clear to me where the correct place to add them is.
@@ -53,6 +53,9 @@ config['INSTALLED_APPS'] = [
     "kolibri.plugins.user",
     "kolibri_exercise_perseus_plugin"
 ]
+
+#: Everything in this list is added to django.conf.settings.INSTALLED_APPS
+config['INSTALLED_APPS'] = DEFAULT_PLUGINS
 
 #: Well-known plugin names that are automatically searched for and enabled on
 #: first-run.
@@ -112,3 +115,27 @@ def autoremove_unavailable_plugins():
 
 
 autoremove_unavailable_plugins()
+
+def enable_default_plugins():
+    """
+    Enable new plugins that have been added between versions
+    This will have the undesired side effect of reactivating
+    default plugins that have been explicitly disabled by a user.
+    However, until we add disabled plugins to a blacklist, this is
+    unavoidable.
+    """
+    global config
+    changed = False
+    for module_path in DEFAULT_PLUGINS:
+        if module_path not in config['INSTALLED_APPS']:
+            config['INSTALLED_APPS'].append(module_path)
+            logger.warning(
+                (
+                    "Default plugin {mod} not found in configuration. To re-disable it, run:\n"
+                    "   $ kolibri plugin {mod} disable"
+                ).format(mod=module_path)
+            )
+            changed = True
+
+    if changed:
+        save()

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -109,12 +109,9 @@ def autoremove_unavailable_plugins():
                 ).format(mod=module_path)
             )
             changed = True
-
     if changed:
         save()
 
-
-autoremove_unavailable_plugins()
 
 def enable_default_plugins():
     """

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -99,7 +99,8 @@ def autoremove_unavailable_plugins():
     """
     global config
     changed = False
-    for module_path in config['INSTALLED_APPS']:
+    # Iterate over a copy of the list so that it is not modified during the loop
+    for module_path in config['INSTALLED_APPS'][:]:
         if not module_exists(module_path):
             config['INSTALLED_APPS'].remove(module_path)
             logger.error(


### PR DESCRIPTION
## Summary

Makes default plugins get activated if they were previously missing.

Important if we add a new plugin (like the media player, particularly when it replaces functionality of removed plugins).

## Issues addressed

Fixes #2008