### PR TITLE
devserver will now respect KOLIBRI_LISTEN_PORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ kolibri/locale/en/
 kolibri.iml
 .pydevproject
 .venv
+.envrc
 .idea
 
 # Complexity
@@ -68,6 +69,7 @@ docs-developer/py_modules/modules.rst
 # node
 node_modules
 npm-debug.log
+.node-version
 
 # Node coverage data
 coverage
@@ -90,6 +92,7 @@ kolibri/content/content_db/*.sqlite3
 
 # virtual environment
 venv/
+.python-version
 
 # leftover from hack day - want to ensure people don't check these in
 kolibri/plugins/learn/assets/src/demo/

--- a/kolibri/core/webpack/management/commands/devserver.py
+++ b/kolibri/core/webpack/management/commands/devserver.py
@@ -14,6 +14,10 @@ from kolibri.content.utils.annotation import update_channel_metadata
 logger = logging.getLogger(__name__)
 
 
+if os.environ['KOLIBRI_LISTEN_PORT']:
+    RunserverCommand.default_port = int(os.environ['KOLIBRI_LISTEN_PORT'])
+
+
 class Command(RunserverCommand):
     """
     Subclass the RunserverCommand from Staticfiles to optionally run webpack.


### PR DESCRIPTION
### Summary

Previously, `KOLIBRI_LISTEN_PORT` was not respected by devserver. now it is.

This helps with easily running multiple servers in parallel, complementing the `KOLIBRI_HOME` variable.

### Reviewer guidance

Please ensure this doesn't break any best-practices or assumptions about how things should work

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
