### PR TITLE
re-add 64 bit Linux C extensions

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -97,7 +97,7 @@ def parse_package_page(files, pk_version):
                 file_name[1] != pk_version or
                 file_name[2][2:] == '26' or
                 'macosx' in file_name[4].split('.')[0] or
-                '64' in file_name[4].split('.')[0]):
+                'win_amd64' in file_name[4].split('.')[0]):
 
             continue
 

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -1,4 +1,4 @@
 # These are unique requirements for C extensions, but the
 # ones that don't need to be shipped in one version per
 # arch/OS/pyVesion
-pyOpenSSL==17.4.0
+pyOpenSSL==17.4.0  # pyup: >=17.4.0,<17.5.0

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -1,4 +1,4 @@
 # These are unique requirements for C extensions, but the
 # ones that don't need to be shipped in one version per
 # arch/OS/pyVesion
-pyOpenSSL==17.5.0
+pyOpenSSL==17.4.0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR re-adds 64 bit Linux C extensions so that debian installers can work. 
I also change the version of PyOpenSSL to 17.4.0 since 17.5.0 is not compatible with cryptography 2.0.3. The version of PyOpenSSL was originally 17.4.0 but may be bumped to 17.5.0 by pyUp.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Install kolibri whl file on 64 bit Ubuntu with Python 3
2. run `kolibri start`

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3308

----

### Contributor Checklist

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] Contributor has fully tested the PR manually
- [ ] Screenshots of any front-end changes are in the PR description
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
