### PR TITLE
User sorting iteration

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/state/actions/class.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/class.js
@@ -11,6 +11,7 @@ import { PageNames } from '../../constants';
 import { _userState } from './helpers/mappers';
 import displayModal from './helpers/displayModal';
 import preparePage from './helpers/preparePage';
+import { filterAndSortUsers } from '../../userSearchUtils';
 
 /**
  * Do a POST to create new class
@@ -193,8 +194,8 @@ export function showClassEditPage(store, classId) {
     modalShown: false,
     currentClass: classroom,
     classes: classrooms,
-    classLearners: facilityUsers.map(_userState),
-    classCoaches: classroom.coaches.map(_userState),
+    classLearners: filterAndSortUsers(facilityUsers).map(_userState),
+    classCoaches: filterAndSortUsers(classroom.coaches).map(_userState),
   });
 
   ConditionalPromise.all(promises).only(

--- a/kolibri/plugins/facility_management/assets/src/userSearchUtils.js
+++ b/kolibri/plugins/facility_management/assets/src/userSearchUtils.js
@@ -5,7 +5,7 @@ export function userMatchesFilter(user, searchFilter) {
   return searchTerms.every(term => fullName.includes(term) || username.includes(term));
 }
 
-export function filterAndSortUsers(users, pred, sortByKey = 'username') {
+export function filterAndSortUsers(users, pred = () => true, sortByKey = 'full_name') {
   return users.filter(pred).sort(
     // use 'search' option to ignore case rather than use locale defaults
     (a, b) => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Going off of feedback from the 3/22 hack session, users should now be sorted by their `full_name` rather than username in the facility page. Because the `full_name` column is now the first column in user tables within `facility_management` and `coach`, I thought I'd make it the default for the `user-table` component.

Also, users in `class_edit_page` were not being sorted. So i tackled that here too.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
