### PR TITLE
pin 0.3.x VF to a tag instead of a commit hash

### DIFF
--- a/requirements/vf.txt
+++ b/requirements/vf.txt
@@ -1,3 +1,3 @@
 -r base.txt
 
-https://github.com/fle-internal/kolibri-instant-schools-plugin/archive/0513e7d90b81aa004c7e296d46e7065ab760cdd1.zip#egg=kolibri_instant_schools_plugin
+https://github.com/fle-internal/kolibri-instant-schools-plugin/archive/v0.3.0.zip#egg=kolibri_instant_schools_plugin


### PR DESCRIPTION

https://github.com/fle-internal/kolibri-instant-schools-plugin/releases/tag/v0.3.0
