### PR TITLE
Simplify logging module interface to reduce risk of undefined this.

### DIFF
--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -99,5 +99,3 @@ class Logging {
 const logging = new Logging();
 
 export default logging;
-
-export const getLogger = (...args) => logging.getLogger(...args);

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -1,8 +1,8 @@
 import vue from 'kolibri.lib.vue';
-import { getLogger } from '../logging';
+import logger from '../logging';
 import importIntlLocale from './import-intl-locale';
 
-const logging = getLogger(__filename);
+const logging = logger.getLogger(__filename);
 
 function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
   if (args) {

--- a/kolibri/plugins/style_guide/assets/src/views/shell/component-docs.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/component-docs.vue
@@ -82,9 +82,9 @@
 
   import escodegen from 'escodegen';
   import CamelCase from 'lodash/camelCase';
-  import { getLogger } from 'kolibri.lib.logging';
+  import logger from 'kolibri.lib.logging';
 
-  const logging = getLogger(__filename);
+  const logging = logger.getLogger(__filename);
 
   export default {
     props: {


### PR DESCRIPTION
## Summary

Ensures logging should never have an undefined this in its getLogger method.