### PR TITLE
update PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,12 +9,22 @@ description of what behavior was expected but did not occur
 
 ### User-facing consequences
 
-implications for a user of the application
+implications and real-world consequences for learners, coaches, admins, and other users of the application
 
 ### Errors and logs
 
+Relevant errors and tracebacks from:
+
+* the command line
+* `~/.kolibri/kolibri.log`
+* the browser console
+
 ```
-logs and errors here
+server logs
+```
+
+```
+browser console logs
 ```
 
 ### Steps to reproduce

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,31 +1,28 @@
-## Summary
 
-*Briefly describe the issue and please DELETE the non applicable headings below. *
+### Observed behavior
 
-## System information
+description of the behavior that was observed, including screenshots or other references when applicable
 
-*Please specify the Kolibri version you were using and your operating system!*
+### Expected behavior
 
- - Version: ?
- - Operating system: ?
- - Browser: ?
+description of what behavior was expected but did not occur
 
-## Traceback or relevant snippet from server.log or browser console
+### User-facing consequences
+
+implications for a user of the application
+
+### Errors and logs
 
 ```
-INSERT TRACEBACK, LOG MESSAGES ETC. HERE
+logs and errors here
 ```
 
-## How to reproduce
+### Steps to reproduce
 
-1. Steps
-1. To
-1. Reproduce
+precise steps that someone else can follow in order to see this behavior
 
-## Screenshots
+### Context
 
-*If applicable*
-
-## Real-life consequences (anything community should be aware of, for instance how it affects your deployment)
-
-*If applicable*
+* Kolibri version: ?
+* Operating system: ?
+* Browser: ?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,28 @@
-## Summary
 
-*Short description*
+# Checklist
 
-## TODO
+- [ ] Target milestone
+- [ ] New tests
+- [ ] Updated documentation
+- [ ] External dependency updates
+- [ ] Internal dependency updates (with link to diff)
+- [ ] Screenshots
+- [ ] Update to CHANGELOG.rst
+- [ ] Update to AUTHORS.rst
 
-- [ ] Have tests been written for the new code?
-- [ ] Has documentation been written/updated?
-- [ ] New dependencies (if any) added to requirements file
-- [ ] Add an entry to CHANGELOG.rst
-- [ ] Add yourself it AUTHORS.rst if you don't appear there
+# Details
 
-## Reviewer guidance
+### Summary
 
-*If you PR has a significant size, give the reviewer some helpful remarks*
+description of the change, including screenshots when applicable
 
-## Issues addressed
+### Reviewer guidance
 
-List the issues solved or partly solved by the PR
+description of how to test the changes
 
-## Documentation
+### References
 
-If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
-
-## Screenshots (if appropriate)
-
-They're nice. :)
+* related issues and PRs
+* related trello links
+* related mockups or specs
+* links to dependency updates

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,23 @@
 
 # Checklist
 
-- [ ] Target milestone
-- [ ] New tests
-- [ ] Updated documentation
-- [ ] External dependency updates
-- [ ] Internal dependency updates (with link to diff)
-- [ ] Screenshots
-- [ ] Update to CHANGELOG.rst
-- [ ] Update to AUTHORS.rst
+- [ ] PR has the correct target milestone when it's merged
+- [ ] Automated test coverage is satisfactory
+- [ ] PR has been fully tested manually
+- [ ] Documentation is updated as necessary
+- [ ] External dependency files are updated (`yarn` and `pip`)
+- [ ] If internal dependency are updated, link to diff is included
+- [ ] Screenshots of any front-end changes are in the PR description
+- [ ] CHANGELOG.rst is updated for high-level changes
+- [ ] You've added yourself to AUTHORS.rst if you're not there
 
 # Details
 
 ### Summary
 
-description of the change, including screenshots when applicable
+* description of the change
+* manual verification steps performed
+* screenshots if the PR affects the UI
 
 ### Reviewer guidance
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,8 @@ description of how to test the changes
 
 ### References
 
-* related issues and PRs
-* related trello links
-* related mockups or specs
-* links to dependency updates
+when applicable, please provide:
+
+* references to related issues and PRs
+* links to mockups or specs for new features
+* links to the diffs for dependency updates, e.g. in iceqube or the perseus plugin


### PR DESCRIPTION

# Checklist

- [x] Target milestone
- [ ] New tests
- [ ] Updated documentation
- [ ] External dependency updates
- [ ] Internal dependency updates (with link to diff)
- [ ] Screenshots
- [ ] Update to CHANGELOG.rst
- [ ] Update to AUTHORS.rst

# Details

Attempting to clean up the github PR and issue templates a bit.

* made the language more concise
* added 'milestone' and 'link to external dependency diffs' to the PR checklist
* added a bit more guidance regarding observed versus expected behaviors to the issue templates


