### PR TITLE
Prevent and handle empty channels

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -23,9 +23,22 @@ def _join_with_logical_operator(lst, operator):
     return "(({items}))".format(items=op.join(lst))
 
 
+class ChannelMetadataFilter(filters.FilterSet):
+    available = filters.django_filters.MethodFilter()
+
+    def filter_available(self, queryset, value):
+        return queryset.filter(root__available=value)
+
+    class Meta:
+        model = models.ChannelMetadata
+        fields = ['available', ]
+
+
 class ChannelMetadataViewSet(viewsets.ModelViewSet):
     permission_classes = (OnlyCanManageContentCanDelete,)
     serializer_class = serializers.ChannelMetadataSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_class = ChannelMetadataFilter
 
     def get_queryset(self):
         return models.ChannelMetadata.objects.all()

--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -124,11 +124,7 @@ class Command(AsyncCommand):
                     os.remove(dest)
                 self.cancel()
             else:
-                annotation.mark_local_files_as_available(file_checksums_to_annotate)
-
-                annotation.set_leaf_node_availability_from_local_file_availability()
-
-                annotation.recurse_availability_up_tree()
+                annotation.set_availability(file_checksums_to_annotate)
 
     def handle_async(self, *args, **options):
         if options['command'] == 'network':

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -41,6 +41,10 @@ class Router {
   getInstance(options) {
     return this._vueRouter;
   }
+
+  replace(location, onComplete, onAbort) {
+    return this._vueRouter.replace(location, onComplete, onAbort);
+  }
 }
 
 const router = new Router();

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -366,7 +366,7 @@ function initContentSession(store, channelId, contentId, contentKind) {
 }
 
 function setChannelInfo(store) {
-  return ChannelResource.getCollection().fetch().then(
+  return ChannelResource.getCollection({ available: true }).fetch().then(
     channelsData => {
       store.dispatch('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));
     },

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -152,6 +152,15 @@ function updateContentNodeProgress(channelId, contentId, progressFraction) {
   model.set({ progress_fraction: progressFraction });
 }
 
+function setAndCheckChannels(store) {
+  return setChannelInfo(store).then(channels => {
+    if (!channels.length) {
+      router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+    }
+    return channels;
+  });
+}
+
 /**
  * Actions
  *
@@ -162,8 +171,11 @@ function showChannels(store) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
   store.dispatch('SET_PAGE_NAME', PageNames.TOPICS_ROOT);
 
-  setChannelInfo(store).then(
+  setAndCheckChannels(store).then(
     channels => {
+      if (!channels.length) {
+        return;
+      }
       const channelRootIds = channels.map(channel => channel.root);
       ContentNodeResource.getCollection({ ids: channelRootIds }).fetch().then(rootNodes => {
         const pageState = {
@@ -342,7 +354,10 @@ function showSearch(store, searchTerm) {
   store.dispatch('CORE_SET_ERROR', null);
   store.dispatch('CORE_SET_TITLE', translator.$tr('searchPageTitle'));
   clearSearch(store);
-  setChannelInfo(store).then(() => {
+  setAndCheckChannels(store).then(channels => {
+    if (!channels.length) {
+      return;
+    }
     if (searchTerm) {
       triggerSearch(store, searchTerm);
     } else {
@@ -623,6 +638,7 @@ function closeExam(store) {
 }
 
 export {
+  setAndCheckChannels,
   contentState,
   showChannels,
   showTopicsChannel,

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -21,7 +21,7 @@ import {
 } from 'kolibri.coreVue.vuex.actions';
 
 import { PageNames } from '../../constants';
-import { contentState } from './main';
+import { contentState, setAndCheckChannels } from './main';
 
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import uniqBy from 'lodash/uniqBy';
@@ -79,12 +79,15 @@ function _showRecSubpage(store, getContentPromise, pageName, windowTitleId, chan
   // promise that resolves with content array, already mapped to state
   const pagePrep = Promise.all([
     getContentPromise(state, channelId),
-    setChannelInfo(store),
+    setAndCheckChannels(store),
     // resolves to mapped content set because then resolves to its function's return value
   ]).then(([content]) => _mapContentSet(content), error => error);
 
   pagePrep.then(
-    recommendations => {
+    (recommendations, channels) => {
+      if (!channels.length) {
+        return;
+      }
       const recPageState = {
         recommendations,
       };
@@ -115,7 +118,7 @@ function showLearn(store) {
     store.dispatch('CORE_SET_PAGE_LOADING', true);
   }
 
-  const channelsPromise = setChannelInfo(store);
+  const channelsPromise = setAndCheckChannels(store);
   ConditionalPromise.all([
     _getNextSteps(state),
     _getPopular(),
@@ -124,6 +127,9 @@ function showLearn(store) {
   ]).only(
     samePageCheckGenerator(store),
     ([nextSteps, popular, resume, channels]) => {
+      if (!channels.length) {
+        return;
+      }
       const featuredChannels = channels.slice(0, 3);
       const pageState = {
         // Hard to guarantee this uniqueness on the database side, so

--- a/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h1>{{ $tr('header') }}</h1>
-    <p v-if="isAdmin || isSuperuser" v-html="$trHtml('adminLink')"></p>
+    <p v-if="isSuperuser" v-html="$trHtml('adminLink')"></p>
     <p v-else>{{ $tr('notAdmin') }}</p>
   </div>
 
@@ -11,7 +11,7 @@
 
 <script>
 
-  import * as getters from 'kolibri.coreVue.vuex.getters';
+  import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
 
   export default {
     name: 'learnContentUnavailable',
@@ -24,8 +24,7 @@
     },
     vuex: {
       getters: {
-        isAdmin: getters.isAdmin,
-        isSuperuser: getters.isSuperuser,
+        isSuperuser,
       },
     },
   };

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <!-- Bootstrapping the initial information for all channels. -->
-  {% kolibri_bootstrap_collection 'channel' 'ChannelResource' %}
+  {% kolibri_bootstrap_collection 'channel' 'ChannelResource' available=True %}
   {% if currentChannel %}
     <!-- Bootstrapping the root node for the current channel in Explore tab. -->
     {% kolibri_bootstrap_model 'contentnode' 'ContentNodeResource' kwargs_pk=currentChannel.root_id %}


### PR DESCRIPTION
## Summary

Ensure that empty channels do not occur so often, and also make sure that we handle them properly when they do.

Do this by more systematically checking for the existence of channels, only returning channels with some available content, and when we do the automatic channel import that happens when moving from 0.5.x to 0.6.x, making sure that availability is set based on existing content.

## Issues addressed

Fixes #2078 