### PR TITLE
add content type tooltips to icons, and remove 'html5' from text

### DIFF
--- a/kolibri/core/assets/src/views/content-icon/index.vue
+++ b/kolibri/core/assets/src/views/content-icon/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <ui-icon>
+    <ui-icon ref="type-icon">
       <mat-svg
         v-if="is(Constants.ContentNodeKinds.CHANNEL)"
         category="navigation"
@@ -63,6 +63,7 @@
         :class="[colorClass]"
       />
     </ui-icon>
+    <ui-tooltip trigger="type-icon" position="top middle">{{ tooltipText }}</ui-tooltip>
   </span>
 
 </template>
@@ -73,8 +74,26 @@
   import * as Constants from 'kolibri.coreVue.vuex.constants';
   import values from 'lodash/values';
   import uiIcon from 'keen-ui/src/UiIcon';
+  import uiTooltip from 'keen-ui/src/UiTooltip';
+
   export default {
-    components: { uiIcon },
+    name: 'contentIcon',
+    $trs: {
+      topic: 'Topic',
+      channel: 'Channel',
+      exercise: 'Exercise',
+      video: 'Video',
+      audio: 'Audio',
+      document: 'Document',
+      html5: 'App',
+      exam: 'Exam',
+      lesson: 'Lesson',
+      item: 'Item',
+    },
+    components: {
+      uiIcon,
+      uiTooltip,
+    },
     props: {
       kind: {
         type: String,
@@ -96,6 +115,29 @@
       },
       colorClass() {
         return `color-${this.colorStyle}`;
+      },
+      tooltipText() {
+        const kind = this.kind;
+        if (kind === Constants.ContentNodeKinds.TOPIC) {
+          return this.$tr('topic');
+        } else if (kind === Constants.ContentNodeKinds.CHANNEL) {
+          return this.$tr('channel');
+        } else if (kind === Constants.ContentNodeKinds.EXERCISE) {
+          return this.$tr('exercise');
+        } else if (kind === Constants.ContentNodeKinds.VIDEO) {
+          return this.$tr('video');
+        } else if (kind === Constants.ContentNodeKinds.AUDIO) {
+          return this.$tr('audio');
+        } else if (kind === Constants.ContentNodeKinds.DOCUMENT) {
+          return this.$tr('document');
+        } else if (kind === Constants.ContentNodeKinds.HTML5) {
+          return this.$tr('html5');
+        } else if (kind === Constants.ContentNodeKinds.EXAM) {
+          return this.$tr('exam');
+        } else if (kind === Constants.ContentNodeKinds.LESSON) {
+          return this.$tr('lesson');
+        }
+        return this.$tr('item');
       },
     },
     methods: {

--- a/kolibri/core/assets/src/views/content-icon/index.vue
+++ b/kolibri/core/assets/src/views/content-icon/index.vue
@@ -88,7 +88,7 @@
       html5: 'App',
       exam: 'Exam',
       lesson: 'Lesson',
-      item: 'Item',
+      user: 'User',
     },
     components: {
       uiIcon,
@@ -136,8 +136,10 @@
           return this.$tr('exam');
         } else if (kind === Constants.ContentNodeKinds.LESSON) {
           return this.$tr('lesson');
+        } else if (kind === Constants.USER) {
+          return this.$tr('user');
         }
-        return this.$tr('item');
+        return '';
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid/index.vue
@@ -57,7 +57,7 @@
       videos: 'Videos',
       audio: 'Audio',
       documents: 'Documents',
-      html5: 'HTML5 Apps',
+      html5: 'Apps',
       channels: 'Channels',
     },
     components: {

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -9,7 +9,7 @@
     <content-icon
       v-if="!thumbnail"
       :kind="kind"
-      class="thumbnail-icon"
+      class="type-icon"
     />
 
     <progress-icon
@@ -140,7 +140,7 @@
     background-position: center
     background-color: $core-grey
 
-  .thumbnail-icon
+  .type-icon
     position: absolute
     top: 50%
     left: 50%
@@ -194,7 +194,7 @@
 
   .mobile-thumbnail
 
-    .thumbnail-icon
+    .type-icon
       transform: translate(-50%, -50%) scale(2)
 
     .content-icon-wrapper

--- a/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup/index.vue
@@ -65,11 +65,12 @@
       niceWork: 'Great work! Keep it up!',
       nextContent: 'Next Item',
       topic: 'Topic',
+      channel: 'Channel',
       exercise: 'Exercise',
       video: 'Video',
       audio: 'Audio',
       document: 'Document',
-      html5: 'HTML5 app',
+      html5: 'App',
       item: 'Item',
       close: 'Close',
       pointsForCompletion: 'Points for completion',
@@ -101,6 +102,8 @@
         const kind = this.kind;
         if (kind === ContentNodeKinds.TOPIC) {
           return this.$tr('topic');
+        } else if (kind === ContentNodeKinds.CHANNEL) {
+          return this.$tr('channel');
         } else if (kind === ContentNodeKinds.EXERCISE) {
           return this.$tr('exercise');
         } else if (kind === ContentNodeKinds.VIDEO) {


### PR DESCRIPTION

### Summary

adds tooltips to content icons

![image](https://user-images.githubusercontent.com/2367265/36570421-cfc20f6c-17e6-11e8-92f4-03d1d44cdac0.png)

![image](https://user-images.githubusercontent.com/2367265/36570428-d51619e0-17e6-11e8-8f8b-ae7d5e84cab1.png)


### Reviewer guidance

check it out

### References

fixes #1979

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
