### PR TITLE
Clean up exam and group pages

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
@@ -78,8 +78,6 @@
 <style lang="stylus" scoped>
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
@@ -40,7 +40,7 @@
     name: 'changeExamVisibilityModal',
     $trs: {
       examVisibility: 'Change exam visibility',
-      shouldBeVisible: `Make '{ examTitle }' visible to entire class or specific groups`,
+      shouldBeVisible: "Make '{ examTitle }' visible to entire class or specific groups",
       group: 'group',
       selectGroups: 'Select groups',
       entireClass: 'Entire { className } class',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
@@ -9,9 +9,10 @@
       @change="deselectGroups"
     />
     <ui-select
+      v-if="classGroups.length"
       :name="$tr('group')"
-      :label="$tr('specificGroups')"
-      :placeholder="$tr('selectGroups')"
+      :label="$tr('selectGroups')"
+      :floatingLabel="true"
       :multiple="true"
       :options="groupOptions"
       v-model="groupsSelected"
@@ -38,10 +39,9 @@
   export default {
     name: 'changeExamVisibilityModal',
     $trs: {
-      examVisibility: 'Exam visibility',
-      shouldBeVisible: "'{ examTitle }' should be visible to:",
+      examVisibility: 'Change exam visibility',
+      shouldBeVisible: `Make '{ examTitle }' visible to entire class or specific groups`,
       group: 'group',
-      specificGroups: 'Specific groups',
       selectGroups: 'Select groups',
       entireClass: 'Entire { className } class',
       cancel: 'Cancel',
@@ -178,9 +178,7 @@
     display: block
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
   .group-select
     padding-bottom: 4rem

--- a/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
@@ -83,9 +83,7 @@
 <style lang="stylus" scoped>
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
   .channel-select
     padding-bottom: 4rem

--- a/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
@@ -78,8 +78,6 @@
 <style lang="stylus" scoped>
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
@@ -62,9 +62,7 @@
 <style lang="stylus" scoped>
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
 </style>
 

--- a/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/exam-row.vue
@@ -12,45 +12,14 @@
 
     <td class="col-title"><strong>{{ examTitle }}</strong></td>
 
-    <td class="col-visibility"><strong>{{ visibilityString }}</strong> |
-      <k-button
-        :primary="false"
-        :raised="false"
-        @click="emitChangeExamVisibility"
-        :text="$tr('change')"
-      />
-    </td>
+    <td class="col-visibility">{{ visibilityString }}</td>
 
     <td class="col-action">
-      <k-button
-        v-if="examActive"
-        :primary="true"
-        :raised="false"
-        @click="emitDeactivateExam"
-        :text="$tr('deactivate')"
+      <dropdown-menu
+        :name="$tr('options')"
+        :options="actionOptions"
+        @select="handleSelection"
       />
-
-      <k-button
-        v-else
-        :primary="false"
-        :raised="false"
-        @click="emitActivateExam"
-        :text="$tr('activate')"
-      />
-
-      <ui-icon-button
-        type="secondary"
-        color="primary"
-        :has-dropdown="true"
-        ref="dropdown"
-        icon="arrow_drop_down">
-        <ui-menu
-          slot="dropdown"
-          :options="actionOptions"
-          @select="handleSelection"
-          @close="$refs.dropdown.closeDropdown();"
-        />
-      </ui-icon-button>
     </td>
   </tr>
 
@@ -61,8 +30,8 @@
 
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiIcon from 'keen-ui/src/UiIcon';
-  import uiIconButton from 'keen-ui/src/UiIconButton';
-  import uiMenu from 'keen-ui/src/UiMenu';
+  import dropdownMenu from 'kolibri.coreVue.components.dropdownMenu';
+
   export default {
     name: 'examRow',
     $trs: {
@@ -70,17 +39,18 @@
       activate: 'Activate',
       deactivate: 'Deactivate',
       previewExam: 'Preview exam',
+      changeVisibility: 'Change visibility',
       viewReport: 'View report',
       rename: 'Rename',
       delete: 'Delete',
       entireClass: 'Entire class',
       groups: '{count, number, integer} {count, plural, one {Group} other {Groups}}',
       nobody: 'Nobody',
+      options: 'Options',
     },
     components: {
-      uiIconButton,
       uiIcon,
-      uiMenu,
+      dropdownMenu,
       kButton,
     },
     props: {
@@ -112,7 +82,9 @@
       },
       actionOptions() {
         return [
+          { label: this.examActive ? this.$tr('deactivate') : this.$tr('activate') },
           { label: this.$tr('previewExam') },
+          { label: this.$tr('changeVisibility') },
           { label: this.$tr('viewReport') },
           { label: this.$tr('rename') },
           { label: this.$tr('delete') },
@@ -120,9 +92,6 @@
       },
     },
     methods: {
-      emitChangeExamVisibility() {
-        this.$emit('changeExamVisibility', this.examId);
-      },
       emitActivateExam() {
         this.$emit('activateExam', this.examId);
       },
@@ -131,6 +100,9 @@
       },
       emitPreviewExam() {
         this.$emit('previewExam', this.examId);
+      },
+      emitChangeExamVisibility() {
+        this.$emit('changeExamVisibility', this.examId);
       },
       emitViewReport() {
         this.$emit('viewReport');
@@ -143,8 +115,14 @@
       },
       handleSelection(optionSelected) {
         const action = optionSelected.label;
-        if (action === this.$tr('previewExam')) {
+        if (action === this.$tr('activate')) {
+          this.emitActivateExam();
+        } else if (action === this.$tr('deactivate')) {
+          this.emitDeactivateExam();
+        } else if (action === this.$tr('previewExam')) {
           this.emitPreviewExam();
+        } else if (action === this.$tr('changeVisibility')) {
+          this.emitChangeExamVisibility();
         } else if (action === this.$tr('viewReport')) {
           this.emitViewReport();
         } else if (action === this.$tr('rename')) {
@@ -163,6 +141,9 @@
 
   @require '~kolibri.styles.definitions'
 
+  .col-icon
+    width: 40px
+
   .icon-active
     color: $core-action-normal
 
@@ -170,7 +151,7 @@
     color: $core-text-annotation
 
   .col-visibility, .col-action
-    text-align: right
+    text-align: left
 
   .active-circle
     display: inline-block

--- a/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
@@ -2,12 +2,12 @@
 
   <div>
     <h1>{{ className }} {{ $tr('exams') }}</h1>
-    <ui-radio-group
-      :name="$tr('examFilter')"
-      :label="$tr('show')"
-      :options="filterOptions"
-      v-model="filterSelected"
-      class="radio-group"
+    <ui-select
+      :label="$tr('exams')"
+      :floatingLabel="true"
+      :options="statusOptions"
+      v-model="statusSelected"
+      class="status-filter"
     />
     <k-button
       :primary="true"
@@ -33,9 +33,6 @@
           :examTitle="exam.title"
           :examActive="exam.active"
           :examVisibility="exam.visibility"
-          :classId="classId"
-          :className="className"
-          :classGroups="[]"
           @changeExamVisibility="openChangeExamVisibilityModal"
           @activateExam="openActivateExamModal"
           @deactivateExam="openDeactivateExamModal"
@@ -108,7 +105,7 @@
   import { PageNames } from '../../constants';
   import orderBy from 'lodash/orderBy';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import uiRadioGroup from 'keen-ui/src/UiRadioGroup';
+  import uiSelect from 'keen-ui/src/UiSelect';
   import examRow from './exam-row';
   import createExamModal from './create-exam-modal';
   import activateExamModal from './activate-exam-modal';
@@ -117,15 +114,14 @@
   import previewExamModal from './preview-exam-modal';
   import renameExamModal from './rename-exam-modal';
   import deleteExamModal from './delete-exam-modal';
+
   export default {
     name: 'coachExamsPage',
     $trs: {
       exams: 'Exams',
-      show: 'Show',
       all: 'All',
       active: 'Active',
       inactive: 'Inactive',
-      examFilter: 'Exam filter',
       newExam: 'New Exam',
       title: 'Title',
       visibleTo: 'Visible to',
@@ -134,7 +130,7 @@
     },
     components: {
       kButton,
-      uiRadioGroup,
+      uiSelect,
       examRow,
       createExamModal,
       activateExamModal,
@@ -146,7 +142,7 @@
     },
     data() {
       return {
-        filterSelected: this.$tr('all'),
+        statusSelected: { label: this.$tr('all') },
         selectedExam: {
           title: '',
           id: '',
@@ -164,20 +160,11 @@
       sortedChannels() {
         return orderBy(this.channels, [channel => channel.name.toUpperCase()], ['asc']);
       },
-      filterOptions() {
+      statusOptions() {
         return [
-          {
-            label: this.$tr('all'),
-            value: this.$tr('all'),
-          },
-          {
-            label: this.$tr('active'),
-            value: this.$tr('active'),
-          },
-          {
-            label: this.$tr('inactive'),
-            value: this.$tr('inactive'),
-          },
+          { label: this.$tr('all') },
+          { label: this.$tr('active') },
+          { label: this.$tr('inactive') },
         ];
       },
       activeExams() {
@@ -187,7 +174,7 @@
         return this.sortedExams.filter(exam => exam.active === false);
       },
       filteredExams() {
-        const filter = this.filterSelected;
+        const filter = this.statusSelected.label;
         if (filter === this.$tr('active')) {
           return this.activeExams;
         } else if (filter === this.$tr('inactive')) {
@@ -285,9 +272,6 @@
   .center-text
     text-align: center
 
-  .radio-group
-    display: inline-block
-
   table
     margin-top: 3em
     width: 100%
@@ -296,6 +280,11 @@
     text-align: left
 
   .col-visibility, .col-action
-    text-align: right
+    text-align: left
+
+  .status-filter
+    display: inline-block
+    margin: 0
+    width: 200px
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/index.vue
@@ -22,7 +22,7 @@
           <th class="col-icon"></th>
           <th class="col-title">{{ $tr('title') }}</th>
           <th class="col-visibility">{{ $tr('visibleTo') }}</th>
-          <th class="col-action">{{ $tr('action') }}</th>
+          <th class="col-action"></th>
         </tr>
       </thead>
       <tbody>
@@ -125,7 +125,6 @@
       newExam: 'New Exam',
       title: 'Title',
       visibleTo: 'Visible to',
-      action: 'Action',
       noExams: `You do not have any exams. Start by creating a new exam above.`,
     },
     components: {
@@ -264,6 +263,8 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.definitions'
+
   .create-button
     float: right
     margin-top: 1em
@@ -279,12 +280,17 @@
   .col-title
     text-align: left
 
-  .col-visibility, .col-action
+  .col-visibility
     text-align: left
 
   .status-filter
     display: inline-block
     margin: 0
     width: 200px
+
+  th
+    color: $core-text-annotation
+    font-size: smaller
+    font-weight: normal
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/rename-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/rename-exam-modal.vue
@@ -127,8 +127,6 @@
 <style lang="stylus" scoped>
 
   .footer
-    text-align: center
-    button
-      min-width: 45%
+    text-align: right
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -14,18 +14,20 @@
           @blur="nameBlurred = true"
           v-model.trim="name"
         />
-        <k-button
-          type="button"
-          :text="$tr('cancel')"
-          :raised="false"
-          @click="close"
-        />
-        <k-button
-          type="submit"
-          :text="$tr('save')"
-          :primary="true"
-          :disabled="submitting"
-        />
+        <div class="ta-r">
+          <k-button
+            type="button"
+            :text="$tr('cancel')"
+            :raised="false"
+            @click="close"
+          />
+          <k-button
+            type="submit"
+            :text="$tr('save')"
+            :primary="true"
+            :disabled="submitting"
+          />
+        </div>
       </form>
     </div>
   </core-modal>
@@ -121,4 +123,9 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .ta-r
+    text-align: right
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -4,12 +4,18 @@
     @cancel="close">
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
     <p>{{ $tr('learnersWillBecome') }} <strong>{{ $tr('ungrouped') }}</strong>.</p>
-    <k-button :text="$tr('cancel')"
-      :raised="false"
-      @click="close" />
-    <k-button :text="$tr('deleteGroup')"
-      :primary="true"
-      @click="deleteGroup(groupId)" />
+    <div class="ta-r">
+      <k-button
+        :text="$tr('cancel')"
+        :raised="false"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('deleteGroup')"
+        :primary="true"
+        @click="deleteGroup(groupId)"
+      />
+    </div>
   </core-modal>
 
 </template>
@@ -62,4 +68,9 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .ta-r
+    text-align: right
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -15,11 +15,10 @@
           {{ `${selectedUsers.length} ${$tr('selected')}` }}
         </span>
         <k-button
-          v-if="canMove"
           class="right-margin"
           :text="$tr('moveLearners')"
           :primary="false"
-          :disabled="selectedUsers.length === 0"
+          :disabled="!canMove || selectedUsers.length === 0"
           @click="emitMove"
         />
         <ui-button

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -126,5 +126,6 @@
 
   .button-section
     margin-top: 1em
+    text-align: right
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
@@ -14,18 +14,20 @@
           @blur="nameBlurred = true"
           v-model.trim="name"
         />
-        <k-button
-          type="button"
-          :text="$tr('cancel')"
-          :raised="false"
-          @click="close"
-        />
-        <k-button
-          type="submit"
-          :text="$tr('save')"
-          :primary="true"
-          :disabled="submitting"
-        />
+        <div class="ta-r">
+          <k-button
+            type="button"
+            :text="$tr('cancel')"
+            :raised="false"
+            @click="close"
+          />
+          <k-button
+            type="submit"
+            :text="$tr('save')"
+            :primary="true"
+            :disabled="submitting"
+          />
+        </div>
       </form>
     </div>
   </core-modal>
@@ -132,4 +134,9 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .ta-r
+    text-align: right
+
+</style>


### PR DESCRIPTION
## Summary

* Fixes #2046
* Fixes #1935
* Right align modal buttons.
* Wording update to exam  visibility modal
* Exam row changes as seen in https://projects.invisionapp.com/share/7D8ZDY4EN#/screens/242551478
* Replace radios with filter.
 
![127 0 0 1-8000-coach-](https://user-images.githubusercontent.com/7193975/30669392-06081b8c-9e13-11e7-972b-a896114239f2.png)

![127 0 0 1-8000-coach- 1](https://user-images.githubusercontent.com/7193975/30669394-0791bd82-9e13-11e7-9ef9-624784789761.png)

![127 0 0 1-8000-coach- 2](https://user-images.githubusercontent.com/7193975/30669397-08bc9baa-9e13-11e7-99fd-ae739bfdab3b.png)
