### PR TITLE
Allow users to be removed from class

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/prepareLearnApp.js
+++ b/kolibri/plugins/learn/assets/src/state/prepareLearnApp.js
@@ -9,7 +9,7 @@ function prepareLearnApp(store) {
   if (userId === null) return Promise.resolve();
 
   const membershipPromise = MembershipResource.getCollection({
-    user_id: userId,
+    user: userId,
   }).fetch();
 
   return membershipPromise

--- a/kolibri/plugins/learn/assets/test/state/prepareLearnApp.spec.js
+++ b/kolibri/plugins/learn/assets/test/state/prepareLearnApp.spec.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import sinon from 'sinon';
 import prepareLearnApp from '../../src/state/prepareLearnApp';
 import makeStore from '../util/makeStore';
-import { mockResource } from 'testUtils';
+import { mockResource } from 'testUtils'; // eslint-disable-line import/no-unresolved
 
 import { MembershipResource } from 'kolibri.resources';
 
@@ -38,7 +38,7 @@ describe('prepareLearnApp action', () => {
 
     return prepareLearnApp(store).then(() => {
       sinon.assert.calledWith(MembershipResource.getCollection, {
-        user_id: 101,
+        user: 101,
       });
       assert.deepEqual(getMemberships(store), fakeMemberships);
     });
@@ -50,7 +50,7 @@ describe('prepareLearnApp action', () => {
 
     return prepareLearnApp(store).catch(() => {
       sinon.assert.calledWith(MembershipResource.getCollection, {
-        user_id: 102,
+        user: 102,
       });
       assert.deepEqual(store.state.core.error, 'fetch error');
       assert.deepEqual(getMemberships(store), []);

--- a/kolibri/plugins/management/assets/src/state/actions.js
+++ b/kolibri/plugins/management/assets/src/state/actions.js
@@ -187,8 +187,8 @@ function removeClassUser(store, classId, userId) {
   }
   // fetch the membership model with this classId and userId.
   const MembershipCollection = MembershipResource.getCollection({
-    user_id: userId,
-    collection_id: classId,
+    user: userId,
+    collection: classId,
   });
 
   MembershipCollection.delete().then(


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Makes all frontend filter query parameters for the membership resource match the specified filter fields on the backend.
* Not doing so causes the bulk DELETE backend throw an error, as it does not allow DELETEs on unfiltered querysets.

### Reviewer guidance

Enroll a user in a class. Remove a user from a class.

### References

when applicable, please provide:

* Fixes #2568

# Contributor Checklist

- [ ] PR has the correct target milestone
- [ ] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [ ] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
