### PR TITLE
language switcher is not wide enough

### DIFF
--- a/kolibri/core/assets/src/views/k-select/index.vue
+++ b/kolibri/core/assets/src/views/k-select/index.vue
@@ -142,7 +142,7 @@
   .k-select-inline
     display: inline-block
     vertical-align: bottom
-    width: 100px
+    width: auto
     margin-right: 16px
 
 </style>

--- a/kolibri/core/assets/src/views/k-select/index.vue
+++ b/kolibri/core/assets/src/views/k-select/index.vue
@@ -142,7 +142,7 @@
   .k-select-inline
     display: inline-block
     vertical-align: bottom
-    width: auto
+    width: 100px
     margin-right: 16px
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -140,4 +140,11 @@
   .language-list-dropdown
     margin-bottom: 8px
 
+  .language-list-dropdown.k-select-inline
+      width: auto
+
+  >>>.ui-select__label-text.is-inline
+    margin-right: 2em
+    width: auto
+
 </style>


### PR DESCRIPTION

### Summary

Adjust the width of the select languages button.

### Reviewer guidance
![screen shot 2018-01-15 at 5 43 01 pm](https://user-images.githubusercontent.com/8663934/34936582-ec91d3bc-fa1c-11e7-9e60-c8dabf513a60.png)


### References
This fixes #2593 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Link to diff of internal dependency change is included
- [x] CHANGELOG.rst is updated for high-level changes
- [x] Contributor is in AUTHORS.rst
