### PR TITLE
Fix how transferred node counts are calculated across workflows

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/getters.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/getters.js
@@ -52,11 +52,29 @@ export function getDriveById(state) {
 }
 
 export function nodeTransferCounts(state) {
-  const { included, omitted } = selectedNodes(state);
-  const getDifference = key => (sumBy(included, key) || 0) - (sumBy(omitted, key) || 0);
-  return {
-    resources: getDifference('total_resources'),
-    fileSize: getDifference('total_file_size'),
+  return function(transferType) {
+    const { included, omitted } = selectedNodes(state);
+    const getDifference = key => (sumBy(included, key) || 0) - (sumBy(omitted, key) || 0);
+    // This will overestimate transfer size, since it counts items under topic that may not
+    // be on the USB drive
+    if (transferType === TransferTypes.LOCALIMPORT) {
+      return {
+        resources: getDifference('total_resources') - getDifference('on_device_resources'),
+        fileSize: getDifference('total_file_size') - getDifference('on_device_file_size'),
+      };
+    }
+    if (transferType === TransferTypes.REMOTEIMPORT) {
+      return {
+        resources: getDifference('total_resources') - getDifference('on_device_resources'),
+        fileSize: getDifference('total_file_size') - getDifference('on_device_file_size'),
+      };
+    }
+    if (transferType === TransferTypes.LOCALEXPORT) {
+      return {
+        resources: getDifference('on_device_resources'),
+        fileSize: getDifference('on_device_file_size'),
+      };
+    }
   };
 }
 

--- a/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/select-content-page/index.vue
@@ -77,8 +77,8 @@
         <!-- Contains size estimates + submit button -->
         <selected-resources-size
           :mode="mode"
-          :fileSize="nodeTransferCounts.fileSize"
-          :resourceCount="nodeTransferCounts.resources"
+          :fileSize="nodeCounts.fileSize"
+          :resourceCount="nodeCounts.resources"
           :spaceOnDrive="availableSpace"
           @clickconfirm="startTransferringContent()"
         />
@@ -154,6 +154,9 @@
       taskInProgress() {
         return this.firstTask && this.firstTask.status !== TaskStatuses.COMPLETED;
       },
+      nodeCounts() {
+        return this.nodeTransferCounts(this.transferType);
+      },
     },
     mounted() {
       this.getAvailableSpaceOnDrive();
@@ -189,6 +192,7 @@
         nodeTransferCounts,
         onDeviceInfoIsReady: state => !isEmpty(wizardState(state).currentTopicNode),
         selectedItems: state => wizardState(state).nodesForTransfer || {},
+        transferType: state => wizardState(state).transferType,
         wizardStatus: state => wizardState(state).status,
       },
       actions: {


### PR DESCRIPTION
### Summary

1. Correct how estimated file sizes/resources are calculated when in an importing or exporting workflow.

### Reviewer guidance

#### 1. Download part of a channel

Here is how the downloaded node should look (import or export):

![screen shot 2017-12-04 at 3 32 39 pm](https://user-images.githubusercontent.com/10248067/33582260-3549a6fa-d909-11e7-94ee-5a42670bc120.png)

#### 2. Select it in export mode

Look at "resources selected" at the top and the message next to the checked node.

![screen shot 2017-12-04 at 3 33 10 pm](https://user-images.githubusercontent.com/10248067/33582272-46fddbb4-d909-11e7-9b4a-40cbd3431eb8.png)

#### 2. Select it in import

Look at "resources selected" at the top and the message next to the checked node.

Note:

* The message next to checked node says "N resources selected", where N is the total, where as "resources selected" message on top is "N - D resources selected", where D is the number of resources on the device already.
* When **importing from a local drive** the number of resources **will be overestimated** since we do not know what percentage of an arbitrary node is actually on the local drive.

![screen shot 2017-12-04 at 3 32 47 pm](https://user-images.githubusercontent.com/10248067/33582296-60e22698-d909-11e7-8e1e-511a0bf5e9be.png)
 mode


### References

Addresses #2797 

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
