### PR TITLE
Show channel version on channels list

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -25,7 +25,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ChannelMetadata
-        fields = ('root', 'id', 'name', 'description', 'author', 'last_updated')
+        fields = ('root', 'id', 'name', 'description', 'author', 'last_updated', 'version')
 
 
 class LowerCaseField(serializers.CharField):

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -142,6 +142,7 @@ function _channelListState(data) {
     description: channel.description,
     root_id: channel.root,
     last_updated: channel.last_updated,
+    version: channel.version,
   }));
 }
 

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -159,6 +159,7 @@
 
   .channel-version
     font-size: 0.85em
+    line-height: 1.5em
     color: $core-text-annotation
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -22,8 +22,11 @@
 
         <tbody class="table-body">
           <tr v-for="channel in sortedChannels" :key="channel.id">
-            <td class="table-cell-title">
-              {{ channel.name }}
+            <td>
+              <div>{{ channel.name }}</div>
+              <div class="channel-version">
+                {{ $tr('channelVersion', { versionNumber: channel.version }) }}
+              </div>
             </td>
 
             <td>
@@ -129,6 +132,7 @@
       nameHeader: 'Channel',
       numResourcesHeader: 'Resources',
       sizeHeader: 'Size',
+      channelVersion: 'Version {versionNumber}',
     },
   };
 
@@ -153,7 +157,8 @@
     td
       padding: 1rem 0
 
-  .table-cell-title
-    font-weight: bold
+  .channel-version
+    font-size: 0.85em
+    color: $core-text-annotation
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/index.vue
@@ -164,7 +164,7 @@
         pageState: ({ pageState }) => pageState,
         firstTask: ({ pageState }) => pageState.taskList[0],
         tasksInQueue: ({ pageState }) => pageState.taskList.length > 0,
-        deviceHasChannels: ({ pageState }) => pageState.channelList > 0,
+        deviceHasChannels: ({ pageState }) => pageState.channelList.length > 0,
       },
       actions: {
         startImportWizard,


### PR DESCRIPTION
Following the design in https://learningequality.gitbooks.io/design-iterations/content/content.html,
this adds the version number, plus adjusts typography on Device > COntent page.

![screen shot 2017-09-18 at 1 53 01 pm](https://user-images.githubusercontent.com/10248067/30564117-da143a4c-9c78-11e7-80a9-282f0f149771.png)
