### PR TITLE
fixup translation strings

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -48,11 +48,11 @@
 
     <div class="metadata">
       <p v-if="content.author">
-        {{ $tr('author') }}: {{ content.author }}
+        {{ $tr('author', {author: content.author}) }}
       </p>
 
       <p v-if="content.license" >
-        {{ $tr('license') }}: {{ content.license }}
+        {{ $tr('license', {license: content.license}) }}
 
         <template v-if="content.license_description">
           <span ref="licensetooltip">
@@ -67,7 +67,7 @@
       </p>
 
       <p v-if="content.license_owner">
-        {{ $tr('copyrightHolder') }}: {{ content.license_owner }}
+        {{ $tr('copyrightHolder', {copyrightHolder: content.license_owner}) }}
       </p>
     </div>
 
@@ -129,10 +129,10 @@
     $trs: {
       recommended: 'Recommended',
       nextContent: 'Go to next item',
-      author: 'Author',
-      license: 'License',
+      author: 'Author: {author}',
+      license: 'License: {license}',
       licenseDescription: 'License description',
-      copyrightHolder: 'Copyright holder',
+      copyrightHolder: 'Copyright holder: {copyrightHolder}',
     },
     data: () => ({ wasIncomplete: false }),
     computed: {


### PR DESCRIPTION

pass contents as arguments rather than constructing in vue template

