### PR TITLE
import/export button updates

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -68,7 +68,6 @@
         @click="$emit('clickselect')"
         name="select"
         :text="$tr('selectButton')"
-        primary
         :disabled="tasksInQueue"
       />
       <k-button

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
@@ -32,7 +32,6 @@
               v-if="deviceHasChannels"
               :text="$tr('export')"
               class="button"
-              :primary="true"
               @click="openWizard('export')"
             />
           </div>

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
@@ -42,8 +42,7 @@
       <k-button
         v-if="taskHasCompleted || taskHasFailed || cancellable"
         :text="taskHasCompleted ? $tr('close') : $tr('cancel')"
-        :primary="false"
-        appearance="flat-button"
+        :primary="true"
         @click="endTask()"
         :disabled="uiBlocked"
       />


### PR DESCRIPTION
### Summary

Brings our buttons more in line with the style guide, which specifies having no more than one primary button visible at a time.

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/37185198-112362b8-22f4-11e8-9c4d-1045f074bbc8.png) | ![image](https://user-images.githubusercontent.com/2367265/37185211-1d92b472-22f4-11e8-8d91-d66ab770d4d0.png) |
| ![image](https://user-images.githubusercontent.com/2367265/37185219-26780e8e-22f4-11e8-8029-22676610d48a.png) | ![image](https://user-images.githubusercontent.com/2367265/37185243-49c038e4-22f4-11e8-92ba-b286be2eeaf7.png) |
| ![image](https://user-images.githubusercontent.com/2367265/37185349-bd6e81f6-22f4-11e8-8ae4-447300a8a52d.png) | ![image](https://user-images.githubusercontent.com/2367265/37185352-c07b19d6-22f4-11e8-83ba-7e580e56d55b.png) |


> 

### Reviewer guidance

Make sure it looks good

### References

http://kolibridemo.learningequality.org/style_guide#/components/buttons

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
