### PR TITLE
Fix broken 'exam' links

### DIFF
--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -120,7 +120,8 @@ class LearnModule extends KolibriModule {
           name: PageNames.EXAM,
           path: '/exams/:id/:questionNumber',
           handler: (toRoute, fromRoute) => {
-            actions.showExam(store, toRoute.params.id, toRoute.params.questionNumber);
+            const { id, questionNumber } = toRoute.params;
+            actions.showExam(store, id, questionNumber);
           },
         },
         {

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -1,18 +1,20 @@
 import {
   ContentNodeResource,
   ContentNodeProgressResource,
-  SessionResource,
   UserExamResource,
   ExamLogResource,
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 
 import { getChannelObject, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
-import { setChannelInfo, handleApiError } from 'kolibri.coreVue.vuex.actions';
+import {
+  setChannelInfo,
+  handleApiError,
+  samePageCheckGenerator,
+} from 'kolibri.coreVue.vuex.actions';
 import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { PageNames } from '../../constants';
-import { samePageCheckGenerator } from 'kolibri.coreVue.vuex.actions';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { now } from 'kolibri.utils.serverClock';
 
@@ -424,7 +426,12 @@ function showExam(store, id, questionNumber) {
       user: store.state.core.session.user_id,
       exam: id,
     }).fetch();
-    ConditionalPromise.all([examPromise, examLogPromise, examAttemptLogPromise]).only(
+    ConditionalPromise.all([
+      examPromise,
+      examLogPromise,
+      examAttemptLogPromise,
+      setAndCheckChannels(store),
+    ]).only(
       samePageCheckGenerator(store),
       ([exam, examLogs, examAttemptLogs]) => {
         const currentChannel = getChannelObject(store.state, exam.channel_id);

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -9,6 +9,7 @@ import {
 import { getChannelObject, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
 import {
   setChannelInfo,
+  handleError,
   handleApiError,
   samePageCheckGenerator,
 } from 'kolibri.coreVue.vuex.actions';

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -70,6 +70,7 @@
           params: {
             channel_id: exam.channelId,
             id: exam.id,
+            questionNumber: exam.answerCount,
           },
         };
       },

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -7,7 +7,7 @@
       <page-header :title="$tr('examName')"></page-header>
       <p v-if="activeExams" class="exams-assigned">{{ $tr('assignedTo', { assigned: activeExams }) }}</p>
       <p v-else class="exams-assigned">{{ $tr('noExams') }}</p>
-      <div class="exam-row" v-for="exam in exams">
+      <div class="exam-row" v-for="exam in exams" :key="exam.id">
         <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment_late"/>
         <h2 class="exam-title">{{ exam.title }}</h2>
         <div class="exam-details" v-if="exam.closed || !exam.active">

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -70,7 +70,7 @@
           params: {
             channel_id: exam.channelId,
             id: exam.id,
-            questionNumber: exam.answerCount,
+            questionNumber: 0,
           },
         };
       },


### PR DESCRIPTION
Addresses #2232, by making sure the "start exam" link has a `questionNumber` param.

Also fixes other runtime bug by making sure the list of channels is available in core state when going into an exam (see `showExam` action in https://github.com/learningequality/kolibri/blob/release-v0.6.x/kolibri/plugins/learn/assets/src/state/actions/main.js).

However, exercises are not rendered when entering an exam, which is probably a different issue #2263 #2282 