### PR TITLE
Consistency in dev docs TOCs, no empty index pages

### DIFF
--- a/docs/architecture/index.rst
+++ b/docs/architecture/index.rst
@@ -3,7 +3,6 @@ Architecture
 
 .. toctree::
   :maxdepth: 1
-  :hidden:
 
   frontend_architecture
   dataflow/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Table of contents
 =================
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    start/index
    references/index

--- a/docs/pipeline/index.rst
+++ b/docs/pipeline/index.rst
@@ -3,7 +3,6 @@ Builds
 
 .. toctree::
   :maxdepth: 1
-  :hidden:
 
   dist_build_pipeline
   frontend_build_pipeline


### PR DESCRIPTION
### Summary

Thanks for spotting this @indirectlylit !

### Reviewer guidance

The main index TOC is now much more useful, too. They origianal TOCs were hidden to remove some clutter, but didn't really achieve that much more than an inconsistent navigation.

![image](https://user-images.githubusercontent.com/374612/36683721-989f5bee-1b1e-11e8-9ea4-32e8eaf98c46.png)

### References

Fixes #3004

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
