### PR TITLE
Update styles for Exercise Attempt Report

### DIFF
--- a/kolibri/core/assets/src/views/progress-icon/index.vue
+++ b/kolibri/core/assets/src/views/progress-icon/index.vue
@@ -46,7 +46,7 @@
     },
     computed: {
       isInProgress() {
-        return this.progress > 0 && this.progress < 1;
+        return this.progress >= 0 && this.progress < 1;
       },
       isCompleted() {
         return this.progress >= 1;

--- a/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/attempt-log-list/index.vue
@@ -7,10 +7,8 @@
       <template v-for="(attemptLog, index) in attemptLogs">
         <li
           @click="setSelectedAttemptLog(index)"
-          :class="{
-            selected: isSelected(index),
-            clickable: true
-          }"
+          class="clickable attempt-item"
+          :class="{selected: isSelected(index)}"
           :key="index"
         >
           <mat-svg
@@ -94,6 +92,7 @@
     margin: 0
     padding-left: 20px
     padding-top: 10px
+    padding-bottom: 10px
 
   .history-list
     list-style-type: none
@@ -109,6 +108,7 @@
     vertical-align: middle
     height: auto
     width: 32px
+    margin-right: 8px
 
   .svg-hint
     fill: $core-text-annotation
@@ -122,7 +122,7 @@
   .svg-noattempt
     fill: $core-text-annotation
 
-  li
+  .attempt-item
     clear: both
     min-width: 120px
     border-bottom: 2px solid $core-text-disabled

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
@@ -2,39 +2,63 @@
 
   <div class="attempt-summary">
     <div class="column pure-u-3-4">
-      <div class="user-name-container">
-        <mat-svg
-          class="svg-item"
-          category="action"
-          name="face"
-        />
-        <h1 class="user-name">{{ userName }}</h1>
+      <div class="summary-item">
+        <div class="icon">
+          <mat-svg
+            class="svg-item"
+            category="action"
+            name="face"
+          />
+        </div>
+        <span class="user-name">
+          {{ userName }}
+        </span>
       </div>
-      <div class="exercise-name">
-        <content-icon class="svg-icon" :kind="kind" />
-        {{ exerciseTitle }}
+
+      <div class="summary-item">
+        <div class="icon">
+          <content-icon
+            class="svg-icon"
+            :kind="kind"
+          />
+        </div>
+        <span class="exercise-name">
+          {{ exerciseTitle }}
+        </span>
       </div>
-      <div :class="{'in-progress': !isCompleted, 'requirements': true}">
-        <progress-icon class="svg-icon" :progress="summaryLog.progress" />
-        {{ requirementsString }}
+
+      <div
+        :class="{'in-progress': !isCompleted}"
+        class="summary-item"
+      >
+        <div class="icon">
+          <progress-icon
+            class="svg-icon"
+            :progress="summaryLog.progress"
+          />
+        </div>
+        <span>
+          {{ requirementsString }}
+        </span>
       </div>
+
     </div>
+
     <div class="column pure-u-1-4">
       <div class="status">
-        <progress-icon class="svg-icon" :progress="summaryLog.progress" />
-        <span v-if="isCompleted">
-          <strong> {{ $tr('statusMastered') }} </strong>
-          <br>
-          <elapsed-time :date="dateCompleted" />
-        </span>
-        <span v-else-if="isCompleted !== null">
-          <strong> {{ $tr('statusInProgress') }} </strong>
-          <br>
-          <elapsed-time :date="dateLastAttempted" />
-        </span>
-        <span v-else>
-          <strong> {{ $tr('notStarted') }} </strong>
-        </span>
+        <div class="status-text">
+          <progress-icon
+            class="svg-icon"
+            :progress="summaryLog.progress"
+          />
+          <strong>{{ statusText }}</strong>
+        </div>
+        <div
+          class="update-time"
+          v-if="isCompleted || isCompleted !== null"
+        >
+          <elapsed-time :date="updateTime" />
+        </div>
       </div>
     </div>
   </div>
@@ -110,6 +134,24 @@
           throw e;
         }
       },
+      statusText() {
+        if (this.isCompleted) {
+          return this.$tr('statusMastered');
+        } else if (this.isCompleted !== null) {
+          return this.$tr('statusInProgress');
+        } else {
+          return this.$tr('notStarted');
+        }
+      },
+      updateTime() {
+        if (this.isCompleted) {
+          return this.dateCompleted;
+        } else if (this.isCompleted !== null) {
+          return this.dateLastAttempted;
+        } else {
+          return null;
+        }
+      },
       requirementsString() {
         try {
           const requirements = this.summaryLog.currentmasterylog.mastery_criterion;
@@ -137,20 +179,16 @@
 
   .attempt-summary
     background-color: $core-bg-light
-    height: 100%
 
-  .user-name-container
-    display: block
+  .user-name
+    font-size: 24px
+    font-weight: bold
+
+  .exercise-name
+    font-weight: bold
 
   .svg-icon
     font-size: 1.3em
-
-  .exercise-name
-    margin-top: 10px
-    font-weight: bold
-
-  .requirements
-    margin-top: 10px
 
   .in-progress
     color: $core-grey
@@ -159,16 +197,31 @@
     display: inline-block
     vertical-align: middle
 
-  .user-name
-    display: inline-block
-    vertical-align: middle
-    margin: 0
-
   .column
     float: left
 
   .status
     float: right
     text-align: right
+
+  .icon
+    display: inline-block
+    margin-right: 16px
+    width: 24px
+
+  .summary-item
+    margin: 8px 0
+    vertical-align: baseline
+    span
+      vertical-align: inherit
+
+  .status-text
+    margin-top: 8px
+    .svg-icon
+      margin-right: 8px
+
+  .update-time
+    padding: 4px 0
+    font-size: 12px
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -10,14 +10,14 @@
           :summaryLog="summaryLog" />
       </div>
       <div class="details-container">
-        <div class="attempt-log-container">
+        <div class="attempt-log-container pure-u-1-3">
           <attempt-log-list
             :attemptLogs="attemptLogs"
             :selectedQuestionNumber="attemptLogIndex"
             @select="navigateToNewAttempt($event)"
           />
         </div>
-        <div class="exercise-container">
+        <div class="exercise-container pure-u-2-3">
           <interaction-list
             :interactions="currentInteractionHistory"
             :selectedInteractionIndex="interactionIndex"

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -2,7 +2,7 @@
 
   <immersive-full-screen :backPageLink="backPageLink" :backPageText="backPageText">
     <template>
-      <div class="summary-container">
+      <div class="pure-u-1-1">
         <attempt-summary
           :exerciseTitle="exercise.title"
           :userName="user.full_name"
@@ -163,12 +163,6 @@
   @require '~kolibri.styles.definitions'
 
   $container-side-padding = 15px
-
-  .summary-container
-    padding-top: $container-side-padding
-    padding-left: $container-side-padding
-    padding-right: $container-side-padding
-    height: 15%
 
   .details-container
     width: 100%


### PR DESCRIPTION
### Summary

Tries to get the Exercise Attempt Report closer to the mockups

https://projects.invisionapp.com/share/XDDT27QP9#/screens/270100332

1. Adds additional margin and padding to give different elements more room
1. Minor refactoring and code style change
1. Change progress-icon to show the inprogress icon even if progress is exactly "0" (e.g. user started an exercise, but did not get anything right).
1. Use Pure CSS grid to get consistency on Grid element padding, widths, etc.

### Reviewer guidance

Compare these screenshots

**Before**
![screen shot 2018-01-09 at 3 41 08 pm](https://user-images.githubusercontent.com/10248067/34749418-2fbc2fb4-f556-11e7-87de-794139b67e12.png)
**After** (not shown: in-progress icon fix)
![screen shot 2018-01-09 at 3 40 50 pm](https://user-images.githubusercontent.com/10248067/34749423-3a575110-f556-11e7-9f90-cf679a325da9.png)

**Before**
![screen shot 2018-01-09 at 3 39 02 pm](https://user-images.githubusercontent.com/10248067/34749421-34bc8d24-f556-11e7-852e-88399630aee3.png)

**After**
![screen shot 2018-01-09 at 3 38 40 pm](https://user-images.githubusercontent.com/10248067/34749426-3e00d4f8-f556-11e7-8064-e0a1593b0097.png)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
