### PR TITLE
Add python compiling to Tox tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
+	# Remove unnecessary python2-syntax'ed file
+	# https://github.com/learningequality/kolibri/issues/3152
+	rm -f kolibri/dist/kolibri_exercise_perseus_plugin/static/mathjax/kathjax.py
 	python build_tools/py2only.py # move `future` and `futures` packages to `kolibri/dist/py2only`
 	make test-namespaced-packages
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ deps =
     -r{toxinidir}/requirements/test.txt
 commands =
     make staticdeps
+    # Ensure that for this Python version, we can actually compile ALL files
+    # in the kolibri directory
+    python -m compileall -q kolibri -x py2only
     # Enable the plugins to ensure the configuration is read without error
     coverage run -p kolibri plugin kolibri.plugins.learn enable
     coverage run -p kolibri plugin kolibri.plugins.facility_management enable


### PR DESCRIPTION
### Summary

Adding this for 0.8, because the fix is small, but the bug is interesting enough.

This directly affects some hard-to-maintain patches in the debian installer, removing current python2-only syntax inside the supposed-ly py2+3 codebase.

Running for current env's Python version

WIP: The tests should reveal that `kathjax.py` shouldn't be there.

### Reviewer guidance

n/a

### References

#3152

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
