### PR TITLE
Prevents Google from offering translations

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google" content="notranslate">
   <link rel="shortcut icon" href="{% static 'images/logo.ico' %}">
   <title>{% trans "Kolibri" %}</title>
   {% if LANGUAGE_CODE == "ach-ug" %}


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Prevents Google from offering translations

#### Before 

![before](https://user-images.githubusercontent.com/7193975/32909998-f61853be-cabc-11e7-82ed-23b90d5031e6.gif)

#### After

![after](https://user-images.githubusercontent.com/7193975/32909999-f636ab2a-cabc-11e7-810f-9102d2ee604a.gif)

### Reviewer guidance

* Switch languages and confirm that chrome does not offer to translate page.

### References

* Fixes #2617 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) - :thinking:  
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~ N/A
- [x] ~External dependency files are updated (`yarn` and `pip`)~ N/A
- [x] ~If internal dependency is updated, link to diff is included~ N/A
- [x] ~Screenshots of any front-end changes are in the PR description
- [x] ~CHANGELOG.rst is updated for high-level changes~ N/A
- [x] ~You've added yourself to AUTHORS.rst if you're not there~ N/A

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
