### PR TITLE
Use studio URL

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -138,7 +138,7 @@ if not os.path.exists(CONTENT_STORAGE_DIR):
     os.makedirs(CONTENT_STORAGE_DIR)
 
 # Base default URL for downloading content from an online server
-CENTRAL_CONTENT_DOWNLOAD_BASE_URL = "http://contentworkshop.learningequality.org"
+CENTRAL_CONTENT_DOWNLOAD_BASE_URL = "https://studio.learningequality.org"
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/


### PR DESCRIPTION
Seems to be more reliable. Everything in /content/storage/ is cached by Cloudflare, so read timeouts should be prevented if they're being caused by our stack.