### PR TITLE
Resolve variable name inconsistency in different APIs for granular import/export

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -400,7 +400,7 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             "lang_name": channel_lang_name,
             "thumbnail": studioresp.get("icon_encoding"),
             "public": studioresp.get("public", True),
-            "total_resource_count": studioresp.get("total_resource_count", 0),
+            "total_resources": studioresp.get("total_resource_count", 0),
             "version": studioresp.get("version", 0),
             "included_languages": included_languages,
             "last_updated": studioresp.get("last_published"),

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -290,7 +290,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
 
 class ContentNodeGranularSerializer(serializers.ModelSerializer):
     total_resources = serializers.SerializerMethodField()
-    resources_on_device = serializers.SerializerMethodField()
+    on_device_resources = serializers.SerializerMethodField()
     importable = serializers.SerializerMethodField()
 
     def get_total_resources(self, obj):
@@ -298,7 +298,7 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
 
         return total_resources
 
-    def get_resources_on_device(self, obj):
+    def get_on_device_resources(self, obj):
         available_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(available=True).count()
 
         return available_resources
@@ -330,7 +330,7 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     class Meta:
         model = ContentNode
         fields = (
-            'pk', 'title', 'available', 'kind', 'total_resources', 'resources_on_device', 'importable',
+            'pk', 'title', 'available', 'kind', 'total_resources', 'on_device_resources', 'importable',
         )
 
 

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -179,14 +179,14 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
-                "total_resources": 4, "resources_on_device": 0, "importable": True, "children": [
+                "total_resources": 4, "on_device_resources": 0, "importable": True, "children": [
                     {
                         "pk": c2_id, "title": "c1", "kind": "video", "available": False,
-                        "total_resources": 1, "resources_on_device": 0, "importable": True
+                        "total_resources": 1, "on_device_resources": 0, "importable": True
                     },
                     {
                         "pk": c3_id, "title": "c2", "kind": "topic", "available": False,
-                        "total_resources": 3, "resources_on_device": 0, "importable": True}]})
+                        "total_resources": 3, "on_device_resources": 0, "importable": True}]})
 
     @mock.patch('kolibri.content.serializers.get_mounted_drives_with_channel_info')
     def test_contentnode_granular_local_import(self, drive_mock):
@@ -205,15 +205,15 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
-                "total_resources": 4, "resources_on_device": 0, "importable": True,
+                "total_resources": 4, "on_device_resources": 0, "importable": True,
                 "children": [
                     {
                         "pk": c2_id, "title": "c1", "kind": "video", "available": False,
-                        "total_resources": 1, "resources_on_device": 0, "importable": False
+                        "total_resources": 1, "on_device_resources": 0, "importable": False
                     },
                     {
                         "pk": c3_id, "title": "c2", "kind": "topic", "available": False,
-                        "total_resources": 3, "resources_on_device": 0, "importable": True
+                        "total_resources": 3, "on_device_resources": 0, "importable": True
                     }]
             })
 
@@ -223,7 +223,7 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "c1", "kind": "video", "available": True,
-                "total_resources": 1, "resources_on_device": 1, "importable": True,
+                "total_resources": 1, "on_device_resources": 1, "importable": True,
                 "children": []})
 
     def test_contentnode_granular_export_unavailable(self):
@@ -233,7 +233,7 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "c1", "kind": "video", "available": False,
-                "total_resources": 1, "resources_on_device": 0, "importable": True,
+                "total_resources": 1, "on_device_resources": 0, "importable": True,
                 "children": []})
 
     def test_contentnodefilesize_resourcenode(self):


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* description of the change

Change the variable name `resources_on_device` to `on_device_resources` in `/api/contentnode_granular` to be consistent with the variable name in `/api/channel/`

Change the variable name `total_resource_count` to `total_resources` in `/api/remotechannel/` to be consistent with the variable name in other API calls

### Reviewer guidance

1. Import a channel
2. Go to `/api/contentnode_granular/<node_id>` to see if the return value contains `on_device_resources`
3. Go to `/api/remotechannel/` to see if the return value contains `total_resources`

### References


* links to mockups or specs for new features
The trello card is [here](https://trello.com/c/eLAEfrgk/26-on-device-key-inconsistent-between-channels-apis-and-contentnodegranular)
The spec is [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=5a09e828#heading=h.5315gj3gvs81) for contentnode_granular and [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=5a09e828#heading=h.i5g7u0h0h7wn) for remotechannel.

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
~- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~ This change shouldn't affect accessibility
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [X] Documentation is updated as necessary~ No documentation update needed
~- [X] External dependency files are updated (`yarn` and `pip`)~ No external dependency updated
~- [X] If internal dependency is updated, link to diff is included~ No internal dependency updated
~- [X] Screenshots of any front-end changes are in the PR description~ No front-end changes
~- [X] CHANGELOG.rst is updated for high-level changes~ No high level changes
~- [X] You've added yourself to AUTHORS.rst if you're not there~ It's already there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
