### PR TITLE
Fix #3110: _get_leaf_node_ids returns embedded query instead of list

### DIFF
--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -1,16 +1,16 @@
 from django.db.models import Sum
-from kolibri.content.models import LocalFile, ContentNode
+from kolibri.content.models import ContentNode, LocalFile
 
 
 def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
     files_to_transfer = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=available)
 
     if node_ids:
-        leaf_node_ids = _get_leaves_ids(node_ids)
+        leaf_node_ids = _get_leaf_node_ids(node_ids)
         files_to_transfer = files_to_transfer.filter(files__contentnode__in=leaf_node_ids)
 
     if exclude_node_ids:
-        exclude_leaf_node_ids = _get_leaves_ids(exclude_node_ids)
+        exclude_leaf_node_ids = _get_leaf_node_ids(exclude_node_ids)
         files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_leaf_node_ids)
 
     # Make sure the files are unique, to avoid duplicating downloads
@@ -21,12 +21,10 @@ def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
     return files_to_transfer, total_bytes_to_transfer
 
 
-def _get_leaves_ids(node_ids):
-    leaf_node_ids = []
-    for node_id in node_ids:
-        node_leaves = ContentNode.objects.get(pk=node_id) \
-            .get_descendants(include_self=True) \
-            .filter(children__isnull=True) \
-            .values_list('id', flat=True)
-        leaf_node_ids += node_leaves
-    return leaf_node_ids
+def _get_leaf_node_ids(node_ids):
+
+    return ContentNode.objects \
+        .filter(pk__in=node_ids) \
+        .get_descendants(include_self=True) \
+        .filter(children__isnull=True) \
+        .values_list('id', flat=True)


### PR DESCRIPTION
### Summary

The old `_get_leaves_ids` function returned a long list of all the leaf IDs (as a Python list), which would then get passed into an `files__contentnode__in` query. On Windows (in particular) this list sometimes exceeded the number of variables that SQLite allows in one query. The new approach calculates these IDs as a QuerySet, which when passed into the `files__contentnode__in` query is embedded inline as a compound query, rather than being expanded into a big list of IDs, which should avoid the "too many SQL variables" issue.

### Reviewer guidance

Can be tested by manual testing (on Windows, and other platforms). I have tested on Linux, and will test on Windows once the assets for this PR are built.

### References

Fixes (:crossed_fingers:) https://github.com/learningequality/kolibri/issues/3110

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
~- [ ] Screenshots of any front-end changes are in the PR description~
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
