### PR TITLE
Sync git tags during travis build + make file comment and release check list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ matrix:
 
 before_install:
   - git fetch
-  - git tag
   - git describe --tags --always
   # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,8 @@ matrix:
         - TRAVIS_NODE_VERSION="6"
 
 before_install:
+  - git fetch
+  - git tag
   - git describe --tags --always
   # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ matrix:
 
 before_install:
   - git describe --tags --always
+  # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112
+  - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
   - pip install -U pip codecov tox
   - . $HOME/.nvm/nvm.sh
   - nvm install $TRAVIS_NODE_VERSION

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,23 @@ docs: clean-docs
 
 release:
 	@ls -l dist/
-	@echo "\nDo you want to upload everything in dist/*?\n\n CTRL+C to exit."
+	@echo "Release process documentation:"
+	@echo ""
+	@echo "http://kolibri-dev.readthedocs.io/en/develop/references/release_process.html"
+	@echo ""
+	@echo ""
+	@echo "Quick check list:"
+	@echo ""
+	@echo "1. Release notes?"
+	@echo "2. Downloaded CrowdIn translations?"
+	@echo "3. Pushed CrowdIn translations to repo?"
+	@echo "4. Version info as tag and in kolibri.VERSION?"
+	@echo "5. Did you do a signed commit and push to Github?"
+	@echo "6. Check that the .whl and .tar.gz dists work?"
+	@echo ""
+	@echo "Do you want to upload everything in dist/*?"
+	@echo ""
+	@echo "CTRL+C to exit. ENTER to continue."
 	@read __
 	twine upload -s dist/*
 
@@ -146,6 +162,8 @@ translation-django-makemessages: assets
 	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*'
 
 translation-django-compilemessages:
+	# Change working directory to kolibri/ such that compilemessages
+	# finds only the .po files nested there.
 	cd kolibri && PYTHONPATH="..:$$PYTHONPATH" python -m kolibri manage compilemessages
 
 translation-crowdin-install:

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -300,7 +300,8 @@ def get_prerelease_version(version):
 
         if git_version[3] == 'final' and version[3] != 'final':
             raise AssertionError(
-                "You have added a final tag without bumping kolibri.VERISON"
+                "You have added a final tag without bumping kolibri.VERSION, " +
+                "OR you need to make a new alpha0 tag. Current tag: {}".format(git_version)
             )
 
         return (


### PR DESCRIPTION
### Summary

Fixes current build errors in PRs against `release-v0.8.x` caused by unsync'ed git data in Travis.

Some more guidance for releasing re: #3251

Also, a comment as requested by @indirectlylit 

### Reviewer guidance

n/a

### References

#3251

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
