### PR TITLE
Remove duplicate property definitions.

### DIFF
--- a/kolibri/core/assets/src/views/elapsed-time/index.vue
+++ b/kolibri/core/assets/src/views/elapsed-time/index.vue
@@ -29,7 +29,6 @@
 
   export default {
     name: 'elapsedTime',
-    name: 'elapsedTime',
     $trs: {
       secondsAgo: '{n, number, integer} {n, plural, one {second} other {seconds} } ago',
       minutesAgo: '{n, number, integer} {n, plural, one {minute} other {minutes} } ago',

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -76,10 +76,6 @@
         required: true,
         validator: validateLinkObject,
       },
-      thumbnail: {
-        type: String,
-        required: false,
-      },
     },
     computed: {
       mastered() {


### PR DESCRIPTION
## Summary

Duplicate property definitions were breaking IE11.

Fixes #2107 