### PR TITLE
Cherry pick sign in page layout fix

### DIFF
--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="fh">
     <div class="wrapper-table">
       <div class="main-row"><div id="main-cell">
         <logo class="logo" />
@@ -378,11 +378,14 @@
     &:hover
       background-color: #0E0E0E
 
+  .fh
+    height: 100%
+
   .wrapper-table
     text-align: center
     background-color: #201A21
-    height: 100%
     width: 100%
+    height: 100%
     display: table
 
   .main-row


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This commit was meant to go into 0.7.x but the PR accidentally targeted Develop.

![localhost_8000_user_](https://user-images.githubusercontent.com/7193975/33351002-9335d26e-d456-11e7-9554-8f2708dd1568.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

View sign in page.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

PR that made was merged into Develop: https://github.com/learningequality/kolibri/pull/2712

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
