### PR TITLE
remove special handling for superusers

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -83,17 +83,14 @@ function _contentSummaryModel(store) {
 
 function _contentSessionModel(store) {
   const sessionLog = store.state.core.logging.session;
-  const mapping = {
+  return {
     start_timestamp: sessionLog.start_timestamp,
     end_timestamp: sessionLog.end_timestamp,
     time_spent: sessionLog.time_spent,
     progress: sessionLog.progress,
     extra_fields: sessionLog.extra_fields,
+    user: store.state.core.session.user_id,
   };
-  if (!getters.isSuperuser(store.state)) {
-    mapping.user = store.state.core.session.user_id;
-  }
-  return mapping;
 }
 
 function _sessionState(data) {
@@ -260,7 +257,7 @@ function initContentSession(store, channelId, contentId, contentKind) {
   const promises = [];
 
   /* Create summary log iff user exists */
-  if (store.state.core.session.user_id && !getters.isSuperuser(store.state)) {
+  if (store.state.core.session.user_id) {
     /* Fetch collection matching content and user */
     const summaryCollection = ContentSummaryLogResource.getCollection({
       content_id: contentId,
@@ -344,11 +341,6 @@ function initContentSession(store, channelId, contentId, contentKind) {
     _contentSessionModel(store)
   );
 
-  if (getters.isSuperuser(store.state)) {
-    // treat deviceOwner as anonymous user.
-    sessionData.user = null;
-  }
-
   /* Save a new session model and set id on state */
   const sessionModel = ContentSessionLogResource.createModel(sessionData);
   const sessionModelPromise = sessionModel.save();
@@ -416,7 +408,7 @@ function saveLogs(store) {
 }
 
 function fetchPoints(store) {
-  if (!getters.isSuperuser(store.state) && getters.isUserLoggedIn(store.state)) {
+  if (getters.isUserLoggedIn(store.state)) {
     const userProgressModel = UserProgressResource.getModel(getters.currentUserId(store.state));
     userProgressModel.fetch().then(progress => {
       store.dispatch('SET_TOTAL_PROGRESS', progress.progress);
@@ -448,7 +440,7 @@ function _updateProgress(store, sessionProgress, summaryProgress, forceSave = fa
   const completedContent = originalProgress < 1 && summaryProgress === 1;
   if (completedContent) {
     store.dispatch('SET_LOGGING_COMPLETION_TIME', now());
-    if (!getters.isSuperuser(store.state) && getters.isUserLoggedIn(store.state)) {
+    if (getters.isUserLoggedIn(store.state)) {
       const userProgressModel = UserProgressResource.getModel(getters.currentUserId(store.state));
       // Fetch first to ensure we never accidentally have an undefined progress
       userProgressModel.fetch().then(progress => {
@@ -637,7 +629,7 @@ function saveAttemptLog(store) {
 }
 
 function createAttemptLog(store, itemId) {
-  const user = getters.isFacilityUser(store.state) ? getters.currentUserId(store.state) : null;
+  const user = getters.isUserLoggedIn(store.state) ? getters.currentUserId(store.state) : null;
   const attemptLogModel = AttemptLogResource.createModel({
     id: null,
     user,

--- a/kolibri/core/assets/src/state/getters.js
+++ b/kolibri/core/assets/src/state/getters.js
@@ -9,10 +9,6 @@ function isSuperuser(state) {
   return state.core.session.kind[0] === UserKinds.SUPERUSER;
 }
 
-function isFacilityUser(state) {
-  return isUserLoggedIn(state) && !isSuperuser(state);
-}
-
 function isAdmin(state) {
   return state.core.session.kind[0] === UserKinds.ADMIN;
 }
@@ -67,7 +63,6 @@ function sessionTimeSpent(state) {
 export {
   isUserLoggedIn,
   isSuperuser,
-  isFacilityUser,
   isAdmin,
   isCoach,
   isLearner,

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -113,7 +113,6 @@
     vuex: {
       getters: {
         pageName: state => state.pageName,
-        isSuperuser: coreGetters.isSuperuser,
         isAdmin: coreGetters.isAdmin,
         isCoach: coreGetters.isCoach,
         classList: state => state.classList,

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -7,7 +7,7 @@ import {
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 
-import { getChannelObject, isUserLoggedIn, isSuperuser } from 'kolibri.coreVue.vuex.getters';
+import { getChannelObject, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
 import { setChannelInfo, handleApiError } from 'kolibri.coreVue.vuex.actions';
 import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -420,7 +420,7 @@ function showExam(store, id, questionNumber) {
 
         const attemptLogs = {};
 
-        if (store.state.core.session.user_id && !isSuperuser(store.state)) {
+        if (store.state.core.session.user_id) {
           if (examLogs.length > 0 && examLogs.some(log => !log.closed)) {
             store.dispatch('SET_EXAM_LOG', _examLoggingState(examLogs.find(log => !log.closed)));
           } else {

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -7,12 +7,7 @@ import {
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 
-import {
-  currentUserId,
-  isFacilityUser,
-  getChannels,
-  getChannelObject,
-} from 'kolibri.coreVue.vuex.getters';
+import { currentUserId, getChannelObject, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
 
 import {
   samePageCheckGenerator,
@@ -55,7 +50,7 @@ function _getFeatured(state, channelId) {
 function _getNextSteps(state) {
   const nextStepsPayload = { next_steps: currentUserId(state) };
 
-  if (isFacilityUser(state)) {
+  if (isUserLoggedIn(state)) {
     return ContentNodeResource.getCollection(nextStepsPayload).fetch();
   }
   return Promise.resolve([]);
@@ -64,7 +59,7 @@ function _getNextSteps(state) {
 function _getResume(state) {
   const resumePayload = { resume: currentUserId(state) };
 
-  if (isFacilityUser(state)) {
+  if (isUserLoggedIn(state)) {
     return ContentNodeResource.getCollection(resumePayload).fetch();
   }
   return Promise.resolve([]);

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -174,7 +174,7 @@ oriented data synchronization.
       },
       saveAttemptLogMasterLog() {
         this.saveAttemptLogAction().then(() => {
-          if (this.canLogInteractions && this.success) {
+          if (this.isUserLoggedIn && this.success) {
             this.setMasteryLogCompleteAction(now());
             this.saveMasteryLogAction();
           }
@@ -283,7 +283,7 @@ oriented data synchronization.
         updateContentNodeProgress(this.channelId, this.id, this.exerciseProgress);
       },
       sessionInitialized() {
-        if (this.canLogInteractions) {
+        if (this.isUserLoggedIn) {
           this.initMasteryLog();
         } else {
           this.createDummyMasteryLogAction();
@@ -323,9 +323,6 @@ oriented data synchronization.
       this.saveAttemptLogMasterLog();
     },
     computed: {
-      canLogInteractions() {
-        return !this.isSuperuser && this.isUserLoggedIn;
-      },
       recentAttempts() {
         if (!this.pastattempts) {
           return [];
@@ -384,7 +381,6 @@ oriented data synchronization.
         updateExerciseProgress: actions.updateExerciseProgress,
       },
       getters: {
-        isSuperuser: getters.isSuperuser,
         isUserLoggedIn: getters.isUserLoggedIn,
         mastered: state => state.core.logging.mastery.complete,
         totalattempts: state => state.core.logging.mastery.totalattempts,

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -109,7 +109,7 @@
   import { PageNames, PageModes } from '../../constants';
   import { pageMode } from '../../state/getters';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
+  import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { updateContentNodeProgress } from '../../state/actions/main';
   import pageHeader from '../page-header';
   import contentCardGroupCarousel from '../content-card-group-carousel';
@@ -188,7 +188,7 @@
         return this.$tr('recommended');
       },
       progress() {
-        if (!this.isSuperuser) {
+        if (this.isUserLoggedIn) {
           return this.summaryProgress;
         }
         return this.sessionProgress;
@@ -270,7 +270,7 @@
         summaryProgress: state => state.core.logging.summary.progress,
         sessionProgress: state => state.core.logging.session.progress,
         pageMode,
-        isSuperuser,
+        isUserLoggedIn,
       },
       actions: {
         initSessionAction,

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -18,13 +18,11 @@
     <h3>{{ $tr('role') }}</h3>
     <p>{{ role }}</p>
 
-    <template v-if="!isSuperuser">
-      <h3>{{ $tr('points') }}</h3>
-      <p>
-        <points-icon class="points-icon" :active="true"/>
-        <span class="points-num">{{ $formatNumber(totalPoints) }}</span>
-      </p>
-    </template>
+    <h3>{{ $tr('points') }}</h3>
+    <p>
+      <points-icon class="points-icon" :active="true"/>
+      <span class="points-num">{{ $formatNumber(totalPoints) }}</span>
+    </p>
 
     <form @submit.prevent="submitEdits">
 


### PR DESCRIPTION

should treat superuser like other users, with only anonymous users still being "special"

not included in this PR: updating UX and nomenclature (device owners, permission stars, etc)
