### PR TITLE
remove c extensions in OSX and 64-bit archs for 0.6 releases

### DIFF
--- a/install_cexts.py
+++ b/install_cexts.py
@@ -39,10 +39,6 @@ def get_path_with_arch(platform, path):
     platform = platform.replace('x86-64', 'x86_64')
     platform = platform.replace('manylinux1', 'linux')
 
-    # For cryptography module, all the macosxs >= 10.9 are supported
-    if 'macosx' in platform:
-        platform = 'macosx'
-
     path = os.path.join(path, platform)
 
     return path
@@ -92,8 +88,15 @@ def parse_package_page(files, pk_version):
     for file in files.find_all('a'):
         file_name = file.string.split('-')
 
-        # If the file format is tar.gz or the package version is not the latest, ignore
-        if file_name[-1].split('.')[-1] != 'whl' or file_name[1] != pk_version or file_name[2][2:] == '26':
+        # We are not going to install the packages if they are:
+        #   * not a whl file
+        #   * not the version specified in requirements.txt
+        #   * not python versions that kolibri supports
+        #   * for macosx or any 64-bit platforms, since the process of setup wizard has been fast enough
+        if (
+            file_name[-1].split('.')[-1] != 'whl' or file_name[1] != pk_version or file_name[2][2:] == '26'
+            or 'macosx' in file_name[4].split('.')[0] or '64' in file_name[4].split('.')[0]
+           ):
             continue
 
         print ('Installing {}...'.format(file.string))

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -140,8 +140,6 @@ def get_cext_path(dist_path):
         else:
             dirname = os.path.join(dirname, python_version+'mu')
 
-    elif 'macosx' in platform:
-        platform = 'macosx'
     dirname = os.path.join(dirname, platform)
     sys.path = sys.path + [os.path.realpath(str(dirname))]
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to remove the c extensions in OSX and 64-bit architectures to reduce the sizes of our 0.6 installers, so the sizes of the installers will not block our 0.6 releases on PyPi.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check that in `kolibri/dist/cext` we don't have macosx or any 64-bit architecture folders

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

issue: https://github.com/learningequality/kolibri/issues/2844#issuecomment-354007717

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Link to diff of internal dependency change is included
- [x] CHANGELOG.rst is updated for high-level changes
- [x] Contributor is in AUTHORS.rst
