### PR TITLE
Update perseus to 0.7.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.0.11
-kolibri_exercise_perseus_plugin==0.7.2
+kolibri_exercise_perseus_plugin==0.7.3
 jsonfield==2.0.1
 https://github.com/learningequality/morango/archive/ef260d263c92a4d3689e9ae742e25b57b52656e2.zip#egg=morango
 requests-toolbelt==0.7.1


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

Note that the new perseus needs to be published first with this change: https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/115

Updates perseus to 0.7.3

### References

fixes https://github.com/learningequality/kolibri/issues/2628

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [x] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [x] External dependency files are updated (`yarn` and `pip`)
- [x] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
