### PR TITLE
Use mixin sort for language sorting

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -48,8 +48,6 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import kSelect from 'kolibri.coreVue.components.kSelect';
 
-  import omit from 'lodash/omit';
-
   const mobileNumberOfLanguageButtons = 5;
   const desktopNumberOfLanguageButtons = 3;
 
@@ -75,13 +73,7 @@
         return allLanguages[currentLanguage].lang_name;
       },
       remainingLanguages() {
-        const remainingLanguages = Object.values(omit(allLanguages, [currentLanguage]));
-        remainingLanguages.sort((lang1, lang2) => {
-          // puts words with foreign characters first in the array
-          return lang2.lang_name.localeCompare(lang1.lang_name);
-        });
-
-        return remainingLanguages;
+        return this.languageOptions.filter(lang => lang.id !== currentLanguage);
       },
       numberOfLanguageButtons() {
         let numBtns = this.isMobile ? mobileNumberOfLanguageButtons : desktopNumberOfLanguageButtons;


### PR DESCRIPTION
### Summary
Use the mixin language sort order in both the list and modal language switchers.

### Reviewer guidance
Check that the language sort order is identical on the sign in page as on the language switcher modal.

### References
Fixes #2843

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
