### PR TITLE
Don't cache frontend messages during development.

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -236,7 +236,7 @@ class WebpackBundleHook(hooks.KolibriHook):
     def frontend_messages(self):
         global _JSON_MESSAGES_FILE_CACHE
         lang_code = get_language()
-        if not _JSON_MESSAGES_FILE_CACHE.get(self.unique_slug, {}).get(lang_code):
+        if not _JSON_MESSAGES_FILE_CACHE.get(self.unique_slug, {}).get(lang_code) or django_settings.DEBUG:
             frontend_message_file = self.frontend_message_file(lang_code)
             if frontend_message_file:
                 with open(frontend_message_file) as f:


### PR DESCRIPTION
### Summary
During production, to prevent reloading JSON files from disk, we cache frontend messages in memory.
We should not do this in development because it means messages don't update.

### Reviewer guidance
Question - would it be advisable to switch this, and the stats file cache over to using Django cache?


### References
Fixes #2293 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
