### PR TITLE
Do not rely on loadedmetadata event for media player

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/index.vue
@@ -212,8 +212,7 @@
         }
 
         this.$nextTick(() => {
-          this.player = videojs(this.$refs.player, videojsConfig);
-          this.player.on('loadedmetadata', this.handleReadyPlayer);
+          this.player = videojs(this.$refs.player, videojsConfig, this.handleReadyPlayer);
         });
       },
       handleReadyPlayer() {


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Meant to address https://github.com/fle-internal/kolibri-instant-schools-plugin/issues/116
* Basically, the `loadedmetadata` event is not fired on some mobile browsers until the video is played. See https://stackoverflow.com/a/21194537
* I tested this on the device, and sure enough, the `loadedmetadata` event was only fired until the video was played. 
* So instead of waiting for this event to fire, we instead just call the handleReadyPlayer method from within the videojs callback.

### Reviewer guidance

* You can test on the Vodacom Smart Kicka ve (A5).
* Also, just test in your regular browser and make sure the video player is initiated properly. 

### References


* Fixes https://github.com/fle-internal/kolibri-instant-schools-plugin/issues/116

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ N/A
- [x] ~External dependency files are updated (`yarn` and `pip`)~ N/A
- [x] ~If internal dependency is updated, link to diff is included~ N/A
- [x] ~Screenshots of any front-end changes are in the PR description~ Video shows up, that's it.
- [x] ~CHANGELOG.rst is updated for high-level changes~ Is this worth an addition?
- [x] ~You've added yourself to AUTHORS.rst if you're not there~ N/A

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
