### PR TITLE
Added h1 tags to the top-level page 'Recommended'

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/learn-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/learn-page/index.vue
@@ -2,6 +2,8 @@
 
   <div>
 
+    <h1 class="visuallyhidden">{{ $tr('recommended') }}</h1>
+
     <template v-if="popular.length">
       <content-card-group-header
         :header="$tr('popularSectionHeader')"
@@ -102,6 +104,7 @@
   export default {
     name: 'recommendedPage',
     $trs: {
+      recommended: 'Recommended',
       popularSectionHeader: 'Most popular',
       suggestedNextStepsSectionHeader: 'Next steps',
       resumeSectionHeader: 'Resume',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I added h1 tags with the class 'visuallyhidden'  to the top-level recommended page. I internationalized the title 'Recommended'. However, users should not be able to view the title while using the kolibri application, but can see the tags while inspecting the html code.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Look at the html code with google chrome.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Originally, the top-level page,  'Recommended',  was missing the h1 tag. All top-level pages must have a h1 tag to make it easier for users of screen readers to understand the content more easily.

Link to issue:

https://github.com/learningequality/kolibri/issues/2818

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
