### PR TITLE
Do not use popover for license description 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -55,13 +55,16 @@
         {{ $tr('license', {license: content.license}) }}
 
         <template v-if="content.license_description">
-          <span ref="licensetooltip">
-            <ui-icon icon="info_outline" :ariaLabel="$tr('licenseDescription')" class="license-tooltip"/>
-          </span>
-
-          <ui-popover trigger="licensetooltip" class="license-description">
+          <ui-icon-button
+            :icon="showLicenceDescription ? 'expand_less' : 'expand_more'"
+            :ariaLabel="$tr('licenseDescription')"
+            size="small"
+            type="secondary"
+            @click="showLicenceDescription=!showLicenceDescription"
+          />
+          <p v-if="showLicenceDescription">
             {{ content.license_description }}
-          </ui-popover>
+          </p>
         </template>
 
       </p>
@@ -120,8 +123,7 @@
   import assessmentWrapper from '../assessment-wrapper';
   import pointsPopup from '../points-popup';
   import pointsSlidein from '../points-slidein';
-  import uiPopover from 'keen-ui/src/UiPopover';
-  import uiIcon from 'keen-ui/src/UiIcon';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
   import markdownIt from 'markdown-it';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
@@ -135,7 +137,7 @@
       licenseDescription: 'License description',
       copyrightHolder: 'Copyright holder: {copyrightHolder}',
     },
-    data: () => ({ wasIncomplete: false }),
+    data: () => ({ wasIncomplete: false, showLicenceDescription: false }),
     computed: {
       canDownload() {
         if (this.content) {
@@ -197,8 +199,7 @@
       assessmentWrapper,
       pointsPopup,
       pointsSlidein,
-      uiPopover,
-      uiIcon,
+      uiIconButton,
     },
     methods: {
       nextContentClicked() {
@@ -271,15 +272,5 @@
 
   .download-button
     display: block
-
-  .license-tooltip
-    cursor: pointer
-    font-size: 1.25em
-    color: $core-action-dark
-
-  .license-description
-    max-width: 300px
-    padding: 1em
-    font-size: smaller
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -56,13 +56,13 @@
 
         <template v-if="content.license_description">
           <ui-icon-button
-            :icon="showLicenceDescription ? 'expand_less' : 'expand_more'"
-            :ariaLabel="$tr('licenseDescription')"
+            :icon="licenceDescriptionIsVisible ? 'expand_less' : 'expand_more'"
+            :ariaLabel="$tr('toggleLicenseDescription')"
             size="small"
             type="secondary"
-            @click="showLicenceDescription=!showLicenceDescription"
+            @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"
           />
-          <p v-if="showLicenceDescription">
+          <p v-if="licenceDescriptionIsVisible">
             {{ content.license_description }}
           </p>
         </template>
@@ -125,7 +125,6 @@
   import pointsSlidein from '../points-slidein';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import markdownIt from 'markdown-it';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     name: 'learnContent',
@@ -134,10 +133,24 @@
       nextContent: 'Go to next item',
       author: 'Author: {author}',
       license: 'License: {license}',
-      licenseDescription: 'License description',
+      toggleLicenseDescription: 'Toggle license description',
       copyrightHolder: 'Copyright holder: {copyrightHolder}',
     },
-    data: () => ({ wasIncomplete: false, showLicenceDescription: false }),
+    components: {
+      pageHeader,
+      contentCardGroupCarousel,
+      contentRenderer,
+      downloadButton,
+      kButton,
+      assessmentWrapper,
+      pointsPopup,
+      pointsSlidein,
+      uiIconButton,
+    },
+    data: () => ({
+      wasIncomplete: false,
+      licenceDescriptionIsVisible: false,
+    }),
     computed: {
       canDownload() {
         if (this.content) {
@@ -190,16 +203,8 @@
         return this.content.files.filter(file => file.preset !== 'Thumbnail');
       },
     },
-    components: {
-      pageHeader,
-      contentCardGroupCarousel,
-      contentRenderer,
-      downloadButton,
-      kButton,
-      assessmentWrapper,
-      pointsPopup,
-      pointsSlidein,
-      uiIconButton,
+    beforeDestroy() {
+      this.stopTracking();
     },
     methods: {
       nextContentClicked() {
@@ -230,9 +235,6 @@
           params: { channel_id: this.channelId, id },
         };
       },
-    },
-    beforeDestroy() {
-      this.stopTracking();
     },
     vuex: {
       getters: {


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* ui-popover positioning/sizing is unreliable on smaller viewports
* Instead just use a simple toggle.
* Another improvement for smaller devices

#### Before
![before](https://user-images.githubusercontent.com/7193975/32859365-2265a576-ca03-11e7-9d4d-faeb66efe41f.gif)

#### After
![after](https://user-images.githubusercontent.com/7193975/32859366-2288ed9c-ca03-11e7-8b6e-6516b744f2ad.gif)


### Reviewer guidance

* Navigate to a piece of content with a license description

### References

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ N/A
- [x] ~External dependency files are updated (`yarn` and `pip`)~ N/A
- [x] ~If internal dependency is updated, link to diff is included~ N/A
- [x] Screenshots of any front-end changes are in the PR description
- [x] ~CHANGELOG.rst is updated for high-level changes~ N/A
- [x] ~You've added yourself to AUTHORS.rst if you're not there~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
