### PR TITLE
Up breakpoint to Nexus 7 portrait size

### DIFF
--- a/kolibri/core/assets/src/views/dropdown-menu/index.vue
+++ b/kolibri/core/assets/src/views/dropdown-menu/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <span v-if="inAppBar && windowSize.breakpoint > 1 || !inAppBar && windowSize.breakpoint > 0 ">
+    <span v-if="inAppBar && windowSize.breakpoint > 2 || !inAppBar && windowSize.breakpoint > 0 ">
       <ui-button
         :ariaLabel="name"
         :type="type"


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [x] Screenshots of any front-end changes are in the PR description

# Details

### Summary

Up the breakpoint for collapsing the channel list to tablet portrait size.

![image](https://user-images.githubusercontent.com/1680573/31906298-09e7df16-b831-11e7-93f5-3fbd3615f4ee.png)

Fixes #2260 