### PR TITLE
Exam completion timestamp setting

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exam-report-detail-page/index.vue
@@ -10,7 +10,7 @@
           :contentName="exam.title"
           :userName="userName"
           :questions="examAttempts"
-          :completionTimestamp="new Date(completionTimestamp)"
+          :completionTimestamp="completionTimestamp"
           :completed="closed"/>
       </div>
       <div class="details-container">

--- a/kolibri/plugins/learn/assets/src/state/actions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions.js
@@ -392,7 +392,7 @@ function triggerSearch(store, channelId, searchTerm) {
     store.dispatch('SET_PAGE_STATE', searchState);
     store.dispatch('CORE_SET_PAGE_LOADING', false);
   })
-  .catch(error => { coreActions.handleApiError(store, error); });
+    .catch(error => { coreActions.handleApiError(store, error); });
 }
 
 function clearSearch(store) {
@@ -499,9 +499,9 @@ function calcQuestionsAnswered(attemptLogs) {
   let questionsAnswered = 0;
   Object.keys(attemptLogs).forEach((key) => {
     Object.keys(attemptLogs[key]).forEach(
-    (innerKey) => {
-      questionsAnswered += attemptLogs[key][innerKey].answer ? 1 : 0;
-    });
+      (innerKey) => {
+        questionsAnswered += attemptLogs[key][innerKey].answer ? 1 : 0;
+      });
   });
   return questionsAnswered;
 }
@@ -606,9 +606,9 @@ function showExam(store, channelId, id, questionNumber) {
 
               const questions = shuffledQuestions.map(question => ({
                 itemId: selectQuestionFromExercise(
-                question.assessmentItemIndex,
-                seed,
-                contentNodeMap[question.contentId]),
+                  question.assessmentItemIndex,
+                  seed,
+                  contentNodeMap[question.contentId]),
                 contentId: question.contentId
               }));
 
@@ -722,7 +722,9 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
 }
 
 function closeExam(store) {
-  const examLog = Object.assign({}, store.state.examLog);
+  const examLog = Object.assign({}, store.state.examLog, {
+    completion_timestamp: now(),
+  });
   examLog.closed = true;
   return ExamLogResource.getModel(examLog.id).save(examLog).catch(
     error => { coreActions.handleApiError(store, error); });


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Don't show null timestamps as 0 Unix Epoch.
Set a completion timestamp when students submit their exam.
Set a completion timestamp on all un-timestamped examlogs when the exam is deactivated.

Fixes #2499 