### PR TITLE
Add proper lang dir to conent

### DIFF
--- a/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
+++ b/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
@@ -11,6 +11,7 @@
                   :text="crumb.text"
                   :to="crumb.link"
                   :style="{ maxWidth: `${collapsedCrumbMaxWidth}px` }"
+                  dir="auto"
                 />
               </li>
             </ol>
@@ -26,7 +27,11 @@
             v-show="!crumb.collapsed"
             :key="index"
           >
-            <k-router-link :text="crumb.text" :to="crumb.link" />
+            <k-router-link
+              :text="crumb.text"
+              :to="crumb.link"
+              dir="auto"
+            />
           </li>
 
           <li
@@ -34,7 +39,12 @@
             class="breadcrumbs-visible-item breadcrumb-visible-item-last"
             :key="index"
           >
-            <span :style="{ maxWidth: `${lastCrumbMaxWidth}px` }">{{ crumb.text }}</span>
+            <span
+              :style="{ maxWidth: `${lastCrumbMaxWidth}px` }"
+              dir="auto"
+            >
+              {{ crumb.text }}
+            </span>
           </li>
         </template>
       </ol>

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -10,7 +10,7 @@
       :isMobile="isMobile"
     />
 
-    <h3 class="text">{{ title }}</h3>
+    <h3 class="text" dir="auto">{{ title }}</h3>
 
   </router-link>
 

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -2,7 +2,8 @@
 
   <div>
 
-    <page-header :title="content.title" />
+    <!-- TODO : RTL : Remove al -->
+    <page-header :title="content.title" :dir="langDir" class="al" />
 
     <content-renderer
       v-if="!content.assessment"
@@ -43,14 +44,17 @@
       <k-button :primary="true" @click="nextContentClicked" v-if="showNextBtn" class="float" :text="$tr('nextContent')" alignment="right" />
     </assessment-wrapper>
 
-    <p v-html="description"></p>
+    <!-- TODO : RTL : Remove al -->
+    <p v-html="description" :dir="langDir" class="al"></p>
 
 
     <div class="metadata">
+      <!-- TODO : RTL : Do not interpolate strings -->
       <p v-if="content.author">
         {{ $tr('author', {author: content.author}) }}
       </p>
 
+      <!-- TODO : RTL : Do not interpolate strings -->
       <p v-if="content.license">
         {{ $tr('license', {license: content.license}) }}
 
@@ -62,7 +66,8 @@
             type="secondary"
             @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"
           />
-          <p v-if="licenceDescriptionIsVisible">
+          <!-- TODO : RTL : Do not interpolate strings -->
+          <p v-if="licenceDescriptionIsVisible" :dir="langDir" class="al">
             {{ content.license_description }}
           </p>
         </template>
@@ -204,6 +209,12 @@
       downloadableFiles() {
         return this.content.files.filter(file => file.preset !== 'Thumbnail');
       },
+      langDir() {
+        if (this.content.lang && this.content.dir) {
+          return this.content.dir;
+        }
+        return 'ltr';
+      },
     },
     beforeDestroy() {
       this.stopTracking();
@@ -276,5 +287,8 @@
 
   .download-button
     display: block
+
+  .al
+    text-align: left
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/content-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page/index.vue
@@ -2,8 +2,8 @@
 
   <div>
 
-    <!-- TODO : RTL : Remove al -->
-    <page-header :title="content.title" :dir="langDir" class="al" />
+    <!-- TODO: RTL - Remove ta-l -->
+    <page-header :title="content.title" dir="auto" class="ta-l" />
 
     <content-renderer
       v-if="!content.assessment"
@@ -44,17 +44,17 @@
       <k-button :primary="true" @click="nextContentClicked" v-if="showNextBtn" class="float" :text="$tr('nextContent')" alignment="right" />
     </assessment-wrapper>
 
-    <!-- TODO : RTL : Remove al -->
-    <p v-html="description" :dir="langDir" class="al"></p>
+    <!-- TODO: RTL - Remove ta-l -->
+    <p v-html="description" dir="auto" class="ta-l"></p>
 
 
     <div class="metadata">
-      <!-- TODO : RTL : Do not interpolate strings -->
+      <!-- TODO: RTL - Do not interpolate strings -->
       <p v-if="content.author">
         {{ $tr('author', {author: content.author}) }}
       </p>
 
-      <!-- TODO : RTL : Do not interpolate strings -->
+      <!-- TODO: RTL - Do not interpolate strings -->
       <p v-if="content.license">
         {{ $tr('license', {license: content.license}) }}
 
@@ -66,8 +66,8 @@
             type="secondary"
             @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"
           />
-          <!-- TODO : RTL : Do not interpolate strings -->
-          <p v-if="licenceDescriptionIsVisible" :dir="langDir" class="al">
+          <!-- TODO: RTL - Do not interpolate strings -->
+          <p v-if="licenceDescriptionIsVisible" dir="auto" class="ta-l">
             {{ content.license_description }}
           </p>
         </template>
@@ -209,12 +209,6 @@
       downloadableFiles() {
         return this.content.files.filter(file => file.preset !== 'Thumbnail');
       },
-      langDir() {
-        if (this.content.lang && this.content.dir) {
-          return this.content.dir;
-        }
-        return 'ltr';
-      },
     },
     beforeDestroy() {
       this.stopTracking();
@@ -288,7 +282,7 @@
   .download-button
     display: block
 
-  .al
+  .ta-l
     text-align: left
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/learn-page/index.vue
@@ -60,6 +60,7 @@
     </template>
 
     <template v-for="(contents, channelId) in featured" v-if="contents.length">
+      <!-- TODO: RTL - Do not interpolate strings -->
       <content-card-group-header
         :key="channelId"
         :header="$tr('featuredSectionHeader', { channelTitle: getChannelTitle(channelId) })"

--- a/kolibri/plugins/learn/assets/src/views/page-header/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header/index.vue
@@ -2,7 +2,7 @@
 
   <div class="header-wrapper">
     <div class="header">
-      <h1 class="title">
+      <h1 class="title" dir="auto">
         {{ title }}
         <progress-icon :progress="progress" />
       </h1>

--- a/kolibri/plugins/learn/assets/src/views/topics-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page/index.vue
@@ -9,7 +9,11 @@
       </div>
     </page-header>
 
-    <p class="page-description" v-if="topic.description">
+    <p
+      v-if="topic.description"
+      dir="auto"
+      class="page-description ta-l"
+    >
       {{ topic.description }}
     </p>
 
@@ -76,5 +80,8 @@
     margin-top: 1em
     margin-bottom: 1em
     line-height: 1.5em
+
+  .ta-l
+    text-align: left
 
 </style>


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Makes sure content data such as titles and descriptions have the proper dir set. This is only for Learn. Still will have to address the other plugins. I added a class `ta-l` to make force some alignment since our page layouts are currently not designed to handle 2 different alignments. 

#### Before

![localhost_8000_learn_ 10](https://user-images.githubusercontent.com/7193975/33497649-78eee326-d683-11e7-9763-ada2b653f62b.png)

![localhost_8000_learn_ 11](https://user-images.githubusercontent.com/7193975/33497655-7a6f2922-d683-11e7-9aba-321c8a1d4cb6.png)

![localhost_8000_learn_ 9](https://user-images.githubusercontent.com/7193975/33497646-776b3fae-d683-11e7-9e9e-bb52dda928e1.png)

#### After
![localhost_8000_learn_ 6](https://user-images.githubusercontent.com/7193975/33497618-65df181e-d683-11e7-9c5b-f5b1b16d5a6d.png)

![localhost_8000_learn_ 5](https://user-images.githubusercontent.com/7193975/33497613-63d3d618-d683-11e7-9f2e-a2422c8d6f01.png)

![localhost_8000_learn_ 7](https://user-images.githubusercontent.com/7193975/33497622-67d9431a-d683-11e7-85fb-f9ca45b7e5ad.png)

![localhost_8000_learn_ 8](https://user-images.githubusercontent.com/7193975/33497624-690f710a-d683-11e7-85df-9bf557c2225f.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Set interface to a `rtl` language and view a channel that contains `ltr` content.
Set interface to a `ltr` language and view a channel that contains `rtl` content.

A channel that is in Arabic is `310ec19477d15cf7b9fed98551ba1e1f`. Use granular import since channel is large.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

* Fixes  #1886

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
