### PR TITLE
Ensures that we use the correct default facility for device owner migrations

### DIFF
--- a/kolibri/auth/migrations/0004_auto_20170816_1607.py
+++ b/kolibri/auth/migrations/0004_auto_20170816_1607.py
@@ -8,15 +8,16 @@ from kolibri.auth.constants.role_kinds import ADMIN
 
 
 def device_owner_to_super_user(apps, schema_editor):
+    from kolibri.auth.models import FacilityUser as RealFacilityUser, Facility as RealFacility, Role as RealRole
+    real_default_facility = RealFacility.get_default_facility()
+
     DeviceOwner = apps.get_model('kolibriauth', 'DeviceOwner')
     FacilityUser = apps.get_model('kolibriauth', 'FacilityUser')
     Facility = apps.get_model('kolibriauth', 'Facility')
-    default_facility = Facility.objects.all().first()
+    default_facility = Facility.objects.get(pk=real_default_facility.id)
     DevicePermissions = apps.get_model('device', 'DevicePermissions')
     DeviceSettings = apps.get_model('device', 'DeviceSettings')
     Role = apps.get_model('kolibriauth', 'Role')
-    from kolibri.auth.models import FacilityUser as RealFacilityUser, Facility as RealFacility, Role as RealRole
-    real_default_facility = RealFacility.get_default_facility()
     # Can't do much if no facilities exist, as no facility to FK the users onto
     if default_facility:
         for device_owner in DeviceOwner.objects.all():

--- a/kolibri/auth/migrations/0004_auto_20170816_1607.py
+++ b/kolibri/auth/migrations/0004_auto_20170816_1607.py
@@ -10,16 +10,15 @@ from kolibri.auth.constants.role_kinds import ADMIN
 def device_owner_to_super_user(apps, schema_editor):
     from kolibri.auth.models import FacilityUser as RealFacilityUser, Facility as RealFacility, Role as RealRole
     real_default_facility = RealFacility.get_default_facility()
-
-    DeviceOwner = apps.get_model('kolibriauth', 'DeviceOwner')
-    FacilityUser = apps.get_model('kolibriauth', 'FacilityUser')
-    Facility = apps.get_model('kolibriauth', 'Facility')
-    default_facility = Facility.objects.get(pk=real_default_facility.id)
-    DevicePermissions = apps.get_model('device', 'DevicePermissions')
-    DeviceSettings = apps.get_model('device', 'DeviceSettings')
-    Role = apps.get_model('kolibriauth', 'Role')
     # Can't do much if no facilities exist, as no facility to FK the users onto
-    if default_facility:
+    if real_default_facility:
+        DeviceOwner = apps.get_model('kolibriauth', 'DeviceOwner')
+        FacilityUser = apps.get_model('kolibriauth', 'FacilityUser')
+        Facility = apps.get_model('kolibriauth', 'Facility')
+        default_facility = Facility.objects.get(pk=real_default_facility.id)
+        DevicePermissions = apps.get_model('device', 'DevicePermissions')
+        DeviceSettings = apps.get_model('device', 'DeviceSettings')
+        Role = apps.get_model('kolibriauth', 'Role')
         for device_owner in DeviceOwner.objects.all():
             dataset_id = real_default_facility.dataset_id
             real_superuser = RealFacilityUser(

--- a/kolibri/auth/test/test_data_migrations.py
+++ b/kolibri/auth/test/test_data_migrations.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connection
+from kolibri.auth.models import Classroom, Facility, FacilityUser
+from kolibri.auth.constants.role_kinds import ADMIN
+
+# Modified from https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
+
+class TestMigrations(TestCase):
+
+    migrate_from = None
+    migrate_to = None
+    app = 'kolibriauth'
+
+    def setUp(self):
+        assert self.migrate_from and self.migrate_to, \
+            "TestCase '{}' must define migrate_from and migrate_to properties".format(type(self).__name__)
+
+        migrate_from = [(self.app, self.migrate_from)]
+        migrate_to = [(self.app, self.migrate_to)]
+        executor = MigrationExecutor(connection)
+        old_apps = executor.loader.project_state(migrate_from).apps
+
+        # Reverse to the original migration
+        executor.migrate(migrate_from)
+
+        self.setUpBeforeMigration(old_apps)
+
+        # Run the migration to test
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()  # reload.
+        executor.migrate(migrate_to)
+
+        self.apps = executor.loader.project_state(migrate_to).apps
+
+    def setUpBeforeMigration(self, apps):
+        pass
+
+
+class MultipleCollectionTestCase(TestMigrations):
+
+    migrate_from = '0003_auto_20170621_0958'
+    migrate_to = '0004_auto_20170816_1607'
+
+    def setUp(self):
+        self.facility = Facility.objects.create(name='Test')
+        self.classroom = Classroom.objects.create(name='TestClass', parent=self.facility)
+        super(MultipleCollectionTestCase, self).setUp()
+
+    def setUpBeforeMigration(self, apps):
+        DeviceOwner = apps.get_model('kolibriauth', 'DeviceOwner')
+        deviceowner = DeviceOwner.objects.create(
+            username="test",
+        )
+        self.username = deviceowner.username
+
+    def test_username_migrated(self):
+        self.assertEqual(self.username, FacilityUser.objects.get().username)
+
+    def test_in_default_facility_migrated(self):
+        self.assertEqual(self.facility, FacilityUser.objects.get().facility)
+
+    def test_admin(self):
+        self.assertEqual(FacilityUser.objects.get().roles.first().collection, self.facility)
+        self.assertEqual(FacilityUser.objects.get().roles.first().kind, ADMIN)


### PR DESCRIPTION
## Summary

During Django migrations, Django stops being aware of models that share database tables.

This had the result that if there were any other Collections (like Classes or Groups) in the database, then the deviceowner might be migrated to a facilityuser with their facility FK set to something that wasn't a facility.

Fix this by explicitly fetching the real default facility, and then using the id of that to fetch the Django migration safe one.

I would love to be able to write tests for Django migrations - and it seems that it is possible here: https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/ but wanted to get this fix in for dev convenience.

## Issues addressed

Fixes #2061