### PR TITLE
Dramatically reduce pyup to every other week

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,7 +1,7 @@
 # update schedule
 # default: empty
 # allowed: "every day", "every week", ..
-schedule: "every day"
+schedule: "every two weeks on monday"
 
 # DON'T CHANGE, BECAUSE WHEN SOMEONE ADDS A NEW REQ
 # FILE IN requirements/ IT WON'T BE SCANNED


### PR DESCRIPTION
### Summary

I recommend just merging this now :) Here's my rationale:

Firstly, sorry fpr all these PyUp PRs, I had opened a PR to shut it down during the holidays, but it never got merged.

I'll delete all stale branches as well.

With this config, it now runs every other Monday. Initially of course you were right @indirectlylit @jamalex , it was very much overkill to have it running so often, and really hard to deal with the PRs because they mixed together upgrades of many deps, and having them in individual PRs was even more of a mayhem.

I thought about it this way: Although it's really nice to be notified and deal with these updates timely, so we don't heap up lots of updates, then there's also this problem:

* A lot of dependencies update more frequently than we release.
* After we release something, there will inevitably be more dependency updates that end-users miss out on

Ultimately, it doesn't make sense to have a frequent, individual process for each and every dependency.

The rate at which we got hit by updates without even having a single release shows this quite well :)

### Reviewer guidance

n/a

### References

n/a

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
