### PR TITLE
PyUp: Filter out a Pex build dependency that does not affect runtime

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -7,4 +7,4 @@ sphinx-rtd-theme
 sphinx-autobuild
 pex
 wheel
-setuptools<20.11,>=2.2          # needed to get pex working
+setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore


### PR DESCRIPTION
### Summary

See why #2907 was closed.
