### PR TITLE
remove all uses of $trHtml

### DIFF
--- a/karma_config/vueLocal.js
+++ b/karma_config/vueLocal.js
@@ -33,8 +33,5 @@ function $trWrapper(formatter, messageId, args) {
 vue.prototype.$tr = function $tr(messageId, args) {
   return $trWrapper.call(this, this.$formatMessage, messageId, args);
 };
-vue.prototype.$trHtml = function $trHtml(messageId, args) {
-  return $trWrapper.call(this, this.$formatHTMLMessage, messageId, args);
-};
 
 export default vue;

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -181,10 +181,6 @@ function setUpVueIntl() {
     const nameSpace = this.$options.name || this.$options.$trNameSpace;
     return $trWrapper(nameSpace, this.$options.$trs, this.$formatMessage, messageId, args);
   };
-  vue.prototype.$trHtml = function $trHtml(messageId, args) {
-    const nameSpace = this.$options.name || this.$options.$trNameSpace;
-    return $trWrapper(nameSpace, this.$options.$trs, this.$formatHTMLMessage, messageId, args);
-  };
 
   if (global.languageCode) {
     currentLanguage = global.languageCode;

--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/page-status.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/page-status.vue
@@ -10,11 +10,11 @@
         />
         <h1 class="user-name">{{ $tr('title', {name: userName}) }}</h1>
       </div>
-      <div v-html="$trHtml('overallScore', {score: score})" class="questions">
+      <div class="questions">
+        {{ $tr('overallScore', {score: score}) }}
       </div>
-      <div
-        v-html="$trHtml('questionsCorrect', { correct: questionsCorrect, total: questions.length })"
-        class="questions">
+      <div class="questions">
+        {{ $tr('questionsCorrect', { correct: questionsCorrect, total: questions.length }) }}
       </div>
     </div>
     <div class="column pure-u-1-4">
@@ -46,9 +46,8 @@
     name: 'coachExamReportDetailPageStatus',
     $trs: {
       title: '{name} - Exam Performance',
-      overallScore: 'Overall Score: <strong>{ score, number, percent }</strong>',
-      questionsCorrect:
-        'Questions Correct: <strong>{correct, number} of {total, number} correct</strong>',
+      overallScore: 'Overall score: { score, number, percent }',
+      questionsCorrect: 'Questions correct: {correct, number} of {total, number}',
       completed: 'Completed',
       inProgress: 'In progress',
       notStarted: 'Not started',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
@@ -2,7 +2,7 @@
 
   <core-modal :title="$tr('activateExam')" @cancel="close">
     <p>
-      <span v-html="$trHtml('areYouSure', { examTitle })"></span>
+      <span>{{ $tr('areYouSure', { examTitle }) }}</span>
       {{ $tr('willBeVisible') }}
     </p>
     <p>
@@ -31,7 +31,7 @@
     name: 'activateExamModal',
     $trs: {
       activateExam: 'Activate exam',
-      areYouSure: 'Are you sure you want to activate <strong>{ examTitle }</strong>?',
+      areYouSure: "Are you sure you want to activate '{ examTitle }'?",
       willBeVisible: 'The exam will be visible to the following:',
       cancel: 'Cancel',
       activate: 'Activate',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
@@ -1,7 +1,7 @@
 <template>
 
   <core-modal :title="$tr('examVisibility')" @cancel="close">
-    <p v-html="$trHtml('shouldBeVisible', { examTitle })"></p>
+    <p>{{ $tr('shouldBeVisible', { examTitle }) }}</p>
     <k-radio-button
       :label="$tr('entireClass', { className })"
       :radiovalue="true"
@@ -39,7 +39,7 @@
     name: 'changeExamVisibilityModal',
     $trs: {
       examVisibility: 'Exam visibility',
-      shouldBeVisible: '<strong>{ examTitle }</strong> should be visible to:',
+      shouldBeVisible: "'{ examTitle }' should be visible to:",
       group: 'group',
       specificGroups: 'Specific groups',
       selectGroups: 'Select groups',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
@@ -2,7 +2,7 @@
 
   <core-modal :title="$tr('deactivateExam')" @cancel="close">
     <p>
-      <span v-html="$trHtml('areYouSure', { examTitle })"></span>
+      <span>{{ $tr('areYouSure', { examTitle }) }}</span>
       {{ $tr('noLongerVisible') }}
     </p>
     <p>
@@ -31,7 +31,7 @@
     name: 'deactivateExamModal',
     $trs: {
       deactivateExam: 'Deactivate exam',
-      areYouSure: 'Are you sure you want to deactivate <strong>{ examTitle }</strong>?',
+      areYouSure: "Are you sure you want to deactivate '{ examTitle }'?",
       noLongerVisible: 'The exam will be no longer be visible to the following:',
       cancel: 'Cancel',
       deactivate: 'Deactivate',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
@@ -1,7 +1,7 @@
 <template>
 
   <core-modal :title="$tr('deleteExam')" @cancel="close">
-    <p v-html="$trHtml('areYouSure', { examTitle })"></p>
+    <p>{{ $tr('areYouSure', { examTitle }) }}</p>
     <div class="footer">
       <k-button :text="$tr('cancel')" :raised="false" @click="close"/>
       <k-button :text="$tr('delete')" :primary="true" @click="deleteExam(examId)"/>
@@ -21,7 +21,7 @@
     $trs: {
       deleteExam: 'Delete exam',
       areYouSure:
-        'Are you sure you want to delete <strong>{ examTitle }</strong>? You will lose all data for this exam.',
+        "Are you sure you want to delete '{ examTitle }'? You will lose all data for this exam.",
       cancel: 'Cancel',
       delete: 'Delete',
     },

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -2,7 +2,7 @@
 
   <core-modal :title="$tr('deleteLearnerGroup')"
     @cancel="close">
-    <p v-html="$trHtml('areYouSure', { groupName: groupName })"></p>
+    <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
     <p>{{ $tr('learnersWillBecome') }} <strong>{{ $tr('ungrouped') }}</strong>.</p>
     <k-button :text="$tr('cancel')"
       :raised="false"
@@ -25,7 +25,7 @@
     name: 'deleteGroupModal',
     $trs: {
       deleteLearnerGroup: 'Delete Learner Group',
-      areYouSure: 'Are you sure you want to delete <strong>{ groupName }</strong>?',
+      areYouSure: "Are you sure you want to delete '{ groupName }'?",
       learnersWillBecome: 'Learners within this group will become',
       ungrouped: 'Ungrouped',
       cancel: 'Cancel',

--- a/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h1>{{ $tr('header') }}</h1>
-    <p v-if="isSuperuser" v-html="$trHtml('adminLink')"></p>
+    <p v-if="isSuperuser"><a href="/management/device#/content">{{ $tr('adminLink') }}</a></p>
     <p v-else>{{ $tr('notAdmin') }}</p>
   </div>
 
@@ -17,8 +17,7 @@
     name: 'learnContentUnavailable',
     $trs: {
       header: 'No content channels available',
-      adminLink:
-        'Download content channels from the <a href="/management/device#/content">Content Management</a> page',
+      adminLink: 'Download content from the Management page',
       notAdmin:
         'You need to sign in as the Device Owner to manage content. (This is the account originally created in the Setup Wizard.)',
     },

--- a/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-edit-modal.vue
@@ -61,7 +61,7 @@
       <!-- User Delete Mode -->
       <template v-if="usr_delete">
         <div class="user-field">
-          {{$trHtml('deleteConfirmation', {user:username})}}
+          {{ $tr('deleteConfirmation', { user: username }) }}
         </div>
       </template>
 
@@ -122,7 +122,7 @@
       no: 'No',
       confirm: 'Confirm',
       cancel: 'Cancel',
-      deleteConfirmation: 'Are you sure you want to delete {user}?',
+      deleteConfirmation: "Are you sure you want to delete '{user}'?",
       pwMismatch: 'Passwords must match',
       noNewPw: 'Please enter a new password',
     },


### PR DESCRIPTION
HTML translations [are a security issue](https://trello.com/c/gHONGfCU/795-question-is-trhtml-a-potential-source-of-bugs-or-security-holes) because they allow arbitrary client-side code to be inserted and run through the translation platform Crowdin.

Overview of changes:

### Bolding used to highlight the name of an item

The most common usage of `$trHtml` was to highlight user-generated names. This would often look something like:

> Would you like to delete the exam **My first Exam**?

In these situations, I replaced bolding with single quotes to look something like:

> Would you like to delete the exam 'My first Exam'?

### Inline text links

There was one instance where HTML was used to link to an external page:

> Download content channels from the [Content Management](http://example.com) page

I updated this to link the entire line, and shortened the wording:

> [Download content from the Management page](http://example.com)

### Bolding for distinguishing numbers from labels

In one instance, bolding was used to highlight numbers next to labels:

> Overall Score: **85%**
> Questions Correct: **32 of 65 correct**

I updated this to simply remove the bolding, and also cleaned up the labels to conform to Material style guidelines:

> Overall score: 85%
> Questions correct: 32 of 65

If desired, in the future we can look for another way of doing this. One possibility would be to use a data small table rather than the label-colon-data structure.


