### PR TITLE
Fix run time error in loading coach pages caused by missing import

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -1,6 +1,6 @@
 import { handleError, handleApiError } from 'kolibri.coreVue.vuex.actions';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
-
+import * as coreGetters from 'kolibri.coreVue.vuex.getters';
 import * as CoreConstants from 'kolibri.coreVue.vuex.constants';
 import * as Constants from '../../constants';
 import * as ReportConstants from '../../reportConstants';


### PR DESCRIPTION
One PR deleted the import because it wasn't needed. Another PR added a line that depended it.

This might be a good case for bringing ESLint back to the build, as it would have caught this.