### PR TITLE
Improved strings formatting in modals.

### DIFF
--- a/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
@@ -44,8 +44,8 @@
       modalTitle: 'Remove User from Class',
       remove: 'Remove from Class',
       cancel: 'Cancel',
-      deleteConfirmation: 'Are you sure you want to remove { username } from { classname }?',
-      accessReassurance: 'You can still access this account from { sectionTabName }',
+      deleteConfirmation: 'Are you sure you want to remove user { username } from { classname }?',
+      accessReassurance: 'You can still access this account from the { sectionTabName } tab.',
       usersTab: 'Users',
     },
     components: {

--- a/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/class-edit-page/user-remove-modal.vue
@@ -6,8 +6,8 @@
     @cancel="close"
   >
     <div>
-      <span v-html="formattedDeleteConfirmation"> </span>
-      <p v-html="formattedAccessReassuranceConfirmation"> </p>
+      <p>{{ $tr('confirmation', { username: username, classname: classname }) }}</p>
+      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -30,13 +30,9 @@
 
 <script>
 
-  import { removeClassUser, displayModal } from '../../state/actions';
+  import * as actions from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
-
-  function bold(stringToBold) {
-    return `<strong v-html> ${stringToBold} </strong>`;
-  }
 
   export default {
     name: 'userRemoveModal',
@@ -44,9 +40,9 @@
       modalTitle: 'Remove User from Class',
       remove: 'Remove from Class',
       cancel: 'Cancel',
-      deleteConfirmation: 'Are you sure you want to remove user { username } from { classname }?',
-      accessReassurance: 'You can still access this account from the { sectionTabName } tab.',
-      usersTab: 'Users',
+      confirmation: "Are you sure you want to remove '{ username }' from '{ classname }'?",
+      description: 'You can still access this account from the tab ',
+      users: 'Users',
     },
     components: {
       kButton,
@@ -70,19 +66,6 @@
         required: true,
       },
     },
-    computed: {
-      formattedDeleteConfirmation() {
-        return this.$tr('deleteConfirmation', {
-          username: bold(this.username),
-          classname: bold(this.classname),
-        });
-      },
-      formattedAccessReassuranceConfirmation() {
-        return this.$tr('accessReassurance', {
-          sectionTabName: bold(this.$tr('usersTab')),
-        });
-      },
-    },
     methods: {
       userRemove() {
         this.removeClassUser(this.classid, this.userid);
@@ -93,8 +76,8 @@
     },
     vuex: {
       actions: {
-        removeClassUser,
-        displayModal,
+        removeClassUser: actions.removeClassUser,
+        displayModal: actions.displayModal,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -7,8 +7,7 @@
   >
     <div>
       <span v-html="formattedDeleteConfirmation"> </span>
-
-      <p>{{ $tr('description') }}</p>
+      <p v-html="formattedAccessReassuranceConfirmation"> </p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -16,7 +15,6 @@
           appearance="flat-button"
           @click="close"
         />
-
         <k-button
           :text="$tr('delete')"
           :primary="true"
@@ -32,18 +30,24 @@
 
 <script>
 
-  import * as actions from '../../state/actions';
+  import { deleteClass, displayModal } from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
+
+  function bold(stringToBold) {
+    return `<strong v-html> ${stringToBold} </strong>`;
+  }
+
   export default {
     name: 'classDeleteModal',
     $trs: {
       modalTitle: 'Delete Class',
       delete: 'Delete Class',
       cancel: 'Cancel',
-      description:
-        'Users will only be removed from the class and are still accessible from the "Users" tab.',
       deleteConfirmation: 'Are you sure you want to delete { classname }?',
+      accessReassurance:
+        'Enrolled users will be removed from the class but still accessible from the { sectionTabName } tab.',
+      usersTab: 'Users',
     },
     components: {
       kButton,
@@ -62,7 +66,12 @@
     computed: {
       formattedDeleteConfirmation() {
         return this.$tr('deleteConfirmation', {
-          classname: `<strong> ${this.classname} </strong>`,
+          classname: bold(this.classname),
+        });
+      },
+      formattedAccessReassuranceConfirmation() {
+        return this.$tr('accessReassurance', {
+          sectionTabName: bold(this.$tr('usersTab')),
         });
       },
     },
@@ -76,8 +85,8 @@
     },
     vuex: {
       actions: {
-        deleteClass: actions.deleteClass,
-        displayModal: actions.displayModal,
+        deleteClass,
+        displayModal,
       },
     },
   };

--- a/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -6,8 +6,8 @@
     @cancel="close"
   >
     <div>
-      <span v-html="formattedDeleteConfirmation"> </span>
-      <p v-html="formattedAccessReassuranceConfirmation"> </p>
+      <p>{{ $tr('confirmation', { classname: classname }) }}</p>
+      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -34,20 +34,16 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
 
-  function bold(stringToBold) {
-    return `<strong v-html> ${stringToBold} </strong>`;
-  }
-
   export default {
     name: 'classDeleteModal',
     $trs: {
       modalTitle: 'Delete Class',
       delete: 'Delete Class',
       cancel: 'Cancel',
-      deleteConfirmation: 'Are you sure you want to delete { classname }?',
-      accessReassurance:
-        'Enrolled users will be removed from the class but still accessible from the { sectionTabName } tab.',
-      usersTab: 'Users',
+      confirmation: "Are you sure you want to delete '{ classname }'?",
+      description:
+        'Enrolled users will be removed from the class but still accessible from the tab ',
+      users: 'Users',
     },
     components: {
       kButton,
@@ -61,18 +57,6 @@
       classid: {
         type: String,
         required: true,
-      },
-    },
-    computed: {
-      formattedDeleteConfirmation() {
-        return this.$tr('deleteConfirmation', {
-          classname: bold(this.classname),
-        });
-      },
-      formattedAccessReassuranceConfirmation() {
-        return this.$tr('accessReassurance', {
-          sectionTabName: bold(this.$tr('usersTab')),
-        });
       },
     },
     methods: {

--- a/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
@@ -4,21 +4,25 @@
     :title="$tr('deleteUser')"
     @cancel="closeModal()"
   >
-    <p>{{ $tr('deleteConfirmation', { username }) }}</p>
-    <div class="core-modal-buttons">
-      <k-button
-        :text="$tr('no')"
-        :primary="false"
-        appearance="flat-button"
-        @click="closeModal()"
-      />
-      <k-button
-        :text="$tr('yes')"
-        :primary="true"
-        appearance="raised-button"
-        :disabled="submitting"
-        @click="handleDeleteUser"
-      />
+    <div>
+      <span v-html="formattedDeleteConfirmation"> </span>
+      <p v-html="formattedDeleteWarning"> </p>
+    
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('cancel')"
+          :primary="false"
+          appearance="flat-button"
+          @click="closeModal()"
+        />
+        <k-button
+          :text="$tr('delete')"
+          :primary="true"
+          appearance="raised-button"
+          :disabled="submitting"
+          @click="handleDeleteUser"
+        />
+      </div>
     </div>
   </core-modal>
 
@@ -31,8 +35,19 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
 
+  function bold(stringToBold) {
+    return `<strong v-html> ${stringToBold} </strong>`;
+  }
+
   export default {
     name: 'deleteUserModal',
+    $trs: {
+      deleteUser: 'Delete user',
+      deleteConfirmation: 'Are you sure you want to delete user { username }?',
+      deleteWarning: 'All the learning records for { username } will be lost.',
+      cancel: 'Cancel',
+      delete: 'Delete',
+    },
     components: {
       coreModal,
       kButton,
@@ -56,6 +71,18 @@
         submitting: false,
       };
     },
+    computed: {
+      formattedDeleteConfirmation() {
+        return this.$tr('deleteConfirmation', {
+          username: bold(this.username),
+        });
+      },
+      formattedDeleteWarning() {
+        return this.$tr('deleteWarning', {
+          username: bold(this.username),
+        });
+      },
+    },
     methods: {
       handleDeleteUser() {
         this.submitting = true;
@@ -71,15 +98,14 @@
         displayModal,
       },
     },
-    $trs: {
-      deleteUser: 'Delete user',
-      deleteConfirmation: 'Are you sure you want to delete { username }?',
-      no: 'No',
-      yes: 'Yes',
-    },
   };
 
 </script>
 
 
-<style lang="stylus"></style>
+<style lang="stylus" scoped>
+
+  p
+    word-break: keep-all
+
+</style>

--- a/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/management/assets/src/views/user-page/delete-user-modal.vue
@@ -5,8 +5,8 @@
     @cancel="closeModal()"
   >
     <div>
-      <span v-html="formattedDeleteConfirmation"> </span>
-      <p v-html="formattedDeleteWarning"> </p>
+      <p>{{ $tr('confirmation', { username: username }) }}</p>
+      <p>{{ $tr('warning', { username: username }) }}</p>
     
       <div class="core-modal-buttons">
         <k-button
@@ -35,16 +35,12 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
 
-  function bold(stringToBold) {
-    return `<strong v-html> ${stringToBold} </strong>`;
-  }
-
   export default {
     name: 'deleteUserModal',
     $trs: {
       deleteUser: 'Delete user',
-      deleteConfirmation: 'Are you sure you want to delete user { username }?',
-      deleteWarning: 'All the learning records for { username } will be lost.',
+      confirmation: "Are you sure you want to delete '{ username }'?",
+      warning: "All the learning records for '{ username }' will be lost.",
       cancel: 'Cancel',
       delete: 'Delete',
     },
@@ -70,18 +66,6 @@
       return {
         submitting: false,
       };
-    },
-    computed: {
-      formattedDeleteConfirmation() {
-        return this.$tr('deleteConfirmation', {
-          username: bold(this.username),
-        });
-      },
-      formattedDeleteWarning() {
-        return this.$tr('deleteWarning', {
-          username: bold(this.username),
-        });
-      },
     },
     methods: {
       handleDeleteUser() {


### PR DESCRIPTION

### Summary
At first I was filing an issue, but then decided to plunge in myself... 😝 

### Reviewer guidance
Should be painless, some formatting for consistency and improved wording.

### Screenshots
#### Before
![selection_278](https://user-images.githubusercontent.com/1457929/34657188-2541a100-f424-11e7-9a37-ca3293169df3.png)

#### After
![selection_279](https://user-images.githubusercontent.com/1457929/34657191-3012c79e-f424-11e7-85c5-01c55fd3eaad.png)

#### Before
![selection_276](https://user-images.githubusercontent.com/1457929/34657208-597290a6-f424-11e7-9618-598266de4ecf.png)

#### After
![selection_277](https://user-images.githubusercontent.com/1457929/34657212-628f2186-f424-11e7-962f-2e855430830c.png)

#### Before
![selection_280](https://user-images.githubusercontent.com/1457929/34657222-75b8c5dc-f424-11e7-85a2-e17e0c0dd812.png)

#### After
![selection_282](https://user-images.githubusercontent.com/1457929/34657229-7df43ff6-f424-11e7-9001-1f424b53807a.png)

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst

cc @indirectlylit @christianmemije @jonboiser 