### PR TITLE
Filter by renderable content on API endpoints for content import.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -306,7 +306,7 @@ class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericView
     serializer_class = serializers.ContentNodeGranularSerializer
 
     def get_queryset(self):
-        return models.ContentNode.objects.all().prefetch_related('files__local_file').filter(renderable_contentnodes_q_filter)
+        return models.ContentNode.objects.all().prefetch_related('files__local_file').filter(renderable_contentnodes_q_filter).distinct()
 
     def retrieve(self, request, pk):
         queryset = self.get_queryset()

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -28,6 +28,7 @@ from .utils.search import fuzz
 from kolibri.content import models
 from kolibri.content import serializers
 from kolibri.content.permissions import CanManageContent
+from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
 from kolibri.content.utils.paths import get_channel_lookup_url
 from kolibri.logger.models import ContentSessionLog
 from kolibri.logger.models import ContentSummaryLog
@@ -305,7 +306,7 @@ class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericView
     serializer_class = serializers.ContentNodeGranularSerializer
 
     def get_queryset(self):
-        return models.ContentNode.objects.all().prefetch_related('files__local_file')
+        return models.ContentNode.objects.all().prefetch_related('files__local_file').filter(renderable_contentnodes_q_filter)
 
     def retrieve(self, request, pk):
         queryset = self.get_queryset()

--- a/kolibri/content/hooks.py
+++ b/kolibri/content/hooks.py
@@ -64,7 +64,7 @@ class ContentRendererHook(WebpackBundleHook):
         abstract = True
 
     @cached_property
-    def _content_type_json(self):
+    def content_types(self):
         global _JSON_CONTENT_TYPES_CACHE
         if not _JSON_CONTENT_TYPES_CACHE.get(self.unique_slug):
             try:
@@ -92,6 +92,6 @@ class ContentRendererHook(WebpackBundleHook):
                 kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
                 bundle=self.unique_slug,
                 urls='","'.join(urls),
-                content_types=json.dumps(self._content_type_json),
+                content_types=json.dumps(self.content_types),
             )]
         return mark_safe('\n'.join(tags))

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -321,13 +321,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     importable = serializers.SerializerMethodField()
 
     def get_total_resources(self, obj):
-        total_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(renderable_contentnodes_q_filter).count()
+        total_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(renderable_contentnodes_q_filter).distinct().count()
 
         return total_resources
 
     def get_on_device_resources(self, obj):
         available_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(
-            renderable_contentnodes_q_filter).filter(available=True).count()
+            renderable_contentnodes_q_filter).filter(available=True).distinct().count()
 
         return available_resources
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -1,12 +1,22 @@
 import os
+
 from django.core.cache import cache
-from django.db.models import Manager, Sum
+from django.db.models import Manager
+from django.db.models import Sum
 from django.db.models.query import RawQuerySet
-from kolibri.content.models import AssessmentMetaData, ChannelMetadata, ContentNode, File, Language, LocalFile
 from le_utils.constants import content_kinds
 from rest_framework import serializers
-from kolibri.content.utils.paths import get_content_storage_file_path
+
+from kolibri.content.models import AssessmentMetaData
+from kolibri.content.models import ChannelMetadata
+from kolibri.content.models import ContentNode
+from kolibri.content.models import File
+from kolibri.content.models import Language
+from kolibri.content.models import LocalFile
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
+from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
+from kolibri.content.utils.content_types_tools import renderable_local_files_q_filter
+from kolibri.content.utils.paths import get_content_storage_file_path
 
 
 class ChannelMetadataSerializer(serializers.ModelSerializer):
@@ -20,9 +30,12 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
 
         # if it has the file_size flag add extra file_size information
         if 'request' in self.context and self.context['request'].GET.get('file_sizes', False):
-            descendants = instance.root.get_descendants().exclude(kind=content_kinds.TOPIC)
+            # only count up currently renderable content types, as only these will be downloaded
+            descendants = instance.root.get_descendants().exclude(kind=content_kinds.TOPIC).filter(renderable_contentnodes_q_filter).distinct()
             total_resources = descendants.count()
-            local_files = LocalFile.objects.filter(files__contentnode__channel_id=instance.id).distinct()
+
+            # only count up currently renderable content types, as only these will be downloaded
+            local_files = LocalFile.objects.filter(files__contentnode__channel_id=instance.id).filter(renderable_local_files_q_filter).distinct()
             total_file_size = local_files.aggregate(Sum('file_size'))['file_size__sum'] or 0
 
             on_device_resources = descendants.filter(available=True).count()
@@ -309,12 +322,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     importable = serializers.SerializerMethodField()
 
     def get_total_resources(self, obj):
-        total_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).count()
+        total_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(renderable_contentnodes_q_filter).count()
 
         return total_resources
 
     def get_on_device_resources(self, obj):
-        available_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(available=True).count()
+        available_resources = obj.get_descendants(include_self=True).exclude(kind=content_kinds.TOPIC).filter(
+            renderable_contentnodes_q_filter).filter(available=True).count()
 
         return available_resources
 

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -15,7 +15,6 @@ from kolibri.content.models import Language
 from kolibri.content.models import LocalFile
 from kolibri.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
-from kolibri.content.utils.content_types_tools import renderable_local_files_q_filter
 from kolibri.content.utils.paths import get_content_storage_file_path
 
 
@@ -31,14 +30,14 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
         # if it has the file_size flag add extra file_size information
         if 'request' in self.context and self.context['request'].GET.get('file_sizes', False):
             # only count up currently renderable content types, as only these will be downloaded
-            descendants = instance.root.get_descendants().exclude(kind=content_kinds.TOPIC).filter(renderable_contentnodes_q_filter).distinct()
-            total_resources = descendants.count()
+            descendants = ContentNode.objects.filter(channel_id=instance.id).filter(renderable_contentnodes_q_filter).distinct()
+            total_resources = descendants.exclude(kind=content_kinds.TOPIC).count()
 
             # only count up currently renderable content types, as only these will be downloaded
-            local_files = LocalFile.objects.filter(files__contentnode__channel_id=instance.id).filter(renderable_local_files_q_filter).distinct()
+            local_files = LocalFile.objects.filter(files__contentnode__in=descendants).distinct()
             total_file_size = local_files.aggregate(Sum('file_size'))['file_size__sum'] or 0
 
-            on_device_resources = descendants.filter(available=True).count()
+            on_device_resources = descendants.exclude(kind=content_kinds.TOPIC).filter(available=True).count()
             on_device_file_size = local_files.filter(available=True).aggregate(Sum('file_size'))['file_size__sum'] or 0
 
             value.update(

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -184,10 +184,10 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
-                "total_resources": 2, "on_device_resources": 0, "importable": True, "children": [
+                "total_resources": 1, "on_device_resources": 0, "importable": True, "children": [
                     {
                         "pk": c2_id, "title": "c1", "kind": "video", "available": False,
-                        "total_resources": 2, "on_device_resources": 0, "importable": True
+                        "total_resources": 1, "on_device_resources": 0, "importable": True
                     },
                     {
                         "pk": c3_id, "title": "c2", "kind": "topic", "available": False,
@@ -210,11 +210,11 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "root", "kind": "topic", "available": False,
-                "total_resources": 2, "on_device_resources": 0, "importable": True,
+                "total_resources": 1, "on_device_resources": 0, "importable": True,
                 "children": [
                     {
                         "pk": c2_id, "title": "c1", "kind": "video", "available": False,
-                        "total_resources": 2, "on_device_resources": 0, "importable": False
+                        "total_resources": 1, "on_device_resources": 0, "importable": False
                     },
                     {
                         "pk": c3_id, "title": "c2", "kind": "topic", "available": False,
@@ -228,7 +228,7 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "c1", "kind": "video", "available": True,
-                "total_resources": 2, "on_device_resources": 2, "importable": True,
+                "total_resources": 1, "on_device_resources": 1, "importable": True,
                 "children": []})
 
     def test_contentnode_granular_export_unavailable(self):
@@ -238,7 +238,7 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(
             response.data, {
                 "pk": c1_id, "title": "c1", "kind": "video", "available": False,
-                "total_resources": 2, "on_device_resources": 0, "importable": True,
+                "total_resources": 1, "on_device_resources": 0, "importable": True,
                 "children": []})
 
     def test_contentnodefilesize_resourcenode(self):

--- a/kolibri/content/utils/content_types_tools.py
+++ b/kolibri/content/utils/content_types_tools.py
@@ -1,30 +1,15 @@
-from functools import reduce
-
 from django.db.models import Q
 from le_utils.constants import content_kinds
 
 from kolibri.content.hooks import ContentRendererHook
 
-content_types = []
+# Regardless of which renderers are installed, we can render topics!
+renderable_contentnodes_q_filter = Q(kind=content_kinds.TOPIC)
 
+# loop through all the registered content renderer hooks
 for hook in ContentRendererHook().registered_hooks:
     for obj in hook.content_types['kinds']:
-        kind = obj['name']
+        # iterate through each of the content types that each hook can handle
         for extension in obj['extensions']:
-            content_types.append({
-                "kind": kind,
-                "extension": extension,
-            })
-
-
-renderable_contentnodes_q_filter = reduce(
-    lambda acc, type: acc | Q(kind=type["kind"], files__local_file__extension=type["extension"]),
-    content_types,
-    Q(kind=content_kinds.TOPIC))
-
-renderable_local_files_q_filter = reduce(
-    lambda acc, type: acc | Q(files__contentnode__kind=type["kind"], extension=type["extension"]) |
-    # Also include files marked as supplementary, otherwise we will only count the directly rendered files
-    Q(files__contentnode__kind=type["kind"], files__supplementary=True),
-    content_types,
-    Q(files__contentnode__kind=content_kinds.TOPIC))
+            # Extend the q filter by ORing with a q filter for this content kind, and this file extension
+            renderable_contentnodes_q_filter |= Q(kind=obj['name'], files__local_file__extension=extension)

--- a/kolibri/content/utils/content_types_tools.py
+++ b/kolibri/content/utils/content_types_tools.py
@@ -1,0 +1,30 @@
+from functools import reduce
+
+from django.db.models import Q
+from le_utils.constants import content_kinds
+
+from kolibri.content.hooks import ContentRendererHook
+
+content_types = []
+
+for hook in ContentRendererHook().registered_hooks:
+    for obj in hook.content_types['kinds']:
+        kind = obj['name']
+        for extension in obj['extensions']:
+            content_types.append({
+                "kind": kind,
+                "extension": extension,
+            })
+
+
+renderable_contentnodes_q_filter = reduce(
+    lambda acc, type: acc | Q(kind=type["kind"], files__local_file__extension=type["extension"]),
+    content_types,
+    Q(kind=content_kinds.TOPIC))
+
+renderable_local_files_q_filter = reduce(
+    lambda acc, type: acc | Q(files__contentnode__kind=type["kind"], extension=type["extension"]) |
+    # Also include files marked as supplementary, otherwise we will only count the directly rendered files
+    Q(files__contentnode__kind=type["kind"], files__supplementary=True),
+    content_types,
+    Q(files__contentnode__kind=content_kinds.TOPIC))

--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -3,22 +3,22 @@ from django.db.models import Sum
 from kolibri.content.models import ContentNode
 from kolibri.content.models import LocalFile
 from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
-from kolibri.content.utils.content_types_tools import renderable_local_files_q_filter
 
 
 def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available, renderable_only=True):
     files_to_transfer = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=available)
 
     if node_ids:
-        node_ids = _get_node_ids(node_ids, renderable_only=renderable_only)
+        node_ids = _get_node_ids(node_ids)
         files_to_transfer = files_to_transfer.filter(files__contentnode__in=node_ids)
 
     if exclude_node_ids:
-        exclude_node_ids = _get_node_ids(exclude_node_ids, renderable_only=renderable_only)
+        exclude_node_ids = _get_node_ids(exclude_node_ids)
         files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_node_ids)
 
     if renderable_only:
-        files_to_transfer = files_to_transfer.filter(renderable_local_files_q_filter)
+        files_to_transfer = files_to_transfer.filter(files__contentnode__in=ContentNode.objects.filter(
+            channel_id=channel_id).filter(renderable_contentnodes_q_filter).distinct())
 
     # Make sure the files are unique, to avoid duplicating downloads
     files_to_transfer = files_to_transfer.distinct()
@@ -28,10 +28,9 @@ def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available, ren
     return files_to_transfer, total_bytes_to_transfer
 
 
-def _get_node_ids(node_ids, renderable_only=True):
+def _get_node_ids(node_ids):
 
     return ContentNode.objects \
         .filter(pk__in=node_ids) \
         .get_descendants(include_self=True) \
-        .filter(renderable_contentnodes_q_filter) \
         .values_list('id', flat=True)

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
@@ -139,7 +139,8 @@
         if (this.transferType === TransferTypes.LOCALEXPORT) {
           return node.available;
         }
-        return node.importable;
+        // If there are no resources at all within the node, do not display at all
+        return node.importable && node.total_resources;
       },
       updateCurrentTopicNode(node) {
         return navigateToTopicUrl.call(this, node);


### PR DESCRIPTION
### Summary
By default forces all content import to only import content types that are renderable by the current instance of Kolibri.

### Reviewer guidance
Disable different content renderers and check that it properly impacts the displayed resources on the content import dialogue, and the resources that get imported after that.

### References
Fixes #3213 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
