### PR TITLE
Auto migrate all active databases.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -215,6 +215,14 @@ def initialize(debug=False):
             )
             update()
 
+def _migrate_databases():
+    """
+    Try to migrate all active databases. This should not be called unless Django has
+    been initialized.
+    """
+    from django.conf import settings
+    for database in settings.DATABASES:
+        call_command("migrate", interactive=False, database=database)
 
 def _first_run():
     """
@@ -237,7 +245,7 @@ def _first_run():
     # We need to migrate the database before enabling plugins, because they
     # might depend on database readiness.
     if not SKIP_AUTO_DATABASE_MIGRATION:
-        call_command("migrate", interactive=False, database="default")
+        _migrate_databases()
 
     for plugin_module in DEFAULT_PLUGINS:
         try:
@@ -274,7 +282,7 @@ def update():
     from kolibri.core.settings import SKIP_AUTO_DATABASE_MIGRATION
 
     if not SKIP_AUTO_DATABASE_MIGRATION:
-        call_command("migrate", interactive=False, database="default")
+        _migrate_databases()
 
     with open(version_file(), "w") as f:
         f.write(kolibri.__version__)


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Instead of only migrating the default database, migrate all databases listed in the settings file being used.

The intention of this is to allow databases specified in customs setting files to be automatically migrated also.

### Reviewer guidance

Main aim is to make the kolibri instant schools plugin database migrate automatically on app initialization.

### References

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] ~Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] ~Documentation is updated as necessary~
- [x] ~External dependency files are updated (`yarn` and `pip`)~
- [x] ~If internal dependency is updated, link to diff is included~
- [x] ~Screenshots of any front-end changes are in the PR description~
- [x] ~CHANGELOG.rst is updated for high-level changes~
- [x] ~You've added yourself to AUTHORS.rst if you're not there~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
