### PR TITLE
Exam selection now only displays channels that contain exercises

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -10,6 +10,7 @@ from django.http import Http404
 from django.utils.translation import ugettext as _
 from django_filters.rest_framework import BooleanFilter, CharFilter, ChoiceFilter, DjangoFilterBackend, FilterSet
 from kolibri.content import models, serializers
+from kolibri.content.models import ChannelMetadata
 from kolibri.content.permissions import CanManageContent
 from kolibri.content.utils.paths import get_channel_lookup_url
 from kolibri.logger.models import ContentSessionLog, ContentSummaryLog
@@ -26,13 +27,22 @@ logger = logging.getLogger(__name__)
 
 class ChannelMetadataFilter(FilterSet):
     available = BooleanFilter(method="filter_available")
+    has_exercise = BooleanFilter(method="filter_has_exercise")
+
+    def filter_has_exercise(self,queryset,name,value):
+        channel_ids = []
+        for c in queryset:
+            num_exercises = c.root.get_descendants().filter(kind=content_kinds.EXERCISE).count()
+            if num_exercises > 0:
+                channel_ids.append(c.id)
+        return queryset.filter(id__in=channel_ids)
 
     def filter_available(self, queryset, name, value):
         return queryset.filter(root__available=value)
 
     class Meta:
         model = models.ChannelMetadata
-        fields = ['available', ]
+        fields = ['available', 'has_exercise',]
 
 
 class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -144,7 +144,7 @@ function showExamsPage(store, classId) {
 
   const promises = [
     LearnerGroupResource.getCollection({ parent: classId }).fetch(),
-    ChannelResource.getCollection().fetch(),
+    ChannelResource.getCollection({ available: true, has_exercise: true }).fetch(),
     ExamResource.getCollection({ collection: classId }).fetch({}, true),
     setClassState(store, classId),
   ];
@@ -382,7 +382,7 @@ function showCreateExamPage(store, classId, channelId) {
   store.dispatch('SET_PAGE_NAME', PageNames.CREATE_EXAM);
   store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamCreationPageTitle'));
 
-  const channelPromise = ChannelResource.getCollection().fetch();
+  const channelPromise = ChannelResource.getCollection({ available: true }).fetch();
   const examsPromise = ExamResource.getCollection({
     collection: classId,
   }).fetch({}, true);

--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get -y update
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sudo software-properties-common
 
-RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update \
-    && apt-get install -y wine1.8
+RUN add-apt-repository ppa:ubuntu-wine/ppa && apt-get update
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+RUN apt-get install -y ttf-mscorefonts-installer
+RUN apt-get install -y wine1.8
 
 COPY ./ /kolibri
 


### PR DESCRIPTION
### Summary

During exam creation, the drop down menu would have channels that didn't have exercises in them. This would be potentially be confusing and inconvenient for coaches who are trying to create exams. 

Now, only exams that actually have exercises are shown in the selection menu. This involved adding another feature in the content api.py file, which looks into each channel and checks if it has at least one exercise.

### Reviewer guidance

This can be tested by having multiple imported channels, some with exercises and some without exercise. Then, go to the coaching tab and create an exam. The exam selection menu should only show the channels that have exercises.

### References

This fixes issue #2770. 

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
