### PR TITLE
Bulk create memberships

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -126,12 +126,23 @@ class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
             Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True))
 
 
+class MembershipFilter(filters.FilterSet):
+    user_ids = filters.django_filters.MethodFilter()
+
+    def filter_user_ids(self, queryset, value):
+        return queryset.filter(user_id__in=value.split(','))
+
+    class Meta:
+        model = Membership
+
+
 class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter, filters.DjangoFilterBackend)
     queryset = Membership.objects.all()
     serializer_class = MembershipSerializer
-    filter_fields = ('user_id', 'collection_id')
+    filter_class = MembershipFilter
+    filter_fields = ['user', 'collection', 'user_ids', ]
 
 
 class RoleViewSet(viewsets.ModelViewSet):

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -6,6 +6,7 @@ from django.contrib.auth import authenticate, get_user, login, logout
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Q
 from django.db.models.query import F
+from kolibri.core.mixins import BulkCreateMixin, BulkDeleteMixin
 from kolibri.logger.models import UserSessionLog
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.response import Response
@@ -52,9 +53,17 @@ class KolibriAuthPermissions(permissions.BasePermission):
 
         # as `has_object_permission` isn't called for POST/create, we need to check here
         if request.method == "POST" and request.data:
+            if type(request.data) is list:
+                data = request.data
+            else:
+                data = [request.data]
+
             model = view.serializer_class.Meta.model
-            validated_data = view.serializer_class().to_internal_value(_ensure_raw_dict(request.data))
-            return request.user.can_create(model, validated_data)
+
+            def validate(datum):
+                validated_data = view.serializer_class().to_internal_value(_ensure_raw_dict(datum))
+                return request.user.can_create(model, validated_data)
+            return all(validate(datum) for datum in data)
 
         # for other methods, we return True, as their permissions get checked below
         return True
@@ -117,7 +126,7 @@ class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
             Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True))
 
 
-class MembershipViewSet(viewsets.ModelViewSet):
+class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter, filters.DjangoFilterBackend)
     queryset = Membership.objects.all()

--- a/kolibri/auth/api_urls.py
+++ b/kolibri/auth/api_urls.py
@@ -1,3 +1,4 @@
+from kolibri.core.routers import BulkDeleteRouter
 from rest_framework import routers
 
 from .api import (
@@ -10,7 +11,6 @@ router = routers.SimpleRouter()
 router.register(r'facilitydataset', FacilityDatasetViewSet, base_name='facilitydataset')
 router.register(r'facilityuser', FacilityUserViewSet, base_name='facilityuser')
 router.register(r'facilityusername', FacilityUsernameViewSet, base_name='facilityusername')
-router.register(r'membership', MembershipViewSet, base_name='membership')
 router.register(r'role', RoleViewSet, base_name='role')
 router.register(r'facility', FacilityViewSet, base_name='facility')
 router.register(r'currentfacility', CurrentFacilityViewSet, base_name='currentfacility')
@@ -19,4 +19,8 @@ router.register(r'classroom', ClassroomViewSet, base_name='classroom')
 router.register(r'learnergroup', LearnerGroupViewSet, base_name='learnergroup')
 router.register(r'signup', SignUpViewSet, base_name='signup')
 
-urlpatterns = router.urls
+bulk_delete_router = BulkDeleteRouter()
+
+bulk_delete_router.register(r'membership', MembershipViewSet, base_name='membership')
+
+urlpatterns = router.urls + bulk_delete_router.urls

--- a/kolibri/core/assets/test/api-resource.js
+++ b/kolibri/core/assets/test/api-resource.js
@@ -206,6 +206,19 @@ describe('Collection', function() {
       client: () => Promise.resolve({ entity: [] }),
       filterAndCheckResourceIds: params => params,
       resourceIds: [],
+      cacheKey: (...params) => {
+        const allParams = Object.assign({}, ...params);
+        // Sort keys in order, then assign those keys to an empty object in that order.
+        // Then stringify to create a cache key.
+        return JSON.stringify(
+          Object.assign(
+            {},
+            ...Object.keys(allParams)
+              .sort()
+              .map(paramKey => ({ [paramKey]: allParams[paramKey] }))
+          )
+        );
+      },
     };
     this.resourceIds = {};
     this.params = {};
@@ -910,6 +923,16 @@ describe('Collection', function() {
         this.collection.set([this.model, this.model]);
         assert.deepEqual(this.collection._model_map, {
           [this.model.id]: this.setModel,
+        });
+      });
+      describe('that have no ids', function() {
+        it(' should not overwrite each other in the model cache', function() {
+          const idLessModel1 = { test: 'testing' };
+          const idLessModel2 = { test: 'testing1' };
+          this.collection._model_map = {};
+          this.collection.models = [];
+          this.collection.set([idLessModel1, idLessModel2]);
+          assert.equal(this.collection.models.length, 2);
         });
       });
     });

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -1,0 +1,46 @@
+"""
+Mixins for Django REST Framework ViewSets
+"""
+from rest_framework import status
+from rest_framework.response import Response
+
+
+class BulkCreateMixin(object):
+
+    def get_serializer(self, *args, **kwargs):
+        """ if an array is passed, set serializer to many """
+        if isinstance(kwargs.get('data', {}), list):
+            kwargs['many'] = True
+        return super(BulkCreateMixin, self).get_serializer(*args, **kwargs)
+
+
+class BulkDeleteMixin(object):
+
+    # Taken from https://github.com/miki725/django-rest-framework-bulk
+
+    def allow_bulk_destroy(self, qs, filtered):
+        """
+        Hook to ensure that the bulk destroy should be allowed.
+        By default this checks that the destroy is only applied to
+        filtered querysets.
+        """
+        # Only let a bulk destroy if the queryset is being filtered by a valid filter_field parameter
+        return any(key in self.filter_fields for key in self.request.query_params.keys())
+
+    def bulk_destroy(self, request, *args, **kwargs):
+        qs = self.get_queryset()
+
+        filtered = self.filter_queryset(qs)
+        if not self.allow_bulk_destroy(qs, filtered):
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        self.perform_bulk_destroy(filtered)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def perform_destroy(self, instance):
+        instance.delete()
+
+    def perform_bulk_destroy(self, objects):
+        for obj in objects:
+            self.perform_destroy(obj)

--- a/kolibri/core/routers.py
+++ b/kolibri/core/routers.py
@@ -1,0 +1,19 @@
+"""
+Custom router to allow bulk deletion
+Modified from https://github.com/miki725/django-rest-framework-bulk
+"""
+from __future__ import print_function, unicode_literals
+
+import copy
+
+from rest_framework.routers import DefaultRouter, SimpleRouter
+
+
+class BulkDeleteRouter(DefaultRouter):
+    """
+    Map http methods to actions defined on the bulk mixins.
+    """
+    routes = copy.deepcopy(SimpleRouter.routes)
+    routes[0].mapping.update({
+        'delete': 'bulk_destroy',
+    })

--- a/kolibri/core/test/test_drf_mixins.py
+++ b/kolibri/core/test/test_drf_mixins.py
@@ -1,0 +1,106 @@
+from __future__ import unicode_literals, print_function
+import json
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+from rest_framework import filters, status
+from rest_framework.viewsets import ModelViewSet
+
+from kolibri.content.models import Language
+from kolibri.content.serializers import LanguageSerializer
+from kolibri.core.mixins import BulkCreateMixin, BulkDeleteMixin
+
+
+class LanguageViewSet(ModelViewSet):
+    filter_backends = (filters.DjangoFilterBackend, )
+    queryset = Language.objects.all()
+    serializer_class = LanguageSerializer
+    filter_fields = ('id', )
+
+
+class BulkDeleteView(BulkDeleteMixin, LanguageViewSet):
+    pass
+
+
+class BulkCreateView(BulkCreateMixin, LanguageViewSet):
+    pass
+
+
+class TestBulkAPIMixins(TestCase):
+    lang1 = {'id': 'en-us', 'lang_code': 'en', 'lang_subcode': 'us'}
+    lang2 = {'id': 'fr-fr', 'lang_code': 'fr', 'lang_subcode': 'fr'}
+
+    def setUp(self):
+        super(TestBulkAPIMixins, self).setUp()
+        self.request = RequestFactory()
+
+    def test_get(self):
+        """
+        Test that GET request is successful on bulk create view.
+        """
+        view = BulkCreateView.as_view({'get': 'list'})
+        response = view(self.request.get(''))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_post_single(self):
+        """
+        Test that POST request with single resource only creates a single resource.
+        """
+        view = BulkCreateView.as_view({'post': 'create'})
+        response = view(self.request.post(
+            '',
+            json.dumps(self.lang1),
+            content_type='application/json',
+        ))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Language.objects.count(), 1)
+        self.assertEqual(Language.objects.get().id, self.lang1['id'])
+
+    def test_post_bulk(self):
+        """
+        Test that POST request with multiple resources creates all posted resources.
+        """
+        view = BulkCreateView.as_view({'post': 'create'})
+        response = view(self.request.post(
+            '',
+            json.dumps([
+                self.lang1,
+                self.lang2,
+            ]),
+            content_type='application/json',
+        ))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Language.objects.count(), 2)
+        self.assertEqual(list(Language.objects.all().values_list('id', flat=True)), [
+            self.lang1['id'],
+            self.lang2['id'],
+        ])
+
+    def test_delete_not_filtered(self):
+        """
+        Test that DELETE is not allowed when results are not filtered.
+        """
+        view = BulkDeleteView.as_view({'delete': 'bulk_destroy'})
+        Language.objects.create(**self.lang1)
+        Language.objects.create(**self.lang2)
+
+        response = view(self.request.delete(''))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_filtered(self):
+        """
+        Test that DELETE removes all filtered resources.
+        """
+        view = BulkDeleteView.as_view({'delete': 'bulk_destroy'})
+        Language.objects.create(**self.lang1)
+        Language.objects.create(**self.lang2)
+
+        response = view(self.request.delete('?id=' + self.lang1['id']))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Language.objects.count(), 1)
+        self.assertEqual(Language.objects.get().id, self.lang2['id'])

--- a/kolibri/plugins/management/assets/src/state/actions.js
+++ b/kolibri/plugins/management/assets/src/state/actions.js
@@ -191,20 +191,15 @@ function removeClassUser(store, classId, userId) {
     collection_id: classId,
   });
 
-  MembershipCollection.fetch().then(membership => {
-    const membershipId = membership[0].id; // will always only have one item in the array.
-    MembershipResource.getModel(membershipId)
-      .delete()
-      .then(
-        () => {
-          store.dispatch('DELETE_CLASS_USER', userId);
-          displayModal(store, false);
-        },
-        error => {
-          handleApiError(store, error);
-        }
-      );
-  });
+  MembershipCollection.delete().then(
+    () => {
+      store.dispatch('DELETE_CLASS_USER', userId);
+      displayModal(store, false);
+    },
+    error => {
+      handleApiError(store, error);
+    }
+  );
 }
 
 function showClassesPage(store) {
@@ -301,14 +296,16 @@ function showClassEnrollPage(store, classId) {
 
 function enrollUsersInClass(store, classId, users) {
   // TODO no error handling
-  return Promise.all(
-    users.map(userId =>
-      MembershipResource.createModel({
-        collection: classId,
-        user: userId,
-      }).save()
-    )
-  );
+  const memberships = users.map(userId => ({
+    collection: classId,
+    user: userId,
+  }));
+  return MembershipResource.createCollection(
+    {
+      collection: classId,
+    },
+    memberships
+  ).save();
 }
 
 // ================================


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Implements DRF ViewSet mixins for bulk creation and bulk deletion.

Adds Collection save and delete methods to the frontend API Resource code.

Implements Bulk creation for learner enrollment in the facility management module.

Implements bulk creation and deletion for learner group membership in the coach module.

Fixes #2325