### PR TITLE
Hide Device Info tab when appropriate 

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/actions/deviceInfoActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/deviceInfoActions.js
@@ -3,6 +3,7 @@ import urls from 'kolibri.urls';
 import bytesForHumans from '../../views/manage-content-page/bytesForHumans';
 import { samePageCheckGenerator, handleApiError } from 'kolibri.coreVue.vuex.actions';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
+import { canManageContent } from 'kolibri.coreVue.vuex.getters';
 
 /* Function to fetch device info from the backend
  * and resolve validated data
@@ -23,15 +24,18 @@ export function getDeviceInfo() {
  * @returns Promise<void>
  */
 export function showDeviceInfoPage(store) {
-  const promises = ConditionalPromise.all([getDeviceInfo()]).only(samePageCheckGenerator(store))
-    ._promise;
-  return promises
-    .then(function onSuccess([deviceInfo]) {
-      store.dispatch('SET_DEVICE_INFO_PAGE_STATE', {
-        deviceInfo,
+  if (canManageContent(store.state)) {
+    const promises = ConditionalPromise.all([getDeviceInfo()]).only(samePageCheckGenerator(store))
+      ._promise;
+    return promises
+      .then(function onSuccess([deviceInfo]) {
+        store.dispatch('SET_DEVICE_INFO_PAGE_STATE', {
+          deviceInfo,
+        });
+      })
+      .catch(function onFailure(error) {
+        handleApiError(store, error);
       });
-    })
-    .catch(function onFailure(error) {
-      handleApiError(store, error);
-    });
+  }
+  return Promise.resolve();
 }

--- a/kolibri/plugins/management/assets/src/device_management/state/actions/manageContentActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/manageContentActions.js
@@ -14,8 +14,8 @@ export function refreshChannelList(store) {
 }
 
 export function showManageContentPage(store) {
+  store.dispatch('RESET_MANAGE_CONTENT_PAGESTATE');
   if (canManageContent(store.state)) {
-    store.dispatch('RESET_MANAGE_CONTENT_PAGESTATE');
     return refreshChannelList(store);
   }
   return Promise.resolve();

--- a/kolibri/plugins/management/assets/src/device_management/views/device-info-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/device-info-page/index.vue
@@ -1,55 +1,60 @@
 <template>
 
-  <subpage-container>
-    <h1>{{ $tr('header') }}</h1>
-    <table>
-      <tr>
-        <th>{{ $tr('kolibriVersion') }}</th>
-        <td>{{ info.version }}</td>
-      </tr>
-      <tr>
-        <th>
-          {{ $tr('url', { count: info.urls.length }) }}
-        </th>
-        <td>
-          <a
-            v-for="(url, index) in info.urls"
-            :key="index"
-            :href="url"
-            target="_blank"
-            class="link"
-          >
-            {{ url }}
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <th>{{ $tr('database') }}</th>
-        <td>{{ info.database_path }}</td>
-      </tr>
-      <tr>
-        <th>{{ $tr('deviceName') }}</th>
-        <td>{{ info.device_name }}</td>
-      </tr>
-      <tr>
-        <th>{{ $tr('os') }}</th>
-        <td>{{ info.os }}</td>
-      </tr>
-      <tr>
-        <th>{{ $tr('freeDisk') }}</th>
-        <td>{{ info.content_storage_free_space }}</td>
-      </tr>
-      <tr>
-        <th>{{ $tr('serverTime') }}</th>
-        <td>{{ $tr('formattedTime', { datetime: info.server_time }) }}</td>
-      </tr>
-      <tr>
-        <th>{{ $tr('serverTimezone') }}</th>
-        <td>{{ info.server_timezone }}</td>
-      </tr>
+  <div>
+    <subpage-container v-if="canManageContent">
+      <h1>{{ $tr('header') }}</h1>
+      <table>
+        <tr>
+          <th>{{ $tr('kolibriVersion') }}</th>
+          <td>{{ info.version }}</td>
+        </tr>
+        <tr>
+          <th>
+            {{ $tr('url', { count: info.urls.length }) }}
+          </th>
+          <td>
+            <a
+              v-for="(url, index) in info.urls"
+              :key="index"
+              :href="url"
+              target="_blank"
+              class="link"
+            >
+              {{ url }}
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <th>{{ $tr('database') }}</th>
+          <td>{{ info.database_path }}</td>
+        </tr>
+        <tr>
+          <th>{{ $tr('deviceName') }}</th>
+          <td>{{ info.device_name }}</td>
+        </tr>
+        <tr>
+          <th>{{ $tr('os') }}</th>
+          <td>{{ info.os }}</td>
+        </tr>
+        <tr>
+          <th>{{ $tr('freeDisk') }}</th>
+          <td>{{ info.content_storage_free_space }}</td>
+        </tr>
+        <tr>
+          <th>{{ $tr('serverTime') }}</th>
+          <td>{{ $tr('formattedTime', { datetime: info.server_time }) }}</td>
+        </tr>
+        <tr>
+          <th>{{ $tr('serverTimezone') }}</th>
+          <td>{{ info.server_timezone }}</td>
+        </tr>
 
-    </table>
-  </subpage-container>
+      </table>
+    </subpage-container>
+
+    <!-- TODO: Update to: Anyone who can manage content -->
+    <auth-message v-else authorizedRole="admin" />
+  </div>
 
 </template>
 
@@ -57,7 +62,7 @@
 <script>
 
   import authMessage from 'kolibri.coreVue.components.authMessage';
-  import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
+  import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import subpageContainer from '../containers/subpage-container';
 
   export default {
@@ -69,7 +74,7 @@
     vuex: {
       getters: {
         info: state => state.pageState.deviceInfo,
-        isSuperuser,
+        canManageContent,
       },
     },
     $trs: {

--- a/kolibri/plugins/management/assets/src/device_management/views/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/index.vue
@@ -6,7 +6,7 @@
     </transition>
 
     <div>
-      <top-navigation />
+      <top-navigation v-if="canManageContent" />
       <component :is="currentPage" />
     </div>
   </core-base>
@@ -17,6 +17,7 @@
 <script>
 
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
+  import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import { PageNames } from '../constants';
   import coreBase from 'kolibri.coreVue.components.coreBase';
   import topNavigation from './device-top-nav';
@@ -54,6 +55,7 @@
       getters: {
         pageName: ({ pageName }) => pageName,
         welcomeModalVisible: ({ welcomeModalVisible }) => welcomeModalVisible,
+        canManageContent,
       },
       actions: {
         hideWelcomeModal(store) {


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Hides Device Info top-nav item when user cannot manage content.
Had to show `You must be signed in as an Admin to view this page` message instead of `You must have permissions to manage content to view this page` due to string freeze.

![info](https://user-images.githubusercontent.com/7193975/33404624-d6efefd0-d519-11e7-975c-61891518f280.gif)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Sign out and try to navigate to `http://localhost:8000/management/device/#/info`

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/2713
Fixes some of #2716

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
