### PR TITLE
Exams selection now only has channels with exercises

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -37,13 +37,22 @@ logger = logging.getLogger(__name__)
 
 class ChannelMetadataFilter(FilterSet):
     available = BooleanFilter(method="filter_available")
+    has_exercise = BooleanFilter(method="filter_has_exercise")
+
+    def filter_has_exercise(self,queryset,name,value):
+        channel_ids = []
+        for c in queryset:
+            num_exercises = c.root.get_descendants().filter(kind=content_kinds.EXERCISE).count()
+            if num_exercises > 0:
+                channel_ids.append(c.id)
+        return queryset.filter(id__in=channel_ids)
 
     def filter_available(self, queryset, name, value):
         return queryset.filter(root__available=value)
 
     class Meta:
         model = models.ChannelMetadata
-        fields = ['available', ]
+        fields = ['available', 'has_exercise',]
 
 
 class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -39,7 +39,7 @@ class ChannelMetadataFilter(FilterSet):
     available = BooleanFilter(method="filter_available")
     has_exercise = BooleanFilter(method="filter_has_exercise")
 
-    def filter_has_exercise(self,queryset,name,value):
+    def filter_has_exercise(self, queryset, name, value):
         channel_ids = []
         for c in queryset:
             num_exercises = c.root.get_descendants().filter(kind=content_kinds.EXERCISE).count()
@@ -52,7 +52,7 @@ class ChannelMetadataFilter(FilterSet):
 
     class Meta:
         model = models.ChannelMetadata
-        fields = ['available', 'has_exercise',]
+        fields = ['available', 'has_exercise', ]
 
 
 class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -143,7 +143,7 @@ function showExamsPage(store, classId) {
 
   const promises = [
     LearnerGroupResource.getCollection({ parent: classId }).fetch(),
-    ChannelResource.getCollection().fetch(),
+    ChannelResource.getCollection({ available: true, has_exercise: true }).fetch(),
     ExamResource.getCollection({ collection: classId }).fetch({}, true),
     setClassState(store, classId),
   ];
@@ -381,7 +381,7 @@ function showCreateExamPage(store, classId, channelId) {
   store.dispatch('SET_PAGE_NAME', PageNames.CREATE_EXAM);
   store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamCreationPageTitle'));
 
-  const channelPromise = ChannelResource.getCollection().fetch();
+  const channelPromise = ChannelResource.getCollection({ available: true }).fetch();
   const examsPromise = ExamResource.getCollection({
     collection: classId,
   }).fetch({}, true);


### PR DESCRIPTION
### Summary
During exam creation, the drop down menu would have channels that didn't have exercises in them. This would be potentially be confusing and inconvenient for coaches who are trying to create exams.

Now, only exams that actually have exercises are shown in the selection menu. This involved adding another feature in the content api.py file, which looks into each channel and checks if it has at least one exercise.

### Reviewer guidance

This can be tested by having multiple imported channels, some with exercises and some without exercise. Then, go to the coaching tab and create an exam. The exam selection menu should only show the channels that have exercises.

### References

This fixes issue #2770.

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
