### PR TITLE
Adding cryptography-compatible pyOpenSSL to source dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REQUIREMENTS=requirements.txt
 REQUIREMENTS_CEXT=requirements/cext.txt
+REQUIREMENTS_CEXT_NOARCH=requirements/cext_noarch.txt
 
 .PHONY: help clean clean-pyc clean-build list test test-all coverage docs release sdist
 
@@ -56,7 +57,7 @@ test:
 test-all:
 	tox
 
-assets: staticdeps
+assets:
 	yarn install
 	yarn run build
 
@@ -83,6 +84,7 @@ staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	python install_cexts.py --file $(REQUIREMENTS_CEXT) # pip install c extensions
+	pip install -t kolibri/dist -r $(REQUIREMENTS_CEXT_NOARCH)
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 
 writeversion:

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r $(REQUIREMENTS)
 	python install_cexts.py --file $(REQUIREMENTS_CEXT) # pip install c extensions
-	pip install -t kolibri/dist -r $(REQUIREMENTS_CEXT_NOARCH)
+	pip install -t kolibri/dist -r $(REQUIREMENTS_CEXT_NOARCH) --no-deps
 	rm -r kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 
 writeversion:

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -1,4 +1,4 @@
 # These are unique requirements for C extensions, but the
 # ones that don't need to be shipped in one version per
 # arch/OS/pyVesion
-pyOpenSSL==17.5.0
+pyOpenSSL==17.4.0

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -1,0 +1,4 @@
+# These are unique requirements for C extensions, but the
+# ones that don't need to be shipped in one version per
+# arch/OS/pyVesion
+pyOpenSSL==17.5.0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Intended as a:

 - **final solution** for the sdist that carries bundled in compiled dependencies for the most popular platforms
 - **temporary solution** in the sense that it fixes an issue caused by having a platform-specific dependency that may interact with the rest of the system, since we cannot rule out that some other system library would expect cryptography x.y.z and find our version 2.0.3

#### Fixing `SNIMissingWarning` ?

To reproduce the error that this PR targets, do the following:

1. Run the Pex provided in our latest release on a system that already has pyOpenSSL
1. `kolibri manage shell`
1. @lyw07 would it be sufficient to just run `requests.get("https://studio.learningequality.org")` to reproduce?


#### Fixing `requests` depends on pyOpenSSL (bindings to system's OpenSSL) which expects system's version of cryptography but gets ours

I don't even rembember what the error was, but it was something with `_lib.SSL_ST_INIT` and some `AttributeError` - @lyw07 ?

To reproduce the error that this PR targets, do the following:

1. Run the Pex provided in our latest release on a system that already has pyOpenSSL
1. `kolibri manage shell`
1. @lyw07 need help here :)

### Reviewer guidance

Is this latest version of pyOpenSSL adequate? Will it work on all platforms?

### References

#2544 

----

### Contributor Checklist

- [x] Test on Ubuntu 14.04
- [x] Test on Ubuntu 16.04
- [x] Test on Ubuntu 17.10
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
