### PR TITLE
Language updates

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
@@ -27,6 +27,7 @@
     <!-- QUESTION use ui-select? -->
     <select
       @input="changeLanguage($event.target.value)"
+      v-if="selectorLanguages.length"
       class="default-language-form-dropdown default-language-form-items">
       <option
         disabled
@@ -103,7 +104,12 @@
         return remainingLanguages;
       },
       numberOfLanguageButtons() {
-        return this.isMobile ? mobileNumberOfLanguageButtons : desktopNumberOfLanguageButtons;
+        let numBtns = this.isMobile ? mobileNumberOfLanguageButtons : desktopNumberOfLanguageButtons;
+        // prevent a case where the selector menu has just a single item
+        if (Object.keys(allLanguages).length === numBtns + 2) {
+          return numBtns + 1;
+        }
+        return numBtns;
       },
       buttonLanguages() {
         return this.remainingLanguages.slice(0, this.numberOfLanguageButtons);

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
@@ -7,10 +7,12 @@
         'default-language-form-items',
         (isMobile ? 'mobile' : '')
       ]">
-      <span :class="['default-language-form-selected-label', (isMobile ? 'mobile' : '')]">
+      <div class="default-language-form-selected-label">
         {{ $tr('selectedLanguageLabel') }}
-      </span>
+      </div>
+      <div>
         {{ selectedLanguage }}
+      </div>
     </label>
 
     <k-button
@@ -174,12 +176,6 @@
         font-weight: normal
         font-size: 10px
         margin-bottom: 8px
-        &.mobile
-          font-weight: none
-          font-size: inherit
-          display: inline
-          &:after
-            content: ':'
 
     &-button-option
       color: $core-action-dark


### PR DESCRIPTION
two changes:

1. remove the special 'colon' handling for mobile view of language chooser - not i18n-safe:

    ![image](https://user-images.githubusercontent.com/2367265/30724316-f521566e-9ef1-11e7-987c-a0a7334b6cce.png)

2. ensure that the language drop-down never has just one item