### PR TITLE
Check whether Kolibri studio is available when beginning import workflow

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -421,6 +421,14 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         """
         return self._cache_kolibri_studio_channel_request(identifier=pk)
 
+    @list_route(methods=['get'])
+    def kolibri_studio_status(self, request, **kwargs):
+        try:
+            requests.get(get_channel_lookup_url())
+            return Response({"status": "online"})
+        except requests.ConnectionError:
+            return Response({"status": "offline"})
+
 
 class ContentNodeFileSizeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ContentNodeGranularSerializer

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -424,8 +424,11 @@ class RemoteChannelViewSet(viewsets.ViewSet):
     @list_route(methods=['get'])
     def kolibri_studio_status(self, request, **kwargs):
         try:
-            requests.get(get_channel_lookup_url())
-            return Response({"status": "online"})
+            resp = requests.get(get_channel_lookup_url())
+            if resp.status_code == 404:
+                raise requests.ConnectionError("Kolibri studio URL is incorrect!")
+            else:
+                return Response({"status": "online"})
         except requests.ConnectionError:
             return Response({"status": "offline"})
 

--- a/kolibri/core/assets/src/api-resources/remoteChannel.js
+++ b/kolibri/core/assets/src/api-resources/remoteChannel.js
@@ -4,4 +4,11 @@ export default class RemoteChannelResource extends Resource {
   static resourceName() {
     return 'remotechannel';
   }
+
+  getKolibriStudioStatus() {
+    return this.client({
+      path: this.urls[`${this.name}-kolibri-studio-status`](),
+      method: 'GET',
+    });
+  }
 }

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -9,12 +9,14 @@
         :label="$tr('network')"
         v-model="source"
         radiovalue="network"
-        autofocus
+        :disabled="disableUi || kolibriStudioIsOffline"
+        :autofocus="!kolibriStudioIsOffline"
       />
       <k-radio-button
         :label="$tr('localDrives')"
         v-model="source"
         radiovalue="local"
+        :disabled="disableUi"
       />
     </div>
 
@@ -27,6 +29,7 @@
       <k-button
         @click="goForward"
         primary
+        :disabled="disableUi"
         :text="$tr('continue')"
       />
     </div>
@@ -41,6 +44,7 @@
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { transitionWizardPage } from '../../../state/actions/contentWizardActions';
+  import { RemoteChannelResource } from 'kolibri.resources';
 
   export default {
     name: 'selectImportSourceModal',
@@ -52,7 +56,18 @@
     data() {
       return {
         source: 'network',
+        disableUi: true,
+        kolibriStudioIsOffline: false,
       };
+    },
+    created() {
+      RemoteChannelResource.getKolibriStudioStatus().then(({ entity }) => {
+        if (entity.status === 'offline') {
+          this.source = 'local';
+          this.kolibriStudioIsOffline = true;
+        }
+        this.disableUi = false;
+      });
     },
     $trs: {
       cancel: 'Cancel',


### PR DESCRIPTION
# Details

### Summary
Addresses #2242 

1. Adds a custom endpoint `api/remotechannel/kolibri_studio_status` that returns the status of Kolibri Studio. Responds with `{ status: "offline"}` when internet is disconnected on client, or when KS returns 404. Returns with `{status: "online"}` otherwise.
1. Modifies the `select-import-source-modal` to first check to see if KS is online; if it's not, it disables the option to import from KS. (A message explaining why may be helpful, but this does not add any new strings to the UI).

#### Online
![online](https://user-images.githubusercontent.com/10248067/33353340-2c9e051a-d462-11e7-8107-19917e5026db.gif)

#### Offline
![offline](https://user-images.githubusercontent.com/10248067/33353336-2a1a5a6e-d462-11e7-989f-f4aee07f57e7.gif)


### Reviewer guidance

1. When online, the workflow works as usual
1. When offline (turn off your computer's wifi connection), the "Kolibri Central Server" option is disabled on the modal you get after clicking "import"

### References

when applicable, please provide:

* references to related issues and PRs
* links to mockups or specs for new features
* links to the diffs for dependency updates, e.g. in iceqube or the perseus plugin

# Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has the appropriate labels
- [ ] Changes in the PR do not introduce accessibility regressions ([confimed by testing with one of the recommended tools](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)) 
- [ ] If PR is ready for review, it has been assigned or requests review from someone
- [ ] Documentation is updated as necessary
- [ ] External dependency files are updated (`yarn` and `pip`)
- [ ] If internal dependency is updated, link to diff is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

# Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
