### PR TITLE
Fix for setup_wizard breakage introduced by #2554

### DIFF
--- a/kolibri/auth/models.py
+++ b/kolibri/auth/models.py
@@ -947,8 +947,12 @@ class Facility(Collection):
     @classmethod
     def get_default_facility(cls):
         from kolibri.core.device.models import DeviceSettings
-        device_settings = DeviceSettings.objects.get()
-        default_facility = device_settings.default_facility
+        try:
+            device_settings = DeviceSettings.objects.get()
+            default_facility = device_settings.default_facility
+        except DeviceSettings.DoesNotExist:
+            # device has not been provisioned yet, so just return None in this case
+            return None
         if not default_facility:
             # Legacy databases will not have this explicitly set.
             # Set this here to ensure future default facility queries are

--- a/kolibri/auth/test/test_models.py
+++ b/kolibri/auth/test/test_models.py
@@ -385,13 +385,15 @@ class StringMethodTestCase(TestCase):
 
 class FacilityTestCase(TestCase):
 
-    def setUp(self):
+    def test_existing_facility_becomes_default_facility(self):
         self.facility = Facility.objects.create()
         self.device_settings = DeviceSettings.objects.create()
-
-    def test_existing_facility_becomes_default_facility(self):
         self.assertEqual(self.device_settings.default_facility, None)
         default_facility = Facility.get_default_facility()
         self.assertEqual(default_facility, self.facility)
         self.device_settings.refresh_from_db()
         self.assertEqual(self.device_settings.default_facility, self.facility)
+
+    def test_default_facility_returns_none_when_no_settings(self):
+        default_facility = Facility.get_default_facility()
+        self.assertEqual(default_facility, None)


### PR DESCRIPTION
# Details

### Summary

#2554 did not take into account that non existent Device Settings would break default facility behaviour, and this occurs during setup wizard.

This fixes this and adds a test.

### Reviewer guidance

Go through onboarding workflow. If it does not give an error page, it works!

### References

* caused by #2554

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
