### PR TITLE
Change user feedback on facility configuration page

### DIFF
--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
@@ -1,6 +1,12 @@
 <template>
 
   <div>
+
+    <notifications
+      :notification="notification"
+      @dismiss="dismissNotification()"
+    />
+
     <div class="mb">
       <h1>{{ $tr('pageHeader') }}</h1>
       <p>{{ $tr('pageDescription') }}</p>
@@ -45,11 +51,6 @@
         </div>
       </div>
     </template>
-
-    <notifications
-      :notification="notification"
-      @dismiss="dismissNotification()"
-    />
 
     <confirm-reset-modal
       id="confirm-reset"

--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/index.vue
@@ -28,6 +28,7 @@
               :label="$tr(setting)"
               :checked="settings[setting]"
               @change="toggleSetting(setting)"
+              :key="setting"
             />
           </template>
         </div>
@@ -44,9 +45,10 @@
           <k-button
             :primary="true"
             :raised="true"
-            @click="saveFacilityConfig()"
+            @click="saveConfig()"
             :text="$tr('saveChanges')"
             name="save-settings"
+            :disabled="!settingsHaveChanged"
           />
         </div>
       </div>
@@ -76,19 +78,41 @@
   import notifications from './config-page-notifications';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import isEqual from 'lodash/isEqual';
+
   export default {
+    name: 'facilityConfigPage',
     components: {
       confirmResetModal,
       notifications,
       kCheckbox,
       kButton,
     },
-    data: () => ({ showModal: false }),
-    computed: { settingsList: () => settingsList },
+    data: () => ({
+      showModal: false,
+      settingsCopy: {},
+    }),
+    computed: {
+      settingsList: () => settingsList,
+      settingsHaveChanged() {
+        return !isEqual(this.settings, this.settingsCopy);
+      },
+    },
+    mounted() {
+      this.copySettings();
+    },
     methods: {
       resetToDefaultSettings() {
         this.showModal = false;
         this.resetFacilityConfig();
+      },
+      saveConfig() {
+        this.saveFacilityConfig().then(() => {
+          this.copySettings();
+        });
+      },
+      copySettings() {
+        this.settingsCopy = Object.assign({}, this.settings);
       },
     },
     vuex: {
@@ -111,7 +135,6 @@
         },
       },
     },
-    name: 'facilityConfigPage',
     $trs: {
       currentFacilityHeader: 'Your current Facility',
       learnerCanDeleteAccount: 'Allow users to delete their account',

--- a/kolibri/plugins/management/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/management/assets/test/views/facility-config-page.spec.js
@@ -50,6 +50,7 @@ describe('facility config page view', () => {
   it('clicking save dispatches a save action', () => {
     const wrapper = makeWrapper();
     const saveActionStub = sinon.stub(wrapper, 'saveFacilityConfig');
+    saveActionStub.returns(Promise.resolve());
     const { saveButton } = getElements(wrapper);
     simulant.fire(saveButton(), 'click');
     return Vue.nextTick().then(() => {


### PR DESCRIPTION
Not sure if it addresses all of the commentary in #1665, but these are the changes:

1. Move notifications to the top of the page
1. Disable the 'save' button if no changes have been made
![facility config](https://user-images.githubusercontent.com/10248067/30671059-e5efa25a-9e19-11e7-88fa-ee781e8d98ba.gif)
