### PR TITLE
Public Channel Display Updates

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
@@ -17,12 +17,18 @@ export function showSelectContentPage(store) {
   store.dispatch('SET_WIZARD_PAGENAME', ContentWizardPages.SELECT_CONTENT);
 
   // Downloading the Content Metadata DB
-  if (channelOnDevice) {
+  if (!channelOnDevice) {
+    // Update metadata when no content has been downloaded
+    dbPromise = downloadChannelMetadata(store);
+  } else if (
+    channelOnDevice.on_device_resources &&
+    channelOnDevice.version < transferredChannel.version
+  ) {
+    dbPromise = downloadChannelMetadata(store);
+  } else {
     // If already on device, then skip the DB download, and use on-device
     // Channel metadata, since it has root id.
     dbPromise = Promise.resolve(channelOnDevice);
-  } else {
-    dbPromise = downloadChannelMetadata(store);
   }
 
   // Hydrating the store with the Channel Metadata

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/task-progress.vue
@@ -32,7 +32,7 @@
       <span class="percentage">{{ progressMessage }}</span>
     </div>
 
-    <div class="buttons dtc">
+    <div v-if="showButtons" class="buttons dtc">
       <k-button
         v-if="taskHasCompleted || taskHasFailed || cancellable"
         :text="taskHasCompleted ? $tr('close') : $tr('cancel')"
@@ -78,6 +78,10 @@
       cancellable: {
         type: Boolean,
         required: true,
+      },
+      showButtons: {
+        type: Boolean,
+        default: true,
       },
     },
     data() {

--- a/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
@@ -10,13 +10,15 @@
         type="UPDATING_CHANNEL"
         status="QUEUED"
         :percentage="0"
+        :showButtons="false"
         :cancellable="false"
         id="updatingchannel"
       />
       <task-progress
-        v-if="tasksInQueue"
+        v-else-if="taskInProgress"
         type="DOWNLOADING_CHANNEL_CONTENTS"
         v-bind="firstTask"
+        :showButtons="false"
         :cancellable="false"
       />
 
@@ -31,7 +33,8 @@
         </ui-alert>
       </section>
 
-      <section class="updates">
+      <section v-if="onDeviceInfoIsReady" class="updates">
+        <!-- QUESTION If auto updating when no content has been downloaded, why even show this? -->
         <div
           class="updates-available"
           v-if="newVersionAvailable"
@@ -107,7 +110,7 @@
   } from '../../state/actions/contentTransferActions';
   import taskProgress from '../manage-content-page/task-progress';
   import { WizardTransitions } from '../../wizardTransitionRoutes';
-  import { PageNames } from '../../constants';
+  import { PageNames, TaskStatuses } from '../../constants';
 
   export default {
     name: 'selectContentPage',
@@ -148,6 +151,9 @@
           name: WizardTransitions.GOTO_AVAILABLE_CHANNELS_PAGE,
         };
       },
+      taskInProgress() {
+        return this.firstTask && this.firstTask.status !== TaskStatuses.COMPLETED;
+      },
     },
     mounted() {
       this.getAvailableSpaceOnDrive();
@@ -183,7 +189,6 @@
         nodeTransferCounts,
         onDeviceInfoIsReady: state => !isEmpty(wizardState(state).currentTopicNode),
         selectedItems: state => wizardState(state).nodesForTransfer || {},
-        tasksInQueue: ({ pageState }) => pageState.taskList.length > 0,
         wizardStatus: state => wizardState(state).status,
       },
       actions: {


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Addressing changes mentioned in #2726
- Having channels auto-update when an update is available and no content is loaded
- Clearing up some transitional bugs between loading bar and "up-to-date"  message (added prop to bar)
- Mobbed with @indirectlylit + @jonboiser 
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
fixes #2726
…

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] Screenshots of any front-end changes are in the PR description

#### NA
- [ ] Link to diff of internal dependency change is included
- [ ] You've added yourself to AUTHORS.rst if you're not there
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] CHANGELOG.rst is updated for high-level changes

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
