### PR TITLE
'enroll users' -> 'enroll learners'

### DIFF
--- a/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/index.vue
@@ -115,7 +115,7 @@
   export default {
     name: 'classEnrollPage',
     $trs: {
-      enrollUsers: 'Enroll users',
+      enrollUsers: 'Enroll learners',
       tableTitle: 'Manage learners in this class',
       searchText: 'Find a learner or coach...',
       users: 'Users',

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
@@ -34,7 +34,7 @@
       confirmEnrollment: 'Confirm Enrollment of Selected Users',
       areYouSure: 'Are you sure you want to enroll the following users into',
       noGoBack: 'No, go back',
-      yesEnrollUsers: 'Yes, enroll users',
+      yesEnrollUsers: 'Yes, enroll learners',
     },
     components: {
       coreModal,


### PR DESCRIPTION

based on feedback from hack session, changing "Enroll users" to "Enroll learners" in the context of class management

