### PR TITLE
Get more control of which pex builds the release

### DIFF
--- a/.buildkite/build_pex.sh
+++ b/.buildkite/build_pex.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-pip install pex                 # pex is really the only thing we need here.
+pip install pex\<1.3  # pex is really the only thing we need here.
 buildkite-agent artifact download 'dist/*.whl' dist/
 make pex
 buildkite-agent artifact upload 'dist/*.pex'

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,6 +5,6 @@ sphinx
 sphinx-intl
 sphinx-rtd-theme
 sphinx-autobuild
-pex
+pex<1.3
 wheel
 setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore


### PR DESCRIPTION
### Summary

We should be slightly more deliberate about which Pex version we use before we've suddenly released some unknown bug into the wild, we know that Pex is a source of issues already: https://github.com/learningequality/kolibri/issues/1710

### Reviewer guidance

n/a

### References

https://github.com/learningequality/kolibri/issues/1710

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] ~Contributor has fully tested the PR manually~
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
