### PR TITLE
fix #3121

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Release Notes
 
 Changes are ordered reverse-chronologically.
 
+0.6.2
+-----
+
+ - Consistent ordering of channels in learner views
+
+
 0.6.1
 -----
 

--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -6,7 +6,7 @@ from .utils.version import get_version
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 6, 1, 'final', 0)
+VERSION = (0, 6, 2, 'final', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -181,11 +181,11 @@ function showChannels(store) {
       }
       const channelRootIds = channels.map(channel => channel.root);
       ContentNodeResource.getCollection({ ids: channelRootIds }).fetch().then(channelCollection => {
-        const rootNodes = _collectionState(channelCollection);
-        rootNodes.forEach(rootNode => {
-          rootNode.thumbnail = channels.find(
-            channel => channel.id === rootNode.channel_id
-          ).thumbnail;
+        // we want them to be in the same order as the channels list
+        const rootNodes = channels.map(channel => {
+          const node = _collectionState(channelCollection).find(n => n.channel_id === channel.id);
+          node.thumbnail = channel.thumbnail;
+          return node;
         });
         const pageState = { rootNodes };
         store.dispatch('SET_PAGE_STATE', pageState);


### PR DESCRIPTION

### Summary

small patch to fix #3121 

with this main ordering:

![image](https://user-images.githubusercontent.com/2367265/35718503-bc82ee06-0799-11e8-8271-8728df285468.png)


old order: 

![image](https://user-images.githubusercontent.com/2367265/35718487-a7cd8502-0799-11e8-9d17-9a35f1bff154.png)


new order:

![image](https://user-images.githubusercontent.com/2367265/35718476-94a41bda-0799-11e8-9927-819eb874fd2b.png)


### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
