### PR TITLE
Some fixes for granular import/export workflows

### DIFF
--- a/kolibri/plugins/device_management/assets/src/state/getters.js
+++ b/kolibri/plugins/device_management/assets/src/state/getters.js
@@ -36,7 +36,7 @@ export function installedChannelsWithResources(state) {
 
 export function channelIsInstalled(state) {
   return function findChannel(channelId) {
-    return find(installedChannelList(state), { id: channelId });
+    return find(installedChannelList(state), { id: channelId, available: true });
   };
 }
 

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
@@ -71,10 +71,10 @@
   import { refreshChannelList } from '../../state/actions/manageContentActions';
 
   const pageNameComponentMap = {
-    [ContentWizardPages.SELECT_IMPORT_SOURCE]: 'selectImportSource',
-    [ContentWizardPages.SELECT_DRIVE]: 'selectDriveModal',
-    [ContentWizardPages.AVAILABLE_CHANNELS]: 'availableChannelsPage',
-    [ContentWizardPages.SELECT_CONTENT]: 'selectContentPage',
+    [ContentWizardPages.SELECT_IMPORT_SOURCE]: selectImportSource,
+    [ContentWizardPages.SELECT_DRIVE]: selectDriveModal,
+    [ContentWizardPages.AVAILABLE_CHANNELS]: availableChannelsPage,
+    [ContentWizardPages.SELECT_CONTENT]: selectContentPage,
   };
 
   const POLL_DELAY = 1000;
@@ -90,14 +90,10 @@
     },
     components: {
       authMessage,
-      availableChannelsPage,
       channelsGrid,
       kButton,
-      selectDriveModal,
-      selectContentPage,
       subpageContainer,
       taskProgress,
-      selectImportSource,
     },
     data: () => ({
       intervalId: undefined,

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -101,7 +101,10 @@
   import subpageContainer from '../containers/subpage-container';
   import { channelIsInstalled, wizardState, nodeTransferCounts } from '../../state/getters';
   import isEmpty from 'lodash/isEmpty';
-  import { getAvailableSpaceOnDrive } from '../../state/actions/selectContentActions';
+  import {
+    getAvailableSpaceOnDrive,
+    updateTreeViewTopic,
+  } from '../../state/actions/selectContentActions';
   import {
     downloadChannelMetadata,
     transferChannelContent,
@@ -167,6 +170,8 @@
         this.showUpdateProgressBar = true;
         return this.downloadChannelMetadata().then(() => {
           this.showUpdateProgressBar = false;
+          // Update the topic in case content names have changed
+          this.updateTreeViewTopic(this.topicNode);
         });
       },
       startTransferringContent() {
@@ -193,12 +198,14 @@
         selectedItems: state => wizardState(state).nodesForTransfer || {},
         transferType: state => wizardState(state).transferType,
         wizardStatus: state => wizardState(state).status,
+        topicNode: state => wizardState(state).currentTopicNode,
       },
       actions: {
         downloadChannelMetadata,
         getAvailableSpaceOnDrive,
         transferChannelContent,
         waitForTaskToComplete,
+        updateTreeViewTopic,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -21,7 +21,9 @@ function makeStore() {
     state: {
       pageState: {
         taskList: [],
-        channelList: [{ id: 'channel_1', name: 'Installed Channel', root: 'channel_1_root', available: true }],
+        channelList: [
+          { id: 'channel_1', name: 'Installed Channel', root: 'channel_1_root', available: true },
+        ],
         wizardState: {
           ...importExportWizardState(),
           pageName: 'SELECT_CONTENT',

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -21,7 +21,7 @@ function makeStore() {
     state: {
       pageState: {
         taskList: [],
-        channelList: [{ id: 'channel_1', name: 'Installed Channel', root: 'channel_1_root' }],
+        channelList: [{ id: 'channel_1', name: 'Installed Channel', root: 'channel_1_root', available: true }],
         wizardState: {
           ...importExportWizardState(),
           pageName: 'SELECT_CONTENT',

--- a/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
@@ -12,7 +12,7 @@ function makeStore() {
     state: {
       pageState: {
         taskList: [],
-        channelList: [{ id: 'installed', name: 'Installed Channel', version: 11 }],
+        channelList: [{ id: 'installed', name: 'Installed Channel', version: 11, available: true }],
       },
     },
     mutations: {

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -26,6 +26,7 @@ function makeStore() {
             ...defaultChannel,
             on_device_file_size: 2200000000,
             on_device_resources: 2000,
+            available: true,
           },
         ],
         taskList: [],


### PR DESCRIPTION
### Summary
Suppose the Kolibri server has downloaded the DB for Unlisted Channel version 10, but has not installed any resources from Unlisted Channel. Shortly after, Unlisted Channel is updated to Version 11 on Kolibri Studio.

**Flashing of update button**
Previously, after visiting the "Select Content Page" on Kolibri, the "Update" button for Unlisted Channel would flash briefly. 

The patch in this PR checks to make sure the Channel is available before showing the "Update" button. So, when viewing Unlisted Channel, the DB will update to Version 11 quietly and not show the update button.

**Tree-view Listing of Channel contents not updated after upgrade**
This PR also updates the listing of contents in the topic treeview after updating a channel. Previously, if Resource/Topic names had changed (or been added/removed) in a version bump, there would no automatic update in the treeview.

**Edge case when channel updated in middle of import/export workflow**
The other issue brought up in #2869 was when any Channel was updated whilst a user in the middle of import/export workflows. If user goes to the "Available Channels Page" or "Select Content Page" after the update, the app will not be aware of the update until a refresh. **This is not fixed in this PR**.


### Reviewer guidance

**To test the "update" button flash**

1. Create an unlisted channel
1. Through the "channel token modal", visit the select content page for the channel. (this downloads the content DB to the server).
1. NOTE: Do not download any resources for the channel
1. Update and republish the channel on Kolibri Studio
1. Go back to the start of the import workflow.
1. Revisit the channel through the "channel token modal"
1. The content DB re-downloads, but the "Update" button should not appear.
1. NOTE: depending on whether you refreshed or not, the version number may still be out of date (see discussion above).

**To test post-update tree-view listing**
1. Import content from a channel you have publish access too
1. Update and republish the channel. Make note of where in the channel tree structure you have made changes.
1. Enter an import/export workflow for that channel.
1. Navigate to the topic where you have made changes.
1. The "update" button should be available. Click it.
1. After the update, the topic listing should have updated to reflect the changes you made.

### References

#2869 
----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [xx] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
