### PR TITLE
Add endpoints for querying channels on studio.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -388,7 +388,6 @@ class RemoteChannelViewSet(viewsets.ViewSet):
 
         return lang_name
 
-
     @classmethod
     def _studio_response_to_kolibri_response(cls, studioresp):
         """

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -418,6 +418,7 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             "total_resource_count": studioresp.get("total_resource_count", 0),
             "version": studioresp.get("version", 0),
             "included_languages": included_languages,
+            "last_updated": studioresp.get("last_published"),
         }
 
         return resp

--- a/kolibri/content/api_urls.py
+++ b/kolibri/content/api_urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from .api import ChannelMetadataViewSet, ContentNodeProgressViewset, ContentNodeViewset, FileViewset, ContentNodeGranularViewset
+from .api import (ChannelMetadataViewSet, ContentNodeGranularViewset,
+                  ContentNodeProgressViewset, ContentNodeViewset, FileViewset,
+                  RemoteChannelViewSet)
 
 router = routers.SimpleRouter()
 router.register('channel', ChannelMetadataViewSet, base_name="channel")
@@ -10,6 +12,7 @@ router.register(r'contentnode', ContentNodeViewset, base_name='contentnode')
 router.register(r'file', FileViewset, base_name='file')
 router.register(r'contentnodeprogress', ContentNodeProgressViewset, base_name='contentnodeprogress')
 router.register(r'contentnode_granular', ContentNodeGranularViewset, base_name='contentnode_granular')
+router.register(r'remotechannel', RemoteChannelViewSet, base_name='remotechannel')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -1,21 +1,26 @@
 """
 To run this test, type this in command line <kolibri manage test -- kolibri.content>
 """
-import tempfile
-import mock
 import datetime
+import tempfile
+from collections import namedtuple
 
-from django.test import TestCase
+import mock
+import requests
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
-
-from kolibri.content import models as content
-from le_utils.constants import content_kinds
-from rest_framework.test import APITestCase
+from django.test import TestCase
 from kolibri.auth.models import Facility, FacilityUser
 from kolibri.auth.test.helpers import provision_device
+from kolibri.content import models as content
+from kolibri.core.device.models import DevicePermissions, DeviceSettings
 from kolibri.logger.models import ContentSummaryLog
-from collections import namedtuple
+from le_utils.constants import content_kinds
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+DUMMY_PASSWORD = "password"
+
 
 class ContentNodeTestBase(object):
     """
@@ -397,3 +402,54 @@ class ContentNodeAPITestCase(APITestCase):
         """
         cache.clear()
         super(ContentNodeAPITestCase, self).tearDown()
+
+
+def mock_patch_decorator(func):
+
+    def wrapper(*args, **kwargs):
+        mock_object = mock.Mock()
+        mock_object.json.return_value = {'good': 'response'}
+        with mock.patch.object(requests, 'get', return_value=mock_object):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+class KolibriStudioAPITestCase(APITestCase):
+
+    def setUp(self):
+        DeviceSettings.objects.create(is_provisioned=True)
+        facility = Facility.objects.create(name='facility')
+        superuser = FacilityUser.objects.create(username='superuser', facility=facility)
+        superuser.set_password(DUMMY_PASSWORD)
+        superuser.save()
+        DevicePermissions.objects.create(user=superuser, is_superuser=True)
+        self.client.login(username=superuser.username, password=DUMMY_PASSWORD)
+
+    @mock_patch_decorator
+    def test_channel_list(self):
+        response = self.client.get(reverse('remotechannel-list'), format='json')
+        self.assertEqual(response.data['good'], 'response')
+
+    @mock_patch_decorator
+    def test_channel_retrieve(self):
+        response = self.client.get(reverse('remotechannel-detail', kwargs={'pk': 'abc'}), format='json')
+        self.assertEqual(response.data['good'], 'response')
+
+    @mock_patch_decorator
+    def test_channel_info_cache(self):
+        self.client.get(reverse('remotechannel-detail', kwargs={'pk': 'abc'}), format='json')
+        with mock.patch.object(cache, 'set') as mock_cache_set:
+            self.client.get(reverse('remotechannel-detail', kwargs={'pk': 'abc'}), format='json')
+            self.assertFalse(mock_cache_set.called)
+
+    @mock_patch_decorator
+    def test_channel_info_404(self):
+        mock_object = mock.Mock()
+        mock_object.status_code = 404
+        requests.get.return_value = mock_object
+        response = self.client.get(reverse('remotechannel-detail', kwargs={'pk': 'abc'}), format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def tearDown(self):
+        cache.clear()

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -408,7 +408,7 @@ def mock_patch_decorator(func):
 
     def wrapper(*args, **kwargs):
         mock_object = mock.Mock()
-        mock_object.json.return_value = {'good': 'response'}
+        mock_object.json.return_value = [{'id': 1, 'name': 'studio'}]
         with mock.patch.object(requests, 'get', return_value=mock_object):
             return func(*args, **kwargs)
 
@@ -429,12 +429,12 @@ class KolibriStudioAPITestCase(APITestCase):
     @mock_patch_decorator
     def test_channel_list(self):
         response = self.client.get(reverse('remotechannel-list'), format='json')
-        self.assertEqual(response.data['good'], 'response')
+        self.assertEqual(response.data[0]['id'], 1)
 
     @mock_patch_decorator
     def test_channel_retrieve(self):
         response = self.client.get(reverse('remotechannel-detail', kwargs={'pk': 'abc'}), format='json')
-        self.assertEqual(response.data['good'], 'response')
+        self.assertEqual(response.data[0]['name'], 'studio')
 
     @mock_patch_decorator
     def test_channel_info_cache(self):

--- a/kolibri/content/utils/paths.py
+++ b/kolibri/content/utils/paths.py
@@ -92,6 +92,14 @@ def get_content_storage_url(baseurl=None):
 def get_content_storage_remote_url(filename, baseurl=None):
     return "{}{}/{}/{}".format(get_content_storage_url(baseurl), filename[0], filename[1], filename)
 
+def get_channel_lookup_url(identifier=None, base_url=None):
+    studio_url = "/api/public/v1/channels"
+    if identifier:
+        studio_url += "/lookup/{}".format(identifier)
+    return urljoin(
+        base_url or settings.CENTRAL_CONTENT_DOWNLOAD_BASE_URL,
+        studio_url
+    )
 
 def get_content_storage_file_url(filename, baseurl=None):
     """


### PR DESCRIPTION
# Details

### Summary

This PR adds an endpoint which will get channel metadata from Kolibri Studio in order to check if an old channel needs updating. Also use that endpoint to be able to get the channel ids from tokens, as well as all public channels on studio.

### References

when applicable, please provide:

Closing this PR https://github.com/learningequality/kolibri/pull/2505 in favor of this one.

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
