### PR TITLE
Prevent downloading usage data on Android

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -48,6 +48,7 @@ import authMessage from '../views/auth-message';
 import kBreadcrumbs from '../views/k-breadcrumbs';
 import kCheckbox from '../views/k-checkbox';
 import kRadioButton from '../views/k-radio-button';
+import kFilterTextbox from '../views/k-filter-textbox';
 import router from '../router';
 import responsiveWindow from '../mixins/responsive-window';
 import responsiveElement from '../mixins/responsive-element';
@@ -61,7 +62,7 @@ import * as resources from '../api-resources';
 import urls from './urls';
 import * as client from './client';
 import * as i18n from '../utils/i18n';
-import kFilterTextbox from '../views/k-filter-textbox';
+import * as browser from '../utils/browser';
 
 export default {
   client,
@@ -123,6 +124,7 @@ export default {
   },
   urls,
   utils: {
+    browser,
     exams,
     validators,
     serverClock,

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -15,7 +15,7 @@ import {
 import { now } from 'kolibri.utils.serverClock';
 import urls from 'kolibri.urls';
 import intervalTimer from '../timer';
-import { redirectBrowser } from '../utils/browser';
+import { redirectBrowser } from 'kolibri.utils.browser';
 import { createTranslator } from 'kolibri.utils.i18n';
 
 const name = 'coreTitles';

--- a/kolibri/core/assets/src/utils/browser.js
+++ b/kolibri/core/assets/src/utils/browser.js
@@ -1,3 +1,37 @@
 export function redirectBrowser(url) {
   window.location.href = url || window.location.origin;
 }
+
+/**
+  * Detects whether an Android device is using WebView.
+  * Based on https://developer.chrome.com/multidevice/user-agent#webview_user_agent
+  */
+export function isAndroidWebView() {
+  const ua = window.navigator.userAgent;
+  const isAndroid = /Android/.test(ua);
+
+  if (isAndroid) {
+    const androidVersion = parseFloat(ua.match(/Android\s([0-9\.]*)/)[1]);
+    const isChrome = /Chrome/.test(ua);
+
+    // WebView UA in Lollipop and Above
+    // Android >=5.0
+    if (androidVersion >= 5.0 && isChrome && /wv/.test(ua)) {
+      return true;
+    }
+
+    // WebView UA in KitKat to Lollipop
+    // Android >= 4.4
+    if (androidVersion >= 4.4 && androidVersion < 5.0 && isChrome && /Version\//.test(ua)) {
+      return true;
+    }
+
+    // Old WebView UA
+    // Android < 4.4
+    if (androidVersion < 4.4 && /Version\//.test(ua) && /\/534.30/.test(ua)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/kolibri/core/assets/src/utils/browser.js
+++ b/kolibri/core/assets/src/utils/browser.js
@@ -10,28 +10,8 @@ export function isAndroidWebView() {
   const ua = window.navigator.userAgent;
   const isAndroid = /Android/.test(ua);
 
-  if (isAndroid) {
-    const androidVersion = parseFloat(ua.match(/Android\s([0-9\.]*)/)[1]);
-    const isChrome = /Chrome/.test(ua);
+  // First checks for 'wv' (Lolipop+), then for 'Version/x.x' (as specified in link above )
+  const isWebview = /wv/.test(ua) || /Version\/\d+\.\d+/.test(ua);
 
-    // WebView UA in Lollipop and Above
-    // Android >=5.0
-    if (androidVersion >= 5.0 && isChrome && /wv/.test(ua)) {
-      return true;
-    }
-
-    // WebView UA in KitKat to Lollipop
-    // Android >= 4.4
-    if (androidVersion >= 4.4 && androidVersion < 5.0 && isChrome && /Version\//.test(ua)) {
-      return true;
-    }
-
-    // Old WebView UA
-    // Android < 4.4
-    if (androidVersion < 4.4 && /Version\//.test(ua) && /\/534.30/.test(ua)) {
-      return true;
-    }
-  }
-
-  return false;
+  return isAndroid && isWebview;
 }

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -55,7 +55,7 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import uiMenu from 'keen-ui/src/UiMenu';
   import uiButton from 'keen-ui/src/UiButton';
-  import { redirectBrowser } from '../../utils/browser';
+  import { redirectBrowser } from 'kolibri.utils.browser';
   import languageSwitcher from '../language-switcher';
   export default {
     mixins: [responsiveWindow],

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -116,6 +116,7 @@
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import downloadButton from 'kolibri.coreVue.components.downloadButton';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { isAndroidWebView } from 'kolibri.utils.browser';
   import assessmentWrapper from '../assessment-wrapper';
   import pointsPopup from '../points-popup';
   import pointsSlidein from '../points-slidein';
@@ -136,45 +137,12 @@
     },
     data: () => ({ wasIncomplete: false }),
     computed: {
-      /**
-        * Detects whether an Android device is using WebView.
-        * Based on https://developer.chrome.com/multidevice/user-agent#webview_user_agent
-        */
-      isAndroidWebView() {
-        const ua = window.navigator.userAgent;
-        const isAndroid = /Android/.test(ua);
-
-        if (isAndroid) {
-          const androidVersion = parseFloat(ua.match(/Android\s([0-9\.]*)/)[1]);
-          const isChrome = /Chrome/.test(ua);
-
-          // WebView UA in Lollipop and Above
-          // Android >=5.0
-          if (androidVersion >= 5.0 && isChrome && /wv/.test(ua)) {
-            return true;
-          }
-
-          // WebView UA in KitKat to Lollipop
-          // Android >= 4.4
-          if (androidVersion >= 4.4 && androidVersion < 5.0 && isChrome && /Version\//.test(ua)) {
-            return true;
-          }
-
-          // Old WebView UA
-          // Android < 4.4
-          if (androidVersion < 4.4 && /Version\//.test(ua) && /\/534.30/.test(ua)) {
-            return true;
-          }
-        }
-
-        return false;
-      },
       canDownload() {
         if (this.content) {
           return (
             this.downloadableFiles.length &&
             this.content.kind !== ContentNodeKinds.EXERCISE &&
-            !this.isAndroidWebView
+            !isAndroidWebView()
           );
         }
         return false;

--- a/kolibri/plugins/management/assets/src/views/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/data-page/index.vue
@@ -102,5 +102,6 @@
   .no-dl
     font-size: 0.8em
     color: $core-text-annotation
+    display: inline-block
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/data-page/index.vue
@@ -70,7 +70,7 @@
     components: { kButton },
     computed: {
       cannotDownload() {
-        return !isAndroidWebView();
+        return isAndroidWebView();
       },
       columnSize() {
         return this.windowSize.breakpoint > 2 ? 'pure-u-1-2' : 'pure-u-1-1';

--- a/kolibri/plugins/management/assets/src/views/data-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/data-page/index.vue
@@ -13,7 +13,10 @@
       <p>
         {{$tr('detailsSubHeading')}}
       </p>
-      <k-button :text="$tr('download')" @click="downloadSessionLog"/>
+      <div>
+        <k-button :text="$tr('download')" :disabled="cannotDownload" @click="downloadSessionLog"/>
+        <span class="no-dl" v-if="cannotDownload">{{ $tr('noDownload') }}</span>
+      </div>
       <p class="infobox">
         <b>{{$tr('note')}}</b>: {{$tr('detailsInfo')}}
       </p>
@@ -24,7 +27,10 @@
       <p>
         {{$tr('summarySubHeading')}}
       </p>
-      <k-button :text="$tr('download')" @click="downloadSummaryLog"/>
+      <div>
+        <k-button :text="$tr('download')" :disabled="cannotDownload" @click="downloadSummaryLog"/>
+        <span class="no-dl" v-if="cannotDownload">{{ $tr('noDownload') }}</span>
+      </div>
       <p class="infobox">
         <b>{{$tr('note')}}</b>: {{$tr('summaryInfo')}}
       </p>
@@ -38,8 +44,10 @@
 <script>
 
   import urls from 'kolibri.urls';
+  import { isAndroidWebView } from 'kolibri.utils.browser';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import kButton from 'kolibri.coreVue.components.kButton';
+
   export default {
     mixins: [responsiveWindow],
     name: 'manageData',
@@ -57,9 +65,13 @@
         'A user may visit the same piece of content multiple times. This file records the total time and progress each user has achieved for each piece of content, summarized across possibly more than one visit. Anonymous usage is not included.',
       download: 'Download',
       note: 'Note',
+      noDownload: 'Download is not supported on Android',
     },
     components: { kButton },
     computed: {
+      cannotDownload() {
+        return !isAndroidWebView();
+      },
       columnSize() {
         return this.windowSize.breakpoint > 2 ? 'pure-u-1-2' : 'pure-u-1-1';
       },
@@ -86,5 +98,9 @@
     border-radius: $radius
     font-size: 0.8em
     padding: 8px
+
+  .no-dl
+    font-size: 0.8em
+    color: $core-text-annotation
 
 </style>


### PR DESCRIPTION
* moves `isAndroidWebView` to core utils
* addresses #1894 by disabling the 'download' button and showing a message indicating why:

![localhost-8000-management-](https://user-images.githubusercontent.com/2367265/29895034-6d7850b2-8d8c-11e7-883e-ae57153e6f37.png)

resolves #1894 


