### PR TITLE
Prevent double-clicks on content management page

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
@@ -38,6 +38,7 @@
         :primary="false"
         :raised="false"
         @click="endTask()"
+        :disabled="uiBlocked"
       />
     </div>
 
@@ -74,6 +75,11 @@
         required: true,
       },
       id: RequiredString,
+    },
+    data() {
+      return {
+        uiBlocked: false,
+      };
     },
     computed: {
       TaskStatuses: () => TaskStatuses,
@@ -123,11 +129,14 @@
     },
     methods: {
       endTask() {
+        this.uiBlocked = true;
         if (this.taskHasCompleted) {
           this.$emit('taskcomplete');
           this.refreshChannelList();
         }
-        this.cancelTask(this.id);
+        this.cancelTask(this.id).then(() => {
+          this.uiBlocked = false;
+        });
       },
     },
     vuex: {

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
@@ -109,7 +109,7 @@
         return this.status === TaskStatuses.QUEUED || this.status === TaskStatuses.SCHEDULED;
       },
       formattedPercentage() {
-        return round(this.percentage * 100, 2).toFixed(1);
+        return Number(round(this.percentage * 100, 2).toFixed(1));
       },
       progressMessage() {
         if (this.percentage > 0) {

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/import-preview.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/import-preview.vue
@@ -44,12 +44,17 @@
       </ui-alert>
 
       <div class="button-wrapper">
-        <k-button @click="cancel" :text="$tr('cancelButtonLabel')" />
+        <k-button
+          @click="cancel"
+          :text="$tr('cancelButtonLabel')"
+          :disabled="wizardBusy"
+        />
         <k-button
           v-show="!error"
           :text="$tr('confirmButtonLabel')"
           @click="submit"
           :primary="true"
+          :disabled="wizardBusy"
         />
       </div>
     </div>
@@ -123,6 +128,7 @@
         coreChannel: state => channelId => {
           return find(state.core.channels.list, { id: channelId });
         },
+        wizardBusy: ({ pageState }) => pageState.wizardState.busy,
       },
       actions: {
         transitionWizardPage,


### PR DESCRIPTION
For #2065 Prevents double clicks on

1. clicking "close" or "cancel" on task-in-progress (POSTING twice to /canceltask with same ID breaks)
1. clicking "import" when importing from internet or local drive (trying to download same content DB twice also breaks)