### PR TITLE
Fix windows server.log error

### DIFF
--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -12,7 +12,9 @@ system/windows.py
 
 etc..
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys
@@ -113,8 +115,9 @@ def _windows_become_daemon(our_home_dir='.', out_log=None, err_log=None, umask=0
     os.chdir(our_home_dir)
     os.umask(umask)
     sys.stdin.close()
-    sys.stdout.close()
-    sys.stderr.close()
+    old_stderr = sys.stderr
+    old_stdout = sys.stdout
+
     if err_log:
         sys.stderr = open(err_log, 'a', buffering)
     else:
@@ -123,6 +126,13 @@ def _windows_become_daemon(our_home_dir='.', out_log=None, err_log=None, umask=0
         sys.stdout = open(out_log, 'a', buffering)
     else:
         sys.stdout = _WindowsNullDevice()
+
+    # Redirect stderr and stdout
+    os.dup2(sys.stderr.fileno(), old_stderr.fileno())
+    os.dup2(sys.stdout.fileno(), old_stdout.fileno())
+
+    old_stderr.flush()
+    old_stdout.flush()
 
 class _WindowsNullDevice:
     "A writeable object that writes to nowhere -- like /dev/null."


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the error `ValueError: I/O operation on closed file` in `server.log` on Windows machines. 
The error exists because `StreamHandler` of the logger has the `stream` attribute set to be the default value `sys.stderr`. When we close `sys.stderr` in `_windows_become_daemon`, we are not able to log to `sys.stderr` anymore. 
Although later in the code of `_windows_become_daemon` we directly assign `sys.stderr` to be a new file-like object, **my assumption** is that the `StreamHandler` doesn't get the updated value of `sys.stderr`. The value of `sys.stderr` still points to the old object, which is closed by us earlier. 

To resolve this issue, I use `os.dup2()` to redirect sys.stdout and sys.stderr

> Note: I'm not sure if my assumption is correct. Please let me know if you have any thoughts! Thanks!
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please use Windows to check if there are still errors in `server.log`.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3275

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
