### PR TITLE
Prevent validation from pushing down submit button

### DIFF
--- a/kolibri/core/assets/src/views/k-textbox/index.vue
+++ b/kolibri/core/assets/src/views/k-textbox/index.vue
@@ -1,24 +1,26 @@
 <template>
 
-  <ui-textbox
-    ref="textbox"
-    class="textbox"
-    v-model.trim="currentText"
-    :label="label"
-    :disabled="disabled"
-    :invalid="invalid"
-    :error="invalidText"
-    :autofocus="autofocus"
-    :maxlength="maxlength"
-    :autocomplete="autocomplete"
-    :type="type"
-    :enforceMaxlength="true"
-    :floatingLabel="true"
-    @input="updateText"
-    @keydown="emitKeydown"
-    @focus="$emit('focus')"
-    @blur="$emit('blur')"
-  />
+  <div class="mh">
+    <ui-textbox
+      ref="textbox"
+      class="textbox"
+      v-model.trim="currentText"
+      :label="label"
+      :disabled="disabled"
+      :invalid="invalid"
+      :error="invalidText"
+      :autofocus="autofocus"
+      :maxlength="maxlength"
+      :autocomplete="autocomplete"
+      :type="type"
+      :enforceMaxlength="true"
+      :floatingLabel="true"
+      @input="updateText"
+      @keydown="emitKeydown"
+      @focus="$emit('focus')"
+      @blur="$emit('blur')"
+    />
+  </div>
 
 </template>
 
@@ -139,5 +141,8 @@
 
   .textbox
     max-width: 400px
+
+  .mh
+    min-height: 72px
 
 </style>


### PR DESCRIPTION
* Gives k-textbox a min-height to prevent pushing down submit button in MOST cases (validation text is one line)
* Addresses #2133

![okay](https://user-images.githubusercontent.com/7193975/30392187-ebf6abb6-9870-11e7-9751-dc12d5a38d28.gif)
