### PR TITLE
Add public facility endpoint.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -17,7 +17,7 @@ from .filters import HierarchyRelationsFilter
 from .models import Classroom, Facility, FacilityDataset, FacilityUser, LearnerGroup, Membership, Role
 from .serializers import (
     ClassroomSerializer, FacilityDatasetSerializer, FacilitySerializer, FacilityUsernameSerializer, FacilityUserSerializer, FacilityUserSignupSerializer,
-    LearnerGroupSerializer, MembershipSerializer, RoleSerializer
+    LearnerGroupSerializer, MembershipSerializer, PublicFacilitySerializer, RoleSerializer
 )
 
 
@@ -185,6 +185,13 @@ class CurrentFacilityViewSet(viewsets.ViewSet):
             return Response(Facility.objects.all().values_list('id', flat=True))
         else:
             return Response([logged_in_user.facility_id])
+
+
+class PublicFacilityViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = (KolibriAuthPermissions,)
+    filter_backends = (KolibriAuthPermissionsFilter,)
+    queryset = Facility.objects.all()
+    serializer_class = PublicFacilitySerializer
 
 
 class ClassroomViewSet(viewsets.ModelViewSet):

--- a/kolibri/auth/api_urls.py
+++ b/kolibri/auth/api_urls.py
@@ -3,7 +3,7 @@ from rest_framework import routers
 
 from .api import (
     ClassroomViewSet, CurrentFacilityViewSet, FacilityDatasetViewSet, FacilityUsernameViewSet, FacilityUserViewSet, FacilityViewSet, LearnerGroupViewSet,
-    MembershipViewSet, RoleViewSet, SessionViewSet, SignUpViewSet
+    MembershipViewSet, PublicFacilityViewSet, RoleViewSet, SessionViewSet, SignUpViewSet
 )
 
 router = routers.SimpleRouter()
@@ -18,6 +18,8 @@ router.register(r'session', SessionViewSet, base_name='session')
 router.register(r'classroom', ClassroomViewSet, base_name='classroom')
 router.register(r'learnergroup', LearnerGroupViewSet, base_name='learnergroup')
 router.register(r'signup', SignUpViewSet, base_name='signup')
+
+router.register(r'public/v1/facility', PublicFacilityViewSet, base_name='publicfacility')
 
 bulk_delete_router = BulkDeleteRouter()
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -63,6 +63,13 @@ class FacilitySerializer(serializers.ModelSerializer):
         exclude = ("dataset", "kind", "parent")
 
 
+class PublicFacilitySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Facility
+        fields = ('dataset', 'name')
+
+
 class ClassroomSerializer(serializers.ModelSerializer):
     learner_count = serializers.SerializerMethodField()
     coach_count = serializers.SerializerMethodField()
@@ -87,6 +94,7 @@ class ClassroomSerializer(serializers.ModelSerializer):
                 fields=('parent', 'name')
             )
         ]
+
 
 class LearnerGroupSerializer(serializers.ModelSerializer):
 

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -210,6 +210,10 @@ class FacilityAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(models.Facility.objects.filter(id=self.facility1.id).count(), 0)
 
+    def test_public_facility_endpoint(self):
+        response = self.client.get(reverse('publicfacility-list'))
+        self.assertEqual(models.Facility.objects.all().count(), len(response.data))
+
 
 class UserCreationTestCase(APITestCase):
 


### PR DESCRIPTION
# Details

### Summary

Added a public facility endpoint to be used when syncing with another device. We request this endpoint to get list of (dataset_id, facility_name) pairs on the device we are syncing with. 

### Reviewer guidance

description of how to test the changes

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
~~- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~~
- [x] If PR is ready for review, it has been assigned or requests review from someone
~~- [ ] Documentation is updated as necessary~~
~~- [ ] External dependency files are updated (`yarn` and `pip`)~~
~~- [ ] If internal dependency is updated, link to diff is included~~
~~- [ ] Screenshots of any front-end changes are in the PR description~~
~~- [ ] CHANGELOG.rst is updated for high-level changes~~
~~- [ ] You've added yourself to AUTHORS.rst if you're not there~~
- [x] Deleted any part of the PR template that you didn’t edit, except for checkboxes, which you should diligently check as necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
