### PR TITLE
Fixed URL-routing issue

### DIFF
--- a/kolibri/plugins/management/urls.py
+++ b/kolibri/plugins/management/urls.py
@@ -5,6 +5,6 @@ from . import views
 
 urlpatterns = [
     url('^$', RedirectView.as_view(url='/')),
-    url('^facility$', views.ManagementView.as_view(), name='management'),
-    url('^device$', views.DeviceManagementView.as_view(), name='device_management'),
+    url('^facility/$', views.ManagementView.as_view(), name='management'),
+    url('^device/$', views.DeviceManagementView.as_view(), name='device_management'),
 ]

--- a/kolibri/plugins/user/kolibri_plugin.py
+++ b/kolibri/plugins/user/kolibri_plugin.py
@@ -9,7 +9,7 @@ class User(KolibriPluginBase):
         return urls
 
     def url_slug(self):
-        return "^user"
+        return "^user/"
 
 
 class UserAsset(webpack_hooks.WebpackBundleHook):


### PR DESCRIPTION
# Checklist

- [ ] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

It turned out to be a small, server-side problem consisting of simply adding slashes after the URL names. I changed the kolibri-plugin.py files for users as well as the urls.py file under management.

### Reviewer guidance

Use Kolibri and navigate to the profile, facility, and/or device pages to verify the URLs.

### References

This solves the problem opened in issue #2157.
