### PR TITLE
RTL carousel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
@@ -6,10 +6,11 @@
       <div class="previous" @click="previousSet">
         <ui-icon-button
           class="previous-button"
+          :style="buttonTransforms"
           v-show="!isFirstSet"
           :disabled="isFirstSet"
           :disableRipple="true"
-          :icon="isRtl ? 'arrow_forward' : 'arrow_back'"
+          icon="arrow_back"
           size="large"
         />
       </div>
@@ -17,10 +18,11 @@
       <div class="next" @click="nextSet">
         <ui-icon-button
           class="next-button"
+          :style="buttonTransforms"
           v-show="!isLastSet"
           :disabled="isLastSet"
           :disableRipple="true"
-          :icon="isRtl ? 'arrow_back' : 'arrow_forward'"
+          icon="arrow_forward"
           size="large"
         />
       </div>
@@ -132,6 +134,15 @@
           'min-width': `${contentCardWidth}px`,
         };
       },
+      buttonTransforms() {
+        const alignmentTransform = 'translate(-50%, -50%)';
+        const mirrorTransform = `scaleX(-1) `;
+
+        return {
+          // must mirror first, order matters
+          transform: (this.isRtl ? mirrorTransform : '') + alignmentTransform,
+        };
+      },
     },
     watch: {
       // ensures that indeces in contentSetStart/End are within bounds of the contents
@@ -199,7 +210,6 @@
         }
       },
       isInThisSet(index) {
-        console.log('belongs');
         return this.contentSetStart <= index && index <= this.contentSetEnd;
       },
       nextSet() {
@@ -258,7 +268,6 @@
           position: absolute
           top: 50%
           left: 50%
-          transform: translate(-50%, -50%)
 
       // position-specific styles for each control button
       .next

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
@@ -62,7 +62,10 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import contentCard from '../content-card';
 
-  contentCard.mixins = [responsiveElement];
+  if (!contentCard.mixins) {
+    contentCard.mixins = [];
+  }
+  contentCard.mixins.push(responsiveElement); //including because carousel breaks without it
 
   const contentCardWidth = 210;
   const gutterWidth = 20;

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
@@ -187,7 +187,7 @@
         // direction depends on `leftToRight`
         const originalPosition = parseInt(el.style.left, 10);
         const cards = this.contentSetSize * contentCardWidth;
-        const gutters = (this.contentSetSize - 1) * gutterWidth;
+        const gutters = this.contentSetSize * gutterWidth;
         const carouselContainerOffset = cards + gutters;
         const sign = this.leftToRight ? -1 : 1;
 
@@ -200,7 +200,7 @@
         // direction depends on `leftToRight`
         const originalPosition = parseInt(el.style.left, 10);
         const cards = this.contentSetSize * contentCardWidth;
-        const gutters = (this.contentSetSize - 1) * gutterWidth;
+        const gutters = this.contentSetSize * gutterWidth;
         const carouselContainerOffset = cards + gutters;
         const sign = this.leftToRight ? 1 : -1;
 

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
@@ -50,11 +50,12 @@
             :id="content.id">
 
             <content-card
-            :title="content.title"
-            :thumbnail="content.thumbnail"
-            :kind="content.kind"
-            :progress="content.progress"
-            :link="genContentLink(content.id, content.kind)" />
+              class="content-card-component"
+              :title="content.title"
+              :thumbnail="content.thumbnail"
+              :kind="content.kind"
+              :progress="content.progress"
+              :link="genContentLink(content.id, content.kind)" />
           </slot>
       </div>
 
@@ -107,6 +108,8 @@
         leftToRight: false,
         // tracks whether the carousel has been interacted with
         interacted: false,
+        contentCardWidth,
+        gutterWidth,
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel/index.vue
@@ -72,6 +72,8 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import contentCard from '../content-card';
 
+  contentCard.mixins = [responsiveElement];
+
   const contentCardWidth = 210;
   const gutterWidth = 20;
 

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -26,7 +26,7 @@
         class="content-icon-bg"
         :style="contentIconBgColor"
       >
-        <polygon stroke-width="0" points="0,0 60,0 0,60" />
+        <polygon stroke-width="0" :points="contentIconBgCoords" />
       </svg>
       <content-icon :kind="kind" class="content-icon"/>
     </div>
@@ -93,6 +93,16 @@
           return { backgroundImage: `url('${this.thumbnail}')` };
         }
         return {};
+      },
+      contentIconBgCoords() {
+        const topLeft = '0,0';
+        const topRight = '64,0';
+        const bottomLeft = '0,64';
+        const bottomRight = '64,64';
+        if (this.isRtl) {
+          return `${topLeft} ${topRight} ${bottomRight}`;
+        }
+        return `${topLeft} ${topRight} ${bottomLeft}`;
       },
       contentIconBgColor() {
         if (this.kind === 'exercise') {

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -20,7 +20,6 @@
 <script>
 
   import values from 'lodash/values';
-  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import cardThumbnail from './card-thumbnail';
@@ -29,7 +28,6 @@
     components: {
       cardThumbnail,
     },
-    mixins: [responsiveElement], // not used, but carousel seems to break without it
     props: {
       title: {
         type: String,


### PR DESCRIPTION
# Details

Getting Carousel to adapt to RTL

### Summary

- Basic tests for Carousel (RTL and LTR)
- Some simple left->right flips being made in JS to match direction change

LTR:
![screenshot from 2017-11-22 13-25-51](https://user-images.githubusercontent.com/9877852/33150553-d4e66944-cf88-11e7-8cd7-3dae6e438edf.png)
RTL:
![screenshot from 2017-11-22 13-26-28](https://user-images.githubusercontent.com/9877852/33150556-d8333230-cf88-11e7-8334-d55c4daae459.png)

### Reviewer guidance

~~This is WIP for now, but the functionality should be there for the carousel at least. Cards need some adapting, tests need to be written~~

Gonna rely on manual testing for now, have all the testing work that was done here on a separate branch, to be merged a little later.

### References

* fixes #1875 

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [X] If PR is ready for review, it has been assigned or requests review from someone
- ~~[ ] Documentation is updated as necessary~~
- ~~[ ] External dependency files are updated (`yarn` and `pip`)~~
- ~~[ ] If internal dependency is updated, link to diff is included~~
- [X] Screenshots of any front-end changes are in the PR description
- ~~[ ] CHANGELOG.rst is updated for high-level changes~~
- ~~[ ] You've added yourself to AUTHORS.rst if you're not there~~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
