### PR TITLE
Only warn when multiple coreAPI spec modifications are specified.

### DIFF
--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -93,7 +93,7 @@ var readBundlePlugins = function(base_dir) {
       return bundle.coreAPISpec;
     }).length > 1
   ) {
-    throw new RangeError('You have more than one coreAPISpec modification specified.');
+    logging.warn('You have more than one coreAPISpec modification specified.');
   }
 
   // One bundle is special - that is the one for the core bundle.


### PR DESCRIPTION
# Checklist

- [X] PR has the correct target milestone when it's merged
- [X] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually


# Details

### Summary

Currently we throw an error when we specify multiple coreAPI specifications, and this breaks the build.

Downgraded to a warning. Caveat developer.