### PR TITLE
Prevent the access of an already submitted exam

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -535,6 +535,10 @@ function showExam(store, channelId, id, questionNumber) {
     ]).only(
       samePageCheckGenerator(store),
       ([exam, channel, examLogs, examAttemptLogs]) => {
+        if (exam.closed) {
+          router.getInstance().replace({ name: constants.PageNames.EXAM_LIST });
+          return;
+        }
         const currentChannel = coreGetters.getCurrentChannelObject(store.state);
         if (!currentChannel) {
           router.replace({ name: constants.PageNames.CONTENT_UNAVAILABLE });


### PR DESCRIPTION
## Summary

* Fixes #2085. 
* @rtibbles Will make a separate pr to prevent this in the backend.