### PR TITLE
Add channel-list-item component, reskin channels-grid

### DIFF
--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -50,6 +50,7 @@ module.exports = function(config) {
       // Detailed pattern to include a file. Similarly other options can be used
       { pattern: './node_modules/core-js/client/core.js', watched: false },
       'kolibri/**/assets/test/**/*.js',
+      'kolibri/**/assets/**/*.spec.js',
     ],
 
     // list of files to exclude
@@ -59,6 +60,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       'kolibri/**/assets/test/**/*.js': ['webpack', 'sourcemap'],
+      'kolibri/**/assets/**/*.spec.js': ['webpack', 'sourcemap'],
     },
 
     // test results reporter to use

--- a/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
@@ -1,0 +1,171 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import Vuex from 'vuex';
+import sinon from 'sinon';
+import assert from 'assert';
+import ChannelListItem from '../../views/manage-content-page/channel-list-item.vue';
+import { mount } from 'avoriaz';
+
+const defaultChannel = {
+  name: 'Channel Title',
+  version: 20,
+  description: 'An awesome channel',
+  total_file_size: 5000000000,
+  thumbnail: '',
+};
+
+function makeStore() {
+  return new Vuex.Store({
+    state: {
+      pageState: {}
+    },
+  });
+}
+
+function makeWrapper(options = {}) {
+  const { props = {}, store } = options;
+  const defaultProps = {
+    channel: defaultChannel,
+    mode: 'managing',
+  };
+  return mount(ChannelListItem, {
+    propsData: Object.assign(defaultProps, props),
+    store: store || makeStore(),
+  });
+}
+
+function getElements(wrapper) {
+  return {
+    resourcesSizeText: () => wrapper.first('.resources-size').text().trim(),
+    resourcesSize: () => wrapper.find('.resources-size'),
+    onDevice: () => wrapper.find('.on-device'),
+    deleteButton: () => wrapper.find('button[name="delete"]'),
+    selectButton: () => wrapper.find('button[name="select"]'),
+    title: () => wrapper.first('.title').text().trim(),
+    version: () => wrapper.first('.version').text().trim(),
+    description: () => wrapper.first('.description').text().trim(),
+    thumbnail: () => wrapper.first('.thumbnail'),
+  }
+}
+
+describe('channelListItem', () => {
+  describe('in either mode', () => {
+    it('shows the channel title, version, and description', () => {
+      const wrapper = makeWrapper();
+      const { title, version, description } = getElements(wrapper);
+      assert.equal(title(), 'Channel Title');
+      assert.equal(version(), 'Version 20');
+      assert.equal(description(), 'An awesome channel');
+    });
+
+    it('shows the thumbnail using encoded string', () => {
+      const wrapper = makeWrapper({
+        props: {
+          channel: Object.assign({}, defaultChannel, {
+            thumbnail: 'abcd1234',
+          }),
+        },
+      });
+      const { thumbnail } = getElements(wrapper);
+      const thumb = thumbnail();
+      assert.equal(thumb.first('img').getAttribute('src'), 'abcd1234');
+      assert(!thumb.contains('svg.default-icon'));
+    });
+
+    it('defaults to a material design icon if there is no thumbnail', () => {
+      const wrapper = makeWrapper();
+      const { thumbnail } = getElements(wrapper);
+      const thumb = thumbnail();
+      assert(thumb.contains('svg.default-icon'));
+      assert(!thumb.contains('img'));
+    });
+  });
+
+  describe('when in "managing" mode', () => {
+    it('shows the file size of the Resources', () => {
+      const wrapper = makeWrapper();
+      const { resourcesSizeText, onDevice } = getElements(wrapper);
+      assert.equal(resourcesSizeText(), '4 GB resources');
+      assert.deepEqual(onDevice(), []);
+    });
+
+    it('shows a delete button', () => {
+      const wrapper = makeWrapper();
+      const { deleteButton, selectButton } = getElements(wrapper);
+      assert(deleteButton()[0].is('button'));
+      // Select button is not shown
+      assert.deepEqual(selectButton(), []);
+    });
+
+    it('delete button is disabled when there are tasks in queue', () => {
+      const store = makeStore();
+      store.state.pageState.taskList = [{id: 'task_1'}]
+      const wrapper = makeWrapper({ store });
+      const { deleteButton } = getElements(wrapper);
+      assert.equal(deleteButton()[0].getAttribute('disabled'), 'disabled');
+    });
+
+    it('delete button is not disabled when there are no tasks in queue', () => {
+      const store = makeStore();
+      store.state.pageState.taskList = [];
+      const wrapper = makeWrapper({ store });
+      const { deleteButton } = getElements(wrapper);
+      assert.equal(deleteButton()[0].hasAttribute('disabled'), false);
+    });
+
+    it('clicking delete button triggers "clickdelete" event', () => {
+      const wrapper = makeWrapper();
+      const emitSpy = sinon.spy(wrapper.vm, '$emit');
+      const { deleteButton } = getElements(wrapper);
+      deleteButton()[0].trigger('click');
+      return wrapper.vm.$nextTick()
+      .then(() => {
+        sinon.assert.calledOnce(emitSpy);
+        sinon.assert.calledWith(emitSpy, 'clickdelete');
+      });
+    });
+  })
+
+  describe('when in "importing" mode', () => {
+    const defaultProps = {
+      mode: 'importing',
+      onDevice: true,
+    };
+
+    it('shows a select button', () => {
+      const wrapper = makeWrapper({ props: defaultProps });
+      const { deleteButton, selectButton } = getElements(wrapper);
+      assert(selectButton()[0].is('button'));
+      assert.deepEqual(deleteButton(), []);
+    });
+
+    it('clicking delete button triggers "clickselect" event', () => {
+      const wrapper = makeWrapper({ props: defaultProps });
+      const emitSpy = sinon.spy(wrapper.vm, '$emit');
+      const { selectButton } = getElements(wrapper);
+      selectButton()[0].trigger('click');
+      return wrapper.vm.$nextTick()
+      .then(() => {
+        sinon.assert.calledOnce(emitSpy);
+        sinon.assert.calledWith(emitSpy, 'clickselect');
+      });
+    });
+
+    it('shows the "on device" indicator if channel is installed', () => {
+      const wrapper = makeWrapper({ props: defaultProps });
+      const { onDevice, resourcesSize } = getElements(wrapper);
+      assert(onDevice()[0].is('div'));
+      assert.deepEqual(resourcesSize(), []);
+    });
+
+    it('does not show the "on device" indicator if channel is not installed', () => {
+      const props = Object.assign({}, defaultProps, {
+        onDevice: false,
+      });
+      const wrapper = makeWrapper({ props });
+      const { onDevice, resourcesSize } = getElements(wrapper);
+      assert.deepEqual(onDevice(), []);
+      assert.deepEqual(resourcesSize(), []);
+    });
+  })
+});

--- a/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
@@ -69,14 +69,14 @@ describe('channelListItem', () => {
       const { thumbnail } = getElements(wrapper);
       const thumb = thumbnail();
       assert.equal(thumb.first('img').getAttribute('src'), 'abcd1234');
-      assert(!thumb.contains('svg.default-icon'));
+      assert(!thumb.contains('svg'));
     });
 
     it('defaults to a material design icon if there is no thumbnail', () => {
       const wrapper = makeWrapper();
       const { thumbnail } = getElements(wrapper);
       const thumb = thumbnail();
-      assert(thumb.contains('svg.default-icon'));
+      assert(thumb.contains('svg'));
       assert(!thumb.contains('img'));
     });
   });

--- a/kolibri/plugins/management/assets/src/device_management/views/device-top-nav.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/device-top-nav.vue
@@ -4,7 +4,7 @@
     <k-navbar-link
       type="icon-and-title"
       :title="$tr('contentLabel')"
-      icon="view_module"
+      icon="apps"
       :link="linkify(PageNames.MANAGE_CONTENT_PAGE)"
     />
     <k-navbar-link

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
@@ -3,13 +3,10 @@
   <div class="channel-list-item">
 
     <div class="thumbnail dtc">
-      <mat-svg
-        v-if="channel.thumbnail === ''"
-        category="action"
-        name="view_module"
-        class="default-icon"
-      />
-      <img v-else :src="thumbnailImg" />
+      <img v-if="thumbnailImg" :src="thumbnailImg" />
+      <div v-else class="default-icon">
+        <mat-svg category="navigation" name="apps" />
+      </div>
     </div>
 
     <div class="details dtc">
@@ -101,10 +98,8 @@
         return this.channel.thumbnail;
       },
       tasksInQueue() {
-        if (this.pageState.taskList === undefined) {
-          return false;
-        }
-        return this.pageState.taskList.length > 0;
+        const { taskList = [] } = this.pageState;
+        return taskList.length > 0;
       },
     },
     vuex: {
@@ -154,6 +149,14 @@
     text-align: left
     img
       width: 100%
+
+  .default-icon
+    background-color: $core-grey
+    text-align: center
+    svg
+      width: 50%
+      height: 50%
+      margin: 20px
 
   .details
     width: 100%

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
@@ -1,0 +1,172 @@
+<template>
+
+  <div class="channel-list-item">
+
+    <div class="thumbnail dtc">
+      <mat-svg
+        v-if="channel.thumbnail === ''"
+        category="action"
+        name="view_module"
+        class="default-icon"
+      />
+      <img v-else :src="thumbnailImg" />
+    </div>
+
+    <div class="details dtc">
+
+      <div class="details-top">
+        <div class="other-details">
+          <div v-if="inImportingMode && onDevice" class="on-device">
+            <mat-svg category="action" name="check_circle" />
+            {{ $tr('onYourDevice') }}
+          </div>
+          <div v-if="inManagingMode" class="resources-size">
+            {{ resourcesSizeText }}
+          </div>
+        </div>
+        <div class="title">
+          {{ channel.name }}
+        </div>
+        <div class="version">
+          {{ $tr('version', { version: channel.version }) }}
+        </div>
+      </div>
+
+      <div class="details-bottom">
+        <div class="description">
+          {{ channel.description || $tr('defaultDescription') }}
+        </div>
+      </div>
+
+    </div>
+
+    <div class="buttons dtc">
+      <k-button
+        v-if="inImportingMode"
+        @click="$emit('clickselect')"
+        name="select"
+        :text="$tr('selectButton')"
+      />
+      <k-button
+        v-if="inManagingMode"
+        @click="$emit('clickdelete')"
+        name="delete"
+        :text="$tr('deleteButton')"
+        :disabled="tasksInQueue"
+      />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import bytesForHumans from './bytesForHumans';
+  import kButton from 'kolibri.coreVue.components.kButton';
+
+  const IMPORTING = 'importing';
+  const MANAGING = 'managing';
+
+  export default {
+    name: 'channelListItem',
+    components: {
+      kButton,
+    },
+    props: {
+      channel: {
+        type: Object,
+        required: true,
+      },
+      mode: {
+        type: String,
+        required: true,
+      },
+      onDevice: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      inImportingMode() {
+        return this.mode === IMPORTING;
+      },
+      inManagingMode() {
+        return this.mode === MANAGING;
+      },
+      resourcesSizeText() {
+        return this.$tr('resourcesSize', { size: bytesForHumans(this.channel.total_file_size) });
+      },
+      thumbnailImg() {
+        return this.channel.thumbnail;
+      },
+      tasksInQueue() {
+        if (this.pageState.taskList === undefined) {
+          return false;
+        }
+        return this.pageState.taskList.length > 0;
+      },
+    },
+    vuex: {
+      getters: {
+        pageState: ({ pageState }) => pageState,
+      },
+    },
+    $trs: {
+      deleteButton: 'Delete',
+      onYourDevice: 'On your device',
+      resourcesSize: '{size} resources',
+      selectButton: 'Select',
+      version: 'Version {version}',
+      defaultDescription: '(No description)',
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  .dtc
+    display: table-cell
+    vertical-align: inherit
+
+  .channel-list-item
+    display: table
+    vertical-align: middle
+
+  .title
+    font-size: 1.2em
+    font-weight: bold
+    line-height: 1.5em
+
+  .version
+    font-size: 0.85em
+    color: $core-text-annotation
+
+  .description
+    padding: 1em 0
+
+  .thumbnail
+    width: 10%
+    text-align: left
+    img
+      width: 100%
+
+  .details
+    width: 100%
+    position: relative
+    padding: 0 2em
+
+  .other-details
+    float: right
+    line-height: 1.7em
+
+  .buttons
+    width: 10%
+    text-align: right
+    vertical-align: baseline
+
+</style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -6,7 +6,7 @@
         {{ $tr('emptyChannelListMessage') }}
       </p>
 
-      <ui-progress-circular v-else-if="this.channelsLoading" :size="16" color="primary"/>
+      <ui-progress-linear v-else-if="this.channelsLoading" type="indefinite" color="primary"/>
 
       <div v-else>
         <div class="channel-list-header">
@@ -41,7 +41,7 @@
 
   import { refreshChannelList } from '../../state/actions/manageContentActions';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import uiProgressCircular from 'keen-ui/src/UiProgressCircular';
+  import uiProgressLinear from 'keen-ui/src/UiProgressLinear';
   import deleteChannelModal from './delete-channel-modal';
   import channelListItem from './channel-list-item';
   import { triggerChannelDeleteTask } from '../../state/actions/taskActions';
@@ -49,7 +49,7 @@
     name: 'channelsGrid',
     components: {
       channelListItem,
-      uiProgressCircular,
+      uiProgressLinear,
       deleteChannelModal,
       kButton,
     },

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -8,48 +8,22 @@
 
       <ui-progress-circular v-else-if="this.channelsLoading" :size="16" color="primary"/>
 
-      <table v-else class="table">
+      <div v-else>
+        <div class="channel-list-header">
+          {{ $tr('channelHeader') }}
+        </div>
 
-        <thead class="table-header">
-          <tr>
-            <th>{{ $tr('nameHeader') }}</th>
-            <th>{{ $tr('numResourcesHeader') }}</th>
-            <th>{{ $tr('sizeHeader') }}</th>
-            <th>{{ $tr('lastUpdatedHeader') }}</th>
-            <th></th>
-          </tr>
-        </thead>
+        <div class="channel-list">
+          <div class="channel-item-wrapper" v-for="channel in sortedChannels" :key="channel.id">
+            <channel-list-item
+              :channel="channel"
+              mode="managing"
+              @clickdelete="selectedChannelId=channel.id"
+            />
+          </div>
+        </div>
+      </div>
 
-        <tbody class="table-body">
-          <tr v-for="channel in sortedChannels" :key="channel.id">
-            <td>
-              <div>{{ channel.name }}</div>
-              <div class="channel-version">
-                {{ $tr('channelVersion', { versionNumber: channel.version }) }}
-              </div>
-            </td>
-
-            <td>
-              <span>{{ channel.total_resources }}</span>
-            </td>
-            <td>
-              <span>{{ bytesForHumans(channel.total_file_size) }}</span>
-            </td>
-            <td>
-              <elapsed-time :date="channel.last_updated" />
-            </td>
-            <td>
-              <k-button
-                @click="selectedChannelId=channel.id"
-                :raised="false"
-                :text="$tr('deleteButtonLabel')"
-                :disabled="tasksInQueue"
-              />
-            </td>
-          </tr>
-        </tbody>
-
-      </table>
     </transition>
 
     <delete-channel-modal
@@ -65,24 +39,22 @@
 
 <script>
 
-  import bytesForHumans from './bytesForHumans';
   import { refreshChannelList } from '../../state/actions/manageContentActions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiProgressCircular from 'keen-ui/src/UiProgressCircular';
   import deleteChannelModal from './delete-channel-modal';
-  import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
+  import channelListItem from './channel-list-item';
   import { triggerChannelDeleteTask } from '../../state/actions/taskActions';
   export default {
     name: 'channelsGrid',
     components: {
+      channelListItem,
       uiProgressCircular,
       deleteChannelModal,
-      elapsedTime,
       kButton,
     },
     data: () => ({
       selectedChannelId: null,
-      notification: null,
       channelsLoading: true,
     }),
     computed: {
@@ -112,15 +84,11 @@
           this.triggerChannelDeleteTask(channelId);
         }
       },
-      bytesForHumans(size) {
-        return size ? bytesForHumans(size) : '';
-      },
     },
     vuex: {
       getters: {
         channelList: state => state.pageState.channelList,
         pageState: state => state.pageState,
-        tasksInQueue: ({ pageState }) => pageState.taskList.length > 0,
       },
       actions: {
         triggerChannelDeleteTask,
@@ -129,12 +97,7 @@
     },
     $trs: {
       emptyChannelListMessage: 'No channels installed',
-      deleteButtonLabel: 'Delete',
-      lastUpdatedHeader: 'Last updated',
-      nameHeader: 'Channel',
-      numResourcesHeader: 'Resources',
-      sizeHeader: 'Size',
-      channelVersion: 'Version {versionNumber}',
+      channelHeader: 'Channel',
     },
   };
 
@@ -145,23 +108,15 @@
 
   @require '~kolibri.styles.definitions'
 
-  .table
-    text-align: left
-    width: 100%
-
-  .table-header
-    th
-      color: $core-text-annotation
-      font-weight: normal
-      font-size: 80%
-
-  .table-body
-    td
-      padding: 1rem 0
-
-  .channel-version
+  .channel-list-header
     font-size: 0.85em
-    line-height: 1.5em
+    padding: 1em 0
     color: $core-text-annotation
+
+  .channel-item-wrapper
+    padding: 2em 0
+    border-bottom: 1px solid $core-grey
+    &:first-of-type
+      border-top: 1px solid $core-grey
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/index.vue
@@ -3,7 +3,7 @@
   <div>
 
     <template v-if="canManageContent">
-      <component v-if="pageState.wizardState.shown" :is="wizardComponent"/>
+      <component v-if="pageState.wizardState.shown" :is="wizardComponent" />
 
       <subpage-container>
         <task-progress
@@ -13,7 +13,9 @@
         />
 
         <div class="table-title">
-          <h1 class="page-title">{{$tr('title')}}</h1>
+          <h1 class="page-title">
+            {{ $tr('title') }}
+          </h1>
           <div class="buttons" v-if="!tasksInQueue">
             <k-button
               :text="$tr('import')"
@@ -22,7 +24,7 @@
               :primary="true"
             />
             <k-button
-              v-show="deviceHasChannels"
+              v-if="deviceHasChannels"
               :text="$tr('export')"
               class="button"
               :primary="true"
@@ -31,9 +33,8 @@
           </div>
         </div>
 
-        <hr />
-
         <channels-grid />
+
       </subpage-container>
     </template>
 
@@ -76,7 +77,7 @@
   export default {
     name: 'manageContentPage',
     $trs: {
-      title: 'My channels',
+      title: 'Content',
       import: 'Import',
       export: 'Export',
       noAccessDetails:
@@ -161,14 +162,6 @@
 
   @require '~kolibri.styles.definitions'
 
-  // Padding height that separates rows from eachother
-  $row-padding = 1.5em
-  // height of elements in toolbar,  based off of icon-button height
-  $toolbar-height = 36px
-
-  .alert-bg
-    background-color: $core-bg-warning
-
   .table-title
     margin-top: 1em
     &:after
@@ -178,7 +171,6 @@
 
   .page-title
     float: left
-    margin: 0.2em
 
   .buttons
     float: right

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/drive-list.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/drive-list.vue
@@ -58,16 +58,21 @@
         required: true,
       },
     },
+    data() {
+      return {
+        selectedDrive: '',
+      };
+    },
     computed: {
-      selectedDrive() {
-        return this.value;
-      },
       enabledDrives() {
         return this.drives.filter(drive => this.enabledDrivePred(drive));
       },
       disabledDrives() {
         return this.drives.filter(drive => !this.enabledDrivePred(drive));
       },
+    },
+    mounted() {
+      this.selectedDrive = this.value;
     },
     methods: {
       enabledDriveLabel(drive) {


### PR DESCRIPTION
This adds a 'channel-list-item' component that is supposed to be used in different parts of the new import/export workflows. It is used initially to reskin the import/export landing page and will be used later for the import and export workflows. See tests for intended usage in other workflows.

Design: https://projects.invisionapp.com/share/Q9D1VQD67#/screens/254175259

![screen shot 2017-10-10 at 12 28 03 pm](https://user-images.githubusercontent.com/10248067/31406598-da17f48a-adb6-11e7-86b6-fcc2c3a5ba84.png)


