### PR TITLE
Seems the requirements/cext.txt parsing is broken

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -16,6 +16,10 @@ requirements:
   - requirements/build.txt:
       # don't use global 'pin' default
       pin: False
+  - requirements/cext.txt:
+      # don't use global 'pin' default
+      pin: False
+      update: False
   - requirements/dev.txt:
       # don't use global 'pin' default
       pin: False

--- a/requirements/cext.txt
+++ b/requirements/cext.txt
@@ -1,3 +1,1 @@
-# See release notes full of backwards incompatibilities
-# https://github.com/learningequality/kolibri/pull/2908
-cryptography==2.0.3 # pyup: ignore
+cryptography==2.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,8 @@
 -r base.txt
 -r cext.txt
 # These are for testing
-factory-boy
-fake-factory
+factory-boy==2.7.0  # pyup: ignore - Needs an update, called 'faker' now
+fake-factory==0.5.7  # pyup: ignore Needs an update
 coverage
 mock
 pytest


### PR DESCRIPTION
Yes, I did in fact break the `develop` branch for this once in a lifetime overriding of the automated checks in #2924 

Wasn't aware of the specially tailored requirements parsing here, seems it doesn't like comments.

Will have to switch off PyUp for now.

```
python install_cexts.py --file requirements/cext.txt # pip install c extensions

Name format in cext.txt is incorrect. Should be 'packageName==packageVersion'.
```