### PR TITLE
Add comment about skipping items in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,20 @@
 # Details
 
+<!--
+Using the template:
+
+ 1. Leave all headlines in place
+ 2. Replace instructional texts with your own words
+ 3. Tick of completed checklist items as you complete them
+ 4. If you intentionally skip a checklist item, see below instruction
+
+Skipping items in checklists:
+
+Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:
+
+- [x] ~Skipped item~ This is a documentation fix
+-->
+
 ### Summary
 
 * description of the change
@@ -29,7 +44,6 @@ when applicable, please provide:
 - [ ] Screenshots of any front-end changes are in the PR description
 - [ ] CHANGELOG.rst is updated for high-level changes
 - [ ] You've added yourself to AUTHORS.rst if you're not there
-- [ ] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary
 
 # Reviewer Checklist
 


### PR DESCRIPTION
# Details

### Summary

Github's Markdown syntax has a comment option `<!-- -->`, so we just add that to the .rst template (even though it's not actually ReST syntax)

### Reviewer guidance

Is the new instruction text nice?

### References

As discussed with fellow devs!

# Contributor Checklist

- [x] ~PR has the correct target milestone~ PR template change
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ PR template change
- [x] ~External dependency files are updated (`yarn` and `pip`)~ PR template change
- [x] ~If internal dependency is updated, link to diff is included~ PR template change
- [x] ~Screenshots of any front-end changes are in the PR description~ PR template change
- [x] ~CHANGELOG.rst is updated for high-level changes~ PR template change
- [x] ~You've added yourself to AUTHORS.rst if you're not there~ PR template change
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
