### PR TITLE
Set last activity on the session during the session request.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Release Notes
 Changes are ordered reverse-chronologically.
 
 
+0.4.8 (unreleased)
+------------------
+
+ - Prevent session timeout if user is still active
+
+
+
 0.4.7
 -----
 

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -228,7 +228,7 @@ class SessionViewSet(viewsets.ViewSet):
 
     def get_session(self, request):
         # Set last activity on session to the current time to prevent session timeout
-        request.session['last_activity'] = int(time.time())
+        request.session['last_session_request'] = int(time.time())
         # Default to active, only assume not active when explicitly set.
         active = True if request.GET.get('active', 'true') == 'true' else False
         user = get_user(request)

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import time
+
 from django.contrib.auth import authenticate, get_user, login, logout
 from django.contrib.auth.models import AnonymousUser
 from django.db.models.query import F
@@ -225,6 +227,8 @@ class SessionViewSet(viewsets.ViewSet):
         return Response(self.get_session(request))
 
     def get_session(self, request):
+        # Set last activity on session to the current time to prevent session timeout
+        request.session['last_activity'] = int(time.time())
         # Default to active, only assume not active when explicitly set.
         active = True if request.GET.get('active', 'true') == 'true' else False
         user = get_user(request)

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -341,6 +341,13 @@ class LoginLogoutTestCase(APITestCase):
         response = self.client.get(reverse('session-detail', kwargs={'pk': 'current'}))
         self.assertTrue(response.data['kind'][0], 'anonymous')
 
+    def test_session_update_last_active(self):
+        self.client.post(reverse('session-list'), data={"username": self.user.username, "password": DUMMY_PASSWORD, "facility": self.facility.id})
+        expire_date = Session.objects.get().expire_date
+        self.client.get(reverse('session-detail', kwargs={'pk': 'current'}))
+        new_expire_date = Session.objects.get().expire_date
+        self.assertTrue(expire_date < new_expire_date)
+
 
 class AnonSignUpTestCase(APITestCase):
 


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [x] CHANGELOG.rst is updated for high-level changes

# Details

### Summary

Django does not update the session expiry on every request, as I thought. So, this explicitly updates the session any time the session endpoint is queried.

Fixes #2389 