### PR TITLE
Make core-snackbar button text white

### DIFF
--- a/kolibri/core/assets/src/views/core-snackbar/index.vue
+++ b/kolibri/core/assets/src/views/core-snackbar/index.vue
@@ -115,6 +115,10 @@
     z-index: 24
     margin: 16px
 
+    >>>.ui-snackbar__action-button
+      color: white
+      font-weight: bold
+
   .snackbar-backdrop
     z-index: 16
     position: fixed

--- a/kolibri/core/assets/src/views/core-snackbar/index.vue
+++ b/kolibri/core/assets/src/views/core-snackbar/index.vue
@@ -108,6 +108,8 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.definitions'
+
   .snackbar
     position: fixed
     bottom: 0
@@ -116,7 +118,7 @@
     margin: 16px
 
     >>>.ui-snackbar__action-button
-      color: white
+      color: $core-bg-light
       font-weight: bold
 
   .snackbar-backdrop


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Make core-snackbar button text white

![localhost_8000_learn_ 14](https://user-images.githubusercontent.com/7193975/33507935-79fc16ca-d6ac-11e7-9dfa-c15dcdf49f5f.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go offline to make disconnected snackbar appear. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #2759 

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
