### PR TITLE
Enable linting (and building) of external plugin JS assets

### DIFF
--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -16,13 +16,14 @@
  */
 
 var path = require('path');
-var merge = require('webpack-merge');
 var mkdirp = require('mkdirp');
 var PrettierFrontendPlugin = require('./prettier-frontend-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+// adds custom rules
+require('./htmlhint_custom');
+var prettierOptions = require('../../.prettier');
 
 var production = process.env.NODE_ENV === 'production';
-var lint = process.env.LINT || production;
 
 var base_dir = path.join(__dirname, '..', '..');
 
@@ -44,10 +45,7 @@ var cssLoader = {
 };
 
 // for stylus blocks in vue files.
-var vueStylusLoaders = [cssLoader, postCSSLoader, 'stylus-loader'];
-if (lint) {
-  vueStylusLoaders.push('stylint-loader');
-}
+var vueStylusLoaders = [cssLoader, postCSSLoader, 'stylus-loader', 'stylint-loader'];
 
 // for scss blocks in vue files (e.g. Keen-UI files)
 var vueSassLoaders = [
@@ -61,10 +59,41 @@ var vueSassLoaders = [
 ];
 
 // primary webpack config
-var config = {
+module.exports = {
   context: base_dir,
   module: {
     rules: [
+      // Linting rules
+      {
+        test: /\.(vue|js)$/,
+        enforce: 'pre',
+        use: {
+          loader: 'eslint-loader',
+          options: {
+            failOnError: production,
+            emitError: production,
+            emitWarning: !production,
+            fix: !production,
+            configFile: path.resolve(path.join(base_dir, '.eslintrc.js')),
+          },
+        },
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.(vue|html)/,
+        enforce: 'pre',
+        use: {
+          loader: 'htmlhint-loader',
+          options: { failOnError: production, emitAs: production ? 'error' : 'warning' },
+        },
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.styl$/,
+        enforce: 'pre',
+        loader: 'stylint-loader',
+      },
+      // Transpilation and code loading rules
       {
         test: /\.vue$/,
         loader: 'vue-loader',
@@ -140,7 +169,13 @@ var config = {
       },
     ],
   },
-  plugins: [],
+  plugins: [
+    new PrettierFrontendPlugin({
+      extensions: ['.js', '.vue'],
+      logLevel: 'warn',
+      prettierOptions,
+    }),
+  ],
   resolve: {
     extensions: ['.js', '.vue', '.styl'],
     alias: {},
@@ -161,55 +196,3 @@ var config = {
   },
   stats: 'minimal',
 };
-
-// Only lint in dev mode if LINT env is set. Always lint in production.
-if (lint) {
-  // adds custom rules
-  require('./htmlhint_custom');
-  var prettierOptions = require('../../.prettier');
-
-  var lintConfig = {
-    module: {
-      rules: [
-        {
-          test: /\.(vue|js)$/,
-          enforce: 'pre',
-          use: {
-            loader: 'eslint-loader',
-            options: {
-              failOnError: production,
-              emitError: production,
-              emitWarning: !production,
-              fix: !production,
-            },
-          },
-          exclude: /node_modules/,
-        },
-        {
-          test: /\.(vue|html)/,
-          enforce: 'pre',
-          use: {
-            loader: 'htmlhint-loader',
-            options: { failOnError: production, emitAs: production ? 'error' : 'warning' },
-          },
-          exclude: /node_modules/,
-        },
-        {
-          test: /\.styl$/,
-          enforce: 'pre',
-          loader: 'stylint-loader',
-        },
-      ],
-    },
-    plugins: [
-      new PrettierFrontendPlugin({
-        extensions: ['.js', '.vue'],
-        logLevel: 'warn',
-        prettierOptions,
-      }),
-    ],
-  };
-  config = merge.smart(config, lintConfig);
-}
-
-module.exports = config;

--- a/kolibri/core/webpack/management/commands/devserver.py
+++ b/kolibri/core/webpack/management/commands/devserver.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import atexit
 import logging
@@ -9,6 +11,7 @@ from threading import Thread
 
 from django.contrib.staticfiles.management.commands.runserver import Command as RunserverCommand
 from django.core.management.base import CommandError
+
 from kolibri.content.utils.annotation import update_channel_metadata
 
 logger = logging.getLogger(__name__)
@@ -37,13 +40,6 @@ class Command(RunserverCommand):
             help='Tells Django runserver to spawn a webpack watch subprocess.',
         )
         parser.add_argument(
-            '--lint',
-            action='store_true',
-            dest='lint',
-            default=False,
-            help='Tells Django runserver to run the linting option on webpack subprocess.',
-        )
-        parser.add_argument(
             '--karma',
             action='store_true',
             dest='karma',
@@ -54,7 +50,7 @@ class Command(RunserverCommand):
     def handle(self, *args, **options):
 
         if options["webpack"]:
-            self.spawn_webpack(lint=options["lint"])
+            self.spawn_webpack()
         if options["karma"]:
             self.spawn_karma()
 
@@ -62,12 +58,11 @@ class Command(RunserverCommand):
 
         return super(Command, self).handle(*args, **options)
 
-    def spawn_webpack(self, lint):
+    def spawn_webpack(self):
         self.spawn_subprocess(
             "webpack_process",
             self.start_webpack,
-            self.kill_webpack_process,
-            lint=lint)
+            self.kill_webpack_process)
 
     def spawn_karma(self):
         self.spawn_subprocess("karma_process", self.start_karma,
@@ -98,15 +93,9 @@ class Command(RunserverCommand):
 
     def start_webpack(self, lint=False):
 
-        if lint:
-            cli_command = 'yarn run watch -- --lint'
-            logger.info(
-                'Starting webpack process with linting from Django runserver command'
-            )
-        else:
-            cli_command = 'yarn run watch'
-            logger.info(
-                'Starting webpack process from Django runserver command')
+        cli_command = 'yarn run watch'
+        logger.info(
+            'Starting webpack process from Django runserver command')
 
         self.webpack_process = subprocess.Popen(
             cli_command,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "preinstall": "node ./frontend_build/src/npm_deprecation_warning.js",
     "lint-js": "node ./frontend_build/src/prettier-frontend.js --prettierPath ./.prettier.js",
     "lint-js:fix": "yarn run lint-js -- -w",
-    "devserver": "kolibri --debug manage devserver --webpack --lint --settings=kolibri.deployment.default.settings.dev",
+    "devserver": "kolibri --debug manage devserver --webpack --settings=kolibri.deployment.default.settings.dev",
     "generate-locale-data": "node ./frontend_build/src/intl_code_gen.js"
   },
   "repository": {
@@ -68,7 +68,7 @@
     "css-loader": "^0.28.7",
     "eslint": "^4.2.0",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-loader": "^1.9.0",
+    "eslint-loader": "https://github.com/learningequality/eslint-loader/",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-vue": "4.2.0",
     "esprima": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,9 +1754,9 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.8"
     resolve "^1.2.0"
 
-eslint-loader@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-1.9.0.tgz#7e1be9feddca328d3dcfaef1ad49d5beffe83a13"
+"eslint-loader@https://github.com/learningequality/eslint-loader/":
+  version "2.0.0"
+  resolved "https://github.com/learningequality/eslint-loader/#2745bc12b3dff786694603734e88d04096fa0b0e"
   dependencies:
     loader-fs-cache "^1.0.0"
     loader-utils "^1.0.2"
@@ -4060,8 +4060,8 @@ object-component@0.0.3:
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
 object-hash@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.2.0.tgz#e96af0e96981996a1d47f88ead8f74f1ebc4422b"
 
 object-keys@^1.0.8:
   version "1.0.11"


### PR DESCRIPTION
### Summary
* Use a fork of eslint-loader to prevent a silly bug until upstream fix is merged.
* Enforce linting all the time, it doesn't break dev builds any more, so no reason to be optional
…

### Reviewer guidance
I can show you it works, unfortunately, kolibri_exercise_perseus_plugin needs linting fixes too!
…

### References
Prerequisite for fixing #3013 

…

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
