### PR TITLE
Use core-snackbar in Exam Creation and other core-snackbar improvements 

### DIFF
--- a/kolibri/core/assets/src/views/connection-snackbars/index.vue
+++ b/kolibri/core/assets/src/views/connection-snackbars/index.vue
@@ -8,18 +8,21 @@
       :actionText="$tr('tryNow')"
       :backdrop="true"
       @actionClicked="tryToReconnect"
+      :key="$tr('tryNow')"
     />
     <core-snackbar
       v-if="tryingToReconnect"
       class="trying-to-reconnect-snackbar"
       :text="$tr('tryingToReconnect')"
       :backdrop="true"
+      :key="$tr('tryingToReconnect')"
     />
     <core-snackbar
       v-if="successfullyReconnected"
       class="successfully-reconnected-snackbar"
       :text="$tr('successfullyReconnected')"
       :autoDismiss="true"
+      :key="$tr('successfullyReconnected')"
     />
   </div>
 

--- a/kolibri/core/assets/src/views/core-snackbar/index.vue
+++ b/kolibri/core/assets/src/views/core-snackbar/index.vue
@@ -6,12 +6,15 @@
       class="snackbar-backdrop"
     >
     </div>
-    <ui-snackbar
-      class="snackbar"
-      :message="text"
-      :action="actionText"
-      @action-click="$emit('actionClicked')"
-    />
+    <transition name="snackbar">
+      <ui-snackbar
+        v-show="isVisible"
+        class="snackbar"
+        :message="text"
+        :action="actionText"
+        @action-click="$emit('actionClicked')"
+      />
+    </transition>
   </div>
 
 </template>
@@ -51,13 +54,16 @@
     },
     data: () => ({
       timeout: null,
+      isVisible: false,
     }),
     mounted() {
+      this.isVisible = true;
       if (this.autoDismiss) {
         this.timeout = window.setTimeout(this.clearSnackbar, this.duration);
       }
     },
     beforeDestroy() {
+      this.isVisible = false;
       if (this.timeout) {
         window.clearTimeout(this.timeout);
       }
@@ -79,6 +85,7 @@
     bottom: 0
     z-index: 24
     margin: 16px
+    transition: transform 0.4s ease
 
   .snackbar-backdrop
     z-index: 16
@@ -88,5 +95,9 @@
     right: 0
     left: 0
     background-color: rgba(0, 0, 0, 0.7)
+
+  .snackbar-enter,
+  .snackbar-leave-active
+    transform: translateY(100px)
 
 </style>

--- a/kolibri/core/assets/src/views/core-snackbar/index.vue
+++ b/kolibri/core/assets/src/views/core-snackbar/index.vue
@@ -9,10 +9,12 @@
     <transition name="snackbar">
       <ui-snackbar
         v-show="isVisible"
+        ref="snackbar"
         class="snackbar"
         :message="text"
         :action="actionText"
         @action-click="$emit('actionClicked')"
+        tabindex="0"
       />
     </transition>
   </div>
@@ -25,28 +27,34 @@
   import uiSnackbar from 'keen-ui/src/UiSnackbar';
   import { clearSnackbar } from 'kolibri.coreVue.vuex.actions';
 
+  /* Snackbars are used to display notification. */
   export default {
     name: 'coreSnackbar',
     components: {
       uiSnackbar,
     },
     props: {
+      /* Text of notification to be displayed */
       text: {
         type: String,
         required: true,
       },
+      /* To provide an action button, provide text */
       actionText: {
         type: String,
         required: false,
       },
+      /* Automatically dismiss the snackbar */
       autoDismiss: {
         type: Boolean,
         default: false,
       },
+      /* Duration that the snackbar is visible before it is automatically dismissed */
       duration: {
         type: Number,
-        default: 5000,
+        default: 4000,
       },
+      /* Show a backdrop to prevent interaction with the page */
       backdrop: {
         type: Boolean,
         default: false,
@@ -55,11 +63,17 @@
     data: () => ({
       timeout: null,
       isVisible: false,
+      previouslyFocusedElement: null,
     }),
     mounted() {
       this.isVisible = true;
       if (this.autoDismiss) {
         this.timeout = window.setTimeout(this.clearSnackbar, this.duration);
+      }
+      if (this.backdrop) {
+        window.addEventListener('focus', this.containFocus, true);
+        this.previouslyFocusedElement = document.activeElement;
+        this.previouslyFocusedElement.blur();
       }
     },
     beforeDestroy() {
@@ -67,9 +81,23 @@
       if (this.timeout) {
         window.clearTimeout(this.timeout);
       }
+      if (this.backdrop) {
+        window.removeEventListener('focus', this.containFocus, true);
+        this.previouslyFocusedElement.focus();
+      }
+    },
+    methods: {
+      containFocus(event) {
+        if (event.target === window) {
+          return;
+        }
+        if (!this.$refs.snackbar.$el.contains(event.target)) {
+          this.$refs.snackbar.$el.focus();
+        }
+      },
     },
     vuex: {
-      action: {
+      actions: {
         clearSnackbar,
       },
     },
@@ -83,9 +111,9 @@
   .snackbar
     position: fixed
     bottom: 0
+    left: 0
     z-index: 24
     margin: 16px
-    transition: transform 0.4s ease
 
   .snackbar-backdrop
     z-index: 16
@@ -96,8 +124,13 @@
     left: 0
     background-color: rgba(0, 0, 0, 0.7)
 
-  .snackbar-enter,
-  .snackbar-leave-active
+  .snackbar-enter-active, .snackbar-leave-active
+    transition-property: transform, opacity
+    transition-duration: 0.4s
+    transition-timing-function: ease
+
+  .snackbar-enter, .snackbar-leave-to
+    opacity: 0
     transform: translateY(100px)
 
 </style>

--- a/kolibri/core/assets/test/views/connection-snackbars-spec.js
+++ b/kolibri/core/assets/test/views/connection-snackbars-spec.js
@@ -7,7 +7,6 @@ import sinon from 'sinon';
 import coreSnackbar from 'kolibri.coreVue.components.coreSnackbar';
 import connectionSnackbars from '../../src/views/connection-snackbars';
 import {
-  tryToReconnect,
   showDisconnectedSnackbar,
   showTryingToReconnectSnackbar,
   showSuccessfullyReconnectedSnackbar,

--- a/kolibri/plugins/coach/assets/src/examConstants.js
+++ b/kolibri/plugins/coach/assets/src/examConstants.js
@@ -9,4 +9,6 @@ const Modals = {
   PREVIEW_NEW_EXAM: 'PREVIEW_NEW_EXAM',
 };
 
-export { Modals };
+const EXAM_MODIFICATION_SNACKBAR = 'EXAM_MODIFICATION_SNACKBAR';
+
+export { Modals, EXAM_MODIFICATION_SNACKBAR };

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -13,7 +13,8 @@ import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import router from 'kolibri.coreVue.router';
 import * as CoreActions from 'kolibri.coreVue.vuex.actions';
 import { ContentNodeKinds, CollectionKinds } from 'kolibri.coreVue.vuex.constants';
-import * as Constants from '../../constants';
+import { PageNames } from '../../constants';
+import { EXAM_MODIFICATION_SNACKBAR } from '../../examConstants';
 import { setClassState } from './main';
 import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
@@ -139,7 +140,7 @@ function displayExamModal(store, modalName) {
 
 function showExamsPage(store, classId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('SET_PAGE_NAME', Constants.PageNames.EXAMS);
+  store.dispatch('SET_PAGE_NAME', PageNames.EXAMS);
 
   const promises = [
     LearnerGroupResource.getCollection({ parent: classId }).fetch(),
@@ -378,7 +379,7 @@ function fetchContent(store, topicId) {
 
 function showCreateExamPage(store, classId, channelId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('SET_PAGE_NAME', Constants.PageNames.CREATE_EXAM);
+  store.dispatch('SET_PAGE_NAME', PageNames.CREATE_EXAM);
   store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamCreationPageTitle'));
 
   const channelPromise = ChannelResource.getCollection().fetch();
@@ -450,7 +451,7 @@ function createExam(store, classCollection, examObj) {
         _assignExamTo(exam.id, classCollection).then(
           () => {
             store.dispatch('CORE_SET_PAGE_LOADING', false);
-            router.getInstance().push({ name: Constants.PageNames.EXAMS });
+            router.getInstance().push({ name: PageNames.EXAMS });
           },
           error => CoreActions.handleError(store, error)
         );
@@ -461,7 +462,7 @@ function createExam(store, classCollection, examObj) {
 
 function showExamReportPage(store, classId, channelId, examId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('SET_PAGE_NAME', Constants.PageNames.EXAM_REPORT);
+  store.dispatch('SET_PAGE_NAME', PageNames.EXAM_REPORT);
   const examLogPromise = ExamLogResource.getCollection({
     exam: examId,
     collection: classId,
@@ -522,9 +523,9 @@ function showExamReportDetailPage(
   questionNumber,
   interactionIndex
 ) {
-  if (store.state.pageName !== Constants.PageNames.EXAM_REPORT_DETAIL) {
+  if (store.state.pageName !== PageNames.EXAM_REPORT_DETAIL) {
     store.dispatch('CORE_SET_PAGE_LOADING', true);
-    store.dispatch('SET_PAGE_NAME', Constants.PageNames.EXAM_REPORT_DETAIL);
+    store.dispatch('SET_PAGE_NAME', PageNames.EXAM_REPORT_DETAIL);
   }
   const examPromise = ExamResource.getModel(examId, {
     channel_id: channelId,
@@ -636,6 +637,10 @@ function showExamReportDetailPage(
   );
 }
 
+function showExamModificationSnackbar(store) {
+  store.dispatch('CORE_SET_CURRENT_SNACKBAR', EXAM_MODIFICATION_SNACKBAR);
+}
+
 export {
   displayExamModal,
   showExamsPage,
@@ -653,4 +658,5 @@ export {
   addExercise,
   removeExercise,
   getAllExercisesWithinTopic,
+  showExamModificationSnackbar,
 };

--- a/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/create-exam-page/index.vue
@@ -118,10 +118,11 @@
       @randomize="seed = generateRandomSeed()"
     />
 
-    <ui-snackbar-container
-      class="snackbar-container"
-      ref="snackbarContainer"
-      position="center"
+    <core-snackbar
+      v-if="examModificationSnackbarIsVisible"
+      :key="snackbarText"
+      :text="snackbarText"
+      :autoDismiss="true"
     />
   </div>
 
@@ -139,26 +140,26 @@
     addExercise,
     removeExercise,
     displayExamModal,
+    showExamModificationSnackbar,
   } from '../../state/actions/exam';
   import { className } from '../../state/getters/main';
-  import { Modals as ExamModals } from '../../examConstants';
+  import { Modals as ExamModals, EXAM_MODIFICATION_SNACKBAR } from '../../examConstants';
   import { CollectionKinds } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
-  import uiSnackbar from 'keen-ui/src/UiSnackbar';
-  import uiSnackbarContainer from 'keen-ui/src/UiSnackbarContainer';
+  import coreSnackbar from 'kolibri.coreVue.components.coreSnackbar';
   import uiProgressLinear from 'keen-ui/src/UiProgressLinear';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
   import shuffle from 'lodash/shuffle';
   import random from 'lodash/random';
+  import { currentSnackbar } from 'kolibri.coreVue.vuex.getters';
 
   export default {
     name: 'createExamPage',
     components: {
-      uiSnackbar,
-      uiSnackbarContainer,
+      coreSnackbar,
       uiProgressLinear,
       kButton,
       kTextbox,
@@ -203,6 +204,7 @@
         selectAll: false,
         previewOrSubmissionAttempt: false,
         submitting: false,
+        snackbarText: null,
       };
     },
     computed: {
@@ -352,6 +354,9 @@
           number_of_questions: 1,
         }));
       },
+      examModificationSnackbarIsVisible() {
+        return this.currentSnackbar === EXAM_MODIFICATION_SNACKBAR;
+      },
     },
     methods: {
       changeSelection() {
@@ -373,28 +378,24 @@
       handleAddExercise(exercise) {
         this.selectionMade = true;
         this.addExercise(exercise);
-        this.$refs.snackbarContainer.createSnackbar({
-          message: `${this.$tr('added')} ${exercise.title}`,
-        });
+        this.snackbarText = `${this.$tr('added')} ${exercise.title}`;
+        this.showExamModificationSnackbar();
       },
       handleRemoveExercise(exercise) {
         this.removeExercise(exercise);
-        this.$refs.snackbarContainer.createSnackbar({
-          message: `${this.$tr('removed')} ${exercise.title}`,
-        });
+        this.snackbarText = `${this.$tr('removed')} ${exercise.title}`;
+        this.showExamModificationSnackbar();
       },
       handleAddTopicExercises(allExercisesWithinTopic, topicTitle) {
         this.selectionMade = true;
         allExercisesWithinTopic.forEach(exercise => this.addExercise(exercise));
-        this.$refs.snackbarContainer.createSnackbar({
-          message: `${this.$tr('added')} ${topicTitle}`,
-        });
+        this.snackbarText = `${this.$tr('added')} ${topicTitle}`;
+        this.showExamModificationSnackbar();
       },
       handleRemoveTopicExercises(allExercisesWithinTopic, topicTitle) {
         allExercisesWithinTopic.forEach(exercise => this.removeExercise(exercise));
-        this.$refs.snackbarContainer.createSnackbar({
-          message: `${this.$tr('removed')} ${topicTitle}`,
-        });
+        this.snackbarText = `${this.$tr('removed')} ${topicTitle}`;
+        this.showExamModificationSnackbar();
       },
       preview() {
         this.previewOrSubmissionAttempt = true;
@@ -457,6 +458,7 @@
         selectedExercises: state => state.pageState.selectedExercises,
         examModalShown: state => state.pageState.examModalShown,
         exams: state => state.pageState.exams,
+        currentSnackbar,
       },
       actions: {
         fetchContent,
@@ -464,6 +466,7 @@
         addExercise,
         removeExercise,
         displayExamModal,
+        showExamModificationSnackbar,
       },
     },
   };


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* Changes that didn't make it the previous PR on time.
* Use core-snackbar in Exam Creation
* Add a transition to snackbars
* Contain focus if a core-snackbar has the backdrop prop enabled

![snack](https://user-images.githubusercontent.com/7193975/33291824-0220fa22-d37c-11e7-9fee-ae68d00fb1c4.gif)

### Reviewer guidance

* Go through exam creation.

### References

* Original PR: #2644 

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) - @radinamatic 
- [x] If PR is ready for review, it has been assigned or requests review from someone
- [ ] ~Documentation is updated as necessary~
- [ ] ~External dependency files are updated (`yarn` and `pip`)~
- [ ] ~If internal dependency is updated, link to diff is included~
- [x] Screenshots of any front-end changes are in the PR description
- [ ] ~CHANGELOG.rst is updated for high-level changes~
- [ ] ~You've added yourself to AUTHORS.rst if you're not there~

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
