### PR TITLE
Only resolve KOLIBRI_HOME once

### DIFF
--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -5,11 +5,14 @@ import re
 import sys
 from datetime import datetime
 
-import kolibri
-# Import db instead of db.connections because we want to use an instance of
-# connections that might be updated from outside.
 from django import db
 from django.conf import settings
+
+import kolibri
+from kolibri.utils.conf import KOLIBRI_HOME
+# Import db instead of db.connections because we want to use an instance of
+# connections that might be updated from outside.
+
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +32,7 @@ class IncompatibleDatabase(Exception):
 
 
 def default_backup_folder():
-    return os.path.join(os.environ['KOLIBRI_HOME'], 'backups')
+    return os.path.join(KOLIBRI_HOME, 'backups')
 
 
 def get_dtm_from_backup_name(fname):

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -115,24 +115,13 @@ class PluginBaseLoadsApp(Exception):
     pass
 
 
-def _get_kolibri_home():
-    """
-    This is preferred to be called through a function as KOLIBRI_HOME is
-    redefined during tests.
-
-    NEEDS TO BE FURTHER CLEANED UP AND CENTRALIZED.
-
-    Please do not expand use of this function to other modules.
-    """
-    return os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))
-
-
 def version_file():
     """
     During test runtime, this path may differ because KOLIBRI_HOME is
     regenerated
     """
-    return os.path.join(_get_kolibri_home(), '.data_version')
+    from .conf import KOLIBRI_HOME
+    return os.path.join(KOLIBRI_HOME, '.data_version')
 
 
 def initialize(debug=False):
@@ -151,7 +140,7 @@ def initialize(debug=False):
     else:
         # Do this here so that we can fix any issues with our configuration file before
         # we attempt to setup django.
-        from kolibri.utils.conf import autoremove_unavailable_plugins, enable_default_plugins
+        from .conf import autoremove_unavailable_plugins, enable_default_plugins
         autoremove_unavailable_plugins()
 
         version = open(version_file(), "r").read()

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -23,13 +23,16 @@ import json
 import logging
 import os
 
-from kolibri.utils.compat import module_exists
+from .compat import module_exists
+
 
 logger = logging.getLogger(__name__)
 
 with open(os.path.join(os.path.dirname(__file__), 'KOLIBRI_CORE_JS_NAME')) as f:
     KOLIBRI_CORE_JS_NAME = f.read().strip()
 
+#: Absolute path of the main user data directory.
+#: Will be created automatically if it doesn't exist.
 KOLIBRI_HOME = os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))
 
 # Creating KOLIBRI_HOME atm. has to happen here as for instance utils.cli is not

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -12,13 +12,16 @@ system/windows.py
 
 etc..
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys
 
 import six
-from django.conf import settings
+
+from .conf import KOLIBRI_HOME
 
 
 def _posix_pid_exists(pid):
@@ -129,7 +132,7 @@ class _WindowsNullDevice:
     def write(self, s):
         pass
 
-def get_free_space(path=settings.KOLIBRI_HOME):
+def get_free_space(path=KOLIBRI_HOME):
     if sys.platform.startswith('win'):
         import ctypes
 


### PR DESCRIPTION
### Summary

Currently, this is Quilt patched in the .deb release, so not very nice.

### Reviewer guidance

Nah, seems simple :)

### References

#3131 
#3388 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
