### PR TITLE
Fix undefined variable caused by merge.

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -445,7 +445,7 @@ function showExam(store, id, questionNumber) {
       samePageCheckGenerator(store),
       ([exam, examLogs, examAttemptLogs]) => {
         if (exam.closed) {
-          router.getInstance().replace({ name: constants.PageNames.EXAM_LIST });
+          router.getInstance().replace({ name: PageNames.EXAM_LIST });
           return;
         }
         const currentChannel = getChannelObject(store.state, exam.channel_id);


### PR DESCRIPTION
# Checklist

- [X] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

When merging changes up from 0.4, the switch from importing 'constants' to just importing 'PageNames' was not reflected in the new code for routing people away from a closed exam. This rectifies this here.

Note: this bug will be extant on 0.5, but all it will do is throw an error if a user attempts to navigate to a closed exam, so this seems not terrible to me.