### PR TITLE
Use call_command for  because of no_color default arg not added

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -7,7 +7,7 @@ import cherrypy
 import ifcfg
 import requests
 from django.conf import settings
-from django.core.management import ManagementUtility
+from django.core.management import call_command
 from kolibri.content.utils import paths
 
 from .system import kill_pid, pid_exists
@@ -95,8 +95,7 @@ class PingbackThread(threading.Thread):
         thread.start()
 
     def run(self):
-        command = ManagementUtility().fetch_command("ping")
-        command.execute()
+        call_command("ping")
 
 
 def stop(pid=None, force=False):


### PR DESCRIPTION
### Summary

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "kolibri/kolibri/utils/server.py", line 99, in run
    command.execute()
  File ".virtualenvs/kolibri/local/lib/python2.7/site-packages/django/core/management/base.py", line 308, in execute
    if options['no_color']:
KeyError: u'no_color'
```

### Reviewer guidance

n/a

### References

n/a

----

### Contributor Checklist

- [x] PR has the correct target milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, it has been assigned or requests review from someone and labeled as 'needs review'
- [x] PR has been fully tested manually
- [x] Documentation is updated
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Link to diff of internal dependency change is included
- [x] Screenshots of any front-end changes are in the PR description
- [x] PR does not introduce [accessibility regressions](http://kolibri.readthedocs.io/en/develop/dev/manual_testing.html#accessibility-a11y-testing)
- [x] CHANGELOG.rst is updated for high-level changes
- [x] You've added yourself to AUTHORS.rst if you're not there

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR has been fully tested manually
