### PR TITLE
Ignore flake8 E501 (lines less than 80 chars) rule

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -116,3 +116,6 @@ commands = {[python_build_base]commands}
 whitelist_externals = {[conditional_testing_base]whitelist_externals}
 commands =
     {toxinidir}/test/if.sh "requirements_changed"
+
+[flake8]
+ignore = E501


### PR DESCRIPTION
This adds a flake8 config entry to `tox.ini` to ignore the pervasive E501 violations. For me, this simply removes the many linting errors from appearing in my text editor.