### PR TITLE
Three small fixes for import export

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -22,7 +22,7 @@
       >
 
         <div class="top-buttons" @keydown.enter.stop v-if="!hideTopButtons">
-          <button :aria-label="$tr('goBack')" @click="emitBackEvent" class="header-btn btn-back" v-if="enableBackBtn">
+          <button :aria-label="$tr('goBack')" @click="emitBackEvent" class="header-btn btn-back">
             <mat-svg category="navigation" name="arrow_back" />
           </button>
           <button :aria-label="$tr('closeWindow')" @click="emitCancelEvent" class="header-btn btn-close">
@@ -80,10 +80,6 @@
       enableBgClickCancel: {
         type: Boolean,
         default: true,
-      },
-      enableBackBtn: {
-        type: Boolean,
-        default: false,
       },
       // toggles error message indicator in header
       hasError: {

--- a/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
@@ -132,11 +132,11 @@ describe('channelListItem', () => {
     assert.equal(version(), 'Version 20');
   });
 
-  it('in MANAGE/EXPORT shows the file sizes of Resources', () => {
+  it('in MANAGE/EXPORT shows the on-device file sizes of Resources', () => {
     // ...and does not show the "On Device" indicator
     function test(wrapper) {
       const { resourcesSizeText, onDevice } = getElements(wrapper);
-      assert.equal(resourcesSizeText(), '4 GB resources');
+      assert.equal(resourcesSizeText(), '90 MB resources');
       assert.deepEqual(onDevice(), []);
     }
     test(manageWrapper);

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
@@ -122,7 +122,7 @@
         return this.mode === Modes.MANAGE;
       },
       resourcesSizeText() {
-        return this.$tr('resourcesSize', { size: bytesForHumans(this.channel.total_file_size) });
+        return this.$tr('resourcesSize', { size: bytesForHumans(this.channel.on_device_file_size) });
       },
       thumbnailImg() {
         return this.channel.thumbnail;

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
@@ -102,6 +102,9 @@
       mode: {
         type: String, // 'IMPORT' | 'EXPORT' | 'MANAGE'
         required: true,
+        validator(val) {
+          return Object.keys(Modes).includes(val);
+        },
       },
       onDevice: {
         type: Boolean,

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
@@ -4,6 +4,8 @@
     :title="title"
     :enableBgClickCancel="false"
     hideTopButtons
+    @enter="goForward"
+    @cancel="cancel"
   >
     <transition mode="out-in">
       <ui-alert

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -3,6 +3,8 @@
   <core-modal
     :title="$tr('title')"
     hideTopButtons
+    @enter="goForward"
+    @cancel="cancel"
   >
     <div class="options">
       <k-radio-button


### PR DESCRIPTION
# Details

### Summary

1. Restores callbacks for cancel and enter on the two core-modals used in import/export UI
1. Removes the `enableBackBtn` prop from core-modal
1. Adds a prop validator for `mode` in `channel-list-item`
1. When viewing channels in the landing page or export workflow, show the _on-device_ resource sizes instead of total resource size.

### Reviewer guidance

1. Enter the localimport/export flows. At the different modals, check that hitting "Enter" on keyboard moves you forward. Confirm that hitting "ESC" cancels you out of the workflow.
1. Verify that `enableBackBtn` really isn't used anywhere in the code.
1. grep the code for `channel-list-item`; pick one call site and force an invalid `mode` value. In the browser, verify that you can a prop validation error.
1. Verify that if you have downloaded anything less than the entire channel, that the "x MB resources" message is less than the total size of the channel.


### References

Fixes #2668 #2667 #2663

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
