### PR TITLE
Flappybirdcenter

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -128,7 +128,7 @@
       width: 90%
       max-width: 550px
       &.mobile
-        margin: 48px
+        margin: 48px auto
         width: auto
         margin-top: 40px
 


### PR DESCRIPTION
### Summary

I made a minor change in the index.vue file within the views folder to center the flappy bird while loading the setup wizard. I also added a pdb line to stop the flappy bird page so that I could see where the problem was and how I could fix it, the line was added and removed from serializers.py. I then removed the line so the only change should be in index.vue. The following are pictures of the bird now staying centered.

<img width="1280" alt="screen shot 2018-02-15 at 4 17 16 pm" src="https://user-images.githubusercontent.com/15150234/36288877-d3a677f0-1271-11e8-96b1-22d0f7aa243b.png">
<img width="1280" alt="screen shot 2018-02-15 at 4 45 25 pm" src="https://user-images.githubusercontent.com/15150234/36288880-d624fdf8-1271-11e8-8343-ce285153d1eb.png">
<img width="1280" alt="screen shot 2018-02-15 at 4 45 31 pm" src="https://user-images.githubusercontent.com/15150234/36288883-d8781c98-1271-11e8-947c-47a861a369b0.png">




…

### Reviewer guidance

These changes can be tested by pausing on the loading page and readjusting the size of the screen. The flappy bird show always be centered. There should be no other changes to the rest of the files, but you can test to see if any other files were affected by this change.



…

### References
Fixes https://github.com/learningequality/kolibri/issues/2730 

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
