### PR TITLE
Upgrade CherryPy to 13.0.1 after namespacing issue was resolved

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-mptt==0.9.0
 djangorestframework-csv==2.0.0
 tqdm==4.19.5                     # progress bars
 requests==2.18.4
-cherrypy==11.0.0  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <11.1.0
+cherrypy==13.0.1
 iceqube==0.0.4
 porter2stemmer==1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Back on track with upstream CherryPy after namespaced packages has temporarily been accepted as a blocker.

Will have to work on `pip install <...> -t <...>` to resolve how we avoid similar errors in the future. Possibly upstream.

### Reviewer guidance

None, I think we're safe -- will give it a manual test spin.

### References

#2972 
https://github.com/cherrypy/cherrypy/pull/1671

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
