### PR TITLE
Precision to the `make clean` chain of commands

### DIFF
--- a/docs-developer/start/getting_started.rst
+++ b/docs-developer/start/getting_started.rst
@@ -131,7 +131,7 @@ To install Kolibri project-specific dependencies make sure you're in the ``kolib
 
 .. tip::
 
-  * We've adopted this concatenated version with added cleanup: ``make clean && pip install -r requirements.txt --upgrade && pip install -e . && yarn install``.
+  * We've adopted this concatenated version with added cleanup: ``pip install -r requirements/dev.txt --upgrade && make clean && pip install -e . && yarn install``.
   * In case you get webpack compilation error with Node modules build failures, add the flag ``--force`` at the end, to ensure binaries get installed.
 
 


### PR DESCRIPTION
### Summary

If you have out-dated requirements, `make clean` will likely fail. Example: On 0.7 we use Django 1.9 and in current develop its Django 1.11, thus `make clean` fails because it invokes `kolibri manage`

### Reviewer guidance

n/a

### References

n/a

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
