### PR TITLE
Force prettier to parse JS from a vue component as JS.

### DIFF
--- a/frontend_build/src/prettier-frontend.js
+++ b/frontend_build/src/prettier-frontend.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const prettier = require('prettier');
 const compiler = require('vue-template-compiler');
 const fs = require('fs');
@@ -29,11 +30,13 @@ function prettierFrontend({ file, write, encoding = 'utf-8', prettierOptions }) 
         } else if (vueComponent && vueComponent.script) {
           const start = vueComponent.script.start;
           const end = vueComponent.script.end;
-          const code = source.slice(start, end).replace(/(\n)  /g, '$1');
+          const code = source.slice(start, end).replace(/(\n) {2}/g, '$1');
           // Prettier strips the 2 space indentation that we enforce within script tags for vue
           // components. So here we account for those 2 spaces that will be added.
           const vueComponentOptions = options;
           vueComponentOptions.printWidth = vueComponentOptions.printWidth - 2;
+          // Force the prettier parser to parse this as JS
+          vueComponentOptions.filepath = 'dummy.js';
           let formattedJs = prettier.format(code, vueComponentOptions);
           // Ensure that the beginning and end of the JS has two newlines to fit our
           // Component linting conventions

--- a/kolibri/core/assets/src/views/k-checkbox/index.vue
+++ b/kolibri/core/assets/src/views/k-checkbox/index.vue
@@ -62,8 +62,8 @@
 <script>
 
   /**
-    * Used for toggling boolean user input
-    */
+   * Used for toggling boolean user input
+   */
   export default {
     name: 'kCheckbox',
     props: {
@@ -140,8 +140,8 @@
       markInactive() {
         this.isActive = false;
         /**
-          * Emits blur event, useful for validation
-          */
+         * Emits blur event, useful for validation
+         */
         this.$emit('blur');
       },
     },

--- a/kolibri/core/assets/src/views/k-navbar/index.vue
+++ b/kolibri/core/assets/src/views/k-navbar/index.vue
@@ -44,8 +44,8 @@
   import throttle from 'lodash/throttle';
 
   /**
-    * Used for navigation between sub-pages of a top-level Kolibri section
-    */
+   * Used for navigation between sub-pages of a top-level Kolibri section
+   */
   export default {
     name: 'kNavbar',
     mixins: [responsiveElement],

--- a/kolibri/core/assets/src/views/k-navbar/link/index.vue
+++ b/kolibri/core/assets/src/views/k-navbar/link/index.vue
@@ -33,8 +33,8 @@
     components: { uiIcon },
     props: {
       /**
-        * The type of tab. title, icon, or icon-and-title
-        */
+       * The type of tab. title, icon, or icon-and-title
+       */
       type: {
         type: String,
         validator(type) {
@@ -43,22 +43,22 @@
         required: true,
       },
       /**
-        * The text
-        */
+       * The text
+       */
       title: {
         type: String,
         required: false,
       },
       /**
-        * A material icon name
-        */
+       * A material icon name
+       */
       icon: {
         type: String,
         required: false,
       },
       /**
-        * A router link object
-        */
+       * A router link object
+       */
       link: {
         type: Object,
         required: true,

--- a/kolibri/core/assets/src/views/k-radio-button/index.vue
+++ b/kolibri/core/assets/src/views/k-radio-button/index.vue
@@ -83,8 +83,8 @@
         default: false,
       },
       /**
-      * Autofocus on mount
-      */
+       * Autofocus on mount
+       */
       autofocus: {
         type: Boolean,
         default: false,


### PR DESCRIPTION
### Summary
Ensure that JS inside vue components gets parsed as JS by prettier.
…

### Reviewer guidance
Modify a .vue file in a way that prettier would correct.

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
