### PR TITLE
Add lockr as a kolibri dependency

### DIFF
--- a/kolibri/plugins/media_player/package.json
+++ b/kolibri/plugins/media_player/package.json
@@ -3,7 +3,6 @@
   "description": "Media Player Plugin for Kolibri",
   "private": true,
   "dependencies": {
-    "lockr": "0.8.4",
     "video.js": "6.1.0"
   }
 }

--- a/kolibri/plugins/media_player/yarn.lock
+++ b/kolibri/plugins/media_player/yarn.lock
@@ -42,10 +42,6 @@ is-function@^1.0.1, is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
-lockr@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/lockr/-/lockr-0.8.4.tgz#7614f9c7c98a60bc4ac45f44567d1d03d8fb493c"
-
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "intl": "1.2.4",
     "js-cookie": "2.1.2",
     "keen-ui": "^1.0.1",
+    "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "1.4.1",
     "markdown-it": "^8.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,6 +3140,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lockr@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/lockr/-/lockr-0.8.4.tgz#7614f9c7c98a60bc4ac45f44567d1d03d8fb493c"
+
 lodash._createcompounder@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz#5dd2cb55372d6e70e0e2392fb2304d6631091075"


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

* Moves [Lockr](https://github.com/tsironis/lockr) to the core package.json so it can be used by other plugins. Useful little utility that can definitely come in handy. 

### References

* https://github.com/fle-internal/kolibri-instant-schools-plugin/pull/61 Depends on this
