### PR TITLE
Upgrade prettier to 1.10

### DIFF
--- a/frontend_build/src/extract_$trs.js
+++ b/frontend_build/src/extract_$trs.js
@@ -118,15 +118,19 @@ extract$trs.prototype.apply = function(compiler) {
                     // Check that the trs id is camelCase.
                     if (!isCamelCase(message.key.name)) {
                       logging.error(
-                        `$trs id "${message.key
-                          .name}" should be in camelCase. Found in ${module.resource}`
+                        `$trs id "${message.key.name}" should be in camelCase. Found in ${
+                          module.resource
+                        }`
                       );
                     }
                     // Check that the value is valid, and not an expression
                     if (!message.value.value) {
                       logging.error(
-                        `The value for $trs "${message.key
-                          .name}", is not valid. Make sure it is not an expression. Found in ${module.resource}.`
+                        `The value for $trs "${
+                          message.key.name
+                        }", is not valid. Make sure it is not an expression. Found in ${
+                          module.resource
+                        }.`
                       );
                     } else {
                       messages[message.key.name] = message.value.value;
@@ -220,7 +224,9 @@ extract$trs.prototype.apply = function(compiler) {
                     messageNameSpace = varScope[firstArg.name].value;
                   } else {
                     logging.warn(
-                      `Translator object called with undefined name space argument in ${module.resource}`
+                      `Translator object called with undefined name space argument in ${
+                        module.resource
+                      }`
                     );
                   }
                 }
@@ -235,7 +241,9 @@ extract$trs.prototype.apply = function(compiler) {
                     messages = generateMessagesObject(varScope[secondArg.name]);
                   } else {
                     logging.warn(
-                      `Translator object called with undefined messages argument in ${module.resource}`
+                      `Translator object called with undefined messages argument in ${
+                        module.resource
+                      }`
                     );
                   }
                 }

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -82,9 +82,10 @@ var readBundlePlugins = function(base_dir) {
   }
 
   // A bundle can specify a modification to the coreAPI.
-  var coreAPISpec = (_.find(bundles, function(bundle) {
-    return bundle.coreAPISpec;
-  }) || {}
+  var coreAPISpec = (
+    _.find(bundles, function(bundle) {
+      return bundle.coreAPISpec;
+    }) || {}
   ).coreAPISpec;
 
   // Check that there is only one bundle modifying the coreAPI spec.

--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -80,12 +80,13 @@ const client = options => {
     .wrap(disconnectInterceptor)
     .wrap(mime, { mime: 'application/json' })
     .wrap(loginTimeoutDetection)
-    .wrap(serverDisconnectDetection)(options).then(response => {
-    if (response.request && response.request.canceled) {
-      return Promise.reject(response);
-    }
-    return response;
-  });
+    .wrap(serverDisconnectDetection)(options)
+    .then(response => {
+      if (response.request && response.request.canceled) {
+        return Promise.reject(response);
+      }
+      return response;
+    });
 };
 
 export default client;

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -55,10 +55,9 @@ export default class CoreApp {
 
     // Shim window.location.origin for IE.
     if (!window.location.origin) {
-      window.location.origin = `${window.location.protocol}//${window.location.hostname}${window
-        .location.port
-        ? `:${window.location.port}`
-        : ''}`;
+      window.location.origin = `${window.location.protocol}//${window.location.hostname}${
+        window.location.port ? `:${window.location.port}` : ''
+      }`;
     }
 
     const intlReady = () => {

--- a/kolibri/core/assets/src/kolibri_module.js
+++ b/kolibri/core/assets/src/kolibri_module.js
@@ -15,11 +15,11 @@ export default class KolibriModule {
     return [];
   }
   /**
-  * The constructor function for the base KolibriModule object.
-  * @param {object} options - an options hash to set properties of the object.
-  * @param {Array} args - any additional arguments that will be passed to initialize.
-  * @constructor
-  */
+   * The constructor function for the base KolibriModule object.
+   * @param {object} options - an options hash to set properties of the object.
+   * @param {Array} args - any additional arguments that will be passed to initialize.
+   * @constructor
+   */
   constructor(options, ...args) {
     /* eslint-disable no-undef */
     // __kolibriModuleName is replaced during webpack compilation with the name derived from

--- a/kolibri/core/assets/src/utils/browser.js
+++ b/kolibri/core/assets/src/utils/browser.js
@@ -3,9 +3,9 @@ export function redirectBrowser(url) {
 }
 
 /**
-  * Detects whether an Android device is using WebView.
-  * Based on https://developer.chrome.com/multidevice/user-agent#webview_user_agent
-  */
+ * Detects whether an Android device is using WebView.
+ * Based on https://developer.chrome.com/multidevice/user-agent#webview_user_agent
+ */
 export function isAndroidWebView() {
   const ua = window.navigator.userAgent;
   const isAndroid = /Android/.test(ua);

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -55,7 +55,7 @@ const ContentReportResource = new ContentReportResourceConstructor();
  * @param {string} classId -
  * @returns {Promise} that resolves channel with lastActive value in object:
  *   { 'channelId': dateOfLastActivity }
-*/
+ */
 function channelLastActivePromise(channel, userScope, userScopeId) {
   const summaryPayload = {
     channel_id: channel.id,

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -621,7 +621,7 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
     // prettier-ignore
     [contentId]: ({
       [itemId]: currentAttemptLog,
-    }),
+    })
   });
   const pageState = Object.assign(store.state.pageState);
   pageState.currentAttempt = currentAttemptLog;
@@ -650,7 +650,7 @@ function setAndSaveCurrentExamAttemptLog(store, contentId, itemId, currentAttemp
           // prettier-ignore
           [contentId]: ({
           [itemId]: log,
-        }),
+        })
         });
         const questionsAnswered = calcQuestionsAnswered(store.state.examAttemptLogs);
         store.dispatch('SET_QUESTIONS_ANSWERED', questionsAnswered);

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mocha": "^4.0.1",
     "node-sass": "^4.5.0",
     "postcss-loader": "^2.0.6",
-    "prettier": "^1.4.2",
+    "prettier": "^1.10.2",
     "rewire": "^2.5.2",
     "sass-loader": "^6.0.6",
     "shelljs": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "commander": "^2.9.0",
     "css-loader": "^0.28.7",
     "eslint": "^4.2.0",
-    "eslint-config-prettier": "^2.3.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-vue": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,7 +4674,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.2, prettier@^1.7.0:
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+
+prettier@^1.7.0:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,9 +1741,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-prettier@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
   dependencies:
     get-stdin "^5.0.1"
 


### PR DESCRIPTION
### Summary

Upgrades prettier to 1.10, and fixes a few files after the update.

In [this branch](https://github.com/jonboiser/kolibri/tree/prettier-vue), I applied Prettier 1.10's built-in formatting for Vue components, but it results in a large diff since it follows the common Vue conventions of 

1. no newlines after <script>, and 
2. no top-level indentation inside of <script>. 

It does not look like prettier will allow configurations to support these conventions.

### Reviewer guidance

The formatting changes in 1.10 are minor, and including support for JS Doc, and template strings. They look mostly safe.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
