### PR TITLE
Escape the hyphen in the hasPuncRe regex

### DIFF
--- a/kolibri/core/assets/src/validators.js
+++ b/kolibri/core/assets/src/validators.js
@@ -12,6 +12,6 @@ export function validateLinkObject(object) {
 }
 
 export function validateUsername(username) {
-  const hasPuncRe = /[\s`~!@#$%^&*()-+={}\[\]\|\\\/:;"'<>,\.\?]/; // eslint-disable-line
+  const hasPuncRe = /[\s`~!@#$%^&*()\-+={}\[\]\|\\\/:;"'<>,\.\?]/; // eslint-disable-line
   return !hasPuncRe.test(username);
 }


### PR DESCRIPTION
### Summary
1. Fixes the `hasPuncRe` regex in validators.js. The `-` should have been escaped, but was instead acting as a range operator.

Fixes #2996 

### Reviewer guidance

1. In the setup wizard, user management page, and user profile page, try creating/editing a username that has punctuation that would appear on an US-ISO keyboard. You should a some validation error appear when attempting to submit the form, or blurring the text field.

### References

#2996

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
