### PR TITLE
Fix Dockerfile to stop buildkite from failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:xenial
 
 # install latest python and nodejs
-RUN apt-get -y update
-RUN apt-get install -y software-properties-common curl
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    curl
 RUN add-apt-repository ppa:voronov84/andreyv
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 
@@ -10,11 +11,17 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get -y update
-RUN apt-get install -y python2.7 python3.6 python-pip git nodejs yarn gettext python-sphinx
+RUN apt-get update && apt-get install -y \
+    python2.7 \
+    python3.6 \
+    python-pip \
+    git \
+    nodejs \
+    yarn \
+    gettext \
+    python-sphinx
 COPY . /kolibri
 
 VOLUME /kolibridist/  # for mounting the whl files into other docker containers
 # add buildkite pipeline specific installation here:
 CMD cd /kolibri && pip install -r requirements/dev.txt && pip install -r requirements/build.txt && yarn install && make dist pex && cp /kolibri/dist/* /kolibridist/
-


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to stop buildkite from failing. It is failing because `apt-get update` is not run. Dockerfile thinks `apt-get update` is identical in the builds, so it reuses the cache from previous build. Thus, the instruction `apt-get update` is actually not executed.

Reference: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check the result of this PR's build.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Previous builds for develop were failing on buildkite.

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
