### PR TITLE
Remove C extensions in OSX and 64-bit archs

### DIFF
--- a/install_cexts.py
+++ b/install_cexts.py
@@ -38,10 +38,6 @@ def get_path_with_arch(platform, path):
     platform = platform.replace('x86-64', 'x86_64')
     platform = platform.replace('manylinux1', 'linux')
 
-    # For cryptography module, all the macosxs >= 10.9 are supported
-    if 'macosx' in platform:
-        platform = 'macosx'
-
     path = os.path.join(path, platform)
 
     return path
@@ -91,8 +87,15 @@ def parse_package_page(files, pk_version):
     for file in files.find_all('a'):
         file_name = file.string.split('-')
 
-        # If the file format is tar.gz or the package version is not the latest, ignore
-        if file_name[-1].split('.')[-1] != 'whl' or file_name[1] != pk_version or file_name[2][2:] == '26':
+        # We are not going to install the packages if they are:
+        #   * not a whl file
+        #   * not the version specified in requirements.txt
+        #   * not python versions that kolibri supports
+        #   * for macosx or any 64-bit platforms, since the process of setup wizard has been fast enough
+        if (
+            file_name[-1].split('.')[-1] != 'whl' or file_name[1] != pk_version or file_name[2][2:] == '26'
+            or 'macosx' in file_name[4].split('.')[0] or '64' in file_name[4].split('.')[0]
+           ):
             continue
 
         print('Installing {}...'.format(file.string))

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -25,8 +25,6 @@ def get_cext_path(dist_path):
         else:
             dirname = os.path.join(dirname, python_version+'mu')
 
-    elif 'macosx' in platform:
-        platform = 'macosx'
     dirname = os.path.join(dirname, platform)
     sys.path = [os.path.realpath(str(dirname))] + sys.path
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to remove the c extension (to be specific, cryptography) in OSX and any 64-bit architectures from kolibri. The process of setup wizard has been fast enough in these architectures, so there's not much improvement after adding the c extension. Removing them from kolibri can also help reduce our current installers' sizes (~40MB).
In the future (but not this PR), we are planning to have different packages bundled inside kolibri depending on the distributions. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Install the whl/pex file to check that in `kolibri/dist/cext` we don't have `macosx` or any 64-bit architecture folders

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
