### PR TITLE
Coach report proper sorting

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
@@ -52,13 +52,10 @@ export function genCompareFunc(sortColumn, sortOrder) {
       return flipped(-1);
     }
     // standard comparisons
-    if (a[key] > b[key]) {
-      return flipped(1);
-    }
-    if (a[key] < b[key]) {
-      return flipped(-1);
-    }
-    // they must be equal
-    return 0;
+    return flipped(
+      String(a[key]).localeCompare(String(b[key]), 'default', {
+        usage: 'search',
+      })
+    );
   };
 }

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
@@ -3,25 +3,23 @@
   <core-modal
     :title="$tr('modalTitle')"
     :hasError="false"
+    @enter="confirmRemoval"
     @cancel="close"
   >
-    <div>
-      <p>{{ $tr('confirmation', { username: username, classname: classname }) }}</p>
-      <p>{{ $tr('description') }}</p>
+    <p>{{ $tr('confirmation', { username: username, classname: classname }) }}</p>
+    <p>{{ $tr('description') }}</p>
 
-      <div class="core-modal-buttons">
-        <k-button
-          :text="$tr('cancel')"
-          appearance="flat-button"
-          @click="close"
-        />
-        <k-button
-          :text="$tr('remove')"
-          :primary="true"
-          @click="confirmRemoval"
-        />
-      </div>
-
+    <div class="core-modal-buttons">
+      <k-button
+        :text="$tr('cancel')"
+        appearance="flat-button"
+        @click="close"
+      />
+      <k-button
+        :text="$tr('remove')"
+        :primary="true"
+        @click="confirmRemoval"
+      />
     </div>
   </core-modal>
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixing sorting, per 3/22 hack session request. Ignores case now + internationalizes sorting.

### Reviewer guidance 

- Tried using `userSearchUtils`, but the tables are really generalized. The sort still works, but fitting the util into the way `reports` structures its sorting seemed like more trouble than it was worth.
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
