### PR TITLE
Breadcrumbs

### DIFF
--- a/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
+++ b/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
@@ -244,8 +244,8 @@
   @require '~kolibri.styles.definitions'
 
   .breadcrumbs
-    margin-top: 24px
-    margin-bottom: 24px
+    margin-top: 8px
+    margin-bottom: 8px
     font-size: 16px
     font-weight: bold
 
@@ -269,7 +269,7 @@
 
   .breadcrumbs-dropdown-item
     display: block
-    padding-top: 8px
+    padding-top: px
     padding-bottom: 8px
     a
       overflow: hidden

--- a/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
+++ b/kolibri/core/assets/src/views/k-breadcrumbs/index.vue
@@ -269,7 +269,7 @@
 
   .breadcrumbs-dropdown-item
     display: block
-    padding-top: px
+    padding-top: 8px
     padding-bottom: 8px
     a
       overflow: hidden


### PR DESCRIPTION

### Summary

 * description of the change: The breadcrumb margin top and margin bottom were changed from 24px to 8px. 
 * manual verification steps performed
 * screenshots if the PR affects the UI: 
Before:
<img width="367" alt="24pxbreadcrumb" src="https://user-images.githubusercontent.com/15150234/36005758-fd299df2-0ced-11e8-81a6-85f7938a6a1d.png">

After:
<img width="350" alt="8pxbreadcrumb" src="https://user-images.githubusercontent.com/15150234/36005766-0cc589b0-0cee-11e8-96f7-3fae291ac99d.png">





…

### Reviewer guidance

 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
You can look at the "Learn Page" and the breadcrumb should have less space between what's on the top and bottom of it. There might need to be some exploration on the rest of the site to see if this change has caused anything else to change.

…

### References

 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
Fixes this issue https://github.com/learningequality/kolibri/issues/2819 

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
