### PR TITLE
A fix for Ubuntu 14.04 parse_version backwards compatibility

### DIFF
--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -1,7 +1,9 @@
 """
 Compatibility layer for Python 2+3
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 
@@ -59,6 +61,8 @@ class VersionCompat:
         # Remove leading 0's
         self.tpl_or_version = map(lambda s: s.lstrip("0"), self.tpl_or_version)
         self.tpl_or_version = map(lambda s: s or "0", self.tpl_or_version)
+        # Replace * with 0 because * seems to appear for instance as 0.8.*
+        self.tpl_or_version = map(lambda s: s.replace("*", "0"), self.tpl_or_version)
         # When map returns a map object in Python 3...
         self.tpl_or_version = tuple(self.tpl_or_version)
 


### PR DESCRIPTION
### Summary

Quick fix as just proven to work in PPA build:

Diff: https://launchpadlibrarian.net/360727184/kolibri-source_0.8.0~b4-0ubuntu1_0.8.0~b4-0ubuntu2.diff.gz
Build: https://launchpad.net/~learningequality/+archive/ubuntu/kolibri-proposed/+build/14457284


### Reviewer guidance

n/a this should only trigger when very old versions of distutils is active

### References

n/a

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
