### PR TITLE
Clear all the tasks in the queue each time the server is started

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -68,6 +68,11 @@ def start(port=8080):
     from kolibri.content.utils.annotation import update_channel_metadata
     update_channel_metadata()
 
+    # This is also run every time the server is started to clear all the tasks
+    # in the queue
+    from kolibri.tasks.client import get_client
+    get_client().clear(force=True)
+
     def rm_pid_file():
         os.unlink(PID_FILE)
 


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is to fix https://github.com/learningequality/kolibri/issues/2761 so that if there are still tasks in the queue when the user stops the server last time, then when the user starts the server, all the tasks in the queue should be removed.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Try to import some content from a channel
2. Don't finish importing by stopping the server
3. Start the server again and check that the import progress bar doesn't exist. Navigate to `api/tasks/`, the return value should be `[]`

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issue: https://github.com/learningequality/kolibri/issues/2761

----

### Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
