### PR TITLE
Show more information before going to daemon mode

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -275,35 +275,11 @@ def start(port=None, daemon=True):
     else:
         logger.info("Running 'kolibri start' as daemon (system service)")
 
-    __, urls = server.get_urls(listen_port=port)
-    if not urls:
-        logger.error(
-            "Could not detect an IP address that Kolibri binds to, but try "
-            "opening up the following addresses:\n")
-        urls = [
-            "http://{}:{}".format(ip, port) for ip in ("localhost", "127.0.0.1")
-        ]
-    else:
-        logger.info("Kolibri running on:\n")
-    for addr in urls:
-        sys.stderr.write("\t{}\n".format(addr))
-    sys.stderr.write("\n")
-
     # Daemonize at this point, no more user output is needed
     if daemon:
+        become_daemon()
 
-        kwargs = {}
-        # Truncate the file
-        if os.path.isfile(server.DAEMON_LOG):
-            open(server.DAEMON_LOG, "w").truncate()
-        logger.info(
-            "Going to daemon mode, logging to {0}".format(server.DAEMON_LOG)
-        )
-        kwargs['out_log'] = server.DAEMON_LOG
-        kwargs['err_log'] = server.DAEMON_LOG
-        become_daemon(**kwargs)
-
-    server.start(port=port)
+    server.start(port=port, daemon=daemon)
 
 
 def stop():
@@ -314,6 +290,7 @@ def stop():
         pid, __, __ = server.get_status()
         server.stop(pid=pid)
         stopped = True
+        logger.info("Kolibri server has been successfully stoppped.")
     except server.NotRunning as e:
         verbose_status = "{msg:s} ({code:d})".format(
             code=e.status_code,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that when `kolibri start` fails, users are only able to find the errors inside `server.log` but not on the terminal. 
What I've changed in this PR is that the program will log to stdout/stderr first. When the server successfully starts, then the program will start to log to `server.log`. 

I also added an additional statement to indicate that the server is stopped when users run `kolibri stop`:
![virtualbox_ubuntu_27_02_2018_16_48_30](https://user-images.githubusercontent.com/19424916/36764532-d144600c-1be1-11e8-8b49-db5697ebaade.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Issues:
1. When testing on Ubuntu 16.04, the output in the terminal got split into two parts. I think this is because the parent process is killed, but I'm not sure how to fix this part. Here is the screenshot:
![virtualbox_ubuntu_27_02_2018_16_48_52](https://user-images.githubusercontent.com/19424916/36764506-b5d82844-1be1-11e8-8917-edbbc938744a.png)
2. When testing on Ubuntu 16.04, after the server started, and the program started to log to `server.log`, I need to press `Enter` key to exit. I'm stuck in finding ways to skip this:
![virtualbox_ubuntu_27_02_2018_16_47_58](https://user-images.githubusercontent.com/19424916/36764636-49b0451a-1be2-11e8-823a-e2dbbea9850f.png)

To test:
Please run `kolibri start` on a non OSX machine. After seeing `Kolibri running on ...`, please press `Enter`. For further logs, please check `server.log`. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/2867

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
