### PR TITLE
Hide Edit on Github button for now

### DIFF
--- a/docs-developer/_static/theme_overrides.css
+++ b/docs-developer/_static/theme_overrides.css
@@ -5,3 +5,12 @@
     white-space: normal !important;
     vertical-align: top !important;
  }
+
+
+/* Removes Edit On Github until there is a fix
+   for https://github.com/rtfd/readthedocs.org/issues/3203
+*/
+.wy-breadcrumbs li.wy-breadcrumbs-aside
+{
+    display: none;
+}

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -5,3 +5,12 @@
     white-space: normal !important;
     vertical-align: top !important;
  }
+
+
+/* Removes Edit On Github until there is a fix
+   for https://github.com/rtfd/readthedocs.org/issues/3203
+*/
+.wy-breadcrumbs li.wy-breadcrumbs-aside
+{
+    display: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,7 @@ def setup(app):
     # Add our custom CSS overrides
     app.add_stylesheet('theme_overrides.css')
 
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary

Because of a series of lame bugs in sphinx_rtd_theme, I reverted to removing the link via CSS. Hopefully they'll merge my fix upstream so we can re-introduce the link.

### Reviewer guidance

Behold my CSS skills :D

### References

https://github.com/learningequality/kolibri/issues/2850

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
