### PR TITLE
Add unit tests for learn breadcrumbs component; refactored

### DIFF
--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const webpack_config = _.clone(require('../frontend_build/src/webpack.config.base'));
 const path = require('path');
 const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 webpack_config.plugins.push(
   new webpack.DefinePlugin({
@@ -12,7 +13,10 @@ webpack_config.plugins.push(
     },
   })
 );
-webpack_config.devtool = '#inline-source-map';
+
+webpack_config.plugins.push(new ExtractTextPlugin("styles.css"));
+
+webpack_config.devtool = 'none';
 
 // html5media plugin requires this
 webpack_config.module.rules.push({
@@ -23,6 +27,8 @@ webpack_config.module.rules.push({
     },
   ],
 });
+
+webpack_config.stats = 'none';
 
 const aliases = require('../frontend_build/src/apiSpecExportTools').coreAliases();
 aliases.testUtils = path.resolve(__dirname, './testUtils');

--- a/kolibri/plugins/learn/assets/src/state/getters.js
+++ b/kolibri/plugins/learn/assets/src/state/getters.js
@@ -1,24 +1,23 @@
-import * as constants from '../constants';
+import { PageNames, PageModes } from '../constants';
 
-function pageMode(state) {
+export function pageMode(state) {
   const topicsPages = [
-    constants.PageNames.TOPICS_ROOT,
-    constants.PageNames.TOPICS_CHANNEL,
-    constants.PageNames.TOPICS_TOPIC,
-    constants.PageNames.TOPICS_CONTENT,
+    PageNames.TOPICS_ROOT,
+    PageNames.TOPICS_CHANNEL,
+    PageNames.TOPICS_TOPIC,
+    PageNames.TOPICS_CONTENT,
   ];
-  const learnPages = [constants.PageNames.RECOMMENDED, constants.PageNames.RECOMMENDED_CONTENT];
-  const examPages = [constants.PageNames.EXAM_LIST, constants.PageNames.EXAM];
-  if (topicsPages.some(page => page === state.pageName)) {
-    return constants.PageModes.TOPICS;
-  } else if (learnPages.some(page => page === state.pageName)) {
-    return constants.PageModes.RECOMMENDED;
-  } else if (constants.PageNames.SEARCH === state.pageName) {
-    return constants.PageModes.SEARCH;
-  } else if (examPages.some(page => page === state.pageName)) {
-    return constants.PageModes.EXAM;
+  const learnPages = [PageNames.RECOMMENDED, PageNames.RECOMMENDED_CONTENT];
+  const examPages = [PageNames.EXAM_LIST, PageNames.EXAM];
+  const pageNameMatches = page => page === state.pageName;
+  if (topicsPages.some(pageNameMatches)) {
+    return PageModes.TOPICS;
+  } else if (learnPages.some(pageNameMatches)) {
+    return PageModes.RECOMMENDED;
+  } else if (PageNames.SEARCH === state.pageName) {
+    return PageModes.SEARCH;
+  } else if (examPages.some(pageNameMatches)) {
+    return PageModes.EXAM;
   }
   return undefined;
 }
-
-export { pageMode };

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
@@ -1,16 +1,15 @@
 <template>
 
-  <k-breadcrumbs v-if="inLearn" :items="learnBreadcrumbs"/>
-  <k-breadcrumbs v-else-if="inTopics" :items="topicsBreadcrumbs"/>
+  <k-breadcrumbs v-if="inLearn" :items="learnBreadcrumbs" />
+  <k-breadcrumbs v-else-if="inTopics" :items="topicsBreadcrumbs" />
 
 </template>
 
 
 <script>
 
-  import { PageNames } from '../../constants';
-  import { PageModes } from '../../constants';
-  import * as getters from '../../state/getters';
+  import { PageNames, PageModes } from '../../constants';
+  import { pageMode } from '../../state/getters';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   export default {
     name: 'learnBreadcrumbs',
@@ -116,7 +115,7 @@
     vuex: {
       getters: {
         pageName: state => state.pageName,
-        pageMode: getters.pageMode,
+        pageMode,
         channelRootId: state => state.pageState.channel.root_id,
         channelTitle: state => state.pageState.channel.title,
         topicTitle: state => state.pageState.topic.title,

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
@@ -1,7 +1,9 @@
 <template>
 
-  <k-breadcrumbs v-if="inLearn" :items="learnBreadcrumbs" />
-  <k-breadcrumbs v-else-if="inTopics" :items="topicsBreadcrumbs" />
+  <div class="learn-breadcrumbs">
+    <k-breadcrumbs v-if="inLearn" :items="learnBreadcrumbs" />
+    <k-breadcrumbs v-else-if="inTopics" :items="topicsBreadcrumbs" />
+  </div>
 
 </template>
 
@@ -20,7 +22,7 @@
     components: { kBreadcrumbs },
     computed: {
       inLearn() {
-        return this.pageMode === PageModes.RECOMMENDED;
+        return this.pageMode === PageModes.RECOMMENDED && this.pageName !== PageNames.RECOMMENDED;
       },
       learnRootLink() {
         return { name: PageNames.RECOMMENDED };
@@ -38,7 +40,7 @@
         return crumbs;
       },
       inTopics() {
-        return this.pageMode === PageModes.TOPICS;
+        return this.pageMode === PageModes.TOPICS && this.pageName !== PageNames.TOPICS_ROOT;
       },
       inTopicsChannel() {
         return this.pageName === PageNames.TOPICS_CHANNEL;
@@ -116,11 +118,11 @@
       getters: {
         pageName: state => state.pageName,
         pageMode,
-        channelRootId: state => state.pageState.channel.root_id,
-        channelTitle: state => state.pageState.channel.title,
-        topicTitle: state => state.pageState.topic.title,
+        channelRootId: state => (state.pageState.channel || {}).root_id,
+        channelTitle: state => (state.pageState.channel || {}).title,
+        topicTitle: state => (state.pageState.topic || {}).title,
         topicCrumbs: state => (state.pageState.topic || {}).breadcrumbs || [],
-        contentTitle: state => state.pageState.content.title,
+        contentTitle: state => (state.pageState.content || {}).title,
         contentCrumbs: state => (state.pageState.content || {}).breadcrumbs || [],
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
@@ -24,20 +24,14 @@
       inLearn() {
         return this.pageMode === PageModes.RECOMMENDED && this.pageName !== PageNames.RECOMMENDED;
       },
-      learnRootLink() {
-        return { name: PageNames.RECOMMENDED };
-      },
       learnBreadcrumbs() {
-        const crumbs = [
+        return [
           {
             text: this.$tr('recommended'),
-            link: this.learnRootLink,
+            link: { name: PageNames.RECOMMENDED },
           },
+          { text: this.contentTitle },
         ];
-        if (this.pageName === PageNames.RECOMMENDED_CONTENT) {
-          crumbs.push({ text: this.contentTitle });
-        }
-        return crumbs;
       },
       inTopics() {
         return this.pageMode === PageModes.TOPICS && this.pageName !== PageNames.TOPICS_ROOT;
@@ -53,23 +47,11 @@
           },
         };
       },
-      topicsRootLink() {
-        return {
-          name: PageNames.TOPICS_ROOT,
-        };
-      },
       topicsBreadcrumbs() {
-        if (this.pageName === PageNames.TOPICS_ROOT) {
-          return [
-            {
-              text: this.$tr('channels'),
-            },
-          ];
-        }
         const crumbs = [
           {
             text: this.$tr('channels'),
-            link: this.topicsRootLink,
+            link: { name: PageNames.TOPICS_ROOT },
           },
         ];
         if (this.inTopicsChannel) {

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs/index.vue
@@ -24,6 +24,9 @@
       inLearn() {
         return this.pageMode === PageModes.RECOMMENDED && this.pageName !== PageNames.RECOMMENDED;
       },
+      inTopics() {
+        return this.pageMode === PageModes.TOPICS && this.pageName !== PageNames.TOPICS_ROOT;
+      },
       learnBreadcrumbs() {
         return [
           {
@@ -33,68 +36,64 @@
           { text: this.contentTitle },
         ];
       },
-      inTopics() {
-        return this.pageMode === PageModes.TOPICS && this.pageName !== PageNames.TOPICS_ROOT;
+      middleTopicBreadcrumbs() {
+        let crumbs = [];
+
+        // Channels have no previous topics
+        if (this.pageName === PageNames.TOPICS_CHANNEL) {
+          return crumbs;
+        }
+
+        // Link to top-level Channel
+        crumbs.push({
+          text: this.channelTitle,
+          link: {
+            name: PageNames.TOPICS_CHANNEL,
+            params: {
+              channel_id: this.channelRootId,
+            },
+          }
+        });
+
+        // Links to previous topics
+        if (this.pageName === PageNames.TOPICS_CONTENT) {
+          crumbs = [...crumbs, ...this.topicCrumbLinks(this.contentCrumbs)];
+        } else if (this.pageName === PageNames.TOPICS_TOPIC) {
+          crumbs = [...crumbs, ...this.topicCrumbLinks(this.topicCrumbs)];
+        }
+        return crumbs;
       },
-      inTopicsChannel() {
-        return this.pageName === PageNames.TOPICS_CHANNEL;
-      },
-      topicsChannelLink() {
-        return {
-          name: PageNames.TOPICS_CHANNEL,
-          params: {
-            channel_id: this.channelRootId,
-          },
-        };
+      lastTopicBreadcrumb() {
+        if (this.pageName === PageNames.TOPICS_CHANNEL) {
+          return { text: this.channelTitle };
+        } else if (this.pageName === PageNames.TOPICS_CONTENT) {
+          return { text: this.contentTitle };
+        } else if (this.pageName === PageNames.TOPICS_TOPIC) {
+          return { text: this.topicTitle };
+        }
       },
       topicsBreadcrumbs() {
-        const crumbs = [
+        return [
+          // All Channels Link
           {
             text: this.$tr('channels'),
             link: { name: PageNames.TOPICS_ROOT },
           },
+          ...this.middleTopicBreadcrumbs,
+          this.lastTopicBreadcrumb,
         ];
-        if (this.inTopicsChannel) {
-          crumbs.push({
-            text: this.channelTitle,
-          });
-          return crumbs;
-        }
-        crumbs.push({
-          text: this.channelTitle,
-          link: this.topicsChannelLink,
-        });
-        if (this.pageName === PageNames.TOPICS_CONTENT) {
-          this.contentCrumbs.forEach(crumb =>
-            crumbs.push({
-              text: crumb.title,
-              link: this.topicLink(crumb.id),
-            })
-          );
-          crumbs.push({ text: this.contentTitle });
-        } else {
-          this.topicCrumbs.forEach(crumb =>
-            crumbs.push({
-              text: crumb.title,
-              link: this.topicLink(crumb.id),
-            })
-          );
-          if (!this.inTopicsChannel) {
-            crumbs.push({ text: this.topicTitle });
-          }
-        }
-        return crumbs;
       },
     },
     methods: {
-      topicLink(topicId) {
-        return {
-          name: PageNames.TOPICS_TOPIC,
-          params: {
-            id: topicId,
+      topicCrumbLinks(crumbs) {
+        return crumbs.map(({ title, id }) => ({
+          text: title,
+          link: {
+            name: PageNames.TOPICS_TOPIC,
+            params: { id },
           },
-        };
-      },
+        }));
+      }
     },
     vuex: {
       getters: {

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -35,7 +35,7 @@
     </div>
 
     <div>
-      <breadcrumbs/>
+      <breadcrumbs />
       <component :is="currentPage"/>
     </div>
 

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -2,7 +2,7 @@
 
   <core-base :topLevelPageName="topLevelPageName" :appBarTitle="$tr('learnTitle')">
     <template slot="app-bar-actions">
-      <action-bar-search-box v-if="!isWithinSearchPage"/>
+      <action-bar-search-box v-if="!isWithinSearchPage" />
     </template>
 
     <div v-if="tabLinksAreVisible" class="k-navbar-links">
@@ -31,12 +31,12 @@
     </div>
 
     <div v-if="pointsAreVisible" class="points-wrapper">
-      <a class="points-link" href="/user"><total-points/></a>
+      <a class="points-link" href="/user"><total-points /></a>
     </div>
 
     <div>
       <breadcrumbs />
-      <component :is="currentPage"/>
+      <component :is="currentPage" />
     </div>
 
   </core-base>
@@ -47,7 +47,7 @@
 <script>
 
   import store from '../state/store';
-  import { PageNames, PageModes, RecommendedPages } from '../constants';
+  import { PageNames, RecommendedPages } from '../constants';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';

--- a/kolibri/plugins/learn/assets/test/util/makeStore.js
+++ b/kolibri/plugins/learn/assets/test/util/makeStore.js
@@ -6,7 +6,7 @@ import initialState from './initialState';
 
 Vue.use(Vuex);
 
-export default function makeStore(options) {
+export default function makeStore(options = {}) {
   const { pageName } = options;
   const state = cloneDeep(initialState);
   if (pageName) {

--- a/kolibri/plugins/learn/assets/test/util/makeStore.js
+++ b/kolibri/plugins/learn/assets/test/util/makeStore.js
@@ -6,9 +6,15 @@ import initialState from './initialState';
 
 Vue.use(Vuex);
 
-export default function makeStore() {
+export default function makeStore(options) {
+  const { pageName } = options;
+  const state = cloneDeep(initialState);
+  if (pageName) {
+    state.pageName = pageName;
+  }
+
   return new Vuex.Store({
     mutations,
-    state: cloneDeep(initialState),
+    state,
   });
 }

--- a/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
@@ -11,6 +11,19 @@ import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
 const router = new VueRouter({
   routes: [
     { path: '/recommended', name: PageNames.RECOMMENDED },
+    { path: '/channels', name: PageNames.TOPICS_ROOT },
+    {
+      path: '/topics/c/:id',
+      name: PageNames.TOPICS_CONTENT,
+    },
+    {
+      path: '/topics/t/:id',
+      name: PageNames.TOPICS_TOPIC,
+    },
+    {
+      path: '/topics/:id',
+      name: PageNames.TOPICS_CHANNEL,
+    },
   ],
 });
 
@@ -41,19 +54,95 @@ describe.only('learn page breadcrumbs', () => {
       };
       const wrapper = makeWrapper({ store });
       const { breadcrumbItems } = getElements(wrapper);
-      assert.equal(breadcrumbItems()[0].link.name, PageNames.RECOMMENDED);
+      const bcs = breadcrumbItems();
+      assert.equal(bcs.length, 2);
+      assert.equal(bcs[0].link.name, PageNames.RECOMMENDED);
       // Content Item has no link, just text
-      assert.equal(breadcrumbItems()[1].link, undefined);
-      assert.equal(breadcrumbItems()[1].text, 'Recommended Content Item');
+      assert.equal(bcs[1].link, undefined);
+      assert.equal(bcs[1].text, 'Recommended Content Item');
     });
   });
 
   describe('when in Topic Browsing mode', () => {
-    it('shows no breadcrumbs on topic root', () => {
+    it('shows no breadcrumbs on topics root (i.e. Channels)', () => {
       const store = makeStore({ pageName: PageNames.TOPICS_ROOT });
       const wrapper = makeWrapper({ store });
       const { breadcrumbs } = getElements(wrapper);
       assert.equal(breadcrumbs(), undefined);
+    });
+
+    it('shows correct breadcrumbs at a Channel', () => {
+      const store = makeStore({ pageName: PageNames.TOPICS_CHANNEL });
+      store.state.pageState.channel = {
+        title: 'Recommended Channel',
+      };
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbItems } = getElements(wrapper);
+      const bcs = breadcrumbItems();
+      assert.equal(bcs.length, 2);
+      assert.equal(bcs[0].link.name, PageNames.TOPICS_ROOT);
+      assert.equal(bcs[1].link, undefined);
+      assert.equal(bcs[1].text, 'Recommended Channel');
+    });
+
+    it('shows correct breadcrumbs at a non-Channel Topic', () => {
+      const store = makeStore({ pageName: PageNames.TOPICS_TOPIC });
+      store.state.pageState.channel = {
+        title: 'Another Recommended Channel',
+        root_id: 'another_channel',
+      };
+      store.state.pageState.topic = {
+        title: 'Recommended Topic',
+        breadcrumbs: [
+          { id: 'previous_topic', title: 'Previous Topic' },
+        ],
+      };
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbItems } = getElements(wrapper);
+      const bcs = breadcrumbItems();
+      assert.equal(bcs.length, 4);
+      // All Channels Link
+      assert.equal(bcs[0].link.name, PageNames.TOPICS_ROOT);
+      assert.equal(bcs[0].text, 'Channels');
+      // Parent Channel Link
+      assert.equal(bcs[1].link.name, PageNames.TOPICS_CHANNEL);
+      assert.equal(bcs[1].text, 'Another Recommended Channel');
+      // Previous Topic Link
+      assert.equal(bcs[2].link.name, PageNames.TOPICS_TOPIC);
+      assert.equal(bcs[2].text, 'Previous Topic');
+      // Topic
+      assert.equal(bcs[3].link, undefined);
+      assert.equal(bcs[3].text, 'Recommended Topic');
+    });
+
+    it('shows correct breadcrumbs at a Content Item', () => {
+      const store = makeStore({ pageName: PageNames.TOPICS_CONTENT });
+      store.state.pageState.channel = {
+        title: 'Another Recommended Channel',
+        root_id: 'another_channel',
+      };
+      store.state.pageState.content = {
+        title: 'Recommended Item',
+        breadcrumbs: [
+          { id: 'previous_topic', title: 'Previous Topic' },
+        ],
+      };
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbItems } = getElements(wrapper);
+      const bcs = breadcrumbItems();
+      assert.equal(bcs.length, 4);
+      // All Channels Link
+      assert.equal(bcs[0].link.name, PageNames.TOPICS_ROOT);
+      assert.equal(bcs[0].text, 'Channels');
+      // Channel Link
+      assert.equal(bcs[1].link.name, PageNames.TOPICS_CHANNEL);
+      assert.equal(bcs[1].text, 'Another Recommended Channel');
+      // Previous Topic link
+      assert.equal(bcs[2].link.name, PageNames.TOPICS_TOPIC);
+      assert.equal(bcs[2].text, 'Previous Topic');
+      // Content Item
+      assert.equal(bcs[3].link, undefined);
+      assert.equal(bcs[3].text, 'Recommended Item');
     });
   })
 });

--- a/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
@@ -1,0 +1,59 @@
+/* eslint-env mocha */
+import Vue from 'vue-test';
+import VueRouter from 'vue-router';
+import assert from 'assert';
+import Breadcrumbs from '../../src/views/breadcrumbs';
+import { mount } from 'avoriaz';
+import makeStore from '../util/makeStore';
+import { PageNames } from '../../src/constants';
+import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
+
+const router = new VueRouter({
+  routes: [
+    { path: '/recommended', name: PageNames.RECOMMENDED },
+  ],
+});
+
+function makeWrapper(options = {}) {
+  return mount(Breadcrumbs, Object.assign(options, { router }));
+}
+
+function getElements(wrapper) {
+  return {
+    breadcrumbs: () => wrapper.find(kBreadcrumbs)[0],
+    breadcrumbItems: () => wrapper.first(kBreadcrumbs).getProp('items'),
+  };
+}
+
+describe.only('learn page breadcrumbs', () => {
+  describe('when in Learn Page mode', () => {
+    it('shows no breadcrumbs on Recommended page', () => {
+      const store = makeStore({ pageName: PageNames.RECOMMENDED });
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbs } = getElements(wrapper);
+      assert.equal(breadcrumbs(), undefined);
+    });
+
+    it('shows correct breadcrumbs when on a Recommended Content Item', () => {
+      const store = makeStore({ pageName: PageNames.RECOMMENDED_CONTENT });
+      store.state.pageState.content = {
+        title: 'Recommended Content Item',
+      };
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbItems } = getElements(wrapper);
+      assert.equal(breadcrumbItems()[0].link.name, PageNames.RECOMMENDED);
+      // Content Item has no link, just text
+      assert.equal(breadcrumbItems()[1].link, undefined);
+      assert.equal(breadcrumbItems()[1].text, 'Recommended Content Item');
+    });
+  });
+
+  describe('when in Topic Browsing mode', () => {
+    it('shows no breadcrumbs on topic root', () => {
+      const store = makeStore({ pageName: PageNames.TOPICS_ROOT });
+      const wrapper = makeWrapper({ store });
+      const { breadcrumbs } = getElements(wrapper);
+      assert.equal(breadcrumbs(), undefined);
+    });
+  })
+});

--- a/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
@@ -21,7 +21,7 @@ const router = new VueRouter({
       name: PageNames.TOPICS_TOPIC,
     },
     {
-      path: '/topics/:id',
+      path: '/topics/:channel_id',
       name: PageNames.TOPICS_CHANNEL,
     },
   ],
@@ -38,7 +38,7 @@ function getElements(wrapper) {
   };
 }
 
-describe.only('learn page breadcrumbs', () => {
+describe('learn page breadcrumbs', () => {
   describe('when in Learn Page mode', () => {
     it('shows no breadcrumbs on Recommended page', () => {
       const store = makeStore({ pageName: PageNames.RECOMMENDED });
@@ -106,9 +106,11 @@ describe.only('learn page breadcrumbs', () => {
       assert.equal(bcs[0].text, 'Channels');
       // Parent Channel Link
       assert.equal(bcs[1].link.name, PageNames.TOPICS_CHANNEL);
+      assert.equal(bcs[1].link.params.channel_id, 'another_channel');
       assert.equal(bcs[1].text, 'Another Recommended Channel');
       // Previous Topic Link
       assert.equal(bcs[2].link.name, PageNames.TOPICS_TOPIC);
+      assert.equal(bcs[2].link.params.id, 'previous_topic');
       assert.equal(bcs[2].text, 'Previous Topic');
       // Topic
       assert.equal(bcs[3].link, undefined);
@@ -136,9 +138,11 @@ describe.only('learn page breadcrumbs', () => {
       assert.equal(bcs[0].text, 'Channels');
       // Channel Link
       assert.equal(bcs[1].link.name, PageNames.TOPICS_CHANNEL);
+      assert.equal(bcs[1].link.params.channel_id, 'another_channel');
       assert.equal(bcs[1].text, 'Another Recommended Channel');
       // Previous Topic link
       assert.equal(bcs[2].link.name, PageNames.TOPICS_TOPIC);
+      assert.equal(bcs[2].link.params.id, 'previous_topic');
       assert.equal(bcs[2].text, 'Previous Topic');
       // Content Item
       assert.equal(bcs[3].link, undefined);


### PR DESCRIPTION
After seeing runtimes errors in the learn-page index test stemming from this component, I wrote some unit tests, then refactored.

Main changes:

1. Breadcrumbs silently fail to render at `/learn/recommended` and `learn/topics` due to type-mismatch in `pageState`. Since this design seems intentional, changed logic to not to render `k-breadcrumbs` at all on these pages.
1. Made the other getters in the component default to Objects, to avoid errors when viewing in devtools.
1. Refactored `topicBreadcrumbs` computed property to hopefully clarify the intended sequence of breadcrumbs in the different contexts.
1. Other mechanical refactors.
1. Made some changes to test webpack config to get rid of some errors and speed things up a little.