### PR TITLE
Show unlisted channels on Remote Import's Available Channels Page

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/actions/availableChannelsActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/availableChannelsActions.js
@@ -62,10 +62,12 @@ export function getRemoteChannelByToken(token) {
  */
 export function getAllRemoteChannels(store, publicChannels) {
   const installedChannels = installedChannelList(store.state);
-  const potentiallyUnlisted = differenceBy(installedChannels, publicChannels, 'id');
+  const potentiallyUnlisted = differenceBy(installedChannels, publicChannels, 'id').filter(
+    channel => channel.on_device_resources > 0
+  );
   const promises = potentiallyUnlisted.map(channel =>
     getRemoteChannelByToken(channel.id)
-      .then(([channel]) => Promise.resolve({ ...channel, unlisted: true }))
+      .then(([channel]) => Promise.resolve(channel))
       .catch(() => Promise.resolve())
   );
   return Promise.all(promises).then(unlisted => {

--- a/kolibri/plugins/management/assets/src/device_management/state/actions/availableChannelsActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/availableChannelsActions.js
@@ -54,8 +54,10 @@ export function getRemoteChannelByToken(token) {
 }
 
 /**
- * Makes a request to Kolibri Studio to get info on unlisted channels. And append
- * them to the public channels.
+ * HACK: Makes a request to Kolibri Studio to get info on unlisted channels, then appends
+ * them to the public channels. This hack is to get around the fact that the ChannelMetadata object
+ * does not indicate the origins of a channel: whether a remote public, remote unlisted, or bespoke channel
+ * from USB, the ChannelMetadata is identical.
  *
  * @param {Array<Channel>} publicChannels - the list of publich channels, which will not be queried
  * @returns {Promise<Array<Channel>>}

--- a/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
@@ -30,7 +30,11 @@ export function showSelectContentPage(store) {
     .then(channel => {
       // The channel objects are not consistent if they come from different workflows.
       // Replacing them here with canonical type from ChannelResource.
-      store.dispatch('SET_TRANSFERRED_CHANNEL', channel);
+      store.dispatch('SET_TRANSFERRED_CHANNEL', {
+        ...channel,
+        version: transferredChannel.version,
+        public: transferredChannel.public,
+      });
       navigateToTopicUrl({ title: channel.name, pk: channel.root });
     })
     .catch(({ errorType }) => {

--- a/kolibri/plugins/management/assets/src/device_management/test/actions/contentWizardActions.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/actions/contentWizardActions.spec.js
@@ -89,7 +89,12 @@ describe('transitionWizardPage action', () => {
       { id: 'public_channel_2', name: 'Public Channel Two' },
     ];
     // makes call to RemoteChannel API
-    const fetchSpy = RemoteChannelResource.__getCollectionFetchReturns(publicChannels).fetch;
+    let fetchSpy = sinon.stub().returns({
+      _promise: Promise.resolve(publicChannels),
+    });
+    RemoteChannelResource.getCollection.returns({
+      fetch: fetchSpy,
+    });
 
     // STEP 1 - click "import" -> SELECT_IMPORT_SOURCE
     transitionWizardPage(store, 'forward', { import: true });
@@ -104,7 +109,7 @@ describe('transitionWizardPage action', () => {
         // Calls from inside showAvailableChannelsPage
         sinon.assert.calledOnce(RemoteChannelResource.getCollection);
         sinon.assert.calledOnce(fetchSpy);
-        assert.equal(availableChannels(store.state), publicChannels);
+        assert.deepEqual(availableChannels(store.state), publicChannels);
 
         // STEP 3 - pick first channel -> SELECT_CONTENT
         return transitionWizardPage(store, 'forward', {

--- a/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channel-list-item.spec.js
@@ -108,6 +108,8 @@ describe('channelListItem', () => {
     });
   });
 
+  xit('shows an icon if the channel is unlisted', () => {});
+
   it('if the channel is installed, the version number is of the installed channel', () => {
     importWrapper.setProps({
       onDevice: true,

--- a/kolibri/plugins/management/assets/src/device_management/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/select-content-page.spec.js
@@ -100,6 +100,8 @@ describe('selectContentPage', () => {
 
   xit('if there is no thumbnail, it shows a placeholder', () => {});
 
+  xit('if channel is unlisted, shows an icon', () => {});
+
   it('shows the total size of the channel', () => {
     const wrapper = makeWrapper({ store });
     const { totalSizeRows } = getElements(wrapper);

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channel-list-item.vue
@@ -39,8 +39,15 @@
             <span>{{ resourcesSizeText }}</span>
           </div>
         </div>
-        <div class="title">
-          {{ channel.name }}
+        <div class="channel-title">
+          <div class="title">
+            {{ channel.name }}
+          </div>
+          <ui-icon
+            class="lock-icon"
+            v-if="channel.public === false"
+            icon="lock_open"
+          />
         </div>
         <div class="version">
           {{ $tr('version', { version: versionNumber }) }}
@@ -82,6 +89,7 @@
   import bytesForHumans from './bytesForHumans';
   import { channelIsInstalled } from '../../state/getters';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import UiIcon from 'keen-ui/src/UiIcon';
 
   const Modes = {
     IMPORT: 'IMPORT',
@@ -93,6 +101,7 @@
     name: 'channelListItem',
     components: {
       kButton,
+      UiIcon,
     },
     props: {
       channel: {
@@ -176,6 +185,7 @@
     font-size: 1.2em
     font-weight: bold
     line-height: 1.5em
+    display: inline
 
   .version
     font-size: 0.85em
@@ -220,5 +230,11 @@
     width: 10%
     text-align: right
     vertical-align: baseline
+
+  .lock-icon
+    vertical-align: sub
+
+  .channel-title
+    margin-bottom: 8px
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/select-content-page/channel-contents-summary.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/select-content-page/channel-contents-summary.vue
@@ -7,9 +7,16 @@
         class="thumbnail"
         :src="channel.thumbnail"
       >
-      <h2 class="title">
-        {{ channel.name }}
-      </h2>
+      <div class="channel-name">
+        <h2 class="title">
+          {{ channel.name }}
+        </h2>
+        <ui-icon
+          class="lock-icon"
+          v-if="channel.public === false"
+          icon="lock_open"
+        />
+      </div>
       <p class="version">
         {{ $tr('version', { version: versionNumber }) }}
       </p>
@@ -45,10 +52,13 @@
 <script>
 
   import bytesForHumans from '../manage-content-page/bytesForHumans';
+  import UiIcon from 'keen-ui/src/UiIcon';
 
   export default {
     name: 'channelContentsSummary',
-    components: {},
+    components: {
+      UiIcon,
+    },
     props: {
       channel: {
         type: Object,
@@ -91,6 +101,14 @@
   .title
     font-size: 32px
     font-weight: bold
+    display: inline
+
+  .lock-icon
+    font-size: 32px
+    vertical-align: sub
+
+  .channel-title
+    margin-bottom: 8px
 
   .version
     font-size: 14px


### PR DESCRIPTION
### Summary

1. Adds some hacks to show unlisted channels from Kolibri Studio at the top of the Available Channels Page
1. Updates UI to show "open lock" icon around unlisted channels. (In import modes only; lock is not shown in export mode)

![screen shot 2017-11-30 at 10 35 09 am](https://user-images.githubusercontent.com/10248067/33448345-9fd35342-d5ba-11e7-8104-bfb5de3b47cb.png)

![screen shot 2017-11-30 at 10 35 14 am](https://user-images.githubusercontent.com/10248067/33448346-a127548c-d5ba-11e7-90ac-a72392c57e13.png)

### Reviewer guidance

#### Happy path testing
1. Publish an unlisted channel
1. Import the channel to your Kolibri server with or without resources (the channel will not appear without resources).
1. Check that the unlisted channel appears as described above.

#### Un happy path testing
1. Somehow get a channel on a USB drive that is not on Kolibri Studio (neither listed/unlisted)
1. Install it to Kolibri
1. Check that the mystery channel does not appear the way unlisted channels do above
…

### References

Addresses #2720 

…

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
