### PR TITLE
Kolibri Server Timezone Issue

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,3 +22,4 @@ Please feel free to add your name on this list if you do a PR!
 * Rafael Aguayo (ralphiee22)
 * Christian Memije (christianmemije)
 * Radina Matic (radinamatic)
+* Alan Chen (alanchenz)

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -19,6 +19,7 @@ import kolibri
 # This is essential! We load the kolibri conf INSIDE the Django conf
 from kolibri.utils import conf, i18n
 from tzlocal import get_localzone
+import pytz
 
 KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
 
@@ -155,7 +156,7 @@ LANGUAGES = [
 
 LANGUAGE_CODE = conf.config.get("LANGUAGE_CODE") or "en"
 
-TIME_ZONE = get_localzone().zone
+TIME_ZONE = get_localzone().zone if get_localzone().zone != "local" else pytz.utc.zone
 
 USE_I18N = True
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -13,13 +13,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+import pytz
+
 # import kolibri, so we can get the path to the module.
 import kolibri
 # we load other utilities related to i18n
 # This is essential! We load the kolibri conf INSIDE the Django conf
 from kolibri.utils import conf, i18n
 from tzlocal import get_localzone
-import pytz
 
 KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
 
@@ -156,7 +157,12 @@ LANGUAGES = [
 
 LANGUAGE_CODE = conf.config.get("LANGUAGE_CODE") or "en"
 
-TIME_ZONE = get_localzone().zone if get_localzone().zone != "local" else pytz.utc.zone
+TIME_ZONE = get_localzone().zone
+# Fixes https://github.com/regebro/tzlocal/issues/44
+# tzlocal 1.4 returns 'local' if unable to detect the timezone,
+# and this TZ id is invalid
+if TIME_ZONE == "local":
+    pytz.utc.zone
 
 USE_I18N = True
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -157,12 +157,18 @@ LANGUAGES = [
 
 LANGUAGE_CODE = conf.config.get("LANGUAGE_CODE") or "en"
 
-TIME_ZONE = get_localzone().zone
+try:
+    TIME_ZONE = get_localzone().zone
+except pytz.UnknownTimeZoneError:
+    # Do not fail at this point because a timezone was not
+    # detected.
+    TIME_ZONE = pytz.utc.zone
+
 # Fixes https://github.com/regebro/tzlocal/issues/44
 # tzlocal 1.4 returns 'local' if unable to detect the timezone,
 # and this TZ id is invalid
 if TIME_ZONE == "local":
-    pytz.utc.zone
+    TIME_ZONE = pytz.utc.zone
 
 USE_I18N = True
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,7 @@ https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e2
 requests-toolbelt==0.7.1
 clint==0.5.1
 tzlocal==1.4
+pytz==2017.2
 python-dateutil==2.6.0
 ifcfg==0.11b6
 sqlalchemy==1.1.12


### PR DESCRIPTION
# Checklist

- [ ] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [x] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Fixed timezone issue that returns local. Now, it returns UTC as a default timezone.

### Reviewer guidance

Run Kolibri server on Ubuntu Bash

### References

Fixes #2476 
