### PR TITLE
Add 'avoriaz' testing utility, rewrite progress-bar test

### DIFF
--- a/kolibri/core/assets/src/views/progress-bar/index.vue
+++ b/kolibri/core/assets/src/views/progress-bar/index.vue
@@ -3,11 +3,12 @@
   <div class="wrapper">
     <div class="visuallyhidden" id="progress-bar-label">{{ $tr('label') }}</div>
     <div class="progress-bar-wrapper"
-         role="progressbar"
-         aria-labelledby="progress-bar-label"
-         :aria-valuenow="percent"
-         aria-valuemin="0"
-         aria-valuemax="100">
+      role="progressbar"
+      aria-labelledby="progress-bar-label"
+      :aria-valuenow="percent"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
       <div class="progress-bar-complete" :style="{ width: percent + '%',  backgroundColor: color}"></div>
     </div>
     <div class="progress-bar-text" v-if="showPercentage">{{ $tr('pct', [progress]) }}</div>

--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -66,7 +66,6 @@
     color: white
     cursor: default
 
-
   .inprogress
     background-color: $core-status-progress
 

--- a/kolibri/core/assets/test/vue.content-renderer.js
+++ b/kolibri/core/assets/test/vue.content-renderer.js
@@ -5,135 +5,112 @@
 
 import Vue from 'vue-test';
 import contentRenderer from '../src/views/content-renderer';
+import { mount } from 'avoriaz';
 
 const ContentRendererComponent = Vue.extend(contentRenderer);
 import assert from 'assert';
 import sinon from 'sinon';
 
 describe('contentRenderer Component', function() {
-  beforeEach(function() {
-    this.kind = 'test';
-    this.files = [
-      {
-        available: true,
-        extension: 'tst',
-      },
-    ];
-    this.id = 'testing';
-  });
+  const defaultFiles = [
+    {
+      available: true,
+      extension: 'tst',
+    },
+  ];
+
   describe('computed property', function() {
+    function defaultPropsDataFromFiles(files) {
+      return {
+        id: 'testing',
+        kind: 'test',
+        files,
+      };
+    }
+
     describe('availableFiles', function() {
+      function testAvailableFiles(files, expected) {
+        const wrapper = mount(contentRenderer, {
+          propsData: defaultPropsDataFromFiles(files),
+        });
+        assert.equal(wrapper.vm.availableFiles.length, expected);
+      }
+
       it('should be 1 when there is one available file', function() {
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.availableFiles.length, 1);
+        testAvailableFiles(defaultFiles, 1);
       });
+
       it('should be 1 when there is one available file and a supplementary file', function() {
-        this.files.push({
+        const newFiles = defaultFiles.concat({
           available: true,
           supplementary: true,
           extension: 'vtt',
         });
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.availableFiles.length, 1);
+        testAvailableFiles(newFiles, 1);
       });
+
       it('should be 1 when there is one available file and a thumbnail file', function() {
-        this.files.push({
+        const newFiles = defaultFiles.concat({
           available: true,
           thumbnail: true,
           extension: 'vtt',
         });
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.availableFiles.length, 1);
+        testAvailableFiles(newFiles, 1);
       });
+
       it('should be 2 when there are two available files', function() {
-        this.files.push({
+        const newFiles = defaultFiles.concat({
           available: true,
           extension: 'vtt',
         });
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.availableFiles.length, 2);
+        testAvailableFiles(newFiles, 2);
       });
     });
+
     describe('defaultFile', function() {
+      function testDefaultFile(files, expected) {
+        const wrapper = mount(contentRenderer, {
+          propsData: defaultPropsDataFromFiles(files),
+        });
+        assert.equal(wrapper.vm.defaultFile, expected);
+      }
+
       it('should be the file when there is one available file', function() {
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.defaultFile, this.files[0]);
+        testDefaultFile(defaultFiles, defaultFiles[0]);
       });
+
       it('should be undefined when there are no available files', function() {
-        this.files = [];
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(typeof this.vm.defaultFile, 'undefined');
+        testDefaultFile([], undefined);
       });
     });
+
     describe('extension', function() {
+      function testExtension(files, expected) {
+        const wrapper = mount(contentRenderer, {
+          propsData: defaultPropsDataFromFiles(files),
+        });
+        assert.equal(wrapper.vm.extension, expected);
+      }
+
       it("should be the file's extension when there is one available file", function() {
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(this.vm.extension, this.files[0].extension);
+        testExtension(defaultFiles, defaultFiles[0].extension);
       });
+
       it('should be undefined when there are no available files', function() {
-        this.files = [];
-        this.vm = new ContentRendererComponent({
-          propsData: {
-            id: this.id,
-            kind: this.kind,
-            files: this.files,
-          },
-        }).$mount();
-        assert.equal(typeof this.vm.extension, 'undefined');
+        testExtension([], undefined);
       });
     });
   });
+
   describe('method', function() {
     describe('updateRendererComponent', function() {
       describe('when content is available', function() {
         beforeEach(function() {
           this.vm = new ContentRendererComponent({
             propsData: {
-              id: this.id,
-              kind: this.kind,
-              files: this.files,
+              id: 'test',
+              kind: 'test',
+              files: defaultFiles,
             },
           }).$mount();
           this.vm.available = true;
@@ -179,9 +156,9 @@ describe('contentRenderer Component', function() {
         beforeEach(function() {
           this.vm = new ContentRendererComponent({
             propsData: {
-              id: this.id,
-              kind: this.kind,
-              files: this.files,
+              id: 'testing',
+              kind: 'test',
+              files: defaultFiles,
             },
           }).$mount();
         });

--- a/kolibri/core/assets/test/vue.content-renderer.js
+++ b/kolibri/core/assets/test/vue.content-renderer.js
@@ -1,17 +1,11 @@
 /* eslint-env mocha */
-// The following two rules are disabled so that we can use anonymous functions with mocha
-// This allows the test instance to be properly referenced with `this`
-/* eslint prefer-arrow-callback: "off", func-names: "off" */
-
 import Vue from 'vue-test';
 import contentRenderer from '../src/views/content-renderer';
 import { mount } from 'avoriaz';
-
-const ContentRendererComponent = Vue.extend(contentRenderer);
 import assert from 'assert';
 import sinon from 'sinon';
 
-describe('contentRenderer Component', function() {
+describe('contentRenderer Component', () => {
   const defaultFiles = [
     {
       available: true,
@@ -27,9 +21,9 @@ describe('contentRenderer Component', function() {
     };
   }
 
-  describe('computed property', function() {
+  describe('computed property', () => {
 
-    describe('availableFiles', function() {
+    describe('availableFiles', () => {
       function testAvailableFiles(files, expected) {
         const wrapper = mount(contentRenderer, {
           propsData: defaultPropsDataFromFiles(files),
@@ -37,11 +31,11 @@ describe('contentRenderer Component', function() {
         assert.equal(wrapper.vm.availableFiles.length, expected);
       }
 
-      it('should be 1 when there is one available file', function() {
+      it('should be 1 when there is one available file', () => {
         testAvailableFiles(defaultFiles, 1);
       });
 
-      it('should be 1 when there is one available file and a supplementary file', function() {
+      it('should be 1 when there is one available file and a supplementary file', () => {
         const newFiles = defaultFiles.concat({
           available: true,
           supplementary: true,
@@ -50,7 +44,7 @@ describe('contentRenderer Component', function() {
         testAvailableFiles(newFiles, 1);
       });
 
-      it('should be 1 when there is one available file and a thumbnail file', function() {
+      it('should be 1 when there is one available file and a thumbnail file', () => {
         const newFiles = defaultFiles.concat({
           available: true,
           thumbnail: true,
@@ -59,7 +53,7 @@ describe('contentRenderer Component', function() {
         testAvailableFiles(newFiles, 1);
       });
 
-      it('should be 2 when there are two available files', function() {
+      it('should be 2 when there are two available files', () => {
         const newFiles = defaultFiles.concat({
           available: true,
           extension: 'vtt',
@@ -68,7 +62,7 @@ describe('contentRenderer Component', function() {
       });
     });
 
-    describe('defaultFile', function() {
+    describe('defaultFile', () => {
       function testDefaultFile(files, expected) {
         const wrapper = mount(contentRenderer, {
           propsData: defaultPropsDataFromFiles(files),
@@ -76,16 +70,16 @@ describe('contentRenderer Component', function() {
         assert.equal(wrapper.vm.defaultFile, expected);
       }
 
-      it('should be the file when there is one available file', function() {
+      it('should be the file when there is one available file', () => {
         testDefaultFile(defaultFiles, defaultFiles[0]);
       });
 
-      it('should be undefined when there are no available files', function() {
+      it('should be undefined when there are no available files', () => {
         testDefaultFile([], undefined);
       });
     });
 
-    describe('extension', function() {
+    describe('extension', () => {
       function testExtension(files, expected) {
         const wrapper = mount(contentRenderer, {
           propsData: defaultPropsDataFromFiles(files),
@@ -93,42 +87,24 @@ describe('contentRenderer Component', function() {
         assert.equal(wrapper.vm.extension, expected);
       }
 
-      it("should be the file's extension when there is one available file", function() {
+      it("should be the file's extension when there is one available file", () => {
         testExtension(defaultFiles, defaultFiles[0].extension);
       });
 
-      it('should be undefined when there are no available files', function() {
+      it('should be undefined when there are no available files', () => {
         testExtension([], undefined);
       });
     });
   });
 
-  describe('method', function() {
-    describe('updateRendererComponent', function() {
-      describe('when content is available', function() {
-
-        beforeEach(function() {
-          // this.vm = new ContentRendererComponent({
-          //   propsData: {
-          //     id: 'test',
-          //     kind: 'test',
-          //     files: defaultFiles,
-          //   },
-          // }).$mount();
-          // this.vm.available = true;
-          this.component = { test: 'testing' };
-          this.initSessionSpy = sinon.stub();
-          this.initSessionSpy.returns(Promise.resolve({}));
-          // this.vm.initSession = this.initSessionSpy;
-          // this.vm.Kolibri = {
-          //   retrieveContentRenderer: () => Promise.resolve(this.component),
-          // };
-        });
-
+  describe('method', () => {
+    describe('updateRendererComponent', () => {
+      describe('when content is available', () => {
         describe('when renderer is available', () => {
+          const dummyComponent = { test: 'testing' };
           before(() => {
             Vue.prototype.Kolibri = {
-              retrieveContentRenderer: () => Promise.resolve({ test: 'testing' }),
+              retrieveContentRenderer: () => Promise.resolve(dummyComponent),
             }
           });
 
@@ -136,7 +112,7 @@ describe('contentRenderer Component', function() {
             Vue.prototype.Kolibri = {};
           });
 
-          it('should set currentViewClass to returned component', function() {
+          it('should set currentViewClass to returned component', () => {
             const props = Object.assign(defaultPropsDataFromFiles(), {
               available: true,
             });
@@ -145,11 +121,11 @@ describe('contentRenderer Component', function() {
             });
             return Vue.nextTick()
             .then(() => {
-              assert.deepEqual(wrapper.vm.currentViewClass, this.component);
+              assert.deepEqual(wrapper.vm.currentViewClass, dummyComponent);
             });
           });
 
-          it('should call initSession', function() {
+          it('should call initSession', () => {
             const props = Object.assign(defaultPropsDataFromFiles(), {
               available: true,
               initSession: sinon.stub().returns(Promise.resolve()),
@@ -164,7 +140,7 @@ describe('contentRenderer Component', function() {
           });
         })
 
-        describe.only('when no renderer is available', function() {
+        describe('when no renderer is available', () => {
           before(() => {
             Vue.prototype.Kolibri = {
               retrieveContentRenderer: () => Promise.reject({ message: 'oh no' }),
@@ -175,7 +151,7 @@ describe('contentRenderer Component', function() {
             Vue.prototype.Kolibri = {};
           });
 
-          it('calling updateRendererComponent should set noRendererAvailable to true', function() {
+          it('calling updateRendererComponent should set noRendererAvailable to true', () => {
             const props = Object.assign(defaultPropsDataFromFiles(), {
               available: true,
             });

--- a/kolibri/core/assets/test/vue.progress-bar.js
+++ b/kolibri/core/assets/test/vue.progress-bar.js
@@ -1,12 +1,13 @@
 /* eslint-env mocha */
+import Vue from 'vue-test';
 import assert from 'assert';
 import { shallow } from 'avoriaz';
 import ProgressBar from '../src/views/progress-bar';
 
 function testProgressBar(wrapper, expected) {
   const { text, width } = expected;
-  assert.equal(wrapper.first('.progress-bar-complete').text(), text);
-  assert(wrapper.first('.progress-bar-text').hasStyle('width', width));
+  assert.equal(wrapper.first('.progress-bar-text').text(), text);
+  assert(wrapper.first('.progress-bar-complete').hasStyle('width', width));
 }
 
 describe('ProgressBar Component', () => {

--- a/kolibri/core/assets/test/vue.progress-bar.js
+++ b/kolibri/core/assets/test/vue.progress-bar.js
@@ -1,35 +1,49 @@
 /* eslint-env mocha */
-import Vue from 'vue-test';
 import assert from 'assert';
-import progressBar from '../src/views/progress-bar';
+import { shallow } from 'avoriaz';
+import ProgressBar from '../src/views/progress-bar';
 
-const ProgressBarComponent = Vue.extend(progressBar);
+function testProgressBar(wrapper, expected) {
+  const { text, width } = expected;
+  assert.equal(wrapper.first('.progress-bar-complete').text(), text);
+  assert(wrapper.first('.progress-bar-text').hasStyle('width', width));
+}
 
-describe('progressBar Component', () => {
-  describe('`percent` computed property', () => {
-    let vm;
-    beforeEach(() => {
-      vm = new ProgressBarComponent({
-        propsData: {
-          progress: 0,
-        },
-      }).$mount();
+describe('ProgressBar Component', () => {
+  it('should give 0 percent for progress of < 0', () => {
+    const wrapper = shallow(ProgressBar, {
+      propsData: {
+        progress: -0.0000001,
+      },
     });
-    it('should give 0 percent for progress of < 0', () => {
-      vm.progress = -0.0000000001;
-      assert.equal(vm.percent, 0);
+    // The negative still shows up...
+    testProgressBar(wrapper, { text: '-0%', width: '0%' });
+  });
+
+  it('should give 10 percent for progress of 0.1', () => {
+    const wrapper = shallow(ProgressBar, {
+      propsData: {
+        progress: 0.1,
+      },
     });
-    it('should give 10 percent for progress of 0.1', () => {
-      vm.progress = 0.1;
-      assert.equal(vm.percent, 10);
+    testProgressBar(wrapper, { text: '10%', width: '10%' });
+  });
+
+  it('should give 100 percent for progress of 1.0', () => {
+    const wrapper = shallow(ProgressBar, {
+      propsData: {
+        progress: 1.0,
+      },
     });
-    it('should give 100 percent for progress of 1.0', () => {
-      vm.progress = 1.0;
-      assert.equal(vm.percent, 100);
+    testProgressBar(wrapper, { text: '100%', width: '100%' });
+  });
+
+  it('should give 100 percent for progress of > 1.0', () => {
+    const wrapper = shallow(ProgressBar, {
+      propsData: {
+        progress: 1.0000001,
+      },
     });
-    it('should give 100 percent for progress of > 1.0', () => {
-      vm.progress = 1.0000000001;
-      assert.equal(vm.percent, 100);
-    });
+    testProgressBar(wrapper, { text: '100%', width: '100%' });
   });
 });

--- a/kolibri/core/assets/test/vue.progress-icon.js
+++ b/kolibri/core/assets/test/vue.progress-icon.js
@@ -1,57 +1,54 @@
 /* eslint-env mocha */
-// The following two rules are disabled so that we can use anonymous functions with mocha
-// This allows the test instance to be properly referenced with `this`
-/* eslint prefer-arrow-callback: "off", func-names: "off" */
-
 import Vue from 'vue-test';
-import progressIcon from '../src/views/progress-icon';
-
-const ProgressIconComponent = Vue.extend(progressIcon);
+import ProgressIcon from '../src/views/progress-icon';
+import { mount } from 'avoriaz';
+import UiTooltip from 'keen-ui/src/UiTooltip';
+import UiIcon from 'keen-ui/src/UiIcon';
 import assert from 'assert';
 
-describe('progressIcon Component', function() {
-  describe('computed property', function() {
-    describe('isInProgress', function() {
-      beforeEach(function() {
-        this.vm = new ProgressIconComponent().$mount();
-      });
-      it('should be false for progress of < 0', function() {
-        this.vm.progress = -1.0;
-        assert.equal(this.vm.isInProgress, false);
-      });
-      it('should be true for progress of 0.1', function() {
-        this.vm.progress = 0.1;
-        assert.equal(this.vm.isInProgress, true);
-      });
-      it('should be false for progress of 1.0', function() {
-        this.vm.progress = 1.0;
-        assert.equal(this.vm.isInProgress, false);
-      });
-      it('should be false for progress of > 1.0', function() {
-        this.vm.progress = 2.0;
-        assert.equal(this.vm.isInProgress, false);
-      });
+function testIcon(wrapper, expected) {
+  const { iconType, text } = expected;
+  assert.equal(wrapper.first(UiIcon).getProp('icon'), iconType);
+  assert.equal(wrapper.first(UiTooltip).text().trim(), text);
+}
+
+describe('ProgressIcon Component', () => {
+  it('should be empty when progress is < 0', () => {
+    const wrapper = mount(ProgressIcon, {
+      propsData: {
+        // Causes a validation error
+        progress: -1.0,
+      },
     });
-    describe('isCompleted', function() {
-      beforeEach(function() {
-        this.vm = new ProgressIconComponent().$mount();
-      });
-      it('should be false for progress of < 0', function() {
-        this.vm.progress = -1.0;
-        assert.equal(this.vm.isCompleted, false);
-      });
-      it('should be false for progress of 0.1', function() {
-        this.vm.progress = 0.1;
-        assert.equal(this.vm.isCompleted, false);
-      });
-      it('should be true for progress of 1.0', function() {
-        this.vm.progress = 1.0;
-        assert.equal(this.vm.isCompleted, true);
-      });
-      it('should be true for progress of > 1.0', function() {
-        this.vm.progress = 2.0;
-        assert.equal(this.vm.isCompleted, true);
-      });
+    const tooltip = wrapper.first(UiTooltip);
+    assert.equal(wrapper.contains(UiIcon), false);
+    // Tooltip is still around, just nothing to trigger it.
+    assert.equal(tooltip.text().trim(), 'Completed');
+  });
+
+  it('it should show an in-progress icon when progress is between 0 and 1', () => {
+    const wrapper = mount(ProgressIcon, { propsData: {
+        progress: 0.1,
+      },
     });
+    testIcon(wrapper, { iconType: 'schedule', text: 'In progress' });
+  });
+
+  it('it should show a completed icon when progress is exactly 1', () => {
+    const wrapper = mount(ProgressIcon, {
+      propsData: {
+        progress: 1.0,
+      },
+    });
+    testIcon(wrapper, { iconType: 'star', text: 'Completed' });
+  });
+
+  it('it should show a completed icon when progress is greater than 1', () => {
+    const wrapper = mount(ProgressIcon, {
+      propsData: {
+        progress: 2.0,
+      },
+    });
+    testIcon(wrapper, { iconType: 'star', text: 'Completed' });
   });
 });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.7.2",
+    "avoriaz": "^6.0.0",
     "buble": "0.15.2",
     "buble-loader": "0.4.0",
     "colors": "1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,6 +279,13 @@ autosize@^3.0.20:
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/autosize/-/autosize-3.0.20.tgz#e343ea7c5603834738169420f0349dc953e62a9e"
 
+avoriaz@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/avoriaz/-/avoriaz-6.0.0.tgz#5e994efe34961979b2161b183807d13f35eaba21"
+  dependencies:
+    lodash "^4.17.4"
+    vue-add-globals "^2.0.0"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -5708,6 +5715,10 @@ vm-browserify@0.0.4:
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+vue-add-globals@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vue-add-globals/-/vue-add-globals-2.0.1.tgz#c9fba6faac44f679ec15d5a9637f518b181fc44d"
 
 vue-eslint-parser@^1.1.0-7:
   version "1.1.0-7"


### PR DESCRIPTION
This adds the 'avoriaz' testing utility to dev dependencies and improves on the progress-bar tests using it.

Instead of just inspecting the view model's attributes, it actually checks the DOM in terms of the width of the progress bar, plus the text. It actually caught a bug with negative values (which wasn't fixed, just encoded in the test).

Update:

* Rewrote test for progress-icon
* Rewrote test for content-renderer