### PR TITLE
Update to use Iceqube from PyPI

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-https://storage.googleapis.com/le-downloads/barbequeue/barbequeue-0.0.1.tar.gz#egg=barbequeue
+iceqube==0.0.1
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5


### PR DESCRIPTION
We now have Iceqube on PyPI, so use that.