### PR TITLE
Point to upstream of css-element-queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "array-includes": "^3.0.3",
     "core-js": "^2.4.1",
-    "css-element-queries": "https://github.com/learningequality/css-element-queries",
+    "css-element-queries": "1.0.1",
     "date-fns": "^1.28.2",
     "engine-strict": "^1.0.0",
     "filesize": "^3.3.0 ",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,9 +1181,9 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-"css-element-queries@https://github.com/learningequality/css-element-queries":
-  version "0.3.2"
-  resolved "https://github.com/learningequality/css-element-queries#7b680b619ffcb657f26b49fb301fcc23f8f9922d"
+css-element-queries@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-1.0.1.tgz#dd14970dd66a7634ec59028fee3820f2a7eff8a8"
 
 css-loader@^0.28.7:
   version "0.28.7"


### PR DESCRIPTION
### Summary

[My fix got merged into upstream](https://github.com/marcj/css-element-queries/pull/201) :tada:, so now we can point to it again.

### Reviewer guidance

Make sure resize sensor still works in rtl.

### References

https://github.com/marcj/css-element-queries/pull/201

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
