### PR TITLE
Allow the plugin registry to be initialized without initializing django.

### DIFF
--- a/kolibri/plugins/registry.py
+++ b/kolibri/plugins/registry.py
@@ -38,13 +38,15 @@ Everything that a plugin does is expected to be defined through
 
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import importlib
 import logging
 
-from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.conf.urls import url
 
 from .base import KolibriPluginBase
 
@@ -57,16 +59,20 @@ __registry = []
 __initialized = False
 
 
-def initialize():
+def initialize(apps=None):
     """
     Called once at load time to register hook callbacks.
     """
     global __initialized, __registry
 
+    if not apps:
+        from django.conf import settings
+        apps = settings.INSTALLED_APPS
+
     if not __initialized:
         logger.debug("Loading kolibri plugin registry...")
 
-        for app in settings.INSTALLED_APPS:
+        for app in apps:
             try:
 
                 # Handle AppConfig INSTALLED_APPS string


### PR DESCRIPTION
### Summary
Currently, the plugin registry uses django settings to populate it, but this means Django must be initialized to populate the registry.
Instead, I make this optional, meaning that, for example, the frontend build process could pass in an explicit list of plugins it is building, and get the relevant information needed from the registry, without running django.

### Reviewer guidance
Default behaviour should be unchanged!

### References
Builds on #2979 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
