### PR TITLE
Single quotes instead of bolding for user generated strings in modals

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -5,7 +5,7 @@
     @cancel="close"
   >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
-    <p>{{ $tr('learnersWillBecome') }} <strong>{{ $tr('ungrouped') }}</strong>.</p>
+    <p>{{ $tr('learnersWillBecomeUngrouped') }}</p>
     <div class="core-modal-buttons">
       <k-button
         :text="$tr('cancel')"
@@ -34,8 +34,7 @@
     $trs: {
       deleteLearnerGroup: 'Delete Learner Group',
       areYouSure: "Are you sure you want to delete '{ groupName }'?",
-      learnersWillBecome: 'Learners within this group will become',
-      ungrouped: 'Ungrouped',
+      learnersWillBecomeUngrouped: "Learners within this group will become 'Ungrouped'.",
       cancel: 'Cancel',
       deleteGroup: 'Delete Group',
     },

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -4,11 +4,7 @@
     :title="$tr('moveLearners')"
     @cancel="close"
   >
-    <p>
-      {{ $tr('moveThe') }}
-      <strong>{{ $tr('learners', {count: usersToMove.length }) }}</strong>
-      {{ $tr('to') }}:
-    </p>
+    <p>{{ $tr('moveLearnerCount', {count: usersToMove.length }) }}</p>
     <k-radio-button
       v-for="group in groupsExcludingCurrent"
       :key="group.id"
@@ -59,9 +55,8 @@
     name: 'moveLearnersModal',
     $trs: {
       moveLearners: 'Move Learners',
-      moveThe: 'Move the',
-      to: 'to',
-      learners: '{count, number, integer} {count, plural, one {Learner} other {Learners}}',
+      moveLearnerCount:
+        'Move {count, number, integer} {count, plural, one {learner} other {learners}} to:',
       ungrouped: 'Ungrouped',
       cancel: 'Cancel',
       move: 'Move',

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-modal.vue
@@ -6,8 +6,8 @@
     @cancel="close"
   >
     <div>
-      <span v-html="formattedDeleteConfirmation"> </span>
-      <p v-html="formattedAccessReassuranceConfirmation"> </p>
+      <p>{{ $tr('confirmation', { username: username, classname: classname }) }}</p>
+      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -34,19 +34,15 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
 
-  function bold(stringToBold) {
-    return `<strong v-html> ${stringToBold} </strong>`;
-  }
-
   export default {
     name: 'userRemoveModal',
     $trs: {
       modalTitle: 'Remove User from Class',
       remove: 'Remove from Class',
       cancel: 'Cancel',
-      deleteConfirmation: 'Are you sure you want to remove { username } from { classname }?',
-      accessReassurance: 'You can still access this account from { sectionTabName }',
-      usersTab: 'Users',
+      confirmation: "Are you sure you want to remove '{ username }' from '{ classname }'?",
+      description: 'You can still access this account from the tab ',
+      users: 'Users',
     },
     components: {
       kButton,
@@ -68,19 +64,6 @@
       userid: {
         type: String,
         required: true,
-      },
-    },
-    computed: {
-      formattedDeleteConfirmation() {
-        return this.$tr('deleteConfirmation', {
-          username: bold(this.username),
-          classname: bold(this.classname),
-        });
-      },
-      formattedAccessReassuranceConfirmation() {
-        return this.$tr('accessReassurance', {
-          sectionTabName: bold(this.$tr('usersTab')),
-        });
       },
     },
     methods: {

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-modal.vue
@@ -7,7 +7,7 @@
   >
     <div>
       <p>{{ $tr('confirmation', { username: username, classname: classname }) }}</p>
-      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
+      <p>{{ $tr('description') }}</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -41,8 +41,7 @@
       remove: 'Remove from Class',
       cancel: 'Cancel',
       confirmation: "Are you sure you want to remove '{ username }' from '{ classname }'?",
-      description: 'You can still access this account from the tab ',
-      users: 'Users',
+      description: "You can still access this account from the 'Users' tab.",
     },
     components: {
       kButton,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -42,7 +42,7 @@
       cancel: 'Cancel',
       confirmation: "Are you sure you want to delete '{ classname }'?",
       description:
-        "Enrolled users will be removed from the class but still accessible from the 'Users' tab.",
+        "Enrolled users will be removed from the class but remain accessible from the 'Users' tab.",
     },
     components: {
       kButton,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -7,7 +7,7 @@
   >
     <div>
       <p>{{ $tr('confirmation', { classname: classname }) }}</p>
-      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
+      <p>{{ $tr('description') }}</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -41,9 +41,7 @@
       delete: 'Delete Class',
       cancel: 'Cancel',
       confirmation: "Are you sure you want to delete '{ classname }'?",
-      description:
-        'Enrolled users will be removed from the class but still accessible from the tab ',
-      users: 'Users',
+      description:  "Enrolled users will be removed from the class but still accessible from the 'Users' tab.",
     },
     components: {
       kButton,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -41,7 +41,8 @@
       delete: 'Delete Class',
       cancel: 'Cancel',
       confirmation: "Are you sure you want to delete '{ classname }'?",
-      description:  "Enrolled users will be removed from the class but still accessible from the 'Users' tab.",
+      description:
+        "Enrolled users will be removed from the class but still accessible from the 'Users' tab.",
     },
     components: {
       kButton,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -6,9 +6,8 @@
     @cancel="close"
   >
     <div>
-      <span v-html="formattedDeleteConfirmation"> </span>
-
-      <p>{{ $tr('description') }}</p>
+      <p>{{ $tr('confirmation', { classname: classname }) }}</p>
+      <p>{{ $tr('description') }} <strong>{{ $tr('users') }}</strong>.</p>
 
       <div class="core-modal-buttons">
         <k-button
@@ -41,9 +40,10 @@
       modalTitle: 'Delete Class',
       delete: 'Delete Class',
       cancel: 'Cancel',
+      confirmation: "Are you sure you want to delete '{ classname }'?",
       description:
-        'Users will only be removed from the class and are still accessible from the "Users" tab.',
-      deleteConfirmation: 'Are you sure you want to delete { classname }?',
+        'Enrolled users will be removed from the class but still accessible from the tab ',
+      users: 'Users',
     },
     components: {
       kButton,
@@ -57,13 +57,6 @@
       classid: {
         type: String,
         required: true,
-      },
-    },
-    computed: {
-      formattedDeleteConfirmation() {
-        return this.$tr('deleteConfirmation', {
-          classname: `<strong> ${this.classname} </strong>`,
-        });
       },
     },
     methods: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
@@ -4,21 +4,25 @@
     :title="$tr('deleteUser')"
     @cancel="closeModal()"
   >
-    <p>{{ $tr('deleteConfirmation', { username }) }}</p>
-    <div class="core-modal-buttons">
-      <k-button
-        :text="$tr('no')"
-        :primary="false"
-        appearance="flat-button"
-        @click="closeModal()"
-      />
-      <k-button
-        :text="$tr('yes')"
-        :primary="true"
-        appearance="raised-button"
-        :disabled="submitting"
-        @click="handleDeleteUser"
-      />
+    <div>
+      <p>{{ $tr('confirmation', { username: username }) }}</p>
+      <p>{{ $tr('warning', { username: username }) }}</p>
+    
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('cancel')"
+          :primary="false"
+          appearance="flat-button"
+          @click="closeModal()"
+        />
+        <k-button
+          :text="$tr('delete')"
+          :primary="true"
+          appearance="raised-button"
+          :disabled="submitting"
+          @click="handleDeleteUser"
+        />
+      </div>
     </div>
   </core-modal>
 
@@ -33,6 +37,13 @@
 
   export default {
     name: 'deleteUserModal',
+    $trs: {
+      deleteUser: 'Delete user',
+      confirmation: "Are you sure you want to delete '{ username }'?",
+      warning: "All the learning records for '{ username }' will be lost.",
+      cancel: 'Cancel',
+      delete: 'Delete',
+    },
     components: {
       coreModal,
       kButton,
@@ -70,12 +81,6 @@
         deleteUser,
         displayModal,
       },
-    },
-    $trs: {
-      deleteUser: 'Delete user',
-      deleteConfirmation: 'Are you sure you want to delete { username }?',
-      no: 'No',
-      yes: 'Yes',
     },
   };
 

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
@@ -4,25 +4,23 @@
     :title="$tr('deleteUser')"
     @cancel="closeModal()"
   >
-    <div>
-      <p>{{ $tr('confirmation', { username: username }) }}</p>
-      <p>{{ $tr('warning', { username: username }) }}</p>
-    
-      <div class="core-modal-buttons">
-        <k-button
-          :text="$tr('cancel')"
-          :primary="false"
-          appearance="flat-button"
-          @click="closeModal()"
-        />
-        <k-button
-          :text="$tr('delete')"
-          :primary="true"
-          appearance="raised-button"
-          :disabled="submitting"
-          @click="handleDeleteUser"
-        />
-      </div>
+    <p>{{ $tr('confirmation', { username: username }) }}</p>
+    <p>{{ $tr('warning', { username: username }) }}</p>
+  
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        :primary="false"
+        appearance="flat-button"
+        @click="closeModal()"
+      />
+      <k-button
+        :text="$tr('delete')"
+        :primary="true"
+        appearance="raised-button"
+        :disabled="submitting"
+        @click="handleDeleteUser"
+      />
     </div>
   </core-modal>
 


### PR DESCRIPTION

### Summary

Supersedes  #3041 (conflicts), included previously requested changes. 

### Screenshots
#### Before
![selection_278](https://user-images.githubusercontent.com/1457929/34657188-2541a100-f424-11e7-9a37-ca3293169df3.png)

#### After
![selection_288](https://user-images.githubusercontent.com/1457929/34809649-9b3955a0-f696-11e7-9327-ed08b4579a59.png)


#### Before
![selection_276](https://user-images.githubusercontent.com/1457929/34657208-597290a6-f424-11e7-9618-598266de4ecf.png)

#### After
![selection_289](https://user-images.githubusercontent.com/1457929/34809658-ace275f2-f696-11e7-8672-87095ad306d4.png)


#### Before
![selection_280](https://user-images.githubusercontent.com/1457929/34657222-75b8c5dc-f424-11e7-85a2-e17e0c0dd812.png)

#### After
![selection_287](https://user-images.githubusercontent.com/1457929/34809661-b5328922-f696-11e7-9d12-0f1615898383.png)

cc @indirectlylit 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
