### PR TITLE
Deliberate module load order + set priority for bundled dependencies in sys.path

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -28,7 +28,7 @@ def get_cext_path(dist_path):
     elif 'macosx' in platform:
         platform = 'macosx'
     dirname = os.path.join(dirname, platform)
-    sys.path = sys.path + [os.path.realpath(str(dirname))]
+    sys.path = [os.path.realpath(str(dirname))] + sys.path
 
 
 def set_env():
@@ -40,7 +40,6 @@ def set_env():
     from the distributed version in case it exists before importing anything
     else.
     """
-
     from kolibri import dist as kolibri_dist  # noqa
     sys.path = sys.path + [
         os.path.realpath(os.path.dirname(kolibri_dist.__file__))

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -1,0 +1,78 @@
+import logging
+import os
+import sys
+from distutils import util
+
+logger = logging.getLogger(__name__)
+
+
+def get_cext_path(dist_path):
+    """
+    Get the directory of dist/cext.
+    """
+    # Python version of current platform
+    python_version = 'cp' + str(sys.version_info.major) + str(sys.version_info.minor)
+    dirname = os.path.join(dist_path, 'cext/' + python_version)
+
+    platform = util.get_platform()
+    # For Linux system with cpython<3.3, there could be abi tags 'm' and 'mu'
+    if 'linux' in platform and int(python_version[2:]) < 33:
+        dirname = os.path.join(dirname, 'linux')
+        # encode with ucs2
+        if sys.maxunicode == 65535:
+            dirname = os.path.join(dirname, python_version+'m')
+        # encode with ucs4
+        else:
+            dirname = os.path.join(dirname, python_version+'mu')
+
+    elif 'macosx' in platform:
+        platform = 'macosx'
+    dirname = os.path.join(dirname, platform)
+    sys.path = sys.path + [os.path.realpath(str(dirname))]
+
+
+def set_env():
+    """
+    Sets the Kolibri environment for the CLI or other application worker
+    manager.
+
+    Do this before importing anything else, we need to add bundled requirements
+    from the distributed version in case it exists before importing anything
+    else.
+    """
+
+    from kolibri import dist as kolibri_dist  # noqa
+    sys.path = sys.path + [
+        os.path.realpath(os.path.dirname(kolibri_dist.__file__))
+    ]
+
+    # Add path for c extensions to sys.path
+    get_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
+    try:
+        import cryptography  # noqa
+    except ImportError:
+        # Fallback
+        logging.warning('No C Extensions available for this platform.\n')
+        sys.path = sys.path[:-1]
+
+    # This was added in
+    # https://github.com/learningequality/kolibri/pull/580
+    # ...we need to (re)move it /benjaoming
+    # Force python2 to interpret every string as unicode.
+    if sys.version[0] == '2':
+        reload(sys)  # noqa
+        sys.setdefaultencoding('utf8')
+
+    try:
+        from .build_config.default_settings import settings_path
+    except ImportError:
+        settings_path = "kolibri.deployment.default.settings.base"
+
+    # Set default env
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", settings_path
+    )
+    os.environ.setdefault(
+        "KOLIBRI_HOME", os.path.join(os.path.expanduser("~"), ".kolibri")
+    )
+    os.environ.setdefault("KOLIBRI_LISTEN_PORT", "8080")

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -41,9 +41,7 @@ def set_env():
     else.
     """
     from kolibri import dist as kolibri_dist  # noqa
-    sys.path = sys.path + [
-        os.path.realpath(os.path.dirname(kolibri_dist.__file__))
-    ]
+    sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
 
     # Add path for c extensions to sys.path
     get_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
@@ -52,7 +50,7 @@ def set_env():
     except ImportError:
         # Fallback
         logging.warning('No C Extensions available for this platform.\n')
-        sys.path = sys.path[:-1]
+        sys.path = sys.path[1:]
 
     # This was added in
     # https://github.com/learningequality/kolibri/pull/580


### PR DESCRIPTION
### Summary

Refactor setting up the environment to load C extensions path before loading morango

### Reviewer guidance

I did this and it looks correct now (NB! I have a system-wide cryptography 1.2.3 installed at the same time, and this is not selected as before)

```
kolibri shell
INFO     Running Kolibri with the following settings: kolibri.deployment.default.settings.base
Python 2.7.12 (default, Nov 19 2016, 06:48:10) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import cryptography
>>> cryptography.__file__
'kolibri/dist/cext/cp27/linux/cp27mu/linux-x86_64/cryptography/__init__.pyc'
```

### References

#2805

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
