### PR TITLE
Actually set dirty attributes on the model during save

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Release Notes
 Changes are ordered reverse-chronologically.
 
 
+0.4.7
+-----
+
+ - Fix bug that made updating existing Django models from the frontend impossible
+
+
 0.4.6
 -----
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -35,7 +35,7 @@ class BaseKolibriUserSerializer(serializers.ModelSerializer):
             facility_user_query = facility_user_query.exclude(id=user_id)
             device_owner_query = device_owner_query.exclude(id=user_id)
 
-        if facility_user_query.exists() | device_owner_query.exists():
+        if facility_user_query.exists() or device_owner_query.exists():
             raise serializers.ValidationError(_('An account with that username already exists'))
         return value
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.validators import UniqueTogetherValidator
 from .constants import role_kinds
 from .models import Classroom, DeviceOwner, Facility, FacilityDataset, FacilityUser, LearnerGroup, Membership, Role
 
+
 class RoleSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -25,7 +26,16 @@ class BaseKolibriUserSerializer(serializers.ModelSerializer):
             return super(BaseKolibriUserSerializer, self).update(instance, validated_data)
 
     def validate_username(self, value):
-        if FacilityUser.objects.filter(username__iexact=value).exists() | DeviceOwner.objects.filter(username__iexact=value).exists():
+        facility_user_query = FacilityUser.objects.filter(username__iexact=value)
+        device_owner_query = DeviceOwner.objects.filter(username__iexact=value)
+
+        user_id = self.initial_data.get("id", None)
+
+        if user_id:
+            facility_user_query = facility_user_query.exclude(id=user_id)
+            device_owner_query = device_owner_query.exclude(id=user_id)
+
+        if facility_user_query.exists() | device_owner_query.exists():
             raise serializers.ValidationError(_('An account with that username already exists'))
         return value
 

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -280,6 +280,14 @@ class UserUpdateTestCase(APITestCase):
         response = self.client.login(username=self.user.username, password=new_password, facility=self.facility)
         self.assertTrue(response)
 
+    def test_user_update_password_non_partial_with_username(self):
+        new_password = 'baz'
+        self.client.patch(reverse('facilityuser-detail', kwargs={'pk': self.user.pk}),
+                          {'password': new_password, 'username': self.user.username}, format="json")
+        self.client.logout()
+        response = self.client.login(username=self.user.username, password=new_password, facility=self.facility)
+        self.assertTrue(response)
+
     def test_device_owner_update_info(self):
         self.client.patch(reverse('deviceowner-detail', kwargs={'pk': self.device_owner.pk}), {'username': 'foo'}, format="json")
         self.device_owner.refresh_from_db()

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -104,6 +104,7 @@ class Model {
               payload[key] = attrs[key];
             }
           });
+          this.set(payload);
         } else {
           this.set(attrs);
           payload = this.attributes;

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -910,6 +910,20 @@ describe('Model', function () {
           done();
         });
       });
+      it('should should call set once with the changed attributes', function (done) {
+        this.model.synced = true;
+        const payload = { somethingNew: 'new' };
+        const entity = {};
+        Object.assign(entity, this.model.attributes, payload);
+        this.response = { entity };
+        this.client = sinon.stub();
+        this.client.returns(Promise.resolve(this.response));
+        this.resource.client = this.client;
+        this.model.save(payload).then(() => {
+          assert.equal(this.model.attributes.somethingNew, 'new');
+          done();
+        });
+      });
     });
     describe('if called when Model.synced = false', function () {
       describe('and the save is successful', function () {


### PR DESCRIPTION
# Checklist

- [X] Automated test coverage is satisfactory
- [X] PR has been fully tested manually
- [X] CHANGELOG.rst is updated for high-level changes

# Details

### Summary

0.4.6 was released with a damaging bug, due to the changes to prevent partial updates. This resolves that by always setting the changed fields on the APIResource model, and adds a test for this regression.

In the course of manual testing, I discovered that the facilityuser username validation was problematic, because it would prevent a user being updated. This also fixes that behaviour.