### PR TITLE
Show only importable nodes in LOCALIMPORT mode

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/test/utils/data.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/utils/data.js
@@ -24,6 +24,8 @@ const defaultNode = {
   path: [],
   // [TOTAL_FILE_SIZE]: 1,
   [TOTAL_RESOURCES]: 1,
+  available: true,
+  importable: true,
 };
 
 export function makeNode(pk, attrs = {}) {

--- a/kolibri/plugins/management/assets/src/device_management/test/views/content-tree-viewer.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/content-tree-viewer.spec.js
@@ -72,16 +72,70 @@ describe('contentTreeViewer component', () => {
     store = makeStore();
   });
 
-  it('shows one content-node-row for each importable node in topic', () => {
+  it('in REMOTEIMPORT, all nodes are shown', () => {
+    // API does annotate them as being importable, though...
+    store.dispatch('SET_TRANSFER_TYPE', 'remoteimport');
+    store.dispatch('SET_CURRENT_TOPIC_NODE', {
+      pk: 'topic',
+      children: [
+        {
+          ...makeNode('1'),
+          available: false,
+          importable: true,
+        },
+        {
+          ...makeNode('1'),
+          available: true,
+          importable: true,
+        },
+      ],
+    });
     const wrapper = makeWrapper({ store });
     const rows = wrapper.find(ContentNodeRow);
-    // TODO: Investigate; CNG Payload has one importable topic
     assert.equal(rows.length, 2);
   });
 
-  xit('if in import mode, then non-importable nodes are filtered from the list', () => {});
+  it('if in LOCALIMPORT, then non-importable nodes are filtered from the list', () => {
+    store.dispatch('SET_TRANSFER_TYPE', 'localimport');
+    store.dispatch('SET_CURRENT_TOPIC_NODE', {
+      pk: 'topic',
+      children: [
+        {
+          ...makeNode('1'),
+          importable: true,
+        },
+        {
+          ...makeNode('1'),
+          importable: false,
+        },
+      ],
+    });
+    const wrapper = makeWrapper({ store });
+    const rows = wrapper.find(ContentNodeRow);
+    assert.equal(rows.length, 1);
+  });
 
-  xit('in LOCALEXPORT, if a node has available: false, then it is not shown', () => {});
+  it('in LOCALEXPORT, if a node has available: false, then it is not shown', () => {
+    store.dispatch('SET_TRANSFER_TYPE', 'localexport');
+    store.dispatch('SET_CURRENT_TOPIC_NODE', {
+      pk: 'topic',
+      children: [
+        {
+          ...makeNode('1'),
+          available: true,
+          importable: true,
+        },
+        {
+          ...makeNode('1'),
+          available: false,
+          importable: false,
+        },
+      ],
+    });
+    const wrapper = makeWrapper({ store });
+    const rows = wrapper.find(ContentNodeRow);
+    assert.equal(rows.length, 1);
+  });
 
   it('it shows an empty state if the topic has no children', () => {
     setChildren([]);

--- a/kolibri/plugins/management/assets/src/device_management/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/select-content-page/content-tree-viewer.vue
@@ -139,7 +139,7 @@
         if (this.transferType === TransferTypes.LOCALEXPORT) {
           return node.available;
         }
-        return true;
+        return node.importable;
       },
       updateCurrentTopicNode(node) {
         return navigateToTopicUrl.call(this, node);
@@ -150,16 +150,15 @@
       toggleSelection(node) {
         // When the clicked node would put the parent at 100% included,
         // add the parent (as a side effect, all the children are removed from "include").
-        const sanitized = sanitizeNode(node);
         this.disableAll = true;
         let promise;
         if (this.nodeIsChecked(node)) {
-          promise = this.removeNodeForTransfer(sanitized);
+          promise = this.removeNodeForTransfer(sanitizeNode(node));
         } else {
           if (this.nodeCompletesParent(node)) {
             promise = this.addNodeForTransfer(sanitizeNode(this.annotatedTopicNode));
           } else {
-            promise = this.addNodeForTransfer(sanitized);
+            promise = this.addNodeForTransfer(sanitizeNode(node));
           }
         }
         return promise.then(() => {


### PR DESCRIPTION
### Summary

Fixes issue where nodes were being flagged as "importable" in local import mode, even when they were not.

This is an oversight that came up investigating #2790, but this PR does not fully resolve it. The reason for this is that, currently, all Topics are flagged as "importable", even if the USB drive has zero leaf-node/non-topic Resources under that topic. Attempting to download such an "Empty" topic node is the root cause of the failures in #2790. @lyw07 

### Reviewer guidance

1. Export a small subset of a channel to a USB drive.
1. Delete that channel from your server, or go to a different computer w/o that channel
1. Try to import that channel from the USB drive.
1. Verify that you only see the resources you exported to USB when you are browsing the content tree.

### References

Partially addresses #2790 

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
