### PR TITLE
Add extra logging to Iceqube tasks

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -250,6 +250,11 @@ LOGGING = {
         'kolibri': {
             'handlers': ['console', 'mail_admins', 'file', 'file_debug'],
             'level': 'INFO',
+        },
+        'iceqube': {
+            'handlers': ['file', 'console'],
+            'level': 'INFO',
+            'propagate': True,
         }
     }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.10.0
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
-iceqube==0.0.2
+iceqube==0.0.3
 porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5


### PR DESCRIPTION
Changes:
- Write all iceqube logs to both console and file
- Update iceqube to the version that has exception logging

Diff on iceqube: https://github.com/learningequality/iceqube/pull/27/files