### PR TITLE
No-op: Filter cherrypy for py-up suggestions once again

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-mptt==0.9.0
 djangorestframework-csv==2.0.0
 tqdm==4.19.5                     # progress bars
 requests==2.18.4
-cherrypy==13.0.1
+cherrypy==13.0.1  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <13.1.0
 iceqube==0.0.4
 porter2stemmer==1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
Because of namespaced packages, sorry -- won't fill in a PR template, this has no effects on the codebase, just want PyUp to not suggest upgrades to 13.1.0

#2984