### PR TITLE
changed source map to cheap-module-source-map

### DIFF
--- a/frontend_build/src/webpack.config.dev.js
+++ b/frontend_build/src/webpack.config.dev.js
@@ -9,7 +9,7 @@ var webpack = require('webpack');
 var bundles = require('./webpack.config.js');
 
 for (var i = 0; i < bundles.length; i++) {
-  bundles[i].devtool = '#source-map';
+  bundles[i].devtool = '#cheap-module-source-map';
   bundles[i].plugins = bundles[i].plugins.concat([
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
# Details

### Summary
I changed source map to cheap-module-source-map, which is faster and works well.

### Reviewer guidance
Building Time Comparison among different source maps.
https://docs.google.com/spreadsheets/u/1/d/13uYVbPvEB-LIBg_0CAx28Cex0mDWi03V1_4TVWb3G-0/edit#gid=0

### References
Webpack Documentation of different source maps
https://webpack.js.org/configuration/devtool/

