### PR TITLE
switch from https to http

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -137,7 +137,7 @@ if not os.path.exists(CONTENT_STORAGE_DIR):
     os.makedirs(CONTENT_STORAGE_DIR)
 
 # Base default URL for downloading content from an online server
-CENTRAL_CONTENT_DOWNLOAD_BASE_URL = "https://contentworkshop.learningequality.org"
+CENTRAL_CONTENT_DOWNLOAD_BASE_URL = "http://contentworkshop.learningequality.org"
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/


### PR DESCRIPTION

re #2324

It would be much better to use HTTPS to protect users' privacy when downloading content. However currently we don't have an effective solution for providing cryptography using pure Python.

It [sounds like there may be a solution](https://github.com/learningequality/kolibri/issues/2324#issuecomment-333602777), so filed a new issue for this: #2338

