### PR TITLE
Change cherrypy version to 11.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-mptt==0.9.0
 djangorestframework-csv==2.0.0
 tqdm==4.19.5                     # progress bars
 requests==2.18.4
-cherrypy==13.0.0
+cherrypy==11.0.0  # pyup: <11.1.0
 iceqube==0.0.4
 porter2stemmer==1.0
 unicodecsv==0.14.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-mptt==0.9.0
 djangorestframework-csv==2.0.0
 tqdm==4.19.5                     # progress bars
 requests==2.18.4
-cherrypy==11.0.0  # pyup: <11.1.0
+cherrypy==11.0.0  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <11.1.0
 iceqube==0.0.4
 porter2stemmer==1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue https://github.com/learningequality/kolibri/issues/2971, which is caused by one of `cherrypy`'s dependencies `jaraco.classes`. According to @benjaoming ,`jaraco.classes` is a namespace package, which could cause the issue we are having. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Install the pex/whl file and run` kolibri` to see if it runs successfully.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issue in our repository: https://github.com/learningequality/kolibri/issues/2971
Issue posted in their github repository: https://github.com/jaraco/jaraco.classes/issues/2

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
