### PR TITLE
show both available and unavailable nodes in export-specific topic tree

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -17,7 +17,6 @@ from rest_framework import filters, mixins, pagination, viewsets
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
-from rest_framework.serializers import ValidationError
 
 from .utils.search import fuzz
 
@@ -293,29 +292,11 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
 class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.ContentNodeGranularSerializer
 
-    def get_queryset(self, available=None):
-        if available is not None:
-            queryset = models.ContentNode.objects.filter(available=available)
-        else:
-            queryset = models.ContentNode.objects.all()
-        return queryset.prefetch_related('files__local_file')
+    def get_queryset(self):
+        return models.ContentNode.objects.all().prefetch_related('files__local_file')
 
     def retrieve(self, request, pk):
-        import_export = request.query_params.get('import_export', None)
-        if import_export == 'import':
-            response = self._get_parent_and_children_info(pk)
-
-        elif import_export == 'export':
-            response = self._get_parent_and_children_info(pk, True)
-
-        else:
-            raise ValidationError(
-                "The 'import_export' field is required and needs to be either import or export.")
-
-        return response
-
-    def _get_parent_and_children_info(self, pk, available=None):
-        queryset = self.get_queryset(available)
+        queryset = self.get_queryset()
         instance = get_object_or_404(queryset, pk=pk)
         children = queryset.filter(parent=instance)
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -304,11 +304,11 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
         return available_resources
 
     def get_importable(self, obj):
-        if 'request' not in self.context or not self.context['request'].query_params.get('drive_id', None) or obj.kind == content_kinds.TOPIC:
+        if 'request' not in self.context or not self.context['request'].query_params.get('importing_from_drive_id', None) or obj.kind == content_kinds.TOPIC:
             return True
         else:
             # check if the external drive exists given drive id
-            drive_id = self.context['request'].query_params.get('drive_id', None)
+            drive_id = self.context['request'].query_params.get('importing_from_drive_id', None)
             drives = get_mounted_drives_with_channel_info()
             if drive_id in drives:
                 datafolder = drives[drive_id].datafolder

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -2,7 +2,6 @@
 To run this test, type this in command line <kolibri manage test -- kolibri.content>
 """
 import datetime
-import tempfile
 from collections import namedtuple
 
 import mock
@@ -176,7 +175,7 @@ class ContentNodeAPITestCase(APITestCase):
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
         content.ContentNode.objects.all().update(available=False)
-        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}), {"import_export": "import"})
+        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}))
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
@@ -191,9 +190,8 @@ class ContentNodeAPITestCase(APITestCase):
 
     @mock.patch('kolibri.content.serializers.get_mounted_drives_with_channel_info')
     def test_contentnode_granular_local_import(self, drive_mock):
-        datafolder = tempfile.mkdtemp()
         DriveData = namedtuple("DriveData", ["id", "datafolder"])
-        drive_mock.return_value = {"123": DriveData(id="123", datafolder=datafolder)}
+        drive_mock.return_value = {"123": DriveData(id="123", datafolder="test/")}
 
         content.LocalFile.objects.update(available=False)
         content.ContentNode.objects.update(available=False)
@@ -203,7 +201,7 @@ class ContentNodeAPITestCase(APITestCase):
         c3_id = content.ContentNode.objects.get(title="c2").id
 
         response = self.client.get(
-            reverse("contentnode_granular-detail", kwargs={"pk": c1_id}), {"import_export": "import", "drive_id": "123"})
+            reverse("contentnode_granular-detail", kwargs={"pk": c1_id}), {"importing_from_drive_id": "123"})
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
@@ -221,7 +219,7 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_contentnode_granular_export_available(self):
         c1_id = content.ContentNode.objects.get(title="c1").id
-        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}), {"import_export": "export"})
+        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}))
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "c1", "kind": "video", "available": True,
@@ -231,8 +229,12 @@ class ContentNodeAPITestCase(APITestCase):
     def test_contentnode_granular_export_unavailable(self):
         c1_id = content.ContentNode.objects.get(title="c1").id
         content.ContentNode.objects.filter(title="c1").update(available=False)
-        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}), {"import_export": "export"})
-        self.assertEqual(response.data, {"detail": "Not found."})
+        response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}))
+        self.assertEqual(
+            response.data, {
+                "pk": c1_id, "title": "c1", "kind": "video", "available": False,
+                "total_resources": 1, "resources_on_device": 0, "importable": True,
+                "children": []})
 
     def test_contentnodefilesize_resourcenode(self):
         c1_id = content.ContentNode.objects.get(title="c1").id


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* description of the change

This PR is to show both available and unavailable contentnodes in the export-specific topic tree to meet with the front-end implementation. 
Since now both network import and export are returning available and unavailable contentnodes, the `import_export` parameter is unused, so I get rid of it.
I also renamed `drive_id` to `importing_from_drive_id` so that the parameter name is easier to understand.


### Reviewer guidance

1. To get the network import specific tree or export specific tree: `/api/contentnode_granular/<contentnode_id>/`
2. To get the local import specific tree: `/api/contentnode_granular/<contentnode_id>/?importing_from_drive_id=<drive_id>`

### References

when applicable, please provide:

* links to mockups or specs for new features
The spec is [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=5a09e828#heading=h.5315gj3gvs81).

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
~- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~ This change shouldn't affect accessibility
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [X] Documentation is updated as necessary~ No need to update documentation
~- [X] External dependency files are updated (`yarn` and `pip`)~  No external dependency files are updated
~- [X] If internal dependency is updated, link to diff is included~ No internal dependency is updated
~- [X] Screenshots of any front-end changes are in the PR description~ No front-end changes
~- [X] CHANGELOG.rst is updated for high-level changes~ No high-level changes
~- [X] You've added yourself to AUTHORS.rst if you're not there~ My name is here

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
