### PR TITLE
Enable backwards browsing when DL'ing content metadata

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/wizardTransitionRoutes.js
+++ b/kolibri/plugins/management/assets/src/device_management/wizardTransitionRoutes.js
@@ -41,6 +41,9 @@ export default [
       ) {
         return router.replace('/content');
       }
+      if (get(params, 'node.pk') === '') {
+        return;
+      }
       if (!params.node) {
         nextNode = {
           // Works fine without title at the moment.


### PR DESCRIPTION

### Summary

1. Causes the browser address to change immediately when selecting a Channel that requires downloading its content metadata from internet or local drive. This allows the user to go back to the list of channels if they don't want to view channel any more.


…

### Reviewer guidance

![go backwards](https://user-images.githubusercontent.com/10248067/33583070-515d61de-d90d-11e7-8806-324da9fc4b72.gif)

### References

Addresses #2745
----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
