### PR TITLE
Download topic thumbnails

### DIFF
--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -6,12 +6,12 @@ def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
     files_to_transfer = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=available)
 
     if node_ids:
-        leaf_node_ids = _get_leaf_node_ids(node_ids)
-        files_to_transfer = files_to_transfer.filter(files__contentnode__in=leaf_node_ids)
+        node_ids = _get_node_ids(node_ids)
+        files_to_transfer = files_to_transfer.filter(files__contentnode__in=node_ids)
 
     if exclude_node_ids:
-        exclude_leaf_node_ids = _get_leaf_node_ids(exclude_node_ids)
-        files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_leaf_node_ids)
+        exclude_node_ids = _get_node_ids(exclude_node_ids)
+        files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_node_ids)
 
     # Make sure the files are unique, to avoid duplicating downloads
     files_to_transfer = files_to_transfer.distinct()
@@ -21,10 +21,9 @@ def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available):
     return files_to_transfer, total_bytes_to_transfer
 
 
-def _get_leaf_node_ids(node_ids):
+def _get_node_ids(node_ids):
 
     return ContentNode.objects \
         .filter(pk__in=node_ids) \
         .get_descendants(include_self=True) \
-        .filter(children__isnull=True) \
         .values_list('id', flat=True)


### PR DESCRIPTION
### Summary
We were only downloading files for leaf nodes, meaning topic thumbnails were not getting downloaded.

### Reviewer guidance
This will fix the issue going forwards, but I don't see a simple solution to force the download of previously downloaded channels' topic thumbnails.

### References
Fixes #3204 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
