### PR TITLE
Do not create a .zip sdist, PyPi now only allows one sdist

### DIFF
--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -70,12 +70,6 @@ file_manifest = {
         'category': PYTHON_PKG_CAT,
         'content_type': 'application/zip',
     },
-    'zip': {
-        'extension': 'zip',
-        'description': 'Zip file',
-        'category': PYTHON_PKG_CAT,
-        'content_type': 'application/zip',
-    },
     'gz': {
         'extension': 'gz',
         'description': 'Tar file',
@@ -95,7 +89,6 @@ file_order = [
     'apk',
     'pex',
     'whl',
-    'zip',
     'gz',
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ buildconfig:
 
 dist: setrequirements writeversion staticdeps buildconfig assets compilemessages
 	pip install -r requirements/build.txt
-	python setup.py sdist --format=gztar,zip --static > /dev/null # silence the sdist output! Too noisy!
+	python setup.py sdist --format=gztar --static > /dev/null # silence the sdist output! Too noisy!
 	python setup.py bdist_wheel --static
 	ls -l dist
 


### PR DESCRIPTION
### Summary

*Retargeted #3007 and removed .zip from buildkite artifacts.*

Shaving off a relic.

We cannot release the .zip on PyPi, it's prohibited by their API.

The .zip sdist is from once when .whl was less integrated. I think we now only rely on the .tar.gz for purposes where special build systems like .deb needs the files in a conventional format for a static build structure.

Wondering if the Windows or Mac build is using the .zip output? I can only see that they're using the .whl in Buildkite, so would consider this safe.

### Reviewer guidance

Know of any active use of .zip?

### References

n/a - just noticed this as I was uploading releases to PyPi

Since this is release and build related, I'd rather have it implemented in an active release branch than let it sit around and wait for something to break during a 0.8 deadline sprint :)

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst

 