### PR TITLE
remove wrong documentation and weird concatenation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ multi_line_output = 5
 line_length = 160
 indent = '    '
 combine_as_imports = true
-skip = wsgi.py,docs,env,cli.py,test,.eggs,build
+skip = wsgi.py,docs,env,cli.py,test,.eggs,build,setup.py
 
 [coverage:run]
 branch = true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import logging
 import os
@@ -29,11 +31,6 @@ def read_file(fname):
 dist_name = 'kolibri'
 
 readme = read_file('README.rst')
-doclink = """
-Documentation
--------------
-
-The full documentation is at `http://kolibri.rtfd.org <http://kolibri.rtfd.org>`_."""
 
 # Default description of the distributed package
 description = ("""Kolibri education platform for offline environments""")
@@ -152,9 +149,7 @@ setup(
     name=dist_name,
     version=kolibri.__version__,
     description=description,
-    long_description="{readme}\n\n{doclink}".format(
-        readme=readme, doclink=doclink
-    ),
+    long_description=readme,
     author='Learning Equality',
     author_email='info@learningequality.org',
     url='https://github.com/learningequality/kolibri',


### PR DESCRIPTION
### Summary

Because of an erroneous and redundant documentation link going up on PyPi:

(it removes the "Documentation" section which was added dynamically.. it's some old cookiecutter template boilerplate)

![image](https://user-images.githubusercontent.com/374612/37437653-a9b961ae-27ee-11e8-8862-da19e9258498.png)


### Reviewer guidance

Seems okay?

### References

n/a

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
