### PR TITLE
Fixed Server 400 error for Superusers

### DIFF
--- a/kolibri/core/assets/src/conditionalPromise.js
+++ b/kolibri/core/assets/src/conditionalPromise.js
@@ -14,12 +14,12 @@ export default class ConditionalPromise {
   }
 
   catch(...args) {
-    this._promise.catch(...args);
+    this._promise = this._promise.catch(...args);
     return this;
   }
 
   then(...args) {
-    this._promise.then(...args);
+    this._promise = this._promise.then(...args);
     return this;
   }
 


### PR DESCRIPTION
### Summary
When running password-less login, previously it would return server 400 response error when trying to login as a admin and/or superuser.

It ended up being a problem with the chaining of the catch and then in the conditionalPromise file. Simply calling the catch with the args does not actually update the promise (it only returns a value). I ended up setting this._promise to the the result of the catch as a way to save and chain it.

### Reviewer guidance

Run the Kolibri devserver and set the configuration to allow password-less login. Login with a user that is a superuser and/or an admin. It will press for a password to be provided and the browser console will no longer throw the server 400 response error.

@DXCanas It seemed last time this conflicted with one of your fixes with the learn page. Can you check to see if it still conflicts with issue #2636? 

### References

Re-submission of pull request #2584 
Fixes issue #2156 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
