### PR TITLE
Use cherrypy from PyPi and not a dependency link

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-mptt==0.8.5
 djangorestframework-csv==1.4.1
 tqdm==4.11.2                     # progress bars
 requests==2.18.4
-https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
+cherrypy==6.2.0
 iceqube==0.0.4
 porter2stemmer==1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
### Summary

We can already get rid of remaining dependency links (links specified as some URL for a zip file) in the 0.7 release since Morango is the other remaining dependency link which is being replaced over in #2698 

For some silly reason, CherryPy was never substituted. The reason is that I left a dangling PR where I proposed to update the CherryPy version (which should also btw be done), but seemed to land the PR in no-priority land.

### Reviewer guidance

Merge this, can't see why there should be a difference between the PyPi release and the zip from github.

### References

#1719

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included **Not really :)**
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
