### PR TITLE
Update modals (remove X-button, right-align buttons)

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -29,9 +29,7 @@
         </h1>
 
         <!-- Modal Content -->
-        <slot>
-          <p>To populate, wrap your content with <code> modal </code>.</p>
-        </slot>
+        <slot></slot>
 
       </div>
     </div>
@@ -196,5 +194,11 @@
 
   .fade-enter, .fade-leave-active
     opacity: 0
+
+  >>>.buttons
+    text-align: right
+
+  >>>.buttons button:last-of-type
+    margin-right: 0
 
 </style>

--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -195,10 +195,10 @@
   .fade-enter, .fade-leave-active
     opacity: 0
 
-  >>>.buttons
+  >>>.core-modal-buttons
     text-align: right
 
-  >>>.buttons button:last-of-type
+  >>>.core-modal-buttons button:last-of-type
     margin-right: 0
 
 </style>

--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -21,16 +21,6 @@
         :style="{ width: width, height: height }"
       >
 
-        <div class="top-buttons" @keydown.enter.stop v-if="!hideTopButtons">
-          <button
-            :aria-label="$tr('closeWindow')"
-            @click="emitCancelEvent"
-            class="header-btn btn-close"
-          >
-            <mat-svg category="navigation" name="close" />
-          </button>
-        </div>
-
         <!-- Modal Title -->
         <h1 v-show="!invisibleTitle" class="title" id="modal-title">
           <!-- Accessible error reporting per @radina -->
@@ -95,10 +85,6 @@
       height: {
         type: String,
         required: false,
-      },
-      hideTopButtons: {
-        type: Boolean,
-        default: false,
       },
     },
     data() {
@@ -201,19 +187,6 @@
 
   .modal.mobile
     width: 85%
-
-  .top-buttons
-    position: relative
-    height: 20px
-    margin-bottom: 25px
-
-  .header-btn
-    color: $core-text-default
-    border: none
-    position: absolute
-    &:focus
-      background-color: $core-grey-300
-      outline: none
 
   .btn-close
     right: -10px

--- a/kolibri/core/assets/src/views/language-switcher/modal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/modal.vue
@@ -13,9 +13,17 @@
         :label="language.lang_name"
         v-model="selectedLanguage"
       />
-      <div class="footer">
-        <k-button :text="$tr('cancelButtonText')" :raised="false" @click="closeModal" />
-        <k-button :text="$tr('confirmButtonText')" :primary="true" @click="setLang" />
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('cancelButtonText')"
+          :raised="false"
+          @click="closeModal"
+        />
+        <k-button
+          :text="$tr('confirmButtonText')"
+          :primary="true"
+          @click="setLang"
+        />
       </div>
     </core-modal>
   </div>
@@ -58,9 +66,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
+<style lang="stylus"></style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('activateExam')" @cancel="close">
+  <core-modal
+    :title="$tr('activateExam')"
+    @cancel="close"
+  >
     <p>
       <span>{{ $tr('areYouSure', { examTitle }) }}</span>
       {{ $tr('willBeVisible') }}
@@ -15,9 +18,17 @@
         </ul>
       </span>
     </p>
-    <div class="footer">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
-      <k-button :text="$tr('activate')" :primary="true" @click="activateExam(examId)" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('activate')"
+        :primary="true"
+        @click="activateExam(examId)"
+      />
     </div>
   </core-modal>
 
@@ -77,9 +88,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
+<style lang="stylus"></style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/change-exam-visibility-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('examVisibility')" @cancel="close">
+  <core-modal
+    :title="$tr('examVisibility')"
+    @cancel="close"
+  >
     <p>{{ $tr('shouldBeVisible', { examTitle }) }}</p>
     <k-radio-button
       :label="$tr('entireClass', { className })"
@@ -15,10 +18,18 @@
       :checked="groupIsSelected(group.id)"
       @change="handleGroupChange(group.id, $event)"
     />
-    <div class="footer">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
-      <k-button :text="$tr('update')" :primary="true" :disabled="busy" @click="updateVisibility" />
-
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('update')"
+        :primary="true"
+        :disabled="busy"
+        @click="updateVisibility"
+      />
     </div>
   </core-modal>
 
@@ -184,9 +195,6 @@
 
   label
     display: block
-
-  .footer
-    text-align: right
 
   .group-select
     padding-bottom: 4rem

--- a/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('createNewExam')" @cancel="close">
+  <core-modal
+    :title="$tr('createNewExam')"
+    @cancel="close"
+  >
     <p>{{ $tr('useContentFrom') }}</p>
     <k-select
       :label="$tr('selectChannel')"
@@ -8,8 +11,12 @@
       v-model="selectedChannel"
       class="channel-select"
     />
-    <div class="footer">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
       <k-button
         :text="$tr('createExam')"
         :primary="true"
@@ -85,9 +92,6 @@
 
 
 <style lang="stylus" scoped>
-
-  .footer
-    text-align: right
 
   .channel-select
     margin-bottom: 4rem

--- a/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('deactivateExam')" @cancel="close">
+  <core-modal
+    :title="$tr('deactivateExam')"
+    @cancel="close"
+  >
     <p>
       <span>{{ $tr('areYouSure', { examTitle }) }}</span>
       {{ $tr('noLongerVisible') }}
@@ -15,9 +18,17 @@
         </ul>
       </span>
     </p>
-    <div class="footer">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
-      <k-button :text="$tr('deactivate')" :primary="true" @click="deactivateExam(examId)" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('deactivate')"
+        :primary="true"
+        @click="deactivateExam(examId)"
+      />
     </div>
   </core-modal>
 
@@ -77,9 +88,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
+<style lang="stylus"></style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/delete-exam-modal.vue
@@ -1,10 +1,21 @@
 <template>
 
-  <core-modal :title="$tr('deleteExam')" @cancel="close">
+  <core-modal
+    :title="$tr('deleteExam')"
+    @cancel="close"
+  >
     <p>{{ $tr('areYouSure', { examTitle }) }}</p>
-    <div class="footer">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
-      <k-button :text="$tr('delete')" :primary="true" @click="deleteExam(examId)" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('delete')"
+        :primary="true"
+        @click="deleteExam(examId)"
+      />
     </div>
   </core-modal>
 
@@ -59,10 +70,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
-
+<style lang="stylus"></style>

--- a/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/preview-exam-modal.vue
@@ -1,6 +1,16 @@
 <template>
 
-  <core-modal :title="$tr('preview')" @cancel="close" width="100%" height="100%">
+  <core-modal
+    :title="$tr('preview')"
+    @cancel="close"
+    width="100%"
+    height="100%"
+  >
+    <k-button
+      :text="$tr('close')"
+      :primary="false"
+      @click="close"
+    />
     <ui-progress-linear v-show="loading" />
     <div v-show="!loading">
       <div>
@@ -182,7 +192,6 @@
 
   .question-selector, .exercise-container
     overflow-y: auto
-
 
   ol
     padding: 0

--- a/kolibri/plugins/coach/assets/src/views/exams-page/rename-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/rename-exam-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('renameExam')" @cancel="close">
+  <core-modal
+    :title="$tr('renameExam')"
+    @cancel="close"
+  >
     <form @submit.prevent="callRenameExam">
       <k-textbox
         ref="name"
@@ -11,9 +14,19 @@
         @blur="titleBlurred = true"
         v-model.trim="newExamTitle"
       />
-      <div class="footer">
-        <k-button :text="$tr('cancel')" appearance="flat-button" type="button" @click="close" />
-        <k-button :text="$tr('rename')" :primary="true" type="submit" :disabled="submitting" />
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('cancel')"
+          appearance="flat-button"
+          type="button"
+          @click="close"
+        />
+        <k-button
+          :text="$tr('rename')"
+          :primary="true"
+          type="submit"
+          :disabled="submitting"
+        />
       </div>
     </form>
   </core-modal>
@@ -124,9 +137,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('newLearnerGroup')" @cancel="close">
+  <core-modal
+    :title="$tr('newLearnerGroup')"
+    @cancel="close"
+  >
     <div>
       <form @submit.prevent="callCreateGroup">
         <k-textbox
@@ -13,7 +16,7 @@
           @blur="nameBlurred = true"
           v-model.trim="name"
         />
-        <div class="ta-r">
+        <div class="core-modal-buttons">
           <k-button
             type="button"
             :text="$tr('cancel')"
@@ -122,9 +125,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .ta-r
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -1,11 +1,22 @@
 <template>
 
-  <core-modal :title="$tr('deleteLearnerGroup')" @cancel="close">
+  <core-modal
+    :title="$tr('deleteLearnerGroup')"
+    @cancel="close"
+  >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
     <p>{{ $tr('learnersWillBecome') }} <strong>{{ $tr('ungrouped') }}</strong>.</p>
-    <div class="ta-r">
-      <k-button :text="$tr('cancel')" appearance="flat-button" @click="close" />
-      <k-button :text="$tr('deleteGroup')" :primary="true" @click="deleteGroup(groupId)" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('deleteGroup')"
+        :primary="true"
+        @click="deleteGroup(groupId)"
+      />
     </div>
   </core-modal>
 
@@ -14,7 +25,7 @@
 
 <script>
 
-  import * as groupActions from '../../state/actions/group';
+  import { displayModal, deleteGroup } from '../../state/actions/group';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -50,8 +61,8 @@
     },
     vuex: {
       actions: {
-        displayModal: groupActions.displayModal,
-        deleteGroup: groupActions.deleteGroup,
+        displayModal,
+        deleteGroup,
       },
     },
   };
@@ -59,9 +70,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .ta-r
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('moveLearners')" @cancel="close">
+  <core-modal
+    :title="$tr('moveLearners')"
+    @cancel="close"
+  >
     <p>
       {{ $tr('moveThe') }}
       <strong>{{ $tr('learners', {count: usersToMove.length }) }}</strong>
@@ -23,7 +26,7 @@
       />
     </div>
 
-    <div class="button-section">
+    <div class="core-modal-buttons button-section">
       <k-button
         :text="$tr('cancel')"
         appearance="flat-button"
@@ -43,7 +46,12 @@
 
 <script>
 
-  import * as groupActions from '../../state/actions/group';
+  import {
+    displayModal,
+    addUsersToGroup,
+    removeUsersFromGroup,
+    moveUsersBetweenGroups,
+  } from '../../state/actions/group';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
@@ -113,10 +121,10 @@
     },
     vuex: {
       actions: {
-        displayModal: groupActions.displayModal,
-        addUsersToGroup: groupActions.addUsersToGroup,
-        removeUsersFromGroup: groupActions.removeUsersFromGroup,
-        moveUsersBetweenGroups: groupActions.moveUsersBetweenGroups,
+        displayModal,
+        addUsersToGroup,
+        removeUsersFromGroup,
+        moveUsersBetweenGroups,
       },
     },
   };
@@ -133,6 +141,5 @@
 
   .button-section
     margin-top: 1em
-    text-align: right
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('renameLearnerGroup')" @cancel="close">
+  <core-modal
+    :title="$tr('renameLearnerGroup')"
+    @cancel="close"
+  >
     <div>
       <form @submit.prevent="callRenameGroup">
         <k-textbox
@@ -13,7 +16,7 @@
           @blur="nameBlurred = true"
           v-model.trim="name"
         />
-        <div class="ta-r">
+        <div class="core-modal-buttons">
           <k-button
             type="button"
             :text="$tr('cancel')"
@@ -133,9 +136,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .ta-r
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -65,11 +65,27 @@
           </div>
         </div>
       </div>
-      <core-modal v-if="submitModalOpen" :title="$tr('submitExam')" @cancel="toggleModal">
+      <core-modal
+        v-if="submitModalOpen"
+        :title="$tr('submitExam')"
+        @cancel="toggleModal"
+      >
         <p>{{ $tr('areYouSure') }}</p>
-        <p v-if="questionsUnanswered">{{ $tr('unanswered', { numLeft: questionsUnanswered } ) }}</p>
-        <k-button :text="$tr('cancel')" appearance="flat-button" @click="toggleModal" />
-        <k-button :text="$tr('submitExam')" @click="finishExam" :primary="true" />
+        <p v-if="questionsUnanswered">
+          {{ $tr('unanswered', { numLeft: questionsUnanswered } ) }}
+        </p>
+        <div class="core-modal-buttons">
+          <k-button
+            :text="$tr('cancel')"
+            appearance="flat-button"
+            @click="toggleModal"
+          />
+          <k-button
+            :text="$tr('submitExam')"
+            @click="finishExam"
+            :primary="true"
+          />
+        </div>
       </core-modal>
     </template>
   </immersive-full-screen>
@@ -81,7 +97,7 @@
 
   import { PageNames } from '../../constants';
   import { InteractionTypes } from 'kolibri.coreVue.vuex.constants';
-  import * as actions from '../../state/actions/main';
+  import { setAndSaveCurrentExamAttemptLog, closeExam } from '../../state/actions/main';
   import isEqual from 'lodash/isEqual';
   import { now } from 'kolibri.utils.serverClock';
   import throttle from 'lodash/throttle';
@@ -131,8 +147,8 @@
         questionsAnswered: state => state.pageState.questionsAnswered,
       },
       actions: {
-        setAndSaveCurrentExamAttemptLog: actions.setAndSaveCurrentExamAttemptLog,
-        closeExam: actions.closeExam,
+        setAndSaveCurrentExamAttemptLog,
+        closeExam,
       },
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('niceWork')" @cancel="closePopover">
+  <core-modal
+    :title="$tr('niceWork')"
+    @cancel="closePopover"
+  >
 
     <div class="progress-icon">
       <progress-icon :progress="1" />
@@ -31,8 +34,11 @@
       </div>
     </div>
 
-    <div class="buttons">
-      <k-button :text="$tr('close')" @click="closePopover" />
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('close')"
+        @click="closePopover"
+      />
       <slot name="nextItemBtn"></slot>
     </div>
 
@@ -146,10 +152,6 @@
   .next-item-section
     text-align: center
     margin-bottom: 2em
-
-  .buttons
-    text-align: center
-    padding: 0 0 0.5em
 
   .next-item-heading
     margin: 0

--- a/kolibri/plugins/management/assets/src/device_management/test/views/select-drive-modal.spec.js
+++ b/kolibri/plugins/management/assets/src/device_management/test/views/select-drive-modal.spec.js
@@ -54,21 +54,18 @@ function makeStore() {
   });
 }
 
+// prettier-ignore
 function getElements(wrapper) {
   return {
     titleText: () => wrapper.first(coreModal).getProp('title'),
     driveListLoading: () => wrapper.find('.drive-list-loading'),
-    driveListLoadingText: () =>
-      wrapper
-        .first('.drive-list-loading')
-        .text()
-        .trim(),
+    driveListLoadingText: () => wrapper.first('.drive-list-loading').text().trim(),
     driveListContainer: () => wrapper.find('.drive-list'),
     writableImportableRadio: () => wrapper.find('input[value="writable_importable_drive"]'),
     noContentRadio: () => wrapper.find('input[value="no_content_drive"]'),
     unwritableRadio: () => wrapper.find('input[value="unwritable_drive"]'),
-    cancelButton: () => wrapper.find('.buttons button')[0],
-    continueButton: () => wrapper.find('.buttons button')[1],
+    cancelButton: () => wrapper.find('.core-modal-buttons button')[0],
+    continueButton: () => wrapper.find('.core-modal-buttons button')[1],
     UiAlerts: () => wrapper.find(UiAlert),
     findingLocalDrives: () => wrapper.find('.finding-local-drives'),
   };

--- a/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/channel-token-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/channel-token-modal.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <core-modal
-    :title="$tr('enterChannelToken')"
-    :hideTopButtons="true"
-  >
+  <core-modal :title="$tr('enterChannelToken')">
     <p>{{ $tr('tokenExplanation') }}</p>
 
     <form @submit.prevent="submitForm">

--- a/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/channel-token-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/available-channels-page/channel-token-modal.vue
@@ -22,7 +22,7 @@
         :disabled="formIsDisabled"
       />
 
-      <div class="buttons">
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
           name="cancel"
@@ -31,7 +31,6 @@
           :disabled="formIsDisabled"
         />
         <k-button
-          class="submit"
           type="submit"
           :text="$tr('confirm')"
           :primary="true"
@@ -119,12 +118,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .buttons
-    text-align: right
-
-  .submit
-    margin-right: 0
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/delete-channel-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/delete-channel-modal.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <modal
+  <core-modal
     :title="$tr('title')"
     @cancel="handleClickCancel()"
   >
@@ -12,7 +12,7 @@
       <p>{{ $tr('confirmationQuestion') }}</p>
     </div>
 
-    <div class="buttons">
+    <div class="core-modal-buttons">
       <k-button
         :primary="false"
         @click="handleClickCancel()"
@@ -26,20 +26,20 @@
         :text="$tr('confirmButtonLabel')"
       />
     </div>
-
-  </modal>
+  </core-modal>
 
 </template>
 
 
 <script>
 
-  import modal from 'kolibri.coreVue.components.coreModal';
+  import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
+
   export default {
     name: 'deleteChannelModal',
     components: {
-      modal,
+      coreModal,
       kButton,
     },
     props: {
@@ -74,8 +74,5 @@
 
   .action-description
     font-weight: bold
-
-  .buttons
-    text-align: right
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
@@ -34,14 +34,13 @@
       :mode="inImportMode ? 'IMPORT' : 'EXPORT'"
     />
 
-    <div class="buttons">
+    <div class="core-modal-buttons">
       <k-button
         :text="$tr('cancel')"
         @click="cancel"
         appearance="flat-button"
       />
       <k-button
-        class="forward-button"
         :text="$tr('continue')"
         @click="goForward"
         :disabled="continueIsDisabled"
@@ -146,12 +145,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .buttons
-    text-align: right
-
-  .forward-button
-    margin-right: 0
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-drive-modal.vue
@@ -3,7 +3,6 @@
   <core-modal
     :title="title"
     :enableBgClickCancel="false"
-    hideTopButtons
     @enter="goForward"
     @cancel="cancel"
   >

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -2,7 +2,6 @@
 
   <core-modal
     :title="$tr('title')"
-    hideTopButtons
     @enter="goForward"
     @cancel="cancel"
   >

--- a/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -21,7 +21,7 @@
       />
     </div>
 
-    <div class="buttons">
+    <div class="core-modal-buttons">
       <k-button
         @click="cancel"
         appearance="flat-button"
@@ -29,7 +29,7 @@
       />
       <k-button
         @click="goForward"
-        primary
+        :primary="true"
         :disabled="disableUi"
         :text="$tr('continue')"
       />
@@ -99,10 +99,5 @@
 
   .options
     margin: 2em 0
-
-  .buttons
-    text-align: right
-    button:nth-child(2)
-      margin-right: 0
 
 </style>

--- a/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
+++ b/kolibri/plugins/management/assets/src/device_management/views/welcome-modal.vue
@@ -14,13 +14,13 @@
       {{ $tr('welcomeModalPermissionsDescription') }}
     </p>
 
-    <span class="welcome-modal-dismiss-button-wrapper">
+    <div class="core-modal-buttons">
       <k-button
         :text="$tr('welcomeButtonDismissText')"
         :primary="true"
         @click="emitCloseModal"
       />
-    </span>
+    </div>
 
   </core-modal>
 
@@ -62,9 +62,5 @@
     &-dismiss-button
       margin-top: 24px
       margin-bottom: 16px
-      &-wrapper
-        display: block
-        width: 100%
-        text-align: right
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/class-edit-page/class-rename-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/class-rename-modal.vue
@@ -17,21 +17,20 @@
           v-model.trim="name"
         />
 
-        <section class="footer">
+        <div class="core-modal-buttons">
           <k-button
             type="button"
             appearance="flat-button"
             :text="$tr('cancel')"
             @click="close"
           />
-
           <k-button
             type="submit"
             :text="$tr('update')"
             :primary="true"
             :disabled="submitting"
           />
-        </section>
+        </div>
       </form>
     </div>
   </core-modal>
@@ -138,9 +137,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: center
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
@@ -9,22 +9,18 @@
       <span v-html="formattedDeleteConfirmation"> </span>
       <p v-html="formattedAccessReassuranceConfirmation"> </p>
 
-      <!-- Button Section TODO: cleaunup -->
-      <section>
-
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
           appearance="flat-button"
           @click="close"
         />
-
         <k-button
           :text="$tr('remove')"
           :primary="true"
           @click="userRemove"
         />
-
-      </section>
+      </div>
 
     </div>
   </core-modal>
@@ -34,12 +30,14 @@
 
 <script>
 
-  import * as actions from '../../state/actions';
+  import { removeClassUser, displayModal } from '../../state/actions';
+  import kButton from 'kolibri.coreVue.components.kButton';
+  import coreModal from 'kolibri.coreVue.components.coreModal';
+
   function bold(stringToBold) {
     return `<strong v-html> ${stringToBold} </strong>`;
   }
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import coreModal from 'kolibri.coreVue.components.coreModal';
+
   export default {
     name: 'userRemoveModal',
     $trs: {
@@ -95,8 +93,8 @@
     },
     vuex: {
       actions: {
-        removeClassUser: actions.removeClassUser,
-        displayModal: actions.displayModal,
+        removeClassUser,
+        displayModal,
       },
     },
   };
@@ -106,15 +104,7 @@
 
 <style lang="stylus" scoped>
 
-  @require '~kolibri.styles.definitions'
-
-  .header
-    text-align: center
-
   p
     word-break: keep-all
-
-  section
-    text-align: right
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <core-modal :title="$tr('confirmEnrollment')" @cancel="close" class="confirm-modal">
+  <core-modal
+    :title="$tr('confirmEnrollment')"
+    @cancel="close"
+    class="confirm-modal"
+  >
     <div>
       <p>{{ $tr('areYouSure', {className}) }}</p>
       <ul class="review-enroll-ul">
@@ -8,15 +12,17 @@
           <strong>{{ getUsername(userId) }}</strong>
         </li>
       </ul>
-      <div class="modal-buttons">
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('noGoBack')"
           appearance="flat-button"
-          @click="close" />
+          @click="close"
+        />
         <k-button
           :text="$tr('yesEnrollUsers')"
           :primary="true"
-          @click="enrollUsers" />
+          @click="enrollUsers"
+        />
       </div>
     </div>
   </core-modal>
@@ -26,8 +32,8 @@
 
 <script>
 
-  import * as actions from '../../state/actions';
-  import * as constants from '../../constants';
+  import { enrollUsersInClass, displayModal } from '../../state/actions';
+  import { PageNames } from '../../constants';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   export default {
@@ -59,7 +65,7 @@
     computed: {
       editClassLink() {
         return {
-          name: constants.PageNames.CLASS_EDIT_MGMT_PAGE,
+          name: PageNames.CLASS_EDIT_MGMT_PAGE,
           id: this.classId,
         };
       },
@@ -81,8 +87,8 @@
     vuex: {
       getters: { facilityUsers: state => state.pageState.facilityUsers },
       actions: {
-        enrollUsersInClass: actions.enrollUsersInClass,
-        displayModal: actions.displayModal,
+        enrollUsersInClass,
+        displayModal,
       },
     },
   };
@@ -98,11 +104,5 @@
 
   .review-enroll-li
     line-height: 1.8em
-
-  .header
-    text-align: center
-
-  .modal-buttons
-    text-align: right
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
@@ -9,7 +9,7 @@
       <p>{{ $tr('changesWillBeLost') }}</p>
     </div>
 
-    <div class="modal-buttons">
+    <div class="core-modal-buttons">
       <k-button
         :primary="false"
         appearance="flat-button"
@@ -24,7 +24,6 @@
         :text="$tr('reset')"
         name="reset"
       />
-
     </div>
 
   </core-modal>
@@ -62,9 +61,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .modal-buttons
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/class-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/class-create-modal.vue
@@ -17,7 +17,7 @@
           v-model.trim="name"
         />
 
-        <section class="footer">
+        <div class="core-modal-buttons">
           <k-button
             type="button"
             :text="$tr('cancel')"
@@ -31,7 +31,7 @@
             :primary="true"
             :disabled="submitting"
           />
-        </section>
+        </div>
       </form>
     </div>
   </core-modal>
@@ -127,9 +127,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  .footer
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -10,9 +10,7 @@
 
       <p>{{ $tr('description') }}</p>
 
-      <!-- Button Section TODO: cleaunup -->
-      <section>
-
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
           appearance="flat-button"
@@ -24,8 +22,7 @@
           :primary="true"
           @click="classDelete"
         />
-
-      </section>
+      </div>
 
     </div>
   </core-modal>
@@ -89,14 +86,6 @@
 
 
 <style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
-
-  section
-    text-align: right
-
-  .header
-    text-align: center
 
   p
     word-break: keep-all

--- a/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
@@ -1,23 +1,24 @@
 <template>
 
-  <core-modal :title="$tr('deleteUser')" @cancel="displayModal(false)">
-    <div>
-      {{ $tr('deleteConfirmation', { username }) }}
-      <div class="ta-r">
-        <k-button
-          :text="$tr('no')"
-          :primary="false"
-          appearance="flat-button"
-          @click="displayModal(false)"
-        />
-        <k-button
-          :text="$tr('yes')"
-          :primary="true"
-          appearance="raised-button"
-          :disabled="submitting"
-          @click="handleDeleteUser"
-        />
-      </div>
+  <core-modal
+    :title="$tr('deleteUser')"
+    @cancel="closeModal()"
+  >
+    <p>{{ $tr('deleteConfirmation', { username }) }}</p>
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('no')"
+        :primary="false"
+        appearance="flat-button"
+        @click="closeModal()"
+      />
+      <k-button
+        :text="$tr('yes')"
+        :primary="true"
+        appearance="raised-button"
+        :disabled="submitting"
+        @click="handleDeleteUser"
+      />
     </div>
   </core-modal>
 
@@ -60,6 +61,9 @@
         this.submitting = true;
         this.deleteUser(this.id);
       },
+      closeModal() {
+        this.displayModal(false);
+      },
     },
     vuex: {
       actions: {
@@ -78,11 +82,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
-
-  .ta-r
-    text-align: right
-
-</style>
+<style lang="stylus"></style>

--- a/kolibri/plugins/management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/edit-user-modal.vue
@@ -1,9 +1,18 @@
 <template>
 
-  <core-modal :title="$tr('editUser')" @cancel="displayModal(false)">
+  <core-modal
+    :title="$tr('editUser')"
+    @cancel="displayModal(false)"
+  >
     <form @submit.prevent="submitForm">
 
-      <ui-alert v-if="error" type="error" :dismissible="false">{{ error }}</ui-alert>
+      <ui-alert
+        v-if="error"
+        type="error"
+        :dismissible="false"
+      >
+        {{ error }}
+      </ui-alert>
 
       <k-textbox
         ref="name"
@@ -35,7 +44,7 @@
         v-model="newKind"
       />
 
-      <div class="ta-r">
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
           :primary="false"
@@ -216,12 +225,7 @@
 
 <style lang="stylus" scoped>
 
-  @require '~kolibri.styles.definitions'
-
   .kind-select
     margin-bottom: 32px
-
-  .ta-r
-    text-align: right
 
 </style>

--- a/kolibri/plugins/management/assets/src/views/user-page/reset-user-password-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/reset-user-password-modal.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <core-modal :title="$tr('resetPassword')" @cancel="displayModal(false)">
+  <core-modal
+    :title="$tr('resetPassword')"
+    @cancel="displayModal(false)"
+  >
     <form @submit.prevent="submitForm">
 
       <p>{{ $tr('username') }}: <strong>{{ username }}</strong></p>
@@ -25,7 +28,7 @@
         v-model="confirmedPassword"
       />
 
-      <div class="ta-r">
+      <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
           :primary="false"
@@ -152,11 +155,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
-
-  .ta-r
-    text-align: right
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/user-create-modal.vue
@@ -64,14 +64,20 @@
       </section>
 
       <!-- Button Options at footer of modal -->
-      <section class="footer">
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('cancel')"
+          :primary="false"
+          appearance="flat-button"
+          @click="close"
+        />
         <k-button
           :text="$tr('createAccount')"
           :primary="true"
           type="submit"
           :disabled="submitting"
         />
-      </section>
+      </div>
     </form>
   </core-modal>
 
@@ -92,6 +98,7 @@
     name: 'userCreateModal',
     $trs: {
       addNewAccountTitle: 'Add new account',
+      cancel: 'Cancel',
       name: 'Full name',
       username: 'Username',
       password: 'Password',
@@ -279,9 +286,6 @@
 
 
 <style lang="stylus" scoped>
-
-  .footer
-    text-align: right
 
   .kind-select
     margin-bottom: 3em

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -8,7 +8,8 @@
       :title=" $tr('facilityPermissionsPresetDetailsHeader')"
       @cancel="hideFacilityPermissionsDetails"
       :enableBgClickCancel="true"
-      v-if="permissionPresetDetailsModalShown">
+      v-if="permissionPresetDetailsModalShown"
+    >
 
       <dl class="permission-preset-human">
         <dt class="permission-preset-human-title">
@@ -49,14 +50,14 @@
         </dd>
       </dl>
 
-      <span class="permission-preset-modal-dismiss-button-wrapper">
+      <div class="core-modal-buttons">
         <k-button
           class="permission-preset-modal-dismiss-button"
           :text="$tr('permissionsModalDismissText')"
           :primary="true"
           @click="hideFacilityPermissionsDetails"
         />
-      </span>
+      </div>
 
     </core-modal>
 
@@ -223,11 +224,6 @@
     &-modal
       &-dismiss-button
         text-transform: uppercase
-        &-wrapper
-          display: block
-          text-align: right
-          width: 100%
-
 
   .permission-preset-human
     margin-bottom: 8px


### PR DESCRIPTION
### Summary

1. Removes the "X" cancelling button from `core-modal`
1. Adds a deep selector `>>>.buttons` (and one for the last button in this div) to apply consistent layout (right aligned, and flushed with right edge of modal contents).
1. Updates extant modals for these changes.

![screen shot 2017-12-14 at 11 37 41 am](https://user-images.githubusercontent.com/10248067/34010953-4a68176c-e0c3-11e7-8d4f-8c328257acec.png)

### Reviewer guidance

1. Use every modal. WIth the exception of the `preview-exam-modal` which did not have a separate cancel button, the modals should be pretty much the same.
1. Check for oversights like the `appearance` prop of the secondary cancel button not being consistent across modals.

### References

Fixes #2772 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
