### PR TITLE
Remove redundant labels on profile page

### DIFF
--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -26,7 +26,6 @@
 
     <form @submit.prevent="submitEdits">
 
-      <h3>{{ $tr('username') }}</h3>
       <k-textbox
         ref="username"
         v-if="canEditUsername"
@@ -40,9 +39,11 @@
         @blur="usernameBlurred = true"
         v-model="username"
       />
-      <p v-else>{{ session.username }}</p>
+      <template v-else>
+        <h3>{{ $tr('username') }}</h3>
+        <p>{{ session.username }}</p>
+      </template>
 
-      <h3>{{ $tr('name') }}</h3>
       <k-textbox
         v-if="canEditName"
         type="text"
@@ -52,7 +53,10 @@
         :disabled="busy"
         v-model="full_name"
       />
-      <p v-else>{{ session.full_name }}</p>
+      <template v-else>
+        <h3>{{ $tr('name') }}</h3>
+        <p>{{ session.full_name }}</p>
+      </template>
 
       <k-button
         v-if="canEditUsername || canEditName"


### PR DESCRIPTION
For #2149 

Manual test on all possible configurations.

Note typographic inconsistency when one fields is read-only and other is not.

![screen shot 2017-09-13 at 1 15 09 pm](https://user-images.githubusercontent.com/10248067/30398594-dfec7fca-9885-11e7-8766-475b798f7c64.png)
