### PR TITLE
Don't dump unescaped text into the frontend

### DIFF
--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -98,11 +98,11 @@ def kolibri_set_server_time():
 def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
     response, kwargs, url_params = _kolibri_bootstrap_helper(context, base_name, api_resource, 'detail', **kwargs)
     html = ("<script type='text/javascript'>"
-            "var model = {0}.resources.{1}.createModel(JSON.parse('{2}'), {3});"
+            "var model = {0}.resources.{1}.createModel(JSON.parse({2}), {3});"
             "model.synced = true;"
             "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
                                api_resource,
-                               JSONRenderer().render(response.data).decode('utf-8'),
+                               json.dumps(JSONRenderer().render(response.data).decode('utf-8')),
                                json.dumps(url_params)))
     return mark_safe(html)
 
@@ -110,13 +110,13 @@ def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
 def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
     response, kwargs, url_params = _kolibri_bootstrap_helper(context, base_name, api_resource, 'list', **kwargs)
     html = ("<script type='text/javascript'>"
-            "var collection = {0}.resources.{1}.createCollection({2}, {3}, JSON.parse('{4}'));"
+            "var collection = {0}.resources.{1}.createCollection({2}, {3}, JSON.parse({4}));"
             "collection.synced = true;"
             "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
                                api_resource,
                                json.dumps(url_params),
                                json.dumps(kwargs),
-                               JSONRenderer().render(response.data).decode('utf-8'),
+                               json.dumps(JSONRenderer().render(response.data).decode('utf-8')),
                                ))
     return mark_safe(html)
 


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
* Calls `json.dumps` on the output of the DRF JSONRenderer, to ensure that we properly escape all characters.

…

### Reviewer guidance
* Change your full name on your profile to `;';';'` and make sure the page does not continually refresh.

…

### References
* Fixes #2750

…

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
