### PR TITLE
remove colons from: labels

### DIFF
--- a/kolibri/core/assets/src/views/core-modal/index.vue
+++ b/kolibri/core/assets/src/views/core-modal/index.vue
@@ -47,7 +47,7 @@
     mixins: [responsiveWindow],
     $trs: {
       // error alerts
-      errorAlert: 'Error in:',
+      errorAlert: 'Error in',
       // aria labels
       closeWindow: 'Close window',
     },

--- a/kolibri/core/assets/src/views/progress-bar/index.vue
+++ b/kolibri/core/assets/src/views/progress-bar/index.vue
@@ -24,7 +24,7 @@
   export default {
     name: 'progressBar',
     $trs: {
-      label: 'Progress:',
+      label: 'Progress',
       pct: '{0, number, percent}',
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/activate-exam-modal.vue
@@ -45,7 +45,7 @@
     $trs: {
       activateExam: 'Activate exam',
       areYouSure: "Are you sure you want to activate '{ examTitle }'?",
-      willBeVisible: 'The exam will be visible to the following:',
+      willBeVisible: 'The exam will be visible to',
       cancel: 'Cancel',
       activate: 'Activate',
       entireClass: 'Entire class',

--- a/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams-page/deactivate-exam-modal.vue
@@ -45,7 +45,7 @@
     $trs: {
       deactivateExam: 'Deactivate exam',
       areYouSure: "Are you sure you want to deactivate '{ examTitle }'?",
-      noLongerVisible: 'The exam will be no longer be visible to the following:',
+      noLongerVisible: 'The exam will be no longer be visible to',
       cancel: 'Cancel',
       deactivate: 'Deactivate',
       entireClass: 'Entire class',

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -56,7 +56,7 @@
     $trs: {
       moveLearners: 'Move learners',
       moveLearnerCount:
-        'Move {count, number, integer} {count, plural, one {learner} other {learners}} to:',
+        'Move {count, number, integer} {count, plural, one {learner} other {learners}} to',
       ungrouped: 'Ungrouped',
       cancel: 'Cancel',
       move: 'Move',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -261,7 +261,7 @@
       multipleResourceRemovalsConfirmationMessage: 'Removed { numberOfRemovals } resources',
       moveResourceUpButtonDescription: 'Move this resource one position up in this lesson',
       moveResourceDownButtonDescription: 'Move this resource one position down in this lesson',
-      parentChannelLabel: 'Parent channel:',
+      parentChannelLabel: 'Parent channel',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/CopyLessonModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/CopyLessonModal.vue
@@ -177,7 +177,7 @@
     },
     $trs: {
       copyLessonTitle: 'Copy lesson',
-      copyLessonExplanation: 'Copy this lesson to:',
+      copyLessonExplanation: 'Copy this lesson to',
       currentClass: '(current class)',
       continue: 'Continue',
       cancel: 'Cancel',

--- a/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
@@ -241,7 +241,7 @@
       exportToDisk: 'Export to {driveName}',
       importFromDisk: 'Import from {driveName}',
       kolibriCentralServer: 'Kolibri Studio',
-      languageFilterLabel: 'Language:',
+      languageFilterLabel: 'Language',
       titleFilterPlaceholder: 'Search for a channel…',
       yourChannels: 'Your channels',
       channelTokenButtonLabel: 'Try adding a token',

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -109,7 +109,7 @@ oriented data synchronization.
     mixins: [responsiveWindow],
     $trs: {
       goal:
-        'Try to get {count, number, integer} {count, plural, one {check mark} other {check marks}} to show up:',
+        'Try to get {count, number, integer} {count, plural, one {check mark} other {check marks}} to show up',
       tryAgain: 'Try again!',
       correct: 'Correct!',
       check: 'Check',

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -83,7 +83,7 @@
       },
     },
     $trs: {
-      teacherNote: 'Teacher note:',
+      teacherNote: 'Teacher note',
       noResourcesInLesson: 'There are no resources in this lesson!',
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -50,7 +50,7 @@
       },
     },
     $trs: {
-      nextInLesson: 'Next in Lesson:',
+      nextInLesson: 'Next in lesson',
     },
   };
 


### PR DESCRIPTION

### Summary

Follows [Material writing guidelines](https://material.io/guidelines/style/writing.html#writing-capitalization-punctuation) and skips colons after labels:

![image](https://user-images.githubusercontent.com/2367265/37004220-89ac769c-2084-11e8-92d5-66ff72a33184.png)


### Reviewer guidance

Check if these changes make sense, and follow this pattern in the future

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
