### PR TITLE
Centralize lookup of KOLIBRI_HOME

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,11 @@
     -   id: check-added-large-files
     -   id: debug-statements
     -   id: end-of-file-fixer
--   repo: git://github.com/FalconSocial/pre-commit-python-sorter
-    sha: b57843b0b874df1d16eb0bef00b868792cb245c2
+-   repo: https://github.com/asottile/reorder_python_imports
+    sha: v0.3.5
     hooks:
-    -   id: python-import-sorter
-        args:
-        - --silent-overwrite
+    -   id: reorder-python-imports
+        language_version: python2.7
 -   repo: local
     hooks:
       -   id: frontend-prettify

--- a/docs-developer/conf.py
+++ b/docs-developer/conf.py
@@ -3,15 +3,14 @@
 # Kolibri 'developer docs' build configuration file
 #
 # This file is execfile()d with the current directory set to its containing dir.
-
-import django
 import inspect
 import os
 import sys
-
 from datetime import datetime
-from django.utils.html import strip_tags
+
+import django
 from django.utils.encoding import force_text
+from django.utils.html import strip_tags
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -20,8 +19,6 @@ cwd = os.getcwd()
 parent = os.path.dirname(cwd)
 sys.path.insert(0, os.path.abspath(parent))
 
-# This import *must* come after the path insertion, otherwise sphinx won't be able to find the kolibri module
-import kolibri  # noqa
 
 builddir = os.path.join(cwd, '_build')
 
@@ -29,10 +26,13 @@ builddir = os.path.join(cwd, '_build')
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
 os.environ["KOLIBRI_HOME"] = os.path.join(builddir, 'kolibri_home')
 
-if not os.path.exists(os.environ["KOLIBRI_HOME"]):
-    os.mkdir(os.environ["KOLIBRI_HOME"])
+
+# This import *must* come after the path insertion, otherwise sphinx won't be able to find the kolibri module
+import kolibri  # noqa
+
 
 django.setup()
+
 
 # Monkey patch this so we don't have any complaints during Sphinx inspect
 from django.db.models.fields import files  # noqa

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -8,24 +8,28 @@ https://docs.djangoproject.com/en/1.9/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-# import kolibri, so we can get the path to the module.
-import kolibri
 import pytz
+from tzlocal import get_localzone
+
+import kolibri
+from kolibri.utils import conf
+from kolibri.utils import i18n
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+# import kolibri, so we can get the path to the module.
 # we load other utilities related to i18n
 # This is essential! We load the kolibri conf INSIDE the Django conf
-from kolibri.utils import conf, i18n
-from tzlocal import get_localzone
 
 KOLIBRI_MODULE_PATH = os.path.dirname(kolibri.__file__)
 
 BASE_DIR = os.path.abspath(os.path.dirname(__name__))
 
-KOLIBRI_HOME = os.environ['KOLIBRI_HOME']
+KOLIBRI_HOME = conf.KOLIBRI_HOME
 
 KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import importlib  # noqa
 import logging  # noqa
@@ -105,7 +107,10 @@ def version_file():
     During test runtime, this path may differ because KOLIBRI_HOME is
     regenerated
     """
-    return os.path.join(os.environ['KOLIBRI_HOME'], '.data_version')
+    return os.path.join(
+        os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"])),
+        '.data_version'
+    )
 
 
 def initialize(debug=False):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -8,9 +8,11 @@ import ifcfg
 import requests
 from django.conf import settings
 from django.core.management import call_command
-from kolibri.content.utils import paths
 
-from .system import kill_pid, pid_exists
+from .system import kill_pid
+from .system import pid_exists
+from kolibri.content.utils import paths
+from kolibri.utils.conf import KOLIBRI_HOME
 
 logger = logging.getLogger(__name__)
 
@@ -28,15 +30,15 @@ STATUS_PID_FILE_INVALID = 100
 STATUS_UNKNOWN = 101
 
 # Used to store PID and port number (both in foreground and daemon mode)
-PID_FILE = os.path.join(os.environ['KOLIBRI_HOME'], "server.pid")
+PID_FILE = os.path.join(KOLIBRI_HOME, "server.pid")
 
 # Used to PID, port during certain exclusive startup process, before we fork
 # to daemon mode
-STARTUP_LOCK = os.path.join(os.environ['KOLIBRI_HOME'], "server.lock")
+STARTUP_LOCK = os.path.join(KOLIBRI_HOME, "server.lock")
 
 # This is a special file with daemon activity. It logs ALL stderr output, some
 # might not have made it to the log file!
-DAEMON_LOG = os.path.join(os.environ['KOLIBRI_HOME'], "server.log")
+DAEMON_LOG = os.path.join(KOLIBRI_HOME, "server.log")
 
 # Currently non-configurable until we know how to properly handle this
 LISTEN_ADDRESS = "0.0.0.0"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r base.txt
 flake8==3.5.0
-pre-commit==1.4.1
+pre-commit==1.5.1
 tox==2.9.1
 django-debug-panel==0.8.3
 django-debug-toolbar==1.9.1


### PR DESCRIPTION
### Summary

 * Adds consistency to how `KOLIBRI_HOME` is read
 * Replaces the pre-commit hook for import sorting with the much better `reorder_python_imports`

The fix in #3130 will not work for all cases in the codebase unless this PR is merged.

#3128 and #3130 are an example of how something should *not* be perceived as a global constant when it's in fact a system environment. It should be a configuration value, read from one central location.

Later on, we could make `kolibri.utils.conf.KOLIBRI_HOME` a lazy module property -- but I think this can be done when necessary. So far, it's just `kolibri.utils.cli.version_file` that seems to need such re-loading from the system environment (and for testing purposes only!).

### Reviewer guidance

n/a

### References

#3130 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
