### PR TITLE
Fix learn page content not found error

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -27,7 +27,7 @@ class ChannelMetadataFilter(filters.FilterSet):
     available = filters.django_filters.MethodFilter()
 
     def filter_available(self, queryset, value):
-        if value == "True":
+        if value == "true":
             value = True
         else:
             value = False

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -309,18 +309,16 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data['lang_code'], None)
         self.assertEqual(response.data['lang_name'], None)
 
-    def test_channelmetadata_content_available_filter_true(self):
-        content.ContentNode.objects.filter(title="c1").update(available=False)
-        response = self.client.get(reverse("channel-list"), {"available": True})
+    def test_channelmetadata_content_available_filter_lowercase_true(self):
+        response = self.client.get(reverse("channel-list"), {"available": "true"})
         self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
 
-    def test_channelmetadata_content_available_filter_false(self):
-        content.ContentNode.objects.filter(title="c1").update(available=False)
-        response = self.client.get(reverse("channel-list"), {"available": False})
+    def test_channelmetadata_content_available_filter_uppercase_true(self):
+        response = self.client.get(reverse("channel-list"), {"available": True})
         self.assertEqual(response.data, [])
 
     def test_channelmetadata_content_unavailable_filter_false(self):
-        content.ContentNode.objects.all().update(available=False)
+        content.ContentNode.objects.filter(title="root").update(available=False)
         response = self.client.get(reverse("channel-list"), {"available": False})
         self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
 

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <!-- Bootstrapping the initial information for all channels. -->
-  {% kolibri_bootstrap_collection 'channel' 'ChannelResource' available=True %}
+  {% kolibri_bootstrap_collection 'channel' 'ChannelResource' available="true" %}
   {% if currentChannel %}
     <!-- Bootstrapping the root node for the current channel in Explore tab. -->
     {% kolibri_bootstrap_model 'contentnode' 'ContentNodeResource' kwargs_pk=currentChannel.root_id %}


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* description of the change

The learn page could not find any content currently. It is because that the parameter passed into the API call is a boolean value True. 
According to @rtibbles 's suggestion, I changed `True` to `"true"` in `learn.html`.
I also changed the "True" value to "true" in `/api/channel` so that it will be consistent with javascript code.
Overall, we will only get channels with available content when we call `/api/channel/?available=true`


### Reviewer guidance

1. `localhost:8080/api/channel/?available=true` should return the channels with available content. All other values, e.g. `True`, `False` would return the channels with no content available.
2. the learn page is showing content now

### References

when applicable, please provide:

* references to related issues and PRs
This is to fix https://github.com/learningequality/kolibri/issues/2647 from this [PR](https://github.com/learningequality/kolibri/pull/2603)
> Note: I also tested updating from 0.6 to 0.7, the content previously imported in 0.6 is showing in the learn page of 0.7. 

* links to mockups or specs for new features
The spec is changed [here](https://docs.google.com/document/d/1FGR4XBEu7IbfoaEy-8xbhQx2PvIyxp0VugoPrMfo4R4/edit?ts=5a09e828#heading=h.dw5c96c3bcob)

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
~- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~ This change shouldn't affect accessibility
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [X] Documentation is updated as necessary~ Documentation doesn't need to update
~- [X] External dependency files are updated (`yarn` and `pip`)~ There's no external dependency updated
~- [X] If internal dependency is updated, link to diff is included~ There's no internal dependency updated
~- [X] Screenshots of any front-end changes are in the PR description~ There's no front-end changes
~- [X] CHANGELOG.rst is updated for high-level changes~ There's no high-level changes
~- [X] You've added yourself to AUTHORS.rst if you're not there~ My name is there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
