### PR TITLE
Filter channels with no content

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Please feel free to add your name on this list if you do a PR!
 * Gerardo Soto (gcodeon)
 * Paul Luna (luna215)
 * Maureen Hernandez(mauhernandez)
+* Lingyi Wang (lyw07)

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -28,6 +28,11 @@ class ChannelMetadataFilter(filters.FilterSet):
     available = filters.django_filters.MethodFilter()
 
     def filter_available(self, queryset, value):
+        if value == "True":
+            value = True
+        else:
+            value = False
+
         return queryset.filter(root__available=value)
 
     class Meta:

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -307,6 +307,21 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data['lang_code'], None)
         self.assertEqual(response.data['lang_name'], None)
 
+    def test_channelmetadata_content_available_filter_true(self):
+        content.ContentNode.objects.filter(title="c1").update(available=False)
+        response = self.client.get(reverse("channel-list"), {"available": True})
+        self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+
+    def test_channelmetadata_content_available_filter_false(self):
+        content.ContentNode.objects.filter(title="c1").update(available=False)
+        response = self.client.get(reverse("channel-list"), {"available": False})
+        self.assertEqual(response.data, [])
+
+    def test_channelmetadata_content_unavailable_filter_false(self):
+        content.ContentNode.objects.all().update(available=False)
+        response = self.client.get(reverse("channel-list"), {"available": False})
+        self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
         self.assertEqual(len(response.data), 5)


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* description of the change

Fix the code filter set for the ChannelMetadataViewset so that we can use "/api/channel/?available=False" to get all the channels with database downloaded but no content at all.

The problem in the original code was that the variable `value` gets a unicode not a boolean value.


### Reviewer guidance

1. Import channel A with its content
2. Import channel B but without its content
3. Go to `/api/channel` to see that both channels are listed
4. Go to `/api/channel/?available=False" to see that only channel B is listed
5. Go to /api/channel/?available=True" to see that only channel A is listed.

### References

* links to mockups or specs for new features
The spec is [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=5a09e828#heading=h.dw5c96c3bcob)

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [X] Documentation is updated as necessary~ No need to update documentation
~- [X] External dependency files are updated (`yarn` and `pip`)~ No external dependency updated
~- [X] If internal dependency is updated, link to diff is included~ No internal dependency updated
~- [X] Screenshots of any front-end changes are in the PR description~ No front-end changes
~- [X] CHANGELOG.rst is updated for high-level changes~ No high-level changes
- [X] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
