### PR TITLE
Use getattr for checking job's extra metadata.

### DIFF
--- a/kolibri/tasks/api.py
+++ b/kolibri/tasks/api.py
@@ -424,8 +424,8 @@ def _job_to_response(job):
         }
     else:
         return {
-            "type": job.extra_metadata.get("type"),
-            "started_by": job.extra_metadata.get("started_by"),
+            "type": getattr(job, "extra_metadata", {}).get("type"),
+            "started_by": getattr(job, "extra_metadata", {}).get("started_by"),
             "status": job.state,
             "exception": str(job.exception),
             "traceback": str(job.traceback),


### PR DESCRIPTION
 fix #2729. Looks like I used the wrong function that didn't work for all cases. Now, we use `getattr`, which should work for all cases now.