### PR TITLE
Collapse channel name at higher breakpoint

### DIFF
--- a/kolibri/core/assets/src/views/dropdown-menu/index.vue
+++ b/kolibri/core/assets/src/views/dropdown-menu/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <span v-if="windowSize.breakpoint > 0">
+    <span v-if="inAppBar && windowSize.breakpoint > 1 || !inAppBar && windowSize.breakpoint > 0 ">
       <ui-button
         :ariaLabel="name"
         :type="type"

--- a/kolibri/plugins/learn/assets/src/views/total-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points/index.vue
@@ -4,7 +4,7 @@
     <div class="circle in-points">
       <points-icon class="icon" :active="true"/>
     </div>
-    <span class="total in-points">{{ $formatNumber(totalPoints) }}</span>
+    <span class="total in-points" v-if="windowSize.breakpoint > 0">{{ $formatNumber(totalPoints) }}</span>
     <ui-tooltip trigger="points" :position="'bottom right'" :openOn="'hover focus'">{{ $tr('totalPoints', { points: totalPoints }) }}</ui-tooltip>
   </div>
 
@@ -15,12 +15,14 @@
 
   const { totalPoints, currentUserId, isUserLoggedIn, isSuperuser } = require('kolibri.coreVue.vuex.getters');
   const { fetchPoints } = require('kolibri.coreVue.vuex.actions');
+  const responsiveWindow = require('kolibri.coreVue.mixins.responsiveWindow');
 
   module.exports = {
     $trNameSpace: 'totalPoints',
     $trs: {
       totalPoints: 'You have earned { points, number } points!',
     },
+    mixins: [responsiveWindow],
     components: {
       'points-icon': require('kolibri.coreVue.components.pointsIcon'),
       'ui-tooltip': require('keen-ui/src/UiTooltip'),


### PR DESCRIPTION
Not too proud of this. I tried to truncate the keen-ui button text but was unable to, due to it's structure. It was kind of possible, but the drop down icon would also get truncated.  I wouldn't consider this a responsive solution.   :rage4: 

![smh](https://user-images.githubusercontent.com/7193975/31568698-be293c4a-b02a-11e7-854c-dc322c662913.gif)
