### PR TITLE
Slight refactor to separate saving from the password-setting function.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -106,22 +106,23 @@ class FacilityUserViewSet(viewsets.ModelViewSet):
     serializer_class = FacilityUserSerializer
     filter_class = FacilityUserFilter
 
-    def set_password_if_needed(self, serializer):
+    def set_password_if_needed(self, instance, serializer):
         with transaction.atomic():
-            instance = serializer.save()
             if serializer.validated_data.get('password', ''):
                 instance.set_password(serializer.validated_data['password'])
                 instance.save()
         return instance
 
     def perform_update(self, serializer):
-        instance = self.set_password_if_needed(serializer)
+        instance = serializer.save()
+        self.set_password_if_needed(instance, serializer)
         # if the user is updating their own password, ensure they don't get logged out
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
 
     def perform_create(self, serializer):
-        self.set_password_if_needed(serializer)
+        instance = serializer.save()
+        self.set_password_if_needed(instance, serializer)
 
 
 class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
# Details

### Summary

Quick final refactor on https://github.com/learningequality/kolibri/pull/2485 that didn't get pushed before merge.

### References

Pre-req for https://github.com/fle-internal/kolibri-instant-schools-plugin/pull/89

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
