### PR TITLE
Extend channel metadata shown in /tasks/localdrive

### DIFF
--- a/kolibri/content/utils/channels.py
+++ b/kolibri/content/utils/channels.py
@@ -72,6 +72,14 @@ def get_channels_for_data_folder(datafolder):
             "path": path,
             "id": channel.id,
             "name": channel.name,
+            "description": channel.description,
+            "thumbnail": channel.thumbnail,
+            "version": channel.version,
+            "root": channel.root_pk,
+            "author": channel.author,
+            "last_updated": getattr(channel, 'last_updated', None),
+            "lang_code": getattr(channel, 'lang_code', None),
+            "lang_name": getattr(channel, 'lang_name', None),
         }
         channels.append(channel_data)
     return channels


### PR DESCRIPTION
# Details

### Summary

* description of the change
This PR will extend the channel metadata showing in /tasks/localdrive, so that it will not only show "path", "id", "name" but also "description", "last_updated", "thumbnail", "version", "root", "author", "lang_code", "lang_name" to match with the channel metadata from /api/channel. 

> Note: "last_updated", "lang_code", "lang_name" could be shown as `null` since they are not in the old database schemas. For the "lang_code" and "lang_name", they are from https://github.com/learningequality/kolibri/pull/2565


### Reviewer guidance

1. export a channel to an external drive
2. go to /api/tasks/localdrive to see the channel information in the external drive

### References

* links to mockups or specs for new features
The trello card related to this is [here](https://trello.com/c/6MIWW4Zs/22-enhance-channel-metadata-coming-back-from-tasks-localdrive).
The spec of /api/channel metadata to match with is [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=59fbaba5#heading=h.ky6rn0inhd26).

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [X] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there
- [X] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
