### PR TITLE
Fix checkbox event propagation

### DIFF
--- a/kolibri/core/assets/src/views/k-checkbox/index.vue
+++ b/kolibri/core/assets/src/views/k-checkbox/index.vue
@@ -3,7 +3,7 @@
   <div
     class="k-checkbox-container"
     :class="{ 'k-checkbox-disabled': disabled }"
-    @click.prevent="toggleCheck"
+    @click.stop="toggleCheck"
   >
     <div class="tr">
 

--- a/kolibri/core/assets/src/views/k-radio-button/index.vue
+++ b/kolibri/core/assets/src/views/k-radio-button/index.vue
@@ -3,7 +3,7 @@
   <div
     class="k-radio-container"
     :class="{ 'k-radio-disabled': disabled }"
-    @click.prevent="select"
+    @click.stop="select"
   >
     <div class="tr">
 

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -83,7 +83,7 @@
 
         <tbody name="row" is="transition-group">
           <tr v-for="learner in visibleFilteredUsers" :class="isSelected(learner.id) ? 'selectedrow' : ''"
-              @click.prevent="toggleSelection(learner.id)" :key="learner.id">
+              @click="toggleSelection(learner.id)" :key="learner.id">
             <td class="col-checkbox">
               <k-checkbox
                 :label="$tr('selectUser')"


### PR DESCRIPTION
## Summary

* FIxes #2209
* Correct behavior is to stop propagation, not prevent default.
* Also, `toggleSelection` does not need need ` @click.prevent`

![result](https://user-images.githubusercontent.com/7193975/30622636-b1c4698c-9d67-11e7-938b-dc4698ad67d9.gif)
