### PR TITLE
Enforce closing bracket spacing eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,5 +80,6 @@ module.exports = {
         multiline: 'always',
       },
     ],
+    'vue/html-closing-bracket-spacing': ['error'],
   },
 };

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -28,7 +28,7 @@
       >
         <polygon stroke-width="0" :points="contentIconBgCoords" />
       </svg>
-      <content-icon :kind="kind" class="content-icon"/>
+      <content-icon :kind="kind" class="content-icon" />
     </div>
 
     <div class="progress-bar-wrapper">


### PR DESCRIPTION
### Summary

Enforces the [vue/html-closing-bracket-spacing](https://github.com/vuejs/eslint-plugin-vue#uncategorized) eslint rule

### Reviewer guidance

Not much.

### References

N/A

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
