### PR TITLE
Fixing topic page

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -389,9 +389,11 @@ function setChannelInfo(store) {
     .then(
       channelsData => {
         store.dispatch('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));
+        return channelsData;
       },
       error => {
         handleApiError(store, error);
+        return error;
       }
     );
 }

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -6,12 +6,7 @@ import {
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 
-import {
-  getChannelObject,
-  isUserLoggedIn,
-  getChannels,
-  currentUserId,
-} from 'kolibri.coreVue.vuex.getters';
+import { getChannelObject, isUserLoggedIn, currentUserId } from 'kolibri.coreVue.vuex.getters';
 import {
   setChannelInfo,
   handleError,
@@ -151,8 +146,7 @@ export function updateContentNodeProgress(channelId, contentId, progressFraction
 
 export function setAndCheckChannels(store) {
   return setChannelInfo(store).then(
-    () => {
-      const channels = getChannels(store.state);
+    channels => {
       if (!channels.length) {
         router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
       }
@@ -160,6 +154,7 @@ export function setAndCheckChannels(store) {
     },
     error => {
       handleApiError(store, error);
+      return error;
     }
   );
 }
@@ -197,6 +192,7 @@ export function showChannels(store) {
     },
     error => {
       handleApiError(store, error);
+      return error;
     }
   );
 }


### PR DESCRIPTION
### Summary

Explicitly returning ContentNode.getCollection() resolution with each helper function.
Previously, original ConditionalPromise was being passed up every level.
Alternative solution to that in bf09c56f14a8538c2a83aa2b6c0d71b1a00556f8. Returns exact same results as it did before promise API was fixed.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Problem was introduced by 2 commits: 
- 35cb40ba3650ecd94f03eaaa942e51382c0ef907 made `ConditionalPromise` more compliant to the Promise spec. In doing so, the `ConditionalPromise` stopped returning itself at any `.then` following it.

#### Example:
With this code
```
Promise.resolve('hi').then(resolution -> (resolution + ' there')).then(resolution => console.log(resolution));
```
If the Promise object used were an API-compliant promise would log `"hi there"`.
if it were a ConditionalPromise would just log `"hi"`

- bf09c56f14a8538c2a83aa2b6c0d71b1a00556f8 used a getter to retrieve the channel list from state, but the state held a transformed version of the server response, which was missing values expected by the `showChannels` function. 

The last time this was fixed, we reverted the change meant to fix #2156. Should we do that again @indirectlylit @rtibbles?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
- resolves #3276 
- #2156 
- #2584 
- 35cb40ba3650ecd94f03eaaa942e51382c0ef907
- 35cb40ba3650ecd94f03eaaa942e51382c0ef907

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
