### PR TITLE
Expand Tox and Travis config to include Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
       env:
         - TOX_ENV=pythonbuild3.5
         - TRAVIS_NODE_VERSION="6"
+    - python: "3.6"
+      env:
+        - TOX_ENV=pythonbuild3.6
+        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint
@@ -53,6 +57,10 @@ matrix:
     - python: "3.5"
       env:
         - TOX_ENV=py3.5
+        - TRAVIS_NODE_VERSION="6"
+    - python: "3.6"
+      env:
+        - TOX_ENV=py3.6
         - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changes are ordered reverse-chronologically.
 0.7 (unreleased)
 ----------------
 
- - (adding changes here)
+ - Officially supporting Python 3.6
 
 
 0.6.1 (unreleased)

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     cmdclass={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,pypy}, pythonlint, npmbuild, node6.x, userdocs, devdocs, node, postgres, pythonbuild{2.7, 3.4, 3.5}
+envlist = py{2.7,3.4,3.5,3.6,pypy}, pythonlint, npmbuild, node6.x, userdocs, devdocs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6}
 
 [testenv]
 usedevelop = True
@@ -12,10 +12,12 @@ basepython =
     pythonbuild2.7: python2.7
     pythonbuild3.4: python3.4
     pythonbuild3.5: python3.5
+    pythonbuild3.6: python3.6
     licenses: python2.7
     py2.7: python2.7
     py3.4: python3.4
     py3.5: python3.5
+    py3.6: python3.6
     pypy: pypy
     docs: python3.5
     pythonlint: python2.7
@@ -109,6 +111,10 @@ whitelist_externals = {[conditional_testing_base]whitelist_externals}
 commands = {[python_build_base]commands}
 
 [testenv:pythonbuild3.5]
+whitelist_externals = {[conditional_testing_base]whitelist_externals}
+commands = {[python_build_base]commands}
+
+[testenv:pythonbuild3.6]
 whitelist_externals = {[conditional_testing_base]whitelist_externals}
 commands = {[python_build_base]commands}
 


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

Adds Python 3.6 (which is the current stable version of Python since december 2016) to the test matrix.

### Reviewer guidance

Any reason NOT to start testing this in 0.7, if it doesn't introduce any real changes?

### References

(don't think we have an issue about this?)

# Contributor Checklist

- [x] PR has the correct target milestone **Let's change the milestone if changes are required**
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [x] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
