### PR TITLE
Don't prefetch on potentially massive queries

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -274,7 +274,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
 
     @list_route(methods=['get'])
     def all_content(self, request, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset()).exclude(kind=content_kinds.TOPIC)
+        queryset = self.filter_queryset(self.get_queryset(prefetch=False)).exclude(kind=content_kinds.TOPIC)
 
         serializer = self.get_serializer(queryset, many=True, limit=24)
         return Response(serializer.data)

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -174,6 +174,11 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"recommendations_for": id})
         self.assertEqual(len(response.data), 2)
 
+    def test_contentnode_allcontent(self):
+        nodes = content.ContentNode.objects.exclude(kind=content_kinds.TOPIC).count()
+        response = self.client.get(self._reverse_channel_url("contentnode-all-content"))
+        self.assertEqual(len(response.data), nodes)
+
     def test_channelmetadata_list(self):
         response = self.client.get(reverse("channel-list", kwargs={}))
         self.assertEqual(response.data[0]['name'], 'testing')


### PR DESCRIPTION
## Summary

Don't prefetch the all_content endpoint, because the prefetch will occur before the limit is applied.

Attempts to fix #2419

## TODO

- [X] Have tests been written for the new code?

Caveat - I wrote a test for this endpoint, because one didn't exist already, but the test I wrote to try to  catch the 'massive channel issue' that seems to cause #2419 did not fail on my local machine, and also took over a minute to run. In the interests of not unnecessarily bloating our test suite, I omit it here.