### PR TITLE
Reduce webpack logging

### DIFF
--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -26,20 +26,13 @@ var server = new WebpackDevServer(compiler, {
   compress: false,
 
   // webpack-dev-middleware options
-  quiet: false,
-  noInfo: false,
   watchOptions: {
     aggregateTimeout: 300,
     poll: 1000,
   },
   // It's a required option.
   publicPath: devServerConfig.publicPath,
-  stats: {
-    colors: true,
-    chunks: false,
-    errorDetails: true,
-    modules: false,
-  },
+  stats: 'minimal',
   headers: {
     'Access-Control-Allow-Origin': '*',
   },


### PR DESCRIPTION
<!--
Using the PR template:
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that aren't applicable
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Reduce webpack logging.

#### Before:

```
Hash: 384a9a78670d5d85b10977f956624ecce0134a8b7e068e0baf8054622386965d43cf6c4cc8651b5c1d2d45418336f3f9c2f5576706514ecb6a8b67bb7a1683350454b7fbd4d73a499ca5da5d4398cd99013b68fd70fc6692cf62607f98454af764854b503bce8d76baf30aca22a8
Version: webpack 3.6.0
Child media_player_module:
    Hash: 384a9a78670d5d85b109
    Time: 40494ms
                                                      Asset     Size  Chunks                    Chunk Names
               VideoJS.eot?00103e881a36640a08f869ff6888f0fd   5.9 kB          [emitted]         
               VideoJS.eot?9499bb60a03b7e136a699cd87b159cc0  7.25 kB          [emitted]         
        media_player_module-0.8.0.dev020171212200236-git.js   950 kB       0  [emitted]  [big]  media_player_module
        media_player_module0.8.0.dev020171212200236-git.css    67 kB       0  [emitted]         media_player_module
    media_player_module-0.8.0.dev020171212200236-git.js.map  1.15 MB       0  [emitted]         media_player_module
    media_player_module0.8.0.dev020171212200236-git.css.map    73 kB       0  [emitted]         media_player_module
    media_player_module0.8.0.dev020171212200236-git.rtl.css  66.9 kB       0  [emitted]         media_player_module
    Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js?{"minimize":false,"sourceMap":true}!node_modules/vue-loader/lib/style-compiler/index.js?{"vue":true,"id":"data-v-5cb9bcdc","scoped":true,"hasInlineConfig":false}!node_modules/postcss-loader/lib/index.js?{"config":{"path":"/home/christian/repos/kolibri/postcss.config.js"},"sourceMap":true}!node_modules/stylus-loader/index.js!node_modules/stylint-loader/index.js!node_modules/vue-loader/lib/selector.js?type=styles&index=0!node_modules/htmlhint-loader/index.js?{"failOnError":false,"emitAs":"warning"}!kolibri/plugins/media_player/assets/src/views/index.vue:
                                               Asset     Size  Chunks  Chunk Names
        VideoJS.eot?00103e881a36640a08f869ff6888f0fd   5.9 kB          
        VideoJS.eot?9499bb60a03b7e136a699cd87b159cc0  7.25 kB          
Child management_module:
    Hash: 77f956624ecce0134a8b
    Time: 54379ms
                                                    Asset     Size  Chunks                    Chunk Names
        management_module-0.8.0.dev020171212200236-git.js   442 kB       0  [emitted]  [big]  management_module
        management_module0.8.0.dev020171212200236-git.css    24 kB       0  [emitted]         management_module
    management_module-0.8.0.dev020171212200236-git.js.map   529 kB       0  [emitted]         management_module
    management_module0.8.0.dev020171212200236-git.css.map  40.7 kB       0  [emitted]         management_module
    management_module0.8.0.dev020171212200236-git.rtl.css    24 kB       0  [emitted]         management_module
Child default_frontend:
    Hash: 7e068e0baf8054622386
    Time: 61475ms
                                                           Asset     Size  Chunks                    Chunk Names
                default_frontend-0.8.0.dev020171212200236-git.js  1.91 MB       8  [emitted]  [big]  default_frontend
    MaterialIcons-Regular.woff2?570eb83859dc23dd0eec423a49e147fe  44.3 kB          [emitted]         
      MaterialIcons-Regular.ttf?a37b0c01c0baf1888ca812cc0508f6e2   128 kB          [emitted]         
            loading-spinner.gif?e850c29286b4eb51d1e5e00738b3fc04  98.8 kB          [emitted]         
                            intl-0.8.0.dev020171212200236-git.js   174 kB       0  [emitted]         intl
                           ur-PK-0.8.0.dev020171212200236-git.js  24.3 kB       1  [emitted]         ur-PK
                           sw-SW-0.8.0.dev020171212200236-git.js  24.7 kB       2  [emitted]         sw-SW
                           fr-FR-0.8.0.dev020171212200236-git.js  24.7 kB       3  [emitted]         fr-FR
                              fa-0.8.0.dev020171212200236-git.js  24.8 kB       4  [emitted]         fa
                           es-ES-0.8.0.dev020171212200236-git.js  24.5 kB       5  [emitted]         es-ES
                              en-0.8.0.dev020171212200236-git.js  24.2 kB       6  [emitted]         en
                              ar-0.8.0.dev020171212200236-git.js  19.9 kB       7  [emitted]         ar
     MaterialIcons-Regular.woff?012cf6a10129e2275d79d6adac7f3b02  57.6 kB          [emitted]         
                default_frontend0.8.0.dev020171212200236-git.css   728 kB       8  [emitted]  [big]  default_frontend
                        intl-0.8.0.dev020171212200236-git.js.map   202 kB       0  [emitted]         intl
                       ur-PK-0.8.0.dev020171212200236-git.js.map  28.1 kB       1  [emitted]         ur-PK
                       sw-SW-0.8.0.dev020171212200236-git.js.map  28.4 kB       2  [emitted]         sw-SW
                       fr-FR-0.8.0.dev020171212200236-git.js.map  28.4 kB       3  [emitted]         fr-FR
                          fa-0.8.0.dev020171212200236-git.js.map  28.5 kB       4  [emitted]         fa
                       es-ES-0.8.0.dev020171212200236-git.js.map  28.2 kB       5  [emitted]         es-ES
                          en-0.8.0.dev020171212200236-git.js.map  27.9 kB       6  [emitted]         en
                          ar-0.8.0.dev020171212200236-git.js.map  23.7 kB       7  [emitted]         ar
            default_frontend-0.8.0.dev020171212200236-git.js.map  2.33 MB       8  [emitted]         default_frontend
            default_frontend0.8.0.dev020171212200236-git.css.map   766 kB       8  [emitted]         default_frontend
            default_frontend0.8.0.dev020171212200236-git.rtl.css   728 kB       8  [emitted]  [big]  default_frontend
    Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js??ref--3-1!node_modules/postcss-loader/lib/index.js??ref--3-2!node_modules/stylus-loader/index.js!node_modules/stylint-loader/index.js!kolibri/core/assets/src/styles/main.styl:
                                                               Asset     Size  Chunks  Chunk Names
        MaterialIcons-Regular.woff2?570eb83859dc23dd0eec423a49e147fe  44.3 kB          
         MaterialIcons-Regular.woff?012cf6a10129e2275d79d6adac7f3b02  57.6 kB          
          MaterialIcons-Regular.ttf?a37b0c01c0baf1888ca812cc0508f6e2   128 kB          
    Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js?{"minimize":false,"sourceMap":true}!node_modules/vue-loader/lib/style-compiler/index.js?{"vue":true,"id":"data-v-1d2a3c57","scoped":true,"hasInlineConfig":false}!node_modules/postcss-loader/lib/index.js?{"config":{"path":"/home/christian/repos/kolibri/postcss.config.js"},"sourceMap":true}!node_modules/stylus-loader/index.js!node_modules/stylint-loader/index.js!node_modules/vue-loader/lib/selector.js?type=styles&index=0!node_modules/htmlhint-loader/index.js?{"failOnError":false,"emitAs":"warning"}!kolibri/core/assets/src/views/loading-spinner/index.vue:
                                                       Asset     Size  Chunks  Chunk Names
        loading-spinner.gif?e850c29286b4eb51d1e5e00738b3fc04  98.8 kB          
Child user_module:
    Hash: 965d43cf6c4cc8651b5c
    Time: 58817ms
                                              Asset     Size  Chunks                    Chunk Names
    background.png?748569b80a3a87b6dc5147547c151d53   428 kB          [emitted]  [big]  
        user_module-0.8.0.dev020171212200236-git.js   174 kB       0  [emitted]         user_module
        user_module0.8.0.dev020171212200236-git.css    25 kB       0  [emitted]         user_module
    user_module-0.8.0.dev020171212200236-git.js.map   200 kB       0  [emitted]         user_module
    user_module0.8.0.dev020171212200236-git.css.map  33.6 kB       0  [emitted]         user_module
    user_module0.8.0.dev020171212200236-git.rtl.css    25 kB       0  [emitted]         user_module
    Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js?{"minimize":false,"sourceMap":true}!node_modules/vue-loader/lib/style-compiler/index.js?{"vue":true,"id":"data-v-2598daee","scoped":true,"hasInlineConfig":false}!node_modules/postcss-loader/lib/index.js?{"config":{"path":"/home/christian/repos/kolibri/postcss.config.js"},"sourceMap":true}!node_modules/stylus-loader/index.js!node_modules/stylint-loader/index.js!node_modules/vue-loader/lib/selector.js?type=styles&index=0!node_modules/htmlhint-loader/index.js?{"failOnError":false,"emitAs":"warning"}!kolibri/plugins/user/assets/src/views/sign-in-page/index.vue:
                                                  Asset    Size  Chunks  Chunk Names
        background.png?748569b80a3a87b6dc5147547c151d53  428 kB          
Child html5_app_renderer_module:
    Hash: 1d2d45418336f3f9c2f5
    Time: 30872ms
                                                            Asset       Size  Chunks             Chunk Names
        html5_app_renderer_module-0.8.0.dev020171212200236-git.js    21.1 kB       0  [emitted]  html5_app_renderer_module
        html5_app_renderer_module0.8.0.dev020171212200236-git.css  905 bytes       0  [emitted]  html5_app_renderer_module
    html5_app_renderer_module-0.8.0.dev020171212200236-git.js.map    24.1 kB       0  [emitted]  html5_app_renderer_module
    html5_app_renderer_module0.8.0.dev020171212200236-git.css.map    1.98 kB       0  [emitted]  html5_app_renderer_module
    html5_app_renderer_module0.8.0.dev020171212200236-git.rtl.css  903 bytes       0  [emitted]  html5_app_renderer_module
Child learn_module:
    Hash: 576706514ecb6a8b67bb
    Time: 55276ms
                                               Asset     Size  Chunks                    Chunk Names
        learn_module-0.8.0.dev020171212200236-git.js   736 kB       0  [emitted]  [big]  learn_module
        learn_module0.8.0.dev020171212200236-git.css  28.1 kB       0  [emitted]         learn_module
    learn_module-0.8.0.dev020171212200236-git.js.map   890 kB       0  [emitted]         learn_module
    learn_module0.8.0.dev020171212200236-git.css.map  48.6 kB       0  [emitted]         learn_module
    learn_module0.8.0.dev020171212200236-git.rtl.css  28.1 kB       0  [emitted]         learn_module
Child coach_module:
    Hash: 7a1683350454b7fbd4d7
    Time: 57950ms
                                               Asset     Size  Chunks                    Chunk Names
        coach_module-0.8.0.dev020171212200236-git.js   843 kB       0  [emitted]  [big]  coach_module
        coach_module0.8.0.dev020171212200236-git.css  26.5 kB       0  [emitted]         coach_module
    coach_module-0.8.0.dev020171212200236-git.js.map   998 kB       0  [emitted]         coach_module
    coach_module0.8.0.dev020171212200236-git.css.map  55.7 kB       0  [emitted]         coach_module
    coach_module0.8.0.dev020171212200236-git.rtl.css  26.6 kB       0  [emitted]         coach_module
Child document_pdf_render_module:
    Hash: 3a499ca5da5d4398cd99
    Time: 53245ms
                                                             Asset     Size  Chunks                    Chunk Names
                                 0-0.8.0.dev020171212200236-git.js  1.44 MB       0  [emitted]  [big]  
        document_pdf_render_module-0.8.0.dev020171212200236-git.js   990 kB       1  [emitted]  [big]  document_pdf_render_module
                       pdfJSWorker-0.8.0.dev020171212200236-git.js  1.45 MB    2, 0  [emitted]  [big]  pdfJSWorker
        document_pdf_render_module0.8.0.dev020171212200236-git.css  17.3 kB       1  [emitted]         document_pdf_render_module
                             0-0.8.0.dev020171212200236-git.js.map   1.7 MB       0  [emitted]         
    document_pdf_render_module-0.8.0.dev020171212200236-git.js.map  1.17 MB       1  [emitted]         document_pdf_render_module
    document_pdf_render_module0.8.0.dev020171212200236-git.css.map  24.4 kB       1  [emitted]         document_pdf_render_module
                   pdfJSWorker-0.8.0.dev020171212200236-git.js.map  1.71 MB    2, 0  [emitted]         pdfJSWorker
    document_pdf_render_module0.8.0.dev020171212200236-git.rtl.css  17.3 kB       1  [emitted]         document_pdf_render_module
Child device_management_module:
    Hash: 013b68fd70fc6692cf62
    Time: 62438ms
                                                           Asset     Size  Chunks                    Chunk Names
        device_management_module-0.8.0.dev020171212200236-git.js   759 kB       0  [emitted]  [big]  device_management_module
        device_management_module0.8.0.dev020171212200236-git.css  24.2 kB       0  [emitted]         device_management_module
    device_management_module-0.8.0.dev020171212200236-git.js.map   907 kB       0  [emitted]         device_management_module
    device_management_module0.8.0.dev020171212200236-git.css.map  47.1 kB       0  [emitted]         device_management_module
    device_management_module0.8.0.dev020171212200236-git.rtl.css  24.2 kB       0  [emitted]         device_management_module
Child style_guide_module:
    Hash: 607f98454af764854b50
    Time: 41563ms
                                                     Asset     Size  Chunks                    Chunk Names
        style_guide_module-0.8.0.dev020171212200236-git.js  1.38 MB       0  [emitted]  [big]  style_guide_module
        style_guide_module0.8.0.dev020171212200236-git.css  9.62 kB       0  [emitted]         style_guide_module
    style_guide_module-0.8.0.dev020171212200236-git.js.map  1.68 MB       0  [emitted]         style_guide_module
    style_guide_module0.8.0.dev020171212200236-git.css.map  20.7 kB       0  [emitted]         style_guide_module
    style_guide_module0.8.0.dev020171212200236-git.rtl.css  9.61 kB       0  [emitted]         style_guide_module
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-map-generator.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
        at CommonJsRequireContextDependency.getWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/dependencies/CommonJsRequireContextDependency.js:27:4)
        at Compilation.reportDependencyErrorsAndWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:694:24)
        at Compilation.finish (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:552:9)
        at applyPluginsParallel.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compiler.js:506:17)
        at /home/christian/repos/kolibri/node_modules/tapable/lib/Tapable.js:289:11
        at _addModuleChain (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:498:11)
        at processModuleDependencies.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:468:14)
        at _combinedTickCallback (internal/process/next_tick.js:73:7)
        at process._tickCallback (internal/process/next_tick.js:104:9)
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-map-consumer.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
        at CommonJsRequireContextDependency.getWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/dependencies/CommonJsRequireContextDependency.js:27:4)
        at Compilation.reportDependencyErrorsAndWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:694:24)
        at Compilation.finish (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:552:9)
        at applyPluginsParallel.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compiler.js:506:17)
        at /home/christian/repos/kolibri/node_modules/tapable/lib/Tapable.js:289:11
        at _addModuleChain (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:498:11)
        at processModuleDependencies.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:468:14)
        at _combinedTickCallback (internal/process/next_tick.js:73:7)
        at process._tickCallback (internal/process/next_tick.js:104:9)
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-node.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
        at CommonJsRequireContextDependency.getWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/dependencies/CommonJsRequireContextDependency.js:27:4)
        at Compilation.reportDependencyErrorsAndWarnings (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:694:24)
        at Compilation.finish (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:552:9)
        at applyPluginsParallel.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compiler.js:506:17)
        at /home/christian/repos/kolibri/node_modules/tapable/lib/Tapable.js:289:11
        at _addModuleChain (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:498:11)
        at processModuleDependencies.err (/home/christian/repos/kolibri/node_modules/webpack/lib/Compilation.js:468:14)
        at _combinedTickCallback (internal/process/next_tick.js:73:7)
        at process._tickCallback (internal/process/next_tick.js:104:9)
Child setup_wizard:
    Hash: 3bce8d76baf30aca22a8
    Time: 56032ms
                                               Asset     Size  Chunks                    Chunk Names
        setup_wizard-0.8.0.dev020171212200236-git.js   255 kB       0  [emitted]  [big]  setup_wizard
        setup_wizard0.8.0.dev020171212200236-git.css  22.2 kB       0  [emitted]         setup_wizard
    setup_wizard-0.8.0.dev020171212200236-git.js.map   329 kB       0  [emitted]         setup_wizard
    setup_wizard0.8.0.dev020171212200236-git.css.map  31.2 kB       0  [emitted]         setup_wizard
    setup_wizard0.8.0.dev020171212200236-git.rtl.css  22.2 kB       0  [emitted]         setup_wizard
webpack: Compiled with warnings.

```

#### After

```
Child media_player_module:
       151 modules
Child management_module:
       306 modules
Child default_frontend:
       938 modules
Child user_module:
       97 modules
Child html5_app_renderer_module:
       12 modules
Child learn_module:
       390 modules
Child coach_module:
       517 modules
Child device_management_module:
       454 modules
Child document_pdf_render_module:
       109 modules
Child style_guide_module:
       286 modules
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-map-generator.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-map-consumer.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
    
    WARNING in ./kolibri/plugins/style_guide/node_modules/source-map/lib/source-map/source-node.js
    8:45-52 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
Child setup_wizard:
       226 modules
webpack: Compiled with warnings.

```

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Run devserver.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [ ] Documentation is updated
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Link to diff of internal dependency change is included
- [ ] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
