### PR TITLE
Don’t fetch sub-topic progress if user is not logged in

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -215,13 +215,14 @@ function showTopicsTopic(store, id, isRoot = false) {
     store.dispatch('SET_PAGE_NAME', PageNames.TOPICS_TOPIC);
   }
 
-  const topicPromise = ContentNodeResource.getModel(id).fetch();
-  const childrenPromise = ContentNodeResource.getCollection({
-    parent: id,
-  }).fetch();
-  const channelsPromise = setChannelInfo(store);
-  const ancestorsPromise = ContentNodeResource.fetchAncestors(id);
-  ConditionalPromise.all([topicPromise, childrenPromise, ancestorsPromise, channelsPromise]).only(
+  const promises = [
+    ContentNodeResource.getModel(id).fetch(), // the topic
+    ContentNodeResource.getCollection({ parent: id }).fetch(), // the topic's children
+    ContentNodeResource.fetchAncestors(id), // the topic's ancestors
+    setChannelInfo(store),
+  ];
+
+  ConditionalPromise.all(promises).only(
     samePageCheckGenerator(store),
     ([topic, children, ancestors]) => {
       const currentChannel = getChannelObject(store.state, topic.channel_id);
@@ -229,32 +230,40 @@ function showTopicsTopic(store, id, isRoot = false) {
         router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
         return;
       }
+      const topicContents = _collectionState(children);
       const pageState = {
-        isRoot: isRoot,
+        isRoot,
+        channel: currentChannel,
+        topic: _topicState(topic, ancestors),
+        contents: topicContents,
       };
-      pageState.channel = currentChannel;
-      pageState.topic = _topicState(topic, ancestors);
-      const collection = _collectionState(children);
-      pageState.contents = collection;
+
       store.dispatch('SET_PAGE_STATE', pageState);
-      // Topics are expensive to compute progress for, so we lazily load progress for them.
-      const subtopicIds = collection
-        .filter(item => item.kind === ContentNodeKinds.TOPIC)
-        .map(subtopic => subtopic.id);
-      if (subtopicIds.length) {
-        const topicProgressPromise = ContentNodeProgressResource.getCollection({
-          ids: subtopicIds,
-        }).fetch();
-        topicProgressPromise.then(progressArray => {
-          store.dispatch('SET_TOPIC_PROGRESS', progressArray);
-        });
+
+      // Only load subtopic progress if the user is logged in
+      if (isUserLoggedIn(store.state)) {
+        const subtopicIds = topicContents
+          .filter(({ kind }) => kind === ContentNodeKinds.TOPIC)
+          .map(({ id }) => id);
+
+        if (subtopicIds.length > 0) {
+          ContentNodeProgressResource.getCollection({ ids: subtopicIds })
+            .fetch()
+            .then(progresses => {
+              store.dispatch('SET_TOPIC_PROGRESS', progresses);
+            });
+        }
       }
+
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       store.dispatch('CORE_SET_ERROR', null);
+
       if (isRoot) {
         store.dispatch(
           'CORE_SET_TITLE',
-          translator.$tr('topicsForChannelPageTitle', { currentChannelTitle: currentChannel.title })
+          translator.$tr('topicsForChannelPageTitle', {
+            currentChannelTitle: currentChannel.title,
+          })
         );
       } else {
         store.dispatch(


### PR DESCRIPTION
### Summary

1. Adds a guard in the 	`showTopicsTopic` action so it only fetches the sub-topic progresses if the user is logged in.
1. Some mechanical refactoring

### Reviewer guidance

1. In an anonymous session, check in vuex that the `SET_TOPIC_PROGRESSES` mutation is never called, nor any calls to `api/contentnodeprogress`
1. In a logged in session check that the above does happen.

### References

Addresses #2981 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
