### PR TITLE
Prevent attemptlog overwriting in vuex store

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -642,8 +642,13 @@ function saveAttemptLog(store) {
 }
 
 function saveAndStoreAttemptLog(store) {
+  const attemptLogId = store.state.core.logging.attempt.id;
+  const attemptLogItem = store.state.core.logging.attempt.item;
+  const storeAttemptLog = () =>
+    !attemptLogId &&
+      attemptLogItem === store.state.core.logging.attempt.item;
   return saveAttemptLog(store).only(
-    samePageCheckGenerator(store),
+    storeAttemptLog,
     newAttemptLog => {
       // mainly we want to set the attemplot id, so we can PATCH subsequent save on this attemptLog
       store.dispatch('SET_LOGGING_ATTEMPT_STATE', _attemptLoggingState(newAttemptLog));

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -644,11 +644,20 @@ function saveAttemptLog(store) {
 function saveAndStoreAttemptLog(store) {
   const attemptLogId = store.state.core.logging.attempt.id;
   const attemptLogItem = store.state.core.logging.attempt.item;
-  const storeAttemptLog = () =>
+  /*
+   * Create a 'same item' check instead of same page check, which only allows the resulting save
+   * payload to be set if two conditions are met: firstly, that at the time the save was
+   * initiated, the attemptlog did not have an id, we need this id for future updating saves,
+   * but no other information saved to the server needs to be persisted back into the vuex store;
+   * secondly, we check that the item id when the save has resolved is the same as when the save
+   * was initiated, ensuring that we are not overwriting the vuex attemptlog representation for a
+   * different question.
+   */
+  const sameItemAndNoLogIdCheck = () =>
     !attemptLogId &&
       attemptLogItem === store.state.core.logging.attempt.item;
   return saveAttemptLog(store).only(
-    storeAttemptLog,
+    sameItemAndNoLogIdCheck,
     newAttemptLog => {
       // mainly we want to set the attemplot id, so we can PATCH subsequent save on this attemptLog
       store.dispatch('SET_LOGGING_ATTEMPT_STATE', _attemptLoggingState(newAttemptLog));


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Previously, we were using `samePageCheckGenerator` to prevent delayed attemptLog saves from writing their payload into the vuex store.

Unfortunately, this strategy does not work, because when we move onto a new item in an exercise (and hence a new attempt log) the page does not change, it's still on the same resource.

This had the unfortunate effect of a new attemptlog being created in the vuex store (using the `createAttemptLog` action), but then that being overwritten when the attemptLog save resolved in `saveAndStoreAttemptLog` action.

This meant that a subsequent answer would then be appended to the attemptlog for the previous question as an additional interaction, and not recorded on the new attempt log.

This PR solves that in a two step strategy:

* Firstly, by creating a test to replicate this scenario.
* Creating a 'same item' check instead of same page check, which only allows the resulting save payload to be set if two conditions are met: firstly, that at the time the save was initiated, the attemptlog did not have an id, we need this id for future updating saves, but no other information saved to the server needs to be persisted back into the vuex store; secondly, we check that the item id when the save has resolved is the same as when the save was initiated, ensuring that we are not overwriting the vuex attemptlog representation for a different question.

Fixes #2417

This is a bit of a pain to test, as it relies on a race condition between the frontend and the API. I think my test case covers the problem well, but to actually check that this is resolved you would need to add this code to the AttemptLogViewSet in kolibri/logger/api.py:
```
    def create(self, request, *args, **kwargs):
        import time
        time.wait(10)
        return super(AttemptLogViewSet, self).create(request, *args, **kwargs)
```
This should delay the initial AttemptLog save by 10 seconds, and then you can wait for that API call to complete, and then answer another question.
Without the patch in this PR, this should replicate the issue. With it, it should not have an effect.