### PR TITLE
duplicate button

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -10,6 +10,15 @@
 
     <search-tools />
 
+    <div class="information">
+      <p> {{ $tr('totalResourcesSelected', { total: workingResources.length }) }} </p>
+      <k-button
+        type="submit"
+        :primary="true"
+        :text="$tr('save')"
+      />
+    </div>
+
     <ul class="content-list">
       <li
         class="content-list-item"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -45,7 +45,7 @@
       </li>
     </ul>
 
-    <div class="information">
+    <div class="information" v-if="contentList.length > 2">
       <p> {{ $tr('totalResourcesSelected', { total: workingResources.length }) }} </p>
       <k-button
         type="submit"


### PR DESCRIPTION
### Summary

fixes #3367

shows two 'save' buttons when there are more than two cards:

![image](https://user-images.githubusercontent.com/2367265/37500828-c671b8ec-2888-11e8-9d25-1f23d7de6b99.png)


Only shows one button otherwise:

![image](https://user-images.githubusercontent.com/2367265/37500840-d22628e4-2888-11e8-9275-97575c563da0.png)



### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
