### PR TITLE
Add missing LANGUAGE_CODE variable needed by in-context code.

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,6 +1,7 @@
 {% load i18n kolibri_tags webpack_tags content_tags cache %}
 {% load staticfiles %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
+{% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr' }}">
 <head>


### PR DESCRIPTION
Needed for in-context translations to work again.