### PR TITLE
Setup.py: keywords should be a list, fix a comment

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -1,3 +1,8 @@
+"""
+CAUTION! Keep everything here at at minimum. Do not import stuff.
+This module is imported in setup.py, so you cannot for instance
+import a dependency.
+"""
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ from pip.req import parse_requirements
 from setuptools import setup
 from setuptools.command.install_scripts import install_scripts
 
-# Notice that we dare do this during setup.py -- this enforces a special
-# restraint on module initialization, namely that it shouldn't do anything
-# that depends on an installed environment.
 import kolibri
 from kolibri import dist as kolibri_dist
 
@@ -164,7 +161,7 @@ setup(
     tests_require=['pytest', 'tox', 'flake8'],
     license='MIT',
     zip_safe=False,
-    keywords='kolibri',
+    keywords=['education', 'offline', 'kolibri'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
### Summary

Been meaning to fix this for a long time :)

![image](https://user-images.githubusercontent.com/374612/38089747-c8e2bda0-3360-11e8-8e67-9b017360db63.png)

https://pypi.org/project/kolibri/

### Reviewer guidance

Nope, not sure if these keywords are really important

### References

none

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
