### PR TITLE
Bump current branch to develop stage

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -3,7 +3,7 @@ from .utils.version import get_version
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 7, 0, 'final', 0)
+VERSION = (0, 7, 1, 'alpha', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION
### Summary

Before doing another beta release, let's get this corrected at least.

Would work nicely with #3116 

New behavior after the version bump:

```
➜  kolibri git:(release-v0.7.x) python -m kolibri --version
WARNING:root:No C Extensions available for this platform.

0.7.1.dev020180129151351-git
```

### Reviewer guidance

n/a - I would think: Just merge this now?

### References

n/a

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
