### PR TITLE
Update perseus with hint button spacing fix.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.9rc14
-kolibri_exercise_perseus_plugin==0.6.15
+kolibri_exercise_perseus_plugin==0.6.18
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ca9e5b5868f7b7ffcf97e80eb7b0d059b4048a21.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

Brings in @christianmemije's fix for #2289.

Incidentally upgrades perseus renderer by three minor versions (one of which was released on 0.5, but not 0.4 previously).

Changeset: https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v0.6.15...v0.6.18

Changes are purely restricted to CSS.

The third minor version was added because I messed up and accidentally updated the Mathjax config file based on the Perseus renderer 0.7 branch.