### PR TITLE
Deletion is overrated

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -38,14 +38,12 @@ class ChannelMetadataViewSet(viewsets.ModelViewSet):
         the filesystem.
         """
 
-        self.get_object(pk).delete_content_tree_and_files()
+        self.get_object().delete_content_tree_and_files()
 
-        super(ChannelMetadataViewSet, self).destroy(request)
+        models.LocalFile.objects.delete_orphans()
 
-        if self.delete_content_db_file(pk):
-            response_msg = 'Channel {} removed from device'.format(pk)
-        else:
-            response_msg = 'Channel {} removed, but no content database was found'.format(pk)
+        self.delete_content_db_file(pk)
+        response_msg = 'Channel {} removed from device'.format(pk)
 
         return Response(response_msg)
 

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -34,8 +34,8 @@ class ChannelMetadataViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, pk=None):
         """
-        Destroys the ChannelMetadata object and its associated sqlite3 file on
-        the filesystem.
+        Destroys the ChannelMetadata object all of its metadata, any orphaned files as a result of its deletion
+        and its associated sqlite3 file on the filesystem.
         """
 
         self.get_object().delete_content_tree_and_files()

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -8,8 +8,11 @@ from kolibri.content import models as content
 from le_utils.constants import content_kinds
 from rest_framework.test import APITestCase
 from kolibri.auth.models import Facility, FacilityUser
-from kolibri.auth.test.helpers import provision_device
+from kolibri.auth.test.test_api import DUMMY_PASSWORD
+from kolibri.auth.test.helpers import create_superuser, provision_device
 from kolibri.logger.models import ContentSummaryLog
+
+from mock import patch, call
 
 class ContentNodeTestBase(object):
     """
@@ -177,6 +180,73 @@ class ContentNodeAPITestCase(APITestCase):
         data = content.ChannelMetadata.objects.values()[0]
         response = self.client.get(reverse("channel-detail", kwargs={'pk': data["id"]}))
         self.assertEqual(response.data['name'], 'testing')
+
+    @patch('kolibri.content.models.paths.get_content_storage_file_path')
+    @patch('kolibri.content.models.os.remove')
+    def test_channelmetadata_delete_remove_metadata_object(self, os_remove_mock, content_file_path):
+        facility = Facility.objects.create(name='name')
+        superuser = create_superuser(facility)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD, facility=facility)
+        data = content.ChannelMetadata.objects.values()[0]
+        response = self.client.delete(reverse("channel-detail", kwargs={'pk': data["id"]}))
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(0, content.ChannelMetadata.objects.count())
+
+    @patch('kolibri.content.models.paths.get_content_storage_file_path')
+    @patch('kolibri.content.models.os.remove')
+    def test_channelmetadata_delete_remove_contentnodes(self, os_remove_mock, content_file_path):
+        facility = Facility.objects.create(name='name')
+        superuser = create_superuser(facility)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD, facility=facility)
+        data = content.ChannelMetadata.objects.values()[0]
+        response = self.client.delete(reverse("channel-detail", kwargs={'pk': data["id"]}))
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(0, content.ContentNode.objects.count())
+
+    @patch('kolibri.content.models.paths.get_content_storage_file_path')
+    @patch('kolibri.content.models.os.remove')
+    def test_channelmetadata_delete_leave_unrelated_contentnodes(self, os_remove_mock, content_file_path):
+        facility = Facility.objects.create(name='name')
+        superuser = create_superuser(facility)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD, facility=facility)
+        data = content.ChannelMetadata.objects.values()[0]
+        c2c1 = content.ContentNode.objects.get(title="c2c1")
+        new_id = c2c1.id[:-1] + '1'
+        content.ContentNode.objects.create(
+            id=new_id,
+            content_id=c2c1.content_id,
+            kind=c2c1.kind,
+            channel_id=c2c1.channel_id,
+            available=True,
+            title=c2c1.title,
+        )
+        response = self.client.delete(reverse("channel-detail", kwargs={'pk': data["id"]}))
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(1, content.ContentNode.objects.count())
+
+    @patch('kolibri.content.models.paths.get_content_storage_file_path')
+    @patch('kolibri.content.models.os.remove')
+    def test_channelmetadata_delete_remove_file_objects(self, os_remove_mock, content_file_path):
+        facility = Facility.objects.create(name='name')
+        superuser = create_superuser(facility)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD, facility=facility)
+        data = content.ChannelMetadata.objects.values()[0]
+        response = self.client.delete(reverse("channel-detail", kwargs={'pk': data["id"]}))
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(0, content.File.objects.count())
+
+    @patch('kolibri.content.models.paths.get_content_storage_file_path')
+    @patch('kolibri.content.models.os.remove')
+    def test_channelmetadata_delete_files(self, os_remove_mock, content_file_path):
+        facility = Facility.objects.create(name='name')
+        superuser = create_superuser(facility)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD, facility=facility)
+        data = content.ChannelMetadata.objects.values()[0]
+        path = 'testing'
+        content_file_path.return_value = path
+        num_files = content.LocalFile.objects.filter(available=True).count()
+        self.client.delete(reverse("channel-detail", kwargs={'pk': data["id"]}))
+        os_remove_mock.assert_has_calls([call(path)]*num_files)
 
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))


### PR DESCRIPTION
## Summary

Deletes all associated content nodes and any orphaned local file objects, plus the associated downloaded files, when a channel is deleted.

- [x] Tests written for deletion endpoint