### PR TITLE
Build system simplification

### DIFF
--- a/frontend_build/src/alias_import_resolver.js
+++ b/frontend_build/src/alias_import_resolver.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var resolve = require('resolve');
 var coreAliases = require('./apiSpecExportTools').coreAliases();
-var coreExternals = require('./apiSpecExportTools').coreExternals('kolibriGlobal');
+var coreExternals = require('./apiSpecExportTools').coreExternals();
 
 function packageFilter(pkg) {
   if (pkg['jsnext:main']) {

--- a/frontend_build/src/apiSpecExportTools.js
+++ b/frontend_build/src/apiSpecExportTools.js
@@ -91,6 +91,8 @@ function specModule(filePath) {
 
 var apiSpec = specModule(specFilePath);
 
+var kolibriName = require('./kolibriName');
+
 function requireName(pathArray) {
   return ['kolibri'].concat(pathArray.slice(1)).join('.');
 }
@@ -103,8 +105,6 @@ var baseAliases = {
     '../../kolibri/core/assets/src/content_renderer_module'
   ),
 };
-
-var kolibriName = 'kolibriGlobal';
 
 function coreExternals() {
   /*

--- a/frontend_build/src/apiSpecExportTools.js
+++ b/frontend_build/src/apiSpecExportTools.js
@@ -104,12 +104,14 @@ var baseAliases = {
   ),
 };
 
-function coreExternals(kolibri_name) {
+var kolibriName = 'kolibriGlobal';
+
+function coreExternals() {
   /*
    * Function for creating a hash of externals for modules that are exposed on the core kolibri object.
    */
   var externalsObj = {
-    kolibri: kolibri_name,
+    kolibri: kolibriName,
   };
   function recurseObjectKeysAndExternalize(obj, pathArray) {
     if (typeof obj === 'object') {
@@ -124,7 +126,7 @@ function coreExternals(kolibri_name) {
       externalsObj[requireName(pathArray)] = pathArray.join('.');
     }
   }
-  recurseObjectKeysAndExternalize(apiSpec, [kolibri_name]);
+  recurseObjectKeysAndExternalize(apiSpec, [kolibriName]);
   return externalsObj;
 }
 

--- a/frontend_build/src/kolibriName.js
+++ b/frontend_build/src/kolibriName.js
@@ -1,0 +1,8 @@
+var fs = require('fs');
+var path = require('path');
+
+var kolibriName = fs
+  .readFileSync(path.resolve(__dirname, '../../kolibri/utils/KOLIBRI_CORE_JS_NAME'), 'utf-8')
+  .trim();
+
+module.exports = kolibriName;

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -2,6 +2,11 @@
 /**
  * Bundle plugin parser module.
  * @module parseBundlePlugin
+ * This file defines a function for parsing frontend plugin specific information in order to
+ * add plugin specific configuration options to the base webpack config defined in the
+ * webpack.config.base.js file. Any configuration that does not require specific information
+ * about the plugin being built (like the entry file, the path for the plugin, etc)
+ * should be added in that file and not in here.
  */
 
 var BundleTracker = require('webpack-bundle-tracker');
@@ -23,11 +28,9 @@ var WebpackRTLPlugin = require('webpack-rtl-plugin');
  * @param {string} data.name - The name that the plugin is referred to by.
  * @param {string} data.static_dir - Directory path to the module in which the plugin is defined.
  * @param {string} data.stats_file - The name of the webpack bundle stats file that the plugin data
- * should be saved to.
- * @param {string} base_dir - The absolute path of the base directory for writing files to.
  * @returns {Object} bundle - An object defining the webpack config.
  */
-var parseBundlePlugin = function(data, base_dir) {
+var parseBundlePlugin = function(data) {
   if (
     typeof data.src_file === 'undefined' ||
     typeof data.name === 'undefined' ||
@@ -44,7 +47,7 @@ var parseBundlePlugin = function(data, base_dir) {
 
   // Start from a base configuration file that defines common features of the webpack configuration
   // for all Kolibri plugins (including the core app).
-  var bundle = _.cloneDeep(base_config);
+  var base_bundle = _.cloneDeep(base_config);
 
   var local_config;
 
@@ -59,27 +62,6 @@ var parseBundlePlugin = function(data, base_dir) {
     local_config.coreAPISpec = path.resolve(path.join(data.plugin_path, local_config.coreAPISpec));
   }
 
-  // This might be non-standard use of the entry option? It seems to
-  // interact with read_bundle_plugins.js
-  bundle.entry = {};
-  bundle.entry[data.name] = path.join(data.plugin_path, data.src_file);
-
-  // Add local resolution paths
-  bundle.resolve.modules = [
-    path.join(data.plugin_path, 'node_modules'),
-    base_dir,
-    path.join(base_dir, 'node_modules'),
-  ];
-  // Add local and global resolution paths for loaders to allow any plugin to
-  // access kolibri/node_modules loaders during bundling.
-  bundle['resolveLoader'] = {
-    modules: [
-      path.join(data.plugin_path, 'node_modules'),
-      base_dir,
-      path.join(base_dir, 'node_modules'),
-    ],
-  };
-
   // Calculate these paths here, so that we can export __publicPath as a variable in the webpack
   // define plugin
   var publicPath, outputPath;
@@ -88,55 +70,71 @@ var parseBundlePlugin = function(data, base_dir) {
     var devServerConfig = require('./webpackdevserverconfig');
     // If running webpack dev server point to that endpoint.
     publicPath = devServerConfig.publicPath;
-    // Set output path to base dir, as no files will be written - all built files are cached in
+    // Set output path to local dir, as no files will be written - all built files are cached in
     // memory.
     outputPath = devServerConfig.basePath
-      ? path.resolve(path.join(base_dir, devServerConfig.basePath))
-      : path.resolve(base_dir);
+      ? path.resolve(path.join('./', devServerConfig.basePath))
+      : path.resolve('./');
   } else {
     publicPath = path.join('/', data.static_url_root, data.name, '/');
     outputPath = path.resolve(path.join(data.static_dir, data.name));
   }
 
-  bundle.plugins = bundle.plugins.concat([
-    new ExtractTextPlugin('[name]' + data.version + '.css'),
-    new WebpackRTLPlugin({
-      minify: { zindex: false },
-    }),
-    // BundleTracker creates stats about our built files which we can then pass to Django to
-    // allow our template tags to load the correct frontend files.
-    new BundleTracker({
-      path: path.dirname(data.stats_file),
-      filename: path.basename(data.stats_file),
-    }),
-    // Plugins know their own name, by having a variable that we define here, based on the name
-    // they are given in kolibri_plugins.py inside their relevant module.
-    // We also pass in the events hashes here as well, as they are defined in the Python
-    // specification of the KolibriModule.
-    new webpack.DefinePlugin({
-      __kolibriModuleName: JSON.stringify(data.name),
-      __events: JSON.stringify(data.events || {}),
-      __once: JSON.stringify(data.once || {}),
-      __version: JSON.stringify(data.version),
-      // This is necessary to allow modules that use service workers to fetch their service
-      // worker code
-      __publicPath: JSON.stringify(publicPath),
-    }),
-    new extract$trs(data.locale_data_folder, data.name),
-  ]);
-
-  bundle.name = data.name;
-  bundle.context = base_dir;
-  bundle.output = {
-    path: outputPath,
-    filename: '[name]-' + data.version + '.js',
-    // Need to define this in order for chunks to be named
-    // Without this chunks from different bundles will likely have colliding names
-    chunkFilename: '[name]-' + data.version + '.js',
-    publicPath: publicPath,
+  var bundle = {
+    // Set the main entry for this module, set the name based on the data.name and the path to the
+    // entry file from the data.src_file
+    entry: {
+      [data.name]: path.join(data.plugin_path, data.src_file),
+    },
+    name: data.name,
+    output: {
+      path: outputPath,
+      filename: '[name]-' + data.version + '.js',
+      // Need to define this in order for chunks to be named
+      // Without this chunks from different bundles will likely have colliding names
+      chunkFilename: '[name]-' + data.version + '.js',
+      publicPath: publicPath,
+    },
+    resolve: {
+      modules: [
+        // Add local resolution paths
+        path.join(data.plugin_path, 'node_modules'),
+      ],
+    },
+    resolveLoader: {
+      // Add local and global resolution paths for loaders to allow any plugin to
+      // access kolibri/node_modules loaders during bundling.
+      modules: [path.join(data.plugin_path, 'node_modules')],
+    },
+    plugins: [
+      new ExtractTextPlugin('[name]' + data.version + '.css'),
+      new WebpackRTLPlugin({
+        minify: { zindex: false },
+      }),
+      // BundleTracker creates stats about our built files which we can then pass to Django to
+      // allow our template tags to load the correct frontend files.
+      new BundleTracker({
+        path: path.dirname(data.stats_file),
+        filename: path.basename(data.stats_file),
+      }),
+      // Plugins know their own name, by having a variable that we define here, based on the name
+      // they are given in kolibri_plugins.py inside their relevant module.
+      // We also pass in the events hashes here as well, as they are defined in the Python
+      // specification of the KolibriModule.
+      new webpack.DefinePlugin({
+        __kolibriModuleName: JSON.stringify(data.name),
+        __events: JSON.stringify(data.events || {}),
+        __once: JSON.stringify(data.once || {}),
+        __version: JSON.stringify(data.version),
+        // This is necessary to allow modules that use service workers to fetch their service
+        // worker code
+        __publicPath: JSON.stringify(publicPath),
+      }),
+      new extract$trs(data.locale_data_folder, data.name),
+    ],
   };
 
-  bundle = merge.smart(bundle, local_config);
+  bundle = merge.smart(bundle, base_bundle, local_config);
 
   return bundle;
 };

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -5,7 +5,6 @@
  */
 
 var BundleTracker = require('webpack-bundle-tracker');
-var fs = require('fs');
 var path = require('path');
 var logging = require('./logging');
 var webpack = require('webpack');
@@ -17,18 +16,16 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var WebpackRTLPlugin = require('webpack-rtl-plugin');
 
 /**
- * Turn an object containing the vital information for a frontend plugin and return a bundle configuration for webpack.
+ * Turn an object containing the vital information for a frontend plugin and return a bundle
+ * configuration for webpack.
  * @param {Object} data - An object that contains the data for configuring the bundle.
  * @param {string} data.src_file - The Javascript source file that initializes the plugin.
  * @param {string} data.name - The name that the plugin is referred to by.
  * @param {string} data.static_dir - Directory path to the module in which the plugin is defined.
- * @param {string} data.stats_file - The name of the webpack bundle stats file that the plugin data should be saved to.
- * @param {string} [data.external] - Flag to indicate that the module should be exposed as an external library
- * to other plugins.
+ * @param {string} data.stats_file - The name of the webpack bundle stats file that the plugin data
+ * should be saved to.
  * @param {string} base_dir - The absolute path of the base directory for writing files to.
- * @returns {Array}
- * @returns {Object} [0] bundle - An object defining the webpack config.
- * @returns {string} [1] [external] - A string flagging the name to be used to refer to the plugin as an external lib.
+ * @returns {Object} bundle - An object defining the webpack config.
  */
 var parseBundlePlugin = function(data, base_dir) {
   if (
@@ -45,11 +42,9 @@ var parseBundlePlugin = function(data, base_dir) {
     return;
   }
 
-  // Start from a base configuration file that defines common features of the webpack configuration for all Kolibri
-  // plugins (including the core app).
+  // Start from a base configuration file that defines common features of the webpack configuration
+  // for all Kolibri plugins (including the core app).
   var bundle = _.cloneDeep(base_config);
-  var external;
-  var library;
 
   var local_config;
 
@@ -69,13 +64,6 @@ var parseBundlePlugin = function(data, base_dir) {
   bundle.entry = {};
   bundle.entry[data.name] = path.join(data.plugin_path, data.src_file);
 
-  if (typeof data.external !== 'undefined' && data.external && data.core_name) {
-    // If we want to create a plugin that can be directly referenced by other plugins, this sets it to be
-    // instantiated as a global variable. Only to be used by the Kolibri core app.
-    external = data.name;
-    library = data.core_name;
-  }
-
   // Add local resolution paths
   bundle.resolve.modules = [
     path.join(data.plugin_path, 'node_modules'),
@@ -92,14 +80,16 @@ var parseBundlePlugin = function(data, base_dir) {
     ],
   };
 
-  // Calculate these paths here, so that we can export __publicPath as a variable in the webpack define plugin
+  // Calculate these paths here, so that we can export __publicPath as a variable in the webpack
+  // define plugin
   var publicPath, outputPath;
 
   if (process.env.DEV_SERVER) {
     var devServerConfig = require('./webpackdevserverconfig');
     // If running webpack dev server point to that endpoint.
     publicPath = devServerConfig.publicPath;
-    // Set output path to base dir, as no files will be written - all built files are cached in memory.
+    // Set output path to base dir, as no files will be written - all built files are cached in
+    // memory.
     outputPath = devServerConfig.basePath
       ? path.resolve(path.join(base_dir, devServerConfig.basePath))
       : path.resolve(base_dir);
@@ -113,30 +103,28 @@ var parseBundlePlugin = function(data, base_dir) {
     new WebpackRTLPlugin({
       minify: { zindex: false },
     }),
-    // BundleTracker creates stats about our built files which we can then pass to Django to allow our template
-    // tags to load the correct frontend files.
+    // BundleTracker creates stats about our built files which we can then pass to Django to
+    // allow our template tags to load the correct frontend files.
     new BundleTracker({
       path: path.dirname(data.stats_file),
       filename: path.basename(data.stats_file),
     }),
-    // Plugins know their own name, by having a variable that we define here, based on the name they are given
-    // in kolibri_plugins.py inside their relevant module.
-    // We also pass in the events hashes here as well, as they are defined in the Python specification of the
-    // KolibriModule.
+    // Plugins know their own name, by having a variable that we define here, based on the name
+    // they are given in kolibri_plugins.py inside their relevant module.
+    // We also pass in the events hashes here as well, as they are defined in the Python
+    // specification of the KolibriModule.
     new webpack.DefinePlugin({
       __kolibriModuleName: JSON.stringify(data.name),
       __events: JSON.stringify(data.events || {}),
       __once: JSON.stringify(data.once || {}),
       __version: JSON.stringify(data.version),
-      // This is necessary to allow modules that use service workers to fetch their service worker code
+      // This is necessary to allow modules that use service workers to fetch their service
+      // worker code
       __publicPath: JSON.stringify(publicPath),
     }),
     new extract$trs(data.locale_data_folder, data.name),
   ]);
 
-  bundle = merge.smart(bundle, local_config);
-
-  bundle.core_name = data.core_name;
   bundle.name = data.name;
   bundle.context = base_dir;
   bundle.output = {
@@ -146,10 +134,11 @@ var parseBundlePlugin = function(data, base_dir) {
     // Without this chunks from different bundles will likely have colliding names
     chunkFilename: '[name]-' + data.version + '.js',
     publicPath: publicPath,
-    library: library,
   };
 
-  return [bundle, external];
+  bundle = merge.smart(bundle, local_config);
+
+  return bundle;
 };
 
 module.exports = parseBundlePlugin;

--- a/frontend_build/src/parse_bundle_plugin.js
+++ b/frontend_build/src/parse_bundle_plugin.js
@@ -102,8 +102,7 @@ var parseBundlePlugin = function(data) {
       ],
     },
     resolveLoader: {
-      // Add local and global resolution paths for loaders to allow any plugin to
-      // access kolibri/node_modules loaders during bundling.
+      // Add local resolution paths for loaders
       modules: [path.join(data.plugin_path, 'node_modules')],
     },
     plugins: [

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -17,7 +17,7 @@ var coreExternals = require('./apiSpecExportTools').coreExternals;
 
 var coreAliases = require('./apiSpecExportTools').coreAliases;
 
-var kolibriName = 'kolibriGlobal';
+var kolibriName = require('./kolibriName');
 
 function setNodePaths(nodePaths) {
   /*
@@ -46,7 +46,6 @@ function setNodePaths(nodePaths) {
  * @returns {Array} bundles - An array containing webpack config objects.
  */
 var readBundlePlugins = function(base_dir) {
-  // Takes a module file path and turns it into a Python module path.
   var bundles = [];
   var externals = {};
 

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -36,10 +36,9 @@ function setNodePaths(nodePaths) {
 }
 
 /**
- * Take a Python plugin file name as input, and extract the information regarding front end plugin
- * configuration from it using a Python script to import the relevant plugins and then run methods
- * against them to retrieve the config data.
- * module names to the global namespace at which those modules can be accessed.
+ * Extract the information regarding front end plugin configuration using a
+ * Python script to import information about the relevant plugins and then run methods
+ * against them to create the config data.
  * @returns {Array} bundles - An array containing webpack config objects.
  */
 var readBundlePlugins = function() {
@@ -80,8 +79,9 @@ var readBundlePlugins = function() {
     logging.warn('You have more than one coreAPISpec modification specified.');
   }
 
-  // For that bundle, we replace all references to library modules (like Vue) that we bundle into
-  // the core app with references to the core app itself, so if someone does
+  // All references to the core API spec will be referenced as subproperties of the global
+  // Kolibri object in the browser, so any references to anything we bundle in the core API
+  // will be replaced by a property reference to the global object, e.g. for a Vue import:
   // `import Vue from 'vue';` webpack will replace it with a reference to Vue bundled into the
   // core Kolibri app.
   var core_externals = coreExternals();

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -145,13 +145,14 @@ var config = {
     extensions: ['.js', '.vue', '.styl'],
     alias: {},
     modules: [
-      // Add local resolution paths
+      // Add resolution paths for modules to allow any plugin to
+      // access kolibri/node_modules modules during bundling.
       base_dir,
       path.join(base_dir, 'node_modules'),
     ],
   },
   resolveLoader: {
-    // Add local and global resolution paths for loaders to allow any plugin to
+    // Add resolution paths for loaders to allow any plugin to
     // access kolibri/node_modules loaders during bundling.
     modules: [base_dir, path.join(base_dir, 'node_modules')],
   },

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -10,16 +10,25 @@
  *  This file is not called directly by webpack.
  *  It copied once for each plugin by parse_bundle_plugin.js
  *  and used as a template, with additional plugin-specific
- *  modifications made on top.
+ *  modifications made on top. Any entries that require plugin specific
+ *  information are added in parse_bundle_plugin.js - such as access to
+ *  plugin name, plugin file paths, and version information.
  */
 
 var path = require('path');
 var merge = require('webpack-merge');
+var mkdirp = require('mkdirp');
 var PrettierFrontendPlugin = require('./prettier-frontend-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var production = process.env.NODE_ENV === 'production';
 var lint = process.env.LINT || production;
+
+var base_dir = path.join(__dirname, '..', '..');
+
+var locale_dir = path.join(base_dir, 'kolibri', 'locale');
+
+mkdirp.sync(locale_dir);
 
 var postCSSLoader = {
   loader: 'postcss-loader',
@@ -53,6 +62,7 @@ var vueSassLoaders = [
 
 // primary webpack config
 var config = {
+  context: base_dir,
   module: {
     rules: [
       {
@@ -134,6 +144,16 @@ var config = {
   resolve: {
     extensions: ['.js', '.vue', '.styl'],
     alias: {},
+    modules: [
+      // Add local resolution paths
+      base_dir,
+      path.join(base_dir, 'node_modules'),
+    ],
+  },
+  resolveLoader: {
+    // Add local and global resolution paths for loaders to allow any plugin to
+    // access kolibri/node_modules loaders during bundling.
+    modules: [base_dir, path.join(base_dir, 'node_modules')],
   },
   node: {
     __filename: true,

--- a/frontend_build/src/webpack.config.js
+++ b/frontend_build/src/webpack.config.js
@@ -12,7 +12,6 @@
 // (specified in package.json)
 require('engine-strict').check();
 
-var path = require('path');
 var readBundlePlugins = require('./read_bundle_plugins');
 
-module.exports = readBundlePlugins(path.join(__dirname, '..', '..'));
+module.exports = readBundlePlugins();

--- a/frontend_build/src/webpack.config.js
+++ b/frontend_build/src/webpack.config.js
@@ -1,9 +1,11 @@
 /*
- * This file acts as the entry point for webpack building of frontend assets. From here, all Kolibri Plugin folders will
- * be scanned for kolibri_plugins.py and the relevant KolibriModule metadata extracted for webpack configuration.
- * The 'bundles' emitted as the module.exports are the Webpack configuration objects that are then parsed by Webpack
- * to bundle the assets. See recurseBundlePlugins and associated functions for details of how we make these
- * configurations and Webpack documentation for details on what the configuration bundles do.
+ * This file acts as the entry point for webpack building of frontend assets. From here, all
+ * Kolibri Plugin folders will be scanned for kolibri_plugins.py and the relevant KolibriModule
+ * metadata extracted for webpack configuration.
+ * The 'bundles' emitted as the module.exports are the Webpack configuration objects that are then
+ * parsed by Webpack to bundle the assets. See recurseBundlePlugins and associated functions for
+ * details of how we make these configurations and Webpack documentation for details on what the
+ * configuration bundles do.
  */
 
 // ensure the correct version of node is being used
@@ -11,8 +13,6 @@
 require('engine-strict').check();
 
 var path = require('path');
-var webpack = require('webpack');
-var logging = require('./logging');
 var readBundlePlugins = require('./read_bundle_plugins');
 
 module.exports = readBundlePlugins(path.join(__dirname, '..', '..'));

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -1,3 +1,5 @@
+/* eslint-env node, mocha */
+
 var assert = require('assert');
 var rewire = require('rewire');
 var _ = require('lodash');
@@ -34,7 +36,7 @@ describe('parseBundlePlugin', function() {
   });
   describe('input is valid, bundles output', function() {
     it('should have one entry', function(done) {
-      assert(typeof parseBundlePlugin(data, '/')[0] !== 'undefined');
+      assert(typeof parseBundlePlugin(data, '/') !== 'undefined');
       done();
     });
   });
@@ -87,22 +89,6 @@ describe('parseBundlePlugin', function() {
       done();
     });
   });
-  describe('input is valid, has externals flag and core_name value, externals output', function() {
-    it('should have one entry', function(done) {
-      data.external = true;
-      data.core_name = 'test_core';
-      assert(typeof parseBundlePlugin(data, '/')[1] !== 'undefined');
-      done();
-    });
-  });
-  describe('input is valid, has core flag', function() {
-    it('should have its name set to kolibriGlobal', function(done) {
-      data.external = true;
-      data.core_name = 'kolibriGlobal';
-      assert.equal(parseBundlePlugin(data, '/')[0].output.library, data.core_name);
-      done();
-    });
-  });
 });
 
 describe('readBundlePlugins', function() {
@@ -138,42 +124,6 @@ describe('readBundlePlugins', function() {
       delete badData1.src_file;
       data = [badData, badData1];
       assert(readBundlePlugins('', '').length === 0);
-      done();
-    });
-  });
-  describe('two external flags on inputs, one with core_name value, externals output', function() {
-    it('should have two entries', function(done) {
-      var coreData = _.clone(baseData);
-      coreData.external = true;
-      coreData.core_name = 'test_global';
-      var coreData1 = _.clone(baseData1);
-      coreData1.external = true;
-      data = [coreData, coreData1];
-      assert(
-        Object.keys(
-          readBundlePlugins('', function() {
-            return {};
-          })[0].externals
-        ).length === 2
-      );
-      done();
-    });
-  });
-  describe('two core bundles specified', function() {
-    it('should throw an error', function(done) {
-      var coreData = _.clone(baseData);
-      coreData.external = true;
-      coreData.core_name = 'test_global';
-      var coreData1 = _.clone(baseData1);
-      coreData1.name = coreData.name;
-      coreData1.external = true;
-      coreData1.core_name = 'test_global';
-      data = [coreData, coreData1];
-      assert.throws(function() {
-        readBundlePlugins('', function() {
-          return {};
-        });
-      });
       done();
     });
   });

--- a/frontend_build/test/test_bundle_parse.js
+++ b/frontend_build/test/test_bundle_parse.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var rewire = require('rewire');
 var _ = require('lodash');
+var path = require('path');
 
 var parseBundlePlugin = require('../src/parse_bundle_plugin');
 var readBundlePlugins = rewire('../src/read_bundle_plugins');
@@ -39,53 +40,117 @@ describe('parseBundlePlugin', function() {
       assert(typeof parseBundlePlugin(data, '/') !== 'undefined');
       done();
     });
+    it('should set the entry name to data.name', function(done) {
+      assert(Object.keys(parseBundlePlugin(data).entry)[0] === data.name);
+      done();
+    });
+    it('should set the entry path to the path to the source file', function(done) {
+      assert(
+        parseBundlePlugin(data).entry[data.name] === path.join(data.plugin_path, data.src_file)
+      );
+      done();
+    });
+    it('should add plugin node modules to resolve paths', function(done) {
+      assert(
+        parseBundlePlugin(data).resolve.modules.includes(
+          path.join(data.plugin_path, 'node_modules')
+        )
+      );
+      done();
+    });
+    it('should add plugin node modules first to resolve paths', function(done) {
+      assert(
+        parseBundlePlugin(data).resolve.modules[0] === path.join(data.plugin_path, 'node_modules')
+      );
+      done();
+    });
+    it('should add plugin node modules to resolve loader paths', function(done) {
+      assert(
+        parseBundlePlugin(data).resolveLoader.modules.includes(
+          path.join(data.plugin_path, 'node_modules')
+        )
+      );
+      done();
+    });
+    it('should add plugin node modules first to resolve loader paths', function(done) {
+      assert(
+        parseBundlePlugin(data).resolveLoader.modules[0] ===
+          path.join(data.plugin_path, 'node_modules')
+      );
+      done();
+    });
+    it('should set the name to data.name', function(done) {
+      assert(parseBundlePlugin(data).name === data.name);
+      done();
+    });
+    it('should set the output path to the correct subdir in static', function(done) {
+      assert(
+        parseBundlePlugin(data).output.path === path.resolve(path.join(data.static_dir, data.name))
+      );
+      done();
+    });
+    it('should include the version in the output filename', function(done) {
+      assert(parseBundlePlugin(data).output.filename.indexOf(data.version) > -1);
+      done();
+    });
+    it('should include the version in the output chunk filename', function(done) {
+      assert(parseBundlePlugin(data).output.chunkFilename.indexOf(data.version) > -1);
+      done();
+    });
+    it('should set the public path to the static url', function(done) {
+      assert(
+        parseBundlePlugin(data).output.publicPath ===
+          path.join('/', data.static_url_root, data.name, '/')
+      );
+      done();
+    });
   });
   describe('input is missing name, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.name;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing src_file, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.src_file;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing stats_file, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.stats_file;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing static_dir, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.static_dir;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing locale_data_folder, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.locale_data_folder;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing plugin_path, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.plugin_path;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
   describe('input is missing version, bundles output', function() {
     it('should be undefined', function(done) {
       delete data.version;
-      assert(typeof parseBundlePlugin(data, '/') === 'undefined');
+      assert(typeof parseBundlePlugin(data) === 'undefined');
       done();
     });
   });
@@ -103,7 +168,7 @@ describe('readBundlePlugins', function() {
   describe('two valid inputs, output', function() {
     it('should have two entries', function(done) {
       data = [baseData, baseData1];
-      assert(readBundlePlugins('', '').length === 2);
+      assert(readBundlePlugins().length === 2);
       done();
     });
   });
@@ -112,7 +177,7 @@ describe('readBundlePlugins', function() {
       var badData = _.clone(baseData);
       delete badData.src_file;
       data = [badData, baseData1];
-      assert(readBundlePlugins('', '').length === 1);
+      assert(readBundlePlugins().length === 1);
       done();
     });
   });
@@ -123,7 +188,7 @@ describe('readBundlePlugins', function() {
       var badData1 = _.clone(baseData1);
       delete badData1.src_file;
       data = [badData, badData1];
-      assert(readBundlePlugins('', '').length === 0);
+      assert(readBundlePlugins().length === 0);
       done();
     });
   });

--- a/kolibri/content/hooks.py
+++ b/kolibri/content/hooks.py
@@ -4,18 +4,20 @@ Kolibri Content hooks
 
 Hooks for managing the display and rendering of content.
 """
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import json
 import logging
 import os
 
-from django.conf import settings as django_settings
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from kolibri.core.webpack.hooks import WebpackBundleHook
 from le_utils.constants import content_kinds
+
+from kolibri.core.webpack.hooks import WebpackBundleHook
+from kolibri.utils import conf
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +89,7 @@ class ContentRendererHook(WebpackBundleHook):
         urls = [chunk['url'] for chunk in self.bundle]
         tags = self.frontend_message_tag() +\
             ['<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(
-                kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
+                kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
                 bundle=self.unique_slug,
                 urls='","'.join(urls),
                 content_types=json.dumps(self._content_type_json),

--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -1,12 +1,13 @@
 import json
 
-from django.conf import settings
-from kolibri.auth.api import SessionViewSet
 from user_agents import parse
+
+from kolibri.auth.api import SessionViewSet
+from kolibri.utils import conf
 
 
 def return_session(request):
-    return {'session': json.dumps(SessionViewSet().get_session(request)), 'kolibri': settings.KOLIBRI_CORE_JS_NAME}
+    return {'session': json.dumps(SessionViewSet().get_session(request)), 'kolibri': conf.KOLIBRI_CORE_JS_NAME}
 
 
 browser_requirements = [

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -2,7 +2,9 @@
 Kolibri template tags
 =====================
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 import json
@@ -11,15 +13,22 @@ import re
 from django import template
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import resolve, reverse
+from django.core.urlresolvers import resolve
+from django.core.urlresolvers import reverse
 from django.utils.html import mark_safe
 from django.utils.timezone import now
-from django.utils.translation import get_language, get_language_bidi, get_language_info
-from django_js_reverse.js_reverse_settings import JS_GLOBAL_OBJECT_NAME, JS_VAR_NAME
+from django.utils.translation import get_language
+from django.utils.translation import get_language_bidi
+from django.utils.translation import get_language_info
+from django_js_reverse.js_reverse_settings import JS_GLOBAL_OBJECT_NAME
+from django_js_reverse.js_reverse_settings import JS_VAR_NAME
 from django_js_reverse.templatetags.js_reverse import js_reverse_inline
-from kolibri.core.hooks import NavigationHook, UserNavigationHook
 from rest_framework.renderers import JSONRenderer
 from six import iteritems
+
+from kolibri.core.hooks import NavigationHook
+from kolibri.core.hooks import UserNavigationHook
+from kolibri.utils import conf
 
 register = template.Library()
 
@@ -79,7 +88,7 @@ def kolibri_set_urls(context):
     js_global_object_name = getattr(settings, 'JS_REVERSE_JS_GLOBAL_OBJECT_NAME', JS_GLOBAL_OBJECT_NAME)
     js_var_name = getattr(settings, 'JS_REVERSE_JS_VAR_NAME', JS_VAR_NAME)
     js = (js_reverse_inline(context) +
-          "Object.assign({0}.urls, {1}.{2})".format(settings.KOLIBRI_CORE_JS_NAME,
+          "Object.assign({0}.urls, {1}.{2})".format(conf.KOLIBRI_CORE_JS_NAME,
                                                     js_global_object_name,
                                                     js_var_name))
     return mark_safe(js)
@@ -89,7 +98,7 @@ def kolibri_set_urls(context):
 def kolibri_set_server_time():
     html = ("<script type='text/javascript'>"
             "{0}.utils.serverClock.setServerTime({1});"
-            "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
+            "</script>".format(conf.KOLIBRI_CORE_JS_NAME,
                                json.dumps(now(), cls=DjangoJSONEncoder)))
     return mark_safe(html)
 
@@ -100,7 +109,7 @@ def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
     html = ("<script type='text/javascript'>"
             "var model = {0}.resources.{1}.createModel(JSON.parse({2}), {3});"
             "model.synced = true;"
-            "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
+            "</script>".format(conf.KOLIBRI_CORE_JS_NAME,
                                api_resource,
                                json.dumps(JSONRenderer().render(response.data).decode('utf-8')),
                                json.dumps(url_params)))
@@ -112,7 +121,7 @@ def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
     html = ("<script type='text/javascript'>"
             "var collection = {0}.resources.{1}.createCollection({2}, {3}, JSON.parse({4}));"
             "collection.synced = true;"
-            "</script>".format(settings.KOLIBRI_CORE_JS_NAME,
+            "</script>".format(conf.KOLIBRI_CORE_JS_NAME,
                                api_resource,
                                json.dumps(url_params),
                                json.dumps(kwargs),

--- a/kolibri/core/webpack.config.js
+++ b/kolibri/core/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  output: {
+    library: 'kolibriGlobal',
+  },
+};

--- a/kolibri/core/webpack.config.js
+++ b/kolibri/core/webpack.config.js
@@ -1,5 +1,8 @@
+// This is only used during build time, so OK to reference files outside of Kolibri src.
+var kolibriName = require('../../frontend_build/src/kolibriName');
+
 module.exports = {
   output: {
-    library: 'kolibriGlobal',
+    library: kolibriName,
   },
 };

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -364,14 +364,6 @@ class WebpackInclusionHook(hooks.KolibriHook):
 
 class FrontEndCoreAssetHook(WebpackBundleHook):
 
-    @property
-    @hooks.registered_method
-    def webpack_bundle_data(self):
-        dct = super(FrontEndCoreAssetHook, self).webpack_bundle_data
-        dct['core_name'] = conf.KOLIBRI_CORE_JS_NAME
-        dct['external'] = True
-        return dct
-
     def render_to_page_load_sync_html(self):
         """
         Generates the appropriate script tags for the core bundle, be they JS or CSS

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -5,8 +5,9 @@ Kolibri Webpack hooks
 To manage assets, we use the webpack format. In order to have assets bundled in,
 you should put them in ``yourapp/assets/src``.
 """
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import json
 import logging
@@ -14,17 +15,19 @@ import os
 import time
 from functools import partial
 
-from pkg_resources import resource_filename
-
-import kolibri
 from django.conf import settings as django_settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language, get_language_info, to_locale
-from kolibri.plugins import hooks
+from django.utils.translation import get_language
+from django.utils.translation import get_language_info
+from django.utils.translation import to_locale
+from pkg_resources import resource_filename
 
+import kolibri
 from . import settings
+from kolibri.plugins import hooks
+from kolibri.utils import conf
 
 # We load quite a few JSON files from disk, as cached properties of
 # the WebpackBundleHook - but these are only cached per instance
@@ -261,7 +264,7 @@ class WebpackBundleHook(hooks.KolibriHook):
     def frontend_message_tag(self):
         if self.frontend_messages():
             return ['<script>{kolibri_name}.registerLanguageAssets("{bundle}", "{lang_code}", {messages});</script>'.format(
-                kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
+                kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
                 bundle=self.unique_slug,
                 lang_code=get_language(),
                 messages=self.frontend_messages(),
@@ -299,7 +302,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         urls = [chunk['url'] for chunk in self.sorted_chunks()]
         tags = self.frontend_message_tag() +\
             ['<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"], {events}, {once});</script>'.format(
-                kolibri_name=django_settings.KOLIBRI_CORE_JS_NAME,
+                kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
                 bundle=self.unique_slug,
                 urls='","'.join(urls),
                 events=json.dumps(self.events),
@@ -365,7 +368,7 @@ class FrontEndCoreAssetHook(WebpackBundleHook):
     @hooks.registered_method
     def webpack_bundle_data(self):
         dct = super(FrontEndCoreAssetHook, self).webpack_bundle_data
-        dct['core_name'] = django_settings.KOLIBRI_CORE_JS_NAME
+        dct['core_name'] = conf.KOLIBRI_CORE_JS_NAME
         dct['external'] = True
         return dct
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -31,8 +31,6 @@ BASE_DIR = os.path.abspath(os.path.dirname(__name__))
 
 KOLIBRI_HOME = conf.KOLIBRI_HOME
 
-KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
-
 LOCALE_PATHS = [
     os.path.join(KOLIBRI_MODULE_PATH, "locale"),
 ]

--- a/kolibri/utils/KOLIBRI_CORE_JS_NAME
+++ b/kolibri/utils/KOLIBRI_CORE_JS_NAME
@@ -1,0 +1,1 @@
+kolibriGlobal

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -15,7 +15,9 @@ This module should be easier to document, for instance by having VARIABLES
 instead of a dict.
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import json
 import logging
@@ -24,6 +26,8 @@ import os
 from kolibri.utils.compat import module_exists
 
 logger = logging.getLogger(__name__)
+
+KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
 
 KOLIBRI_HOME = os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))
 

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -27,7 +27,8 @@ from kolibri.utils.compat import module_exists
 
 logger = logging.getLogger(__name__)
 
-KOLIBRI_CORE_JS_NAME = 'kolibriGlobal'
+with open(os.path.join(os.path.dirname(__file__), 'KOLIBRI_CORE_JS_NAME')) as f:
+    KOLIBRI_CORE_JS_NAME = f.read().strip()
 
 KOLIBRI_HOME = os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))
 


### PR DESCRIPTION
### Summary
 * Removes lots of flexibility from the frontend build pipeline, in an attempt to simplify the logic and process.
 * Ran the build, Kolibri still built, app still loaded properly in the browser.

### Reviewer guidance
Check that Kolibri still builds and runs.
Look through the new files and see if it is easier to follow the build flow.

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
