### PR TITLE
make 'guest' button less significant

### DIFF
--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -341,13 +341,13 @@
 </script>
 
 
-<style lang="stylus">
+<style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
 
   $login-text = #D8D8D8
 
-  #main-cell
+  #main-cell >>>
     .ui-
       &textbox__
         &label-text
@@ -371,21 +371,6 @@
 
       &:hover
         background: none
-
-</style>
-
-
-<style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
-
-  $login-text = #D8D8D8
-
-  .k-button-secondary-raised
-    background-color: $core-text-default
-    color: $core-bg-canvas
-    &:hover
-      background-color: #0E0E0E
 
   .fh
     height: 100%

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -70,7 +70,7 @@
         <div class="divider"></div>
 
         <p class="login-text no-account">{{ $tr('noAccount') }}</p>
-        <div id="btn-group">
+        <div>
           <k-router-link
             v-if="canSignUp"
             :text="$tr('createAccount')"
@@ -78,11 +78,13 @@
             :primary="false"
             appearance="raised-button"
           />
+        </div>
+        <div>
           <k-external-link
             :text="$tr('accessAsGuest')"
             href="/learn"
             :primary="false"
-            appearance="raised-button"
+            appearance="flat-button"
           />
         </div>
         <p class="login-text version">{{ versionMsg }}</p>
@@ -362,6 +364,13 @@
 
       &:hover
         background-color: #0E0E0E
+
+    .button.secondary.flat
+      color: $core-grey
+      font-weight: normal
+
+      &:hover
+        background: none
 
 </style>
 


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

similar change as https://github.com/fle-internal/kolibri-instant-schools-plugin/pull/150

![image](https://user-images.githubusercontent.com/2367265/33469568-7d7cdad0-d618-11e7-84e6-b2675ff906ab.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

make sure it looks good and works all right

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/fle-internal/kolibri-instant-schools-plugin/issues/146

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
