### PR TITLE
Add test and fix for malformed databases that lack a root node.

### DIFF
--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -7,7 +7,7 @@ from kolibri.content.models import CONTENT_SCHEMA_VERSION, NO_VERSION, ChannelMe
 from kolibri.utils.time import local_now
 from sqlalchemy.exc import SQLAlchemyError
 
-from .annotation import set_leaf_node_availability_from_local_file_availability, recurse_availability_up_tree
+from .annotation import recurse_availability_up_tree, set_leaf_node_availability_from_local_file_availability
 from .channels import read_channel_metadata_from_db_file
 from .paths import get_content_database_file_path
 from .sqlalchemybridge import Bridge, ClassNotFoundError
@@ -357,4 +357,14 @@ def import_channel_from_local_db(channel_id):
 
     channel = ChannelMetadata.objects.get(id=channel_id)
     channel.last_updated = local_now()
+    try:
+        assert channel.root
+    except ContentNode.DoesNotExist:
+        node_id = channel.root_id
+        ContentNode.objects.create(
+            id=node_id,
+            title=channel.name,
+            content_id=node_id,
+            channel_id=channel_id,
+        )
     channel.save()


### PR DESCRIPTION
### Summary
Adds a root node to channels that get imported without one.

### Reviewer guidance
Follow steps in issue. Be amazed as it doesn't break.

### References
Fixes #2738

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] PR has been fully tested manually
