### PR TITLE
Annotate only the channel we just downloaded.

### DIFF
--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -173,7 +173,7 @@ class Command(AsyncCommand):
                     os.remove(dest)
                 self.cancel()
             else:
-                annotation.set_availability(file_checksums_to_annotate)
+                annotation.set_availability(channel_id, file_checksums_to_annotate)
 
     def handle_async(self, *args, **options):
         if options['command'] == 'network':

--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -61,19 +61,19 @@ class AnnotationTreeRecursion(TransactionTestCase):
 
     def test_all_content_nodes_available(self):
         ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(available=True)
-        recurse_availability_up_tree()
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
         self.assertTrue(ContentNode.objects.get(id="da7ecc42e62553eebc8121242746e88a").available)
         self.assertTrue(ContentNode.objects.get(id="2e8bac07947855369fe2d77642dfc870").available)
 
     def test_no_content_nodes_available(self):
         ContentNode.objects.filter(kind=content_kinds.TOPIC).update(available=True)
-        recurse_availability_up_tree()
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
         # 2, as there are two childless topics in the fixture, these cannot exist in real databases
         self.assertEqual(ContentNode.objects.filter(kind=content_kinds.TOPIC).filter(available=True).count(), 2)
 
     def test_one_content_node_available(self):
         ContentNode.objects.filter(id='32a941fb77c2576e8f6b294cde4c3b0c').update(available=True)
-        recurse_availability_up_tree()
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
         # Check parent is available
         self.assertTrue(ContentNode.objects.get(id='da7ecc42e62553eebc8121242746e88a').available)
 


### PR DESCRIPTION
Fixes #2632. 

Only annotate the current channel we're importing. Significantly speeds up annotation, since we only care about the channel we're downloading.

