### PR TITLE
Update perseus renderer to 0.7.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.11
-kolibri_exercise_perseus_plugin==0.7.1
+kolibri_exercise_perseus_plugin==0.7.2
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e25b57b52656e2.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
## Summary

Android bug fix, hint button fix from the 0.6 renderer, and updated translations:

https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v0.7.1...v0.7.2