### PR TITLE
Add more guidance to AssertionError for missing git version tag

### DIFF
--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -101,7 +101,10 @@ package foo that depended on kolibri, and kolibri is installed as a dependency
 while foo is installing, then foo won't be able to access kolibri before after
 setuptools has completed installation of everything.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import datetime
 import logging
@@ -301,7 +304,12 @@ def get_prerelease_version(version):
         if git_version[3] == 'final' and version[3] != 'final':
             raise AssertionError(
                 "You have added a final tag without bumping kolibri.VERSION, " +
-                "OR you need to make a new alpha0 tag. Current tag: {}".format(git_version)
+                "OR you need to make a new alpha0 tag. Current tag: {}".format(git_version) +
+                "\n\n"
+                "Often, this is because of missing tag information, try "
+                "running:\n"
+                "\n"
+                "   git fetch <upstream>"
             )
 
         return (


### PR DESCRIPTION
### Summary

Running into this when the version is bumped, assuming most devs could encounter this once in a while :)

### Reviewer guidance

Easy one!

### References

None

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
