### PR TITLE
upgrade keen-ui to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "frame-throttle": "^2.0.1",
     "intl": "1.2.4",
     "js-cookie": "2.1.2",
-    "keen-ui": "1.0.0",
+    "keen-ui": "^1.0.1",
     "lodash": "^4.17.4",
     "loglevel": "1.4.1",
     "markdown-it": "^8.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,9 +3047,9 @@ katex@^0.6.0:
   dependencies:
     match-at "^0.1.0"
 
-keen-ui@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/keen-ui/-/keen-ui-1.0.0.tgz#379f35a9222c4492613a1b755d462d4044afc5a4"
+keen-ui@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/keen-ui/-/keen-ui-1.0.1.tgz#9f85bd82d3c9f258c95df8f5abba07d5cd9803bb"
   dependencies:
     autosize "^3.0.20"
     deep-assign "^2.0.0"


### PR DESCRIPTION

Currently, there are lots of warning from vue that look like this:

`WARNING in ./~/vue-loader/lib/template-compiler?{"id":"data-v-2d6b61c2","preserveWhitespace":false}!./~/svg-icon-inline-loader!./~/vue-loader/lib/selector.js?type=template&index=0!./~/keen-ui/src/UiMenu.vue`

Yuck.

This PR points our Keen dependency at the `next` branch, because it hasn't been released yet but does address this issue. [The full diff is here](https://github.com/JosephusPaye/Keen-UI/compare/next).

Looks like it contains some other changes - for example an attempt to make the tooltip accessible. This is in theory great, but also carries risk since this hasn't actually been released.

We should probably check in with Josephus or at least do some good regression testing before merging this in. Maybe he'd even do a stable 1.0.1 release on npm.
