### PR TITLE
Only cache for pure parent queries.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -38,7 +38,8 @@ class ContentNodeFilter(filters.FilterSet):
 
     class Meta:
         model = models.ContentNode
-        fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related', 'recommendations_for', 'ids', 'content_id']
+        fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related',
+                  'recommendations_for', 'next_steps', 'popular', 'resume', 'ids', 'content_id', 'kind']
 
     def title_description_filter(self, queryset, value):
         """

--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -158,6 +158,27 @@
   },
   {
     "fields": {
+      "license_owner": "",
+      "parent": "b391bfeec8a458f89f013cf1ca9cf33a",
+      "title": "c3c1",
+      "license": 2,
+      "tags": [],
+      "kind": "topic",
+      "content_id": "f2332710c2fd483386cdeb5dcbdda81f",
+      "tree_id": 1,
+      "rght": 10,
+      "description": "balbla5",
+      "available": false,
+      "lft": 9,
+      "sort_order": null,
+      "level": 2,
+      "author": ""
+    },
+    "pk": "c391bfeec8a458f89f013cf1ca9cf33a",
+    "model": "content.contentnode"
+  },
+  {
+    "fields": {
       "lang_code": "en",
       "lang_subcode": "01"
     },

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -82,9 +82,17 @@ class ContentNodeListSerializer(serializers.ListSerializer):
         # so, first get a queryset from the Manager if needed
         data = data.all() if isinstance(data, Manager) else data
 
+        # initialize cache key
         cache_key = None
+
+        # ensure that we are filtering by the parent only
+        # this allows us to only cache results on the learn page
+        from .api import ContentNodeFilter
+        pure_parent_query = "parent" in self.context['request'].GET and \
+            not any(field in self.context['request'].GET for field in ContentNodeFilter.Meta.fields if field != "parent")
+
         # Cache parent look ups only
-        if "parent" in self.context['request'].GET:
+        if pure_parent_query:
             cache_key = 'contentnode_list_{db}_{parent}'.format(
                 db=get_active_content_database(),
                 parent=self.context['request'].GET.get('parent'))
@@ -112,7 +120,7 @@ class ContentNodeListSerializer(serializers.ListSerializer):
         # This has the happy side effect of not caching our dynamically calculated
         # recommendation queries, which might change for the same user over time
         # because they do not return topics
-        if topic_only and cache_key:
+        if topic_only and pure_parent_query:
             cache.set(cache_key, result, 60 * 10)
 
         return result

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -2,10 +2,12 @@
 To run this test, type this in command line <kolibri manage test -- kolibri.content>
 """
 import datetime
+import mock
 import os
 import shutil
 import tempfile
 from django.test import TestCase
+from django.core.cache import cache
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.db import connections
@@ -114,8 +116,8 @@ class ContentNodeTestCase(TestCase):
     def test_descendants_of_kind(self):
 
         p = content.ContentNode.objects.get(title="root")
-        expected_output = content.ContentNode.objects.filter(title__in=["c2"])
-        actual_output = p.get_descendants(include_self=False).filter(kind=content_kinds.TOPIC)
+        expected_output = content.ContentNode.objects.filter(title__in=["c1"])
+        actual_output = p.get_descendants(include_self=False).filter(kind=content_kinds.VIDEO)
         self.assertEqual(set(expected_output), set(actual_output))
 
     def test_get_top_level_topics(self):
@@ -252,8 +254,10 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['title'], 'c2')
 
     def test_contentnode_list(self):
+        root = content.ContentNode.objects.get(title="root")
+        expected_output = root.get_descendants(include_self=True).count()
         response = self.client.get(self._reverse_channel_url("contentnode-list"))
-        self.assertEqual(len(response.data), 6)
+        self.assertEqual(len(response.data), expected_output)
 
     def test_contentnode_retrieve(self):
         c1_id = content.ContentNode.objects.get(title="c1").id
@@ -332,10 +336,30 @@ class ContentNodeAPITestCase(APITestCase):
         assert_progress(c2, None)
         assert_progress(c2c1, 0.7)
 
+    @mock.patch.object(cache, 'set')
+    def test_parent_query_cache_is_set(self, mock_cache_set):
+        id = content.ContentNode.objects.get(title="c2c3").id
+        self.client.get(self._reverse_channel_url("contentnode-list"), data={"parent": id})
+        self.assertTrue(mock_cache_set.called)
+
+    @mock.patch.object(cache, 'set')
+    def test_parent_query_cache_not_set(self, mock_cache_set):
+        id = content.ContentNode.objects.get(title="c2c3").id
+        self.client.get(self._reverse_channel_url("contentnode-list"), data={"parent": id, 'kind': content_kinds.EXERCISE})
+        self.assertFalse(mock_cache_set.called)
+
+    def test_parent_query_cache_hit(self):
+        id = content.ContentNode.objects.get(title="c2c3").id
+        self.client.get(self._reverse_channel_url("contentnode-list"), data={"parent": id})
+        with mock.patch.object(cache, 'set') as mock_cache_set:
+            self.client.get(self._reverse_channel_url("contentnode-list"), data={"parent": id})
+            self.assertFalse(mock_cache_set.called)
+
     def tearDown(self):
         """
         clean up files/folders created during the test
         """
         # set the active content database to None now that the test is over
         set_active_content_database(None)
+        cache.clear()
         super(ContentNodeAPITestCase, self).tearDown()


### PR DESCRIPTION
## Summary

We check the query parameters against the list of available filters for a `ContentNode`, and if `parent` is the only param in the request, then we cache the results.

## TODO

- [x] Have tests been written for the new code?

## Issues addressed

Solves https://github.com/learningequality/kolibri/issues/2086