### PR TITLE
Enable gziping

### DIFF
--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -23,7 +23,7 @@ var server = new WebpackDevServer(compiler, {
   historyApiFallback: false,
 
   // Set this if you want to enable gzip compression for assets
-  compress: false,
+  compress: true,
 
   // webpack-dev-middleware options
   watchOptions: {

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -86,6 +86,7 @@ LOCALE_PATHS += [
 ]
 
 MIDDLEWARE = [
+    'django.middleware.gzip.GZipMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'kolibri.core.device.middleware.KolibriLocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -133,7 +133,11 @@ def run_server(port):
     from kolibri.deployment.default.wsgi import application
     cherrypy.tree.graft(application, "/")
 
-    cherrypy.config.update({"environment": "production"})
+    cherrypy.config.update({
+        "environment": "production",
+        "tools.gzip.on": True,
+        "tools.gzip.mime_types": ["text/*", "application/*"],
+        })
 
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
     serve_static_dir(settings.CONTENT_DATABASE_DIR,

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -137,7 +137,7 @@ def run_server(port):
         "environment": "production",
         "tools.gzip.on": True,
         "tools.gzip.mime_types": ["text/*", "application/javascript"],
-        })
+    })
 
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
     serve_static_dir(settings.CONTENT_DATABASE_DIR,

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -136,7 +136,7 @@ def run_server(port):
     cherrypy.config.update({
         "environment": "production",
         "tools.gzip.on": True,
-        "tools.gzip.mime_types": ["text/*", "application/*"],
+        "tools.gzip.mime_types": ["text/*", "application/javascript"],
         })
 
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)


### PR DESCRIPTION
### Summary

Enables gziping in for pycherry, django, and webpack server (just for fun).
Increases Lighthouse performance score of by 20 points.
To test ` yarn run build && kolibri start`

#### Before

![before](https://user-images.githubusercontent.com/7193975/38218429-9e981b0c-3686-11e8-9864-d47b7f9e6fff.png)

#### After

![after](https://user-images.githubusercontent.com/7193975/38218433-a2837ffe-3686-11e8-974b-b3446f59db73.png)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
