### PR TITLE
Hides channels with no exercises from the exam creation navigator.

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -295,7 +295,10 @@ export function showCreateExamPage(store, classId) {
 // TODO: Optimize
 export function goToTopLevel(store) {
   return new Promise((resolve, reject) => {
-    const channelPromise = ChannelResource.getCollection({ available: true }).fetch();
+    const channelPromise = ChannelResource.getCollection({
+      available: true,
+      has_exercise: true,
+    }).fetch();
 
     ConditionalPromise.all([channelPromise]).only(
       samePageCheckGenerator(store),
@@ -310,7 +313,7 @@ export function goToTopLevel(store) {
               const subtopic = channel.topic;
               subtopic.allExercisesWithinTopic = channel.subtopics.reduce(
                 (acc, subtopic) => acc.concat(subtopic.allExercisesWithinTopic),
-                []
+                channel.exercises
               );
               return subtopic;
             });

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -328,6 +328,7 @@ export function goToTopLevel(store) {
             };
             store.dispatch('SET_TOPIC', topic);
             store.dispatch('SET_SUBTOPICS', subtopics);
+            store.dispatch('SET_EXERCISES', []);
             resolve();
           },
           error => reject(error)


### PR DESCRIPTION
### Summary
* Hides channels with no exercises from the exam creation navigator.
* Fixes weird edge case where a channel with no topics and only exercises was greyed out.
* Fixes bug where exercises were not cleared when navigating to top level.

### Reviewer guidance
Check that a channel with no exercises does not appear in exam creation.

### References
Fixes #3423

Also fixes issue where navigating to the top level would preserve exercises from the level you were just at.

----
Before:
![image](https://user-images.githubusercontent.com/1680573/37939765-863c9c94-3119-11e8-8c67-3bc6489e6096.png)


After:
![image](https://user-images.githubusercontent.com/1680573/37939736-5cee088c-3119-11e8-9a7c-52737160489a.png)


### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
