### PR TITLE
Prevent csv export blowing up when content is deleted.

### DIFF
--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -35,13 +35,10 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
         return channel.name
 
     def get_content_title(self, obj):
-        try:
-            node = ContentNode.objects.filter(content_id=obj.content_id).first()
-            if node:
-                return node.title
-            else:
-                return ""
-        except ContentNode.DoesNotExist:
+        node = ContentNode.objects.filter(content_id=obj.content_id).first()
+        if node:
+            return node.title
+        else:
             return ""
 
     def get_time_spent(self, obj):

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -35,11 +35,17 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
         return channel.name
 
     def get_content_title(self, obj):
-        channel = ChannelMetadata.objects.get(id=obj.channel_id)
-        node = ContentNode.objects.filter(tree_id=channel.root.tree_id).first()
-        if node:
-            return node.title
-        else:
+        try:
+            channel = ChannelMetadata.objects.get(id=obj.channel_id)
+        except ChannelMetadata.DoesNotExist:
+            return ""
+        try:
+            node = ContentNode.objects.filter(tree_id=channel.root.tree_id).first()
+            if node:
+                return node.title
+            else:
+                return ""
+        except ContentNode.DoesNotExist:
             return ""
 
     def get_time_spent(self, obj):

--- a/kolibri/logger/csv.py
+++ b/kolibri/logger/csv.py
@@ -36,11 +36,7 @@ class LogCSVSerializerBase(serializers.ModelSerializer):
 
     def get_content_title(self, obj):
         try:
-            channel = ChannelMetadata.objects.get(id=obj.channel_id)
-        except ChannelMetadata.DoesNotExist:
-            return ""
-        try:
-            node = ContentNode.objects.filter(tree_id=channel.root.tree_id).first()
+            node = ContentNode.objects.filter(content_id=obj.content_id).first()
             if node:
                 return node.title
             else:

--- a/kolibri/logger/test/test_api.py
+++ b/kolibri/logger/test/test_api.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from kolibri.content.models import ChannelMetadata, ContentNode
 from kolibri.core.exams.models import Exam
 from kolibri.logger.models import ExamLog
 
@@ -326,6 +327,17 @@ class ContentSummaryLogCSVExportTestCase(APITestCase):
             self.assertEqual(len(results[0]), len(row))
         self.assertEqual(len(results[1:]), expected_count)
 
+    def test_csv_download_deleted_content(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD, facility=self.facility)
+        expected_count = ContentSummaryLog.objects.count()
+        ContentNode.objects.all().delete()
+        ChannelMetadata.objects.all().delete()
+        response = self.client.get(reverse('contentsummarylogcsv-list'))
+        results = list(csv.reader(row for row in response.content.decode("utf-8").split("\n") if row))
+        for row in results[1:]:
+            self.assertEqual(len(results[0]), len(row))
+        self.assertEqual(len(results[1:]), expected_count)
+
 
 class ContentSessionLogCSVExportTestCase(APITestCase):
 
@@ -347,6 +359,17 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
     def test_csv_download(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD, facility=self.facility)
         expected_count = ContentSessionLog.objects.count()
+        response = self.client.get(reverse('contentsessionlogcsv-list'))
+        results = list(csv.reader(row for row in response.content.decode("utf-8").split("\n") if row))
+        for row in results[1:]:
+            self.assertEqual(len(results[0]), len(row))
+        self.assertEqual(len(results[1:]), expected_count)
+
+    def test_csv_download_deleted_content(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD, facility=self.facility)
+        expected_count = ContentSessionLog.objects.count()
+        ContentNode.objects.all().delete()
+        ChannelMetadata.objects.all().delete()
         response = self.client.get(reverse('contentsessionlogcsv-list'))
         results = list(csv.reader(row for row in response.content.decode("utf-8").split("\n") if row))
         for row in results[1:]:


### PR DESCRIPTION
### Summary
Makes titles for unfound content nodes blank.

### Reviewer guidance
Log data on some content.
Delete content from Kolibri.
Export log data to CSV.

### References
 * Fixes #2766

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
