### PR TITLE
Removed name attribute from presets

### DIFF
--- a/kolibri/auth/constants/facility_configuration_presets.json
+++ b/kolibri/auth/constants/facility_configuration_presets.json
@@ -1,6 +1,5 @@
 {
   "formal": {
-    "name": "Admin-managed",
     "mappings": {
       "learner_can_edit_username": false,
       "learner_can_edit_name": false,
@@ -11,7 +10,6 @@
     }
   },
   "nonformal": {
-    "name": "Self-managed",
     "default": true,
     "mappings": {
       "learner_can_edit_username": true,
@@ -23,7 +21,6 @@
     }
   },
   "informal": {
-    "name": "Informal and personal use",
     "mappings": {
       "learner_can_edit_username": true,
       "learner_can_edit_name": true,

--- a/kolibri/auth/constants/facility_presets.py
+++ b/kolibri/auth/constants/facility_presets.py
@@ -8,9 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 with open(os.path.join(os.path.dirname(__file__), './facility_configuration_presets.json'), 'r') as f:
     presets = json.load(f)
 
-choices = list(
-    (key, _(item['name'])) for key, item in presets.items()
-)
+choices = [(key, key) for key in presets]
 
 mappings = {
     key: item['mappings'] for key, item in presets.items()

--- a/kolibri/auth/constants/facility_presets.py
+++ b/kolibri/auth/constants/facility_presets.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import json
 import os
 
-# from django.utils.translation import ugettext_lazy as _
-
 with open(os.path.join(os.path.dirname(__file__), './facility_configuration_presets.json'), 'r') as f:
     presets = json.load(f)
 

--- a/kolibri/auth/constants/facility_presets.py
+++ b/kolibri/auth/constants/facility_presets.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 import os
 
-from django.utils.translation import ugettext_lazy as _
+# from django.utils.translation import ugettext_lazy as _
 
 with open(os.path.join(os.path.dirname(__file__), './facility_configuration_presets.json'), 'r') as f:
     presets = json.load(f)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Removed the name attribute from the presets as to avoid developers from accidentally using the name attribute in the front-end. We want to avoid this since the name attributes are not internationalized.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Link to the issue:
https://github.com/learningequality/kolibri/issues/2296

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
