### PR TITLE
add on-device resource information into channelmetadata

### DIFF
--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -183,6 +183,16 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(reverse("channel-detail", kwargs={'pk': data["id"]}))
         self.assertEqual(response.data['name'], 'testing')
 
+    def test_channelmetadata_resource_info(self):
+        data = content.ChannelMetadata.objects.values()[0]
+        c1_id = content.ContentNode.objects.get(title="c1").id
+        content.ContentNode.objects.filter(pk=c1_id).update(available=False)
+        response = self.client.get(reverse("channel-detail", kwargs={'pk': data["id"]}), {'file_sizes': True})
+        self.assertEqual(response.data['total_resources'], 4)
+        self.assertEqual(response.data['total_file_size'], 0)
+        self.assertEqual(response.data['on_device_resources'], 3)
+        self.assertEqual(response.data['on_device_file_size'], 0)
+
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
         self.assertEqual(len(response.data), 5)


### PR DESCRIPTION
# Checklist

- [X] PR has the correct target milestone when it's merged
- [X] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

* description of the change

After discussing with @jonboiser , we think that it will be better to add on-device resource information (on_device_resources and on_device_file_size) into the ChannelMetadata endpoint so that when the `file_sizes` parameter is set to be True (or anything except False, as the code suggested), then the endpoint will return additional information `total_resources`, `total_file_size`, `on_device_resources` and `on_device_file_size`. 
 
* manual verification steps performed

1. Do `importchannel` through command line
2. open browser and type `/api/channel/?file_sizes=True to see total_resources and total_file_size. Note that on_device_resources and on_device_file_size should be zero.
3. Do `importcontent` through command line
4. open browser and type `/api/channel/?file_sizes=True to see that on_device resources and total_resources should be the same. Also, total_file_size should be the same as on_device_file_size.


### Reviewer guidance

Both Jonathan and me think that the parameter `file_sizes` may not be a good variable name for now, since it's now returning four different resource information. May need to find a new variable name for this.

### References

when applicable, please provide:

* links to mockups or specs for new features
Please see `Downloaded channel detail` and `Downloaded channel list` sections in this [doc](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?pli=1#heading=h.ky6rn0inhd26)

mockups [here](https://projects.invisionapp.com/share/Q9D1VQD67#/screens/254175337).

### TODO
- Need to test on Ubuntu and Windows after the pex file and windows installer are built through buildkite.