### PR TITLE
SQLAlchemy SQLite Pragmas and Scoped Sessions

### DIFF
--- a/kolibri/content/utils/sqlalchemybridge.py
+++ b/kolibri/content/utils/sqlalchemybridge.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS, START_PRAGMAS
 from sqlalchemy import ColumnDefault, MetaData, create_engine, event
 from sqlalchemy.ext.automap import automap_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 
@@ -67,7 +67,7 @@ def make_session(connection_string):
     when we actually commit to the database.
     """
     engine = get_engine(connection_string)
-    Session = sessionmaker(bind=engine, autoflush=False)
+    Session = scoped_session(sessionmaker(bind=engine, autoflush=False))
     return Session(), engine
 
 def get_class(DjangoModel, Base):

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.apps import AppConfig
 from django.db.backends.signals import connection_created
+from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS, START_PRAGMAS
 
 
 class KolibriCoreConfig(AppConfig):
@@ -26,7 +27,7 @@ class KolibriCoreConfig(AppConfig):
             cursor = connection.cursor()
 
             # Shorten the default WAL autocheckpoint from 1000 pages to 500
-            cursor.execute("PRAGMA wal_autocheckpoint=500;")
+            cursor.execute(CONNECTION_PRAGMAS)
 
             # We don't turn on the following pragmas, because they have negligible
             # performance impact. For reference, here's what we've tested:
@@ -54,4 +55,4 @@ class KolibriCoreConfig(AppConfig):
             # WAL's main advantage allows simultaneous reads
             # and writes (vs. the default exclusive write lock)
             # at the cost of a slight penalty to all reads.
-            cursor.execute("PRAGMA journal_mode=WAL;")
+            cursor.execute(START_PRAGMAS)

--- a/kolibri/core/sqlite/pragmas.py
+++ b/kolibri/core/sqlite/pragmas.py
@@ -1,0 +1,3 @@
+CONNECTION_PRAGMAS = "PRAGMA wal_autocheckpoint=500;"
+
+START_PRAGMAS = "PRAGMA journal_mode=WAL;"


### PR DESCRIPTION
## Summary

Activate pragmas on SQLite connections in SQLAlchemy.

Use SQLAlchemy scoped sessions to attempt to prevent thread issues.