### PR TITLE
mobile content cards

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Release Notes
 
 Changes are ordered reverse-chronologically.
 
+0.6.1 (unreleased)
+------------------
+
+ - Added mobile-friendly content cards
+
+
 0.6.0
 -----
 

--- a/kolibri/core/assets/src/styles/core-theme.styl
+++ b/kolibri/core/assets/src/styles/core-theme.styl
@@ -24,14 +24,6 @@ $core-bg-warning = #fff3e1
 $core-text-error = #b93329
 $core-bg-error = #fee9e7
 
-/* Content type colors */
-$core-content-topic = #262626
-$core-content-exercise = #0eafaf
-$core-content-video = #3938A5
-$core-content-audio = #E65997
-$core-content-document = #ED2828
-$core-content-html5 = #FF8B41
-
 /* Status colors */
 $core-status-progress = #2196f3
 $core-status-mastered = #ffc107

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
@@ -23,6 +23,7 @@
       v-for="content in contents"
       v-show="showContentCard(content)"
       class="grid-item"
+      :isMobile="isMobile"
       :class="{ 'mobile': isMobile }"
       :key="content.id"
       :title="content.title"

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
@@ -22,10 +22,11 @@
     <content-card
       v-for="content in contents"
       v-show="showContentCard(content)"
+      class="grid-item"
+      :class="{ 'mobile': isMobile }"
       :key="content.id"
       :title="content.title"
       :thumbnail="content.thumbnail"
-      :class="{'grid-item': true, 'mobile': isMobile}"
       :kind="content.kind"
       :progress="content.progress"
       :link="genContentLink(content.id, content.kind)"

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
@@ -24,7 +24,6 @@
       v-show="showContentCard(content)"
       class="grid-item"
       :isMobile="isMobile"
-      :class="{ 'mobile': isMobile }"
       :key="content.id"
       :title="content.title"
       :thumbnail="content.thumbnail"
@@ -191,8 +190,6 @@
   .grid-item
     margin-right: $gutters
     margin-bottom: $gutters
-    &.mobile
-      width: 100%
 
   .filter
     display: inline-block

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -1,0 +1,170 @@
+<template>
+
+  <div class="card-thumbnail" :style="thumbnailBackground">
+
+    <content-icon
+      v-if="!thumbnail"
+      :kind="kind"
+      class="thumbnail-icon"
+    />
+
+    <progress-icon
+      v-if="progress > 0"
+      class="progress-icon"
+      :progress="progress"
+    />
+
+    <div class="content-icon-wrapper">
+      <svg
+        height="64"
+        width="64"
+        viewBox="0 0 64 64"
+        class="content-icon-bg"
+        :style="contentIconBgColor"
+      >
+        <polygon stroke-width="0" points="0,0 60,0 0,60"/>
+      </svg>
+      <content-icon :kind="kind" class="content-icon"/>
+    </div>
+
+    <div class="progress-bar-wrapper">
+      <div
+        class="progress-bar"
+        :style="{ width: `${progress * 100}%` }"
+        :class="{ 'progress-bar-mastered': isMastered, 'progress-bar-progress': isInProgress }">
+      </div>
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import values from 'lodash/values';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import contentIcon from 'kolibri.coreVue.components.contentIcon';
+  import progressIcon from 'kolibri.coreVue.components.progressIcon';
+
+  export default {
+    props: {
+      thumbnail: {
+        type: String,
+        required: false,
+      },
+      kind: {
+        type: String,
+        required: true,
+        validator(value) {
+          return values(ContentNodeKinds).includes(value);
+        },
+      },
+      progress: {
+        type: Number,
+        required: true,
+        default: 0.0,
+        validator(value) {
+          return value >= 0.0 && value <= 1.0;
+        },
+      },
+    },
+    computed: {
+      isMastered() {
+        return this.progress === 1;
+      },
+      isInProgress() {
+        return this.progress > 0 && this.progress < 1;
+      },
+      thumbnailBackground() {
+        if (this.thumbnail) {
+          return { backgroundImage: `url('${this.thumbnail}')` };
+        }
+        return {};
+      },
+      contentIconBgColor() {
+        if (this.kind === 'exercise') {
+          return { fill: '#0eafaf' };
+        } else if (this.kind === 'video') {
+          return { fill: '#3938A5' };
+        } else if (this.kind === 'audio') {
+          return { fill: '#E65997' };
+        } else if (this.kind === 'document') {
+          return { fill: '#ED2828' };
+        } else if (this.kind === 'topic') {
+          return { fill: '#262626' };
+        } else if (this.kind === 'html5') {
+          return { fill: '#FF8B41' };
+        }
+        return {};
+      },
+    },
+    components: {
+      contentIcon,
+      progressIcon,
+    },
+  };
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+  @require './card.styl'
+
+  .card-thumbnail
+    width: $thumb-width-desktop
+    height: $thumb-height-desktop
+    position: relative
+    background-size: cover
+    background-position: center
+    background-color: $core-grey
+
+  .thumbnail-icon
+    position: absolute
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%) scale(3)
+    color: $core-text-annotation
+
+  .progress-icon
+    position: absolute
+    top: 4px
+    right: 4px
+
+  .content-icon-wrapper
+    position: absolute
+    width: 56px
+    height: 56px
+
+  .content-icon
+    position: absolute
+    color: white
+    transform: translate(25%, 0)
+    font-size: 20px
+
+  .content-icon-bg
+    position: absolute
+    width: 100%
+    height: 100%
+    fill-opacity: 0.9
+
+  .progress-bar-wrapper
+    position: absolute
+    bottom: 0
+    background-color: $core-grey
+    width: 100%
+    height: 5px
+    opacity: 0.9
+
+  .progress-bar
+    height: 100%
+
+  .progress-bar-mastered
+    background-color: $core-status-mastered
+
+  .progress-bar-progress
+    background-color: $core-status-progress
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <div class="card-thumbnail" :style="thumbnailBackground">
+  <div
+    class="card-thumbnail-wrapper"
+    :class="{ 'mobile-thumbnail' : isMobile }"
+    :style="thumbnailBackground"
+  >
 
     <content-icon
       v-if="!thumbnail"
@@ -68,6 +72,10 @@
           return value >= 0.0 && value <= 1.0;
         },
       },
+      isMobile: {
+        type: Boolean,
+        default: false,
+      },
     },
     computed: {
       isMastered() {
@@ -113,7 +121,7 @@
   @require '~kolibri.styles.definitions'
   @require './card.styl'
 
-  .card-thumbnail
+  .card-thumbnail-wrapper
     width: $thumb-width-desktop
     height: $thumb-height-desktop
     position: relative
@@ -166,5 +174,23 @@
 
   .progress-bar-progress
     background-color: $core-status-progress
+
+
+  /* MOBILE OVERRIDES */
+  .mobile-thumbnail.card-thumbnail-wrapper
+    width: $thumb-width-mobile
+    height: $thumb-height-mobile
+
+  .mobile-thumbnail
+
+    .thumbnail-icon
+      transform: translate(-50%, -50%) scale(2)
+
+    .content-icon-wrapper
+      width: 48px
+      height: 48px
+
+    .content-icon
+      font-size: 18px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -26,7 +26,7 @@
         class="content-icon-bg"
         :style="contentIconBgColor"
       >
-        <polygon stroke-width="0" points="0,0 60,0 0,60"/>
+        <polygon stroke-width="0" points="0,0 60,0 0,60" />
       </svg>
       <content-icon :kind="kind" class="content-icon"/>
     </div>
@@ -52,6 +52,10 @@
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
 
   export default {
+    components: {
+      contentIcon,
+      progressIcon,
+    },
     props: {
       thumbnail: {
         type: String,
@@ -106,10 +110,6 @@
         }
         return {};
       },
-    },
-    components: {
-      contentIcon,
-      progressIcon,
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/content-card/card.styl
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card.styl
@@ -1,0 +1,8 @@
+
+$ratio = 16 / 9
+
+$thumb-width-desktop = 210px
+$thumb-height-desktop = round($thumb-width-desktop / $ratio)
+
+$thumb-width-mobile = 150px
+$thumb-height-mobile = round($thumb-width-mobile / $ratio)

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -24,7 +24,6 @@
 
     <div class="card-text">
       <h3 class="card-title">{{ title }}</h3>
-      <h4 v-if="subtitle" class="card-subtitle">{{ subtitle }}</h4>
     </div>
 
   </router-link>
@@ -47,10 +46,6 @@
       title: {
         type: String,
         required: true,
-      },
-      subtitle: {
-        type: String,
-        required: false,
       },
       thumbnail: {
         type: String,
@@ -231,18 +226,11 @@
     height: $card-text-height
     color: $core-text-default
 
-  .card-title, .card-subtitle
-    margin: 0
-
   .card-title
+    margin: 0
     overflow: hidden
     line-height: ($card-width / (320 / 32))
     height: ($card-width / (320 / 64))
     font-size: ($card-width / (320 / 24))
-
-  .card-subtitle
-    padding-top: ($card-width / (320 / 16))
-    font-size: ($card-width / (320 / 14))
-    color: $core-text-annotation
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -2,29 +2,14 @@
 
   <router-link :to="link" class="card">
 
-    <div class="card-thumbnail" :style="cardThumbnail">
-      <content-icon v-if="!thumbnail" :kind="kind" :style="iconSize" class="card-thumbnail-backup"/>
-      <div v-show="progress > 0" class="card-progress-icon-wrapper">
-        <progress-icon :progress="progress"/>
-      </div>
+    <card-thumbnail
+      class="thumbnail"
+      :thumbnail="thumbnail"
+      :kind="kind"
+      :progress="progress"
+    />
 
-      <div class="card-content-icon-background" :class="backgroundClass"></div>
-      <div class="card-content-icon-wrapper">
-        <content-icon :kind="kind" class="card-content-icon"/>
-      </div>
-
-      <div class="card-progress-bar-wrapper">
-        <div
-          class="card-progress-bar"
-          :style="{ width: `${progress * 100}%` }"
-          :class="{ 'card-progress-bar-mastered': mastered, 'card-progress-bar-progress': inProgress }">
-        </div>
-      </div>
-    </div>
-
-    <div class="card-text">
-      <h3 class="card-title">{{ title }}</h3>
-    </div>
+    <h3 class="text">{{ title }}</h3>
 
   </router-link>
 
@@ -33,15 +18,12 @@
 
 <script>
 
-  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import values from 'lodash/values';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import contentIcon from 'kolibri.coreVue.components.contentIcon';
-  import progressIcon from 'kolibri.coreVue.components.progressIcon';
+  import cardThumbnail from './card-thumbnail';
 
   export default {
-    mixins: [responsiveElement],
     props: {
       title: {
         type: String,
@@ -71,50 +53,13 @@
         required: true,
         validator: validateLinkObject,
       },
-    },
-    computed: {
-      mastered() {
-        return this.progress === 1;
-      },
-      thumbnailHeight() {
-        return this.elSize.width * (9 / 16);
-      },
-      iconSize() {
-        // maintain the thumbnail 16:9 ratio
-        return {
-          'font-size': `${this.thumbnailHeight / 2}px`,
-        };
-      },
-      inProgress() {
-        return this.progress > 0 && this.progress < 1;
-      },
-      cardThumbnail() {
-        const thumbnailStyles = {
-          height: `${this.thumbnailHeight}px`,
-        };
-        if (this.thumbnail) {
-          thumbnailStyles.backgroundImage = `url('${this.thumbnail}')`;
-        }
-        return thumbnailStyles;
-      },
-      backgroundClass() {
-        if (this.kind === 'exercise') {
-          return 'card-content-icon-background-exercise';
-        } else if (this.kind === 'video') {
-          return 'card-content-icon-background-video';
-        } else if (this.kind === 'audio') {
-          return 'card-content-icon-background-audio';
-        } else if (this.kind === 'document') {
-          return 'card-content-icon-background-document';
-        } else if (this.kind === 'html5') {
-          return 'card-content-icon-background-html5';
-        }
-        return '';
+      isMobile: {
+        type: Boolean,
+        default: false,
       },
     },
     components: {
-      contentIcon,
-      progressIcon,
+      cardThumbnail,
     },
   };
 
@@ -124,113 +69,23 @@
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
-
-  $card-width = 210px
-  $card-thumbnail-ratio = (9 / 16)
-  $card-text-height = $card-width - ($card-width * $card-thumbnail-ratio)
-  $card-text-padding = ($card-width / (320 / 24))
-  $card-elevation-resting = 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12)
-  $card-elevation-raised = 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2)
-  $elevation-transition = box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)
-
-  a
-    text-decoration: none
+  @require './card.styl'
 
   .card
+    text-decoration: none
     display: inline-block
-    width: $card-width
+    width: $thumb-width-desktop
     border-radius: 2px
     background-color: $core-bg-light
-    box-shadow: $card-elevation-resting
-    transition: $elevation-transition
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12)
+    transition: box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)
     &:hover, &:focus
-      box-shadow: $card-elevation-raised
+      box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2)
 
-  .card-thumbnail
-    position: relative
-    width: 100%
-    background-size: cover
-    background-position: center
-    background-color: $core-grey
-
-  .card-thumbnail-backup
-    position: absolute
-    top: 50%
-    left: 50%
-    transform: translate(-50%, -50%)
-    color: $core-text-annotation
-
-  .card-progress-icon-wrapper
-    position: absolute
-    top: 0.25em
-    right: 0.25em
-    width: 1.5em
-    height: 1.5em
-
-  .card-content-icon-background
-    position: absolute
-    top: 0
-    left: 0
-    width: 0
-    height: 0
-    border-style: solid
-    border-width: 3.5em 3.5em 0 0
-    border-top-color: $core-content-topic
-    border-right-color: transparent
-    border-bottom-color: transparent
-    border-left-color: transparent
-
-  .card-content-icon-background-exercise
-    border-top-color: $core-content-exercise
-
-  .card-content-icon-background-video
-    border-top-color: $core-content-video
-
-  .card-content-icon-background-audio
-    border-top-color: $core-content-audio
-
-  .card-content-icon-background-document
-    border-top-color: $core-content-document
-
-  .card-content-icon-background-html5
-    border-top-color: $core-content-html5
-
-  .card-content-icon-wrapper
-    position: absolute
-    top: 0
-    left: 0
-    padding: 0.25em
-    color: white
-
-  .card-content-icon
-    font-size: 1.25em
-
-  .card-progress-bar-wrapper
-    position: absolute
-    bottom: 0
-    background-color: $core-grey
-    width: 100%
-    height: 5px
-
-  .card-progress-bar
-    height: 100%
-
-  .card-progress-bar-mastered
-    background-color: $core-status-mastered
-
-  .card-progress-bar-progress
-    background-color: $core-status-progress
-
-  .card-text
-    padding: $card-text-padding
-    height: $card-text-height
+  .text
     color: $core-text-default
-
-  .card-title
-    margin: 0
     overflow: hidden
-    line-height: ($card-width / (320 / 32))
-    height: ($card-width / (320 / 64))
-    font-size: ($card-width / (320 / 24))
+    margin: 16px
+    height: 54px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -19,11 +19,13 @@
 <script>
 
   import values from 'lodash/values';
+  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import cardThumbnail from './card-thumbnail';
 
   export default {
+    mixins: [responsiveElement], // not used, but carousel seems to break without it
     props: {
       title: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -1,12 +1,13 @@
 <template>
 
-  <router-link :to="link" class="card">
+  <router-link :to="link" class="card" :class="{ 'mobile-card': isMobile }">
 
     <card-thumbnail
       class="thumbnail"
       :thumbnail="thumbnail"
       :kind="kind"
       :progress="progress"
+      :isMobile="isMobile"
     />
 
     <h3 class="text">{{ title }}</h3>
@@ -89,5 +90,15 @@
     overflow: hidden
     margin: 16px
     height: 54px
+
+  .mobile-card.card
+    width: 100%
+    height: $thumb-height-mobile
+
+  .mobile-card
+    .thumbnail
+      position: absolute
+    .text
+      margin-left: $thumb-width-mobile + 16
 
 </style>


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] PR has been fully tested manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes

# Details

### Summary

new mobile layout for cards:

![image](https://user-images.githubusercontent.com/2367265/31868866-7783901c-b758-11e7-9c83-340b05a0075c.png)

![image](https://user-images.githubusercontent.com/2367265/31868871-80b3ed1c-b758-11e7-87ad-d756b553f765.png)

![image](https://user-images.githubusercontent.com/2367265/31868875-8dffb60e-b758-11e7-97ed-416666f14bcd.png)

![image](https://user-images.githubusercontent.com/2367265/31868877-95489f5c-b758-11e7-9855-ca8cd38a2a40.png)

Manually tested on a range of browser sizes. Ran into some issues with the carousel - see commit 0c37f372a1f076fe4454b5b006a6cbc6c055db5e



### Reviewer guidance

Please check all the places you can think of where cards are shown to test. I tested on android chrome using browserstack, but some additional cross-browser testing would be appreciated.

### References

fixes #2466
