### PR TITLE
Prevent facility name from having more than 100 characters

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
@@ -39,6 +39,7 @@
         'A Facility is the location where you are installing Kolibri, such as a school or training center.',
       facilityNameFieldLabel: 'Facility name',
       facilityNameFieldEmptyErrorMessage: 'Facility cannot be empty',
+      facilityNameFieldMaxLengthReached: 'Facility name cannot be more than 100 characters',
     },
     props: {
       submitText: {
@@ -56,6 +57,9 @@
       facilityNameErrorMessage() {
         if (this.facilityName === '') {
           return this.$tr('facilityNameFieldEmptyErrorMessage');
+        }
+        if (this.facilityName.length > 100) {
+          return this.$tr('facilityNameFieldMaxLengthReached');
         }
         return '';
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When a facility name has more than 100 characters, it triggers a server error:
```
"facility":{"name":["Ensure this field has no more than 100 characters."]}}
```

Let's add a client-side validation to prevent this from happening.

![screen shot 2018-01-10 at 4 50 13 pm](https://user-images.githubusercontent.com/27984604/34763501-6a120f32-f626-11e7-8675-0014c91a076b.png)


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#2270 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
