### PR TITLE
Fixes #2840: Fix timer tracking to avoid excess progress when seeking

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/index.vue
@@ -304,11 +304,19 @@
         wrapper.getElementsByClassName('vjs-play-control')[0].focus();
       },
       handleSeek() {
+        // record progress before updating the times, to capture any progress that happened pre-seeking
         this.recordProgress();
+
+        // now, update all the timestamps to set the new time location as the baseline starting point
         this.dummyTime = this.player.currentTime();
         this.lastUpdateTime = this.dummyTime;
+        this.progressStartingPoint = this.dummyTime;
       },
       updateTime() {
+        // skip out of here if we're currently seeking, so we don't update this.dummyTime before calculating old progress
+        if (this.player.seeking()) {
+          return;
+        }
         this.dummyTime = this.player.currentTime();
         if (this.dummyTime - this.lastUpdateTime >= 5) {
           this.recordProgress();
@@ -316,7 +324,10 @@
         }
       },
       setPlayState(state) {
-        this.recordProgress();
+        // avoid recording progress if we're currently seeking, as timers are in an intermediate state
+        if (!this.player.seeking()) {
+          this.recordProgress();
+        }
         if (state === true) {
           this.$emit('startTracking');
         } else {


### PR DESCRIPTION
### Summary

Fixes https://github.com/learningequality/kolibri/issues/2840. It turns out that there were a few things going on:

1. The result of `this.player.currentTime()` is the _post-seek time_ within *both* the `seeking` and `seeked` event (even though the former ostensibly happens before the seek happens).
1. We weren't updating (resetting) `this.progressStartingPoint` upon seek. This meant that the next time we called `recordProgress` after a seek, it counted all the time between the old seek location and the new location as progress. This was probably the main problem.
1. Sometimes the `timeupdate` event is fired while the seek is in still in progress. The `play` and `pause` events (and hence `setPlayState`) are also triggered during the seek process. As we call `recordProgress` from these methods, this meant we were recording progress while the timers were partially updated (after the seeking happened and `currentTime` was returning the new time, but before we updated `progressStartingPoint` etc). It now checks that it's not currently seeking and skips progress updating if so.

### Reviewer guidance

Run in production mode (`start`, not `devserver`) so you can click around in the video. Click around in the video. Shouldn't pop up with completion rapidly as before.

----

### Contributor Checklist

- [x] PR has the correct target milestone
~- [ ] PR has 'needs review' or 'work-in-progress' label~
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
~- [ ] Documentation is updated~
~- [ ] External dependencies files were updated (`yarn` and `pip`)~
~- [ ] Link to diff of internal dependency change is included~
~- [ ] Screenshots of any front-end changes are in the PR description~
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
~- [ ] CHANGELOG.rst is updated for high-level changes~
~- [ ] You've added yourself to AUTHORS.rst if you're not there~

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
