### PR TITLE
Protect local import from crashing if a content is not found in usb drive

### DIFF
--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -24,6 +24,9 @@ def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
 def _get_leaves_ids(node_ids):
     leaf_node_ids = []
     for node_id in node_ids:
-        node_leaves = ContentNode.objects.get(pk=node_id).get_descendants(include_self=True).filter(children__isnull=True).values_list('id', flat=True)
+        node_leaves = ContentNode.objects.get(pk=node_id) \
+            .get_descendants(include_self=True) \
+            .filter(children__isnull=True) \
+            .values_list('id', flat=True)
         leaf_node_ids += node_leaves
     return leaf_node_ids


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to handle the issue https://github.com/learningequality/kolibri/issues/2790 better so that it won't show the error "transfer failed, please try again". 

Since all the topic nodes have "importable" marked as true, users won't able to know whether there are resources under a specific topic node not available. If they select the topic node to import, then the server will try to import all the resources under the topic node, although probably not all the resources are available in the external drive.

Currently this error is handled by skipping the files that are not found in the external drive and showing an error message in the terminal that a number of files are skipped because they are not found in the external drive.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test:
1. Import all the content from a topic node in a channel
2. Export a subset of the content downloaded to the external drive
3. Trying to import all the content from the topic node
4. There should be no errors showing during the import. And after import, we can check in the network import page that only the subset of the content that we exported to the external drive before got imported during the local import

Any suggestions appreciated! Maybe there could be better messages showing to users?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

The issue: https://github.com/learningequality/kolibri/issues/2790
The spec for handling local import: https://docs.google.com/document/d/1v2sW_kTBEeOoalUd1a3jqXowVZjr1o1mB7vtDlgdQ9g/edit

----

### Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
