### PR TITLE
fix kolibripippex in Makefile to generate the correct pip.pex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,5 +123,4 @@ dockerenvdist: writeversion
 
 kolibripippex:
 	git clone https://github.com/learningequality/pip.git
-	python pip/setup.py bdist_wheel
-	cd pip && pex -m pip dist/*.whl -o kolibripip.pex && mv kolibripip.pex ../
+	cd pip && python setup.py bdist_wheel && pex -m pip dist/*.whl -o kolibripip.pex && mv kolibripip.pex ../


### PR DESCRIPTION
## Summary

Fix the command for `kolibripippex` in Makefile so that the `kolibripip.pex` file can be correctly generated.

## Issues addressed

Previously, the Makefile command could not generate the correct pip wheel file.
