### PR TITLE
Fix checkbox label click

### DIFF
--- a/kolibri/core/assets/src/views/k-checkbox/index.vue
+++ b/kolibri/core/assets/src/views/k-checkbox/index.vue
@@ -3,7 +3,7 @@
   <div
     class="k-checkbox-container"
     :class="{ 'k-checkbox-disabled': disabled }"
-    @click.stop="toggleCheck"
+    @click="toggleCheck"
   >
     <div class="tr">
 
@@ -48,6 +48,7 @@
         class="k-checkbox-label"
         :for="id"
         :class="{ 'visuallyhidden': !showLabel }"
+        @click.prevent
       >
         {{ label }}
       </label>

--- a/kolibri/core/assets/src/views/k-radio-button/index.vue
+++ b/kolibri/core/assets/src/views/k-radio-button/index.vue
@@ -3,7 +3,7 @@
   <div
     class="k-radio-container"
     :class="{ 'k-radio-disabled': disabled }"
-    @click.stop="select"
+    @click="select"
   >
     <div class="tr">
 
@@ -19,7 +19,7 @@
           @blur="isActive = false"
           @change="emitChange"
           v-model="model"
-          @click.stop
+          @click.stop="select"
         >
 
         <mat-svg
@@ -37,7 +37,7 @@
 
       </div>
 
-      <label :for="id" class="k-radio-label">{{ label }}</label>
+      <label :for="id" class="k-radio-label" @click.prevent>{{ label }}</label>
 
     </div>
   </div>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -68,7 +68,7 @@
               :showLabel="false"
               :checked="isSelected(user.id)"
               @change="toggleSelection(user.id)"
-              @click.stop
+              @click.native.stop
             />
           </td>
           <td class="col-name"><strong>{{ user.full_name }}</strong></td>

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -91,6 +91,7 @@
                 :checked="isSelected(learner.id)"
                 @change="toggleSelection(learner.id)"
                 class="inline-block check"
+                 @click.native.stop
               />
             </td>
             <th class="col-username">{{ learner.username }}</th>

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -91,7 +91,7 @@
                 :checked="isSelected(learner.id)"
                 @change="toggleSelection(learner.id)"
                 class="inline-block check"
-                 @click.native.stop
+                @click.native.stop
               />
             </td>
             <th class="col-username">{{ learner.username }}</th>


### PR DESCRIPTION
The issue was that clicking on the label was triggering a change which would cause the toggle/selection to be called twice. Preventing the default behavior of label clicks fixes this. Fixes #2233