### PR TITLE
Reset to defaults settings need to refresh the page.

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/constants.js
+++ b/kolibri/plugins/facility_management/assets/src/constants.js
@@ -27,6 +27,7 @@ const defaultFacilityConfig = {
   learnerCanEditPassword: true,
   learnerCanSignUp: true,
   learnerCanDeleteAccount: true,
+  learnerCanLoginWithNoPassword: false,
 };
 
 const notificationTypes = {


### PR DESCRIPTION

### Summary
Add the learnerCanLoginWithNoPassword at the defaultFacilityConfig.


### Reviewer guidance
Navigate at facility settings page and check the `allow learners to sign in with no password` checkbox and click the `reset default settings` button.

### References
This fixes #3049 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
