### PR TITLE
Provide coreVue component object that supports named imports

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -73,6 +73,7 @@ import appBar from '../views/app-bar';
 import coreSnackbar from '../views/core-snackbar';
 import customUiMenu from '../views/custom-ui-menu';
 import heartbeat from '../heartbeat';
+import allComponents from '../views/index.js';
 
 export default {
   client,
@@ -95,6 +96,7 @@ export default {
       store,
       mappers,
     },
+    allComponents,
     components: {
       contentRenderer,
       downloadButton,

--- a/kolibri/core/assets/src/views/index.js
+++ b/kolibri/core/assets/src/views/index.js
@@ -1,0 +1,65 @@
+import appBar from './app-bar';
+import authMessage from './auth-message';
+import contentIcon from './content-icon';
+import contentRenderer from './content-renderer';
+import coreBase from './core-base';
+import coreModal from './core-modal';
+import coreSnackbar from './core-snackbar';
+import customUiMenu from './custom-ui-menu';
+import downloadButton from './content-renderer/download-button';
+import dropdownMenu from './dropdown-menu';
+import elapsedTime from './elapsed-time';
+import immersiveFullScreen from './immersive-full-screen';
+import kBreadcrumbs from './k-breadcrumbs';
+import kButton from './buttons-and-links/k-button';
+import kCheckbox from './k-checkbox';
+import kExternalLink from './buttons-and-links/k-external-link';
+import kFilterTextbox from './k-filter-textbox';
+import kNavbar from './k-navbar';
+import kNavbarLink from './k-navbar/link';
+import kRadioButton from './k-radio-button';
+import kRouterLink from './buttons-and-links/k-router-link';
+import kSelect from './k-select';
+import kTextbox from './k-textbox';
+import languageSwitcherList from './language-switcher/list.vue';
+import loadingSpinner from './loading-spinner';
+import logo from './logo';
+import permissionsIcon from './permissions-icon';
+import pointsIcon from './points-icon';
+import progressBar from './progress-bar';
+import progressIcon from './progress-icon';
+import sideNav from './side-nav';
+
+export default {
+  appBar,
+  authMessage,
+  contentIcon,
+  contentRenderer,
+  coreBase,
+  coreModal,
+  coreSnackbar,
+  customUiMenu,
+  downloadButton,
+  dropdownMenu,
+  elapsedTime,
+  immersiveFullScreen,
+  kBreadcrumbs,
+  kButton,
+  kCheckbox,
+  kExternalLink,
+  kFilterTextbox,
+  kNavbar,
+  kNavbarLink,
+  kRadioButton,
+  kRouterLink,
+  kSelect,
+  kTextbox,
+  languageSwitcherList,
+  loadingSpinner,
+  logo,
+  permissionsIcon,
+  pointsIcon,
+  progressBar,
+  progressIcon,
+  sideNav,
+};

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -21,7 +21,7 @@
 
   import { PageNames } from '../constants';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
-  import coreBase from 'kolibri.coreVue.components.coreBase';
+  import { coreBase } from 'kolibri.coreVue.allComponents';
   import signInPage from './sign-in-page';
   import signUpPage from './sign-up-page';
   import profilePage from './profile-page';

--- a/kolibri/plugins/user/assets/src/views/language-switcher-footer/index.vue
+++ b/kolibri/plugins/user/assets/src/views/language-switcher-footer/index.vue
@@ -9,7 +9,7 @@
 
 <script>
 
-  import languageSwitcherList from 'kolibri.coreVue.components.languageSwitcherList';
+  import { languageSwitcherList } from 'kolibri.coreVue.allComponents';
 
   export default {
     name: 'languageSwitcherFooter',

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -112,10 +112,7 @@
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { validateUsername } from 'kolibri.utils.validators';
   import { fetchPoints } from 'kolibri.coreVue.vuex.actions';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import kTextbox from 'kolibri.coreVue.components.kTextbox';
-  import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
-  import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
+  import { kButton, kTextbox, permissionsIcon, pointsIcon } from 'kolibri.coreVue.allComponents';
   import uiAlert from 'keen-ui/src/UiAlert';
   import { PermissionTypes, UserKinds } from 'kolibri.coreVue.vuex.constants';
 

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -111,15 +111,17 @@
   import { facilityConfig, currentFacilityId, currentSnackbar } from 'kolibri.coreVue.vuex.getters';
   import { FacilityUsernameResource } from 'kolibri.resources';
   import { LoginErrors, SignedOutDueToInactivitySnackbar } from 'kolibri.coreVue.vuex.constants';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
-  import kExternalLink from 'kolibri.coreVue.components.kExternalLink';
-  import kTextbox from 'kolibri.coreVue.components.kTextbox';
-  import logo from 'kolibri.coreVue.components.logo';
+  import {
+    coreSnackbar,
+    kButton,
+    kExternalLink,
+    kRouterLink,
+    kTextbox,
+    logo,
+  } from 'kolibri.coreVue.allComponents';
   import uiAutocompleteSuggestion from 'keen-ui/src/UiAutocompleteSuggestion';
   import uiAlert from 'keen-ui/src/UiAlert';
   import languageSwitcherFooter from '../language-switcher-footer';
-  import coreSnackbar from 'kolibri.coreVue.components.coreSnackbar';
 
   export default {
     name: 'signInPage',

--- a/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page/index.vue
@@ -101,13 +101,9 @@
   import { signUp, resetSignUpState } from '../../state/actions';
   import { PageNames } from '../../constants';
   import { validateUsername } from 'kolibri.utils.validators';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import uiAlert from 'kolibri.coreVue.components.uiAlert';
-  import kTextbox from 'kolibri.coreVue.components.kTextbox';
+  import { kButton, kSelect, kTextbox, logo, uiAlert } from 'kolibri.coreVue.allComponents';
   import uiToolbar from 'keen-ui/src/UiToolbar';
-  import logo from 'kolibri.coreVue.components.logo';
   import uiIcon from 'keen-ui/src/UiIcon';
-  import kSelect from 'kolibri.coreVue.components.kSelect';
   import languageSwitcherFooter from '../language-switcher-footer';
 
   export default {


### PR DESCRIPTION
### Summary

1. Minor refactors of `apiExportSpecTool.specModule` to fix lints and use ES2015 features
1. Creates an `allComponents` object aliased to `kolibri.coreVue.allComponents` that supports named imports e.g. `import { foo } from 'bar'`.
1. Replace `kolibri.coreVue.components.*` imports in user plugin pages with `import { ... } from kolibri.coreVue.allComponents`


### Reviewer guidance

1. Check to see user plugin pages still work

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
