### PR TITLE
Check if port is occupied before starting Kolibri

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -312,7 +312,7 @@ def stop():
         pid, __, __ = server.get_status()
         server.stop(pid=pid)
         stopped = True
-        logger.info("Kolibri server has been successfully stoppped.")
+        logger.info("Kolibri server has successfully been stoppped.")
     except server.NotRunning as e:
         verbose_status = "{msg:s} ({code:d})".format(
             code=e.status_code,

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -24,6 +24,7 @@ from kolibri.core.deviceadmin.utils import IncompatibleDatabase  # noqa
 
 from . import server  # noqa
 from .system import become_daemon  # noqa
+from .sanity_checks import check_other_kolibri_running  # noqa
 
 USAGE = """
 Kolibri
@@ -262,12 +263,9 @@ def start(port=None, daemon=True):
     # https://github.com/learningequality/kolibri/issues/1615
     update()
 
-    if port is None:
-        try:
-            port = int(os.environ['KOLIBRI_LISTEN_PORT'])
-        except ValueError:
-            logger.error("Invalid KOLIBRI_LISTEN_PORT, must be an integer")
-            raise
+    # In case that some tests run start() function only
+    if not isinstance(port, int):
+        port = _get_port(port)
 
     if not daemon:
         logger.info("Running 'kolibri start' in foreground...")
@@ -314,6 +312,7 @@ def stop():
         pid, __, __ = server.get_status()
         server.stop(pid=pid)
         stopped = True
+        logger.info("Kolibri server has been successfully stoppped.")
     except server.NotRunning as e:
         verbose_status = "{msg:s} ({code:d})".format(
             code=e.status_code,
@@ -576,6 +575,17 @@ def parse_args(args=None):
     return docopt(USAGE, **docopt_kwargs), django_args
 
 
+def _get_port(port):
+    port = int(port) if port else None
+    if port is None:
+        try:
+            port = int(os.environ['KOLIBRI_LISTEN_PORT'])
+        except ValueError:
+            logger.error("Invalid KOLIBRI_LISTEN_PORT, must be an integer")
+            raise
+    return port
+
+
 def main(args=None):
     """
     Kolibri's main function. Parses arguments and calls utility functions.
@@ -588,6 +598,10 @@ def main(args=None):
     arguments, django_args = parse_args(args)
 
     debug = arguments['--debug']
+
+    if arguments['start']:
+        port = _get_port(arguments['--port'])
+        check_other_kolibri_running(port)
 
     initialize(debug=debug)
 
@@ -607,8 +621,6 @@ def main(args=None):
         return
 
     if arguments['start']:
-        port = arguments['--port']
-        port = int(port) if port else None
         daemon = not arguments['--foreground']
         if sys.platform == 'darwin':
             daemon = False

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -14,7 +14,8 @@ def check_other_kolibri_running(port):
         pid, listen_address, listen_port = get_status()
         logger.error(
             "There is another Kolibri server running. "
-            "Please use `kolibri stop` and try again.")
+            "Please use `kolibri stop` and try again."
+        )
         sys.exit(1)
 
     except NotRunning:
@@ -37,6 +38,7 @@ def check_port_availability(host, port):
         logger.error(
             "Port {} is occupied.\n"
             "Please check that you do not have other processes "
-            "running on this port and try again.\n".format(port))
+            "running on this port and try again.\n".format(port)
+        )
         s.close()
         sys.exit(1)

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -1,0 +1,42 @@
+import logging
+import socket
+import sys
+
+from .server import get_status
+from .server import NotRunning
+
+logger = logging.getLogger(__name__)
+
+def check_other_kolibri_running(port):
+    try:
+        # Check if there are other kolibri instances running
+        # If there are, then we need to stop users from starting kolibri again.
+        pid, listen_address, listen_port = get_status()
+        logger.error(
+            "There is another Kolibri server running. "
+            "Please use `kolibri stop` and try again.")
+        sys.exit(1)
+
+    except NotRunning:
+        # In case that something other than Kolibri occupies the port,
+        # check the port's availability.
+        check_port_availability('127.0.0.1', port)
+
+
+def check_port_availability(host, port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # This is to prevent the previous execution has left the socket
+    # in a TIME_WAIT start, and can't be immediately reused.
+    # From the bottom of https://docs.python.org/2/library/socket.html#example
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind((host, port))
+        s.close()
+    except socket.error:
+        # Port is occupied
+        logger.error(
+            "Port {} is occupied.\n"
+            "Please check that you do not have other processes "
+            "running on this port and try again.\n".format(port))
+        s.close()
+        sys.exit(1)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to implement one of the sanity checks before starting Kolibri.
In this PR, before launching Kolibri:
1. I check if a Kolibri server has been running using `server.get_status()`. If a Kolibri server is running, then users should not be able to run `kolibri start` again. The program will exit with an error message.
2. If there is no Kolibri server running currently, then I continue to check if the port is occupied, since it could be possible that something other than Kolibri occupies the port. If the port is occupied, the program will exit with an error message.

Additionally, I added a line in the function `stop()` of `cli.py` to indicate that kolibri server has been stopped.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Start a kolibri instance using installers other than the ones from this PR
2. Get an installer from this PR and try to start another kolibri instance

Running with two pex files could be an easier approach. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issues: 
https://github.com/learningequality/kolibri/issues/3285
https://github.com/learningequality/kolibri/issues/2867
https://github.com/learningequality/kolibri/issues/3048

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
