### PR TITLE
Update ExamLogFilter.filter_collection

### DIFF
--- a/kolibri/logger/api.py
+++ b/kolibri/logger/api.py
@@ -154,7 +154,7 @@ class ExamLogFilter(BaseLogFilter):
 
     collection = ModelChoiceFilter(method="filter_collection", queryset=Collection.objects.all())
 
-    def filter_collection(self, queryset, collection):
+    def filter_collection(self, queryset, name, collection):
         return HierarchyRelationsFilter(queryset).filter_by_hierarchy(
             target_user=F('user'),
             ancestor_collection=collection,


### PR DESCRIPTION
### Summary
Fixes #3053. The method being passed into `ExamLog`'s `ModelChoiceFilter` did not have the same signature as other such filters in the file.


### Reviewer guidance

Manual check is to try to view an Exam report. Should not get an error with this patch.

### References

#3053 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
