### PR TITLE
Reset parts of the import/export wizard state when going back to channel list

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/mutations/contentWizardMutations.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/mutations/contentWizardMutations.js
@@ -1,4 +1,5 @@
 import set from 'lodash/set';
+import { ContentWizardPages } from '../../constants';
 import { getDriveById } from '../getters';
 
 function setWizardState(state, path, value) {
@@ -31,4 +32,21 @@ export function SET_TRANSFER_TYPE(state, transferType) {
 
 export function SET_WIZARD_STATUS(state, status) {
   setWizardState(state, 'status', status);
+}
+
+export function RESET_WIZARD_STATE_FOR_AVAILABLE_CHANNELS(state) {
+  const oldState = state.pageState.wizardState;
+  state.pageState.wizardState = {
+    ...oldState,
+    currentTopicNode: {},
+    nodesForTransfer: {
+      included: [],
+      omitted: [],
+    },
+    pageName: ContentWizardPages.AVAILABLE_CHANNELS,
+    path: [],
+    status: '',
+    pathCache: {},
+    transferredChannel: {},
+  };
 }

--- a/kolibri/plugins/management/assets/src/device_management/test/actions/contentWizardActions.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/actions/contentWizardActions.spec.js
@@ -66,6 +66,10 @@ describe('transitionWizardPage action', () => {
   const transferType = () => wizardState(store.state).transferType;
   const selectedDrive = () => wizardState(store.state).selectedDrive;
 
+  before(() => {
+    TaskResource.localDrives = sinon.stub();
+  });
+
   beforeEach(() => {
     store = makeStore();
 
@@ -76,6 +80,7 @@ describe('transitionWizardPage action', () => {
 
   afterEach(() => {
     showSelectContentPageStub.restore();
+    TaskResource.localDrives.reset();
   });
 
   it('REMOTEIMPORT flow correctly updates wizardState', () => {
@@ -115,7 +120,7 @@ describe('transitionWizardPage action', () => {
   });
 
   it('LOCALIMPORT flow correctly updates wizardState', () => {
-    const localDrivesStub = sinon.stub(TaskResource, 'localDrives').returns(
+    TaskResource.localDrives.returns(
       Promise.resolve({
         entity: [],
       })
@@ -146,12 +151,11 @@ describe('transitionWizardPage action', () => {
       })
       .then(() => {
         sinon.assert.calledOnce(showSelectContentPageStub);
-        localDrivesStub.restore();
       });
   });
 
   it('LOCALEXPORT flow correctly updates wizardState', () => {
-    const localDrivesStub = sinon.stub(TaskResource, 'localDrives').returns(
+    TaskResource.localDrives.returns(
       Promise.resolve({
         entity: [],
       })
@@ -176,7 +180,50 @@ describe('transitionWizardPage action', () => {
       })
       .then(() => {
         sinon.assert.calledOnce(showSelectContentPageStub);
-        localDrivesStub.restore();
       });
+  });
+
+  it('in all modes, going back from SELECT_CONTENT to AVAILABLE_CHANNELS should reset parts of wizardState', () => {
+    // Putting unrealistic data into state to emphasize the generality of this behavior
+    const initial = {
+      currentTopicNode: {
+        id: 'currentTopicNode',
+      },
+      nodesForTransfer: {
+        included: [1, 2, 3],
+        omitted: [4, 5, 6],
+      },
+      pageName: 'SELECT_CONTENT',
+      availableSpace: 123123123,
+      availableChannels: ['a', 'b', 'c'],
+      driveList: ['c', 'd', 'e'],
+      selectedDrive: {
+        foo: 'bar',
+      },
+      transferType: 'intergalatic',
+      path: [{ bar: 'foo', baz: 'buzz' }],
+      status: 'awesome',
+      pathCache: { a: { b: 1 } },
+      transferredChannel: {
+        id: 'channelios',
+      },
+    };
+    const expected = {
+      ...initial,
+      currentTopicNode: {},
+      nodesForTransfer: {
+        included: [],
+        omitted: [],
+      },
+      pageName: 'AVAILABLE_CHANNELS',
+      path: [],
+      status: '',
+      pathCache: {},
+      transferredChannel: {},
+    };
+    store.state.pageState.wizardState = { ...initial };
+    return transitionWizardPage(store, 'backward').then(() => {
+      assert.deepEqual(wizardState(store.state), expected);
+    });
   });
 });

--- a/kolibri/plugins/management/assets/src/device_management/wizardTransitionRoutes.js
+++ b/kolibri/plugins/management/assets/src/device_management/wizardTransitionRoutes.js
@@ -57,14 +57,13 @@ export default [
     name: WizardTransitions.GOTO_AVAILABLE_CHANNELS_PAGE,
     path: '/content/wizard/availablechannels',
     handler: () => {
-      if (!get(store.state.pageState, 'wizardState.pageName')) {
+      const pageName = get(store.state.pageState, 'wizardState.pageName');
+      if (!pageName) {
         return router.replace('/content');
       }
-      // This action should maintain most of the state, except for nodesForTransfer
-      store.dispatch('REPLACE_INCLUDE_LIST', []);
-      store.dispatch('REPLACE_OMIT_LIST', []);
-      // TODO adjust tests to account for this flow (they assume fresh start from /content).
-      return store.dispatch('SET_WIZARD_PAGENAME', ContentWizardPages.AVAILABLE_CHANNELS);
+      if (pageName === ContentWizardPages.SELECT_CONTENT) {
+        return transitionWizardPage(store, 'backward');
+      }
     },
   },
   {


### PR DESCRIPTION
# Details

### Summary

Addresses #2721 by making resetting all parts of the state that should not leak when going from "Select Content" to "Available Channels" back to "Select Content"

### Reviewer guidance

For each workflow (remote import, local import, export):

1. Select a channel to select content from
1. Either go back one step (to the channels list) or cancel out of workflow entirely
1. Go through workflow again and select another channel (different from Step 1).
1. Verify that the contents/checkboxes do not appear prematurely

Review the diff in `contentWizardMutations` and tests to see if the `RESET_WIZARD_STATE_FOR_AVAILABLE_CHANNELS` mutations represents the correct behavior.

### References

#2721


----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
