### PR TITLE
Add app bar to core api spec

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -64,6 +64,7 @@ import urls from './urls';
 import * as client from './client';
 import * as i18n from '../utils/i18n';
 import * as browser from '../utils/browser';
+import appBar from '../views/app-bar';
 
 export default {
   client,
@@ -111,6 +112,7 @@ export default {
       kRadioButton,
       kFilterTextbox,
       languageSwitcher,
+      appBar,
     },
     router,
     mixins: {

--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -59,7 +59,7 @@
   import keenMenuPort from '../side-nav/keen-menu-port';
   import uiButton from 'keen-ui/src/UiButton';
   import { redirectBrowser } from 'kolibri.utils.browser';
-  import languageSwitcher from '../language-switcher';
+  import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
   export default {
     mixins: [responsiveWindow],
     name: 'appBar',

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -45,7 +45,7 @@
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import values from 'lodash/values';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
-  import appBar from './app-bar';
+  import appBar from 'kolibri.coreVue.components.appBar';
   import sideNav from 'kolibri.coreVue.components.sideNav';
   import errorBox from './error-box';
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

* Adds app bar to core api spec so it can be overridden by plugins.

### References

* Necessary to address https://github.com/fle-internal/kolibri-instant-schools-plugin/issues/77
