### PR TITLE
Allow user signups

### DIFF
--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -48,7 +48,11 @@ export default class KolibriApp extends KolibriModule {
    *                           routes are handled. Use this to do initial state setup that needs to
    *                           be dynamically determined, and done before every route in the app.
    *                           Each function should return a promise that resolves when the state
-   *                           has been set.
+   *                           has been set. These will be invoked after the current session has
+   *                           been set in the vuex store, in order to allow these actions to
+   *                           reference getters that return data set by the getCurrentSession
+   *                           action. As this has always been bootstrapped into the base template
+   *                           this should not cause any real slow down in page loading.
    */
   get stateSetters() {
     return [];
@@ -58,21 +62,22 @@ export default class KolibriApp extends KolibriModule {
       state: this.initialState,
       mutations: this.mutations,
     });
-    Promise.all([
-      getCurrentSession(store),
-      // Invoke each of the state setters before initializing the app.
-      ...this.stateSetters.map(setter => setter(this.store)),
-    ]).then(() => {
-      this.rootvue = new Vue(
-        Object.assign(
-          {
-            el: 'rootvue',
-            store: store,
-            router: router.init(this.routes),
-          },
-          this.RootVue
-        )
-      );
+    getCurrentSession(store).then(() => {
+      Promise.all([
+        // Invoke each of the state setters before initializing the app.
+        ...this.stateSetters.map(setter => setter(this.store)),
+      ]).then(() => {
+        this.rootvue = new Vue(
+          Object.assign(
+            {
+              el: 'rootvue',
+              store: store,
+              router: router.init(this.routes),
+            },
+            this.RootVue
+          )
+        );
+      });
     });
   }
 }

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -5,6 +5,7 @@ import * as actions from './state/actions';
 import { initialState, mutations } from './state/store';
 import { PageNames } from './constants';
 import store from 'kolibri.coreVue.vuex.store';
+import { getFacilityConfig } from 'kolibri.coreVue.vuex.actions';
 
 const routes = [
   {
@@ -42,6 +43,9 @@ const routes = [
 ];
 
 class UserModule extends KolibriApp {
+  get stateSetters() {
+    return [getFacilityConfig];
+  }
   get routes() {
     return routes;
   }


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Set session data before calling any app specific state setters.
* Add getFacilityConfig to user app state setters.

![image](https://user-images.githubusercontent.com/1680573/33288565-97e30b32-d371-11e7-9aad-31c109993add.png)

![image](https://user-images.githubusercontent.com/1680573/33288581-a3ddb0b8-d371-11e7-8b7a-ff16842046d0.png)


### Reviewer guidance

Turn on 'allow signups' in facility configuration.

See if you are allowed to signup on the user page.

### References

when applicable, please provide:

* Fixes #2606 

# Contributor Checklist

- [ ] PR has the correct target milestone
- [ ] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [ ] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
