### PR TITLE
Don't lock up the terminal with SQLAlchemy echo output.

### DIFF
--- a/kolibri/content/utils/sqlalchemybridge.py
+++ b/kolibri/content/utils/sqlalchemybridge.py
@@ -33,9 +33,8 @@ def get_engine(connection_string):
     should consistently return the same engine for the same connection string.
     """
     if connection_string not in ENGINES_CACHES:
-        # At the moment, the echo argument is set to our DEBUG setting, so we will get
-        # a lot of SQLAlchemy output in DEBUG mode
-        engine = create_engine(connection_string, echo=settings.DEBUG, convert_unicode=True)
+        # Set echo to False, as otherwise we get full SQL Query outputted, which can overwhelm the terminal
+        engine = create_engine(connection_string, echo=False, convert_unicode=True)
         ENGINES_CACHES[connection_string] = engine
     return ENGINES_CACHES[connection_string]
 


### PR DESCRIPTION
## Summary

Sets SQLAlchemy echo to `False` so that the terminal doesn't get deluged with SQL Query data.

## Issues addressed

Goes some way to addressing #2066 