### PR TITLE
Fixing learn page

### DIFF
--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -14,12 +14,12 @@ export default class ConditionalPromise {
   }
 
   catch(...args) {
-    this._promise = this._promise.catch(...args);
+    this._promise.catch(...args);
     return this;
   }
 
   then(...args) {
-    this._promise = this._promise.then(...args);
+    this._promise.then(...args);
     return this;
   }
 

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -6,7 +6,7 @@ import {
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 
-import { getChannelObject, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
+import { getChannelObject, isUserLoggedIn, getChannels } from 'kolibri.coreVue.vuex.getters';
 import {
   setChannelInfo,
   handleError,
@@ -156,12 +156,18 @@ function updateContentNodeProgress(channelId, contentId, progressFraction) {
 }
 
 function setAndCheckChannels(store) {
-  return setChannelInfo(store).then(channels => {
-    if (!channels.length) {
-      router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+  return setChannelInfo(store).then(
+    () => {
+      const channels = getChannels(store.state);
+      if (!channels.length) {
+        router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+      }
+      return channels;
+    },
+    error => {
+      handleApiError(store, error);
     }
-    return channels;
-  });
+  );
 }
 
 /**


### PR DESCRIPTION
Not sure if this was broken for anyone else, but this was a blocker for my work on carousel after I updated my branch.

A promise was being expected to resolve a channel list, and it didn't.

Also added some error handling. because it took me too long to find this.

# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Retrieving channel list for `setAndCheckChannels` (method used in learn) from the state, rather than expecting it from a promise.
* manual verification steps: navigate to /learn
* screenshots if the PR affects the UI:
#### Before
![screenshot from 2017-11-17 16-31-48](https://user-images.githubusercontent.com/9877852/32974675-dee70d04-cbb4-11e7-95dd-59dfd2020f64.png)
#### After
![screenshot from 2017-11-17 16-30-59](https://user-images.githubusercontent.com/9877852/32974658-c36a0414-cbb4-11e7-91af-2a1e20cdff9e.png)


### Reviewer guidance

Confirm fix, please! I was initially just going to return `channelsData` from `setChannelInfo`, but thought this was more aligned with our patterns.

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [X] If PR is ready for review, it has been assigned or requests review from someone
- ~~[ ] Documentation is updated as necessary~~
- ~~[ ] External dependency files are updated (`yarn` and `pip`)~~
- ~~[ ] If internal dependency is updated, link to diff is included~~
- [X] Screenshots of any front-end changes are in the PR description
- ~~[ ] CHANGELOG.rst is updated for high-level changes~~
- ~~[ ] You've added yourself to AUTHORS.rst if you're not there~~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
