### PR TITLE
sets Kolibri v0.7.0 to track the develop branch of the windows installer

### DIFF
--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 PARENT_PATH=$(pwd)
 KOLIBRI_DOCKER_PATH="$PARENT_PATH/windows_installer_docker_build"
-KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installers/windows"
+KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installers-windows/windows"
 
 mkdir dist
 buildkite-agent artifact download 'dist/*.whl' dist/
@@ -12,9 +12,9 @@ make writeversion
 
 # Clone kolibri windows installer base in develop branch.
 cd $KOLIBRI_DOCKER_PATH \
-    && git clone https://github.com/learningequality/kolibri-installers.git \
-    && cd kolibri-installers \
-    && git checkout develop
+    && git clone https://github.com/learningequality/kolibri-installer-windows.git \
+    && cd kolibri-installers-windows \
+    && git checkout v1.0.0
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.
 cd $PARENT_PATH

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -14,7 +14,7 @@ make writeversion
 cd $KOLIBRI_DOCKER_PATH
 git clone https://github.com/learningequality/kolibri-installer-windows.git
 cd kolibri-installer-windows
-git checkout v1.0.0
+git checkout develop
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.
 cd $PARENT_PATH

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 PARENT_PATH=$(pwd)
 KOLIBRI_DOCKER_PATH="$PARENT_PATH/windows_installer_docker_build"
-KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installers-windows/windows"
+KOLIBRI_WINDOWS_PATH="$KOLIBRI_DOCKER_PATH/kolibri-installer-windows/windows"
 
 mkdir dist
 buildkite-agent artifact download 'dist/*.whl' dist/
@@ -13,7 +13,7 @@ make writeversion
 # Clone kolibri windows installer base in develop branch.
 cd $KOLIBRI_DOCKER_PATH
 git clone https://github.com/learningequality/kolibri-installer-windows.git
-cd kolibri-installers-windows
+cd kolibri-installer-windows
 git checkout v1.0.0
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -11,10 +11,10 @@ buildkite-agent artifact download 'dist/*.whl' dist/
 make writeversion
 
 # Clone kolibri windows installer base in develop branch.
-cd $KOLIBRI_DOCKER_PATH \
-    && git clone https://github.com/learningequality/kolibri-installer-windows.git \
-    && cd kolibri-installers-windows \
-    && git checkout v1.0.0
+cd $KOLIBRI_DOCKER_PATH
+git clone https://github.com/learningequality/kolibri-installer-windows.git
+cd kolibri-installers-windows
+git checkout v1.0.0
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.
 cd $PARENT_PATH

--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:xenial
 
-RUN apt-get -y update 
+RUN apt-get -y update
 
 # Install wine and related packages
-RUN dpkg --add-architecture i386 
+RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sudo software-properties-common
 
 RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update \
@@ -15,7 +15,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Build kolibri windows installer.
 RUN mkdir /installer/
-RUN cd /kolibri/kolibri-installers/windows \
+RUN cd /kolibri/kolibri-installer-windows/windows \
     && WHL_FILE=$(find ./ -name \*.whl) \
     && WHL_FILE=$(basename $WHL_FILE) \
     && WHL_FILE=${WHL_FILE:8} \
@@ -23,4 +23,4 @@ RUN cd /kolibri/kolibri-installers/windows \
     && export KOLIBRI_BUILD_VERSION=$WHL_FILE_VERSION \
     && wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss
 
-CMD cp /kolibri/kolibri-installers/windows/*.exe /installer/
+CMD cp /kolibri/kolibri-installer-windows/windows/*.exe /installer/


### PR DESCRIPTION
* cherry-picks changes from #2431
* track the `develop` branch

cc @radinamatic @mrpau-richard 



