### PR TITLE
Fixed server 400 response error for Admin/Superuser login

### DIFF
--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -14,12 +14,12 @@ export default class ConditionalPromise {
   }
 
   catch(...args) {
-    this._promise.catch(...args);
+    this._promise=this._promise.catch(...args);
     return this;
   }
 
   then(...args) {
-    this._promise.then(...args);
+    this._promise=this._promise.then(...args);
     return this;
   }
 

--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -14,12 +14,12 @@ export default class ConditionalPromise {
   }
 
   catch(...args) {
-    this._promise=this._promise.catch(...args);
+    this._promise = this._promise.catch(...args);
     return this;
   }
 
   then(...args) {
-    this._promise=this._promise.then(...args);
+    this._promise = this._promise.then(...args);
     return this;
   }
 


### PR DESCRIPTION
# Details

### Summary

When running password-less login, previously it would return server 400 response error when trying to login as a admin and/or superuser. 

It ended up being a problem with the chaining of the catch and then in the conditionalPromise file. Simply calling the catch with the args does not actually update the promise (it only returns a value). I ended up setting this._promise to the the result of the catch as a way to save and chain it. 

### Reviewer guidance

Run the Kolibri devserver and set the configuration to allow password-less login. Login with a user that is a superuser and/or an admin. It will press for a password to be provided and the browser console will no longer throw the server 400 response error.

### References

Fixes Issue #2156 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
