### PR TITLE
 Ensure superuser password set correctly during device provisioning

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -63,6 +63,8 @@ class DeviceProvisionSerializer(serializers.Serializer):
             superuser_data = validated_data.pop('superuser')
             superuser_data['facility'] = facility
             superuser = FacilityUserSerializer(data=superuser_data).create(superuser_data)
+            superuser.set_password(superuser_data["password"])
+            superuser.save()
             facility.add_role(superuser, ADMIN)
             DevicePermissions.objects.create(user=superuser, is_superuser=True)
             language_id = validated_data.pop('language_id')

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -48,6 +48,16 @@ class DeviceProvisionTestCase(APITestCase):
         self.client.post(reverse('deviceprovision'), data, format="json")
         self.assertEqual(FacilityUser.objects.get().username, self.superuser_data["username"])
 
+    def test_superuser_password_set_correctly(self):
+        data = {
+            "superuser": self.superuser_data,
+            "facility": self.facility_data,
+            "preset": self.preset_data,
+            "language_id": self.language_id,
+        }
+        self.client.post(reverse('deviceprovision'), data, format="json")
+        self.assertTrue(FacilityUser.objects.get().check_password(self.superuser_data["password"]))
+
     def test_superuser_device_permissions_created(self):
         data = {
             "superuser": self.superuser_data,


### PR DESCRIPTION
# Details

### Summary

Adds a test and a fix for a problem caused by https://github.com/learningequality/kolibri/pull/2485 that caused the superuser password to be set incorrectly during device provisioning.

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
~- [ ] Documentation is updated as necessary~
~- [ ] External dependency files are updated (`yarn` and `pip`)~
~- [ ] If internal dependency is updated, link to diff is included~
~- [ ] Screenshots of any front-end changes are in the PR description~
~- [ ] CHANGELOG.rst is updated for high-level changes~
~- [ ] You've added yourself to AUTHORS.rst if you're not there~
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
