### PR TITLE
Cherry-pick automated pre-release versioning fix from #3116 for 0.7.1

### DIFF
--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -22,7 +22,7 @@ cp $PARENT_PATH/dist/*.whl $KOLIBRI_WINDOWS_PATH
 
 # Build kolibri windows installer docker image.
 cd $KOLIBRI_DOCKER_PATH
-KOLIBRI_VERSION=$(cat $PARENT_PATH/kolibri/VERSION)
+KOLIBRI_VERSION=$(cat $PARENT_PATH/kolibri/VERSION | sed -s 's/+/_/g')
 DOCKER_BUILD_CMD="docker build -t $KOLIBRI_VERSION-build ."
 $DOCKER_BUILD_CMD
 if [ $? -ne 0 ]; then

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ dist: setrequirements writeversion staticdeps buildconfig assets compilemessages
 	ls -l dist
 
 pex: writeversion
-	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION`.pex -m kolibri --python-shebang=/usr/bin/python; done
+	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed -s 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python; done
 
 makedocsmessages:
 	make -C docs/ gettext
@@ -134,10 +134,10 @@ dockerenvclean:
 	docker image prune -f
 
 dockerenvbuild: writeversion
-	docker image build -t learningequality/kolibri:$$(cat kolibri/VERSION) -t learningequality/kolibri:latest .
+	docker image build -t "learningequality/kolibri:$$(cat kolibri/VERSION | sed -s 's/+/_/g')" -t learningequality/kolibri:latest .
 
 dockerenvdist: writeversion
-	docker run --env-file ./env.list -v $$PWD/dist:/kolibridist learningequality/kolibri:$$(cat kolibri/VERSION)
+	docker run --env-file ./env.list -v $$PWD/dist:/kolibridist "learningequality/kolibri:$$(cat kolibri/VERSION | sed -s 's/+/_/g')"
 
 kolibripippex:
 	git clone https://github.com/learningequality/pip.git

--- a/docs-developer/release_process.rst
+++ b/docs-developer/release_process.rst
@@ -144,6 +144,11 @@ Copy the entries from the changelog into Github's "Release notes".
     chronology will break. Do not add tags in feature branches or in the master
     branch. You can add tags for pre-releases in ``develop``, for releases that don't yet have a release branch.
 
+.. warning:: Tagging is known to break after rebasing, so in case you rebase
+    a branch after tagging it, delete the tag and add it again. Basically,
+    ``git describe --tags`` detects the closest tag, but after a rebase, its
+    concept of distance is misguided.
+
 
 Release to PyPI
 ~~~~~~~~~~~~~~~

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -83,6 +83,15 @@ class TestKolibriVersion(unittest.TestCase):
         v = get_version((0, 1, 0, "alpha", 1))
         self.assertIn("0.1.0a1", v)
 
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git-2-gfd48a7a")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    def test_version_file_local_git_version(self, describe_mock, file_mock):
+        """
+        Test that a version file with git describe output is correctly parsed
+        """
+        v = get_version((0, 7, 1, "beta", 1))
+        self.assertIn("0.7.1b1.dev+git-2-gfd48a7a", v)
+
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
     @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
     def test_alpha_0_inconsistent_version_file(self, get_git_changeset_mock, describe_mock):
@@ -145,12 +154,12 @@ class TestKolibriVersion(unittest.TestCase):
 
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b1")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.0.1")
-    @mock.patch('kolibri.utils.version.get_git_changeset', return_value="-git123")
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value="+git123")
     def test_version_file_ignored(self, get_git_changeset_mock, describe_mock, file_mock):
         """
         Test that the VERSION file is NOT used where git data is available
         """
-        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0.dev0-git123"
+        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0.dev+git123"
 
     def test_alpha_1_inconsistent_git(self):
         """
@@ -185,7 +194,7 @@ class TestKolibriVersion(unittest.TestCase):
         """
         Test that we get the git describe data when it's there
         """
-        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git-123-abcdfe12"
 
     @mock.patch('subprocess.Popen')
     def test_git_describe_parser(self, popen_mock):
@@ -196,7 +205,7 @@ class TestKolibriVersion(unittest.TestCase):
         attrs = {'communicate.return_value': ('v0.1.0-beta1-123-abcdfe12', '')}
         process_mock.configure_mock(**attrs)
         popen_mock.return_value = process_mock
-        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git-123-abcdfe12"
 
     @mock.patch('subprocess.Popen')
     @mock.patch('kolibri.utils.version.get_version_file', return_value=None)

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -4,9 +4,9 @@ Tests for `kolibri` module.
 from __future__ import absolute_import, print_function, unicode_literals
 
 import unittest
-from functools import wraps
 
 import kolibri
+import mock
 from kolibri.utils import version
 
 #: Because we don't want to call the original (decorated function), it uses
@@ -19,23 +19,6 @@ def dont_call_me_maybe(msg):
     raise AssertionError(msg)
 
 
-def mock_get_git_describe(func):
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-
-        # Simple mocking
-        git_describe = version.get_git_describe
-        version.get_git_describe = lambda *x: None
-        try:
-            ret_val = func(*args, **kwargs)
-        finally:
-            version.get_git_describe = git_describe
-        return ret_val
-
-    return wrapper
-
-
 class TestKolibriVersion(unittest.TestCase):
 
     def test_version(self):
@@ -45,8 +28,9 @@ class TestKolibriVersion(unittest.TestCase):
         major_version_tuple = "{}.{}".format(*kolibri.VERSION[0:2])
         self.assertIn(major_version_tuple, kolibri.__version__)
 
-    @mock_get_git_describe
-    def test_alpha_0_version(self):
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
+    def test_alpha_0_version(self, file_mock, describe_mock):
         """
         Test that when doing something with a 0th alpha doesn't provoke any
         hickups with ``git describe --tag``.
@@ -54,23 +38,19 @@ class TestKolibriVersion(unittest.TestCase):
         v = get_version((0, 1, 0, "alpha", 0))
         self.assertIn("0.1.0.dev", v)
 
-    def test_alpha_1_version(self):
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
+    def test_alpha_1_version(self, file_mock, describe_mock):
         """
         Test some normal alpha version, but don't assert that the
         ``git describe --tag`` is consistent (it will change in future test
         runs)
         """
-        # Simple mocking
-        assert_version = version.assert_git_version
-        version.assert_git_version = lambda *x: True
-        try:
-            v = get_version((0, 1, 0, "alpha", 1))
-            self.assertIn("0.1.0a1", v)
-        finally:
-            version.assert_git_version = assert_version
+        v = get_version((0, 1, 0, "alpha", 1))
+        self.assertIn("0.1.0a1", v)
 
-    @mock_get_git_describe
-    def test_alpha_1_version_no_git(self):
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    def test_alpha_1_version_no_git(self, describe_mock):
         """
         Not running from git and no VERSION file.
         """
@@ -83,52 +63,94 @@ class TestKolibriVersion(unittest.TestCase):
         finally:
             version.get_version_file = get_version_file
 
-    @mock_get_git_describe
-    def test_alpha_1_version_file(self):
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0a1")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    def test_alpha_1_version_file(self, describe_mock, file_mock):
         """
         Test that a simple 0.1a1 works when loaded from a VERSION file
         """
-        # Simple mocking
-        get_version_file = version.get_version_file
-        version.get_version_file = lambda: "0.1.0a1"
-        try:
-            v = get_version((0, 1, 0, "alpha", 1))
-            self.assertIn("0.1.0a1", v)
-        finally:
-            version.get_version_file = get_version_file
+        v = get_version((0, 1, 0, "alpha", 1))
+        self.assertIn("0.1.0a1", v)
 
-    @mock_get_git_describe
-    def test_version_file_linebreaks(self):
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0a1\n")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    def test_version_file_linebreaks(self, describe_mock, file_mock):
         """
         Test that line breaks don't get included in the final version
 
         See: https://github.com/learningequality/kolibri/issues/2464
         """
-        # Simple mocking
-        get_version_file = version.get_version_file
-        version.get_version_file = lambda: "0.1.0a1\n"
-        try:
-            v = get_version((0, 1, 0, "alpha", 1))
-            self.assertIn("0.1.0a1", v)
-        finally:
-            version.get_version_file = get_version_file
+        v = get_version((0, 1, 0, "alpha", 1))
+        self.assertIn("0.1.0a1", v)
 
-    @mock_get_git_describe
-    def test_alpha_1_inconsistent_version_file(self):
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_alpha_0_inconsistent_version_file(self, get_git_changeset_mock, describe_mock):
         """
         Test that inconsistent file data also just fails
         """
         # Simple mocking
         get_version_file = version.get_version_file
-        version.get_version_file = lambda: "0.2.0a1"
-        try:
-            self.assertRaises(
-                AssertionError,
-                get_version,
-                (0, 1, 0, "alpha", 1)
-            )
-        finally:
-            version.get_version_file = get_version_file
+        inconsistent_versions = ("0.2.0a1", "0.1.1a1", "0.1.0")
+        for v in inconsistent_versions:
+            version.get_version_file = lambda: v
+            try:
+                self.assertRaises(
+                    AssertionError,
+                    get_version,
+                    (0, 1, 0, "alpha", 0)
+                )
+            finally:
+                version.get_version_file = get_version_file
+
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_alpha_1_inconsistent_version_file(self, get_git_changeset_mock, describe_mock):
+        """
+        Test that inconsistent file data also just fails
+        """
+        # Simple mocking
+        get_version_file = version.get_version_file
+        inconsistent_versions = ("0.2.0a1", "0.1.1a1", "0.1.0")
+        for v in inconsistent_versions:
+            version.get_version_file = lambda: v
+            try:
+                self.assertRaises(
+                    AssertionError,
+                    get_version,
+                    (0, 1, 0, "alpha", 1)
+                )
+            finally:
+                version.get_version_file = get_version_file
+
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b1")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_alpha_0_consistent_version_file(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION file can overwrite an alpha-0 (dev) state.
+        Because a prerelease can be made with a version file.
+        """
+        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0b1"
+
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b2")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_beta_1_consistent_version_file(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION file can overwrite an beta-1 state in case the
+        version was bumped in ``kolibri.VERSION``.
+        """
+        assert get_version((0, 1, 0, "beta", 1)) == "0.1.0b2"
+
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b1")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.0.1")
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value="-git123")
+    def test_version_file_ignored(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that the VERSION file is NOT used where git data is available
+        """
+        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0.dev0-git123"
 
     def test_alpha_1_inconsistent_git(self):
         """
@@ -137,57 +159,99 @@ class TestKolibriVersion(unittest.TestCase):
         # Simple mocking
         git_describe = version.get_git_describe
         try:
-            version.get_git_describe = lambda *x: 'v0.2.0-beta1-29-gc61d5f4'
+            version.get_git_describe = lambda *x: 'v0.2.0-beta1'
             self.assertRaises(
                 AssertionError,
                 get_version,
                 (0, 1, 0, "alpha", 1)
             )
-            version.get_git_describe = lambda *x: 'v0.2.0-beta2-29-gc61d5f4'
+            version.get_git_describe = lambda *x: 'v0.2.0-beta2'
             self.assertRaises(
                 AssertionError,
                 get_version,
                 (0, 1, 0, "beta", 0)
             )
-            version.get_git_describe = lambda *x: 'v0.1.0-beta2-29-gc61d5f4'
+            version.get_git_describe = lambda *x: 'v0.1.0'
             self.assertRaises(
                 AssertionError,
                 get_version,
-                (0, 1, 0, "beta", 1)
+                (0, 1, 0, "alpha", 0)
             )
         finally:
             version.get_git_describe = git_describe
 
-    @mock_get_git_describe
-    def test_final(self):
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.1.0-beta1-123-abcdfe12")
+    def test_alpha_1_consistent_git(self, describe_mock):
+        """
+        Test that we get the git describe data when it's there
+        """
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev-123-abcdfe12"
+
+    @mock.patch('subprocess.Popen')
+    def test_git_describe_parser(self, popen_mock):
+        """
+        Test that we get the git describe data when it's there
+        """
+        process_mock = mock.Mock()
+        attrs = {'communicate.return_value': ('v0.1.0-beta1-123-abcdfe12', '')}
+        process_mock.configure_mock(**attrs)
+        popen_mock.return_value = process_mock
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev-123-abcdfe12"
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
+    def test_git_random_tag(self, file_mock, popen_mock):
+        """
+        Test that we don't fail if some random tag appears
+        """
+        process_mock = mock.Mock()
+        attrs = {'communicate.return_value': ('foobar', '')}
+        process_mock.configure_mock(**attrs)
+        popen_mock.return_value = process_mock
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0a1"
+
+    @mock.patch('subprocess.Popen', side_effect=EnvironmentError())
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0a2")
+    def test_prerelease_no_git(self, file_mock, popen_mock):
+        """
+        Test that we don't fail and that the version file is used
+        """
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0a2"
+
+    @mock.patch('kolibri.utils.version.get_complete_version', side_effect=lambda x: x if x else (0, 2, 0, 'alpha', 2))
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.2.0-beta1")
+    def test_beta_1_git(self, describe_mock, complete_mock):
+        """
+        Test that we use git tag data when our version is alpha
+        """
+        self.assertEqual(
+            get_version(),
+            '0.2.0b1'
+        )
+
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    def test_final(self, describe_mock):
         """
         Test that the major version is set as expected on a final release
         """
         v = get_version((0, 1, 0, "final", 0))
         self.assertEqual(v, "0.1.0")
+        assert describe_mock.call_count == 0
 
-    def test_final_patch(self):
+    @mock.patch('kolibri.utils.version.get_git_describe')
+    def test_final_patch(self, describe_mock):
         """
         Test that the major version is set as expected on a final release
         """
-        # Simple mocking
-        git_describe = version.get_git_describe
-        version.get_git_describe = lambda *x: dont_call_me_maybe("get_git_describe called")
-        try:
-            v = get_version((0, 1, 1, "final", 0))
-            self.assertEqual(v, "0.1.1")
-        finally:
-            version.get_git_describe = git_describe
+        v = get_version((0, 1, 1, "final", 0))
+        self.assertEqual(v, "0.1.1")
+        assert describe_mock.call_count == 0
 
-    def test_final_post(self):
+    @mock.patch('kolibri.utils.version.get_git_describe')
+    def test_final_post(self, describe_mock):
         """
         Test that the major version is set as expected on a final release
         """
-        # Simple mocking
-        git_describe = version.get_git_describe
-        version.get_git_describe = lambda *x: dont_call_me_maybe("get_git_describe called")
-        try:
-            v = get_version((0, 1, 1, "final", 1))
-            self.assertEqual(v, "0.1.1.post1")
-        finally:
-            version.get_git_describe = git_describe
+        v = get_version((0, 1, 1, "final", 1))
+        self.assertEqual(v, "0.1.1.post1")
+        assert describe_mock.call_count == 0

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -177,7 +177,7 @@ def get_git_changeset():
         # repo - it's safe.
         timestamp = git_log.communicate()[0]
         timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
-        return "{}-git".format(timestamp.strftime('%Y%m%d%H%M%S'))
+        return "+git-{}".format(timestamp.strftime('%Y%m%d%H%M%S'))
     except (EnvironmentError, ValueError):
         return None
 
@@ -233,7 +233,7 @@ def get_version_from_git(get_git_describe_string):
         major, minor, patch = version_split
 
     suffix = m.group('suffix')
-    suffix = ".dev" + suffix if suffix else ""
+    suffix = ".dev+git" + suffix if suffix else ""
 
     return get_complete_version((
         int(major),
@@ -283,7 +283,7 @@ def get_prerelease_version(version):
                 # Throw away the description from git
                 suffix = get_git_changeset()
                 # Replace 'alpha' with .dev
-                return major + ".dev0" + suffix
+                return major + ".dev" + suffix
 
             # If the tag was not of a final version, we will fail.
             elif not git_version[4] == 'final' and git_version[:3] > version[:3]:


### PR DESCRIPTION
### Summary

See #3116

### Reviewer guidance

Check out the artifacts of this PR for evidence?

### References

#3116

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
