### PR TITLE
replace un-scoped styles with deep selectors

### DIFF
--- a/kolibri/core/assets/src/views/app-bar/index.vue
+++ b/kolibri/core/assets/src/views/app-bar/index.vue
@@ -180,19 +180,12 @@
 </script>
 
 
-<style lang="stylus">
-
-  @require '~kolibri.styles.definitions'
-
-  .override-ui-toolbar
-    color: $core-text-default
-
-</style>
-
-
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
+
+  >>>.override-ui-toolbar
+    color: $core-text-default
 
   .app-bar
     overflow: hidden

--- a/kolibri/core/assets/src/views/dropdown-menu/index.vue
+++ b/kolibri/core/assets/src/views/dropdown-menu/index.vue
@@ -103,17 +103,12 @@
 
 <style lang="stylus" scoped>
 
+  @require '~kolibri.styles.definitions'
+
   span
     display: inline-block
 
-</style>
-
-
-<style lang="stylus">
-
-  @require '~kolibri.styles.definitions'
-
-  .dropdown-menu
+  >>>.dropdown-menu
     &.ui-menu
       max-width: 210px
 

--- a/kolibri/plugins/coach/assets/src/views/reports/report-table.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/report-table.vue
@@ -40,12 +40,7 @@
   .tbody-move
     transition: transform 0.5s cubic-bezier(0.55, 0, 0.1, 1)
 
-</style>
-
-
-<style lang="stylus">
-
-  .data-table
+  >>>.data-table
     td, th
       padding: 8px
 

--- a/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
+++ b/kolibri/plugins/management/assets/src/views/class-enroll-page/index.vue
@@ -350,19 +350,6 @@
 </script>
 
 
-<style lang="stylus">
-
-  .switch
-    margin-top: 20px
-    .ui-switch__track
-      z-index: 0
-
-    .ui-switch__thumb
-      z-index: 1
-
-</style>
-
-
 <style lang="stylus" scoped>
 
   @require '~kolibri.styles.definitions'
@@ -370,6 +357,14 @@
   // based on material design data table spec
   $table-row-selected = #F5F5F5
   $table-row-hover = #EEEEEE
+
+  >>>.switch
+    margin-top: 20px
+    .ui-switch__track
+      z-index: 0
+
+    .ui-switch__thumb
+      z-index: 1
 
   .align-right
     text-align: right

--- a/kolibri/plugins/media_player/assets/src/views/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/index.vue
@@ -409,10 +409,8 @@
     height: 100%
     background-color: black
 
-</style>
 
-
-<style lang="stylus">
+  /***** PLAYER OVERRIDES *****/
 
   @require '~kolibri.styles.definitions'
 
@@ -427,13 +425,13 @@
 
 
   /* Hide control bar when playing & inactive */
-  .vjs-has-started.vjs-playing.vjs-user-inactive
+  >>>.vjs-has-started.vjs-playing.vjs-user-inactive
     .vjs-control-bar
       visibility: hidden
 
 
   /*** CUSTOM VIDEOJS SKIN ***/
-  .custom-skin
+  >>>.custom-skin
     $button-height-normal = 40px
     $button-font-size-normal = 24px
 
@@ -565,7 +563,7 @@
 
 
   /*** MEDIUM: < 600px ***/
-  .player-medium
+  >>>.player-medium
     /* Seek bar moves up. */
     .vjs-progress-control
       position: absolute
@@ -581,7 +579,7 @@
 
 
   /*** SMALL: < 480px ***/
-  .player-small
+  >>>.player-small
     $button-height-small = 44px
     $button-font-size-normal = 24px
 
@@ -638,7 +636,7 @@
 
 
   /*** TINY: < 360px ***/
-  .player-tiny
+  >>>.player-tiny
     /* Time divider is hidden */
     .vjs-time-divider
       display: none


### PR DESCRIPTION

### Summary

Replaces all Kolibri unscoped styles with the new vue `deep` selector


### Reviewer guidance

Make sure things all still work the same.

(man wish I had some visual diffs :) )

### References

fixes #2367

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
