### PR TITLE
Prevent lesson creation modal lock up

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -120,7 +120,8 @@
         };
       },
       titleIsInvalidText() {
-        if (this.titleIsVisited || this.formIsSubmitted) {
+        // submission is handled because "blur" event happens on submit
+        if (this.titleIsVisited) {
           if (this.title === '') {
             return this.$tr('required');
           }

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -14,6 +14,7 @@
         {{ $tr('submitLessonError') }}
       </ui-alert>
       <k-textbox
+        @blur="titleIsVisited = true"
         :label="$tr('title')"
         :maxlength="50"
         :autofocus="true"
@@ -200,6 +201,9 @@
                 this.handleSubmitFailure();
               });
           }
+        } else {
+          // shouldn't ever be true, but being safe
+          this.formIsSubmitted = false;
         }
       },
       createLesson() {

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -227,12 +227,23 @@
     vuex: {
       getters: {
         classId: state => state.classId,
-        currentLesson: state => state.pageState.currentLesson || null,
+        currentLesson: state => {
+          const newLesson = {
+            title: '',
+            description: '',
+          };
+          return state.pageState.currentLesson || newLesson;
+        },
         groups: state => state.pageState.learnerGroups,
         // If the page name is (Lesson) SUMMARY, then should be in edit mode
         isInEditMode: state => state.pageName === LessonsPageNames.SUMMARY,
-        currentLessonAssignedCollectionIds: state =>
-          state.pageState.currentLesson.lesson_assignments.map(a => a.collection),
+        // This only exists in edit mode
+        currentLessonAssignedCollectionIds: state => {
+          if (state.pageState.currentLesson) {
+            return state.pageState.currentLesson.lesson_assignments.map(a => a.collection);
+          }
+          return [state.classId];
+        },
       },
       actions: {
         createSnackbar,

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -15,6 +15,7 @@
       </ui-alert>
       <k-textbox
         @blur="titleIsVisited = true"
+        ref="titleField"
         :label="$tr('title')"
         :maxlength="50"
         :autofocus="true"
@@ -204,6 +205,7 @@
         } else {
           // shouldn't ever be true, but being safe
           this.formIsSubmitted = false;
+          this.$refs.titleField.focus();
         }
       },
       createLesson() {

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -86,12 +86,12 @@
     },
     data() {
       return {
-        description: '',
-        descriptionIsVisited: false,
-        formIsSubmitted: false,
-        selectedCollectionIds: [],
-        title: '',
+        // set default values
+        title: this.currentLesson.title,
+        description: this.currentLesson.description,
+        selectedCollectionIds: this.currentLessonAssignedCollectionIds,
         titleIsVisited: false,
+        formIsSubmitted: false,
         showServerError: false,
       };
     },
@@ -147,15 +147,6 @@
           this.groupsHaveChanged
         );
       },
-    },
-    created() {
-      if (this.isInEditMode) {
-        this.title = this.currentLesson.title;
-        this.description = this.currentLesson.description;
-        this.selectedCollectionIds = [...this.currentLessonAssignedCollectionIds];
-      } else {
-        this.selectedCollectionIds = [this.classId];
-      }
     },
     methods: {
       showSuccessSnackbar() {

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -5,14 +5,15 @@
     @cancel="closeModal()"
     width="400px"
   >
+    <ui-alert
+      v-if="showServerError"
+      type="error"
+      :dismissible="false"
+    >
+      {{ $tr('submitLessonError') }}
+    </ui-alert>
+
     <form @submit.prevent="submitLessonData">
-      <ui-alert
-        v-if="showError"
-        type="error"
-        :dismissible="false"
-      >
-        {{ $tr('submitLessonError') }}
-      </ui-alert>
       <k-textbox
         @blur="titleIsVisited = true"
         ref="titleField"
@@ -41,6 +42,7 @@
           :disabled="formIsSubmitted"
         />
       </fieldset>
+
       <div class="core-modal-buttons">
         <k-button
           :text="$tr('cancel')"
@@ -90,7 +92,7 @@
         selectedCollectionIds: [],
         title: '',
         titleIsVisited: false,
-        showError: false,
+        showServerError: false,
       };
     },
     computed: {
@@ -168,10 +170,10 @@
       },
       handleSubmitFailure() {
         this.formIsSubmitted = false;
-        this.showError = true;
+        this.showServerError = true;
       },
       submitLessonData() {
-        this.showError = false;
+        this.showServerError = false;
         // Return immediately if "submit" has already been clicked
         if (this.formIsSubmitted) {
           return;

--- a/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/ManageLessonModals/LessonDetailsModal.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="modalTexts.title"
     @cancel="closeModal()"
+    :hasError="showServerError || !formIsValid"
     width="400px"
   >
     <ui-alert


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Prevent lock up discovered during March 8, 2018 hack session.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Before: submitting with no title would lock the modal up and prevent creation or edit.

Changes were iterative, but I've reordered commits so that the SIMPLEST fix lies in the first commit of this PR. 
@indirectlylit I think all the changes are worthwhile, but they haven't been tested as thoroughly :man_shrugging: 

Other things were wrong with the modal; it couldn't be debugged using Vue dev tools outside of the summary page because some `null` or `undefined` properties were trying to be accessed.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://docs.google.com/document/d/1YnnbfoRziICOA6VX7tdiFkyIPKTrHwCQIw9MWbexP2U/edit#bookmark=id.y62n5sphmp40

Thanks for finding this, @lyw07 
----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
