### PR TITLE
Do not include '\n' if it's somehow in the VERSION file

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -185,7 +185,8 @@ def initialize(debug=False):
         autoremove_unavailable_plugins()
 
         version = open(version_file(), "r").read()
-        change_version = kolibri.__version__ != version.strip()
+        version = version.strip() if version else ""
+        change_version = kolibri.__version__ != version
         if change_version:
             enable_default_plugins()
 

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -98,6 +98,22 @@ class TestKolibriVersion(unittest.TestCase):
             version.get_version_file = get_version_file
 
     @mock_get_git_describe
+    def test_version_file_linebreaks(self):
+        """
+        Test that line breaks don't get included in the final version
+
+        See: https://github.com/learningequality/kolibri/issues/2464
+        """
+        # Simple mocking
+        get_version_file = version.get_version_file
+        version.get_version_file = lambda: "0.1a1\n"
+        try:
+            v = get_version((0, 1, 0, "alpha", 1))
+            self.assertIn("0.1a1", v)
+        finally:
+            version.get_version_file = get_version_file
+
+    @mock_get_git_describe
     def test_alpha_1_inconsistent_version_file(self):
         """
         Test that inconsistent file data also just fails

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -152,7 +152,6 @@ import subprocess
 
 from .lru_cache import lru_cache
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -364,6 +363,9 @@ def get_prerelease_version(version):
 
         # Check that the version file is consistent
         if version_file:
+
+            # Because \n may have been appended
+            version_file = version_file.strip()
 
             # If there is a '.dev', we can remove it, otherwise we check it
             # for consistency and fail if inconsistent


### PR DESCRIPTION
## Summary

Wouldn't be very nice if these `\n` are in our `__version__`. @indirectlylit spotted this while looking at the file names generated in backups from .pex files that use the `VERSION` file.

## TODO

- [x] Have tests been written for the new code?
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file
- [x] ~Add an entry to CHANGELOG.rst~ Doesn't matter, it's a fix to a bug in a new addition
- [x] Add yourself it AUTHORS.rst if you don't appear there

## Reviewer guidance

Shouldn't be too complicated I hope

## Issues addressed

#2464 