### PR TITLE
Makes core modal more responsive

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -184,8 +184,8 @@
     left: 50%
     transform: translate(-50%, -50%)
     background: #fff
-    max-width: 100%
-    max-height: 100%
+    max-width: 90%
+    max-height: 90%
     overflow-y: auto
     border-radius: $radius
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33)
@@ -197,7 +197,6 @@
 
   .modal.mobile
     width: 85%
-    top: 45%
 
   .top-buttons
     position: relative


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary
Makes `core-modal` more responsive.
Before

![localhost_8000_user_ 7](https://user-images.githubusercontent.com/7193975/32797520-ea5dc668-c926-11e7-8a90-7877b898315d.png)

After

![localhost_8000_user_ 6](https://user-images.githubusercontent.com/7193975/32797519-e949cfce-c926-11e7-982a-819d65d41754.png)


### Reviewer guidance

Open a modal in a small viewport.

### References

N/A

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ Not necessary 
- [x] ~External dependency files are updated (`yarn` and `pip`)~ N/A
- [x] ~If internal dependency is updated, link to diff is included~ N/A
- [x] Screenshots of any front-end changes are in the PR description
- [x] ~CHANGELOG.rst is updated for high-level changes~ Not necessary  
- [x] ~You've added yourself to AUTHORS.rst if you're not there~ Not necessary

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
