### PR TITLE
Exams and nested permissions

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -86,10 +86,10 @@ class KolibriAuthPermissions(permissions.BasePermission):
             else:
                 data = [request.data]
 
-            model = view.serializer_class.Meta.model
+            model = view.get_serializer_class().Meta.model
 
             def validate(datum):
-                validated_data = view.serializer_class().to_internal_value(_ensure_raw_dict(datum))
+                validated_data = view.get_serializer().to_internal_value(_ensure_raw_dict(datum))
                 return request.user.can_create(model, validated_data)
             return all(validate(datum) for datum in data)
 

--- a/kolibri/core/exams/api.py
+++ b/kolibri/core/exams/api.py
@@ -48,13 +48,17 @@ class ExamViewset(viewsets.ModelViewSet):
 
 
 class ExamAssignmentViewset(viewsets.ModelViewSet):
-    serializer_class = serializers.ExamAssignmentSerializer
     pagination_class = OptionalPageNumberPagination
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
 
     def get_queryset(self):
         return models.ExamAssignment.objects.all()
+
+    def get_serializer_class(self):
+        if hasattr(self, 'action') and self.action == 'create':
+            return serializers.ExamAssignmentCreationSerializer
+        return serializers.ExamAssignmentRetrieveSerializer
 
 
 class UserExamViewset(viewsets.ModelViewSet):

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -17,10 +17,10 @@ class Exam(AbstractFacilityDataModel):
 
     permissions = RoleBasedPermissions(
         target_field="collection",
-        can_be_created_by=(),
+        can_be_created_by=(role_kinds.ADMIN, role_kinds.COACH),
         can_be_read_by=(role_kinds.ADMIN, role_kinds.COACH),
         can_be_updated_by=(role_kinds.ADMIN, role_kinds.COACH),
-        can_be_deleted_by=(),
+        can_be_deleted_by=(role_kinds.ADMIN, role_kinds.COACH),
     )
 
     title = models.CharField(max_length=200)

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -1,11 +1,12 @@
 from django.db import models
 from jsonfield import JSONField
 
-from kolibri.auth.constants import role_kinds
-from kolibri.auth.models import AbstractFacilityDataModel, Collection, FacilityUser
-from kolibri.auth.permissions.base import RoleBasedPermissions
-
 from .permissions import UserCanReadExamAssignmentData
+from kolibri.auth.constants import role_kinds
+from kolibri.auth.models import AbstractFacilityDataModel
+from kolibri.auth.models import Collection
+from kolibri.auth.models import FacilityUser
+from kolibri.auth.permissions.base import RoleBasedPermissions
 
 class Exam(AbstractFacilityDataModel):
     """
@@ -67,10 +68,10 @@ class ExamAssignment(AbstractFacilityDataModel):
     permissions = (
         RoleBasedPermissions(
             target_field="collection",
-            can_be_created_by=(),
+            can_be_created_by=(role_kinds.ADMIN, role_kinds.COACH),
             can_be_read_by=(role_kinds.ADMIN, role_kinds.COACH),
-            can_be_updated_by=(role_kinds.ADMIN, role_kinds.COACH),
-            can_be_deleted_by=(),
+            can_be_updated_by=(),
+            can_be_deleted_by=(role_kinds.ADMIN, role_kinds.COACH),
         ) | UserCanReadExamAssignmentData()
     )
     exam = models.ForeignKey(Exam, related_name='assignments', blank=False, null=False)


### PR DESCRIPTION
### Summary
* Sorts out permission issues for ExamAssignment.
* Creates a separate serializer for creation operations to avoid nested creation operations
* Makes KolibriAuthPermissions do more idiomatic access of DRF serializer classes
* Sorts out permission issues for Exam.
* Use `to_internal_value` for custom data processing, rather than `create`, in order to have the data available for validation.

### Reviewer guidance
Test that exam creation and assignment works.

### References
Fixes #3186 and resolves #3189 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
