### PR TITLE
Adds permissions tests for DRF endpoints that should prevent deletion

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -1,25 +1,51 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import time
 
-from django.contrib.auth import authenticate, get_user, login, logout, update_session_auth_hash
+from django.contrib.auth import authenticate
+from django.contrib.auth import get_user
+from django.contrib.auth import login
+from django.contrib.auth import logout
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import AnonymousUser
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.query import F
-from django_filters.rest_framework import CharFilter, DjangoFilterBackend, FilterSet, ModelChoiceFilter
-from kolibri.core.mixins import BulkCreateMixin, BulkDeleteMixin
-from kolibri.logger.models import UserSessionLog
-from rest_framework import filters, permissions, status, viewsets
+from django_filters.rest_framework import CharFilter
+from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import FilterSet
+from django_filters.rest_framework import ModelChoiceFilter
+from rest_framework import filters
+from rest_framework import permissions
+from rest_framework import status
+from rest_framework import viewsets
 from rest_framework.response import Response
 
 from .constants import collection_kinds
 from .filters import HierarchyRelationsFilter
-from .models import Classroom, Collection, Facility, FacilityDataset, FacilityUser, LearnerGroup, Membership, Role
-from .serializers import (
-    ClassroomSerializer, FacilityDatasetSerializer, FacilitySerializer, FacilityUsernameSerializer, FacilityUserSerializer, FacilityUserSignupSerializer,
-    LearnerGroupSerializer, MembershipSerializer, PublicFacilitySerializer, RoleSerializer
-)
+from .models import Classroom
+from .models import Collection
+from .models import Facility
+from .models import FacilityDataset
+from .models import FacilityUser
+from .models import LearnerGroup
+from .models import Membership
+from .models import Role
+from .serializers import ClassroomSerializer
+from .serializers import FacilityDatasetSerializer
+from .serializers import FacilitySerializer
+from .serializers import FacilityUsernameSerializer
+from .serializers import FacilityUserSerializer
+from .serializers import FacilityUserSignupSerializer
+from .serializers import LearnerGroupSerializer
+from .serializers import MembershipSerializer
+from .serializers import PublicFacilitySerializer
+from .serializers import RoleSerializer
+from kolibri.core.mixins import BulkCreateMixin
+from kolibri.core.mixins import BulkDeleteMixin
+from kolibri.logger.models import UserSessionLog
 
 
 class KolibriAuthPermissionsFilter(filters.BaseFilterBackend):
@@ -83,7 +109,7 @@ class KolibriAuthPermissions(permissions.BasePermission):
 
 
 class FacilityDatasetViewSet(viewsets.ModelViewSet):
-    permissions_classes = (KolibriAuthPermissions,)
+    permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
     serializer_class = FacilityDatasetSerializer
 

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -1,18 +1,19 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
-import factory
 import sys
 
+import factory
+from django.contrib.sessions.models import Session
 from django.core.urlresolvers import reverse
-
 from rest_framework import status
 from rest_framework.test import APITestCase as BaseTestCase
-from django.contrib.sessions.models import Session
-
-from .helpers import create_superuser, provision_device
 
 from .. import models
+from .helpers import create_superuser
+from .helpers import provision_device
 
 DUMMY_PASSWORD = "password"
 
@@ -379,6 +380,7 @@ class FacilityDatasetAPITestCase(APITestCase):
     def setUp(self):
         provision_device()
         self.facility = FacilityFactory.create()
+        self.facility2 = FacilityFactory.create()
         self.superuser = create_superuser(self.facility)
         self.admin = FacilityUserFactory.create(facility=self.facility)
         self.user = FacilityUserFactory.create(facility=self.facility)
@@ -399,3 +401,7 @@ class FacilityDatasetAPITestCase(APITestCase):
         self.client.login(username=self.user.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse('facilitydataset-list'))
         self.assertEqual(len(response.data), len(models.FacilityDataset.objects.all()))
+
+    def test_facility_user_cannot_delete_dataset(self):
+        response = self.client.delete(reverse('facilitydataset-detail', kwargs={'pk': self.facility.dataset_id}), format="json")
+        self.assertEqual(response.status_code, 403)

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -4,22 +4,33 @@ from random import sample
 
 import requests
 from django.core.cache import cache
-from django.db.models import Q, Sum
+from django.db.models import Q
+from django.db.models import Sum
 from django.db.models.aggregates import Count
 from django.http import Http404
 from django.utils.translation import ugettext as _
-from django_filters.rest_framework import BooleanFilter, CharFilter, ChoiceFilter, DjangoFilterBackend, FilterSet
-from kolibri.content import models, serializers
-from kolibri.content.permissions import CanManageContent
-from kolibri.content.utils.paths import get_channel_lookup_url
-from kolibri.logger.models import ContentSessionLog, ContentSummaryLog
-from le_utils.constants import content_kinds, languages
-from rest_framework import mixins, pagination, viewsets
-from rest_framework.decorators import detail_route, list_route
+from django_filters.rest_framework import BooleanFilter
+from django_filters.rest_framework import CharFilter
+from django_filters.rest_framework import ChoiceFilter
+from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import FilterSet
+from le_utils.constants import content_kinds
+from le_utils.constants import languages
+from rest_framework import mixins
+from rest_framework import pagination
+from rest_framework import viewsets
+from rest_framework.decorators import detail_route
+from rest_framework.decorators import list_route
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from .utils.search import fuzz
+from kolibri.content import models
+from kolibri.content import serializers
+from kolibri.content.permissions import CanManageContent
+from kolibri.content.utils.paths import get_channel_lookup_url
+from kolibri.logger.models import ContentSessionLog
+from kolibri.logger.models import ContentSummaryLog
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +344,7 @@ class FileViewset(viewsets.ReadOnlyModelViewSet):
 
 
 class RemoteChannelViewSet(viewsets.ViewSet):
-    permissions_classes = (CanManageContent,)
+    permission_classes = (CanManageContent,)
 
     http_method_names = ['get']
 

--- a/kolibri/core/exams/api.py
+++ b/kolibri/core/exams/api.py
@@ -1,12 +1,17 @@
 from django.db.models.query import F
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet
-from kolibri.auth.api import KolibriAuthPermissions, KolibriAuthPermissionsFilter
-from kolibri.auth.filters import HierarchyRelationsFilter
-from kolibri.core.exams import models, serializers
-from rest_framework import pagination, viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import FilterSet
+from rest_framework import pagination
+from rest_framework import viewsets
 from rest_framework.response import Response
+
+from kolibri.auth.api import KolibriAuthPermissions
+from kolibri.auth.api import KolibriAuthPermissionsFilter
+from kolibri.auth.filters import HierarchyRelationsFilter
+from kolibri.core.exams import models
+from kolibri.core.exams import serializers
 
 
 class OptionalPageNumberPagination(pagination.PageNumberPagination):
@@ -27,7 +32,7 @@ class ExamFilter(FilterSet):
 class ExamViewset(viewsets.ModelViewSet):
     serializer_class = serializers.ExamSerializer
     pagination_class = OptionalPageNumberPagination
-    permissions_classes = (KolibriAuthPermissions,)
+    permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend)
     filter_class = ExamFilter
 
@@ -45,7 +50,7 @@ class ExamViewset(viewsets.ModelViewSet):
 class ExamAssignmentViewset(viewsets.ModelViewSet):
     serializer_class = serializers.ExamAssignmentSerializer
     pagination_class = OptionalPageNumberPagination
-    permissions_classes = (KolibriAuthPermissions,)
+    permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
 
     def get_queryset(self):
@@ -55,7 +60,7 @@ class ExamAssignmentViewset(viewsets.ModelViewSet):
 class UserExamViewset(viewsets.ModelViewSet):
     serializer_class = serializers.UserExamSerializer
     pagination_class = OptionalPageNumberPagination
-    permissions_classes = (KolibriAuthPermissions,)
+    permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
 
     def get_queryset(self):

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -1,13 +1,14 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
-
-from kolibri.auth.models import Facility, FacilityUser
-from kolibri.auth.test.helpers import provision_device
-
 from rest_framework.test import APITestCase
 
 from .. import models
+from kolibri.auth.models import Facility
+from kolibri.auth.models import FacilityUser
+from kolibri.auth.test.helpers import provision_device
 
 class UserExamAPITestCase(APITestCase):
 
@@ -40,6 +41,76 @@ class UserExamAPITestCase(APITestCase):
         response = self.client.get(reverse("userexam-list"))
         self.assertEqual(len(response.data), 1)
 
+    def test_logged_in_user_userexam_no_delete(self):
+
+        user = FacilityUser.objects.create(username="learner", facility=self.facility)
+        user.set_password("pass")
+        user.save()
+
+        self.client.login(username=user.username, password="pass")
+
+        response = self.client.delete(reverse("userexam-detail", kwargs={'pk': self.assignment.id}))
+        self.assertEqual(response.status_code, 403)
+
     def test_anonymous_userexam_list(self):
         response = self.client.get(reverse("userexam-list"))
         self.assertEqual(len(response.data), 0)
+
+
+class ExamAPITestCase(APITestCase):
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="admin", facility=self.facility)
+        self.exam = models.Exam.objects.create(
+            title="title",
+            channel_id="test",
+            question_count=1,
+            active=True,
+            collection=self.facility,
+            creator=user
+        )
+
+    def test_logged_in_user_exam_no_delete(self):
+
+        user = FacilityUser.objects.create(username="learner", facility=self.facility)
+        user.set_password("pass")
+        user.save()
+
+        self.client.login(username=user.username, password="pass")
+
+        response = self.client.delete(reverse("exam-detail", kwargs={'pk': self.exam.id}))
+        self.assertEqual(response.status_code, 403)
+
+
+class ExamAssignmentAPITestCase(APITestCase):
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="admin", facility=self.facility)
+        self.exam = models.Exam.objects.create(
+            title="title",
+            channel_id="test",
+            question_count=1,
+            active=True,
+            collection=self.facility,
+            creator=user
+        )
+        self.assignment = models.ExamAssignment.objects.create(
+            exam=self.exam,
+            collection=self.facility,
+            assigned_by=user,
+        )
+
+    def test_logged_in_user_examassignment_no_delete(self):
+
+        user = FacilityUser.objects.create(username="learner", facility=self.facility)
+        user.set_password("pass")
+        user.save()
+
+        self.client.login(username=user.username, password="pass")
+
+        response = self.client.delete(reverse("examassignment-detail", kwargs={'pk': self.assignment.id}))
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
### Summary
Fixes typos in permission_classes assignment in several DRF endpoint definitions.
Adds regression tests.

### Reviewer guidance
My impression is that the effect of this was to just be very permissive in what users could do to data, but because most of these end points are also using `KolibriAuthPermissionsFilter`, the data that people see is almost certainly unchanged. This just tightens up security somewhat.

### References
Fixes #3166 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
