### PR TITLE
Properly remove models based on the cacheKey, not model id.

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -569,7 +569,9 @@ class Resource {
   }
 
   removeModel(model) {
-    delete this.models[model.id];
+    const filteredResourceIds = this.filterAndCheckResourceIds(model.resourceIds);
+    const cacheKey = this.cacheKey({ [this.idKey]: model.id }, filteredResourceIds);
+    delete this.models[cacheKey];
   }
 
   /**

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -175,6 +175,9 @@ class Model {
             this.resource.removeModel(this);
             // Set a flag so that any collection containing this can ignore this model
             this.deleted = true;
+            // Any collection containing this model is now probably out of date,
+            // set synced to false to ensure that they update their data on fetch
+            this.synced = false;
             // Resolve the promise with the id.
             // Vuex will use this id to delete the model in its state.
             resolve(this.id);

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -196,12 +196,10 @@ describe('Resource', function () {
   });
   describe('removeModel method', function () {
     it('should remove model from model cache', function () {
-      const id = 'test';
-      this.resource.models[id] = 'test';
-      this.resource.removeModel({
-        id,
-      });
-      assert.equal(typeof this.resource.models[id], 'undefined');
+      const model = new Resources.Model({ id: 'test' }, {}, this.resource);
+      this.resource.addModel(model);
+      this.resource.removeModel(model);
+      assert.equal(Object.keys(this.resource.models).length, 0);
     });
   });
   describe('unCacheModel method', function () {


### PR DESCRIPTION
## Summary

Fixes #2163, by fixing the general issue that models were not being properly removed from the resource cache.