### PR TITLE
Make content import export tasks progress trackable and cancellable again

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/constants.js
+++ b/kolibri/plugins/management/assets/src/device_management/constants.js
@@ -13,10 +13,10 @@ export const ContentWizardPages = {
 };
 
 export const TaskTypes = {
-  REMOTE_IMPORT: 'remoteimport',
-  LOCAL_IMPORT: 'localimport',
-  LOCAL_EXPORT: 'localexport',
-  DELETE_CHANNEL: 'deletechannel',
+  REMOTE_IMPORT: 'REMOTECONTENTIMPORT',
+  LOCAL_IMPORT: 'DISKCONTENTIMPORT',
+  LOCAL_EXPORT: 'DISKEXPORT',
+  DELETE_CHANNEL: 'DELETECHANNEL',
 };
 
 export const TaskStatuses = {

--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -115,6 +115,8 @@ class TasksViewSet(viewsets.ViewSet):
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             extra_metadata=job_metadata,
+            track_progress=True,
+            cancellable=True,
         )
 
         resp = _job_to_response(get_client().status(job_id))
@@ -201,6 +203,8 @@ class TasksViewSet(viewsets.ViewSet):
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             extra_metadata=job_metadata,
+            track_progress=True,
+            cancellable=True,
         )
 
         resp = _job_to_response(get_client().status(job_id))
@@ -231,7 +235,8 @@ class TasksViewSet(viewsets.ViewSet):
             "deletechannel",
             channel_id,
             track_progress=True,
-            extra_metadata=job_metadata,)
+            extra_metadata=job_metadata,
+        )
 
         # attempt to get the created Task, otherwise return pending status
         resp = _job_to_response(get_client().status(task_id))


### PR DESCRIPTION
Fixes #2705. We missed the keyword arguments that makes a task progress trackable and cancellable, so I added them in again.