### PR TITLE
Autoaccept fonts EULA for windows builds.

### DIFF
--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get -y update
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sudo software-properties-common
 
-RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update \
-    && apt-get install -y wine1.8
+RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+RUN apt-get install -y ttf-mscorefonts-installer
+RUN apt-get install -y wine1.8
 
 COPY ./ /kolibri
 


### PR DESCRIPTION
### Summary
Attempts to permanently fix the issue with EULA acceptance blocking our Windows installer build pipeline.

### Reviewer guidance
Does it build?

Opening on release-v0.7.x so that we can be sure of making builds for this series and later.

Can cherry pick to earlier releases if needed.

### References
Solution taken from: https://askubuntu.com/questions/16225/how-can-i-accept-the-microsoft-eula-agreement-for-ttf-mscorefonts-installer/25614#25614

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
