### PR TITLE
Update reference to string.

### DIFF
--- a/kolibri/core/assets/src/views/side-nav/index.vue
+++ b/kolibri/core/assets/src/views/side-nav/index.vue
@@ -23,7 +23,7 @@
             icon="close"
             @click="toggleNav"
           />
-          <span class="side-nav-header-name">{{ $tr('Kolibri') }}</span>
+          <span class="side-nav-header-name">{{ $tr('kolibri') }}</span>
         </div>
 
         <div


### PR DESCRIPTION
### Summary

Update reference to string. Missed in #3209. My mistake.

![image](https://user-images.githubusercontent.com/7193975/36447869-8cc46b4a-163a-11e8-938d-d04ea7563caa.png)


### Reviewer guidance

Open side nav. Make sure string is there.

### References

#3209 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
