### PR TITLE
Remove duplicate fonts

### DIFF
--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -89,9 +89,7 @@ svg:not(:root)
   font-weight: 400
   src: local('Material Icons'),
 local('MaterialIcons-Regular'),
-url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'),
-url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff'),
-url('../../../../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype')
+url('~material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff')
 
 .material-icons
   font-family: 'Material Icons'


### PR DESCRIPTION
### Summary

Removes woff2 and tff versions of material icons. We already just serve the woff version of Noto.
227kb -> 206kb 


### Reviewer guidance

Make sure everything looks good.


### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
