### PR TITLE
Resolve dev docs warnings

### DIFF
--- a/docs-developer/architecture/content/implementation.rst
+++ b/docs-developer/architecture/content/implementation.rst
@@ -62,7 +62,7 @@ A router that decides what content database to read from based on a thread-local
 ContentNode
 -----------
 
-``ContentNode`` is implemented as a Django model that inherits from two abstract classes, MPTTModel and ContentDatabaseModel. 
+``ContentNode`` is implemented as a Django model that inherits from two abstract classes, MPTTModel and ContentDatabaseModel.
 `django-mptt's MPTTModel <http://django-mptt.github.io/django-mptt/>`_, which
 allows for efficient traversal and querying of the ContentNode tree.
 ``ContentDatabaseModel`` is used as a marker so that the content_db_router knows to query against the content database only if the model inherits from ContentDatabaseModel.
@@ -87,9 +87,9 @@ Content Constants
 
 A Python module that stores constants for the ``kind`` field in ContentNode model and the ``preset`` field and ``extension`` field in File model.
 
-.. automodule:: kolibri.content.constants.content_kinds
-.. automodule:: kolibri.content.constants.extensions
-.. automodule:: kolibri.content.constants.presets
+.. automodule:: le_utils.constants.content_kinds
+.. automodule:: le_utils.constants.file_formats
+.. automodule:: le_utils.constants.format_presets
 
 Workflows
 ---------

--- a/docs-developer/architecture/dataflow/index.rst
+++ b/docs-developer/architecture/dataflow/index.rst
@@ -136,6 +136,7 @@ For particular views on a data table (which could range from 'show me everything
 Collections are a cached view onto the data table, which are populated by Models - so if a Model that has previously been fetched from the server by a Collection is requested from :code:`getModel`, it is already cachced.
 
 .. code-block:: javascript
+
   // corresponds to /api/content/<channelId>/contentnode/?popular=1
   const contentCollection = ContentNodeResource.getCollection({ channel_id: channelId }, { popular: 1 });
 

--- a/docs-developer/architecture/frontend_architecture.rst
+++ b/docs-developer/architecture/frontend_architecture.rst
@@ -115,7 +115,7 @@ The ``ready`` method will be automatically executed once the Module is loaded an
 Content Renderers
 ~~~~~~~~~~~~~~~~~
 
-A special kind of Kolibri Module is dedicated to rendering particular content types. All content renderers should extend the ``ContentRendererModule`` class found in `kolibri/core/assets/src/content_renderer_module.js`. In addition, rather than subclassing the ``WebpackBundleHook`` class, content renderers should be defined in the Python code using the ``ContentRendererHook`` class defined in ``kolibri.content.hooks``. In addition to the standard options for the ``WebpackBundleHook``, the ``ContentRendererHook`` also accepts a json file defining the content types that it renders::
+A special kind of Kolibri Module is dedicated to rendering particular content types. All content renderers should extend the ``ContentRendererModule`` class found in `kolibri/core/assets/src/content_renderer_module.js`. In addition, rather than subclassing the ``WebpackBundleHook`` class, content renderers should be defined in the Python code using the ``ContentRendererHook`` class defined in ``kolibri.content.hooks``. In addition to the standard options for the ``WebpackBundleHook``, the ``ContentRendererHook`` also accepts a json file defining the content types that it renders.
 
 .. automodule:: kolibri.content.hooks
     :members:

--- a/docs-developer/architecture/frontend_architecture.rst
+++ b/docs-developer/architecture/frontend_architecture.rst
@@ -12,7 +12,7 @@ Each component contains HTML with dynamic Vue.js directives, styling which is sc
 
 Components allow us to define new custom tags that encapsulate a piece of self-contained, re-usable UI functionality. When composed together, they form a tree structure of parents and children. Each component has a well-defined interface used by its parent component, made up of `input properties <https://vuejs.org/guide/components.html#Props>`_, `events <https://vuejs.org/guide/components.html#Custom-Events>`_ and `content slots <https://vuejs.org/guide/components.html#Content-Distribution-with-Slots>`_. Components should never reference their parent.
 
-Read through :doc:`conventions` for some important consistency tips on writing new components.
+Read through :doc:`/references/conventions` for some important consistency tips on writing new components.
 
 
 Layout of Frontend Code
@@ -69,7 +69,7 @@ In the example above, the *vue/another-page/index.vue* file in *learn* can use o
 
   For many development scenarios, only files in these directories need to be touched.
 
-  There is also a lot of logic and configuration relevant to front-end code loading, parsing, testing, and linting. This includes webpack, NPM, and integration with the plugin system. This is somewhat scattered, and includes logic in *frontend_build/...*, *package.json*, *kolibri/core/webpack/...*, and other locations. Much of this functionality is described in other sections of the docs (such as :doc:`asset_loading`), but it can take some time to understand how it all hangs together.
+  There is also a lot of logic and configuration relevant to front-end code loading, parsing, testing, and linting. This includes webpack, NPM, and integration with the plugin system. This is somewhat scattered, and includes logic in *frontend_build/...*, *package.json*, *kolibri/core/webpack/...*, and other locations. Much of this functionality is described in other sections of the docs (such as :doc:`/pipeline/frontend_build_pipeline`), but it can take some time to understand how it all hangs together.
 
 
 SVG Icons
@@ -106,7 +106,7 @@ Defining a New Kolibri Module
 
   This section is mostly relevant if you are creating a new app or plugin. If you are just creating new components, you don't need to do this.
 
-A Kolibri Module is initially defined in Python by sub-classing the ``WebpackBundleHook`` class (in ``kolibri.core.webpack.hooks``). The hook defines the JS entry point (conventionally called *app.js*) where the ``KolibriModule`` subclass is instantiated, and where events and callbacks on the module are registered. These are defined in the ``events`` and ``once`` properties. Each defines key-value pairs of the name of an event, and the name of the method on the ``KolibriModule`` object. When these events are triggered on the Kolibri core JavaScript app, these callbacks will be called. (If the ``KolibriModule`` is registered for asynchronous loading, the Kolibri Module will first be loaded, and then the callbacks called when it is ready. See :doc:`asset_loading` for more information.)
+A Kolibri Module is initially defined in Python by sub-classing the ``WebpackBundleHook`` class (in ``kolibri.core.webpack.hooks``). The hook defines the JS entry point (conventionally called *app.js*) where the ``KolibriModule`` subclass is instantiated, and where events and callbacks on the module are registered. These are defined in the ``events`` and ``once`` properties. Each defines key-value pairs of the name of an event, and the name of the method on the ``KolibriModule`` object. When these events are triggered on the Kolibri core JavaScript app, these callbacks will be called. (If the ``KolibriModule`` is registered for asynchronous loading, the Kolibri Module will first be loaded, and then the callbacks called when it is ready. See :doc:`/pipeline/frontend_build_pipeline` for more information.)
 
 All apps should extend the ``KolibriModule`` class found in `kolibri/core/assets/src/kolibri_module.js`.
 
@@ -188,7 +188,7 @@ And many others. The complete specification for commonly shared modules can be f
   const vue = require('kolibri.lib.vue');
   const coreBase = require('kolibri.coreVue.components.coreBase');
 
-Adding additional globally-available objects is relatively straightforward due to the `plugin and webpack build system <asset_loading>`_.
+Adding additional globally-available objects is relatively straightforward due to the `plugin and webpack build system </pipeline/frontend_build_pipeline>`_.
 
 To expose something on the core app, add a key to the object in `apiSpec.js` which maps to an object with the following keys:
 

--- a/docs-developer/architecture/plugins.rst
+++ b/docs-developer/architecture/plugins.rst
@@ -23,7 +23,7 @@ Kolibri Javascript code. Each of these Javascript plugins are defined in the `ko
 ``KolibriFrontEndPluginBase`` class to define each frontend Kolibri module. This defines the base Javascript file that
 defines the Kolibri module. In addition, this Plugin object within the app will automatically add these Kolibri modules
 to an internal frontend asset registry for loading in the front end. For more information on developing frontend code
-for Kolibri please see :doc:`frontend`.
+for Kolibri please see :doc:`/architecture/frontend_architecture`.
 
 Plugins can be standalone Django apps in their own right, meaning they can define templates, models, new urls, and
 views just like any other app. However the API for all of this hasn't yet been determined... Coming soon!

--- a/docs-developer/conf.py
+++ b/docs-developer/conf.py
@@ -115,7 +115,7 @@ release = kolibri.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'py_modules/kolibri*rst', 'py_modules/modules.rst']
+exclude_patterns = ['_build']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs-developer/conf.py
+++ b/docs-developer/conf.py
@@ -115,7 +115,7 @@ release = kolibri.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'py_modules/kolibri*rst', 'py_modules/modules.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs-developer/pipeline/frontend_build_pipeline.rst
+++ b/docs-developer/pipeline/frontend_build_pipeline.rst
@@ -3,7 +3,7 @@ Front-end build pipeline
 
 Asset pipelining is done using Webpack - this allows the use of require to import modules - as such all written code should be highly modular, individual files should be responsible for exporting a single function or object.
 
-There are two distinct entities that control this behaviour - a Kolibri Hook on the Python side, which manages the registration of the frontend code within Django (and also facilitates building of that code into compiled assets with Webpack) and a Kolibri Module (a subclass of ``KolibriModule``) on the JavaScript side (see :doc:`frontend`).
+There are two distinct entities that control this behaviour - a Kolibri Hook on the Python side, which manages the registration of the frontend code within Django (and also facilitates building of that code into compiled assets with Webpack) and a Kolibri Module (a subclass of ``KolibriModule``) on the JavaScript side (see :doc:`/architecture/frontend_architecture`).
 
 Kolibri has a system for synchronously and asynchronously loading these bundled JavaScript modules which is mediated by a small core JavaScript app, ``kolibriGlobal``. Kolibri Modules define to which events they subscribe, and asynchronously registered Kolibri Modules are loaded by ``kolibriGlobal`` only when those events are triggered. For example if the Video Viewer's Kolibri Module subscribes to the *content_loaded:video* event, then when that event is triggered on ``kolibriGlobal`` it will asynchronously load the Video Viewer module and re-trigger the *content_loaded:video* event on the object the module returns.
 

--- a/docs-developer/references/i18n.rst
+++ b/docs-developer/references/i18n.rst
@@ -18,17 +18,17 @@ Frontend Translation
 
 For any strings in the frontend, we are using `Vue-Intl <https://www.npmjs.com/package/vue-intl>`_ an in house port of `React-intl <https://www.npmjs.com/package/react-intl>`_.
 
-Within Kolibri, messages are defined on the body of the Vue component::
+Within Kolibri, messages are defined on the body of the Vue component:
 
-  - ``$trs``, an object of the form::
+- ``$trs``, an object of the form::
 
     {
       msgId: 'Message text',
     }
 
-  - ``name``, we use the Vue component name to namespace the messages.
+- ``name``, we use the Vue component name to namespace the messages.
 
-The ``name`` and all ``msgId``s should be in camelCase.
+The ``name`` and every ``msgId`` should be in camelCase.
 
 User visible strings should be rendered directly in the template with ``{{ $tr('msgId') }}``. These strings are collected during the build process, and bundled into exported JSON files. These files are then uploaded to Crowdin for translation.
 

--- a/docs-developer/references/manual_testing.rst
+++ b/docs-developer/references/manual_testing.rst
@@ -16,10 +16,10 @@ Inclusive design benefits all users, and we strive to make Kolibri accessible fo
 
 Here are a few tools that we use in testing for accessibility:
 
-* WAVE Evaluation Tool - `Firefox Add-on <https://addons.mozilla.org/en-US/firefox/addon/wave-accessibility-tool/>`_ and `Chrome extension <https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh>`_.
+* WAVE Evaluation Tool - `Firefox Add-on <https://addons.mozilla.org/en-US/firefox/addon/wave-accessibility-tool/>`__ and `Chrome extension <https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh>`__.
 * `tota11y <http://khan.github.io/tota11y/>`_ accessibility visualization toolkit - bookmarklet for Firefox and Chrome.
 * `Accessibility Developer Tools <https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb>`_ - Chrome extension.
-* aXe Accessibility Engine - `Firefox Add-on <https://addons.mozilla.org/en-us/firefox/addon/axe-devtools/>`_ and `Chrome extension <https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd>`_.
+* aXe Accessibility Engine - `Firefox Add-on <https://addons.mozilla.org/en-us/firefox/addon/axe-devtools/>`__ and `Chrome extension <https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd>`__.
 
 There is a much longer list on our `Kolibri Accessibility Tools Wiki page <https://github.com/learningequality/kolibri/wiki/Accessibility-Resources-(Tools)>`_ if you want to go deeper, but these four should be enough to help you avoid the most important accessibility pitfalls.
 

--- a/docs-developer/start/getting_started.rst
+++ b/docs-developer/start/getting_started.rst
@@ -371,7 +371,7 @@ All changes should be thoroughly tested and vetted before being merged in. Our p
  * Localization
  * Consistency
 
-For more information, see the next section on :doc:`manual_testing`.
+For more information, see the next section on :doc:`/references/manual_testing`.
 
 
 Submitting a Pull Request

--- a/kolibri/content/hooks.py
+++ b/kolibri/content/hooks.py
@@ -24,9 +24,12 @@ _JSON_CONTENT_TYPES_CACHE = {}
 class ContentRendererHook(WebpackBundleHook):
     """
     An inheritable hook that allows special behaviour for a frontend module that defines
-    a content renderer.
+    a content renderer. Reads a JSON file detailing the kinds and file extensions that the
+    renderer can handle.
+    """
 
-    Reads a JSON file of this format:
+    """
+    JSON file format:
     {
         "kinds": [
             {
@@ -50,7 +53,6 @@ class ContentRendererHook(WebpackBundleHook):
             }
         ]
     }
-    Detailing the kinds and file extensions that the renderer can handle.
     """
 
     # Set local path to content type JSON that details the kind, extension pairs this deals with.

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -27,15 +27,13 @@ class Exam(AbstractFacilityDataModel):
     channel_id = models.CharField(max_length=32)
     # Number of total questions this exam has
     question_count = models.IntegerField()
-    """
-    JSON blob describing content ids for the assessments this exam draws from, and how many
-    questions each assessment contributes to the exam. e.g.:
-
-    [
-        {"exercise_id": <content_id1>, "number_of_questions": 6},
-        {"exercise_id": <content_id2>, "number_of_questions": 5}
-    ]
-    """
+    # JSON blob describing content ids for the assessments this exam draws from, and how many
+    # questions each assessment contributes to the exam. e.g.:
+    #
+    # [
+    #     {"exercise_id": <content_id1>, "number_of_questions": 6},
+    #     {"exercise_id": <content_id2>, "number_of_questions": 5}
+    # ]
     question_sources = JSONField(default=[], blank=True)
     # The random seed we use to decide which questions are in the exam
     seed = models.IntegerField(default=1)

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -156,7 +156,8 @@ class WebpackBundleHook(hooks.KolibriHook):
         customize this.
 
         :returns: A dict with information expected by webpack parsing process,
-        or None if the src_file does not exist.
+            or None if the src_file does not exist.
+
         """
         if os.path.exists(os.path.join(os.path.dirname(self._build_path), self.src_file)):
             return {

--- a/kolibri/plugins/device_management/templatetags/device_management_tags.py
+++ b/kolibri/plugins/device_management/templatetags/device_management_tags.py
@@ -1,6 +1,6 @@
 """
 Device Management template tags
-========================
+===============================
 
 Tags for including management app javascript assets in a template. To use:
 

--- a/kolibri/plugins/facility_management/templatetags/facility_management_tags.py
+++ b/kolibri/plugins/facility_management/templatetags/facility_management_tags.py
@@ -1,6 +1,6 @@
 """
 Facility Management template tags
-========================
+=================================
 
 Tags for including management app javascript assets in a template. To use:
 

--- a/kolibri/plugins/setup_wizard/templatetags/setup_wizard_tags.py
+++ b/kolibri/plugins/setup_wizard/templatetags/setup_wizard_tags.py
@@ -1,6 +1,6 @@
 """
 setup_wizard template tags
-===================
+==========================
 
 Tags for including setup_wizard app javascript assets ina template. To use:
 

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -9,7 +9,7 @@ def is_external_plugin(appname):
     Returns true when the given app is an external plugin.
 
     Implementation note: does a simple check on the name to see if it's
-    prefixed with "kolibri_". If so, we think it's a plugin.
+    prefixed with "kolibri\_". If so, we think it's a plugin.
     '''
 
     return appname.startswith(EXTERNAL_PLUGINS_PREFIX)

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -211,9 +211,10 @@ def get_status():  # noqa: max-complexity=16
     The behavior is also quite redundant given that `kalite start` should
     always create a PID file, and if its been started directly with the
     runserver command, then its up to the developer to know what's happening.
+
     :returns: (PID, address, port), where address is not currently detected in
-              a valid way because it's not configurable, and we might be
-              listening on several IPs.
+        a valid way because it's not configurable, and we might be
+        listening on several IPs.
     :raises: NotRunning
     """
 

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -212,7 +212,8 @@ def get_version_from_git(get_git_describe_string):
     Fetches the latest git tag (NB! broken behavior!)
 
     :returns: A validated tuple, same format as kolibri.VERSION, but with extra
-    data suffixed. Example: (1, 2, 3, 'alpha', '1-123-f12345')
+        data suffixed. Example: (1, 2, 3, 'alpha', '1-123-f12345')
+
     """
     git_tag_validity_check = re.compile(
         r'v(?P<version>\d+\.\d+(\.\d+)?)'

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -282,8 +282,8 @@ def get_prerelease_version(version):
     Called when kolibri.VERSION is set to a non-final version:
 
     if version ==
-    *, *, *, "alpha", 0: Maps to latest commit timestamp
-    *, *, *, "alpha", >0: Uses latest git tag, asserting that there is such.
+    \*, \*, \*, "alpha", 0: Maps to latest commit timestamp
+    \*, \*, \*, "alpha", >0: Uses latest git tag, asserting that there is such.
     """
 
     major = get_major_version(version)


### PR DESCRIPTION
### Summary
This change resolves approximately 40 warnings when building the developer docs using sphinx. This has the side effect of fixing broken links throughout the docs by updating their references and fixing docstring formatting output. Resolved warnings include

- ImportError: no module named ______
- Error in code block directive
- Unexpected indentation
- Duplicate explicit target name
- Unknown document
- Inline literal start-string without end-string
- Title underline too short
- Inline emphasis start-string without end-string
- Unknown target name

These changes were in response to issue 2960 (referenced below). I believe I was able to resolve all of the warnings in that issue, though it seems like many more have popped up since that issue was created. Many of these issue are related to .rst files in docs-developer/py_modules. Since those files are not under source control, I was not able to fix them.

### Reviewer guidance
To test these changes, navigate to the docs-developer folder and run `sphinx-build -aE ./ ./_build/`. On my machine, 134 warnings still appear (down from 175 warnings before changes). Ensure that these warnings fall into 3 categories:

- more than one target found for cross-reference u'DateTimeTzField' : kolibri.core.serializers.DateTimeTzField, kolibri.core.fields.DateTimeTzField
- document isn't included in any toctree
- duplicate object description ... use :noindex: for one of them

I was unable to resolve these warnings and this pull request does not include fixes for them. All other build warnings should be resolved.

### References
 Issue [2960](https://github.com/learningequality/kolibri/issues/2960)

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
