### PR TITLE
Adjusts line height after having ignored it for years. :skull_and_crossbones: 

### DIFF
--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -30,7 +30,7 @@ html
   text-size-adjust: 100%
   box-sizing: border-box
   // from normalize v5
-  line-height: 1.15
+  line-height: 1.3
 
 html, body
   height:100%
@@ -143,4 +143,3 @@ button
 
 .rtl-icon
   transform: scaleX(-1)
-

--- a/kolibri/core/assets/src/views/k-select/index.vue
+++ b/kolibri/core/assets/src/views/k-select/index.vue
@@ -145,4 +145,7 @@
     width: 150px
     margin-right: 16px
 
+  >>>.ui-select__display-value
+    line-height: 1.3
+
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
@@ -14,11 +14,11 @@
           <p>{{ $tr('channelsAvailable', { channels: numberOfAvailableChannels }) }}</p>
         </div>
         <div class="filters dib">
-          <ui-select
+          <k-select
             :options="languageFilterOptions"
             v-model="languageFilter"
             :label="$tr('languageFilterLabel')"
-            class="language-filter dib"
+            :inline="true"
           />
           <k-filter-textbox
             :placeholder="$tr('titleFilterPlaceholder')"
@@ -81,7 +81,7 @@
 <script>
 
   import UiProgressLinear from 'keen-ui/src/UiProgressLinear';
-  import UiSelect from 'keen-ui/src/UiSelect';
+  import kSelect from 'kolibri.coreVue.components.kSelect';
   import channelListItem from '../manage-content-page/channel-list-item';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
@@ -109,7 +109,7 @@
       kFilterTextbox,
       subpageContainer,
       UiProgressLinear,
-      UiSelect,
+      kSelect,
     },
     data() {
       return {
@@ -278,9 +278,6 @@
     width: 70%
     vertical-align: top
     margin: 16px 0
-
-  .language-filter
-    width: 45%
 
   .title-filter
     width: 50%

--- a/kolibri/plugins/device_management/assets/test/views/available-channels-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/available-channels-page.spec.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { mount } from 'avoriaz';
 import AvailableChannelsPage from '../../src/views/available-channels-page';
 import ChannelListItem from '../../src/views/manage-content-page/channel-list-item.vue';
-import UiSelect from 'keen-ui/src/UiSelect';
+import kSelect from 'kolibri.coreVue.components.kSelect';
 import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
 import ImmersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
 import ChannelTokenModal from '../../src/views/available-channels-page/channel-token-modal';
@@ -95,7 +95,7 @@ function getElements(wrapper) {
     channelListItems: () => wrapper.find(ChannelListItem),
     channelTokenModal: () => wrapper.first(ChannelTokenModal),
     filters: () => wrapper.find('.filters'),
-    languageFilter: () => wrapper.first(UiSelect),
+    languageFilter: () => wrapper.first(kSelect),
     titleText: () => wrapper.first('.channels h1').text().trim(),
     titleFilter: () => wrapper.first(kFilterTextbox),
     unlistedChannelsSection: () => wrapper.find('section.unlisted-channels'),
@@ -254,10 +254,11 @@ describe('availableChannelsPage', () => {
     const wrapper = makeWrapper();
     const { languageFilter } = getElements(wrapper);
     const filter = languageFilter();
-    // Can't seem to trigger the event, so calling setValue method directly
-    filter.vm.setValue({ label: 'English', value: 'en' });
     return wrapper.vm.$nextTick().then(() => {
-      testChannelVisibility(wrapper, [true, false, false, false]);
+      filter.vm.selection = { label: 'English', value: 'en' };
+      return wrapper.vm.$nextTick().then(() => {
+        testChannelVisibility(wrapper, [true, false, false, false]);
+      });
     });
   });
 
@@ -278,10 +279,12 @@ describe('availableChannelsPage', () => {
     const { languageFilter, titleFilter } = getElements(wrapper);
     const lFilter = languageFilter();
     const tFilter = titleFilter();
-    lFilter.vm.setValue({ label: 'German', value: 'de' });
     tFilter.vm.model = 'hund';
     return wrapper.vm.$nextTick().then(() => {
-      testChannelVisibility(wrapper, [false, false, true, false]);
+      lFilter.vm.selection = { label: 'German', value: 'de' };
+      return wrapper.vm.$nextTick().then(() => {
+        testChannelVisibility(wrapper, [false, false, true, false]);
+      });
     });
   });
 


### PR DESCRIPTION
### Summary

Adjusts line height after having ignored it for years. :skull_and_crossbones: 
Wanted to adjust the line-height of the filter in available channels page and realized that it was using a ui-select so replaced it with a k-select. Also adjusted the line height for k-selects.

![screenshot at 2018-02-20 14-51-08](https://user-images.githubusercontent.com/7193975/36454012-0e5ad00e-164f-11e8-8aba-83aa923ff5c7.png)
![screenshot at 2018-02-20 14-51-21](https://user-images.githubusercontent.com/7193975/36454013-0e7a6748-164f-11e8-817a-42775f45d31e.png)


### Reviewer guidance

Make sure everything looks and that the channel filter works properly.

### References

Fixes #2874

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
