### PR TITLE
Merge pageState rather than overwrite in learn

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -481,7 +481,6 @@ function showContentUnavailable(store) {
 
 function redirectToChannelSearch(store) {
   store.dispatch('SET_PAGE_NAME', PageNames.SEARCH_ROOT);
-  store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('CORE_SET_ERROR', null);
   store.dispatch('CORE_SET_TITLE', 'Search');
@@ -502,7 +501,6 @@ function redirectToChannelSearch(store) {
 
 function showSearch(store, channelId, searchTerm) {
   store.dispatch('SET_PAGE_NAME', PageNames.SEARCH);
-  store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('CORE_SET_ERROR', null);
   store.dispatch('CORE_SET_TITLE', 'Search');

--- a/kolibri/plugins/learn/assets/src/state/store.js
+++ b/kolibri/plugins/learn/assets/src/state/store.js
@@ -21,7 +21,8 @@ const mutations = {
     state.pageName = name;
   },
   SET_PAGE_STATE(state, pageState) {
-    state.pageState = pageState;
+    const oldPageState = state.pageState;
+    state.pageState = Object.assign(oldPageState, pageState);
   },
   SET_EXAM_LOG(state, examLog) {
     state.examLog = examLog;


### PR DESCRIPTION
## Summary

Merges pageState rather than overwriting, to allow components that are being torn down as a result of changes in Vuex state to still reference pre-existing vuex state in their beforeDestroy methods.

Fixes #2027.