### PR TITLE
Display resource counts on manage content page

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -15,11 +15,14 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 
         # if it has the file_size flag add extra file_size information
         if 'request' in self.context and self.context['request'].GET.get('file_sizes', False):
-            file_summary = instance.root.get_descendants().prefetch_related('files__local_file').aggregate(
+            descendants = instance.root.get_descendants()
+            total_resources = descendants.exclude(kind=content_kinds.TOPIC).count()
+            channel_summary = descendants.prefetch_related('files__local_file').aggregate(
                 total_file_size=Sum('files__local_file__file_size'),
                 total_files=Count('files__local_file__file_size')
             )
-            value.update(file_summary)
+            value.update({"total_resources": total_resources})
+            value.update(channel_summary)
         return value
 
     class Meta:

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -18,8 +18,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
             descendants = instance.root.get_descendants()
             total_resources = descendants.exclude(kind=content_kinds.TOPIC).count()
             channel_summary = descendants.prefetch_related('files__local_file').aggregate(
-                total_file_size=Sum('files__local_file__file_size'),
-                total_files=Count('files__local_file__file_size')
+                total_file_size=Sum('files__local_file__file_size')
             )
             value.update({"total_resources": total_resources})
             value.update(channel_summary)

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -1,6 +1,5 @@
 from django.core.cache import cache
 from django.db.models import Manager, Sum
-from django.db.models.aggregates import Count
 from django.db.models.query import RawQuerySet
 from kolibri.content.models import AssessmentMetaData, ChannelMetadata, ContentNode, File, Language
 from le_utils.constants import content_kinds
@@ -96,9 +95,10 @@ def get_topic_progress_fraction(topic, user):
     leaf_ids = topic.get_descendants(include_self=False).order_by().exclude(
         kind=content_kinds.TOPIC).values_list("content_id", flat=True)
     return round(
-        (get_summary_logs(leaf_ids, user).aggregate(Sum('progress'))['progress__sum'] or 0)/(len(leaf_ids) or 1),
+        (get_summary_logs(leaf_ids, user).aggregate(Sum('progress'))['progress__sum'] or 0) / (len(leaf_ids) or 1),
         4
     )
+
 
 def get_content_progress_fraction(content, user):
     from kolibri.logger.models import ContentSummaryLog
@@ -109,11 +109,13 @@ def get_content_progress_fraction(content, user):
         return None
     return round(overall_progress, 4)
 
+
 def get_topic_and_content_progress_fraction(node, user):
     if node.kind == content_kinds.TOPIC:
         return get_topic_progress_fraction(node, user)
     else:
         return get_content_progress_fraction(node, user)
+
 
 def get_topic_and_content_progress_fractions(nodes, user):
     leaf_ids = nodes.get_descendants(include_self=True).order_by().exclude(
@@ -128,11 +130,12 @@ def get_topic_and_content_progress_fractions(nodes, user):
             leaf_ids = node.get_descendants(include_self=True).order_by().exclude(
                 kind=content_kinds.TOPIC).values_list("content_id", flat=True)
             overall_progress[node.content_id] = round(
-                sum(overall_progress.get(leaf_id, 0) for leaf_id in leaf_ids)/len(leaf_ids),
+                sum(overall_progress.get(leaf_id, 0) for leaf_id in leaf_ids) / len(leaf_ids),
                 4
             )
 
     return overall_progress
+
 
 def get_content_progress_fractions(nodes, user):
     if isinstance(nodes, RawQuerySet) or isinstance(nodes, list):
@@ -256,6 +259,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
 
         list_serializer_class = ContentNodeListSerializer
 
+
 class ContentNodeProgressListSerializer(serializers.ListSerializer):
 
     def to_representation(self, data):
@@ -281,6 +285,7 @@ class ContentNodeProgressListSerializer(serializers.ListSerializer):
                 annotate_progress_fraction=False
             ) for item in iterable
         ]
+
 
 class ContentNodeProgressSerializer(serializers.Serializer):
 

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -13,7 +13,7 @@
         <thead class="table-header">
           <tr>
             <th>{{ $tr('nameHeader') }}</th>
-            <th>{{ $tr('numContentsHeader') }}</th>
+            <th>{{ $tr('numResourcesHeader') }}</th>
             <th>{{ $tr('sizeHeader') }}</th>
             <th>{{ $tr('lastUpdatedHeader') }}</th>
             <th></th>
@@ -27,7 +27,7 @@
             </td>
 
             <td>
-              <span>{{ channel.total_files }}</span>
+              <span>{{ channel.total_resources }}</span>
             </td>
             <td>
               <span>{{ bytesForHumans(channel.total_file_size) }}</span>
@@ -68,6 +68,7 @@
   import deleteChannelModal from './delete-channel-modal';
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
   export default {
+    name: 'channelsGrid',
     data: () => ({
       selectedChannelId: null,
       notification: null,
@@ -126,13 +127,12 @@
         refreshChannelList,
       },
     },
-    name: 'channelsGrid',
     $trs: {
       emptyChannelListMessage: 'No channels installed',
       deleteButtonLabel: 'Delete',
       lastUpdatedHeader: 'Last updated',
       nameHeader: 'Channel',
-      numContentsHeader: '# Contents',
+      numResourcesHeader: 'Resources',
       sizeHeader: 'Size',
     },
   };


### PR DESCRIPTION
This replaces `total_files` with `total_resources` on ContentNodeMetadata serializer and displays the latter number on the UI.

Addresses #2185 #1663 

![screen shot 2017-09-13 at 2 29 09 pm](https://user-images.githubusercontent.com/10248067/30401796-541be5c0-9890-11e7-8438-ea46cb4f7ab5.png)
