### PR TITLE
Always make the "channel update" available (even if no resources)

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/actions/contentWizardActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/contentWizardActions.js
@@ -69,7 +69,7 @@ export function transitionWizardPage(store, transition, params) {
   // At AVAILABLE_CHANNELS
   // Forward with params: { channel }
   if (wizardPage === PageNames.AVAILABLE_CHANNELS && transition === FORWARD) {
-    store.dispatch('SET_TRANSFER_CHANNEL', params.channel);
+    store.dispatch('SET_TRANSFERRED_CHANNEL', params.channel);
     return showSelectContentPage(store);
   }
 

--- a/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
@@ -30,7 +30,10 @@ export function showSelectContentPage(store) {
     .then(channel => {
       // The channel objects are not consistent if they come from different workflows.
       // Replacing them here with canonical type from ChannelResource.
-      store.dispatch('SET_TRANSFERRED_CHANNEL', channel);
+      store.dispatch('SET_TRANSFERRED_CHANNEL', {
+        ...channel,
+        version: transferredChannel.version,
+      });
       navigateToTopicUrl({ title: channel.name, pk: channel.root });
     })
     .catch(({ errorType }) => {

--- a/kolibri/plugins/management/assets/src/device_management/state/mutations/contentTransferMutations.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/mutations/contentTransferMutations.js
@@ -61,7 +61,3 @@ export function UPDATE_PATH_BREADCRUMBS(state, topic) {
 export function SET_AVAILABLE_SPACE(state, space) {
   state.pageState.wizardState.availableSpace = space;
 }
-
-export function SET_TRANSFERRED_CHANNEL(state, channel) {
-  state.pageState.wizardState.transferredChannel = channel;
-}

--- a/kolibri/plugins/management/assets/src/device_management/state/mutations/contentWizardMutations.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/mutations/contentWizardMutations.js
@@ -22,7 +22,7 @@ export function SET_SELECTED_DRIVE(state, driveId) {
   setWizardState(state, 'selectedDrive', getDriveById(state)(driveId));
 }
 
-export function SET_TRANSFER_CHANNEL(state, transferredChannel) {
+export function SET_TRANSFERRED_CHANNEL(state, transferredChannel) {
   setWizardState(state, 'transferredChannel', transferredChannel);
 }
 

--- a/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
@@ -11,6 +11,7 @@
         status="QUEUED"
         :percentage="0"
         :cancellable="false"
+        id="updatingchannel"
       />
       <task-progress
         v-if="tasksInQueue"
@@ -30,10 +31,7 @@
         </ui-alert>
       </section>
 
-      <section
-        v-if="channelOnDevice.on_device_resources > 0"
-        class="updates"
-      >
+      <section class="updates">
         <div
           class="updates-available"
           v-if="newVersionAvailable"


### PR DESCRIPTION
### Summary

Before, the "update" button was hidden for channels with no on-device resources. So this might have been possible:

1. View KA channel, but don't download anything
1. Someone upgrades KA
1. Viewing KA post-upgrade, there is no indication that the upgrade had happened

Now, if a user has a stale channel DB, even without Resources, they can click "upgrade" to update just the metadata db.


### Reviewer guidance

Testing with your own personal channel

1. Publish a channel
1. "install" it on your computer by viewing it, with or without resources
1. update and republish your channel
1. go back to Kolibri and you should see some indicators that it has been updated (even if you did not install any resources).

### References

Should improve experience in #2726

----

### Contributor Checklist

- [ ] PR has the correct target milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
