### PR TITLE
User/developer docs split subsequent updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,10 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 clean-docs:
-	rm -f docs/py_modules/kolibri*rst
-	rm -f docs/py_modules/modules.rst
-	rm -f docs/kolibri*rst # old location
-	rm -f docs/modules.rst # old location
+	rm -f docs-developer/py_modules/kolibri*rst
+	rm -f docs-developer/py_modules/modules.rst
 	$(MAKE) -C docs clean
+	$(MAKE) -C docs-developer clean
 
 lint:
 	flake8 kolibri
@@ -65,9 +64,14 @@ coverage:
 	coverage run --source kolibri setup.py test
 	coverage report -m
 
-docs: clean-docs
-	sphinx-apidoc -d 10 -H "Python Reference" -o docs/py_modules/ kolibri kolibri/test kolibri/deployment/ kolibri/dist/
+docs-developer: clean-docs
+	sphinx-apidoc -d 10 -H "Python Reference" -o docs-developer/py_modules/ kolibri kolibri/test kolibri/deployment/ kolibri/dist/
+	$(MAKE) -C docs-developer html
+
+docs-user: clean-docs
 	$(MAKE) -C docs html
+
+docs: docs-user docs-developer
 
 release:
 	ls -l dist/

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,10 @@ Kolibri
   :target: https://travis-ci.org/learningequality/kolibri
 .. image:: http://codecov.io/github/learningequality/kolibri/coverage.svg?branch=master
   :target: http://codecov.io/github/learningequality/kolibri?branch=master
-.. image:: https://readthedocs.org/projects/kolibri/badge/?version=latest
+.. image:: https://img.shields.io/badge/docs-user-ff69b4.svg
   :target: http://kolibri.readthedocs.org/en/latest/
+.. image:: https://img.shields.io/badge/docs-developer-69ffb4.svg
+  :target: http://kolibri-dev.readthedocs.org/en/developer/
 .. image:: https://img.shields.io/badge/support-on%20discourse-blue.svg
   :target: https://community.learningequality.org/
 .. image:: https://img.shields.io/badge/irc-%23kolibri%20on%20freenode-blue.svg

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Kolibri
 =======
 
 .. image:: https://badge.fury.io/py/kolibri.svg
-   :target: https://pypi.python.org/pypi/kolibri/
-.. image:: https://travis-ci.org/learningequality/kolibri.svg
+  :target: https://pypi.python.org/pypi/kolibri/
+.. image:: https://travis-ci.org/learningequality/kolibri.svg?branch=develop
   :target: https://travis-ci.org/learningequality/kolibri
 .. image:: http://codecov.io/github/learningequality/kolibri/coverage.svg?branch=master
   :target: http://codecov.io/github/learningequality/kolibri?branch=master

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node6.x, userdocs, devdocs, node, postgres, pythonbuild{2.7, 3.4, 3.5}
+envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7, 3.4, 3.5}
 
 [testenv]
 usedevelop = True
@@ -55,19 +55,11 @@ deps =
 commands =
     flake8 kolibri
 
-[testenv:userdocs]
-changedir=docs/
+[testenv:docs]
 deps =
     -r{toxinidir}/requirements/docs.txt
 commands =
-    sphinx-build ./ _build/
-
-[testenv:devdocs]
-changedir=docs-developer/
-deps =
-    -r{toxinidir}/requirements/docs.txt
-commands =
-    sphinx-build ./ _build/
+    make docs
 
 [node_base]
 whitelist_externals =


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

After splitting user and developer docs, we need to bring back the `make docs` target and the automated Tox build to target the new `docs-developer/` Sphinx project.

### Reviewer guidance

If Travis is fine, so should everything else be :)

### References

#2597 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
