### PR TITLE
Hide 'channels' header

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
@@ -52,6 +52,6 @@
 <style lang="stylus" scoped>
 
   .grid
-    margin-top: 48px
+    margin-top: 24px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
@@ -2,11 +2,7 @@
 
   <div>
 
-    <page-header :title="$tr('channels')">
-      <div slot="icon">
-        <mat-svg category="navigation" name="apps"/>
-      </div>
-    </page-header>
+    <page-header :title="$tr('channels')" />
 
     <content-card-group-grid
       :contents="channels"

--- a/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page/index.vue
@@ -2,9 +2,10 @@
 
   <div>
 
-    <page-header :title="$tr('channels')" />
+    <page-header :title="$tr('channels')" class="visuallyhidden" />
 
     <content-card-group-grid
+      class="grid"
       :contents="channels"
       :gen-content-link="genChannelLink"
       v-if="channels.length"
@@ -50,9 +51,7 @@
 
 <style lang="stylus" scoped>
 
-  .page-description
-    margin-top: 1em
-    margin-bottom: 1em
-    line-height: 1.5em
+  .grid
+    margin-top: 48px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -2,8 +2,7 @@
 
   <div>
 
-    <page-header :title="content.title">
-    </page-header>
+    <page-header :title="content.title" />
 
     <content-renderer
       v-if="!content.assessment"

--- a/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-list/index.vue
@@ -4,7 +4,7 @@
     <auth-message v-if="!isUserLoggedIn" authorizedRole="learner" />
 
     <div v-else>
-      <page-header :title="$tr('examName')"></page-header>
+      <page-header :title="$tr('examName')" />
       <p v-if="activeExams" class="exams-assigned">{{ $tr('assignedTo', { assigned: activeExams }) }}</p>
       <p v-else class="exams-assigned">{{ $tr('noExams') }}</p>
 

--- a/kolibri/plugins/learn/assets/src/views/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header/index.vue
@@ -1,15 +1,10 @@
 <template>
 
   <div class="header-wrapper">
-    <div class="header">
-      <h1 class="title">
-        {{ title }}
-        <progress-icon :progress="progress"/>
-      </h1>
-      <div class="end">
-        <slot name="end-header"/>
-      </div>
-    </div>
+    <h1 class="title">
+      {{ title }}
+      <progress-icon :progress="progress"/>
+    </h1>
   </div>
 
 </template>
@@ -24,12 +19,6 @@
     props: { title: { type: String } },
     vuex: {
       getters: {
-        contentKind: state => {
-          if (state.pageState.content) {
-            return state.pageState.content.kind;
-          }
-          return ContentNodeKinds.TOPIC;
-        },
         progress: state => {
           if (state.pageState.content) {
             if (
@@ -49,30 +38,9 @@
 </script>
 
 
-<style lang="stylus">
-
-  /** WARNING - unscoped styles for children                  */
-  /* use very precise selectors to minimize risk of collision */
-
-  @require '~kolibri.styles.definitions'
-
-  .header-wrapper .extra-nav a
-    color: $core-text-annotation
-    font-weight: 300
-
-</style>
-
-
 <style lang="stylus" scoped>
-
-  .extra-nav
-    font-size: 12px
-    min-height: 16px
 
   .title
     display: inline-block
-
-  .end
-    float: right
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage/index.vue
@@ -3,8 +3,7 @@
   <div>
     <k-breadcrumbs :items="breadcrumbItems" />
 
-    <content-card-group-header
-      :header="header"/>
+    <h1>{{ header }}</h1>
 
     <content-card-group-grid
       :contents="recommendations"
@@ -86,4 +85,9 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  h1
+    font-size: 21px
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/topics-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page/index.vue
@@ -2,12 +2,7 @@
 
   <div>
 
-    <page-header :title="topic.title">
-      <div slot="icon">
-        <mat-svg v-if="isRoot" category="action" name="explore"/>
-        <mat-svg v-else category="file" name="folder"/>
-      </div>
-    </page-header>
+    <page-header :title="topic.title" />
 
     <p class="page-description" v-if="topic.description">
       {{ topic.description }}


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

* visually hides 'channels' title
* deletes a lot of seemingly unused code


old:

![image](https://user-images.githubusercontent.com/2367265/33468224-96359c32-d60f-11e7-921d-e5a338d7167e.png)

new:

![image](https://user-images.githubusercontent.com/2367265/33468113-a83acf70-d60e-11e7-87c5-7acc7a806530.png)



### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

* Make sure behavior is as expected
* Make sure I didn't "clean up" anything that was being used

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

fixes #2758

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
