### PR TITLE
Do not install requirements during make dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ buildconfig:
 	python build_tools/customize_build.py
 
 dist: writeversion staticdeps staticdeps-cext buildconfig assets compilemessages
-	pip install -r requirements/build.txt
 	python setup.py sdist --format=gztar --static > /dev/null # silence the sdist output! Too noisy!
 	python setup.py bdist_wheel --static
 	ls -l dist


### PR DESCRIPTION
### Summary

This the sort of dangerous thing where you think you have environment X that you're building on, and then during `make dist`, the environment changes.

I'll make sure to add `pip install -r requiements/build.txt` somewhere else when I know where Buildkite would need it.

### Reviewer guidance

n/a

### References

n/a

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
