### PR TITLE
Re-enable "Edit on Github" because it got fixed

### DIFF
--- a/docs-developer/_static/theme_overrides.css
+++ b/docs-developer/_static/theme_overrides.css
@@ -5,12 +5,3 @@
     white-space: normal !important;
     vertical-align: top !important;
  }
-
-
-/* Removes Edit On Github until there is a fix
-   for https://github.com/rtfd/readthedocs.org/issues/3203
-*/
-.wy-breadcrumbs li.wy-breadcrumbs-aside
-{
-    display: none;
-}

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -5,12 +5,3 @@
     white-space: normal !important;
     vertical-align: top !important;
  }
-
-
-/* Removes Edit On Github until there is a fix
-   for https://github.com/rtfd/readthedocs.org/issues/3203
-*/
-.wy-breadcrumbs li.wy-breadcrumbs-aside
-{
-    display: none;
-}


### PR DESCRIPTION
### Summary

Disabled in #2850 
Fixed upstream in https://github.com/rtfd/readthedocs.org/issues/3203

Has to be sync'ed to develop after.

### Reviewer guidance

IMO we should re-introduce it on User Docs, too, until a feedback button is created to replace it.

### References

n/a

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
