### PR TITLE
Catch OSErrors when running git describe

### DIFF
--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -241,7 +241,7 @@ def get_git_describe():
         # repo - it's safe.
         version_string = p.communicate()[0].rstrip()
         return version_string
-    except EnvironmentError:
+    except EnvironmentError, OSError:
         return None
 
 def get_version_from_git(get_git_describe_string):


### PR DESCRIPTION
Sometimes subprocess.call raises this for some valid reason (e.g. kolibri is imported through a wheel file), so don't error out completely.