### PR TITLE
Device info endpoint

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -1,5 +1,3 @@
-import platform
-
 import kolibri
 from django.conf import settings
 from kolibri.auth.api import KolibriAuthPermissions, KolibriAuthPermissionsFilter
@@ -73,9 +71,11 @@ class DeviceInfoView(views.APIView):
             # If any other database backend, will not be file backed, so no database path to return
             info['database_path'] = settings.DATABASES['default']['NAME']
 
-        info['device_name'] = platform.node()
-        info['device_id'] = InstanceIDModel.get_or_create_current_instance()[0].id
-        info['os'] = platform.platform()
+        instance_model = InstanceIDModel.get_or_create_current_instance()[0]
+
+        info['device_name'] = instance_model.hostname
+        info['device_id'] = instance_model.id
+        info['os'] = instance_model.platform
 
         info['content_storage_free_space'] = get_free_space()
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -59,6 +59,12 @@ class DeviceInfoView(views.APIView):
         if not urls:
             # Will not return anything when running the debug server, so at least return the current URL
             urls = [request.build_absolute_uri('/')]
+
+        filtered_urls = [url for url in urls if '127.0.0.1' not in url and 'localhost' not in url]
+
+        if filtered_urls:
+            urls = filtered_urls
+
         info['urls'] = urls
 
         if settings.DATABASES['default']['ENGINE'].endswith('sqlite3'):

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -12,7 +12,7 @@ from rest_framework import mixins, status, views, viewsets
 from rest_framework.response import Response
 
 from .models import DevicePermissions
-from .permissions import NotProvisionedCanPost
+from .permissions import NotProvisionedCanPost, UserHasAnyDevicePermissions
 from .serializers import DevicePermissionsSerializer, DeviceProvisionSerializer
 
 
@@ -49,6 +49,8 @@ class FreeSpaceView(mixins.ListModelMixin, viewsets.GenericViewSet):
 
 
 class DeviceInfoView(views.APIView):
+
+    permission_classes = (UserHasAnyDevicePermissions, )
 
     def get(self, request, format=None):
         info = {}

--- a/kolibri/core/device/api_urls.py
+++ b/kolibri/core/device/api_urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from .api import DevicePermissionsViewSet, DeviceProvisionView, FreeSpaceView
+from .api import DeviceInfoView, DevicePermissionsViewSet, DeviceProvisionView, FreeSpaceView
 
 router = routers.SimpleRouter()
 router.register(r'devicepermissions', DevicePermissionsViewSet, base_name='devicepermissions')
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^deviceprovision/', DeviceProvisionView.as_view({'post': 'create'}), name='deviceprovision'),
     url(r'^freespace/', FreeSpaceView.as_view({'get': 'list'}), name='freespace'),
+    url(r'^deviceinfo/', DeviceInfoView.as_view(), name='deviceinfo'),
 ]

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -4,6 +4,11 @@ from kolibri.auth.models import Facility, FacilityUser
 
 from .permissions import UserCanManageDevicePermissions
 
+device_permissions_fields = [
+    'is_superuser',
+    'can_manage_content',
+]
+
 
 class DevicePermissions(models.Model):
     """

--- a/kolibri/core/device/permissions.py
+++ b/kolibri/core/device/permissions.py
@@ -28,3 +28,9 @@ class NotProvisionedCanPost(BasePermission):
     def has_permission(self, request, view):
         from .utils import device_provisioned
         return not device_provisioned() and request.method == 'POST'
+
+
+class UserHasAnyDevicePermissions(DenyAll):
+    def has_permission(self, request, view):
+        from .models import device_permissions_fields
+        return any(getattr(request.user, field) for field in device_permissions_fields)

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -18,6 +18,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from collections import namedtuple
 
+from mock import patch
+
 DUMMY_PASSWORD = "password"
 
 class DeviceProvisionTestCase(APITestCase):
@@ -203,6 +205,16 @@ class DeviceInfoTestCase(APITestCase):
         for url in response.data['urls']:
             # Make sure each url is a valid link
             self.assertTrue(url.startswith('http://'))
+
+    @patch('kolibri.core.device.api.get_urls', return_value=(1, ['http://127.0.0.1:8000', 'http://kolibri.com']))
+    def test_no_localhost_urls_when_others_available(self, get_urls_mock):
+        response = self.client.get(reverse('deviceinfo'), format="json")
+        self.assertEqual(len(response.data['urls']), 1)
+
+    @patch('kolibri.core.device.api.get_urls', return_value=(1, ['http://127.0.0.1:8000']))
+    def test_localhost_urls_when_no_others_available(self, get_urls_mock):
+        response = self.client.get(reverse('deviceinfo'), format="json")
+        self.assertEqual(len(response.data['urls']), 1)
 
     def test_database_path(self):
         response = self.client.get(reverse('deviceinfo'), format="json")

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -213,11 +213,13 @@ class DeviceInfoTestCase(APITestCase):
     def test_no_localhost_urls_when_others_available(self, get_urls_mock):
         response = self.client.get(reverse('deviceinfo'), format="json")
         self.assertEqual(len(response.data['urls']), 1)
+        self.assertEqual(response.data['urls'][0], 'http://kolibri.com')
 
     @patch('kolibri.core.device.api.get_urls', return_value=(1, ['http://127.0.0.1:8000']))
     def test_localhost_urls_when_no_others_available(self, get_urls_mock):
         response = self.client.get(reverse('deviceinfo'), format="json")
         self.assertEqual(len(response.data['urls']), 1)
+        self.assertEqual(response.data['urls'][0], 'http://127.0.0.1:8000')
 
     def test_database_path(self):
         response = self.client.get(reverse('deviceinfo'), format="json")

--- a/kolibri/plugins/management/assets/src/device_management/state/actions/deviceInfoActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/deviceInfoActions.js
@@ -1,0 +1,15 @@
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
+import bytesForHumans from '../../views/manage-content-page/bytesForHumans';
+
+/* Function to feth device info from the backend
+ * and resolve validated data
+ */
+export function getDeviceInfo() {
+  return client({ path: urls['deviceinfo']() }).then(response => {
+    const data = response.entity;
+    data.server_time = new Date(data.server_time);
+    data.content_storage_free_space = bytesForHumans(data.content_storage_free_space);
+    return data;
+  });
+}


### PR DESCRIPTION
# Checklist

- [x] PR has the correct target milestone when it's merged
- [ ] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency are updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Details

### Summary

Implements an API endpoint to provide data for #1910.

Returns: version, URLs, DB Path (when available), Device Name, Morango Device ID, OS, Free Space in Content Drive, Server Date and Time, Server Timezone.

Also adds a function on the frontend to retrieve from the endpoint, and do some initial data validation and cleaning on the clientside.