### PR TITLE
Channel info

### DIFF
--- a/kolibri/content/utils/paths.py
+++ b/kolibri/content/utils/paths.py
@@ -92,6 +92,11 @@ def get_content_storage_url(baseurl=None):
 def get_content_storage_remote_url(filename, baseurl=None):
     return "{}{}/{}/{}".format(get_content_storage_url(baseurl), filename[0], filename[1], filename)
 
+def get_channel_lookup_url(identifier, base_url=None):
+    return urljoin(
+        base_url or settings.CENTRAL_CONTENT_DOWNLOAD_BASE_URL,
+        "/api/public/channels/lookup/{}".format(identifier)
+    )
 
 def get_content_storage_file_url(filename, baseurl=None):
     """

--- a/kolibri/content/utils/paths.py
+++ b/kolibri/content/utils/paths.py
@@ -95,7 +95,7 @@ def get_content_storage_remote_url(filename, baseurl=None):
 def get_channel_lookup_url(identifier, base_url=None):
     return urljoin(
         base_url or settings.CENTRAL_CONTENT_DOWNLOAD_BASE_URL,
-        "/api/public/channels/lookup/{}".format(identifier)
+        "/api/public/v1/channels/lookup/{}".format(identifier)
     )
 
 def get_content_storage_file_url(filename, baseurl=None):

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 from kolibri.content.models import ChannelMetadata
 from kolibri.content.permissions import CanManageContent
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
-from kolibri.content.utils.paths import get_content_database_file_path, get_content_database_file_url
+from kolibri.content.utils.paths import get_content_database_file_path, get_content_database_file_url, get_channel_lookup_url
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
@@ -190,6 +190,18 @@ class TasksViewSet(viewsets.ViewSet):
 
         return Response(out)
 
+    @list_route(methods=['get'])
+    def channelinfo(self, request):
+        """
+        Gets metadata about a channel through a token or channel id.
+        """
+        url = get_channel_lookup_url(request.data['channel_id'])
+        resp = requests.get(url)
+        if resp.status_code == 404:
+            raise Http404(
+                _("The requested channel does not exist on the content server")
+            )
+        return Response(resp.json())
 
 def _networkimport(channel_id, update_progress=None, check_for_cancel=None):
     call_command(

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 from kolibri.content.models import ChannelMetadata
 from kolibri.content.permissions import CanManageContent
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
-from kolibri.content.utils.paths import get_content_database_file_path, get_content_database_file_url, get_channel_lookup_url
+from kolibri.content.utils.paths import get_content_database_file_path, get_channel_lookup_url
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
@@ -95,15 +95,8 @@ class TasksViewSet(viewsets.ViewSet):
             raise serializers.ValidationError(
                 "The 'channel_id' field is required.")
 
-        channel_id = request.data['channel_id']
-
-        # ensure the requested channel_id can be found on the central server, otherwise error
-        status = requests.head(
-            get_content_database_file_url(channel_id)).status_code
-        if status == 404:
-            raise Http404(
-                _("The requested channel does not exist on the content server")
-            )
+        # if channel_id is a token, will get actual channel_id to download channel properly
+        channel_id = self.as_view({'get': 'channelinfo'})(request).data['id']
 
         task_id = get_client().schedule(
             _networkimport, channel_id, track_progress=True, cancellable=True)

--- a/kolibri/tasks/test/test_api.py
+++ b/kolibri/tasks/test/test_api.py
@@ -1,0 +1,57 @@
+import mock
+import requests
+
+from django.core.cache import cache
+from django.core.urlresolvers import reverse
+from kolibri.auth.models import Facility, FacilityUser
+from kolibri.core.device.models import DeviceSettings, DevicePermissions
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+DUMMY_PASSWORD = "password"
+
+
+def mock_patch_decorator(func):
+
+    def wrapper(*args, **kwargs):
+        mock_object = mock.Mock()
+        mock_object.json.return_value = {'good': 'response'}
+        with mock.patch.object(requests, 'get', return_value=mock_object):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+class TasksAPITestCase(APITestCase):
+
+    def setUp(self):
+        DeviceSettings.objects.create(is_provisioned=True)
+        facility = Facility.objects.create(name='facility')
+        superuser = FacilityUser.objects.create(username='superuser', facility=facility)
+        superuser.set_password(DUMMY_PASSWORD)
+        superuser.save()
+        DevicePermissions.objects.create(user=superuser, is_superuser=True)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD)
+
+    @mock_patch_decorator
+    def test_channel_info(self):
+        response = self.client.post(reverse('task-channelinfo'), {'channel_id': 'abc'}, format='json')
+        self.assertEqual(response.data['good'], 'response')
+
+    @mock_patch_decorator
+    def test_channel_info_cache(self):
+        self.client.post(reverse('task-channelinfo'), {'channel_id': 'abc'}, format='json')
+        with mock.patch.object(cache, 'set') as mock_cache_set:
+            self.client.post(reverse('task-channelinfo'), {'channel_id': 'abc'}, format='json')
+            self.assertFalse(mock_cache_set.called)
+
+    @mock_patch_decorator
+    def test_channel_info_404(self):
+        mock_object = mock.Mock()
+        mock_object.status_code = 404
+        requests.get.return_value = mock_object
+        response = self.client.post(reverse('task-channelinfo'), {'channel_id': 'abc'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def tearDown(self):
+        cache.clear()


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [x] Add tests. (will do after approach is OKed)

# Details

### Summary

This PR adds an endpoint which will get channel metadata from Kolibri Studio in order to check if an old channel needs updating. Also use that endpoint to be able to get the channel ids from tokens in order download channels using that token. 

NOTE: Not sure if there is too much overhead in getting the metadata anyways even when we have the `channel_id`. Can parse whats passed in to know whether to call that endpoint if it is a token or not instead of always calling it. 