### PR TITLE
Resource counts are incorrect until refresh after updating channel

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -166,8 +166,19 @@
         // This could produced unexpected behavior for users.
         this.showUpdateProgressBar = true;
         return this.downloadChannelMetadata().then(() => {
+          this.updateChannelTotalResouce();
           this.showUpdateProgressBar = false;
         });
+      },
+      updateChannelTotalResouce() {
+        let availableChannel = this.availableChannels;
+        for (let i = 0; i < availableChannel.length; i++) {
+          if (this.channel.id === availableChannel[i].id) {
+            // Update channel total resources.
+            this.channel.total_resources = availableChannel[i].total_resources;
+            this.channel.total_file_size = availableChannel[i].total_file_size;
+          }
+        }
       },
       startTransferringContent() {
         this.contentTransferError = false;
@@ -193,6 +204,7 @@
         selectedItems: state => wizardState(state).nodesForTransfer || {},
         transferType: state => wizardState(state).transferType,
         wizardStatus: state => wizardState(state).status,
+        availableChannels: state => wizardState(state).availableChannels,
       },
       actions: {
         downloadChannelMetadata,


### PR DESCRIPTION
### Summary
After the channel updated, also update its total resources.  

### Reviewer guidance
* Create a channel with a couple items and publish
* Import everything in it
* Delete an item from the channel. republish it
* Go to import it. click 'update'


### References
This fixes #2939 

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
