### PR TITLE
Mark the ancestors of available resource nodes to be available too during channel import

### DIFF
--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -7,7 +7,7 @@ from kolibri.content.models import CONTENT_SCHEMA_VERSION, NO_VERSION, ChannelMe
 from kolibri.utils.time import local_now
 from sqlalchemy.exc import SQLAlchemyError
 
-from .annotation import set_leaf_node_availability_from_local_file_availability
+from .annotation import set_leaf_node_availability_from_local_file_availability, recurse_availability_up_tree
 from .channels import read_channel_metadata_from_db_file
 from .paths import get_content_database_file_path
 from .sqlalchemybridge import Bridge, ClassNotFoundError
@@ -353,6 +353,7 @@ def import_channel_from_local_db(channel_id):
     import_manager.end()
 
     set_leaf_node_availability_from_local_file_availability()
+    recurse_availability_up_tree(channel_id)
 
     channel = ChannelMetadata.objects.get(id=channel_id)
     channel.last_updated = local_now()


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is to fix https://github.com/learningequality/kolibri/issues/2841. 
Previously, when we update a channel, we call `importchannel` which removes specific channelmetadata in the database and downloads it again. In this case, only the leaf nodes (resources) are marked as available. Since the root node is a topic node, it will not be marked as available. So the channel is shown as unavailable.

After this PR's change, not only the leaf nodes but also its ancestors (topic nodes, which include the root node) will be marked as available, so the channel will be shown as available if there are resource nodes available inside the channel.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test the change:
1. Create a test channel on Studio and publish it
2. Import the channel and its content to Kolibri
3. Make changes to the test channel on Studio and publish it again
4. Go to Kolibri and update the test channel
5. Unlike described in https://github.com/learningequality/kolibri/issues/2841, the test channel should be shown in the `content` page now.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issue: https://github.com/learningequality/kolibri/issues/2841

----

### Contributor Checklist

- [X] PR has the correct target milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [X] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
