### PR TITLE
Use ltr for pdfs to avoid distortion

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/views/pageComponent.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/pageComponent.vue
@@ -8,6 +8,7 @@
       v-show="active"
       class="canvas"
       ref="canvas"
+      dir="ltr"
       :height="pageHeight"
       :width="pageWidth">
     </canvas>


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Use `ltr` for pdfs to avoid distortion. I tested using a pdf that was in Arabic. Leaving as `rtl` still distorted it. So it has to be `ltr` in all cases.

#### Original PDF

![original](https://user-images.githubusercontent.com/7193975/33405856-defa0148-d51e-11e7-854b-b3a9200e1b87.png)

#### Using `ltr`

![ltr](https://user-images.githubusercontent.com/7193975/33405878-f5932ff6-d51e-11e7-825d-d6594c378fba.png)

#### Using `rtl`
![rtl](https://user-images.githubusercontent.com/7193975/33405885-fa83932a-d51e-11e7-9294-36941ff15373.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Switch to RTL and make sure pdfs render correctly.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #2693 

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
