### PR TITLE
Use 'channel.available' to govern channel visibility and auto-updating

### DIFF
--- a/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/actions/selectContentActions.js
@@ -20,10 +20,9 @@ export function showSelectContentPage(store) {
   if (!channelOnDevice) {
     // Update metadata when no content has been downloaded
     dbPromise = downloadChannelMetadata(store);
-  } else if (
-    channelOnDevice.on_device_resources &&
-    channelOnDevice.version < transferredChannel.version
-  ) {
+  } else if (!channelOnDevice.available && channelOnDevice.version < transferredChannel.version) {
+    // If channel _is_ on the device, but not "available" (i.e. no resources installed yet)
+    // _and_ has been updated, then download the metadata
     dbPromise = downloadChannelMetadata(store);
   } else {
     // If already on device, then skip the DB download, and use on-device

--- a/kolibri/plugins/management/assets/src/device_management/state/getters.js
+++ b/kolibri/plugins/management/assets/src/device_management/state/getters.js
@@ -29,6 +29,11 @@ export function installedChannelList(state) {
   return state.pageState.channelList;
 }
 
+// Channels that are installed & also "available"
+export function installedChannelsWithResources(state) {
+  return state.pageState.channelList.filter(channel => channel.available);
+}
+
 export function channelIsInstalled(state) {
   return function findChannel(channelId) {
     return find(installedChannelList(state), { id: channelId });

--- a/kolibri/plugins/management/assets/src/device_management/test/views/available-channels-page.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/available-channels-page.spec.js
@@ -52,9 +52,13 @@ const channelsOnDevice = cloneDeep(availableChannels);
 // Pretending that metadata has been downloaded previously for Bird & Hunden channel,
 // but no resources. Awesome & Kaetze channel have some resources.
 channelsOnDevice[0].on_device_resources = 90;
+channelsOnDevice[0].available = true;
 channelsOnDevice[1].on_device_resources = 0;
+channelsOnDevice[1].available = false;
 channelsOnDevice[2].on_device_resources = 0;
+channelsOnDevice[2].available = false;
 channelsOnDevice[3].on_device_resources = 90;
+channelsOnDevice[3].available = true;
 
 function makeStore() {
   return new Vuex.Store({

--- a/kolibri/plugins/management/assets/src/device_management/test/views/channels-grid.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/channels-grid.spec.js
@@ -57,6 +57,7 @@ describe('channelsGrid component', () => {
         id: 'visible_channel',
         on_device_resources: 10,
         total_resources: 1000,
+        available: true,
       },
     ]);
   });
@@ -67,6 +68,7 @@ describe('channelsGrid component', () => {
       {
         name: 'hidden channel',
         id: 'hidden_channel',
+        available: false,
         on_device_resources: 0,
         total_resources: 1000,
       },
@@ -97,12 +99,14 @@ describe('channelsGrid component', () => {
       {
         name: 'beautiful channel',
         id: 'beautiful_channel',
+        available: true,
         on_device_resources: 10,
         total_resources: 1000,
       },
       {
         name: 'awesome channel',
         id: 'awesome_channel',
+        available: true,
         on_device_resources: 10,
         total_resources: 1000,
       },

--- a/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/index.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/index.vue
@@ -89,7 +89,11 @@
   import channelTokenModal from '../available-channels-page/channel-token-modal';
   import subpageContainer from '../containers/subpage-container';
   import uniqBy from 'lodash/uniqBy';
-  import { installedChannelList, wizardState } from '../../state/getters';
+  import {
+    installedChannelList,
+    installedChannelsWithResources,
+    wizardState,
+  } from '../../state/getters';
   import { transitionWizardPage } from '../../state/actions/contentWizardActions';
   import { TransferTypes } from '../../constants';
 
@@ -192,8 +196,8 @@
     },
     methods: {
       channelIsOnDevice(channel) {
-        const match = this.installedChannelList.find(({ id }) => id === channel.id);
-        return match && match.on_device_resources > 0;
+        const match = this.installedChannelsWithResources.find(({ id }) => id === channel.id);
+        return Boolean(match);
       },
       goToChannel(channel) {
         this.transitionWizardPage('forward', { channel });
@@ -221,6 +225,7 @@
         availableChannels: state => wizardState(state).availableChannels,
         selectedDrive: state => wizardState(state).selectedDrive,
         installedChannelList,
+        installedChannelsWithResources,
         transferType: state => wizardState(state).transferType,
         wizardStatus: state => wizardState(state).status,
       },

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -82,8 +82,7 @@
       sortedChannels() {
         return this.installedChannelsWithResources
           .slice()
-          .sort((c1, c2) => c1.name > c2.name)
-          .filter(channel => channel.available);
+          .sort((c1, c2) => c1.name > c2.name);
       },
     },
     created() {

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -80,9 +80,7 @@
         return this.sortedChannels.length === 0 && !this.channelsLoading;
       },
       sortedChannels() {
-        return this.installedChannelsWithResources
-          .slice()
-          .sort((c1, c2) => c1.name > c2.name);
+        return this.installedChannelsWithResources.slice().sort((c1, c2) => c1.name > c2.name);
       },
     },
     created() {

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/channels-grid.vue
@@ -52,6 +52,8 @@
   import deleteChannelModal from './delete-channel-modal';
   import channelListItem from './channel-list-item';
   import { triggerChannelDeleteTask } from '../../state/actions/taskActions';
+  import { installedChannelsWithResources } from '../../state/getters';
+
   export default {
     name: 'channelsGrid',
     components: {
@@ -70,7 +72,7 @@
       },
       selectedChannelTitle() {
         if (this.channelIsSelected) {
-          return this.channelList.find(channel => channel.id === this.selectedChannelId).name;
+          return this.sortedChannels.find(channel => channel.id === this.selectedChannelId).name;
         }
         return '';
       },
@@ -78,10 +80,10 @@
         return this.sortedChannels.length === 0 && !this.channelsLoading;
       },
       sortedChannels() {
-        return this.channelList
+        return this.installedChannelsWithResources
           .slice()
           .sort((c1, c2) => c1.name > c2.name)
-          .filter(channel => channel.on_device_resources > 0);
+          .filter(channel => channel.available);
       },
     },
     created() {
@@ -100,7 +102,7 @@
     },
     vuex: {
       getters: {
-        channelList: state => state.pageState.channelList,
+        installedChannelsWithResources,
         pageState: state => state.pageState,
       },
       actions: {


### PR DESCRIPTION
### Summary

After finding that `channel.on_device_resources` isn't a reliable indicator of a channel's availability/accessibility in the app, this changes code to rely on `channel.available` for certain decisions:

1. When to show a channel on the "Manage content page"
1. When to show a channel on the "Available Channels Page" during Export workflow
1. When to auto-update a channel metadata DB if it's already on the device

### Reviewer guidance

**Channel visibility**

1. Download Channel contents that overlap with another channel (e.g. KA english overlaps with KA testing channel).
1. Verify that the not-download channel does not appear on the Manage Content Page, nor the Available Channels Page (in export flow)

**Channel metadata auto-updating**
1. Create a custom channel on Kolibri Studio
1. Download it once via viewing it in Kolibri
1. Increment it's version on Kolibri Studio
1. Go back to Kolibri and verify that it auto-updates
1. Actually download a resource from the custom channel
1. (checking visibility) Verify that it appears on Manage COntent Page and Available Channels page in export flow
1. (checking auto-update) Increment its version on Kolibri Studio and verify that it _does not_ auto-update in Kolibri

### References

Addresses #2806 

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [ ] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
