### PR TITLE
Added header over recommended content carousel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -71,6 +71,10 @@
     </div>
 
     <download-button v-if="canDownload" :files="downloadableFiles" class="download-button" />
+    
+    <template v-if="showRecommended">
+      <h2>Recommended Content</h2>
+    </template>
 
     <content-card-group-carousel
       v-if="showRecommended"

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -74,13 +74,11 @@
     
     <template v-if="showRecommended">
       <h2>{{ $tr('recommended') }}</h2>
+      <content-card-group-carousel
+        :genContentLink="genContentLink"
+        :header="recommendedText"
+        :contents="recommended" />
     </template>
-
-    <content-card-group-carousel
-      v-if="showRecommended"
-      :genContentLink="genContentLink"
-      :header="recommendedText"
-      :contents="recommended" />
 
     <template v-if="progress >= 1 && wasIncomplete">
       <points-popup

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -73,7 +73,7 @@
     <download-button v-if="canDownload" :files="downloadableFiles" class="download-button" />
     
     <template v-if="showRecommended">
-      <h2>Recommended Content</h2>
+      <h2>{{ $tr('recommended') }}</h2>
     </template>
 
     <content-card-group-carousel


### PR DESCRIPTION
# Checklist


- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [x] Screenshots of any front-end changes are in the PR description

# Details

### Summary

 Added header over recommended content carousel
 h tag added to the learn plugin's content page
<img width="779" alt="2017-10-26 04 01 55 pm" src="https://user-images.githubusercontent.com/19736673/32081546-fc085b78-ba6a-11e7-93af-38406faae5e0.png">

### Reviewer guidance

Access a lesson via recommended

### References

Fixes #2285 
