### PR TITLE
Make all page titles translatable

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -18,6 +18,15 @@ import { now } from 'kolibri.utils.serverClock';
 import urls from 'kolibri.urls';
 import intervalTimer from '../timer';
 import { redirectBrowser } from '../utils/browser';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'coreTitles';
+
+const messages = {
+  errorPageTitle: 'Error',
+};
+
+const translator = createTranslator(name, messages);
 
 const logging = logger.getLogger(__filename);
 const intervalTime = 5000; // Frequency at which time logging is updated
@@ -150,7 +159,7 @@ function _channelListState(data) {
 function handleError(store, errorString) {
   store.dispatch('CORE_SET_ERROR', errorString);
   store.dispatch('CORE_SET_PAGE_LOADING', false);
-  store.dispatch('CORE_SET_TITLE', 'Error');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('errorPageTitle'));
 }
 
 function handleApiError(store, errorObject) {

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -25,12 +25,14 @@ function createStore() {
 
 describe('Vuex store/actions for core module', () => {
   describe('error handling', () => {
+    const errorMessage = 'testError';
+    Vue.prototype.$formatMessage = () => errorMessage;
     it('handleError action updates core state', () => {
       const store = createStore();
       coreActions.handleError(store, 'catastrophic failure');
       assert.equal(store.state.core.error, 'catastrophic failure');
       assert.equal(store.state.core.loading, false);
-      assert.equal(store.state.core.title, 'Error');
+      assert.equal(store.state.core.title, errorMessage);
     });
 
     it('handleApiError action updates core state', () => {
@@ -39,7 +41,7 @@ describe('Vuex store/actions for core module', () => {
       coreActions.handleApiError(store, apiError);
       assert(store.state.core.error.match(/Too Bad/));
       assert.equal(store.state.core.loading, false);
-      assert.equal(store.state.core.title, 'Error');
+      assert.equal(store.state.core.title, errorMessage);
     });
   });
 

--- a/kolibri/plugins/coach/assets/src/constants.js
+++ b/kolibri/plugins/coach/assets/src/constants.js
@@ -26,11 +26,6 @@ const PageNames = {
   GROUPS: 'GROUPS',
 };
 
-const PageTitles = {
-  EXAMS: 'Exams',
-  CREATE_EXAM: 'Create new exam',
-};
-
 const RecentReports = [
   PageNames.RECENT_CHANNELS,
   PageNames.RECENT_ITEMS_FOR_CHANNEL,
@@ -69,12 +64,4 @@ const GroupModals = {
   MOVE_LEARNERS: 'MOVE_LEARNERS',
 };
 
-export {
-  PageNames,
-  PageTitles,
-  RecentReports,
-  TopicReports,
-  ExamPages,
-  LearnerReports,
-  GroupModals,
-};
+export { PageNames, RecentReports, TopicReports, ExamPages, LearnerReports, GroupModals };

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -17,6 +17,18 @@ import * as Constants from '../../constants';
 import { setClassState } from './main';
 import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'coachExamPageTitles';
+
+const messages = {
+  coachExamListPageTitle: 'Exams',
+  coachExamCreationPageTitle: 'Create new exam',
+  coachExamReportPageTitle: 'Exam Report',
+  coachExamReportDetailPageTitle: 'Exam Report Detail',
+};
+
+const translator = createTranslator(name, messages);
 
 const pickIdAndName = pick(['id', 'name']);
 
@@ -148,7 +160,7 @@ function showExamsPage(store, classId) {
 
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', Constants.PageTitles.EXAMS);
+      store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamListPageTitle'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
     },
     error => CoreActions.handleError(store, error)
@@ -358,7 +370,7 @@ function fetchContent(store, channelId, topicId) {
 function showCreateExamPage(store, classId, channelId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.CREATE_EXAM);
-  store.dispatch('CORE_SET_TITLE', Constants.PageTitles.CREATE_EXAM);
+  store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamCreationPageTitle'));
 
   const channelPromise = ChannelResource.getCollection().fetch();
   const examsPromise = ExamResource.getCollection({
@@ -481,7 +493,7 @@ function showExamReportPage(store, classId, channelId, examId) {
       };
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', 'Exam Report');
+      store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamReportPageTitle'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
     },
     error => {
@@ -603,7 +615,7 @@ function showExamReportDetailPage(
 
             store.dispatch('SET_PAGE_STATE', pageState);
             store.dispatch('CORE_SET_ERROR', null);
-            store.dispatch('CORE_SET_TITLE', 'Exam Report Detail');
+            store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamReportDetailPageTitle'));
             store.dispatch('CORE_SET_PAGE_LOADING', false);
           },
           error => CoreActions.handleApiError(store, error)

--- a/kolibri/plugins/coach/assets/src/state/actions/group.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/group.js
@@ -4,6 +4,15 @@ import * as Constants from '../../constants';
 import { setClassState } from './main';
 
 import { LearnerGroupResource, MembershipResource, FacilityUserResource } from 'kolibri.resources';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'groupManagementPageTitles';
+
+const messages = {
+  groupManagementPageTitle: 'Groups',
+};
+
+const translator = createTranslator(name, messages);
 
 function _userState(user) {
   return {
@@ -74,7 +83,7 @@ function showGroupsPage(store, classId) {
           store.dispatch('SET_PAGE_STATE', pageState);
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
-          store.dispatch('CORE_SET_TITLE', 'Groups');
+          store.dispatch('CORE_SET_TITLE', translator.$tr('groupManagementPageTitle'));
         },
         error => coreActions.handleError(store, error)
       );

--- a/kolibri/plugins/coach/assets/src/state/actions/main.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/main.js
@@ -1,6 +1,15 @@
 import * as Constants from '../../constants';
 import * as coreActions from 'kolibri.coreVue.vuex.actions';
 import { ClassroomResource } from 'kolibri.resources';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'classListTitles';
+
+const messages = {
+  classListPageTitle: 'Classes',
+};
+
+const translator = createTranslator(name, messages);
 
 // ================================
 // CLASS LIST ACTIONS
@@ -28,7 +37,7 @@ function showClassListPage(store) {
       store.dispatch('SET_PAGE_STATE', {});
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', 'Coach - Classes'); // Follow Naming Scheme
+      store.dispatch('CORE_SET_TITLE', translator.$tr('classListPageTitle'));
     },
     error => {
       coreActions.handleApiError(store, error);

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -21,6 +21,29 @@ import RecentReportResourceConstructor from '../../apiResources/recentReport';
 import UserReportResourceConstructor from '../../apiResources/userReport';
 import ContentSummaryResourceConstructor from '../../apiResources/contentSummary';
 import ContentReportResourceConstructor from '../../apiResources/contentReport';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'coachReportPageTitles';
+
+const messages = {
+  recentChannelsPageTitle: 'Recent - All channels',
+  recentItemsForChannelPageTitle: 'Recent - Items',
+  recentPageTitle: 'Recent',
+  recentLearnerActivityReportPageTitle: 'Recent - Learners',
+  recentActivityLearnerDetailsReportPageTitle: 'Recent - Learner Details',
+  topicsReportAllChannelsPageTitle: 'Topics - All channels',
+  topicsForChannelReportPageTitle: 'Topics - Channel',
+  topicsContentItemsReportPageTitle: 'Topics - Items',
+  topicsLearnersReportForContentItemPageTitle: 'Topics - Learners',
+  topicsLearnerDetailReportPageTitle: 'Topics - Learner Details',
+  learnersReportPageTitle: 'Learners',
+  learnersReportAllChannelsPageTitle: 'Learners - All channels',
+  learnersReportForChannelPageTitlle: 'Learners - Channel',
+  learnersReportForContentItemsPageTitle: 'Learners - Items',
+  learnersItemDetailsReportPageTitle: 'Learners - Item Details',
+};
+
+const translator = createTranslator(name, messages);
 
 const RecentReportResource = new RecentReportResourceConstructor();
 const UserReportResource = new UserReportResourceConstructor();
@@ -376,14 +399,14 @@ function setReportSorting(store, sortColumn, sortOrder) {
 
 function showRecentChannels(store, classId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.RECENT_CHANNELS);
-  store.dispatch('CORE_SET_TITLE', 'Recent - All channels');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('recentChannelsPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   _showChannelList(store, classId, null, true);
 }
 
 function showRecentItemsForChannel(store, classId, channelId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.RECENT_ITEMS_FOR_CHANNEL);
-  store.dispatch('CORE_SET_TITLE', 'Recent - Items');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('recentItemsForChannelPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   const channelPromise = ChannelResource.getModel(channelId).fetch();
 
@@ -419,7 +442,7 @@ function showRecentItemsForChannel(store, classId, channelId) {
           );
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);
-          store.dispatch('CORE_SET_TITLE', 'Recents');
+          store.dispatch('CORE_SET_TITLE', translator.$tr('recentPageTitle'));
         },
         error => coreActions.handleApiError(store, error)
       );
@@ -430,7 +453,7 @@ function showRecentItemsForChannel(store, classId, channelId) {
 
 function showRecentLearnersForItem(store, classId, channelId, contentId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.RECENT_LEARNERS_FOR_ITEM);
-  store.dispatch('CORE_SET_TITLE', 'Recent - Learners');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('recentLearnerActivityReportPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   _showLearnerList(store, {
@@ -457,7 +480,7 @@ function showRecentLearnerItemDetails(
     store.dispatch('SET_PAGE_NAME', Constants.PageNames.RECENT_LEARNER_ITEM_DETAILS);
     store.dispatch('CORE_SET_PAGE_LOADING', true);
   }
-  store.dispatch('CORE_SET_TITLE', 'Recent - Learner Details');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('recentActivityLearnerDetailsReportPageTitle'));
   _showExerciseDetailView(
     store,
     classId,
@@ -472,7 +495,7 @@ function showRecentLearnerItemDetails(
 function showTopicChannels(store, classId) {
   clearReportSorting(store);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.TOPIC_CHANNELS);
-  store.dispatch('CORE_SET_TITLE', 'Topics - All channels');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('topicsReportAllChannelsPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   _showChannelList(store, classId, null, false);
 }
@@ -480,7 +503,7 @@ function showTopicChannels(store, classId) {
 function showTopicChannelRoot(store, classId, channelId) {
   clearReportSorting(store);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.TOPIC_CHANNEL_ROOT);
-  store.dispatch('CORE_SET_TITLE', 'Topics - Channel');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('topicsForChannelReportPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   const channelPromise = ChannelResource.getModel(channelId).fetch();
@@ -503,7 +526,7 @@ function showTopicChannelRoot(store, classId, channelId) {
 function showTopicItemList(store, classId, channelId, topicId) {
   clearReportSorting(store);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.TOPIC_ITEM_LIST);
-  store.dispatch('CORE_SET_TITLE', 'Topics - Items');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('topicsContentItemsReportPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   _showContentList(store, {
@@ -520,7 +543,7 @@ function showTopicItemList(store, classId, channelId, topicId) {
 function showTopicLearnersForItem(store, classId, channelId, contentId) {
   clearReportSorting(store);
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.TOPIC_LEARNERS_FOR_ITEM);
-  store.dispatch('CORE_SET_TITLE', 'Topics - Learners');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('topicsLearnersReportForContentItemPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   _showLearnerList(store, {
@@ -547,7 +570,7 @@ function showTopicLearnerItemDetails(
     store.dispatch('SET_PAGE_NAME', Constants.PageNames.TOPIC_LEARNER_ITEM_DETAILS);
     store.dispatch('CORE_SET_PAGE_LOADING', true);
   }
-  store.dispatch('CORE_SET_TITLE', 'Topics - Learner Details');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('topicsLearnerDetailReportPageTitle'));
   _showExerciseDetailView(
     store,
     classId,
@@ -561,7 +584,7 @@ function showTopicLearnerItemDetails(
 
 function showLearnerList(store, classId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.LEARNER_LIST);
-  store.dispatch('CORE_SET_TITLE', 'Learners');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('learnersReportPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   const promises = [
@@ -594,14 +617,14 @@ function showLearnerList(store, classId) {
 
 function showLearnerChannels(store, classId, userId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.LEARNER_CHANNELS);
-  store.dispatch('CORE_SET_TITLE', 'Learners - All channels');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('learnersReportAllChannelsPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   _showChannelList(store, classId, userId, false);
 }
 
 function showLearnerChannelRoot(store, classId, userId, channelId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.LEARNER_CHANNEL_ROOT);
-  store.dispatch('CORE_SET_TITLE', 'Learners - Channel');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('learnersReportForChannelPageTitlle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
 
   const channelPromise = ChannelResource.getModel(channelId).fetch();
@@ -623,7 +646,7 @@ function showLearnerChannelRoot(store, classId, userId, channelId) {
 
 function showLearnerItemList(store, classId, userId, channelId, topicId) {
   store.dispatch('SET_PAGE_NAME', Constants.PageNames.LEARNER_ITEM_LIST);
-  store.dispatch('CORE_SET_TITLE', 'Learners - Items');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('learnersReportForContentItemsPageTitle'));
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   _showContentList(store, {
     classId,
@@ -649,7 +672,7 @@ function showLearnerItemDetails(
     store.dispatch('SET_PAGE_NAME', Constants.PageNames.LEARNER_ITEM_DETAILS);
     store.dispatch('CORE_SET_PAGE_LOADING', true);
   }
-  store.dispatch('CORE_SET_TITLE', 'Learners - Item Details');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('learnersItemDetailsReportPageTitle'));
   _showExerciseDetailView(
     store,
     classId,

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -20,6 +20,21 @@ import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import router from 'kolibri.coreVue.router';
 import seededShuffle from 'kolibri.lib.seededshuffle';
 import prepareLearnApp from '../prepareLearnApp';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'topicTreeExplorationPageTitles';
+
+const messages = {
+  topicsForChannelPageTitle: 'Topics - { currentChannelTitle }',
+  currentTopicForChannelPageTitle: '{ currentTopicTitle } - { currentChannelTitle }',
+  currentContentForChannelPageTitle: '{ currentContentTitle } - { currentChannelTitle }',
+  contentUnavailablePageTitle: 'Content Unavailable',
+  searchPageTitle: 'Search',
+  examsForChannelPageTitle: 'Exams - { currentChannelTitle }',
+  currentExamPageTitle: '{ currentExamTitle} - { currentChannelTitle }',
+};
+
+const translator = createTranslator(name, messages);
 
 /**
  * Vuex State Mappers
@@ -229,9 +244,18 @@ function showExploreTopic(store, channelId, id, isRoot = false) {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
       if (isRoot) {
-        store.dispatch('CORE_SET_TITLE', `Topics - ${currentChannel.title}`);
+        store.dispatch(
+          'CORE_SET_TITLE',
+          translator.$tr('topicsForChannelPageTitle', { currentChannelTitle: currentChannel.title })
+        );
       } else {
-        store.dispatch('CORE_SET_TITLE', `${pageState.topic.title} - ${currentChannel.title}`);
+        store.dispatch(
+          'CORE_SET_TITLE',
+          translator.$tr('currentTopicForChannelPageTitle', {
+            currentTopicTitle: pageState.topic.title,
+            currentChannelTitle: currentChannel.title,
+          })
+        );
       }
     },
     error => {
@@ -287,7 +311,13 @@ function showExploreContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', `${pageState.content.title} - ${currentChannel.title}`);
+      store.dispatch(
+        'CORE_SET_TITLE',
+        translator.$tr('currentContentForChannelPageTitle', {
+          currentContentTitle: pageState.content.title,
+          currentChannelTitle: currentChannel.title,
+        })
+      );
     },
     error => {
       handleApiError(store, error);
@@ -337,7 +367,7 @@ function showContentUnavailable(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
-  store.dispatch('CORE_SET_TITLE', 'Content Unavailable');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('contentUnavailablePageTitle'));
 }
 
 function redirectToChannelSearch(store) {
@@ -345,7 +375,7 @@ function redirectToChannelSearch(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('CORE_SET_ERROR', null);
-  store.dispatch('CORE_SET_TITLE', 'Search');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('searchPageTitle'));
   clearSearch(store);
   setChannelInfo(store).then(
     () => {
@@ -366,7 +396,7 @@ function showSearch(store, channelId, searchTerm) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('CORE_SET_ERROR', null);
-  store.dispatch('CORE_SET_TITLE', 'Search');
+  store.dispatch('CORE_SET_TITLE', translator.$tr('searchPageTitle'));
   clearSearch(store);
   setChannelInfo(store, channelId).then(() => {
     if (searchTerm) {
@@ -402,7 +432,10 @@ function showExamList(store, channelId) {
         store.dispatch('SET_PAGE_STATE', pageState);
         store.dispatch('CORE_SET_PAGE_LOADING', false);
         store.dispatch('CORE_SET_ERROR', null);
-        store.dispatch('CORE_SET_TITLE', `Exams - ${currentChannel.title}`);
+        store.dispatch(
+          'CORE_SET_TITLE',
+          translator.$tr('examsForChannelPageTitle', { currentChannelTitle: currentChannel.title })
+        );
       },
       error => {
         handleApiError(store, error);
@@ -579,7 +612,10 @@ function showExam(store, channelId, id, questionNumber) {
                 store.dispatch('CORE_SET_ERROR', null);
                 store.dispatch(
                   'CORE_SET_TITLE',
-                  `${pageState.exam.title} - ${currentChannel.title}`
+                  translator.$tr('currentExamPageTitle', {
+                    currentExamTitle: pageState.exam.title,
+                    currentChannelTitle: currentChannel.title,
+                  })
                 );
               }
             },

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -25,6 +25,19 @@ import { contentState } from './main';
 
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import uniqBy from 'lodash/uniqBy';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const name = 'learnerRecommendationPageTitles';
+
+const messages = {
+  popularPageTitle: 'Popular - { currentChannel }',
+  resumePageTitle: 'Resume - { currentChannel }',
+  nextStepsPageTitle: 'Next Steps - { currentChannel }',
+  FeaturedInChannelPageTitle: 'Featured - { currentChannel }',
+  learnContentPageTitle: '{ currentContent } - { currentChannel }',
+};
+
+const translator = createTranslator(name, messages);
 
 // User-agnostic recommendations
 
@@ -65,7 +78,7 @@ function _mapContentSet(contentSet) {
   return uniqBy(contentSet, 'content_id').map(contentState);
 }
 
-function _showRecSubpage(store, channelId, getContentPromise, pageName, windowTitle) {
+function _showRecSubpage(store, channelId, getContentPromise, pageName, windowTitleId) {
   const state = store.state;
   // promise that resolves with content array, already mapped to state
   const pagePrep = Promise.all([
@@ -87,7 +100,7 @@ function _showRecSubpage(store, channelId, getContentPromise, pageName, windowTi
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
 
-      store.dispatch('CORE_SET_TITLE', `${windowTitle} - ${channelTitle}`);
+      store.dispatch('CORE_SET_TITLE', translator.$tr(windowTitleId, { channelTitle }));
     },
     error => handleApiError(error)
   );
@@ -148,19 +161,31 @@ function showLearnChannel(store, channelId, cursor) {
 }
 
 function showPopularPage(store, channelId) {
-  _showRecSubpage(store, channelId, _getPopular, PageNames.RECOMMENDED_POPULAR, 'Popular');
+  _showRecSubpage(store, channelId, _getPopular, PageNames.RECOMMENDED_POPULAR, 'popularPageTitle');
 }
 
 function showResumePage(store, channelId) {
-  _showRecSubpage(store, channelId, _getResume, PageNames.RECOMMENDED_RESUME, 'Resume');
+  _showRecSubpage(store, channelId, _getResume, PageNames.RECOMMENDED_RESUME, 'resumePageTitle');
 }
 
 function showNextStepsPage(store, channelId) {
-  _showRecSubpage(store, channelId, _getNextSteps, PageNames.RECOMMENDED_NEXT_STEPS, 'Next Steps');
+  _showRecSubpage(
+    store,
+    channelId,
+    _getNextSteps,
+    PageNames.RECOMMENDED_NEXT_STEPS,
+    'nextStepsPageTitle'
+  );
 }
 
 function showFeaturedPage(store, channelId) {
-  _showRecSubpage(store, channelId, _getFeatured, PageNames.RECOMMENDED_FEATURED, 'Featured');
+  _showRecSubpage(
+    store,
+    channelId,
+    _getFeatured,
+    PageNames.RECOMMENDED_FEATURED,
+    'featuredInChannelPageTitle'
+  );
 }
 
 function showLearnContent(store, channelId, id) {
@@ -190,7 +215,13 @@ function showLearnContent(store, channelId, id) {
       store.dispatch('SET_PAGE_STATE', pageState);
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
-      store.dispatch('CORE_SET_TITLE', `${pageState.content.title} - ${currentChannel.title}`);
+      store.dispatch(
+        'CORE_SET_TITLE',
+        translator.$tr('learnContentPageTitle', {
+          currentContent: pageState.content.title,
+          currentChannel: currentChannel.title,
+        })
+      );
     },
     error => {
       handleApiError(store, error);

--- a/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-slidein/index.vue
@@ -27,7 +27,7 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
 
   export default {
-    $trNameSpace: 'pointsSlidein',
+    name: 'pointsSlidein',
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
       close: 'Close',

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage/index.vue
@@ -19,7 +19,7 @@
   import contentCardGroupHeader from '../content-card-group-header';
 
   export default {
-    $trNameSpace: 'recommendedSubpage',
+    name: 'recommendedSubpage',
     $trs: {
       popularPageHeader: 'Most popular',
       resumePageHeader: 'Resume',

--- a/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/import-preview.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-content-page/wizards/import-preview.vue
@@ -125,7 +125,7 @@
         transitionWizardPage,
       },
     },
-    $trNameSpace: 'previewImportWizard',
+    name: 'previewImportWizard',
     $trs: {
       cancelButtonLabel: 'Cancel',
       channelAlreadyInstalled: 'Already installed',

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-vue": "beta",
-    "esprima": "2.7.2",
+    "esprima": "^4.0.0",
     "exports-loader": "0.6.3",
     "extract-text-webpack-plugin": "^2.1.2",
     "fg-loadcss": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,7 +1712,7 @@ espree@>=3.3.2, espree@^3.1.6, espree@^3.4.3:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
-esprima@2.7.2, esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
+esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.2.tgz#f43be543609984eae44c933ac63352a6af35f339"
 


### PR DESCRIPTION
## Summary

Fixes a vital bug in message extraction that cause any module containing a function with default arguments to break compilation.

Makes all page titles translatable.

## Issues addressed

Fixes #1144 (I think - if anyone knows of any other strings in JS files, let's get them wrapped).