### PR TITLE
Cherry pick kNavabr responsive behavior

### DIFF
--- a/kolibri/core/assets/src/views/k-navbar/index.vue
+++ b/kolibri/core/assets/src/views/k-navbar/index.vue
@@ -1,10 +1,36 @@
 <template>
 
-  <nav class="tabs">
-    <ul>
-      <!-- Can contain either tab-buttons or tab-links. -->
-      <slot/>
+  <nav>
+    <button
+      v-show="!enoughSpace"
+      class="k-navbar-scroll-button"
+      @click="scrollLeft"
+    >
+      <mat-svg
+        name="keyboard_arrow_left"
+        category="hardware"
+      />
+    </button>
+
+    <ul
+      ref="kNavbar"
+      class="k-navbar"
+      :style="{ maxWidth: `${ maxWidth }px` }"
+    >
+      <!-- Contains k-navbar-link components -->
+      <slot></slot>
     </ul>
+
+    <button
+      v-show="!enoughSpace"
+      class="k-navbar-scroll-button"
+      @click="scrollRight"
+    >
+      <mat-svg
+        name="keyboard_arrow_right"
+        category="hardware"
+      />
+    </button>
   </nav>
 
 </template>
@@ -12,12 +38,48 @@
 
 <script>
 
+  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
+  import throttle from 'lodash/throttle';
+
   /**
     * Used for navigation within a plugin
     */
-
   export default {
     name: 'kNavbar',
+    mixins: [responsiveElement],
+    data: () => ({
+      enoughSpace: true,
+    }),
+    computed: {
+      maxWidth() {
+        return this.enoughSpace ? this.elSize.width : this.elSize.width - 36 * 2;
+      },
+    },
+    mounted() {
+      this.checkSpace();
+      this.$watch('elSize.width', this.throttleCheckSpace);
+    },
+    methods: {
+      checkSpace() {
+        const availableWidth = this.elSize.width;
+        const items = this.$children;
+        let widthOfItems = 0;
+        items.forEach(item => {
+          const itemWidth = Math.ceil(item.$el.getBoundingClientRect().width);
+          widthOfItems += itemWidth;
+        });
+        this.enoughSpace = widthOfItems <= availableWidth;
+      },
+      throttleCheckSpace: throttle(function() {
+        this.checkSpace();
+      }, 100),
+      scrollLeft() {
+        this.$refs.kNavbar.scrollLeft -= this.maxWidth;
+      },
+      scrollRight() {
+        this.$refs.kNavbar.scrollLeft += this.maxWidth;
+      },
+    },
   };
 
 </script>
@@ -27,13 +89,20 @@
 
   @require '~kolibri.styles.definitions'
 
-  .tabs
+  .k-navbar
     white-space: nowrap
     overflow-x: auto
     overflow-y: hidden
-
-  ul
     margin: 0
     padding: 0
+    display: inline-block
+    vertical-align: middle
+
+  .k-navbar-scroll-button
+    width: 36px
+    height: 36px
+    vertical-align: middle
+    &:focus
+      outline: $core-outline
 
 </style>


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Tried to cherry-pick the commit in this PR https://github.com/learningequality/kolibri/pull/2520, but it resulted in a different commit.
* Targeted as making IS more responsive.
 
![localhost_8000_management_facility](https://user-images.githubusercontent.com/7193975/32800620-ac4a74b2-c92f-11e7-9230-d5cb7dce4086.png)


### Reviewer guidance

Adjust viewport

### References

Original PR: https://github.com/learningequality/kolibri/pull/2520

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ N/A
- [x] ~External dependency files are updated (`yarn` and `pip`)~  N/A
- [x] ~If internal dependency is updated, link to diff is included~  N/A
- [x] Screenshots of any front-end changes are in the PR description
- [x] ~CHANGELOG.rst is updated for high-level changes~  N/A
- [x] ~You've added yourself to AUTHORS.rst if you're not there~  N/A

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
