### PR TITLE
Better handling of optional arguments in ping command, for later Django versions.

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -31,9 +31,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        interval = float(options.get("interval", DEFAULT_PING_INTERVAL))
-        checkrate = float(options.get("checkrate", DEFAULT_PING_CHECKRATE))
-        server = options.get("server", DEFAULT_PING_SERVER_URL)
+        interval = float(options.get("interval") or DEFAULT_PING_INTERVAL)
+        checkrate = float(options.get("checkrate") or DEFAULT_PING_CHECKRATE)
+        server = options.get("server") or DEFAULT_PING_SERVER_URL
 
         self.started = datetime.now()
 


### PR DESCRIPTION
### Summary

Later versions of Django seem to have changed how they handle management command arguments that are not provided. Previously, they were not simply included in the `options` dictionary. On the `develop` branch version, they are instead included, but with a value of `None`.

I'm targeting 0.7 with this even though it doesn't affect 0.7, as we want to continue extending this management command for 0.7, and I want to minimize merge conflicts when merging upstream.

### References

Fixes https://github.com/learningequality/kolibri/issues/2967

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Link to diff of internal dependency change is included
- [x] CHANGELOG.rst is updated for high-level changes
- [x] Contributor is in AUTHORS.rst
