### PR TITLE
Don't use the entire screenheight for the sign in page.

### DIFF
--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -335,7 +335,7 @@
 
   .login
     background-color: $login-overlay
-    height: 100%
+    height: 90%
     // Fallback for older browers.
     background: $core-bg-canvas
     background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center fixed


### PR DESCRIPTION
## Summary

Limit the height of the sign in component to allow the language switcher on the login page to be visible.

## Issues addressed

Fixes #2203 

Not sure why this suddenly started happening, but this is the simplest fix I can see for it.