### PR TITLE
Learner loses all memberships for higher order collection

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -174,17 +174,9 @@ class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
 
 class MembershipFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")
-    collection = CharFilter(method="filter_collection_id")
 
     def filter_user_ids(self, queryset, name, value):
         return queryset.filter(user_id__in=value.split(','))
-
-    def filter_collection_id(self, queryset, name, value):
-        # for deleting memberships, we want to include collections that belong to the target collection (ex. learnergroup belonging to classroom)
-        if self.request.method == 'DELETE':
-            collection_ids = Collection.objects.filter(Q(parent_id=value) | Q(id=value)).values_list('id', flat=True)
-            return queryset.filter(collection_id__in=collection_ids)
-        return queryset.filter(collection_id=value)
 
     class Meta:
         model = Membership

--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -174,9 +174,17 @@ class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
 
 class MembershipFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")
+    collection = CharFilter(method="filter_collection_id")
 
     def filter_user_ids(self, queryset, name, value):
         return queryset.filter(user_id__in=value.split(','))
+
+    def filter_collection_id(self, queryset, name, value):
+        # for deleting memberships, we want to include collections that belong to the target collection (ex. learnergroup belonging to classroom)
+        if self.request.method == 'DELETE':
+            collection_ids = Collection.objects.filter(Q(parent_id=value) | Q(id=value)).values_list('id', flat=True)
+            return queryset.filter(collection_id__in=collection_ids)
+        return queryset.filter(collection_id=value)
 
     class Meta:
         model = Membership

--- a/kolibri/auth/apps.py
+++ b/kolibri/auth/apps.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from django.apps import AppConfig
 
@@ -7,3 +9,6 @@ class KolibriAuthConfig(AppConfig):
     name = 'kolibri.auth'
     label = 'kolibriauth'
     verbose_name = 'Kolibri Auth'
+
+    def ready(self):
+        from .signals import cascade_delete_membership  # noqa: F401

--- a/kolibri/auth/signals.py
+++ b/kolibri/auth/signals.py
@@ -1,0 +1,13 @@
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+
+from .models import Membership
+
+
+@receiver(pre_delete, sender=Membership)
+def cascade_delete_membership(sender, instance=None, *args, **kwargs):
+    """
+    For a given membership instance and the collection associated with it,
+    we delete all membership objects whose collection is a child of the instance's collection.
+    """
+    Membership.objects.filter(collection__parent_id=instance.collection_id).delete()

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -428,11 +428,17 @@ class MembershipCascadeDeletion(APITestCase):
         self.user = FacilityUserFactory.create(facility=self.facility)
         self.classroom = ClassroomFactory.create(parent=self.facility)
         self.lg = LearnerGroupFactory.create(parent=self.classroom)
+        self.classroom_membership = models.Membership.objects.create(collection=self.classroom, user=self.user)
+        models.Membership.objects.create(collection=self.lg, user=self.user)
 
     def test_delete_classroom_membership(self):
-        models.Membership.objects.create(collection=self.classroom, user=self.user)
-        models.Membership.objects.create(collection=self.lg, user=self.user)
         url = reverse('membership-list') + "?user={}&collection={}".format(self.user.id, self.classroom.id)
         response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(models.Membership.objects.all().exists())
+
+    def test_delete_detail(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD, facility=self.facility)
+        response = self.client.delete(reverse('membership-detail', kwargs={'pk': self.classroom_membership.id}))
         self.assertEqual(response.status_code, 204)
         self.assertFalse(models.Membership.objects.all().exists())


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Add signals which delete related membership models through collections. We now include all membership objects that belong to target collection (ex. learnergroup belonging to classroom).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Before fix: Learner enrolled in both classroom and learner group. Learner removed from classroom does not remove membership in group.

**How to test**: 
Enroll a Learner in Classroom C and Learner Group LG (inside of C)
Remove Learner from Classroom C
Learner no longer in Classroom C and Group LG

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

fixes #3271 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
