### PR TITLE
Disabled CREATE EXAM button while no content is selected

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/create-exam-modal.vue
@@ -20,7 +20,7 @@
       <k-button
         :text="$tr('createExam')"
         :primary="true"
-        :disabled="!selectedChannel"
+        :disabled="Object.keys(selectedChannel).length === 0"
         @click="routeToCreateExamPage"
       />
     </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Disabled the CREATE EXAM button while no channels are selected.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/7971405/36052802-05e9a264-0da4-11e8-90f4-3cecb8654562.png)

After:
![image](https://user-images.githubusercontent.com/7971405/36052856-3e7ac6f8-0da4-11e8-9b38-7277585cdc50.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Create a new exam and try to click the CREATE EXAM button while non of the channels are selected.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Link to issue:
https://github.com/learningequality/kolibri/issues/3171

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
