### PR TITLE
Autodocument REST APIs with an API explorer

### DIFF
--- a/docs/dev/dataflow/index.rst
+++ b/docs/dev/dataflow/index.rst
@@ -28,6 +28,8 @@ Finally, in the ``api_urls.py`` file, the ViewSets are given a name (through the
       url(r'^content/(?P<channel_id>[^/.]+)/', include(content_router.urls)),
   ]
 
+To explore the server REST APIs, visit `/api_explorer/` on the Kolibri server while running with developer settings.
+
 
 Client Resource Layer
 ---------------------

--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -143,8 +143,13 @@ To start up the development server and build the client-side dependencies, use t
 
 .. code-block:: bash
 
-  (kolibri)$ kolibri --debug manage devserver --webpack
+  (kolibri)$ yarn run devserver
 
+If this does not work, you can run the command that this is invoking:
+
+.. code-block:: bash
+
+  (kolibri)$ kolibri --debug manage devserver --webpack --lint --settings=kolibri.deployment.default.settings.dev
 
 Wait for the build process to complete. This takes a while the first time, will complete faster as you make edits and the assets are automatically re-built.
 
@@ -175,14 +180,14 @@ More advanced examples of the ``devserver`` command:
 
 .. code-block:: bash
 
-  # runs the dev server and rebuild client assets when files change
-  kolibri --debug manage devserver --webpack
+  # runs the dev server, rebuild client assets when files change, and use developer settings
+  kolibri --debug manage devserver --webpack --settings=kolibri.deployment.default.settings.dev
 
   # runs the dev server and re-run client-side tests when files changes
   kolibri --debug manage devserver --karma
 
   # runs all of the above
-  kolibri --debug manage devserver --webpack --karma
+  kolibri --debug manage devserver --webpack --karma --settings=kolibri.deployment.default.settings.dev
 
 
 Running the Production Server

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -69,6 +69,9 @@ INSTALLED_APPS = [
     'morango',
 ] + conf.config['INSTALLED_APPS']
 
+if os.environ['KOLIBRI_DEBUG']:
+    INSTALLED_APPS += ['rest_framework_swagger']
+
 # Add in the external plugins' locale paths. Our frontend messages depends
 # specifically on the value of LOCALE_PATHS to find its catalog files.
 LOCALE_PATHS += [

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -69,9 +69,6 @@ INSTALLED_APPS = [
     'morango',
 ] + conf.config['INSTALLED_APPS']
 
-if os.environ['KOLIBRI_DEBUG']:
-    INSTALLED_APPS += ['rest_framework_swagger']
-
 # Add in the external plugins' locale paths. Our frontend messages depends
 # specifically on the value of LOCALE_PATHS to find its catalog files.
 LOCALE_PATHS += [

--- a/kolibri/deployment/default/settings/debug_panel.py
+++ b/kolibri/deployment/default/settings/debug_panel.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-from .base import *  # noqa
+from .dev import *  # noqa
 
 INTERNAL_IPS = ['127.0.0.1']
 

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from .base import *  # noqa isort:skip @UnusedWildImport
+
+INSTALLED_APPS += ['rest_framework_swagger']  # noqa
+
+REST_SWAGGER = True

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -46,7 +46,7 @@ if getattr(settings, 'DEBUG_PANEL_ACTIVE', False):
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
 
-if getattr(settings, 'DEBUG', False):
+if getattr(settings, 'REST_SWAGGER', False):
     urlpatterns += [
         url(r'^api_explorer/', include('rest_framework_swagger.urls'))
     ]

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -45,3 +45,8 @@ if getattr(settings, 'DEBUG_PANEL_ACTIVE', False):
     urlpatterns = [
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
+
+if getattr(settings, 'DEBUG', False):
+    urlpatterns += [
+        url(r'^api_explorer/', include('rest_framework_swagger.urls'))
+    ]

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -173,9 +173,6 @@ def initialize(debug=False):
 
     :param: debug: Tells initialization to setup logging etc.
     """
-    if debug:
-        os.environ['KOLIBRI_DEBUG'] = 'true'
-
     if not os.path.isfile(version_file()):
         django.setup()
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -173,6 +173,8 @@ def initialize(debug=False):
 
     :param: debug: Tells initialization to setup logging etc.
     """
+    if debug:
+        os.environ['KOLIBRI_DEBUG'] = 'true'
 
     if not os.path.isfile(version_file()):
         django.setup()

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "node ./frontend_build/src/clean.js",
     "preinstall": "node ./frontend_build/src/npm_deprecation_warning.js",
     "lint-js": "node ./frontend_build/src/prettier-frontend.js --prettierPath ./.prettier.js",
-    "lint-js:fix": "yarn run lint-js -- -w"
+    "lint-js:fix": "yarn run lint-js -- -w",
+    "devserver": "kolibri --debug manage devserver --webpack --lint --settings=kolibri.deployment.default.settings.dev"
   },
   "repository": {
     "type": "git",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ tox==2.9.1
 django-debug-panel==0.8.3
 django-debug-toolbar==1.8
 sphinx-autobuild
+django-rest-swagger==0.3.10


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [x] PR has been fully tested manually
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [X] Screenshots of any front-end changes are in the PR description

# Details

### Summary

Adds Django REST Swagger to provide a browseable interface of all API endpoints, with appropriate metadata.

![image](https://user-images.githubusercontent.com/1680573/32239257-588fdde6-be6a-11e7-84fd-1352af4bcde2.png)

To test, reinstall `pip install -r requirements/dev.txt`, then visit the `http://127.0.0.1/api_explorer` endpoint to browse the REST APIs.