### PR TITLE
Adds test and reverts regression to exam display behaviour to learners.

### DIFF
--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -1,12 +1,14 @@
+from django.db.models import Q
 from django.db.models import Sum
+from rest_framework.serializers import JSONField
+from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import SerializerMethodField
+
 from kolibri.auth.models import Classroom
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSummaryLog
 from kolibri.logger.models import ExamLog
-from rest_framework.serializers import JSONField
-from rest_framework.serializers import ModelSerializer
-from rest_framework.serializers import SerializerMethodField
 
 
 class ExamProgressSerializer(ModelSerializer):
@@ -107,8 +109,7 @@ class LearnerClassroomSerializer(ModelSerializer):
         filtered_exams = Exam.objects.filter(
             assignments__collection__in=learner_groups,
             collection=instance,
-            active=True,
-        )
+        ).filter(Q(active=True) | Q(examlogs__user=current_user))
 
         return {
             'lessons': LessonProgressSerializer(


### PR DESCRIPTION
### Summary
The introduction of lessons in 0.8 accidentally removed the display of attempted, but inactive exams to learners, meaning that an inactive exam was no longer visible to learners to review their data.

### Reviewer guidance
Check that attempted, but inactive exams show up for learners.

----

Should we cherry pick this to 0.8.x also?

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
