### PR TITLE
don't cache the Facility Collection when loading sign-in page

### DIFF
--- a/kolibri/plugins/user/templates/user/user.html
+++ b/kolibri/plugins/user/templates/user/user.html
@@ -3,9 +3,7 @@
 {% load kolibri_tags %}
 {% load cache %}
 {% block content %}
-  {% cache 500 facility_collection_bootstrap %}
-    {% kolibri_bootstrap_collection 'facility' 'FacilityResource' %}
-  {% endcache %}
+  {% kolibri_bootstrap_collection 'facility' 'FacilityResource' %}
   {% user_async_assets %}
   {% user_assets %}
 {% endblock %}


### PR DESCRIPTION
### Summary

Fixes #3459 and #3460.

1. Removes the 500 second cache on FacilityResource on user.html template

If this caching is crucial, we could try to untangle the code that fetches Facility(Datasets) during the log-in flow to make sure we always do a force-fetch. It is complicated because, depending on different circumstances, the facility configuration is derived either from the Facility or FacilityDataset endpoints.

### Reviewer guidance

1. Create two facilities (make sure to assign an admin to the second one)
1. Mess around with the configurations for the different facility.
1. Make sure they are reflected on the different facilities.

### References

#3459 
#3460 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
