### PR TITLE
Version test and legacy pkg resources

### DIFF
--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -56,7 +56,9 @@ class VersionCompat:
 
         # Otherwise assume we have the old tuple with strings.
 
+        # Remove leading 0's
         self.tpl_or_version = map(lambda s: s.lstrip("0"), self.tpl_or_version)
+        self.tpl_or_version = map(lambda s: s or "0", self.tpl_or_version)
         # When map returns a map object in Python 3...
         self.tpl_or_version = tuple(self.tpl_or_version)
 

--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 
+from pkg_resources import parse_version as _parse_version
+
 
 def module_exists(module_path):
     """
@@ -29,3 +31,46 @@ def module_exists(module_path):
             return False
     else:
         raise NotImplementedError("No compatibility with Python 3.0 and 3.2")
+
+
+class VersionCompat:
+    """
+    This is an exactly-what-we-need version of the newer
+    packaging.version.Version object.
+
+    It is made to exclusively filter out properties of the later
+    ``packaging.version.Version`` that we should not access because they are
+    unsupported.
+
+    So please avoid using anything directly from ``packaging.version.Version``
+    """
+
+    def __init__(self, tpl_or_version):
+        self.tpl_or_version = tpl_or_version
+
+    @property
+    def base_version(self):
+        # if it's a real Version object...
+        if hasattr(self.tpl_or_version, 'base_version'):
+            return self.tpl_or_version.base_version
+
+        # Otherwise assume we have the old tuple with strings.
+
+        self.tpl_or_version = map(lambda s: s.lstrip("0"), self.tpl_or_version)
+        # When map returns a map object in Python 3...
+        self.tpl_or_version = tuple(self.tpl_or_version)
+
+        # Always just assume the first 3 members of the tuple... because this
+        # is Kolibri's version scheme (For instance, version 1 is always
+        # 1.0.0)
+        return ".".join(self.tpl_or_version[:3])
+
+
+def parse_version(v):
+    """
+    In old versions of Python (for instance on Ubuntu 14.04),
+    pkg_resources.parse_version returns a tuple and not a version object.
+    """
+    parsed = _parse_version(v)
+
+    return VersionCompat(parsed)

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -161,6 +161,16 @@ class TestKolibriVersion(unittest.TestCase):
         """
         assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0.dev+git123"
 
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_version_file_final(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION specifying a final version will work when the
+        kolibri.VERSION tuple is consistent.
+        """
+        assert get_version((0, 1, 0, "final", 0)) == "0.1.0"
+
     def test_alpha_1_inconsistent_git(self):
         """
         Test that we fail when git returns inconsistent data

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -152,6 +152,16 @@ class TestKolibriVersion(unittest.TestCase):
         """
         assert get_version((0, 1, 0, "beta", 1)) == "0.1.0b2"
 
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git-12-g2a8fe31")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_beta_1_consistent_dev_release_version_file(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION file can overwrite an beta-1 state in case the
+        version was bumped in ``kolibri.VERSION``.
+        """
+        assert get_version((0, 7, 1, "alpha", 0)) == "0.7.1b1.dev+git-12-g2a8fe31"
+
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b1")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.0.1")
     @mock.patch('kolibri.utils.version.get_git_changeset', return_value="+git123")
@@ -322,3 +332,7 @@ class TestKolibriVersion(unittest.TestCase):
         assert VersionCompat(
             ('00000001', '00000002', '00000003', '*b', '00000001', '*+', '*git', '*final-', '00000123', '*final')
         ).base_version == "1.2.3"
+
+        assert VersionCompat(
+            ('00000000', '00000002', '00000003', '*b', '00000001', '*+', '*git', '*final-', '00000123', '*final')
+        ).base_version == "0.2.3"

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -110,8 +110,7 @@ import pkgutil
 import re
 import subprocess
 
-from pkg_resources import parse_version
-
+from .compat import parse_version
 from .lru_cache import lru_cache
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Summary

I kindly ask everyone's understanding for the complexity nightmare that this versioning stuff is. The truth is in the code and the tests.

### Reviewer guidance

n/a

### References

Fixes #3145

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
