### PR TITLE
Fix intl polyfilling

### DIFF
--- a/frontend_build/src/intl_code_gen.js
+++ b/frontend_build/src/intl_code_gen.js
@@ -76,7 +76,7 @@ const generateIntlItems = language => {
    *     require.ensure(
    *       ['intl/locale-data/jsonp/sw-TZ.js'],
    *       function(require) {
-   *         resolve(require('intl/locale-data/jsonp/sw-TZ.js'));
+   *         resolve(() => require('intl/locale-data/jsonp/sw-TZ.js'));
    *       }
    *     );
    *   });
@@ -96,7 +96,7 @@ const generateIntlItems = language => {
         require.ensure(
           ['intl/locale-data/jsonp/${language_code}${language_script_string}${language_territory_string}.js'],
           function(require) {
-            resolve(require('intl/locale-data/jsonp/${language_code}${language_script_string}${language_territory_string}.js'));
+            resolve(() => require('intl/locale-data/jsonp/${language_code}${language_script_string}${language_territory_string}.js'));
           }
         );
       });`;
@@ -108,7 +108,7 @@ const intlFooter = `
         require.ensure(
           ['intl/locale-data/jsonp/en.js'],
           function(require) {
-            resolve(require('intl/locale-data/jsonp/en.js'));
+            resolve(() => require('intl/locale-data/jsonp/en.js'));
           }
         );
       });

--- a/kolibri/core/assets/src/utils/intl-locale-data.js
+++ b/kolibri/core/assets/src/utils/intl-locale-data.js
@@ -9,55 +9,55 @@ module.exports = function(locale) {
     case 'ar':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/ar.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/ar.js'));
+          resolve(() => require('intl/locale-data/jsonp/ar.js'));
         });
       });
     case 'en':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/en.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/en.js'));
+          resolve(() => require('intl/locale-data/jsonp/en.js'));
         });
       });
     case 'es-ES':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/es-ES.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/es-ES.js'));
+          resolve(() => require('intl/locale-data/jsonp/es-ES.js'));
         });
       });
     case 'fa':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/fa.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/fa.js'));
+          resolve(() => require('intl/locale-data/jsonp/fa.js'));
         });
       });
     case 'fr-FR':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/fr-FR.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/fr-FR.js'));
+          resolve(() => require('intl/locale-data/jsonp/fr-FR.js'));
         });
       });
     case 'fr-HT':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/fr-HT.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/fr-HT.js'));
+          resolve(() => require('intl/locale-data/jsonp/fr-HT.js'));
         });
       });
     case 'my':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/my.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/my.js'));
+          resolve(() => require('intl/locale-data/jsonp/my.js'));
         });
       });
     case 'ur-PK':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/ur-PK.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/ur-PK.js'));
+          resolve(() => require('intl/locale-data/jsonp/ur-PK.js'));
         });
       });
     default:
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/en.js'], function(require) {
-          resolve(require('intl/locale-data/jsonp/en.js'));
+          resolve(() => require('intl/locale-data/jsonp/en.js'));
         });
       });
   }


### PR DESCRIPTION
### Summary
I tried to simplify code by returning the require statement instead of a function that returns the require statement inside the intl locale data. Reverted this change that fits with the way that the requiring is now done.

### Reviewer guidance
Checkout release-v0.8.x.
In kolibri/core/assets/src/core-app/index.js, near the top add the line `delete window.Intl;` to replicate the broken behaviour.

Checkout this branch, and add the same modification. The behaviour should no longer be broken.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
