### PR TITLE
Fail loudly when trying to build dist on python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,9 @@ before_install:
   - nvm use $TRAVIS_NODE_VERSION
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - make staticdeps  # install staticdeps for all envs
+  # Until we have staged builds, we will be running this in each and every
+  # environment even though builds should be done in Py 2.7
+  - SKIP_PY_CHECK=1 make staticdeps  # install staticdeps for all envs
   - yarn  # build and install yarn deps for all envs
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,8 @@ before_install:
   - nvm use $TRAVIS_NODE_VERSION
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+  - make staticdeps  # install staticdeps for all envs
+  - yarn  # build and install yarn deps for all envs
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,6 @@ before_install:
   - nvm use $TRAVIS_NODE_VERSION
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  # Until we have staged builds, we will be running this in each and every
-  # environment even though builds should be done in Py 2.7
-  - SKIP_PY_CHECK=1 make staticdeps  # install staticdeps for all envs
-  - yarn  # build and install yarn deps for all envs
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ test-namespaced-packages:
 	! find kolibri/dist -mindepth 1 -maxdepth 1 -type d -not -name __pycache__ -not -name cext -not -name py2only -exec ls {}/__init__.py \; 2>&1 | grep  "No such file"
 
 staticdeps:
+	python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
 	rm -rf kolibri/dist/* || true # remove everything
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r "requirements.txt"

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-namespaced-packages:
 	! find kolibri/dist -mindepth 1 -maxdepth 1 -type d -not -name __pycache__ -not -name cext -not -name py2only -exec ls {}/__init__.py \; 2>&1 | grep  "No such file"
 
 staticdeps:
-	python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
+	test "${SKIP_PY_CHECK}" = "1" || python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
 	rm -rf kolibri/dist/* || true # remove everything
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r "requirements.txt"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ test = pytest
 ignore = E226,E302,E41
 max-line-length = 160
 max-complexity = 10
-exclude = kolibri/*/migrations/*
+exclude = kolibri/*/migrations/*,kolibri/dist/*
 
 [isort]
 atomic = true

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ basepython =
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
-    make staticdeps
     # Ensure that for this Python version, we can actually compile ALL files
     # in the kolibri directory
     python -m compileall -q kolibri -x py2only

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv =
     KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
     KOLIBRI_RUN_MODE = tox
+    SKIP_PY_CHECK = 1
 basepython =
     pythonbuild2.7: python2.7
     pythonbuild3.4: python3.4
@@ -30,6 +31,9 @@ basepython =
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
+    # Until we have staged builds, we will be running this in each and every
+    # environment even though builds should be done in Py 2.7
+    make staticdeps  # install staticdeps for all envs
     # Ensure that for this Python version, we can actually compile ALL files
     # in the kolibri directory
     python -m compileall -q kolibri -x py2only


### PR DESCRIPTION
### Summary

Fixes #3319 

Disallows `staticdeps` on Python 3. Of course we should allow it when it's a thing that can work :)

### Reviewer guidance

I can't build Kolibri with Python 3 (it fails), and I don't know of any cases where this should be a deliberate action at present.

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
