### PR TITLE
reduce the cache time of remote channels to 5 seconds

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -354,13 +354,12 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             raise Http404(
                 _("The requested channel does not exist on the content server")
             )
-        cache.set(cache_key, resp.json(), 60 * 10)
 
         kolibri_mapped_response = []
         for channel in resp.json():
             kolibri_mapped_response.append(self._studio_response_to_kolibri_response(channel))
 
-        cache.set(cache_key, kolibri_mapped_response, 60 * 10)
+        cache.set(cache_key, kolibri_mapped_response, 5)
 
         return Response(kolibri_mapped_response)
 


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR is to reduce the cache time of remote channels from 10 minutes to 5 seconds. After this change, if a channel is changed and gets published on Studio, the API call should return the new version of the channel very soon.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create a channel on Studio and publish it
2. Import this channel on Kolibri 
3. Make changes in the channel on Studio and publish it again
4. Check the `/api/remotechannel/<channel_id>` to see that it returns the latest version of the channel

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

This is to fix the issue https://github.com/learningequality/kolibri/issues/2726

----

### Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
