### PR TITLE
Fix inconsistent naming/terminology - users vs. learners #3021

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -118,15 +118,13 @@
   export default {
     name: 'classEnrollPage',
     $trs: {
-      enrollUsers: 'Enroll learners',
-      tableTitle: 'Manage learners in this class',
-      searchText: 'Find a learner or coach...',
+      enrollUsers: 'Enroll users ',
+      tableTitle: 'Manage users in this class',
+      searchText: 'Find a user...',
       users: 'Users',
       fullName: 'Full name',
       username: 'Username',
       role: 'Role',
-      learner: 'Learner',
-      coach: 'Coach',
       remove: 'Remove',
       noUsersExist: 'No users in this class',
       allUsersFilteredOut: 'No matching users',

--- a/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
@@ -42,7 +42,7 @@
       confirmEnrollment: 'Confirm enrollment of selected users',
       areYouSure: 'Are you sure you want to enroll the following users into {className}?',
       noGoBack: 'No, go back',
-      yesEnrollUsers: 'Yes, enroll learners',
+      yesEnrollUsers: 'Yes, enroll users',
     },
     components: {
       coreModal,

--- a/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
@@ -40,7 +40,7 @@
     name: 'confirmEnrollmentModal',
     $trs: {
       confirmEnrollment: 'Confirm enrollment of selected users',
-      areYouSure: 'Are you sure you want to enroll the following users into {className}?',
+      areYouSure: "Are you sure you want to enroll the following users into '{className}'?",
       noGoBack: 'No, go back',
       yesEnrollUsers: 'Yes, enroll users',
     },
@@ -99,8 +99,8 @@
 <style lang="stylus" scoped>
 
   .review-enroll-ul
-    list-style: none
-    margin: 20px 0
+    list-style: inside
+    padding: 0
 
   .review-enroll-li
     line-height: 1.8em

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -39,7 +39,7 @@
 
       <k-select
         class="kind-select"
-        :label="$tr('userKind')"
+        :label="$tr('userType')"
         :options="userKinds"
         v-model="newKind"
       />
@@ -82,7 +82,7 @@
       editUser: 'Edit user',
       fullName: 'Full name',
       username: 'Username',
-      userKind: 'User kind',
+      userType: 'User type',
       admin: 'Admin',
       coach: 'Coach',
       learner: 'Learner',

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
@@ -249,7 +249,7 @@
       },
     },
     $trs: {
-      filterUserType: 'User kind',
+      filterUserType: 'User type',
       searchText: 'Search for a user...',
       allUsers: 'All',
       admins: 'Admins',

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -56,7 +56,7 @@
         />
 
         <k-select
-          :label="$tr('typeOfUser')"
+          :label="$tr('userType')"
           :options="userKinds"
           v-model="kind"
           class="kind-select"
@@ -103,7 +103,7 @@
       username: 'Username',
       password: 'Password',
       reEnterPassword: 'Re-enter password',
-      typeOfUser: 'Type of user',
+      userType: 'User type',
       createAccount: 'Create Account',
       learner: 'Learner',
       coach: 'Coach',


### PR DESCRIPTION
### Summary

Fix inconsistent naming/terminology - users vs. learners #3021

![localhost_8000_facility_](https://user-images.githubusercontent.com/7193975/36560279-24a45f70-17c5-11e8-8927-9708f9f95cc0.png)
![localhost_8000_facility_ 1](https://user-images.githubusercontent.com/7193975/36560280-24cead70-17c5-11e8-80ff-5123fad383b4.png)
![localhost_8000_facility_ 2](https://user-images.githubusercontent.com/7193975/36560281-24eac4ba-17c5-11e8-8eed-bc6da3e5d977.png)
![localhost_8000_facility_ 3](https://user-images.githubusercontent.com/7193975/36560283-250f0a64-17c5-11e8-9bfe-5151c6c5f951.png)
![localhost_8000_facility_ 4](https://user-images.githubusercontent.com/7193975/36560285-252cc3e2-17c5-11e8-9628-931900b482f0.png)


### Reviewer guidance

View UI and make sure strings are correct.

### References

Fixes #3021 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
