### PR TITLE
add 'enter' handler, fixes #3182

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -7,6 +7,7 @@
     <core-modal
       :title=" $tr('facilityPermissionsPresetDetailsHeader')"
       @cancel="hideFacilityPermissionsDetails"
+      @enter="hideFacilityPermissionsDetails"
       :enableBgClickCancel="true"
       v-if="permissionPresetDetailsModalShown"
     >


### PR DESCRIPTION
### Summary

adds 'enter' handler to this modal:

![image](https://user-images.githubusercontent.com/2367265/36107621-833deef0-0fcf-11e8-8143-200b715c20c7.png)

### Reviewer guidance

See issue #3182

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
