### PR TITLE
remove responsive behaviors from dropdown when there’s no icon

### DIFF
--- a/kolibri/core/assets/src/views/dropdown-menu/index.vue
+++ b/kolibri/core/assets/src/views/dropdown-menu/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <span v-if="windowSize.breakpoint > 2">
+    <span v-if="windowSize.breakpoint > 2 || !icon">
       <ui-button
         :disabled="disabled"
         :ariaLabel="name"


### PR DESCRIPTION

fixes #2434 by checking for icon existence before applying responsive behavior in the core dropdown component

This responsive behavior was unexpected, and should probably be turned off by default since it was specific to the needs of the Learn download button

Note that responsive behavior in the user management page is still really bad, but at least it's not entirely broken now
