### PR TITLE
update PR template and release docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,11 +35,12 @@
 
 ### Contributor Checklist
 
+- [ ] Contributor has fully tested the PR manually
 - [ ] PR has the correct target branch and milestone
 - [ ] PR has 'needs review' or 'work-in-progress' label
-- [ ] Contributor has fully tested the PR manually
-- [ ] Screenshots of any front-end changes are in the PR description
 - [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
+- [ ] If there are any front-end changes, before/after screenshots are included
+- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
 
 ### Reviewer Checklist
 

--- a/docs/references/release_process.rst
+++ b/docs/references/release_process.rst
@@ -41,6 +41,8 @@ Keep entries concise and consistent with the established writing style. The chan
 
 Note that for older patch releases, the change should only be mentioned once: it is implied that fixes in older releases are propagated forward.
 
+Additionally, we should also be adding the 'changelog' label to issues and pull requests on github. A more technical and granular overview of changes can be obtained by filtering by milestone and the 'changelog' label. Go through these issues and PRs, and ensure that the titles would be clear and meaningful.
+
 
 Create a release branch
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Summary

* adds new 'changelog' item to PR template, re #3134
* re-order checkboxes
* add guidance in release docs to clean up those labeled PRs and issues


### Reviewer guidance

check it out


### Contributor Checklist

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
