### PR TITLE
Prevent plugin django stack loading in plugins

### DIFF
--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
-from . import hooks, urls
+
+from . import hooks
 
 
 class Coach(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/device_management/kolibri_plugin.py
+++ b/kolibri/plugins/device_management/kolibri_plugin.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
 from kolibri.core.hooks import UserNavigationHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.plugins.base import KolibriPluginBase
+
 from .hooks import DeviceManagementSyncHook
-from . import urls
 
 
 class DeviceManagementPlugin(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/facility_management/kolibri_plugin.py
+++ b/kolibri/plugins/facility_management/kolibri_plugin.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
 from kolibri.core.hooks import UserNavigationHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.plugins.base import KolibriPluginBase
+
 from .hooks import FacilityManagementSyncHook
-from . import urls
 
 
 class FacilityManagementPlugin(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import, print_function, unicode_literals
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
 
-from . import hooks, urls
+from . import hooks
 
 
 class LearnPlugin(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import, print_function, unicode_literals
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
 
-from . import hooks, urls
+from . import hooks
 
 
 class SetupWizardPlugin(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/style_guide/kolibri_plugin.py
+++ b/kolibri/plugins/style_guide/kolibri_plugin.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
-from . import hooks, urls
+
+from . import hooks
 
 
 class StyleGuide(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/plugins/user/kolibri_plugin.py
+++ b/kolibri/plugins/user/kolibri_plugin.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
-from . import hooks, urls
+
+from . import hooks
 
 
 class User(KolibriPluginBase):
     def url_module(self):
+        from . import urls
         return urls
 
     def url_slug(self):

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -17,6 +17,7 @@ env.set_env()
 import kolibri  # noqa
 import django  # noqa
 from django.core.management import call_command  # noqa
+from django.core.exceptions import AppRegistryNotReady  # noqa
 from docopt import docopt  # noqa
 
 from kolibri.core.deviceadmin.utils import IncompatibleDatabase  # noqa
@@ -102,6 +103,14 @@ class PluginDoesNotExist(Exception):
     """
 
 
+class PluginBaseLoadsApp(Exception):
+    """
+    An exception raised in case a kolibri_plugin.py results in loading of the
+    Django app stack.
+    """
+    pass
+
+
 def version_file():
     """
     During test runtime, this path may differ because KOLIBRI_HOME is
@@ -169,6 +178,7 @@ def _migrate_databases():
     from django.conf import settings
     for database in settings.DATABASES:
         call_command("migrate", interactive=False, database=database)
+
 
 def _first_run():
     """
@@ -440,13 +450,21 @@ def get_kolibri_plugin(plugin_name):
             if _is_plugin(obj):
                 plugin_classes.append(obj)
     except ImportError as e:
-        if str(e).startswith("No module named"):
-            raise PluginDoesNotExist(
-                "Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?".
-                format(plugin_name)
-            )
+        # Python 2: message, Python 3: msg
+        exc_message = getattr(e, 'message', getattr(e, 'msg', None))
+        if exc_message.startswith("No module named"):
+            msg = (
+                "Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?"
+            ).format(plugin_name)
+            raise PluginDoesNotExist(msg)
         else:
             raise
+    except AppRegistryNotReady:
+        msg = (
+            "Plugin '{}' loads the Django app registry, which it isn't "
+            "allowed to do while enabling or disabling itself."
+        ).format(plugin_name)
+        raise PluginBaseLoadsApp(msg)
 
     if not plugin_classes:
         # There's no clear use case for a plugin without a KolibriPluginBase
@@ -458,19 +476,19 @@ def get_kolibri_plugin(plugin_name):
     return plugin_classes
 
 
-def plugin(plugin_name, **args):
+def plugin(plugin_name, **kwargs):
     """
     Receives a plugin identifier and tries to load its main class. Calls class
     functions.
     """
     from kolibri.utils import conf
 
-    if args.get('enable', False):
+    if kwargs.get('enable', False):
         plugin_classes = get_kolibri_plugin(plugin_name)
         for klass in plugin_classes:
             klass.enable()
 
-    if args.get('disable', False):
+    if kwargs.get('disable', False):
         try:
             plugin_classes = get_kolibri_plugin(plugin_name)
             for klass in plugin_classes:


### PR DESCRIPTION
### Summary

This was started a while back, opening a PR to remind us that this should happen if we don't want module load order complexity to get out of hand.

### Reviewer guidance

Should find a priority for this.

### References

#2510

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
