### PR TITLE
Add user warning when database corruption is encountered

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -621,7 +621,9 @@ def main(args=None):  # noqa: max-complexity=13
         from django.conf import settings
         if "malformed" in str(e):
             recover_cmd = (
-                "sqlite3 {path} .dump > {path}"
+                "    sqlite3 {path} .dump | sqlite3 fixed.db \n"
+                "    cp fixed.db {path}"
+                ""
             ).format(
                 path=settings.DATABASES['default']['NAME'],
             )
@@ -630,8 +632,8 @@ def main(args=None):  # noqa: max-complexity=13
                 "Your database is corrupted. This is a "
                 "known issue that is usually fixed by running this "
                 "command: "
-                "\n\n"
-                "    " + recover_cmd +
+                "\n\n" +
+                recover_cmd +
                 "\n\n"
                 "Notice that you need the 'sqlite3' command available "
                 "on your system prior to running this."


### PR DESCRIPTION
### Summary

Adds some limited user guidance in a critical situation. This will be improved in 0.9 when we can rule out that a database connection is established before `dbrestore`

![image](https://user-images.githubusercontent.com/374612/37222538-c61e318c-23cd-11e8-8191-12a1fb149bf4.png)

Updated text (but showing a case where it fails before logging is configured)

![image](https://user-images.githubusercontent.com/374612/37234533-9e648c74-23f8-11e8-99d5-f5eb0503e589.png)



### Reviewer guidance

This is not tested... but I did test it manually with a  corrupt db (screenshot)

### References

#3228

----

### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [x] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
