### PR TITLE
Close modal buttons focus outline + keyboard accessibility fix

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -212,7 +212,9 @@
     color: $core-text-default
     border: none
     position: absolute
-
+    &:focus
+      background-color: $core-grey-300
+  
   .btn-back
     left: -10px
 

--- a/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
@@ -3,7 +3,7 @@
   <core-modal
     :title="$tr('welcomeModalHeader')"
     :enableBgClickCancel="false"
-    @cancel="emitCloseModal"
+    @keyup.enter="emitCloseModal"
   >
     <p class="welcome-modal-description">
       {{ $tr('welcomeModalContentDescription') }}
@@ -42,6 +42,9 @@
       welcomeButtonDismissText: 'OK',
     },
     components: { coreModal, kButton },
+    created: function() {
+      window.addEventListener('keyup', this.emitCloseModal);
+    },
     methods: {
       emitCloseModal() {
         this.$emit('closeModal');

--- a/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="$tr('welcomeModalHeader')"
     :enableBgClickCancel="false"
+    @cancel="emitCloseModal"
     @keyup.enter="emitCloseModal"
   >
     <p class="welcome-modal-description">


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* The Esc button 'X' now have grey background focus for the following modals

* Add a class
<img width="301" alt="screen shot 2017-11-09 at 2 57 42 pm" src="https://user-images.githubusercontent.com/22454655/32975527-ef8585ac-cbbc-11e7-86d7-789cf54a2433.png">

* Import - choose the source
<img width="359" alt="screen shot 2017-11-17 at 6 00 01 pm" src="https://user-images.githubusercontent.com/22454655/32975919-93a0f190-cbc1-11e7-988d-7b78c941c49a.png">

* Add a user
<img width="400" alt="screen shot 2017-11-17 at 6 01 22 pm" src="https://user-images.githubusercontent.com/22454655/32975924-aad70a7a-cbc1-11e7-8c7a-2846bb10716f.png">

* Welcome to Kolibri
the ESC button does have a focus but as soon as the user uses TAB to navigate onto
the 'X' the welcome modal closes itself immediately


* Now after the onboarding process, the user is able to close the welcome modal using
both the ENTER key and the ESC key


### Reviewer guidance

For all the modals checked above except the welcome one, just open the corresponding modal
and use TAB key to verify whether the 'X' is in focus, and for the welcome-modal, need to delete
the hidden '.kolibri' folder under the user's home directory and go through a complete new on-
boarding process in order for the welcome-modal to show up, and then follow the same checking
procedure.

### References

* Fixed issue #2380 and #2269 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- ~Documentation is updated as necessary~
- ~External dependency files are updated (`yarn` and `pip`)~
- ~If internal dependency is updated, link to diff is included~
- [x] Screenshots of any front-end changes are in the PR description
- ~CHANGELOG.rst is updated for high-level changes~
- [x] You've added yourself to AUTHORS.rst if you're not there


# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
