### PR TITLE
Add sign in message to points-popup

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
@@ -15,6 +15,14 @@
       </div>
     </div>
 
+    <ui-alert
+      v-if="!isUserLoggedIn"
+      :dismissible="false"
+      type="warning"
+    >
+      {{ $tr('signIn') }}
+    </ui-alert>
+
     <div class="next-item-section">
       <h2 class="next-item-heading">{{ $tr('nextContent') }}</h2>
       <div>
@@ -35,13 +43,15 @@
 
 <script>
 
-  import { contentPoints } from 'kolibri.coreVue.vuex.getters';
+  import { contentPoints, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import uiAlert from 'keen-ui/src/UiAlert';
+
   export default {
     name: 'pointsPopup',
     $trs: {
@@ -57,6 +67,7 @@
       item: 'Item',
       close: 'Close',
       pointsForCompletion: 'Points for completion',
+      signIn: 'Sign in or create an account to save points you earn',
     },
     components: {
       pointsIcon,
@@ -64,8 +75,14 @@
       progressIcon,
       coreModal,
       kButton,
+      uiAlert,
     },
-    vuex: { getters: { contentPoints } },
+    vuex: {
+      getters: {
+        contentPoints,
+        isUserLoggedIn,
+      },
+    },
     props: {
       kind: { type: String },
       title: { type: String },


### PR DESCRIPTION
# Details

### Summary

Adds warning for points when not signed in

![localhost_8000_learn_ 4](https://user-images.githubusercontent.com/7193975/32515701-c31d9892-c3b5-11e7-8cb3-93eebdfae630.png)

### Reviewer guidance

Complete content item without being signed in.

### References

* Fixes #2546 and https://github.com/learningequality/clearinghouse/issues/53

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ Not necessary?
- [x] ~External dependency files are updated (`yarn` and `pip`)~ Not applicable
- [x] ~If internal dependency is updated, link to diff is included~ Not applicable
- [x] Screenshots of any front-end changes are in the PR description
- [x] ~CHANGELOG.rst is updated for high-level changes~ Not high level 
- [x] You've added yourself to AUTHORS.rst if you're not there
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
