### PR TITLE
tweak docs and makefile around crowdin process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,10 @@ help:
 	@echo "Internationalization"
 	@echo "--------------------"
 	@echo ""
-	@echo "translation-django-makemessages: creates source messages for django"
-	@echo "translation-django-compilemessages: compiles all language translation sources"
-	@echo "translation-crowdin-install: installs the CrowdIn CLI"
-	@echo "translation-crowdin-upload branch=<crowdin-branch>: uploads kolibri translation sources via CrowdIn"
-	@echo "translation-crowdin-download branch=<crowdin-branch>: downloads kolibri translated languages via CrowdIn"
+	@echo "translation-extract: extract strings from application"
+	@echo "translation-crowdin-upload branch=<crowdin-branch>: upload strings to Crowdin"
+	@echo "translation-crowdin-download branch=<crowdin-branch>: download strings from Crowdin and compile"
+	@echo "translation-crowdin-install: installs the Crowdin CLI"
 
 
 clean: clean-build clean-pyc clean-assets
@@ -161,7 +160,7 @@ dist: writeversion staticdeps staticdeps-cext buildconfig assets translation-dja
 pex: writeversion
 	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed -s 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python; done
 
-translation-django-makemessages: assets
+translation-extract: assets
 	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*'
 
 translation-django-compilemessages:
@@ -177,6 +176,7 @@ translation-crowdin-upload:
 
 translation-crowdin-download:
 	java -jar build_tools/crowdin-cli.jar -c build_tools/crowdin.yaml download -b ${branch}
+	cd kolibri && PYTHONPATH="..:$$PYTHONPATH" python -m kolibri manage compilemessages
 
 dockerenvclean:
 	docker container prune -f

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,11 @@ help:
 	@echo "Internationalization"
 	@echo "--------------------"
 	@echo ""
-	@echo "translation-extract: extract strings from application"
+	@echo "translation-extract: extract all strings from application (both front- and back-end)"
 	@echo "translation-crowdin-upload branch=<crowdin-branch>: upload strings to Crowdin"
 	@echo "translation-crowdin-download branch=<crowdin-branch>: download strings from Crowdin and compile"
 	@echo "translation-crowdin-install: installs the Crowdin CLI"
+	@echo "translation-django-compilemessages: compiles .po files to .mo files for Django"
 
 
 clean: clean-build clean-pyc clean-assets
@@ -176,7 +177,6 @@ translation-crowdin-upload:
 
 translation-crowdin-download:
 	java -jar build_tools/crowdin-cli.jar -c build_tools/crowdin.yaml download -b ${branch}
-	cd kolibri && PYTHONPATH="..:$$PYTHONPATH" python -m kolibri manage compilemessages
 
 dockerenvclean:
 	docker container prune -f

--- a/docs/references/i18n.rst
+++ b/docs/references/i18n.rst
@@ -150,6 +150,9 @@ You can download them using this command:
 
 This will update local translation files. Find and delete all files for unsupported or partially-translated languages. Then, check in new strings to git and submit them in a PR to the release branch.
 
+Finally, build the backend .mo files for Django:
+
+    $ make translation-django-compilemessages
 
 .. _new_language:
 

--- a/docs/references/i18n.rst
+++ b/docs/references/i18n.rst
@@ -7,137 +7,166 @@ Internationalization
 As a platform intended for use around the world, Kolibri has a strong mandate for translation and internationalization. As such, it has been designed with technologies to enable this built in.
 
 
-Backend Translation
--------------------
+Writing localized strings
+-------------------------
+
+Backend
+~~~~~~~
 
 For any strings in Django, we are using the standard Django i18n machinery (gettext and associated functions) to provide translations. See the `Django i18n documentation <https://docs.djangoproject.com/en/1.10/topics/i18n/>`_ for more information.
 
-
-Frontend Translation
---------------------
+Frontend
+~~~~~~~~
 
 For any strings in the frontend, we are using `Vue-Intl <https://www.npmjs.com/package/vue-intl>`_ an in house port of `React-intl <https://www.npmjs.com/package/react-intl>`_.
 
 Within Kolibri, messages are defined on the body of the Vue component:
 
-- ``$trs``, an object of the form::
+.. code-block:: javascript
 
-    {
-      msgId: 'Message text',
-    }
-
-- ``name``, we use the Vue component name to namespace the messages.
+  name: 'componentName'
+  $trs: {
+    msgId: 'Message text',
+  }
 
 The ``name`` and every ``msgId`` should be in camelCase.
 
 User visible strings should be rendered directly in the template with ``{{ $tr('msgId') }}``. These strings are collected during the build process, and bundled into exported JSON files. These files are then uploaded to Crowdin for translation.
 
-An example Vue component would then look like this::
+An example Vue component would then look like this
+
+.. code-block:: html
 
   <template>
-
     <div>
       <p>{{ $tr('exampleMessage') }}</p>
     </div>
-
   </template>
 
 
-  <script>
+.. code-block:: javascript
 
     module.exports = {
-
       name: 'example',
       $trs: {
         exampleMessage: 'This message is just an example',
       },
     };
 
-  </script>
+In order to translate strings in Javascript source files, the namespace and messages are defined like this:
 
-
-  <style lang="stylus" scoped></style>
-
-In order to translate strings outside of the scope of Vue components, i.e. in Javascript source files, the name space and messages object still need to be defined, as shown in this example::
+.. code-block:: javascript
 
   import { createTranslator } from 'kolibri.utils.i18n';
-
   const name = 'exampleTitles';
-
   const messages = {
     msgIdForThisMessage: 'This is a message',
   };
-
   const translator = createTranslator(name, messages);
-
   console.log(translator.$tr('msgIdForThisMessage'));
+
 
 In this way, messages are namespaced, and then available off the ``$tr`` method of the translator object returned from the createTranslator function.
 
 These messages will then be discovered for any registered plugins and loaded into the page if that language is set as the Django language. All language setting for the Frontend is based off the current Django language for the request.
 
+All front-end translations can be parameterized using `ICU message syntax <https://formatjs.io/guides/message-syntax/>`_.
+
 
 .. _crowdin:
 
-Translation CrowdIn workflow
-----------------------------
+Crowdin workflow
+----------------
 
-Translations are maintained in release branches on CrowdIn in the following projects:
-  
-* `CrowdIn: kolibri <http://crowdin.com/project/kolibri>`__
-* `CrowdIn: kolibri-docs <http://crowdin.com/project/kolibri-docs>`__
+We use the Crowdin platform to enable third parties to translate the strings in our application.
 
-To build translated user documentation, please see the `kolibri-docs repository <https://github.com/learningequality/kolibri-docs/>`__.
+Note that you have to specify branch names for most commands.
 
-In order to pull the latest messages, invoke the following commands, fetching your API key using `these instructions <https://support.crowdin.com/api/api-integration-setup/>`__. Notice that you have to specify from which branch you are pulling the translations.
+.. note:: These notes are only for the Kolibri application. For translation of user documentation, please see the `kolibri-docs repository <https://github.com/learningequality/kolibri-docs/>`_.
+
+
+Prerequisites
+~~~~~~~~~~~~~
+
+First, you'll need to have these dependencies available on your path:
+
+* GNU ``gettext``
+* Java
+
+You may be able to install them using your system's package manager.
+
+Next, download the crowdin jar to the current directory using this command:
 
 .. code-block:: bash
 
-    $ CROWDIN_API_KEY="your-secret-key" make translation-crowdin-download branch=release-v0.7.x
+    $ make translation-crowdin-install
 
-.. warning:: By default Crowdin will download all translations, not just approved ones, and will often download untranslated strings also. Do not just add all the files that are downloaded, as this will lead to untranslated and poor quality strings being included.
+
+Finally, ensure you have an environment variable ``CROWDIN_API_KEY`` set to the Learning Equality organization `account API key <https://support.crowdin.com/api/api-integration-setup/>`_.
+
+.. note:: We do not currently support making translations on Windows. It might be possible, but would require inspection of the Makefile and running alternate commands.
+
+.. note:: If you install ``gettext`` on Mac with Homebrew, you may need to add the binary to your path manually
+
+
+Exporting and uploading
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Typically, strings will be uploaded when a new release branch is cut from ``develop``, signifying the beginning of string freeze and the ``beta`` releases.
+
+Before translators can begin working on the strings in our application, they need to be uploaded to Crowdin. Translations are maintained in release branches on Crowdin in the `Crowdin kolibri project <http://crowdin.com/project/kolibri>`_.
+
+This command will extract front- and backend strings from the Kolibri application code:
+
+.. code-block:: bash
+
+  $ make translation-extract
+
+And this command will upload the strings to Crowdin:
+
+.. code-block:: bash
+
+  $ make translation-crowdin-upload branch=[release-branch-name]
+
+The branch name will typically look something like: ``release-v0.8.x``
+
+Next, apply `translation memory <https://support.crowdin.com/translation-memory/#applying-translation-memory-via-pre-translation>`_ via the Crowdin UI to copy over perfect matches from previous releases for all languages. This could take some time.
+
+Now, some percentage of the newly updated strings should show as already having been translated in crowdin because the perfect matches were automatically copied over.
 
 
 Fetching and building translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each 30 minutes, you can fetch updated translations from CrowdIn. After changing and approving translations on CrowdIn, you should download them and build them to see if they work before releasing them.
+In order to get the newly translated strings into the application, they need to be downloaded from Crowdin and checked in to the Kolibri github repo.
 
-UI (backend & frontend):
+.. warning:: By default Crowdin will download all translations, not just approved ones. It will often download untranslated strings also. You must manually delete files that are not relevant.
 
-.. code-block:: bash
-
-    $ CROWDIN_API_KEY="your-secret-key" make translation-crowdin-download branch=release-v0.7.x
-    $ make translation-django-compilemessages
-
-
-Translation workflow prerequisites
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Translation relies on having `crowdin-cli <https://support.crowdin.com/cli-tool/>`__ available as a jar, and you need Java to run this. Make sure you have completed the following steps:
+You can download them using this command:
 
 .. code-block:: bash
-  
-    # Install crowdin-cli
-    $ make translation-crowdin-install
 
-.. note:: The Make shortcuts for working with translation are not set up for Windows. The configured paths etc. are different on a Windows system, so you have to both rewrite the `CrowdIn Configuration <https://support.crowdin.com/configuration-file/#cli-2>`__.
+    $ make translation-crowdin-download branch=[release-branch-name]
 
+This will update local translation files. Find and delete all files for unsupported or partially-translated languages. Then, check in new strings to git and submit them in a PR to the release branch.
 
 
 .. _new_language:
 
-Adding a new language
----------------------
+
+Adding a newly supported language
+---------------------------------
 
 In order to add a new supported language to Kolibri, the appropriate language information object must be added to the array in ``kolibri/locale/supported_languages.json``.
 
-The language must be described using the following keys, with everything in lower case::
+The language must be described using the following keys, with everything in lower case
+
+.. code-block:: javascript
 
   {
     "language_code": "<Two or three letter language code>",
-    "territory_code": "<Optional: Language territory code>",
     "language_name": "<Language name in the target language>",
+    "territory_code": "<Optional: Language territory code>",
     "script_code": "<Optional: Language script code>"
   }
 

--- a/docs/references/index.rst
+++ b/docs/references/index.rst
@@ -3,13 +3,13 @@ References
 
 .. toctree::
   :maxdepth: 2
-  
+
   manual_testing
   release_process
   i18n
   conventions
   files
-  /py_modules/modules.rst
+
 
 API reference
 -------------

--- a/kolibri/locale/en/LC_MESSAGES/django.po
+++ b/kolibri/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-22 18:11-0800\n"
+"POT-Creation-Date: 2018-02-23 17:34-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,24 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: kolibri/auth/constants/collection_kinds.py:12
-#: kolibri/plugins/management/kolibri_plugin.py:29
+#: kolibri/auth/constants/collection_kinds.py:14
+#: kolibri/plugins/facility_management/kolibri_plugin.py:30
 msgid "Facility"
 msgstr ""
 
-#: kolibri/auth/constants/collection_kinds.py:13
+#: kolibri/auth/constants/collection_kinds.py:15
 msgid "Classroom"
 msgstr ""
 
-#: kolibri/auth/constants/collection_kinds.py:14
+#: kolibri/auth/constants/collection_kinds.py:16
 msgid "Learner group"
 msgstr ""
 
-#: kolibri/auth/constants/role_kinds.py:10
+#: kolibri/auth/constants/role_kinds.py:12
 msgid "Admin"
 msgstr ""
 
-#: kolibri/auth/constants/role_kinds.py:11
+#: kolibri/auth/constants/role_kinds.py:13
 msgid "Coach"
 msgstr ""
 
@@ -60,15 +60,19 @@ msgstr ""
 msgid "date joined"
 msgstr ""
 
-#: kolibri/auth/serializers.py:31
+#: kolibri/auth/serializers.py:28 kolibri/auth/serializers.py:36
 msgid "An account with that username already exists"
 msgstr ""
 
-#: kolibri/content/api.py:355
+#: kolibri/content/api.py:74
+msgid "Content"
+msgstr ""
+
+#: kolibri/content/api.py:363
 msgid "The requested channel does not exist on the content server"
 msgstr ""
 
-#: kolibri/content/models.py:183
+#: kolibri/content/models.py:187
 msgid "Unknown format"
 msgstr ""
 
@@ -94,6 +98,10 @@ msgstr ""
 
 #: kolibri/core/templates/kolibri/unsupported_browser.html:31
 msgid "You can also try updating your current browser."
+msgstr ""
+
+#: kolibri/plugins/device_management/kolibri_plugin.py:30
+msgid "Device"
 msgstr ""
 
 #: kolibri/tasks/api.py:31


### PR DESCRIPTION
### Summary

Try to make the whole process for uploading and downloading strings with crowdin a little more clear. 

 * adds process details and rationale
 * reduces shell- and os- specific guidance
 * tweaks makefile commands to be simpler and named more clearly
 * improves formatting of code blocks

### Reviewer guidance

make sure it all makes sense



### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
