### PR TITLE
PDF Logging Issue Fix

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -210,7 +210,12 @@
             this.hidePage(i);
           }
         }
+        // update progress after we determine which pages to render
+        this.updateProgress();
       }, renderDebounceTime),
+      updateProgress() {
+        this.$emit('updateProgress', this.sessionTimeSpent / this.targetTime);
+      },
     },
     watch: {
       scrollPos: 'checkPages',
@@ -278,18 +283,18 @@
       this.prepComponentData.then(() => {
         this.$emit('startTracking');
         this.checkPages();
-      });
 
-      // progress tracking
-      const self = this;
-      this.timeout = setTimeout(() => {
-        self.$emit('updateProgress', self.sessionTimeSpent / self.targetTime);
-      }, 30000);
+        // Automatically master after the targetTime, convert seconds -> milliseconds
+        this.timeout = setTimeout(this.updateProgress, this.targetTime * 1000);
+      });
     },
     beforeDestroy() {
       if (this.timeout) {
         clearTimeout(this.timeout);
       }
+
+      this.updateProgress();
+
       this.pdfDocument.cleanup();
       this.pdfDocument.destroy();
       this.$emit('stopTracking');


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Progress complete after (#ofPages * 30) seconds.

Updates on first render, zoom, and scroll. Also automatically logs after (#ofPages*30) seconds and when the component is destroyed (any time you leave the page). @jeepurs 

- Updating progress in `checkPages`, which is already debounced.
- Changing timeout progresss update to the amount necessary for mastery.
- Updating progress on destroy.
- Fixes #2625

![image](https://user-images.githubusercontent.com/9877852/33584880-50ea8944-d916-11e7-9c22-246d756cb23b.png)
![image](https://user-images.githubusercontent.com/9877852/33584891-676da124-d916-11e7-8bbf-0fa479cf5916.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Open a PDF in kolibri
2. See if it's mastered in the following scenarios:
    - do nothing
    - zooming
    - Scrolling
    - Opening, waiting, then going back (this is a good way to check progress, too)
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)

#### NA
- [ ] You've added yourself to AUTHORS.rst if you're not there
- [ ] Link to diff of internal dependency change is included
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Documentation is updated

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
