### PR TITLE
Refactor user plugin JS, add smoke tests for components

### DIFF
--- a/karma_config/karma.conf.js
+++ b/karma_config/karma.conf.js
@@ -54,8 +54,8 @@ module.exports = function(config) {
       './karma_config/globals.js',
       // Detailed pattern to include a file. Similarly other options can be used
       { pattern: './node_modules/core-js/client/core.js', watched: false },
-      'kolibri/**/assets/test/**/*.js',
-      'kolibri/**/assets/**/*.spec.js',
+      { pattern: 'kolibri/**/assets/test/**/*.js', watched: false },
+      { pattern: 'kolibri/**/assets/**/*.spec.js', watched: false },
     ],
 
     // list of files to exclude

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -1,39 +1,68 @@
 import KolibriApp from 'kolibri_app';
 import RootVue from './views';
-import { showRoot, showSignIn, showSignUp, showProfile } from './state/actions';
+import { showSignIn, showSignUp, showProfile } from './state/actions';
 import initialState from './state/initialState';
 import mutations from './state/mutations';
 import { PageNames } from './constants';
 import store from 'kolibri.coreVue.vuex.store';
 import { getFacilityConfig } from 'kolibri.coreVue.vuex.actions';
+import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
+import router from 'kolibri.coreVue.router';
 
 const routes = [
   {
     name: PageNames.ROOT,
     path: '/',
     handler: () => {
-      showRoot(store);
+      if (isUserLoggedIn(store.state)) {
+        router.getInstance().replace({
+          name: PageNames.PROFILE,
+        });
+        return;
+      }
+      router.getInstance().replace({
+        name: PageNames.SIGN_IN,
+      });
     },
   },
   {
     name: PageNames.SIGN_IN,
     path: '/signin',
     handler: () => {
-      showSignIn(store);
+      if (isUserLoggedIn(store.state)) {
+        router.getInstance().replace({
+          name: PageNames.PROFILE,
+        });
+      } else {
+        showSignIn(store);
+      }
     },
   },
   {
     name: PageNames.SIGN_UP,
     path: '/create_account',
     handler: () => {
-      showSignUp(store);
+      if (isUserLoggedIn(store.state)) {
+        router.getInstance().replace({
+          name: PageNames.PROFILE,
+        });
+        return Promise.resolve();
+      } else {
+        return showSignUp(store);
+      }
     },
   },
   {
     name: PageNames.PROFILE,
     path: '/profile',
     handler: () => {
-      showProfile(store);
+      if (!isUserLoggedIn(store.state)) {
+        router.getInstance().replace({
+          name: PageNames.SIGN_IN,
+        });
+      } else {
+        showProfile(store);
+      }
     },
   },
   {

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -18,10 +18,11 @@ const routes = [
         router.getInstance().replace({
           name: PageNames.PROFILE,
         });
+      } else {
+        router.getInstance().replace({
+          name: PageNames.SIGN_IN,
+        });
       }
-      router.getInstance().replace({
-        name: PageNames.SIGN_IN,
-      });
     },
   },
   {

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -1,6 +1,6 @@
 import KolibriApp from 'kolibri_app';
 import RootVue from './views';
-import * as actions from './state/actions';
+import { showRoot, showSignIn, showSignUp, showProfile } from './state/actions';
 import initialState from './state/initialState';
 import mutations from './state/mutations';
 import { PageNames } from './constants';
@@ -12,28 +12,28 @@ const routes = [
     name: PageNames.ROOT,
     path: '/',
     handler: () => {
-      actions.showRoot(store);
+      showRoot(store);
     },
   },
   {
     name: PageNames.SIGN_IN,
     path: '/signin',
     handler: () => {
-      actions.showSignIn(store);
+      showSignIn(store);
     },
   },
   {
     name: PageNames.SIGN_UP,
     path: '/create_account',
     handler: () => {
-      actions.showSignUp(store);
+      showSignUp(store);
     },
   },
   {
     name: PageNames.PROFILE,
     path: '/profile',
     handler: () => {
-      actions.showProfile(store);
+      showProfile(store);
     },
   },
   {
@@ -60,6 +60,4 @@ class UserModule extends KolibriApp {
   }
 }
 
-const userModule = new UserModule();
-
-export { userModule as default };
+export default new UserModule();

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -1,8 +1,8 @@
 import KolibriApp from 'kolibri_app';
-
 import RootVue from './views';
 import * as actions from './state/actions';
-import { initialState, mutations } from './state/store';
+import initialState from './state/initialState';
+import mutations from './state/mutations';
 import { PageNames } from './constants';
 import store from 'kolibri.coreVue.vuex.store';
 import { getFacilityConfig } from 'kolibri.coreVue.vuex.actions';

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -1,6 +1,6 @@
 import KolibriApp from 'kolibri_app';
 import RootVue from './views';
-import { showSignIn, showSignUp, showProfile } from './state/actions';
+import { showSignInPage, showSignUpPage, showProfilePage } from './state/actions';
 import initialState from './state/initialState';
 import mutations from './state/mutations';
 import { PageNames } from './constants';
@@ -18,7 +18,6 @@ const routes = [
         router.getInstance().replace({
           name: PageNames.PROFILE,
         });
-        return;
       }
       router.getInstance().replace({
         name: PageNames.SIGN_IN,
@@ -34,7 +33,7 @@ const routes = [
           name: PageNames.PROFILE,
         });
       } else {
-        showSignIn(store);
+        showSignInPage(store);
       }
     },
   },
@@ -48,7 +47,7 @@ const routes = [
         });
         return Promise.resolve();
       } else {
-        return showSignUp(store);
+        return showSignUpPage(store);
       }
     },
   },
@@ -61,7 +60,7 @@ const routes = [
           name: PageNames.SIGN_IN,
         });
       } else {
-        showProfile(store);
+        showProfilePage(store);
       }
     },
   },

--- a/kolibri/plugins/user/assets/src/constants.js
+++ b/kolibri/plugins/user/assets/src/constants.js
@@ -1,9 +1,6 @@
-// a name for every URL pattern
-const PageNames = {
+export const PageNames = {
   ROOT: 'ROOT',
   SIGN_IN: 'SIGN_IN',
   SIGN_UP: 'SIGN_UP',
   PROFILE: 'PROFILE',
 };
-
-export { PageNames };

--- a/kolibri/plugins/user/assets/src/state/actions.js
+++ b/kolibri/plugins/user/assets/src/state/actions.js
@@ -19,11 +19,11 @@ function redirectToHome() {
   window.location = '/';
 }
 
-function resetSignUpState(store) {
+export function resetSignUpState(store) {
   store.dispatch('RESET_SIGN_UP_STATE');
 }
 
-function resetProfileState(store) {
+export function resetProfileState(store) {
   store.dispatch('RESET_PROFILE_STATE');
 }
 
@@ -34,7 +34,7 @@ function resetAndSetPageName(store, { pageName, title }) {
   store.dispatch('CORE_SET_TITLE', title);
 }
 
-function editProfile(store, edits, session) {
+export function editProfile(store, edits, session) {
   // payload needs username, fullname, and facility
   // used to save changes to API
   function getUserModel() {
@@ -91,7 +91,7 @@ function editProfile(store, edits, session) {
   );
 }
 
-function showProfile(store) {
+export function showProfile(store) {
   resetAndSetPageName(store, {
     pageName: PageNames.PROFILE,
     title: translator.$tr('userProfilePageTitle'),
@@ -99,7 +99,7 @@ function showProfile(store) {
   resetProfileState(store);
 }
 
-function showSignIn(store) {
+export function showSignIn(store) {
   if (Lockr.get(SignedOutDueToInactivitySnackbar)) {
     store.dispatch('CORE_SET_CURRENT_SNACKBAR', SignedOutDueToInactivitySnackbar);
     Lockr.set(SignedOutDueToInactivitySnackbar, null);
@@ -112,22 +112,25 @@ function showSignIn(store) {
   store.dispatch('SET_PAGE_STATE', {});
 }
 
-
-function showSignUp(store) {
-  return FacilityResource.getCollection().fetch().then(facilities => {
-    store.dispatch('CORE_SET_FACILITIES', facilities);
-    resetAndSetPageName(store, {
-      pageName: PageNames.SIGN_UP,
-      title: translator.$tr('userSignUpPageTitle'),
-    });
-    resetSignUpState(store);
-  }).catch(error => coreActions.handleApiError(store, error));
+export function showSignUp(store) {
+  return FacilityResource.getCollection()
+    .fetch()
+    .then(facilities => {
+      store.dispatch('CORE_SET_FACILITIES', facilities);
+      resetAndSetPageName(store, {
+        pageName: PageNames.SIGN_UP,
+        title: translator.$tr('userSignUpPageTitle'),
+      });
+      resetSignUpState(store);
+    })
+    .catch(error => coreActions.handleApiError(store, error));
 }
 
-function signUp(store, signUpCreds) {
+export function signUp(store, signUpCreds) {
   store.dispatch('SET_SIGN_UP_BUSY', true);
   resetSignUpState(store);
-  return SignUpResource.createModel(signUpCreds).save(signUpCreds)
+  return SignUpResource.createModel(signUpCreds)
+    .save(signUpCreds)
     .then(() => {
       store.dispatch('SET_SIGN_UP_ERROR', null, '');
       // TODO: Better solution?
@@ -145,13 +148,3 @@ function signUp(store, signUpCreds) {
       store.dispatch('SET_SIGN_UP_BUSY', false);
     });
 }
-
-export {
-  showSignIn,
-  showSignUp,
-  signUp,
-  resetSignUpState,
-  showProfile,
-  editProfile,
-  resetProfileState,
-};

--- a/kolibri/plugins/user/assets/src/state/actions.js
+++ b/kolibri/plugins/user/assets/src/state/actions.js
@@ -26,7 +26,7 @@ function resetAndSetPageName(store, { pageName, title }) {
   store.dispatch('CORE_SET_TITLE', title);
 }
 
-export function editProfile(store, edits, session) {
+export function updateUserProfile(store, edits, session) {
   // payload needs username, fullname, and facility
   // used to save changes to API
   const savedUserModel = FacilityUserResource.getModel(session.user_id);
@@ -75,7 +75,7 @@ export function editProfile(store, edits, session) {
   );
 }
 
-export function showProfile(store) {
+export function showProfilePage(store) {
   resetAndSetPageName(store, {
     pageName: PageNames.PROFILE,
     title: translator.$tr('userProfilePageTitle'),
@@ -83,7 +83,7 @@ export function showProfile(store) {
   resetProfileState(store);
 }
 
-export function showSignIn(store) {
+export function showSignInPage(store) {
   if (Lockr.get(SignedOutDueToInactivitySnackbar)) {
     store.dispatch('CORE_SET_CURRENT_SNACKBAR', SignedOutDueToInactivitySnackbar);
     Lockr.set(SignedOutDueToInactivitySnackbar, null);
@@ -96,7 +96,7 @@ export function showSignIn(store) {
   store.dispatch('SET_PAGE_STATE', {});
 }
 
-export function showSignUp(store) {
+export function showSignUpPage(store) {
   return FacilityResource.getCollection()
     .fetch()
     .then(facilities => {
@@ -110,7 +110,7 @@ export function showSignUp(store) {
     .catch(error => coreActions.handleApiError(store, error));
 }
 
-export function signUp(store, signUpCreds) {
+export function signUpNewUser(store, signUpCreds) {
   store.dispatch('SET_SIGN_UP_BUSY', true);
   resetSignUpState(store);
   return SignUpResource.createModel(signUpCreds)

--- a/kolibri/plugins/user/assets/src/state/actions.js
+++ b/kolibri/plugins/user/assets/src/state/actions.js
@@ -26,7 +26,7 @@ function resetAndSetPageName(store, { pageName, title }) {
   store.dispatch('CORE_SET_TITLE', title);
 }
 
-export function updateUserProfile(store, edits, session) {
+export function updateUserProfile(store, { edits, session }) {
   // payload needs username, fullname, and facility
   // used to save changes to API
   const savedUserModel = FacilityUserResource.getModel(session.user_id);

--- a/kolibri/plugins/user/assets/src/state/initialState.js
+++ b/kolibri/plugins/user/assets/src/state/initialState.js
@@ -1,0 +1,5 @@
+export default {
+  pageName: undefined,
+  pageState: {},
+  facility: undefined,
+};

--- a/kolibri/plugins/user/assets/src/state/mutations.js
+++ b/kolibri/plugins/user/assets/src/state/mutations.js
@@ -1,14 +1,4 @@
-/**
- ** pageState schemas
- **/
-
-export const initialState = {
-  pageName: undefined,
-  pageState: {},
-  facility: undefined,
-};
-
-export const mutations = {
+export default {
   SET_PAGE_NAME(state, name) {
     state.pageName = name;
   },

--- a/kolibri/plugins/user/assets/src/state/mutations.js
+++ b/kolibri/plugins/user/assets/src/state/mutations.js
@@ -12,7 +12,7 @@ export default {
   SET_PROFILE_SUCCESS(state, isSuccessful) {
     state.pageState.success = isSuccessful;
   },
-  SET_PROFILE_ERROR(state, isError, errorMessage) {
+  SET_PROFILE_ERROR(state, { isError, errorMessage = '' }) {
     state.pageState.error = isError;
     state.pageState.errorMessage = errorMessage;
   },
@@ -20,7 +20,7 @@ export default {
   SET_SIGN_UP_BUSY(state, isBusy) {
     state.pageState.busy = isBusy;
   },
-  SET_SIGN_UP_ERROR(state, errorCode, errorMessage) {
+  SET_SIGN_UP_ERROR(state, { errorCode, errorMessage = '' }) {
     state.pageState.errorCode = errorCode;
     state.pageState.errorMessage = errorMessage;
   },

--- a/kolibri/plugins/user/assets/src/state/mutations.js
+++ b/kolibri/plugins/user/assets/src/state/mutations.js
@@ -24,4 +24,19 @@ export default {
     state.pageState.errorCode = errorCode;
     state.pageState.errorMessage = errorMessage;
   },
+  RESET_PROFILE_STATE(state) {
+    state.pageState = {
+      busy: false,
+      success: false,
+      error: false,
+      errorMessage: '',
+    };
+  },
+  RESET_SIGN_UP_STATE(state) {
+    state.pageState = {
+      busy: false,
+      errorCode: null,
+      errorMessage: '',
+    };
+  },
 };

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -27,9 +27,9 @@
   import profilePage from './profile-page';
 
   const pageNameComponentMap = {
-    [PageNames.SIGN_IN]: 'signInPage',
-    [PageNames.SIGN_UP]: 'signUpPage',
-    [PageNames.PROFILE]: 'profilePage',
+    [PageNames.SIGN_IN]: signInPage,
+    [PageNames.SIGN_UP]: signUpPage,
+    [PageNames.PROFILE]: profilePage,
   };
 
   export default {

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -73,8 +73,6 @@
 
 <style lang="stylus" scoped>
 
-  @require '~kolibri.styles.definitions'
-
   .full-page
     position: absolute
     top: 0

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -26,8 +26,13 @@
   import signUpPage from './sign-up-page';
   import profilePage from './profile-page';
 
+  const pageNameComponentMap = {
+    [PageNames.SIGN_IN]: 'signInPage',
+    [PageNames.SIGN_UP]: 'signUpPage',
+    [PageNames.PROFILE]: 'profilePage',
+  };
+
   export default {
-    $trs: { userProfileTitle: 'Profile' },
     name: 'userPlugin',
     components: {
       coreBase,
@@ -44,28 +49,20 @@
       },
       topLevelPageName: () => TopLevelPageNames.USER,
       currentPage() {
-        if (this.pageName === PageNames.SIGN_IN) {
-          return 'sign-in-page';
-        }
-        if (this.pageName === PageNames.SIGN_UP) {
-          return 'sign-up-page';
-        }
-        if (this.pageName === PageNames.PROFILE) {
-          return 'profile-page';
-        }
-        return null;
+        return pageNameComponentMap[this.pageName] || null;
       },
       navBarNeeded() {
-        if (this.pageName === PageNames.SIGN_IN) {
-          return false;
-        }
-        if (this.pageName === PageNames.SIGN_UP) {
-          return false;
-        }
-        return true;
+        return this.pageName !== PageNames.SIGN_IN && this.pageName !== PageNames.SIGN_UP;
       },
     },
-    vuex: { getters: { pageName: state => state.pageName } },
+    vuex: {
+      getters: {
+        pageName: state => state.pageName,
+      },
+    },
+    $trs: {
+      userProfileTitle: 'Profile',
+    },
   };
 
 </script>

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -97,7 +97,7 @@
 
 <script>
 
-  import { editProfile, resetProfileState } from '../../state/actions';
+  import { updateUserProfile, resetProfileState } from '../../state/actions';
   import {
     facilityConfig,
     isSuperuser,
@@ -237,7 +237,7 @@
             username: this.username,
             full_name: this.name,
           };
-          this.editProfile(edits, this.session);
+          this.updateUserProfile(edits, this.session);
         } else {
           if (this.nameIsInvalid) {
             this.$refs.name.focus();
@@ -271,7 +271,7 @@
         userHasPermissions,
       },
       actions: {
-        editProfile,
+        updateUserProfile,
         resetProfileState,
         fetchPoints,
       },

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -205,7 +205,7 @@
         return '';
       },
       nameIsInvalid() {
-        return !!this.nameIsInvalidText;
+        return Boolean(this.nameIsInvalidText);
       },
       usernameIsInvalidText() {
         if (this.usernameBlurred || this.formSubmitted) {
@@ -219,7 +219,7 @@
         return '';
       },
       usernameIsInvalid() {
-        return !!this.usernameIsInvalidText;
+        return Boolean(this.usernameIsInvalidText);
       },
       formIsValid() {
         return !this.usernameIsInvalid;
@@ -233,11 +233,13 @@
         this.formSubmitted = true;
         this.resetProfileState();
         if (this.formIsValid) {
-          const edits = {
-            username: this.username,
-            full_name: this.name,
-          };
-          this.updateUserProfile(edits, this.session);
+          this.updateUserProfile({
+            edits: {
+              username: this.username,
+              full_name: this.name,
+            },
+            session: this.session,
+          });
         } else {
           if (this.nameIsInvalid) {
             this.$refs.name.focus();
@@ -316,5 +318,8 @@
 
   .permissions-icon
     padding-right: 8px
+
+  button[type='submit']
+    margin-left: 0
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -177,9 +177,9 @@
         return null;
       },
       permissionTypeText() {
-        if (this.permissionType === PermissionTypes.SUPERUSER) {
+        if (this.isSuperuser) {
           return this.$tr('isSuperuser');
-        } else if (this.permissionType === PermissionTypes.LIMITED_PERMISSIONS) {
+        } else if (this.userHasPermissions) {
           return this.$tr('limitedPermissions');
         }
         return '';
@@ -319,7 +319,7 @@
   .permissions-icon
     padding-right: 8px
 
-  button[type='submit']
+  .submit
     margin-left: 0
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -171,14 +171,6 @@
           sug.toLowerCase().startsWith(this.username.toLowerCase())
         );
       },
-      // TODO: not used
-      uniqueMatch() {
-        // If we have a matching username entered, don't show any suggestions.
-        return (
-          this.suggestions.length === 1 &&
-          this.suggestions[0].toLowerCase() === this.username.toLowerCase()
-        );
-      },
       usernameIsInvalidText() {
         if (this.usernameBlurred || this.formSubmitted) {
           if (this.username === '') {
@@ -188,7 +180,7 @@
         return '';
       },
       usernameIsInvalid() {
-        return !!this.usernameIsInvalidText;
+        return Boolean(this.usernameIsInvalidText);
       },
       passwordIsInvalidText() {
         if (this.passwordBlurred || this.formSubmitted) {
@@ -201,7 +193,7 @@
         return '';
       },
       passwordIsInvalid() {
-        return !!this.passwordIsInvalidText;
+        return Boolean(this.passwordIsInvalidText);
       },
       formIsValid() {
         if (this.simpleSignIn) {

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -114,7 +114,7 @@
 
 <script>
 
-  import { signUp, resetSignUpState } from '../../state/actions';
+  import { signUpNewUser, resetSignUpState } from '../../state/actions';
   import { PageNames } from '../../constants';
   import { validateUsername } from 'kolibri.utils.validators';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -279,7 +279,7 @@
         this.formSubmitted = true;
         const canSubmit = this.formIsValid && !this.busy;
         if (canSubmit) {
-          this.signUpAction({
+          this.signUpNewUser({
             facility: this.selectedFacility.value,
             full_name: this.name,
             username: this.username,
@@ -310,8 +310,8 @@
         facilities: state => state.core.facilities,
       },
       actions: {
-        signUpAction: signUp,
-        resetSignUpState: resetSignUpState,
+        signUpNewUser,
+        resetSignUpState,
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -100,6 +100,7 @@
         :primary="true"
         :text="$tr('finish')"
         type="submit"
+        class="submit"
       />
 
     </form>
@@ -373,7 +374,7 @@
     margin: 36px
     margin-top: 96px
 
-  button[type='submit']
+  .submit
     margin-left: 0
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -10,14 +10,25 @@
         {{ $tr('kolibri') }}
       </template>
       <div slot="actions">
-        <router-link id="signin" :to="signInPage">
+        <router-link
+          id="signin"
+          :to="signInPage"
+        >
           <span>{{ $tr('logIn') }}</span>
         </router-link>
       </div>
     </ui-toolbar>
 
-    <form class="signup-form" ref="form" @submit.prevent="signUp">
-      <ui-alert type="error" @dismiss="resetSignUpState" v-if="unknownError">
+    <form
+      class="signup-form"
+      ref="form"
+      @submit.prevent="signUp"
+    >
+      <ui-alert
+        v-if="unknownError"
+        type="error"
+        @dismiss="resetSignUpState"
+      >
         {{ errorMessage }}
       </ui-alert>
 
@@ -84,7 +95,12 @@
         @blur="facilityBlurred = true"
       />
 
-      <k-button :disabled="busy" :primary="true" :text="$tr('finish')" type="submit" />
+      <k-button
+        :disabled="busy"
+        :primary="true"
+        :text="$tr('finish')"
+        type="submit"
+      />
 
     </form>
 

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -373,4 +373,7 @@
     margin: 36px
     margin-top: 96px
 
+  button[type='submit']
+    margin-left: 0
+
 </style>

--- a/kolibri/plugins/user/assets/test/util/makeStore.js
+++ b/kolibri/plugins/user/assets/test/util/makeStore.js
@@ -1,0 +1,20 @@
+import Vuex from 'vuex';
+import initialState from '../../src/state/initialState';
+
+export default function makeStore() {
+  return new Vuex.Store({
+    state: {
+      core: {
+        connection: {
+          connected: true,
+        },
+        facilityConfig: {},
+        session: {
+          kind: [],
+          facilities: [],
+        },
+      },
+      ...initialState,
+    },
+  });
+}

--- a/kolibri/plugins/user/assets/test/views/profile-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/profile-page.spec.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import assert from 'assert';
+import { mount } from 'avoriaz';
+import ProfilePage from '../../src/views/profile-page';
+import makeStore from '../util/makeStore';
+
+ProfilePage.vuex.actions.fetchPoints = () => {};
+
+function makeWrapper() {
+  return mount(ProfilePage, {
+    store: makeStore(),
+  });
+}
+
+describe('profilePage component', () => {
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    assert(wrapper.isVueComponent);
+  });
+});

--- a/kolibri/plugins/user/assets/test/views/sign-in-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/sign-in-page.spec.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import assert from 'assert';
+import { mount } from 'avoriaz';
+import SignInPage from '../../src/views/sign-in-page';
+import makeStore from '../util/makeStore';
+
+function makeWrapper() {
+  return mount(SignInPage, {
+    store: makeStore(),
+  });
+}
+
+describe('signInPage component', () => {
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    assert(wrapper.isVueComponent);
+  });
+});

--- a/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import VueRouter from 'vue-router';
+import assert from 'assert';
+import { mount } from 'avoriaz';
+import SignUpPage from '../../src/views/sign-up-page';
+import makeStore from '../util/makeStore';
+
+function makeWrapper() {
+  return mount(SignUpPage, {
+    store: makeStore(),
+    router: new VueRouter(),
+  });
+}
+
+describe('signUpPage component', () => {
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    assert(wrapper.isVueComponent);
+  });
+});

--- a/kolibri/plugins/user/assets/test/views/user-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/user-page.spec.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+import Vue from 'vue-test'; // eslint-disable-line
+import assert from 'assert';
+import { mount } from 'avoriaz';
+import UserPage from '../../src/views/index.vue';
+import makeStore from '../util/makeStore';
+
+function makeWrapper() {
+  return mount(UserPage, {
+    store: makeStore(),
+  });
+}
+
+describe('user index page component', () => {
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    assert(wrapper.isVueComponent);
+  });
+});


### PR DESCRIPTION
### Summary

Some mechanical refactors in User plugin:

1. Fixes issue where Karma tests run twice in watch mode
1. Move redirect-if-(not) logged-in logic out of `show*` actions into the router. `show*` actions are more single purpose.
1. Many mechanical refactors (e.g. remove temp variable, change argument list to object, named import/export, remove duplication, etc.)
1. Rename actions to match naming conventions elsewhere in app.
1. Add "smoke tests" for the 4 main vue components in this plugin.
1. Break out mutations from initialState object.

### Reviewer guidance

Manually test user plugin journeys

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
