### PR TITLE
Tox fails if models have changes that are not yet reflected in a migration

### DIFF
--- a/kolibri/auth/migrations/0007_auto_20171226_1125.py
+++ b/kolibri/auth/migrations/0007_auto_20171226_1125.py
@@ -4,6 +4,16 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+# This is necessary because:
+# 1. The list generator has an unpredictable order, and when items swap places
+#    then this would be picked up as a change in Django if we had used
+# 2. These choices can be changed in facility_configuration_presets.json
+#    and such change should not warrant warnings that models are inconsistent
+#    as it has no impact.
+# Notice: The 'choices' property of a field does NOT have any impact on DB
+# See: https://github.com/learningequality/kolibri/pull/3180
+from ..constants.facility_presets import choices as facility_choices
+
 
 class Migration(migrations.Migration):
 
@@ -15,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='facilitydataset',
             name='preset',
-            field=models.CharField(choices=[('informal', 'Informal and personal use'), ('nonformal', 'Self-managed'), ('formal', 'Admin-managed')], default='nonformal', max_length=50),
+            field=models.CharField(choices=facility_choices, default='nonformal', max_length=50),
         ),
         migrations.AlterUniqueTogether(
             name='facilityuser',

--- a/kolibri/content/migrations/0004_auto_20170825_1038.py
+++ b/kolibri/content/migrations/0004_auto_20170825_1038.py
@@ -65,9 +65,13 @@ class Migration(migrations.Migration):
             options={
                 'ordering': ('lft',),
             },
-            managers=[
-                ('_default_manager', django.db.models.manager.Manager()),
-            ],
+            # Removed because django-mptt 0.8.7 patched up an error in
+            # Django 1.9 (fixed since 1.10).
+            # Ref: https://code.djangoproject.com/ticket/26643
+            # https://github.com/learningequality/kolibri/pull/3180
+            # managers=[
+            #     ('_default_manager', django.db.models.manager.Manager()),
+            # ],
         ),
         migrations.CreateModel(
             name='ContentTag',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ djangorestframework==3.3.3
 django==1.9.13
 colorlog==2.6.0
 docopt==0.6.2
-django-mptt==0.8.5
+django-mptt==0.8.7
 djangorestframework-csv==1.4.1
 tqdm==4.11.2                     # progress bars
 requests==2.18.4

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ usedevelop = True
 whitelist_externals=
     rm
     make
+    sh
 setenv =
     PYTHONPATH = {toxinidir}
     KOLIBRI_HOME = {envtmpdir}/.kolibri
@@ -35,6 +36,10 @@ commands =
     coverage run -p kolibri plugin kolibri.plugins.management enable
     coverage run -p kolibri start
     coverage run -p kolibri stop
+    # Test that there are no migrations needed -- on Django 1.11, we can
+    # use --check and remove the '!' which likely doesn't work on Windows
+    sh -c '! kolibri manage makemigrations --dry-run --exit --noinput'
+    # Run the actual tests
     py.test {posargs:--cov=kolibri --color=no}
     # This is currently disabled because some process seems to be locking
     # the directory:


### PR DESCRIPTION
### Summary

I'll apply the good old "fail+fix" pattern here:

1. First commit fails tests to prove that a new problem is caught
2. Second commit fixes the first migration inconsistency in kolibri
3. Third commit fixes the first migration inconsistency in morango

I would assume that both can actually be fixed without adding migrations, but in case the newer `develop` branch contains new migrations, they have to be updated, too.

I would prefer to not introduce any new migrations at this point, because porting them into `develop` will cause a mess for everyone developing on 0.8 in case they have also added migrations.

### django-mptt upgrade

https://github.com/django-mptt/django-mptt/compare/0.8.5...0.8.7

Release notes:
https://github.com/django-mptt/django-mptt/releases

### Reviewer guidance

Inputs always welcome :)

### References

#3162

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
