### PR TITLE
Remove docker's dangling images on vader for every build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,4 +20,4 @@ steps:
   - wait
   
   - label: Upload artifacts
-    command: .buildkite/setup_and_upload_artifact.sh
+    command: .buildkite/setup_and_upload_artifact.sh && docker image prune -f


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to remove docker's dangling images on vader using `docker image prune -f` when running builds on buildkite, so vader won't easily get full.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I think we just need to make sure that the ubuntu image doesn't get deleted as well.
We can go to the buildkite's build to see that certain gigabytes are freed in vader.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
