### PR TITLE
Upgrade requests.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ docopt==0.6.2
 django-mptt==0.8.5
 djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
-requests==2.10.0
+requests==2.18.4
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
 iceqube==0.0.2
 porter2stemmer==1.0


### PR DESCRIPTION
# Checklist

- [ ] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

@aronasorman and I discovered an issue that seemed to replicate this: https://github.com/requests/requests/issues/3421 upgrade to the latest requests in order to prevent this from happening by using a later version of urllib3.