### PR TITLE
Add descendants' ids to download list when a topic node is selected

### DIFF
--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -2,12 +2,10 @@ import os
 
 from django.conf import settings
 from django.core.management.base import CommandError
-from django.db.models import Sum
 from kolibri.tasks.management.commands.base import AsyncCommand
 from requests.exceptions import HTTPError
 
-from ...models import LocalFile, ContentNode
-from ...utils import annotation, paths, transfer
+from ...utils import annotation, paths, transfer, import_export_content
 
 # constants to specify the transfer method to be used
 DOWNLOAD_METHOD = "download"
@@ -103,29 +101,10 @@ class Command(AsyncCommand):
     def copy_content(self, channel_id, path, node_ids=None, exclude_node_ids=None):
         self._transfer(COPY_METHOD, channel_id, path=path, node_ids=node_ids, exclude_node_ids=exclude_node_ids)
 
-    def _get_leaves_ids(self, node_ids):
-        leaf_node_ids = []
-        for node_id in node_ids:
-            node_leaves = ContentNode.objects.get(pk=node_id).get_descendants(include_self=True).filter(children__isnull=True).values_list('id', flat=True)
-            leaf_node_ids += node_leaves
-        return leaf_node_ids
-
     def _transfer(self, method, channel_id, path=None, node_ids=None, exclude_node_ids=None, baseurl=None):  # noqa: max-complexity=16
 
-        files_to_download = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=False)
-
-        if node_ids:
-            leaf_node_ids = self._get_leaves_ids(node_ids)
-            files_to_download = files_to_download.filter(files__contentnode__in=leaf_node_ids)
-
-        if exclude_node_ids:
-            exclude_leaf_node_ids = self._get_leaves_ids(exclude_node_ids)
-            files_to_download = files_to_download.exclude(files__contentnode__in=exclude_leaf_node_ids)
-
-        # Make sure the files are unique, to avoid duplicating downloads
-        files_to_download = files_to_download.distinct()
-
-        total_bytes_to_transfer = files_to_download.aggregate(Sum('file_size'))['file_size__sum'] or 0
+        files_to_download, total_bytes_to_transfer = import_export_content.get_files_to_transfer(
+            channel_id, node_ids, exclude_node_ids, False)
 
         downloaded_files = []
         file_checksums_to_annotate = []

--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -1,0 +1,29 @@
+from django.db.models import Sum
+from kolibri.content.models import LocalFile, ContentNode
+
+
+def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
+    files_to_transfer = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=available)
+
+    if node_ids:
+        leaf_node_ids = _get_leaves_ids(node_ids)
+        files_to_transfer = files_to_transfer.filter(files__contentnode__in=leaf_node_ids)
+
+    if exclude_node_ids:
+        exclude_leaf_node_ids = _get_leaves_ids(exclude_node_ids)
+        files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_leaf_node_ids)
+
+    # Make sure the files are unique, to avoid duplicating downloads
+    files_to_transfer = files_to_transfer.distinct()
+
+    total_bytes_to_transfer = files_to_transfer.aggregate(Sum('file_size'))['file_size__sum'] or 0
+
+    return files_to_transfer, total_bytes_to_transfer
+
+
+def _get_leaves_ids(node_ids):
+    leaf_node_ids = []
+    for node_id in node_ids:
+        node_leaves = ContentNode.objects.get(pk=node_id).get_descendants(include_self=True).filter(children__isnull=True).values_list('id', flat=True)
+        leaf_node_ids += node_leaves
+    return leaf_node_ids


### PR DESCRIPTION
# Details

<!--
Using the template:

 1. Leave all headlines in place
 2. Replace instructional texts with your own words
 3. Tick of completed checklist items as you complete them
 4. If you intentionally skip a checklist item, see below instruction

Skipping items in checklists:

Tick the item checkbox, ~strikethrough item text~, and write why it was skipped, example:

- [x] ~Skipped item~ This is a documentation fix
-->

### Summary

* description of the change

This PR is to fix https://github.com/learningequality/kolibri/issues/2692.
Previously, when a topic node is selected, only the topic node would be passed into the download file list, so that none of the resources under this topic node were downloaded.
Currently, if a topic node is selected, then all of its descendants will be downloaded. On the other hand, if a topic node is de-selected, then all of its descendants will be excluded from the download list.

### Reviewer guidance

I'm not sure if the number of queries here is the most optimized. Any suggestions appreciated!

To test the changes:
1. Import content with a topic node selected, then all of its descendants will be imported
2. Import content with a topic node selected and a resource node under that topic node not selected, then all of the topic node's descendants except the one resource node will be imported

### References

* references to related issues and PRs
Issue: https://github.com/learningequality/kolibri/issues/2692

# Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has the appropriate labels
~- [X] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing))~ No accessibility regressions introduced 
- [X] If PR is ready for review, it has been assigned or requests review from someone
~- [X] Documentation is updated as necessary~ No need to update documentation
~- [X] External dependency files are updated (`yarn` and `pip`)~ No external dependency updated
~- [X] If internal dependency is updated, link to diff is included~ No internal dependency updated
~- [X] Screenshots of any front-end changes are in the PR description~ No front-end changes
~- [X] CHANGELOG.rst is updated for high-level changes~ No high-level changes
~- [X] You've added yourself to AUTHORS.rst if you're not there~ My name is there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
