### PR TITLE
Bump base version to 0.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Release Notes
 
 Changes are ordered reverse-chronologically.
 
+0.7 (unreleased)
+----------------
+
+ - (adding changes here)
+
+
 0.6
 ---
 

--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -6,7 +6,7 @@ from .utils.version import get_version
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 6, 0, 'alpha', 0)
+VERSION = (0, 7, 0, 'alpha', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION
## Summary

As per our release flow, final release version changes are committed to the repo.

This bumps develop to 0.7 which will be the next release from this branch.