### PR TITLE
prop should be js, not string

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/error-page/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/error-page/index.vue
@@ -9,7 +9,7 @@
     <k-button
       class="error-page-retry-button"
       :text="$tr('errorPageRetryButtonLabel')"
-      primary="true"
+      :primary="true"
       @click="refreshPage"
     />
 


### PR DESCRIPTION

### Summary

fixes this prop validation issue:

![image](https://user-images.githubusercontent.com/2367265/36701557-b7920a4e-1b08-11e8-8185-2fa7a36109e3.png)


----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
