### PR TITLE
add available field to indicate the availability of root node

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -13,6 +13,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
     root = serializers.PrimaryKeyRelatedField(read_only=True)
     lang_code = serializers.SerializerMethodField()
     lang_name = serializers.SerializerMethodField()
+    available = serializers.SerializerMethodField()
 
     def to_representation(self, instance):
         value = super(ChannelMetadataSerializer, self).to_representation(instance)
@@ -49,6 +50,9 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 
         return instance.root.lang.lang_name
 
+    def get_available(self, instance):
+        return instance.root.available
+
     class Meta:
         model = ChannelMetadata
         fields = (
@@ -62,6 +66,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
             'root',
             'thumbnail',
             'version',
+            'available',
         )
 
 

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -309,18 +309,27 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data['lang_code'], None)
         self.assertEqual(response.data['lang_name'], None)
 
-    def test_channelmetadata_content_available_filter_lowercase_true(self):
+    def test_channelmetadata_content_available_param_filter_lowercase_true(self):
         response = self.client.get(reverse("channel-list"), {"available": "true"})
         self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
 
-    def test_channelmetadata_content_available_filter_uppercase_true(self):
+    def test_channelmetadata_content_available_param_filter_uppercase_true(self):
         response = self.client.get(reverse("channel-list"), {"available": True})
         self.assertEqual(response.data, [])
 
-    def test_channelmetadata_content_unavailable_filter_false(self):
+    def test_channelmetadata_content_unavailable_param_filter_false(self):
         content.ContentNode.objects.filter(title="root").update(available=False)
         response = self.client.get(reverse("channel-list"), {"available": False})
         self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+
+    def test_channelmetadata_content_available_field_true(self):
+        response = self.client.get(reverse("channel-list"))
+        self.assertEqual(response.data[0]["available"], True)
+
+    def test_channelmetadata_content_available_field_false(self):
+        content.ContentNode.objects.filter(title="root").update(available=False)
+        response = self.client.get(reverse("channel-list"))
+        self.assertEqual(response.data[0]["available"], False)
 
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue https://github.com/learningequality/kolibri/issues/2719 by adding an extra field `available` on channelmetadata to indicate that the root contentnode is not imported. 
This is because if the user doesn't actively import content from a channel, the channel's root will not be imported.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Import all the content from channel 'portion control' `fb51dae6df7545af8455aa3a0c32048d`
2. View the channel 'khan academy en' in the public channel page so that its database will be downloaded
3. Go to `api/channel/` to see that 'portion control' has `available` marked as true while 'khan academy en' has `available` marked as false
4. Go to the  'khan academy en' channel page and import any content from the channel
5. Go to `api/channel/` to see that both channels have `available` marked as true now

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issue: https://github.com/learningequality/kolibri/issues/2719

----

### Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
