### PR TITLE
adding note about dev installers

### DIFF
--- a/docs/dev/release_process.rst
+++ b/docs/dev/release_process.rst
@@ -48,6 +48,12 @@ Create a release branch
 If this is a new major or minor release, you need to make a new branch as described above.
 
 
+Pin installer versions
+~~~~~~~~~~~~~~~~~~~~~~
+
+On Kolibri's ``develop`` branch, we sometimes allow the installers to track the latest development versions on github. Before releasing Kolibri, we need to pin the Buildkite configuration to a tagged version of each installer.
+
+
 Update any translation files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [x] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Adds a note that installers should be pinned prior to release

### Reviewer guidance

proofread

### References

follow-up from #2461
