### PR TITLE
Fix time filtering on recent coach report

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -5,6 +5,7 @@ from django.db.models import Min, Q
 from django.utils import timezone
 from kolibri.auth.constants import role_kinds
 from kolibri.auth.models import Collection, FacilityUser
+from kolibri.content.content_db_router import default_database_is_attached, get_active_content_database
 from kolibri.content.models import ContentNode
 from kolibri.logger.models import ContentSummaryLog, MasteryLog
 from rest_framework import pagination, permissions, viewsets
@@ -93,10 +94,17 @@ class RecentReportViewSet(viewsets.ModelViewSet):
             datetime_cutoff = timezone.now() - datetime.timedelta(7)
         # Set on the kwargs to pass into the serializer
         self.kwargs['last_active_time'] = datetime_cutoff.isoformat()
-        recent_content_items = ContentSummaryLog.objects.filter_by_topic(query_node).filter(
+        if default_database_is_attached():  # if possible, do a direct join between the content and default databases
+            channel_alias = get_active_content_database()
+            SummaryLogManager = ContentSummaryLog.objects.using(channel_alias)
+        else:
+            SummaryLogManager = ContentSummaryLog.objects
+        recent_content_items = SummaryLogManager.filter_by_topic(query_node).filter(
             Q(progress__gt=0) | Q(masterylogs__in=attempted_mastery_logs),
             user__in=list(get_members_or_user(self.kwargs['collection_kind'], self.kwargs['collection_id'])),
-            end_timestamp__gte=datetime_cutoff).values_list('content_id')
+            end_timestamp__gte=datetime_cutoff).values_list('content_id', flat=True)
+        if not default_database_is_attached():
+            recent_content_items = list(recent_content_items)
         # note from rtibbles:
         # As good as either I or jamalex could come up with to ensure that we only return
         # unique content_id'ed ContentNodes from the coach recent report endpoint.

--- a/kolibri/plugins/coach/serializers.py
+++ b/kolibri/plugins/coach/serializers.py
@@ -90,7 +90,7 @@ def get_progress_and_last_active(target_nodes, **kwargs):
         .filter(user__in=users, content_id__in=content_ids)
     # Conditionally filter by last active time
     if kwargs.get('last_active_time'):
-        progress_query.filter(end_timestamp__gte=parse(kwargs.get('last_active_time')))
+        progress_query = progress_query.filter(end_timestamp__gte=parse(kwargs.get('last_active_time')))
     # Get an annotated list of dicts of type:
     # {
     #   'content_id': <content_id>,


### PR DESCRIPTION
## Summary

Actually use the time filtered queryset in the coach report serializers.

## TODOs

[x] - Tests written for the new code

## Issues addressed

Fixes #2009
