### PR TITLE
points is an un-clickable link with incorrect styling 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -200,6 +200,8 @@
   .points-link
     display: inline-block
     text-decoration: none
+    color: $core-status-correct
+    position: relative
 
   .points-wrapper
     margin-top: -70px

--- a/kolibri/plugins/learn/assets/src/views/total-points/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points/index.vue
@@ -56,6 +56,8 @@
     display: inline-block
     width: 20px
     height: 20px
+    position: relative
+    top: 2px
 
   .description
     display: inline-block


### PR DESCRIPTION
### Summary
Add position relative to score element.
Change the font color to core-status-correct

### Reviewer guidance
Sign in and navigate to learn page then hover and click the score link.

### References
This fixes #2937 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
