### PR TITLE
Content renderer api update

### DIFF
--- a/docs/architecture/frontend_architecture.rst
+++ b/docs/architecture/frontend_architecture.rst
@@ -121,15 +121,14 @@ A special kind of Kolibri Module is dedicated to rendering particular content ty
     :members:
     :noindex:
 
-The ``ContentRendererModule`` class has one required property ``getRendererComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``defaultFile``, ``files``, ``supplementaryFiles``, and ``thumbnailFiles`` props, defining the files associated with the piece of content.
+The ``ContentRendererModule`` class has one required property ``getRendererComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``defaultFile``, ``files``, ``supplementaryFiles``, and ``thumbnailFiles`` props, defining the files associated with the piece of content. These can be automatically mixed into a content renderer component definition using the content renderer mixin.
 
 .. code-block:: javascript
 
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
+
   {
-    props: [
-      'defaultFile',
-      'files',
-    ]
+    mixins: [contentRendererMixin],
   };
 
 In order to log data about users viewing content, the component should emit ``startTracking``, ``updateProgress``, and ``stopTracking`` events, using the Vue ``$emit`` method. ``startTracking`` and ``stopTracking`` are emitted without any arguments, whereas ``updateProgress`` should be emitted with a single value between 0 and 1 representing the current proportion of progress on the content.
@@ -140,17 +139,16 @@ In order to log data about users viewing content, the component should emit ``st
   this.$emit('stopTracking');
   this.$emit('updateProgress', 0.25);
 
-For content that has assessment functionality two additional props will be passed: ``itemId`` and ``answerState``. ``itemId`` is a unique identifier for that content for a particular question in the assessment, ``answerState`` is passed to prefill an answer (one that has been previously given on an exam, or for a coach to preview a learner's given answers). The answer renderer should also define a ``checkAnswer`` method in its component methods, this method should return an object with the following keys: ``correct``, ``answerState``, and ``simpleAnswer`` - describing the correctness, an object describing the answer that can be used to reconstruct it within the renderer, and a simple, human readable answer. If no valid answer is given, ``null`` should be returned. In addition to the base content renderer events, assessment items can also emit a ``hintTaken`` event to indicate that the user has taken a hint in the assessment, an ``itemError`` event to indicate that there has been an error in rendering the requested question corresponding to the ``itemId``, and an ``interaction`` event that indicates a user has interacted with the assessment.
+For content that has assessment functionality three additional props will be passed: ``itemId``, ``answerState``, and ``showCorrectAnswer``. ``itemId`` is a unique identifier for that content for a particular question in the assessment, ``answerState`` is passed to prefill an answer (one that has been previously given on an exam, or for a coach to preview a learner's given answers), ``showCorrectAnswer`` is a Boolean that determines if the correct answer for the question should be automatically prefilled without user input - this will only be activated in the case that ``answerState`` is falsy - if the renderer is asked to fill in the correct answer, but is unable to do so, it should emit an ``answerUnavailable`` event.
+
+The answer renderer should also define a ``checkAnswer`` method in its component methods, this method should return an object with the following keys: ``correct``, ``answerState``, and ``simpleAnswer`` - describing the correctness, an object describing the answer that can be used to reconstruct it within the renderer, and a simple, human readable answer. If no valid answer is given, ``null`` should be returned. In addition to the base content renderer events, assessment items can also emit a ``hintTaken`` event to indicate that the user has taken a hint in the assessment, an ``itemError`` event to indicate that there has been an error in rendering the requested question corresponding to the ``itemId``, and an ``interaction`` event that indicates a user has interacted with the assessment.
 
 .. code-block:: javascript
 
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
+
   {
-    props: [
-      'defaultFile',
-      'files',
-      'itemId',
-      'answerState',
-    ],
+    mixins: [contentRendererMixin],
     methods: {
       checkAnswer() {
         return {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -56,6 +56,7 @@ import kSelect from '../views/k-select';
 import router from '../router';
 import responsiveWindow from '../mixins/responsive-window';
 import responsiveElement from '../mixins/responsive-element';
+import contentRendererMixin from '../mixins/contentRenderer';
 import theme from '../styles/core-theme.styl';
 import definitions from '../styles/definitions.styl';
 import keenVars from '../keen-config/variables.scss';
@@ -145,6 +146,7 @@ export default {
       responsiveWindow,
       responsiveElement,
       languageSwitcherMixin,
+      contentRenderer: contentRendererMixin,
     },
   },
   resources,

--- a/kolibri/core/assets/src/mixins/contentRenderer.js
+++ b/kolibri/core/assets/src/mixins/contentRenderer.js
@@ -1,0 +1,101 @@
+import { defaultLanguage, languageValidator } from 'kolibri.utils.i18n';
+
+const fileFieldMap = {
+  storage_url: {
+    type: String,
+  },
+  id: {
+    type: String,
+  },
+  priority: {
+    type: Number,
+  },
+  available: {
+    type: Boolean,
+  },
+  file_size: {
+    type: Number,
+  },
+  extension: {
+    type: String,
+  },
+  preset: {
+    type: String,
+  },
+  lang: {
+    type: Object,
+    validator: lang => lang === null || languageValidator(lang),
+  },
+  supplementary: {
+    type: Boolean,
+  },
+  thumbnail: {
+    type: Boolean,
+  },
+  download_url: {
+    type: String,
+  },
+};
+
+const fileValidator = file => {
+  // Do this as a reduce, as any failure will short cut any other computation
+  return Object.keys(fileFieldMap).reduce(
+    (acc, key) =>
+      acc &&
+      typeof file[key] !== undefined &&
+      typeof file[key] === typeof fileFieldMap[key].type() &&
+      (fileFieldMap[key].validator ? fileFieldMap[key].validator(file[key]) : true),
+    true
+  );
+};
+
+const multipleFileValidator = files => {
+  return files.reduce((acc, file) => acc && fileValidator(file), true);
+};
+
+export default {
+  props: {
+    files: {
+      type: Array,
+      required: true,
+      validator: multipleFileValidator,
+    },
+    defaultFile: {
+      type: Object,
+      required: true,
+      validator: fileValidator,
+    },
+    itemId: {
+      type: String,
+    },
+    answerState: {
+      type: Object,
+      default: () => ({}),
+    },
+    allowHints: {
+      type: Boolean,
+      default: true,
+    },
+    supplementaryFiles: {
+      type: Array,
+      validator: multipleFileValidator,
+    },
+    thumbnailFiles: {
+      type: Array,
+      validator: multipleFileValidator,
+    },
+    interactive: {
+      type: Boolean,
+      default: true,
+    },
+    lang: {
+      type: Object,
+      default: () => defaultLanguage,
+      validator: languageValidator,
+    },
+    showCorrectAnswer: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -25,6 +25,7 @@
         :thumbnailFiles="thumbnailFiles"
         :interactive="interactive"
         :lang="lang"
+        :showCorrectAnswer="showCorrectAnswer"
         ref="contentView"
       />
     </template>
@@ -109,6 +110,10 @@
         type: Object,
         default: () => defaultLanguage,
         validator: languageValidator,
+      },
+      showCorrectAnswer: {
+        type: Boolean,
+        default: false,
       },
     },
     data: () => ({

--- a/kolibri/plugins/document_epub_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/index.vue
@@ -51,6 +51,7 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
   import { sessionTimeSpent } from 'kolibri.coreVue.vuex.getters';
   import throttle from 'lodash/throttle';
 
@@ -65,12 +66,7 @@
       kButton,
       uiIconButton,
     },
-    mixins: [responsiveWindow, responsiveElement],
-    props: {
-      defaultFile: {
-        type: Object,
-      },
-    },
+    mixins: [responsiveWindow, responsiveElement, contentRendererMixin],
     data: () => ({
       isFullscreen: false,
       progress: 0,

--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -66,6 +66,7 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
   import { sessionTimeSpent } from 'kolibri.coreVue.vuex.getters';
   import throttle from 'lodash/throttle';
   import debounce from 'lodash/debounce';
@@ -93,12 +94,7 @@
       uiIconButton,
       pageComponent,
     },
-    mixins: [responsiveWindow, responsiveElement],
-    props: {
-      defaultFile: {
-        type: Object,
-      },
-    },
+    mixins: [responsiveWindow, responsiveElement, contentRendererMixin],
     data: () => ({
       isFullscreen: false,
       progress: 0,

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -22,9 +22,12 @@
 
   import ScreenFull from 'screenfull';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
+
   export default {
     name: 'html5Renderer',
     components: { kButton },
+    mixins: [contentRendererMixin],
     props: {
       defaultFile: {
         type: Object,

--- a/kolibri/plugins/media_player/assets/src/views/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/index.vue
@@ -53,6 +53,7 @@
   import Lockr from 'lockr';
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';
   import ResponsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
+  import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
   import ScreenFull from 'screenfull';
   import audioIconPoster from './audio-icon-poster.svg';
 
@@ -89,16 +90,8 @@
     },
     components: { loadingSpinner },
 
-    mixins: [ResponsiveElement],
+    mixins: [ResponsiveElement, contentRendererMixin],
 
-    props: {
-      files: {
-        type: Array,
-        required: true,
-      },
-      supplementaryFiles: { type: Array },
-      thumbnailFiles: { type: Array },
-    },
     data: () => ({
       dummyTime: 0,
       progressStartingPoint: 0,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.5
-kolibri_exercise_perseus_plugin==0.7.5
+kolibri_exercise_perseus_plugin==0.8.0b1
 jsonfield==2.0.2
 morango==0.2.4
 requests-toolbelt==0.8.0


### PR DESCRIPTION
### Summary
Updates the content renderer API to allow for 'showCorrectAnswer' prop, and emitting of 'answerUnavaialble` event if not possible.

Adds a content renderer mixin for common props.

Updates documentation.

Upgrades perseus renderer to be compatible with updates.

### Reviewer guidance
Try setting the `showCorrectAnswer` prop to true on the content renderer when attempting exercises.

### References
Allows showing correct answers for answer keys in exam reports.

Perseus renderer diff: https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/release-v0.7.x...release-v0.8.x

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
