### PR TITLE
Command to recover the database: dbrecover

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -5,7 +5,9 @@ import os
 
 from django.apps import AppConfig
 from django.db.backends.signals import connection_created
-from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS, START_PRAGMAS
+
+from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
+from kolibri.core.sqlite.pragmas import START_PRAGMAS
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/deviceadmin/management/commands/dbbackup.py
+++ b/kolibri/core/deviceadmin/management/commands/dbbackup.py
@@ -1,12 +1,15 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import logging
 
-import kolibri
 from django.core.management.base import BaseCommand
-from kolibri.utils import server
 
+import kolibri
 from ...utils import dbbackup
+from kolibri.core.deviceadmin.utils import dbbackup_sqlite3_dump
+from kolibri.utils import server
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,14 @@ class Command(BaseCommand):
                 "is created in the default location ~/.kolibri/backups"
             )
         )
+        parser.add_argument(
+            '--external',
+            action='store_true',
+            dest='external',
+            help=(
+                "Use external `sqlite3` command."
+            )
+        )
 
     def handle(self, *args, **options):
 
@@ -48,8 +59,13 @@ class Command(BaseCommand):
             pass
 
         dest_folder = options.get("dest_folder", None)
+        external = options.get("external", False)
 
-        backup = dbbackup(kolibri.__version__, dest_folder=dest_folder)
+        if external:
+            backup = dbbackup_sqlite3_dump(kolibri.__version__, dest_folder=dest_folder)
+        else:
+            backup = dbbackup(kolibri.__version__, dest_folder=dest_folder)
+
         self.stdout.write(self.style.SUCCESS(
             "Backed up database to: {path}".format(path=backup)
         ))

--- a/kolibri/core/deviceadmin/management/commands/dbrecover.py
+++ b/kolibri/core/deviceadmin/management/commands/dbrecover.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
         prompt = (
             "Only use this command to recover a corrupt database. It "
             "would (if successful) recover data without any loss. "
-            "Your old database will be backed up in {}. Continue? [y/N)]"
+            "Your old database will be backed up in {}. Continue? [y/N)] "
         ).format(utils.default_backup_folder())
 
         if not no_input:

--- a/kolibri/core/deviceadmin/management/commands/dbrecover.py
+++ b/kolibri/core/deviceadmin/management/commands/dbrecover.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import sys
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from six.moves import input
+
+from ... import utils
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    output_transaction = True
+
+    # @ReservedAssignment
+    help = (
+        "Use this command if your database is corrupted. This will attempt "
+        "to restore the current database, it is not supposed to cause any "
+        "loss of data."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-input',
+            action='store_true',
+            dest='no_input',
+            help=(
+                "Skip user prompt before restoring database"
+            )
+        )
+
+    def handle(self, *args, **options):
+
+        utils.exit_if_kolibri_running(self)
+
+        if 'sqlite3' not in settings.DATABASES['default']['ENGINE']:
+            self.stderr.write(
+                "Database recovery is only supported for SQLite3."
+            )
+            sys.exit(1)
+
+        no_input = options.get("no_input", False)
+
+        prompt = (
+            "Only use this command to recover a corrupt database. It "
+            "would (if successful) recover data without any loss. "
+            "Your old database will be backed up in {}. Continue? [y/N)]"
+        ).format(utils.default_backup_folder())
+
+        if not no_input:
+
+            cont_response = (input(prompt) or "").lower()
+            if cont_response != "y":
+                logging.error("Exiting")
+                return
+
+        if not utils.check_for_sqlite3():
+
+            self.stderr.write(
+                "In order to recover the database, you need the 'sqlite3' "
+                "command on your system. We apologize for this, but the "
+                "functionality for recovering after database corruption is "
+                "only available in this external tool."
+            )
+            sys.exit(1)
+
+        call_command("dbbackup", external=True)
+        call_command("dbrestore", latest=True)

--- a/kolibri/core/deviceadmin/management/commands/dbrestore.py
+++ b/kolibri/core/deviceadmin/management/commands/dbrestore.py
@@ -1,13 +1,18 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import logging
 import os
 
-import kolibri
-from django.core.management.base import BaseCommand, CommandError
-from kolibri.utils import server
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 
-from ...utils import dbrestore, default_backup_folder, search_latest
+import kolibri
+from ...utils import dbrestore
+from ...utils import default_backup_folder
+from ...utils import exit_if_kolibri_running
+from ...utils import search_latest
 
 logger = logging.getLogger(__name__)
 
@@ -42,17 +47,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        try:
-            server.get_status()
-            self.stderr.write(self.style.ERROR(
-                "Cannot restore while Kolibri is running, please run:\n"
-                "\n"
-                "    kolibri stop\n"
-            ))
-            raise SystemExit()
-        except server.NotRunning:
-            # Great, it's not running!
-            pass
+        exit_if_kolibri_running(self)
 
         latest = options['latest']
         use_backup = options.get("dump_file", None)

--- a/kolibri/core/deviceadmin/tests/test_dbrecover.py
+++ b/kolibri/core/deviceadmin/tests/test_dbrecover.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import random
+import tempfile
+
+import pytest
+from django.conf import settings
+from django.core.management import call_command
+from django.test.utils import override_settings
+from mock import patch
+
+from kolibri.auth.constants.collection_kinds import FACILITY
+from kolibri.utils.server import NotRunning
+from kolibri.utils.server import STATUS_UNKNOWN
+
+MOCK_DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ":memory:",
+        'OPTIONS': {
+            'timeout': 100,
+        }
+    }
+}
+
+MOCK_DB_MALFORMED_FILE = os.path.join(
+    tempfile.mkdtemp(),
+    "test{}.db".format(random.randint(0, 100000))
+)
+
+MOCK_DATABASES_FILE = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': MOCK_DB_MALFORMED_FILE,
+        'OPTIONS': {
+            'timeout': 100,
+        }
+    }
+}
+
+
+def is_sqlite_settings():
+    """
+    This does not work during pytest collection, needs to be called while
+    executing tests!
+    """
+    return 'sqlite3' in settings.DATABASES['default']['ENGINE']
+
+
+def mock_status_not_running():
+    raise NotRunning(STATUS_UNKNOWN)
+
+
+@pytest.mark.django_db
+@pytest.mark.filterwarnings('ignore:Overriding setting DATABASES')
+def test_recover():
+    if not is_sqlite_settings():
+        return
+    with patch(
+        "kolibri.utils.server.get_status",
+        side_effect=mock_status_not_running
+    ):
+
+        # Recover corrupt database
+        with override_settings(DATABASES=MOCK_DATABASES):
+            from django import db
+            from kolibri.auth.models import Facility
+            # Destroy current connections and create new ones:
+            db.connections.close_all()
+            db.connections = db.ConnectionHandler()
+            call_command("dbrestore", latest=True)
+            # Test that the user has been restored!
+            assert Facility.objects.filter(name="test latest", kind=FACILITY).count() == 1
+
+    call_command("dbrecover", no_input=True)

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -6,15 +6,14 @@ import subprocess
 import sys
 from datetime import datetime
 
-# Import db instead of db.connections because we want to use an instance of
-# connections that might be updated from outside.
 from django import db
 from django.conf import settings
 
 import kolibri
-
-from ...utils import server
-from ...utils.conf import KOLIBRI_HOME
+from kolibri.utils import server
+from kolibri.utils.conf import KOLIBRI_HOME
+# Import db instead of db.connections because we want to use an instance of
+# connections that might be updated from outside.
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -2,17 +2,19 @@ import io
 import logging
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime
 
+# Import db instead of db.connections because we want to use an instance of
+# connections that might be updated from outside.
 from django import db
 from django.conf import settings
 
 import kolibri
-from kolibri.utils.conf import KOLIBRI_HOME
-# Import db instead of db.connections because we want to use an instance of
-# connections that might be updated from outside.
 
+from ...utils import server
+from ...utils.conf import KOLIBRI_HOME
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +35,24 @@ class IncompatibleDatabase(Exception):
 
 def default_backup_folder():
     return os.path.join(KOLIBRI_HOME, 'backups')
+
+
+def exit_if_kolibri_running(instance):
+    """
+    :param: instance: An instance of BaseCommand
+    """
+
+    try:
+        server.get_status()
+        instance.stderr.write(instance.style.ERROR(
+            "Cannot recover database while Kolibri is running, please run:\n"
+            "\n"
+            "    kolibri stop\n"
+        ))
+        raise SystemExit()
+    except server.NotRunning:
+        # Great, it's not running!
+        pass
 
 
 def get_dtm_from_backup_name(fname):
@@ -62,6 +82,28 @@ def is_full_version(fname):
     )
 
 
+def get_path_backup_dump_file(old_version, dest_folder):
+    """
+    :param: old_version: The kolibri version used when creating the backup
+    :param: dest_folder: Default is ~/.kolibri/backups/db-[version]-[date].dump
+    """
+
+    if not dest_folder:
+        dest_folder = default_backup_folder()
+
+    if not os.path.exists(dest_folder):
+        os.makedirs(dest_folder)
+
+    # This file name is a convention, used to figure out the latest backup
+    # that was made (by the dbrestore command)
+    fname = "db-v{version}_{dtm}.dump".format(
+        version=old_version,
+        dtm=datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    )
+
+    return os.path.join(dest_folder, fname)
+
+
 def dbbackup(old_version, dest_folder=None):
     """
     Sqlite3 only
@@ -74,6 +116,7 @@ def dbbackup(old_version, dest_folder=None):
     the same date overwrite each other. It's also quite important for the user
     to know which version of Kolibri that a certain database should match.
 
+    :param: old_version: The kolibri version used when creating the backup
     :param: dest_folder: Default is ~/.kolibri/backups/db-[version]-[date].dump
 
     :returns: Path of new backup file
@@ -82,20 +125,7 @@ def dbbackup(old_version, dest_folder=None):
     if 'sqlite3' not in settings.DATABASES['default']['ENGINE']:
         raise IncompatibleDatabase()
 
-    if not dest_folder:
-        dest_folder = default_backup_folder()
-
-    # This file name is a convention, used to figure out the latest backup
-    # that was made (by the dbrestore command)
-    fname = "db-v{version}_{dtm}.dump".format(
-        version=old_version,
-        dtm=datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    )
-
-    if not os.path.exists(dest_folder):
-        os.makedirs(dest_folder)
-
-    backup_path = os.path.join(dest_folder, fname)
+    backup_path = get_path_backup_dump_file(old_version, dest_folder)
 
     # Setting encoding=utf-8: io.open() is Python 2 compatible
     # See: https://github.com/learningequality/kolibri/issues/2875
@@ -107,6 +137,39 @@ def dbbackup(old_version, dest_folder=None):
             f.write(line)
 
     return backup_path
+
+
+def dbbackup_sqlite3_dump(old_version, dest_folder=None):
+    """
+    Sqlite3 only - uses external sqlite3 command
+
+    Uses the external `sqlite3 .dump` command.
+
+    :param: dest_folder: Default is ~/.kolibri/backups/db-[version]-[date].dump
+
+    :returns: Path of new backup file
+    """
+
+    if 'sqlite3' not in settings.DATABASES['default']['ENGINE']:
+        raise IncompatibleDatabase()
+
+    backup_path = get_path_backup_dump_file(old_version, dest_folder)
+
+    dump_result = open(backup_path, "w")
+    origin = settings.DATABASES['default']['NAME']
+
+    try:
+        p = subprocess.Popen(
+            "sqlite3 {} .dump".format(origin),
+            stdout=dump_result,
+            shell=True,
+        )
+        p.wait()
+        if p.returncode == 0:
+            return True
+        raise RuntimeError(p.stderr)
+    except EnvironmentError:
+        return False
 
 
 def dbrestore(from_file):
@@ -179,3 +242,25 @@ def search_latest(search_root, fallback_version):
 
     if newest:
         return os.path.join(search_root, newest)
+
+
+def check_for_sqlite3():
+    """
+    Tests if current environment has the `sqlite3` command, common on many
+    systems.
+
+    :returns: Version of sqlite3
+    """
+    try:
+        p = subprocess.Popen(
+            "sqlite3 -version",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            universal_newlines=True
+        )
+        # This does not fail if sqlite3 is not available
+        sqlite_3_version = p.communicate()[0].strip()
+        return bool(sqlite_3_version)
+    except EnvironmentError:
+        return False

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -236,7 +236,7 @@ def search_latest(search_root, fallback_version):
         except ValueError:
             continue
         # Always pick the newest version
-        if is_full_version(backup) or dtm > newest_dtm:
+        if is_full_version(backup) or (newest_dtm and dtm > newest_dtm):
             newest_dtm = dtm
             newest = backup
 


### PR DESCRIPTION
### Summary

New command `dbrecover` uses external `sqlite3` command to recover the current database. By dumping it and then loading it back in.

Usage:

```
kolibri manage dbrecover  
INFO     Running Kolibri with the following settings: kolibri.deployment.default.settings.base
Only use this command to recover a corrupt database. It would (if successful) recover data without any loss. Your old database will be backed up in /home/benjamin/.kolibri/backups. Continue? [y/N)] y
Backed up database to: True
INFO     Beginning database restore
INFO     Searching latest backup in /home/kolibri/.kolibri/backups...
INFO     Using backup file: /home/kolibri/.kolibri/backups/db-v0.9.0.dev+git-20180309174016_2018-03-09_18-45-52.dump
Restored database from: /home/kolibri/.kolibri/backups/db-v0.9.0.dev+git-20180309174016_2018-03-09_18-45-52.dump
```

Works fine except with a corrupt database :)

The reason is that Morango is connecting to the database very early on:  https://github.com/learningequality/morango/issues/48

### Reviewer guidance

Tests are missing currently, will fix that.

### References

#3228 

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
