### PR TITLE
Responsive login

### DIFF
--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -36,7 +36,7 @@
         if (this.pageName === PageNames.PROFILE) {
           return this.$tr('userProfileTitle');
         }
-        return null;
+        return '';
       },
       topLevelPageName: () => TopLevelPageNames.USER,
       currentPage() {

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -6,7 +6,6 @@
     </core-base>
     <div v-if="!navBarNeeded" class="full-page">
       <component :is="currentPage"/>
-      <language-switcher :footer="true"/>
     </div>
   </div>
 
@@ -22,7 +21,7 @@
   import signInPage from './sign-in-page';
   import signUpPage from './sign-up-page';
   import profilePage from './profile-page';
-  import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
+
   export default {
     $trs: { userProfileTitle: 'Profile' },
     name: 'userPlugin',
@@ -31,7 +30,6 @@
       signInPage,
       signUpPage,
       profilePage,
-      languageSwitcher,
     },
     computed: {
       appBarTitle() {

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -333,6 +333,13 @@
 
   $login-text = #D8D8D8
 
+  .k-button-secondary-raised
+    background-color: $core-text-default
+    color: $core-bg-canvas
+    &:hover
+      background-color: #0E0E0E
+
+
   .login
     background-color: #201A21
     height: 100%

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -1,7 +1,7 @@
 <template>
 
-  <div class="login">
-    <div id="login-container">
+  <div class="wrapper-table">
+    <div class="main-row"><div id="main-cell">
       <logo class="logo"/>
       <h1 class="login-text title">{{ $tr('kolibri') }}</h1>
       <form class="login-form" ref="form" @submit.prevent="signIn">
@@ -78,9 +78,9 @@
         </a>
       </div>
       <p class="login-text version">{{ versionMsg }}</p>
-    </div>
-    <div class="footer">
-      <language-switcher-footer/>
+    </div></div>
+    <div class="footer-row">
+      <language-switcher-footer class="footer-cell"/>
     </div>
   </div>
 
@@ -313,7 +313,7 @@
 
   $login-text = #D8D8D8
 
-  #login-container
+  #main-cell
     .ui-
       &textbox__
         &label-text
@@ -339,15 +339,22 @@
     &:hover
       background-color: #0E0E0E
 
-
-  .login
+  .wrapper-table
+    text-align: center
     background-color: #201A21
     height: 100%
-    // Fallback for older browers.
-    background: $core-bg-canvas
-    background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center fixed
+    width: 100%
+    display: table
+
+  .main-row
+    display: table-row
+
+  #main-cell
+    background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center
     background-size: cover
-    text-align: center
+    display: table-cell
+    vertical-align: middle
+    height: 100%
 
   .logo
     margin-top: 36px
@@ -374,17 +381,25 @@
     margin: auto
     margin-top: 48px
     margin-bottom: 36px
-    width: 412px
+    width: 100%
+    max-width: 412px
     height: 1px
     background-color: $core-text-annotation
-    background-color: $login-text
 
   .version
     font-size: 0.8em
     margin-top: 36px
+    margin-bottom: 36px
 
-  .footer
+  .footer-row
+    display: table-row
     background-color: $core-bg-canvas
+
+  .footer-cell
+    display: table-cell
+    vertical-align: middle
+    min-height: 50px
+    padding: 18px
 
   .sign-in-error
     color: $core-text-error

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -4,7 +4,7 @@
     <div id="login-container">
       <logo class="logo"/>
       <h1 class="login-text title">{{ $tr('kolibri') }}</h1>
-      <form id="login-form" ref="form" @submit.prevent="signIn">
+      <form class="login-form" ref="form" @submit.prevent="signIn">
         <ui-alert
           v-if="invalidCredentials"
           type="error"
@@ -59,14 +59,14 @@
           />
         </transition>
         <k-button
-          id="login-btn"
+          class="login-btn"
           type="submit"
           :text="$tr('signIn')"
           :primary="true"
           :disabled="busy"
         />
       </form>
-      <div id="divid-line"></div>
+      <div class="divider"></div>
 
       <p class="login-text no-account">{{ $tr('noAccount') }}</p>
       <div id="btn-group">
@@ -78,6 +78,9 @@
         </a>
       </div>
       <p class="login-text version">{{ versionMsg }}</p>
+    </div>
+    <div class="footer">
+      <language-switcher-footer/>
     </div>
   </div>
 
@@ -320,8 +323,6 @@
           color: $login-text
           &:autofill
             background-color: transparent
-      &button
-        background-color: $login-red
 
 </style>
 
@@ -330,83 +331,53 @@
 
   @require '~kolibri.styles.definitions'
 
-  $login-overlay = #201A21
   $login-text = #D8D8D8
 
   .login
-    background-color: $login-overlay
+    background-color: #201A21
     height: 100%
     // Fallback for older browers.
     background: $core-bg-canvas
     background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(./background.png) no-repeat center center fixed
     background-size: cover
-    overflow: hidden
-
-  #login-container
-    display: block
-    margin: auto
+    text-align: center
 
   .logo
-    position: relative
-    display: block
-    margin: auto
-    margin-top: 34px
-    width: 30%
-    height: auto
-    max-width: 120px
-    min-width: 60px
+    margin-top: 36px
+    width: 120px
 
   .login-text
     color: $login-text
 
   .title
-    font-weight: 100
     font-size: 1.3em
-    letter-spacing: 0.1em
-    text-align: center
 
-  #login-form
+  .login-form
     width: 70%
     max-width: 300px
-    margin: auto
-    margin-top: 30px
     position: relative
-
-  #password
-    margin-top: 30px
-
-  #login-btn
-    display: block
+    text-align: left
     margin: auto
-    margin-top: 38px
+
+  .login-btn
+    display: block
     width: 100%
 
-  #btn-group
-    display: table
+  .divider
     margin: auto
-    margin-top: 28px
-    margin-bottom: 20px
-    text-align: center
-
-  .group-btn
-    padding: 5px
-    display: inline-block
-    text-decoration: none
-
-  #divid-line
+    margin-top: 48px
+    margin-bottom: 36px
     width: 412px
     height: 1px
     background-color: $core-text-annotation
     background-color: $login-text
-    margin: auto
-    margin-top: 24px
 
   .version
-    text-align: center
     font-size: 0.8em
+    margin-top: 36px
 
-  .no-account
-    text-align: center
+  .footer
+    background-color: $core-bg-canvas
 
   .sign-in-error
     color: $core-text-error

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -400,8 +400,6 @@
   .footer-cell
     display: table-cell
     vertical-align: middle
-    min-height: 50px
-    padding: 18px
 
   .sign-in-error
     color: $core-text-error

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -80,7 +80,7 @@
       <p class="login-text version">{{ versionMsg }}</p>
     </div></div>
     <div class="footer-row">
-      <language-switcher-footer class="footer-cell"/>
+      <language-switcher :footer="true" class="footer-cell"/>
     </div>
   </div>
 
@@ -99,6 +99,7 @@
   import logo from 'kolibri.coreVue.components.logo';
   import uiAutocompleteSuggestion from 'keen-ui/src/UiAutocompleteSuggestion';
   import uiAlert from 'keen-ui/src/UiAlert';
+  import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
 
   export default {
     name: 'signInPage',
@@ -122,6 +123,7 @@
       logo,
       uiAutocompleteSuggestion,
       uiAlert,
+      languageSwitcher,
     },
     data: () => ({
       username: '',

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -92,7 +92,7 @@
     </form>
 
     <div class="footer">
-      <language-switcher-footer/>
+      <language-switcher :footer="true"/>
     </div>
   </div>
 
@@ -111,6 +111,8 @@
   import logo from 'kolibri.coreVue.components.logo';
   import uiIcon from 'keen-ui/src/UiIcon';
   import uiSelect from 'keen-ui/src/UiSelect';
+  import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
+
   export default {
     name: 'signUpPage',
     $trs: {
@@ -138,6 +140,7 @@
       logo,
       uiIcon,
       uiSelect,
+      languageSwitcher,
     },
     data: () => ({
       name: '',

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -91,6 +91,9 @@
 
     </form>
 
+    <div class="footer">
+      <language-switcher-footer/>
+    </div>
   </div>
 
 </template>
@@ -354,5 +357,9 @@
   .app-bar-icon
     font-size: 2.5em
     margin-left: 0.25em
+
+  .footer
+    margin: 36px
+    margin-top: 96px
 
 </style>


### PR DESCRIPTION

simpler variation of #2259 - takes the new layout but leaves the old (non-keyboard-accessible) language switcher:

![image](https://user-images.githubusercontent.com/2367265/30995937-0f8e3348-a472-11e7-8e26-21c6b4284b2f.png)


![image](https://user-images.githubusercontent.com/2367265/30995948-24f88dfa-a472-11e7-9e2d-a94134bb8e95.png)

![image](https://user-images.githubusercontent.com/2367265/30995950-291d963c-a472-11e7-8884-5227e0005111.png)

fixes #2238
