### PR TITLE
Hack to fix placeholder issue for Chrome

### DIFF
--- a/kolibri/core/assets/src/views/k-textbox/index.vue
+++ b/kolibri/core/assets/src/views/k-textbox/index.vue
@@ -14,7 +14,7 @@
       :autocomplete="autocomplete"
       :type="type"
       :enforceMaxlength="true"
-      :floatingLabel="true"
+      :floatingLabel="floatingLabel"
       :multiLine="textArea"
       :rows="3"
       @input="updateText"
@@ -106,6 +106,13 @@
       textArea: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Whether or not to display as a floating label
+       */
+      floatingLabel: {
+        type: Boolean,
+        default: true,
       },
     },
     data() {

--- a/kolibri/core/assets/src/views/k-textbox/index.vue
+++ b/kolibri/core/assets/src/views/k-textbox/index.vue
@@ -108,6 +108,7 @@
         default: false,
       },
       /**
+       * @private
        * Whether or not to display as a floating label
        */
       floatingLabel: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

After some further reading about Chrome's autofill, it seems like it's not a bug on their part but rather some sort of security feature that if Chrome autofill is enabled, it doesn't update the value of the `[input type="password"]` if the user doesn't interact with the page (e.g. clicking anywhere or pressing anything on the keyboard).

Seems like many have tried simulating a users actions by focusing from one element and then focus on another in order to trigger the event that adds value to the password but none of them were successful since Chrome has also fixed this.

This fix was inspired from @indirectlylit's fix (#3232) by disabling the floatingLabel when it is autofilled by chrome. It feels more natural (at least for me). I also increased the timeout since `100ms` doesn't guarantee that chrome's autofill will trigger. Some also claim that `200ms` isn't also a guarantee. `300 to 500` could be an ideal number but it might cause some performance issues. `250ms` for me seems to be a bit good. Although password placeholder still appears (but rarely).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Enable chrome autofill.
1. Try refreshing the page many times.
1. See if placeholder still exists

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
