### PR TITLE
Fix up simplified login scenarios for Superusers

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from django.contrib.auth import authenticate, get_user, login, logout
 from django.contrib.auth.models import AnonymousUser
+from django.db.models import Q
 from django.db.models.query import F
 from kolibri.logger.models import UserSessionLog
 from rest_framework import filters, permissions, status, viewsets
@@ -105,7 +106,8 @@ class FacilityUserViewSet(viewsets.ModelViewSet):
 
 class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter, )
-    queryset = FacilityUser.objects.filter(dataset__learner_can_login_with_no_password=True, roles=None)
+    queryset = FacilityUser.objects.filter(dataset__learner_can_login_with_no_password=True, roles=None).filter(
+        Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True))
     serializer_class = FacilityUsernameSerializer
     filter_fields = ('facility', )
     search_fields = ('^username', )

--- a/kolibri/auth/backends.py
+++ b/kolibri/auth/backends.py
@@ -29,7 +29,7 @@ class FacilityUserBackend(object):
                 return user
             # Allow login without password for learners for facilities that allow this.
             # Must specify the facility, to prevent accidental logins
-            elif facility and user.dataset.learner_can_login_with_no_password and not user.roles.count():
+            elif facility and user.dataset.learner_can_login_with_no_password and not user.roles.count() and not user.is_superuser:
                 return user
         return None
 

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils.translation import check_for_language, ugettext_lazy as _
 from kolibri.auth.constants.facility_presets import choices, mappings
+from kolibri.auth.constants.role_kinds import ADMIN
 from kolibri.auth.models import Facility, FacilityUser
 from kolibri.auth.serializers import FacilitySerializer, FacilityUserSerializer
 from rest_framework import serializers
@@ -59,6 +60,7 @@ class DeviceProvisionSerializer(serializers.Serializer):
             superuser_data = validated_data.pop('superuser')
             superuser_data['facility'] = facility
             superuser = FacilityUserSerializer(data=superuser_data).create(superuser_data)
+            facility.add_role(superuser, ADMIN)
             DevicePermissions.objects.create(user=superuser, is_superuser=True)
             language_code = validated_data.pop('language_code')
             device_settings, created = DeviceSettings.objects.get_or_create()

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -1,5 +1,6 @@
+from kolibri.auth.constants.role_kinds import ADMIN
 from kolibri.auth.test.helpers import provision_device
-from kolibri.auth.models import Facility, FacilityDataset, FacilityUser
+from kolibri.auth.models import Facility, FacilityDataset, FacilityUser, Role
 from kolibri.core.device.models import DevicePermissions
 
 from django.core.urlresolvers import reverse
@@ -63,6 +64,26 @@ class DeviceProvisionTestCase(APITestCase):
         }
         self.client.post(reverse('deviceprovision'), data, format="json")
         self.assertEqual(Facility.objects.get().name, self.facility_data["name"])
+
+    def test_admin_role_created(self):
+        data = {
+            "superuser": self.superuser_data,
+            "facility": self.facility_data,
+            "preset": self.preset_data,
+            "language_code": self.language_code,
+        }
+        self.client.post(reverse('deviceprovision'), data, format="json")
+        self.assertEqual(Role.objects.get().kind, ADMIN)
+
+    def test_facility_role_created(self):
+        data = {
+            "superuser": self.superuser_data,
+            "facility": self.facility_data,
+            "preset": self.preset_data,
+            "language_code": self.language_code,
+        }
+        self.client.post(reverse('deviceprovision'), data, format="json")
+        self.assertEqual(Role.objects.get().collection.name, self.facility_data["name"])
 
     def test_dataset_set_created(self):
         data = {


### PR DESCRIPTION
## Summary

Ensures that DeviceOwner gets migrate to a FacilityAdmin on the default facility.
Ensures that newly created superusers at device provisioning are also set as FacilityAdmins.
Prevents superusers from utilizing simplified login, in the login auth backend.
Prevents superusers from appearing in the simplified login username autocomplete.

Fixes #2038