### PR TITLE
Pass proper data to backend for exam assignment

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -203,7 +203,7 @@ function deactivateExam(store, examId) {
 function _assignExamTo(examId, collection) {
   const assignmentPayload = {
     exam: examId,
-    collection,
+    collection: collection.id,
   };
   return new Promise((resolve, reject) => {
     ExamAssignmentResource.createModel(assignmentPayload)


### PR DESCRIPTION
### Summary
Updates to the permissions for exam assignment had removed the nested collection serializer for exam creation. The appropriate equivalent change on the frontend had not been done. This PR makes that change.

### Reviewer guidance
Can you create exams without a 500?
Can you change the assignment of exams without a 500?
Does exam assignment work now?

### References
Fixes #3219

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
