### PR TITLE
Add KOLIBRI_RUN_MODE envvar to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
+    KOLIBRI_RUN_MODE = tox
 basepython =
     pythonbuild2.7: python2.7
     pythonbuild3.4: python3.4
@@ -43,6 +44,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.postgres_test
+    KOLIBRI_RUN_MODE = tox
 basepython =
     postgres: python3.5
 deps =


### PR DESCRIPTION
### Summary

Needed in order to identify pingbacks triggered by tox builds, so we can filter them out.

### Reviewer guidance

As long as tests still pass, no further testing needed.

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
