### PR TITLE
Pre make default db sql alchemy bridge

### DIFF
--- a/kolibri/content/apps.py
+++ b/kolibri/content/apps.py
@@ -11,8 +11,13 @@ class KolibriContentConfig(AppConfig):
     def ready(self):
         # Initialize bridge for default db/content app here
         # to avoid a race condition during runtime.
-        from kolibri.content.utils.sqlalchemybridge import Bridge
+        from kolibri.content.utils.sqlalchemybridge import Bridge, DatabaseNotReady
 
-        default_db_bridge = Bridge(app_name=self.label)
+        try:
 
-        default_db_bridge.end()
+            default_db_bridge = Bridge(app_name=self.label)
+
+            default_db_bridge.end()
+
+        except DatabaseNotReady:
+            pass

--- a/kolibri/content/apps.py
+++ b/kolibri/content/apps.py
@@ -7,3 +7,12 @@ class KolibriContentConfig(AppConfig):
     name = 'kolibri.content'
     label = 'content'
     verbose_name = 'Kolibri Content'
+
+    def ready(self):
+        # Initialize bridge for default db/content app here
+        # to avoid a race condition during runtime.
+        from kolibri.content.utils.sqlalchemybridge import Bridge
+
+        default_db_bridge = Bridge(app_name=self.label)
+
+        default_db_bridge.end()

--- a/kolibri/content/utils/sqlalchemybridge.py
+++ b/kolibri/content/utils/sqlalchemybridge.py
@@ -195,8 +195,3 @@ class Bridge(object):
         self.session.close()
         for connection in self.connections:
             connection.close()
-        self.engine.dispose()
-        for key, engine in ENGINES_CACHES.items():
-            if engine == self.engine:
-                ENGINES_CACHES.pop(key)
-                break

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.apps import AppConfig
 from django.db.backends.signals import connection_created
+from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS, START_PRAGMAS
 
 
 class KolibriCoreConfig(AppConfig):
@@ -26,7 +27,7 @@ class KolibriCoreConfig(AppConfig):
             cursor = connection.cursor()
 
             # Shorten the default WAL autocheckpoint from 1000 pages to 500
-            cursor.execute("PRAGMA wal_autocheckpoint=500;")
+            cursor.execute(CONNECTION_PRAGMAS)
 
             # We don't turn on the following pragmas, because they have negligible
             # performance impact. For reference, here's what we've tested:
@@ -54,4 +55,4 @@ class KolibriCoreConfig(AppConfig):
             # WAL's main advantage allows simultaneous reads
             # and writes (vs. the default exclusive write lock)
             # at the cost of a slight penalty to all reads.
-            cursor.execute("PRAGMA journal_mode=WAL;")
+            cursor.execute(START_PRAGMAS)

--- a/kolibri/core/sqlite/pragmas.py
+++ b/kolibri/core/sqlite/pragmas.py
@@ -1,0 +1,3 @@
+CONNECTION_PRAGMAS = "PRAGMA wal_autocheckpoint=500;"
+
+START_PRAGMAS = "PRAGMA journal_mode=WAL;"


### PR DESCRIPTION
## Summary

To avoid the race condition at runtime, this initializes the sqlalchemy bridge for the default db, and only for the content app, at app ready.