### PR TITLE
Prevent webpack rtl from modifying z indices

### DIFF
--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -110,7 +110,9 @@ var parseBundlePlugin = function(data, base_dir) {
 
   bundle.plugins = bundle.plugins.concat([
     new ExtractTextPlugin('[name]' + data.version + '.css'),
-    new WebpackRTLPlugin(),
+    new WebpackRTLPlugin({
+      minify: { zindex: false },
+    }),
     // BundleTracker creates stats about our built files which we can then pass to Django to allow our template
     // tags to load the correct frontend files.
     new BundleTracker({


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

* Disables z index optimization that is done by cssnano

#### Before

![127 0 0 1-8000-learn-](https://user-images.githubusercontent.com/7193975/31468209-a75f40e4-ae91-11e7-9520-52f3100d49cd.png)

### Afrer

![image](https://user-images.githubusercontent.com/7193975/31841904-79563ce6-b5a0-11e7-9f5f-9cfffa309c6a.png)


### Reviewer guidance

Inspect z-indices

### References

when applicable, please provide:

* Fixes #2422
