### PR TITLE
update windows installer to 1.1.1

### DIFF
--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -14,7 +14,7 @@ make writeversion
 cd $KOLIBRI_DOCKER_PATH
 git clone https://github.com/learningequality/kolibri-installer-windows.git
 cd kolibri-installer-windows
-git checkout v1.1.0
+git checkout v1.1.1
 
 # Copy kolbri whl file at KOLIBRI_WINDOWS_PATH path.
 cd $PARENT_PATH


### PR DESCRIPTION

### Summary

Updates windows installer to latest patch, with these changes: https://github.com/learningequality/kolibri-installer-windows/pull/59/files

### Reviewer guidance

Test 0.7.x on Windows and ensure that the latest fixes are in

### References

Summary of changes: https://github.com/learningequality/kolibri-installer-windows/milestone/2?closed=1

fixes #3043

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
