### PR TITLE
Make kNavbar more responsive

### DIFF
--- a/kolibri/core/assets/src/views/k-navbar/index.vue
+++ b/kolibri/core/assets/src/views/k-navbar/index.vue
@@ -1,10 +1,36 @@
 <template>
 
-  <nav class="tabs">
-    <ul>
+  <nav>
+    <button
+      v-show="!enoughSpace"
+      class="k-navbar-scroll-button"
+      @click="scrollLeft"
+    >
+      <mat-svg
+        name="keyboard_arrow_left"
+        category="hardware"
+      />
+    </button>
+
+    <ul
+      ref="kNavbar"
+      class="k-navbar"
+      :style="{ maxWidth: `${ maxWidth }px` }"
+    >
       <!-- Contains k-navbar-link components -->
       <slot></slot>
     </ul>
+
+    <button
+      v-show="!enoughSpace"
+      class="k-navbar-scroll-button"
+      @click="scrollRight"
+    >
+      <mat-svg
+        name="keyboard_arrow_right"
+        category="hardware"
+      />
+    </button>
   </nav>
 
 </template>
@@ -12,12 +38,48 @@
 
 <script>
 
+  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
+  import throttle from 'lodash/throttle';
+
   /**
     * Used for navigation between sub-pages of a top-level Kolibri section
     */
-
   export default {
     name: 'kNavbar',
+    mixins: [responsiveElement],
+    data: () => ({
+      enoughSpace: true,
+    }),
+    computed: {
+      maxWidth() {
+        return this.enoughSpace ? this.elSize.width : this.elSize.width - 36 * 2;
+      },
+    },
+    mounted() {
+      this.checkSpace();
+      this.$watch('elSize.width', this.throttleCheckSpace);
+    },
+    methods: {
+      checkSpace() {
+        const availableWidth = this.elSize.width;
+        const items = this.$children;
+        let widthOfItems = 0;
+        items.forEach(item => {
+          const itemWidth = Math.ceil(item.$el.getBoundingClientRect().width);
+          widthOfItems += itemWidth;
+        });
+        this.enoughSpace = widthOfItems <= availableWidth;
+      },
+      throttleCheckSpace: throttle(function() {
+        this.checkSpace();
+      }, 100),
+      scrollLeft() {
+        this.$refs.kNavbar.scrollLeft -= this.maxWidth;
+      },
+      scrollRight() {
+        this.$refs.kNavbar.scrollLeft += this.maxWidth;
+      },
+    },
   };
 
 </script>
@@ -27,13 +89,20 @@
 
   @require '~kolibri.styles.definitions'
 
-  .tabs
+  .k-navbar
     white-space: nowrap
     overflow-x: auto
     overflow-y: hidden
-
-  ul
     margin: 0
     padding: 0
+    display: inline-block
+    vertical-align: middle
+
+  .k-navbar-scroll-button
+    width: 36px
+    height: 36px
+    vertical-align: middle
+    &:focus
+      outline: $core-outline
 
 </style>


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

* Adds scroll right/left buttons to kNavbar when there is not enough room.

![knavbar](https://user-images.githubusercontent.com/7193975/31966316-307650ac-b8bf-11e7-9eea-d7e87d7346e1.gif)


### References

* Addresses #1914 
