### PR TITLE
simplify PR instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,46 +1,53 @@
-# Details
-
 <!--
-Using the template:
-
- 1. Replace instructional texts with your own words
- 2. Remove headlines when not applicable
- 3. Tick of completed checklist items as you complete them
- 4. Feel free to skip checklist items that aren't applicable
+Using the PR template:
+ 1. Following guidance below, replace …'s with your own words
+ 2. After saving the PR, tick of completed checklist items
+ 3. Skip checklist items that aren't applicable
 -->
 
 ### Summary
+<!--
+ * description of the change
+ * manual verification steps performed
+ * screenshots if the PR affects the UI
+-->
 
-* description of the change
-* manual verification steps performed
-* screenshots if the PR affects the UI
+…
 
 ### Reviewer guidance
+<!--
+ * how can a reviewer test these changes?
+ * are there any risky areas that deserve extra testing
+-->
 
-description of how to test the changes
+…
 
 ### References
+<!--
+ * references to related issues and PRs
+ * links to mockups or specs for new features
+ * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
+-->
 
-when applicable, please provide:
+…
 
-* references to related issues and PRs
-* links to mockups or specs for new features
-* links to the diffs for dependency updates, e.g. in iceqube or the perseus plugin
+----
 
-# Contributor Checklist
+### Contributor Checklist
 
 - [ ] PR has the correct target milestone
-- [ ] PR has the appropriate labels
-- [ ] If PR is ready for review, it has been assigned or requests review from someone
-- [ ] Documentation is updated as necessary
-- [ ] External dependency files are updated (`yarn` and `pip`)
-- [ ] If internal dependency is updated, link to diff is included
+- [ ] PR has 'needs review' or 'work-in-progress' label
+- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
+- [ ] PR has been fully tested manually
+- [ ] Documentation is updated
+- [ ] External dependencies files were updated (`yarn` and `pip`)
+- [ ] Link to diff of internal dependency change is included
 - [ ] Screenshots of any front-end changes are in the PR description
-- [ ] PR has been [tested for accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
+- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
 - [ ] CHANGELOG.rst is updated for high-level changes
 - [ ] You've added yourself to AUTHORS.rst if you're not there
 
-# Reviewer Checklist
+### Reviewer Checklist
 
 - [ ] Automated test coverage is satisfactory
 - [ ] PR has been fully tested manually

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,13 +6,7 @@ Using the template:
  1. Leave all headlines in place
  2. Replace instructional texts with your own words
  3. Tick of completed checklist items as you complete them
- 4. If you intentionally skip a checklist item, see below instruction
-
-Skipping items in checklists:
-
-Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:
-
-- [x] ~Skipped item~ This is a documentation fix
+ 4. Feel free to skip checklist items that aren't applicable
 -->
 
 ### Summary
@@ -37,7 +31,7 @@ when applicable, please provide:
 
 - [ ] PR has the correct target milestone
 - [ ] PR has the appropriate labels
-- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
+- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))
 - [ ] If PR is ready for review, it has been assigned or requests review from someone
 - [ ] Documentation is updated as necessary
 - [ ] External dependency files are updated (`yarn` and `pip`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,12 +31,12 @@ when applicable, please provide:
 
 - [ ] PR has the correct target milestone
 - [ ] PR has the appropriate labels
-- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))
 - [ ] If PR is ready for review, it has been assigned or requests review from someone
 - [ ] Documentation is updated as necessary
 - [ ] External dependency files are updated (`yarn` and `pip`)
 - [ ] If internal dependency is updated, link to diff is included
 - [ ] Screenshots of any front-end changes are in the PR description
+- [ ] PR has been [tested for accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
 - [ ] CHANGELOG.rst is updated for high-level changes
 - [ ] You've added yourself to AUTHORS.rst if you're not there
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
 <!--
 Using the template:
 
- 1. Leave all headlines in place
- 2. Replace instructional texts with your own words
+ 1. Replace instructional texts with your own words
+ 2. Remove headlines when not applicable
  3. Tick of completed checklist items as you complete them
  4. Feel free to skip checklist items that aren't applicable
 -->


### PR DESCRIPTION
# Details

### Summary

The instructions for the PR template were overly complicated:

* they caused people to spend too much time on what ought to be a fast process
* they result in overly complex PRs even for very simple changes

### Reviewer guidance

See if this strikes a better balance between completeness and expediency

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
