### PR TITLE
add language code and language name to channelmetadata

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -8,6 +8,8 @@ from rest_framework import serializers
 
 class ChannelMetadataSerializer(serializers.ModelSerializer):
     root = serializers.PrimaryKeyRelatedField(read_only=True)
+    lang_code = serializers.SerializerMethodField()
+    lang_name = serializers.SerializerMethodField()
 
     def to_representation(self, instance):
         value = super(ChannelMetadataSerializer, self).to_representation(instance)
@@ -32,9 +34,22 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 
         return value
 
+    def get_lang_code(self, instance):
+        if instance.root.lang is None:
+            return None
+
+        return instance.root.lang.lang_code
+
+    def get_lang_name(self, instance):
+        if instance.root.lang is None:
+            return None
+
+        return instance.root.lang.lang_name
+
     class Meta:
         model = ChannelMetadata
-        fields = ('root', 'id', 'name', 'description', 'author', 'last_updated', 'version', 'thumbnail')
+        fields = ('root', 'id', 'name', 'description', 'author', 'last_updated', 'version', 'thumbnail',
+                  'lang_code', 'lang_name')
 
 
 class LowerCaseField(serializers.CharField):

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -193,6 +193,23 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data['on_device_resources'], 3)
         self.assertEqual(response.data['on_device_file_size'], 0)
 
+    def test_channelmetadata_langfield(self):
+        data = content.ChannelMetadata.objects.first()
+        root_lang = content.Language.objects.get(pk=1)
+        data.root.lang = root_lang
+        data.root.save()
+
+        response = self.client.get(self._reverse_channel_url("channel-detail", {'pk': data.id}))
+        self.assertEqual(response.data['lang_code'], root_lang.lang_code)
+        self.assertEqual(response.data['lang_name'], root_lang.lang_name)
+
+    def test_channelmetadata_langfield_none(self):
+        data = content.ChannelMetadata.objects.first()
+
+        response = self.client.get(self._reverse_channel_url("channel-detail", {'pk': data.id}))
+        self.assertEqual(response.data['lang_code'], None)
+        self.assertEqual(response.data['lang_name'], None)
+
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
         self.assertEqual(len(response.data), 5)


### PR DESCRIPTION
# Details

### Summary

* description of the change

Added two fields, `lang_code` and `lang_name` to ChannelMetadata according to the request of @jonboiser . These two fields are from the root contentnode's Language object. If the Language object of the root contentnode is None, then both fields will set to be None as well. Otherwise, they will get the `lang_code` and `lang_name` of the root contentnode's Language object.

* manual verification steps performed
When entering `api/channel/` to get the channel information, two additional fields `lang_code` and `lang_name` will show up

### Reviewer guidance

Check if `api/channel` shows two additional fields `lang_code` and `lang_name` of the ChannelMetadata

### References

* links to mockups or specs for new features
Spec is [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=59fbaba5#heading=h.ky6rn0inhd26) and [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=59fbaba5#heading=h.dw5c96c3bcob)


# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [X] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there
- [X] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
