### PR TITLE
Fix language filter bugs

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/test/views/available-channels-page.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/available-channels-page.spec.js
@@ -22,8 +22,8 @@ const availableChannels = [
   {
     name: 'Awesome Channel',
     id: 'awesome_channel',
-    language_code: 'en',
-    language: 'English',
+    lang_code: 'en',
+    lang_name: 'English',
     total_resources: 100,
   },
   {
@@ -34,15 +34,15 @@ const availableChannels = [
   {
     name: 'Hunden Channel',
     id: 'hunden_channel',
-    language_code: 'de',
-    language: 'German',
+    lang_code: 'de',
+    lang_name: 'German',
     total_resources: 100,
   },
   {
     name: 'Kaetze Channel',
     id: 'kaetze_channel',
-    language_code: 'de',
-    language: 'German',
+    lang_code: 'de',
+    lang_name: 'German',
     total_resources: 100,
   },
 ];

--- a/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/index.vue
@@ -146,10 +146,16 @@
         }
       },
       languageFilterOptions() {
-        const codes = uniqBy(this.availableChannels, 'language')
-          .map(({ language, language_code }) => ({
-            value: language_code,
-            label: language,
+        let channels;
+        if (this.transferType === TransferTypes.LOCALEXPORT) {
+          channels = this.availableChannels.filter(this.channelIsOnDevice);
+        } else {
+          channels = [...this.availableChannels];
+        }
+        const codes = uniqBy(channels, 'lang_code')
+          .map(({ lang_name, lang_code }) => ({
+            value: lang_code,
+            label: lang_name,
           }))
           .filter(x => x.value);
         return [this.allLanguagesOption, ...codes];
@@ -200,7 +206,7 @@
           isOnDevice = this.channelIsOnDevice(channel);
         }
         if (this.languageFilter.value !== ALL_FILTER) {
-          languageMatches = channel.language_code === this.languageFilter.value;
+          languageMatches = channel.lang_code === this.languageFilter.value;
         }
         if (this.titleFilter) {
           // Similar code in userSearchUtils
@@ -212,8 +218,6 @@
     },
     vuex: {
       getters: {
-        // TODO do correct filtering for LOCALEXPORT. Possible that languages and
-        // other things might still leak out from unavailable channels.
         availableChannels: state => wizardState(state).availableChannels,
         selectedDrive: state => wizardState(state).selectedDrive,
         installedChannelList,


### PR DESCRIPTION
### Summary
1. Updates the Available Channels Page to reflect the schema changes to language info
1. Fixes a bug where installed-but-should-be-hidden-channels have their languages appear in the filter during export workflow.

### Reviewer guidance
1. To test (1), try to import a channel from Kolibri Studio. All the represented languages should be in the filter.
1. To test (2), view some channels from Kolibri Studio, but do not download resources. Download resources for at least one. Go to export workflow. You should only see language filter options for the channels with resources.


### References

fixes #2743 
----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
