### PR TITLE
Browser not supported warning

### DIFF
--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -2,18 +2,50 @@ import json
 
 from django.conf import settings
 from kolibri.auth.api import SessionViewSet
+from user_agents import parse
 
 
 def return_session(request):
     return {'session': json.dumps(SessionViewSet().get_session(request)), 'kolibri': settings.KOLIBRI_CORE_JS_NAME}
 
+
+browser_requirements = [
+    {
+        'family': 'IE',
+        'major_version': 11,
+    },
+    {
+        'family': 'Mobile Safari',
+        'blacklist': True,
+    },
+    {
+        'family': 'Android',
+        'major_version': 4,
+        'minor_version': 0,
+        'patch_version': 2,
+    },
+]
+
+def pass_browser_entry(agent, entry):
+    if agent.browser.family == entry['family']:
+        if 'blacklist' in entry and entry['blacklist']:
+            return False
+        if 'major_version' in entry:
+            major_ok = agent.browser.version[0] >= entry['major_version']
+            if 'minor_version' in entry:
+                minor_ok = agent.browser.version[1] >= entry['minor_version']
+                if 'patch_version' in entry:
+                    patch_ok = agent.browser.version[2] >= entry['patch_version']
+                    return major_ok and minor_ok and patch_ok
+                return major_ok and minor_ok
+            return major_ok
+    return True
+
+
 def supported_browser(request):
     if 'supported_browser' not in request.session:
 
-        is_ie = 'msie' in request.META['HTTP_USER_AGENT'].lower()
-        if is_ie:
-            ie_version = int(request.META['HTTP_USER_AGENT'].lower().split('msie')[1].split('.')[0].strip())
-            request.session['supported_browser'] = ie_version > 10
-        else:
-            request.session['supported_browser'] = True
+        user_agent = parse(request.META['HTTP_USER_AGENT'])
+        request.session['supported_browser'] = all(
+            pass_browser_entry(user_agent, entry) for entry in browser_requirements)
     return {'supported_browser': request.session['supported_browser']}

--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -6,3 +6,14 @@ from kolibri.auth.api import SessionViewSet
 
 def return_session(request):
     return {'session': json.dumps(SessionViewSet().get_session(request)), 'kolibri': settings.KOLIBRI_CORE_JS_NAME}
+
+def supported_browser(request):
+    if 'supported_browser' not in request.session:
+
+        is_ie = 'msie' in request.META['HTTP_USER_AGENT'].lower()
+        if is_ie:
+            ie_version = int(request.META['HTTP_USER_AGENT'].lower().split('msie')[1].split('.')[0].strip())
+            request.session['supported_browser'] = ie_version > 10
+        else:
+            request.session['supported_browser'] = True
+    return {'supported_browser': request.session['supported_browser']}

--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -45,7 +45,7 @@ def pass_browser_entry(agent, entry):
 def supported_browser(request):
     if 'supported_browser' not in request.session:
 
-        user_agent = parse(request.META['HTTP_USER_AGENT'])
+        user_agent = parse(request.META.get('HTTP_USER_AGENT', ''))
         request.session['supported_browser'] = all(
             pass_browser_entry(user_agent, entry) for entry in browser_requirements)
     return {'supported_browser': request.session['supported_browser']}

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -19,6 +19,7 @@
   {% endif %}
 </head>
 <body>
+{% if supported_browser %}
 <rootvue>
   <style>
     .loading-spinner-wrapper-base{
@@ -76,5 +77,10 @@
 
 {% endblock %}
 
+{% else %}
+
+Sorry, mate. Use a better browser.
+
+{% endif %}
 </body>
 </html>

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -79,7 +79,7 @@
 
 {% else %}
 
-Sorry, mate. Use a better browser.
+{% include 'kolibri/unsupported_browser.html' %}
 
 {% endif %}
 </body>

--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+<style>
+  body {
+    font-family: sans-serif;
+  }
+  .topbar {
+    background-color: #996189;
+    height: 64px;
+    width: 100%;
+    color: white;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  .topbar h1 {
+    font-size: x-large;
+    display: inline-block;
+  }
+  .content-container {
+    background-color: #F9F9F9;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    padding-left: 80px;
+    padding-right: 80px;
+  }
+</style>
+<div class="topbar">
+  <h1>Kolibri</h1>
+</div>
+
+<div class="content-container">
+  <h2>{% trans "Unsupported browser" %}</h2>
+  <p>{% trans "Sorry, your browser version is not supported." %}</p>
+  <p>{% trans "To use Kolibri, we recommend using Firefox or Chrome." %}</p>
+</div>

--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -2,25 +2,22 @@
 <style>
   body {
     font-family: sans-serif;
+    margin: 0;
+    background-color: white;
   }
   .topbar {
     background-color: #996189;
-    height: 64px;
     width: 100%;
     color: white;
-    padding-left: 20px;
-    padding-right: 20px;
   }
   .topbar h1 {
     font-size: x-large;
     display: inline-block;
+    padding-left: 32px;
+    padding-right: 32px;
   }
   .content-container {
-    background-color: #F9F9F9;
-    padding-top: 20px;
-    padding-bottom: 20px;
-    padding-left: 80px;
-    padding-right: 80px;
+    padding: 32px;
   }
 </style>
 <div class="topbar">
@@ -31,4 +28,5 @@
   <h2>{% trans "Unsupported browser" %}</h2>
   <p>{% trans "Sorry, your browser version is not supported." %}</p>
   <p>{% trans "To use Kolibri, we recommend using Firefox or Chrome." %}</p>
+  <p>{% trans "You can also try updating your current browser." %}</p>
 </div>

--- a/kolibri/core/test/test_context_processor.py
+++ b/kolibri/core/test/test_context_processor.py
@@ -15,6 +15,7 @@ class ContextProcessorTestCase(APITestCase):
     def setUp(self):
         self.request = mock.Mock()
         self.request.session = {}
+        self.request.META = {}
         self.template = Template("My name is...")
         self.context = RequestContext(self.request)
 

--- a/kolibri/core/test/test_context_processor.py
+++ b/kolibri/core/test/test_context_processor.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from django.template import Template, RequestContext
 from rest_framework.test import APITestCase
+from unittest import TestCase
+
+from kolibri.core.context_processors.custom_context_processor import pass_browser_entry
 
 import json
 import mock
@@ -24,3 +27,95 @@ class ContextProcessorTestCase(APITestCase):
         self.request = None
         self.template = None
         self.context = None
+
+
+class BrowserEntryTestCase(TestCase):
+    def test_pass_browser_entry_patch_fail(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (4, 0, 1, )
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 4,
+            'minor_version': 0,
+            'patch_version': 2,
+        }
+        self.assertFalse(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_patch_pass(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (4, 0, 2, )
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 4,
+            'minor_version': 0,
+            'patch_version': 2,
+        }
+        self.assertTrue(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_minor_fail(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (4, 0, 1)
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 4,
+            'minor_version': 1,
+        }
+        self.assertFalse(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_minor_pass(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (4, 1, 1)
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 4,
+            'minor_version': 1,
+        }
+        self.assertTrue(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_major_fail(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (4, 0, 1)
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 5,
+        }
+        self.assertFalse(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_major_pass(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (5, 0, 1)
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'major_version': 5,
+        }
+        self.assertTrue(pass_browser_entry(user_agent, entry))
+
+    def test_pass_browser_entry_black_fail(self):
+        user_agent = mock.MagicMock()
+        browser_mock = mock.MagicMock()
+        browser_mock.family = 'Android'
+        browser_mock.version = (5, 0, 1)
+        user_agent.browser = browser_mock
+        entry = {
+            'family': 'Android',
+            'blacklist': True,
+        }
+        self.assertFalse(pass_browser_entry(user_agent, entry))

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -105,6 +105,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'kolibri.core.context_processors.custom_context_processor.return_session',
+                'kolibri.core.context_processors.custom_context_processor.supported_browser',
             ],
         },
     },

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,3 +25,4 @@ pytz==2017.2
 python-dateutil==2.6.0
 ifcfg==0.11b6
 sqlalchemy==1.1.12
+user-agents==1.1.0


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Adds a custom context processor to annotate the session with information about whether the user is using a supported browser.
* Uses a blackish list to specifically ban certain browsers and set minimum versions for some others. All others are permitted.
* Implements a browser not supported page.

### Reviewer guidance

Use IE <= 10, Android <= 4.0.1, or iOS Safari to view the not supported page.

### References

when applicable, please provide:

* Fixes #2035 

![image](https://user-images.githubusercontent.com/1680573/33151232-0927f080-cf8c-11e7-8f08-bb26499035fd.png)


# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
