### PR TITLE
Fix soon-to-be-deleted line with some python3-specific code

### DIFF
--- a/docs-developer/conf.py
+++ b/docs-developer/conf.py
@@ -26,6 +26,10 @@ builddir = os.path.join(cwd, '_build')
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
 os.environ["KOLIBRI_HOME"] = os.path.join(builddir, 'kolibri_home')
 
+# This is necessary because the directory needs to exist for Kolibri to run when
+# not invoked through CLI.
+if not os.path.exists(os.environ["KOLIBRI_HOME"]):
+    os.makedirs(os.environ["KOLIBRI_HOME"])
 
 # This import *must* come after the path insertion, otherwise sphinx won't be able to find the kolibri module
 import kolibri  # noqa

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,11 +3,9 @@
 # Kolibri 'user docs' documentation build configuration file
 #
 # This file is execfile()d with the current directory set to its containing dir.
-
-
-from datetime import datetime
 import os
 import sys
+from datetime import datetime
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -27,7 +25,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.sett
 os.environ["KOLIBRI_HOME"] = os.path.join(builddir, 'kolibri_home')
 
 if not os.path.exists(os.environ["KOLIBRI_HOME"]):
-    os.mkdir(os.environ["KOLIBRI_HOME"])
+    os.makedirs(os.environ["KOLIBRI_HOME"])
 
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
### Summary

Fixes current build errors. Might also be caused by a Sphinx update.

### Reviewer guidance

Don't pay attention to the fact that `os.makedirs` is Python 3 only

### References

Not sure

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
