### PR TITLE
Fix filtering of channels; add tests

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/test/views/channels-grid.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channels-grid.spec.js
@@ -1,0 +1,146 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import Vuex from 'vuex';
+import assert from 'assert';
+import sinon from 'sinon';
+import { mount } from 'avoriaz';
+import ChannelsGrid from '../../views/manage-content-page/channels-grid.vue';
+import DeleteChannelModal from '../../views/manage-content-page/delete-channel-modal.vue';
+import ChannelListItem from '../../views/manage-content-page/channel-list-item.vue';
+import { manageContentPageState } from '../../state/wizardState';
+import mutations from '../../state/mutations';
+import SlottedDiv from '../../../../../../learn/assets/test/util/SlottedDiv.vue';
+import UiProgressLinear from 'keen-ui/src/UiProgressLinear.vue';
+
+function makeStore() {
+  return new Vuex.Store({
+    state: {
+      pageState: manageContentPageState(),
+    },
+    mutations,
+  });
+}
+
+function makeWrapper(options) {
+  const { store = {}, props = {} } = options;
+  return mount(ChannelsGrid, {
+    propsData: { ...props },
+    store,
+    components: {
+      transition: SlottedDiv,
+    },
+    vuex: {
+      actions: {
+        refreshChannelList: () => Promise.resolve(),
+      },
+    },
+  });
+}
+
+function getElements(wrapper) {
+  return {
+    channelListItems: () => wrapper.find(ChannelListItem),
+    emptyState: () => wrapper.find('.no-channels'),
+    progressBar: () => wrapper.find(UiProgressLinear),
+    deleteChannelModal: () => wrapper.first(DeleteChannelModal),
+  };
+}
+
+describe('channelsGrid component', () => {
+  let store;
+
+  beforeEach(() => {
+    store = makeStore();
+    store.dispatch('SET_CHANNEL_LIST', [
+      {
+        name: 'visible channel',
+        id: 'visible_channel',
+        on_device_resources: 10,
+        total_resources: 1000,
+      },
+    ]);
+  });
+
+  it('shows an empty state if there are no visible channels', () => {
+    // "visible" meaning it has on-device resources
+    store.dispatch('SET_CHANNEL_LIST', [
+      {
+        name: 'hidden channel',
+        id: 'hidden_channel',
+        on_device_resources: 0,
+        total_resources: 1000,
+      },
+    ]);
+    const wrapper = makeWrapper({ store });
+    const { emptyState } = getElements(wrapper);
+    return wrapper.vm.$nextTick().then(() => {
+      assert(emptyState()[0].is('p'));
+    });
+  });
+
+  it('shows a progress bar if channels are loading', () => {
+    const wrapper = makeWrapper({ store });
+    const { progressBar } = getElements(wrapper);
+    return wrapper.vm
+      .$nextTick()
+      .then(() => {
+        wrapper.setData({ channelsLoading: true });
+        return wrapper.vm.$nextTick();
+      })
+      .then(() => {
+        assert(progressBar()[0].isVueComponent);
+      });
+  });
+
+  it('channels appear sorted by name', () => {
+    store.dispatch('SET_CHANNEL_LIST', [
+      {
+        name: 'beautiful channel',
+        id: 'beautiful_channel',
+        on_device_resources: 10,
+        total_resources: 1000,
+      },
+      {
+        name: 'awesome channel',
+        id: 'awesome_channel',
+        on_device_resources: 10,
+        total_resources: 1000,
+      },
+    ]);
+    const wrapper = makeWrapper({ store });
+    const { channelListItems } = getElements(wrapper);
+    return wrapper.vm.$nextTick().then(() => {
+      const [ch1, ch2] = channelListItems();
+      assert.equal(ch1.getProp('channel').id, 'awesome_channel');
+      assert.equal(ch2.getProp('channel').id, 'beautiful_channel');
+    });
+  });
+
+  it('a modal appears if channel is selected for deletion', () => {
+    // and clicking "confirm" triggers an action
+    let deleteModal;
+    const wrapper = makeWrapper({ store });
+    const deleteActionStub = sinon.stub(wrapper.vm, 'triggerChannelDeleteTask');
+    const { channelListItems, deleteChannelModal } = getElements(wrapper);
+    return wrapper.vm
+      .$nextTick()
+      .then(() => {
+        const [ch1] = channelListItems();
+        const button = ch1.first('button');
+        assert.equal(button.text().trim(), 'Delete');
+        button.trigger('click');
+        return wrapper.vm.$nextTick();
+      })
+      .then(() => {
+        deleteModal = deleteChannelModal();
+        assert(deleteModal.isVueComponent);
+        const deleteButton = deleteModal.first('button[name="confirm"]');
+        assert.equal(deleteButton.text().trim(), 'Confirm');
+        deleteButton.trigger('click');
+        return wrapper.vm.$nextTick();
+      })
+      .then(() => {
+        sinon.assert.calledWith(deleteActionStub, 'visible_channel');
+      });
+  });
+});

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -2,11 +2,18 @@
 
   <div>
     <transition mode="out-in">
-      <p class="core-text-alert" v-if="sortedChannels.length===0 && !channelsLoading">
+      <p
+        class="core-text-alert no-channels"
+        v-if="noChannelsToShow"
+      >
         {{ $tr('emptyChannelListMessage') }}
       </p>
 
-      <ui-progress-linear v-else-if="channelsLoading" type="indefinite" color="primary" />
+      <ui-progress-linear
+        v-else-if="channelsLoading"
+        type="indefinite"
+        color="primary"
+      />
 
       <div v-else>
         <div class="channel-list-header">
@@ -17,7 +24,6 @@
           <channel-list-item
             class="channel-list-item"
             v-for="channel in sortedChannels"
-            v-show="channel.on_device_resources > 0"
             :key="channel.id"
             :channel="channel"
             mode="MANAGE"
@@ -25,7 +31,6 @@
           />
         </div>
       </div>
-
     </transition>
 
     <delete-channel-modal
@@ -69,8 +74,14 @@
         }
         return '';
       },
+      noChannelsToShow() {
+        return this.sortedChannels.length === 0 && !this.channelsLoading;
+      },
       sortedChannels() {
-        return this.channelList.slice().sort(channel => channel.name);
+        return this.channelList
+          .slice()
+          .sort((c1, c2) => c1.name > c2.name)
+          .filter(channel => channel.on_device_resources > 0);
       },
     },
     created() {

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/delete-channel-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/delete-channel-modal.vue
@@ -20,6 +20,7 @@
       />
 
       <k-button
+        name="confirm"
         :primary="true"
         @click="handleClickConfirm()"
         :text="$tr('confirmButtonLabel')"


### PR DESCRIPTION
# Details

### Summary

1. Updates the empty state for "Manage Content Page"; now if the number of channels which have on-device resources is zero, then it is hidden.
1. Backfilled tests on `channels-grid` component

### Reviewer guidance

1. If you have channels installed, delete them all. Then verify that the empty state appears.
1. Then import some Resources from channels. Then verify that the channel appears on the content management page. 

### References

Fixes #2669 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
