### PR TITLE
Added the no-a11y-regressions item in the contributor checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ when applicable, please provide:
 
 - [ ] PR has the correct target milestone
 - [ ] PR has the appropriate labels
+- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
 - [ ] If PR is ready for review, it has been assigned or requests review from someone
 - [ ] Documentation is updated as necessary
 - [ ] External dependency files are updated (`yarn` and `pip`)


### PR DESCRIPTION
# Details

### Summary

Added the checkbox for contributor to attest that the accessibility testing in browser has been performed with the tools recommended in the dev documentation, and that the changes do not introduce accessibility failures.

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [ ] Documentation is updated as necessary~
~- [ ] External dependency files are updated (`yarn` and `pip`)~
~- [ ] If internal dependency is updated, link to diff is included~
~- [ ] Screenshots of any front-end changes are in the PR description~
~- [ ] CHANGELOG.rst is updated for high-level changes~
~- [ ] You've added yourself to AUTHORS.rst if you're not there~
~- [ ] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
