### PR TITLE
Redirect users to `/` if they go to `/management`

### DIFF
--- a/kolibri/plugins/management/urls.py
+++ b/kolibri/plugins/management/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url
+from django.views.generic.base import RedirectView
 
 from . import views
 
 urlpatterns = [
+    url('^$', RedirectView.as_view(url='/')),
     url('^facility$', views.ManagementView.as_view(), name='management'),
     url('^device$', views.DeviceManagementView.as_view(), name='device_management'),
 ]


### PR DESCRIPTION
For #2213. Sends user to `/` (then whatever that redirects to) if they attempt to go to `/management`.