### PR TITLE
Fix content unavailable link

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-unavailable-page/index.vue
@@ -3,7 +3,7 @@
   <div>
     <h1>{{ $tr('header') }}</h1>
     <p>
-      <k-external-link :text="$tr('adminLink')" href="/management/device#/content" />
+      <k-external-link :text="$tr('adminLink')" href="/device/#/content" />
     </p>
   </div>
 


### PR DESCRIPTION
### Summary
Fixes issue [#3089](https://github.com/learningequality/kolibri/issues/3089)
Changed content-unavailable-page index.vue link at line 6 to link specified in issue
Navigated to page and link is now correct

### Reviewer guidance
**Steps to reproduce**
- remove all content
- go to 'learn' as a superuser
- click link

### References
Issue [#3089](https://github.com/learningequality/kolibri/issues/3089)

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
