### PR TITLE
Made it so when you press enter, the action of enrolling someone happens

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-enroll-page/confirm-enrollment-modal.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="$tr('confirmEnrollment')"
     @cancel="close"
+    @enter="enrollUsers"
     class="confirm-modal"
   >
     <div>


### PR DESCRIPTION
### Summary
I made a change so that whenever you press enter, it triggers the action to enroll the user in the class. It hasn't affected the UI besides pressing on that button when you press enter.


### Reviewer guidance
The reviewer can try to enroll a user into a class and press enter. It should automatically enroll the user in the class instead of you having to click on the button itself. There shouldn't be any risks involved while testing, I only added one line of code in one file.

### References
Fixes https://github.com/learningequality/kolibri/issues/3234

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
