### PR TITLE
Add eslint import rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,5 +81,10 @@ module.exports = {
       },
     ],
     'vue/html-closing-bracket-spacing': ['error'],
+
+    'import/first': 1,
+    'import/no-duplicates': 1,
+    'import/newline-after-import': 1,
+    'import/order': 1,
   },
 };

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -1,11 +1,11 @@
 import logger from 'kolibri.lib.logging';
-import ConditionalPromise from './conditionalPromise';
 import find from 'lodash/find';
 import matches from 'lodash/matches';
 import isEqual from 'lodash/isEqual';
-import cloneDeep from './cloneDeep';
 import urls from 'kolibri.urls';
 import client from 'kolibri.client';
+import cloneDeep from './cloneDeep';
+import ConditionalPromise from './conditionalPromise';
 
 export const logging = logger.getLogger(__filename);
 

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -1,5 +1,5 @@
-import { Resource } from '../api-resource';
 import logger from 'kolibri.lib.logging';
+import { Resource } from '../api-resource';
 
 const logging = logger.getLogger(__filename);
 

--- a/kolibri/core/assets/src/api-resources/facilityUser.js
+++ b/kolibri/core/assets/src/api-resources/facilityUser.js
@@ -1,5 +1,5 @@
-import { Resource } from '../api-resource';
 import logger from 'kolibri.lib.logging';
+import { Resource } from '../api-resource';
 
 const logging = logger.getLogger(__filename);
 

--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -1,5 +1,5 @@
-import { Resource } from '../api-resource';
 import pickBy from 'lodash/pickBy';
+import { Resource } from '../api-resource';
 
 export default class TaskResource extends Resource {
   static resourceName() {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -12,12 +12,15 @@
 // N.B. You cannot use keys that require quotation marks in this object.
 // e.g. 'content-icon' (although this can be used as a value in module).
 
-import logging from '../logging';
 import vue from 'vue';
 import vuex from 'vuex';
+import seededshuffle from 'seededshuffle';
+import uiAlert from 'keen-ui/src/UiAlert';
+import tetherDrop from 'tether-drop';
+import tetherTooltip from 'tether-tooltip';
+import logging from '../logging';
 import conditionalPromise from '../conditionalPromise';
 import * as apiResource from '../api-resource';
-import seededshuffle from 'seededshuffle';
 import * as constants from '../constants';
 import * as getters from '../state/getters';
 import * as actions from '../state/actions';
@@ -64,13 +67,8 @@ import * as exams from '../exams/utils';
 import * as validators from '../validators';
 import * as serverClock from '../serverClock';
 import * as resources from '../api-resources';
-import urls from './urls';
-import * as client from './client';
 import * as i18n from '../utils/i18n';
 import * as browser from '../utils/browser';
-import uiAlert from 'keen-ui/src/UiAlert';
-import tetherDrop from 'tether-drop';
-import tetherTooltip from 'tether-tooltip';
 import appBar from '../views/app-bar';
 import coreSnackbar from '../views/core-snackbar';
 import customUiMenu from '../views/custom-ui-menu';
@@ -86,6 +84,8 @@ import * as contentNode from '../utils/contentNodeUtils';
 import attemptLogList from '../views/attempt-log-list';
 import interactionList from '../views/interaction-list';
 import examReport from '../views/exam-report';
+import * as client from './client';
+import urls from './urls';
 
 export default {
   client,

--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -4,12 +4,12 @@
 
 import interceptor from 'rest/interceptor';
 import mime from 'rest/interceptor/mime';
-import baseClient from './baseClient';
-import errorCodes from '../disconnectionErrorCodes';
 
 import heartbeat from 'kolibri.heartbeat';
 import { connected } from 'kolibri.coreVue.vuex.getters';
 import store from 'kolibri.coreVue.vuex.store';
+import errorCodes from '../disconnectionErrorCodes';
+import baseClient from './baseClient';
 
 const disconnectInterceptor = interceptor({
   request: function(request) {

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -6,10 +6,10 @@
 import vue from 'vue';
 import vuex from 'vuex';
 import router from 'vue-router';
+import merge from 'lodash/merge';
+import { setUpIntl } from '../utils/i18n';
 import Mediator from './mediator';
 import apiSpec from './apiSpec';
-import { setUpIntl } from '../utils/i18n';
-import merge from 'lodash/merge';
 
 /**
  * Array containing the names of all methods of the Mediator that

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -1,12 +1,12 @@
 import logger from 'kolibri.lib.logging';
 import { currentUserId, connected, reconnectTime } from 'kolibri.coreVue.vuex.getters';
 import store from 'kolibri.coreVue.vuex.store';
-import { SIGNED_OUT_DUE_TO_INACTIVITY } from './constants';
 import Lockr from 'lockr';
 import urls from 'kolibri.urls';
-import baseClient from './core-app/baseClient';
 import mime from 'rest/interceptor/mime';
 import interceptor from 'rest/interceptor';
+import baseClient from './core-app/baseClient';
+import { SIGNED_OUT_DUE_TO_INACTIVITY } from './constants';
 import errorCodes from './disconnectionErrorCodes';
 import {
   createTryingToReconnectSnackbar,

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -1,9 +1,9 @@
-import KolibriModule from 'kolibri_module';
 import { getCurrentSession } from 'kolibri.coreVue.vuex.actions';
 import router from 'kolibri.coreVue.router';
 import Vue from 'kolibri.lib.vue';
 import store from 'kolibri.coreVue.vuex.store';
 import heartbeat from 'kolibri.heartbeat';
+import KolibriModule from 'kolibri_module';
 
 /*
  * A class for single page apps that control routing and vuex state.

--- a/kolibri/core/assets/src/mixins/responsive-window.js
+++ b/kolibri/core/assets/src/mixins/responsive-window.js
@@ -69,6 +69,8 @@
       12 columns, 24px gutter
 */
 
+import { throttle } from 'frame-throttle';
+
 /* module internal state */
 
 const windowListeners = [];
@@ -146,8 +148,6 @@ function windowMetrics() {
     range: getRange(breakpoint),
   };
 }
-
-import { throttle } from 'frame-throttle';
 
 const windowResizeHandler = throttle(() => {
   const metrics = windowMetrics();

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -7,7 +7,6 @@ import {
   facilities,
 } from 'kolibri.coreVue.vuex.getters';
 import * as CoreMappers from 'kolibri.coreVue.vuex.mappers';
-import { MasteryLoggingMap, AttemptLoggingMap, InteractionTypes, LoginErrors } from '../constants';
 import logger from 'kolibri.lib.logging';
 import {
   SessionResource,
@@ -23,9 +22,10 @@ import {
 import { now } from 'kolibri.utils.serverClock';
 import urls from 'kolibri.urls';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
-import intervalTimer from '../timer';
 import { redirectBrowser } from 'kolibri.utils.browser';
 import { createTranslator } from 'kolibri.utils.i18n';
+import intervalTimer from '../timer';
+import { MasteryLoggingMap, AttemptLoggingMap, InteractionTypes, LoginErrors } from '../constants';
 
 const name = 'coreTitles';
 

--- a/kolibri/core/assets/src/state/getters.js
+++ b/kolibri/core/assets/src/state/getters.js
@@ -1,5 +1,5 @@
-import { UserKinds, MaxPointsPerContent } from '../constants';
 import some from 'lodash/some';
+import { UserKinds, MaxPointsPerContent } from '../constants';
 
 // ROLES
 export function isAdmin(state) {

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -1,6 +1,6 @@
-import { UserKinds } from '../constants';
 import Vuex from 'vuex';
 import Vue from 'vue';
+import { UserKinds } from '../constants';
 
 Vue.use(Vuex);
 

--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -41,10 +41,12 @@
 <script>
 
   import logger from 'kolibri.lib.logging';
-  const logging = logger.getLogger(__filename);
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';
   import uiAlert from 'keen-ui/src/UiAlert';
   import { defaultLanguage, languageValidator } from 'kolibri.utils.i18n';
+
+  const logging = logger.getLogger(__filename);
+
   export default {
     name: 'contentRender',
     $trs: {

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -56,13 +56,13 @@
 <script>
 
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
-  import immersiveToolbar from './immersive-toolbar';
-  import globalSnackbar from './global-snackbar';
-  import appBody from './app-body';
   import values from 'lodash/values';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import appBar from 'kolibri.coreVue.components.appBar';
   import sideNav from 'kolibri.coreVue.components.sideNav';
+  import appBody from './app-body';
+  import globalSnackbar from './global-snackbar';
+  import immersiveToolbar from './immersive-toolbar';
 
   export default {
     name: 'coreBase',

--- a/kolibri/core/assets/src/views/exam-report/index.vue
+++ b/kolibri/core/assets/src/views/exam-report/index.vue
@@ -59,11 +59,11 @@
 
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
-  import pageStatus from './page-status';
   import attemptLogList from 'kolibri.coreVue.components.attemptLogList';
   import interactionList from 'kolibri.coreVue.components.interactionList';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+  import pageStatus from './page-status';
 
   export default {
     name: 'examReport',

--- a/kolibri/core/assets/src/views/exam-report/page-status.vue
+++ b/kolibri/core/assets/src/views/exam-report/page-status.vue
@@ -42,6 +42,7 @@
 
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
+
   export default {
     name: 'pageStatus',
     $trs: {

--- a/kolibri/core/assets/src/views/interaction-list/index.vue
+++ b/kolibri/core/assets/src/views/interaction-list/index.vue
@@ -28,6 +28,7 @@
 
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import interactionItem from './interaction-item';
+
   export default {
     name: 'coachExerciseQuestionAttempt',
     components: { interactionItem },

--- a/kolibri/core/assets/src/views/progress-icon.vue
+++ b/kolibri/core/assets/src/views/progress-icon.vue
@@ -25,6 +25,7 @@
 
   import uiIcon from 'keen-ui/src/UiIcon';
   import uiTooltip from 'keen-ui/src/UiTooltip';
+
   export default {
     name: 'progressIcon',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -1,8 +1,8 @@
-import KolibriApp from 'kolibri_app';
-import RootVue from './views';
 import { setChannelInfo } from 'kolibri.coreVue.vuex.actions';
+import RootVue from './views';
 import { initialState, mutations } from './state/store';
 import routes from './routes';
+import KolibriApp from 'kolibri_app';
 
 class CoachToolsModule extends KolibriApp {
   get stateSetters() {

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -1,5 +1,5 @@
-import lessonsRoutes from './lessonsRoutes';
-import examRoutes from './examRoutes';
+import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
 import { showClassListPage, shouldRedirectToClassRootPage } from '../state/actions/main';
 import { showGroupsPage } from '../state/actions/group';
 import {
@@ -15,8 +15,8 @@ import {
   showTopicLearnerItemDetails,
 } from '../state/actions/reports';
 import { PageNames } from '../constants';
-import store from 'kolibri.coreVue.vuex.store';
-import router from 'kolibri.coreVue.router';
+import examRoutes from './examRoutes';
+import lessonsRoutes from './lessonsRoutes';
 
 export default [
   ...lessonsRoutes,

--- a/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
@@ -1,3 +1,5 @@
+import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
 import {
   showLessonResourceContentPreview,
   showLessonResourceSelectionRootPage,
@@ -11,8 +13,6 @@ import {
   showLessonResourceUserSummaryPage,
 } from '../state/actions/lessonReportsActions';
 import { LessonsPageNames } from '../constants/lessonsConstants';
-import store from 'kolibri.coreVue.vuex.store';
-import router from 'kolibri.coreVue.router';
 
 // Redirect to the Lessons List of a different classroom if
 // classroom switcher is used in e.g. a Lesson Summary page

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -15,11 +15,11 @@ import {
   samePageCheckGenerator,
 } from 'kolibri.coreVue.vuex.actions';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-import { PageNames } from '../../constants';
-import { setClassState } from './main';
 import { getExamReport } from 'kolibri.utils.exams';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { createTranslator } from 'kolibri.utils.i18n';
+import { PageNames } from '../../constants';
+import { setClassState } from './main';
 
 const translator = createTranslator('coachExamPageTitles', {
   coachExamListPageTitle: 'Exams',

--- a/kolibri/plugins/coach/assets/src/state/actions/group.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/group.js
@@ -1,10 +1,10 @@
 import { handleError, samePageCheckGenerator } from 'kolibri.coreVue.vuex.actions';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
-import { PageNames } from '../../constants';
-import { setClassState } from './main';
 import logger from 'kolibri.lib.logging';
 import { LearnerGroupResource, MembershipResource, FacilityUserResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
+import { PageNames } from '../../constants';
+import { setClassState } from './main';
 
 const logging = logger.getLogger(__filename);
 

--- a/kolibri/plugins/coach/assets/src/state/actions/lessonReportsActions.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/lessonReportsActions.js
@@ -1,10 +1,10 @@
 import find from 'lodash/find';
 import { LessonResource, ContentNodeResource, LearnerGroupResource } from 'kolibri.resources';
+import { getChannelObject } from 'kolibri.coreVue.vuex.getters';
+import { handleApiError } from 'kolibri.coreVue.vuex.actions';
 import LessonReportResource from '../../apiResources/lessonReport';
 import UserReportResource from '../../apiResources/userReport';
 import { CollectionTypes, LessonsPageNames } from '../../constants/lessonsConstants';
-import { getChannelObject } from 'kolibri.coreVue.vuex.getters';
-import { handleApiError } from 'kolibri.coreVue.vuex.actions';
 import { showExerciseDetailView } from './reports';
 
 /* Refreshes the Lesson Report (resource vs. fraction of learners-who-completed-it)

--- a/kolibri/plugins/coach/assets/src/state/actions/lessons.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/lessons.js
@@ -1,16 +1,16 @@
-import { LessonsPageNames } from '../../constants/lessonsConstants';
 import { getChannels } from 'kolibri.coreVue.vuex.getters';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
-import { setClassState } from './main';
 import { LearnerGroupResource, LessonResource, ContentNodeResource } from 'kolibri.resources';
-import LessonReportResource from '../../apiResources/lessonReport';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import { handleApiError, createSnackbar } from 'kolibri.coreVue.vuex.actions';
 import { error as logError } from 'kolibri.lib.logging';
 import router from 'kolibri.coreVue.router';
+import LessonReportResource from '../../apiResources/lessonReport';
+import { LessonsPageNames } from '../../constants/lessonsConstants';
 import { lessonSummaryLink } from '../../views/lessons/lessonsRouterUtils';
+import { setClassState } from './main';
 
 const translator = createTranslator('lessonsPageTitles', {
   lessons: 'Lessons',

--- a/kolibri/plugins/coach/assets/src/state/actions/main.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/main.js
@@ -1,7 +1,7 @@
-import { PageNames } from '../../constants';
 import { handleApiError } from 'kolibri.coreVue.vuex.actions';
 import { ClassroomResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
+import { PageNames } from '../../constants';
 
 const translator = createTranslator('classListTitles', {
   classListPageTitle: 'Classes',

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -2,6 +2,16 @@ import { handleError, handleApiError } from 'kolibri.coreVue.vuex.actions';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { getChannels } from 'kolibri.coreVue.vuex.getters';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+import { now } from 'kolibri.utils.serverClock';
+import {
+  AttemptLogResource,
+  ChannelResource,
+  ContentNodeResource,
+  FacilityUserResource,
+  ContentSummaryLogResource,
+  LearnerGroupResource,
+} from 'kolibri.resources';
+import { createTranslator } from 'kolibri.utils.i18n';
 import { PageNames } from '../../constants';
 import {
   ContentScopes,
@@ -12,21 +22,11 @@ import {
   ViewBy,
 } from '../../constants/reportConstants';
 import { className } from '../getters/classes';
-import { setClassState } from './main';
-import { now } from 'kolibri.utils.serverClock';
-import {
-  AttemptLogResource,
-  ChannelResource,
-  ContentNodeResource,
-  FacilityUserResource,
-  ContentSummaryLogResource,
-  LearnerGroupResource,
-} from 'kolibri.resources';
 import RecentReportResourceConstructor from '../../apiResources/recentReport';
 import UserReportResource from '../../apiResources/userReport';
 import ContentSummaryResourceConstructor from '../../apiResources/contentSummary';
 import ContentReportResourceConstructor from '../../apiResources/contentReport';
-import { createTranslator } from 'kolibri.utils.i18n';
+import { setClassState } from './main';
 
 const translator = createTranslator('coachReportPageTitles', {
   recentChannelsPageTitle: 'Recent - All channels',

--- a/kolibri/plugins/coach/assets/src/state/getters/classes.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/classes.js
@@ -1,5 +1,6 @@
-const getCurrentClassroom = state => state.classList.find(({ id }) => id === state.classId);
 import { filterAndSortUsers } from '../../../../../facility_management/assets/src/userSearchUtils';
+
+const getCurrentClassroom = state => state.classList.find(({ id }) => id === state.classId);
 
 export function className(state) {
   return state.class;

--- a/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
@@ -1,5 +1,5 @@
-import { TableColumns, SortOrders } from '../../constants/reportConstants';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+import { TableColumns, SortOrders } from '../../constants/reportConstants';
 
 /* given an array of objects sum the keys on those that pass the filter */
 function _sumOfKeys(array, key, filter = () => true) {

--- a/kolibri/plugins/coach/assets/src/state/getters/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/reports.js
@@ -1,11 +1,11 @@
-import { ViewBy, SortOrders, RECENCY_THRESHOLD_IN_DAYS } from '../../constants/reportConstants';
-import { PageNames } from '../../constants';
 import { ContentNodeKinds, USER } from 'kolibri.coreVue.vuex.constants';
 import { now } from 'kolibri.utils.serverClock';
-import * as ReportUtils from './reportUtils';
-import { classMemberCount } from './classes';
 import differenceInDays from 'date-fns/difference_in_days';
 import logger from 'kolibri.lib.logging';
+import { ViewBy, SortOrders, RECENCY_THRESHOLD_IN_DAYS } from '../../constants/reportConstants';
+import { PageNames } from '../../constants';
+import * as ReportUtils from './reportUtils';
+import { classMemberCount } from './classes';
 
 const logging = logger.getLogger(__filename);
 

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentDetailsModal.vue
@@ -69,8 +69,8 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
-  import RecipientSelector from './RecipientSelector';
   import UiAlert from 'keen-ui/src/UiAlert';
+  import RecipientSelector from './RecipientSelector';
 
   export default {
     name: 'assignmentDetailsModal',

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -76,9 +76,9 @@
 
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
-  import StatusIcon from './StatusIcon';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { CollectionKinds } from 'kolibri.coreVue.vuex.constants';
+  import StatusIcon from './StatusIcon';
 
   export default {
     name: 'assignmentSummary',

--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -57,9 +57,9 @@
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
-  import { PageNames } from '../constants';
   import orderBy from 'lodash/orderBy';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
+  import { PageNames } from '../constants';
   import { filterAndSortUsers } from '../../../../facility_management/assets/src/userSearchUtils';
 
   function learnerPageLink(classId) {

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -129,20 +129,6 @@
 
 <script>
 
-  import topicRow from './topic-row';
-  import exerciseRow from './exercise-row';
-  import previewNewExamModal from './preview-new-exam-modal';
-  import {
-    goToTopic,
-    goToTopLevel,
-    createExamAndRoute,
-    addExercise,
-    removeExercise,
-    setExamsModal,
-    setSelectedExercises,
-  } from '../../../state/actions/exam';
-  import { className } from '../../../state/getters/classes';
-  import { Modals as ExamModals } from '../../../constants/examConstants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -157,6 +143,20 @@
   import { createSnackbar } from 'kolibri.coreVue.vuex.actions';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import flatMap from 'lodash/flatMap';
+  import { Modals as ExamModals } from '../../../constants/examConstants';
+  import { className } from '../../../state/getters/classes';
+  import {
+    goToTopic,
+    goToTopLevel,
+    createExamAndRoute,
+    addExercise,
+    removeExercise,
+    setExamsModal,
+    setSelectedExercises,
+  } from '../../../state/actions/exam';
+  import previewNewExamModal from './preview-new-exam-modal';
+  import exerciseRow from './exercise-row';
+  import topicRow from './topic-row';
 
   export default {
     name: 'createExamPage',

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
@@ -19,9 +19,10 @@
 
 <script>
 
+  import kButton from 'kolibri.coreVue.components.kButton';
   import { setExamsModal } from '../../../state/actions/exam';
   import previewExamModal from '../exams-page/preview-exam-modal';
-  import kButton from 'kolibri.coreVue.components.kButton';
+
   export default {
     name: 'previewNewExamModal',
     $trs: { randomize: 'Randomize questions' },

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
@@ -39,6 +39,7 @@
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+
   export default {
     name: 'topicRow',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -24,8 +24,8 @@
 
 <script>
 
-  import { PageNames } from '../../../constants';
   import examReport from 'kolibri.coreVue.components.examReport';
+  import { PageNames } from '../../../constants';
 
   export default {
     name: 'coachExamDetailPage',

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
@@ -57,6 +57,7 @@
 
 <script>
 
+  import xorWith from 'lodash/xorWith';
   import AssignmentChangeStatusModal from '../../assignments/AssignmentChangeStatusModal';
   import previewExamModal from '../exams-page/preview-exam-modal';
   import AssignmentDetailsModal from '../../assignments/AssignmentDetailsModal';
@@ -72,7 +73,6 @@
     copyExam,
     deleteExam,
   } from '../../../state/actions/exam';
-  import xorWith from 'lodash/xorWith';
 
   export default {
     name: 'manageExamModals',

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
@@ -104,18 +104,18 @@
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
-  import { PageNames } from '../../../constants';
   import sumBy from 'lodash/sumBy';
   import orderBy from 'lodash/orderBy';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import { USER, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
+  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+  import { PageNames } from '../../../constants';
   import { setExamsModal } from '../../../state/actions/exam';
   import { Modals as ExamModals } from '../../../constants/examConstants';
   import { AssignmentActions } from '../../../constants/assignmentsConstants';
   import AssignmentSummary from '../../assignments/AssignmentSummary';
   import ManageExamModals from './ManageExamModals';
-  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
 
   export default {
     name: 'examReportPage',

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
@@ -74,14 +74,14 @@
 <script>
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
-  import { PageNames } from '../../../constants';
   import orderBy from 'lodash/orderBy';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
-  import StatusIcon from '../../assignments/StatusIcon';
   import { ContentNodeKinds, CollectionKinds } from 'kolibri.coreVue.vuex.constants';
+  import StatusIcon from '../../assignments/StatusIcon';
+  import { PageNames } from '../../../constants';
 
   export default {
     name: 'coachExamsPage',

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -67,7 +67,6 @@
 
 <script>
 
-  import { setExamsModal } from '../../../state/actions/exam';
   import { ContentNodeResource } from 'kolibri.resources';
   import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
   import coreModal from 'kolibri.coreVue.components.coreModal';
@@ -76,6 +75,8 @@
   import kGrid from 'kolibri.coreVue.components.kGrid';
   import kGridItem from 'kolibri.coreVue.components.kGridItem';
   import uiProgressLinear from 'keen-ui/src/UiProgressLinear';
+  import { setExamsModal } from '../../../state/actions/exam';
+
   export default {
     name: 'previewExamModal',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -39,10 +39,11 @@
 
 <script>
 
-  import { displayModal, createGroup } from '../../state/actions/group';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { displayModal, createGroup } from '../../state/actions/group';
+
   export default {
     name: 'createGroupModal',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -25,10 +25,11 @@
 
 <script>
 
-  import { displayModal, deleteGroup } from '../../state/actions/group';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { displayModal, deleteGroup } from '../../state/actions/group';
+
   export default {
     name: 'deleteGroupModal',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -82,7 +82,6 @@
 <script>
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
-  import { displayModal } from '../../state/actions/group';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import ResponsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
@@ -90,6 +89,7 @@
   import kGrid from 'kolibri.coreVue.components.kGrid';
   import kGridItem from 'kolibri.coreVue.components.kGridItem';
   import sortBy from 'lodash/sortBy';
+  import { displayModal } from '../../state/actions/group';
 
   export default {
     name: 'groupSection',

--- a/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
@@ -63,12 +63,12 @@
 
 <script>
 
-  import { displayModal } from '../../state/actions/group';
-  import { GroupModals } from '../../constants';
   import differenceWith from 'lodash/differenceWith';
   import orderBy from 'lodash/orderBy';
   import flatMap from 'lodash/flatMap';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { GroupModals } from '../../constants';
+  import { displayModal } from '../../state/actions/group';
   import createGroupModal from './create-group-modal';
   import groupSection from './group-section';
   import renameGroupModal from './rename-group-modal';

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -42,15 +42,16 @@
 
 <script>
 
+  import coreModal from 'kolibri.coreVue.components.coreModal';
+  import kButton from 'kolibri.coreVue.components.kButton';
+  import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import {
     displayModal,
     addUsersToGroup,
     removeUsersFromGroup,
     moveUsersBetweenGroups,
   } from '../../state/actions/group';
-  import coreModal from 'kolibri.coreVue.components.coreModal';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
+
   export default {
     name: 'moveLearnersModal',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
@@ -39,10 +39,11 @@
 
 <script>
 
-  import { renameGroup, displayModal } from '../../state/actions/group';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { renameGroup, displayModal } from '../../state/actions/group';
+
   export default {
     name: 'renameGroupModal',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -30,11 +30,13 @@
 
 <script>
 
-  import { PageNames } from '../constants';
-  import { className, classCoaches } from '../state/getters/classes';
   import { isAdmin, isCoach, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
+  import coreBase from 'kolibri.coreVue.components.coreBase';
+  import { PageNames } from '../constants';
+  import { className, classCoaches } from '../state/getters/classes';
+  import { LessonsPageNames } from '../constants/lessonsConstants';
   import topNav from './top-nav';
   import classListPage from './class-list-page';
   import examsPage from './exams/exams-page';
@@ -42,14 +44,12 @@
   import examReportPage from './exams/exam-report-page';
   import examReportDetailPage from './exams/exam-report-detail-page';
   import groupsPage from './groups-page';
-  import coreBase from 'kolibri.coreVue.components.coreBase';
   import learnerExerciseDetailPage from './reports/learner-exercise-detail-page';
   import recentItemsPage from './reports/recent-items-page';
   import channelListPage from './reports/channel-list-page';
   import itemListPage from './reports/item-list-page';
   import learnerListPage from './reports/learner-list-page';
   import navTitle from './nav-title';
-  import { LessonsPageNames } from '../constants/lessonsConstants';
   import LessonsRootPage from './lessons/LessonsRootPage';
   import LessonSummaryPage from './lessons/LessonSummaryPage';
   import LessonResourceSelectionPage from './lessons/LessonResourceSelectionPage';

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -39,11 +39,11 @@
 
 <script>
 
+  import kButton from 'kolibri.coreVue.components.kButton';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
   import MetadataArea from './MetadataArea';
   import SelectOptions from './SelectOptions';
-  import kButton from 'kolibri.coreVue.components.kButton';
 
   export default {
     name: 'lessonContentPreviewPage',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -61,15 +61,15 @@
 <script>
 
   import uiToolbar from 'keen-ui/src/UiToolbar';
-  import contentCard from './content-card';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
-  import searchTools from './searchTools';
-  import { saveLessonResources } from '../../../state/actions/lessons';
   import { createSnackbar } from 'kolibri.coreVue.vuex.actions';
-  import { LessonsPageNames } from '../../../constants/lessonsConstants';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { saveLessonResources } from '../../../state/actions/lessons';
+  import { LessonsPageNames } from '../../../constants/lessonsConstants';
   import { lessonSummaryLink, topicListingLink } from '../lessonsRouterUtils';
+  import searchTools from './searchTools';
+  import contentCard from './content-card';
 
   export default {
     name: 'lessonResourceSelectionPage',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
@@ -161,8 +161,8 @@
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
   // TODO add to core
-  import { filterAndSortUsers } from '../../../../../facility_management/assets/src/userSearchUtils';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { filterAndSortUsers } from '../../../../../facility_management/assets/src/userSearchUtils';
   import { LessonsPageNames } from '../../constants/lessonsConstants';
 
   export default {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -101,10 +101,10 @@
   import progressBar from 'kolibri.coreVue.components.progressBar';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
-  import { resourceUserSummaryLink } from '../lessonsRouterUtils';
   import { createSnackbar, clearSnackbar } from 'kolibri.coreVue.vuex.actions';
-  import { saveLessonResources } from '../../../state/actions/lessons';
   import debounce from 'lodash/debounce';
+  import { resourceUserSummaryLink } from '../lessonsRouterUtils';
+  import { saveLessonResources } from '../../../state/actions/lessons';
 
   const removalSnackbarTime = 5000;
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -53,15 +53,15 @@
 <script>
 
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
-  import ResourceListTable from './ResourceListTable';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import map from 'lodash/map';
-  import ManageLessonModals from './ManageLessonModals';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { AssignmentActions } from '../../../constants/assignmentsConstants';
   import { selectionRootLink } from '../lessonsRouterUtils';
   import AssignmentSummary from '../../assignments/AssignmentSummary';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { setLessonsModal } from '../../../state/actions/lessons';
+  import ManageLessonModals from './ManageLessonModals';
+  import ResourceListTable from './ResourceListTable';
 
   export default {
     name: 'lessonSummaryPage',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -92,15 +92,15 @@
   import countBy from 'lodash/countBy';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import StatusIcon from '../assignments/StatusIcon';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import { ContentNodeKinds, CollectionKinds } from 'kolibri.coreVue.vuex.constants';
-  import { lessonSummaryLink } from './lessonsRouterUtils';
+  import StatusIcon from '../assignments/StatusIcon';
   import { createLesson } from '../../state/actions/lessons';
   import AssignmentDetailsModal from '../assignments/AssignmentDetailsModal';
+  import { lessonSummaryLink } from './lessonsRouterUtils';
 
   export default {
     name: 'lessonsRootPage',

--- a/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
@@ -8,6 +8,7 @@
 <script>
 
   import { getChannels, getChannelObject } from 'kolibri.coreVue.vuex.getters';
+  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../../constants';
   import {
     isTopicPage,
@@ -15,7 +16,7 @@
     isLearnerPage,
     numberOfAssignedClassrooms,
   } from '../../state/getters/main';
-  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
+
   export default {
     name: 'breadcrumbs',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
@@ -65,6 +65,7 @@
   import activityCell from './table-cells/activity-cell';
   import alignMixin from './align-mixin';
   import breadcrumbs from './breadcrumbs';
+
   export default {
     name: 'channelListPage',
     components: {

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -70,11 +70,11 @@
 <script>
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
-  import { TopicReports, LearnerReports, PageNames } from '../../constants';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import contentIcon from 'kolibri.coreVue.components.contentIcon';
+  import { TopicReports, LearnerReports, PageNames } from '../../constants';
   import { exerciseCount, contentCount, standardDataTable } from '../../state/getters/reports';
   import { TableColumns } from '../../constants/reportConstants';
-  import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import breadcrumbs from './breadcrumbs';
   import headerCell from './table-cells/header-cell';
   import nameCell from './table-cells/name-cell';

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
@@ -71,6 +71,7 @@
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
+
   export default {
     name: 'attemptSummary',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -9,8 +9,8 @@
 
 <script>
 
-  import { PageNames, LearnerReports } from '../../../constants';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
+  import { PageNames, LearnerReports } from '../../../constants';
   import learnerExerciseReport from './learner-exercise-report';
 
   export default {

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -53,9 +53,10 @@
 
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import attemptSummary from './attempt-summary';
   import attemptLogList from 'kolibri.coreVue.components.attemptLogList';
   import interactionList from 'kolibri.coreVue.components.interactionList';
+  import attemptSummary from './attempt-summary';
+
   export default {
     name: 'learnerExerciseReport',
     $trs: { backPrompt: 'Back to { backTitle }' },

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
@@ -75,10 +75,10 @@
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import { PageNames } from '../../constants';
   import { exerciseCount, contentCount, standardDataTable } from '../../state/getters/reports';
   import { TableColumns } from '../../constants/reportConstants';
-  import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import breadcrumbs from './breadcrumbs';
   import headerCell from './table-cells/header-cell';
   import nameCell from './table-cells/name-cell';

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -57,17 +57,18 @@
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import progressBar from 'kolibri.coreVue.components.progressBar';
   import { PageNames } from '../../constants';
   import { TableColumns, RECENCY_THRESHOLD_IN_DAYS } from '../../constants/reportConstants';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { classMemberCount } from '../../state/getters/classes';
   import * as reportGetters from '../../state/getters/reports';
   import breadcrumbs from './breadcrumbs';
   import headerCell from './table-cells/header-cell';
   import nameCell from './table-cells/name-cell';
   import activityCell from './table-cells/activity-cell';
-  import progressBar from 'kolibri.coreVue.components.progressBar';
   import alignMixin from './align-mixin';
+
   export default {
     name: 'coachRecentReports',
     components: {

--- a/kolibri/plugins/coach/assets/src/views/reports/table-cells/activity-cell.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/table-cells/activity-cell.vue
@@ -10,6 +10,7 @@
 <script>
 
   import elapsedTime from 'kolibri.coreVue.components.elapsedTime';
+
   export default {
     name: 'activityCell',
     components: { elapsedTime },

--- a/kolibri/plugins/coach/assets/src/views/reports/table-cells/progress-cell.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/table-cells/progress-cell.vue
@@ -21,6 +21,7 @@
 <script>
 
   import progressBar from 'kolibri.coreVue.components.progressBar';
+
   export default {
     name: 'progressIndicator',
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/top-nav.vue
+++ b/kolibri/plugins/coach/assets/src/views/top-nav.vue
@@ -44,10 +44,11 @@
 
 <script>
 
-  import { PageNames } from '../constants';
-  import { LessonsPageNames } from '../constants/lessonsConstants';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
+  import { PageNames } from '../constants';
+  import { LessonsPageNames } from '../constants/lessonsConstants';
+
   export default {
     name: 'topNav',
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/app.js
+++ b/kolibri/plugins/device_management/assets/src/app.js
@@ -1,17 +1,17 @@
 import KolibriApp from 'kolibri_app'; // eslint-disable-line
-import RootVue from './views';
-import mutations from './state/mutations';
-import initialState from './state/initialState';
-import { PageNames } from './constants';
-import preparePage from './state/preparePage';
+import store from 'kolibri.coreVue.vuex.store';
+import { createTranslator } from 'kolibri.utils.i18n';
+import { showDeviceInfoPage } from './state/actions/deviceInfoActions';
+import { showManageContentPage } from './state/actions/manageContentActions';
 import {
   showManagePermissionsPage,
   showUserPermissionsPage,
 } from './state/actions/managePermissionsActions';
-import { showManageContentPage } from './state/actions/manageContentActions';
-import { showDeviceInfoPage } from './state/actions/deviceInfoActions';
-import store from 'kolibri.coreVue.vuex.store';
-import { createTranslator } from 'kolibri.utils.i18n';
+import preparePage from './state/preparePage';
+import { PageNames } from './constants';
+import initialState from './state/initialState';
+import mutations from './state/mutations';
+import RootVue from './views';
 import wizardTransitionRoutes from './wizardTransitionRoutes';
 
 const translator = createTranslator('deviceAppPageTitles', {

--- a/kolibri/plugins/device_management/assets/src/state/actions/availableChannelsActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/availableChannelsActions.js
@@ -1,8 +1,8 @@
 import { RemoteChannelResource } from 'kolibri.resources';
-import { ContentWizardPages, TransferTypes } from '../../constants';
-import { driveChannelList, installedChannelList, wizardState } from '../getters';
 import router from 'kolibri.coreVue.router';
 import differenceBy from 'lodash/differenceBy';
+import { ContentWizardPages, TransferTypes } from '../../constants';
+import { driveChannelList, installedChannelList, wizardState } from '../getters';
 
 /**
  * Prepares the Available Channels Page for import/export flows

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
@@ -1,5 +1,5 @@
-import { taskList, wizardState } from '../getters';
 import { ChannelResource, TaskResource } from 'kolibri.resources';
+import { taskList, wizardState } from '../getters';
 import { TaskStatuses, TransferTypes } from '../../constants';
 
 export const ErrorTypes = {

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTreeViewerActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTreeViewerActions.js
@@ -2,8 +2,8 @@ import sumBy from 'lodash/sumBy';
 import map from 'lodash/fp/map';
 import partition from 'lodash/partition';
 import find from 'lodash/find';
-import { selectedNodes, inExportMode } from '../getters';
 import { ContentNodeGranularResource } from 'kolibri.resources';
+import { selectedNodes, inExportMode } from '../getters';
 
 const pluckPks = map('pk');
 

--- a/kolibri/plugins/device_management/assets/src/state/actions/deviceInfoActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/deviceInfoActions.js
@@ -1,9 +1,9 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
-import bytesForHumans from '../../views/manage-content-page/bytesForHumans';
 import { samePageCheckGenerator, handleApiError } from 'kolibri.coreVue.vuex.actions';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { canManageContent } from 'kolibri.coreVue.vuex.getters';
+import bytesForHumans from '../../views/manage-content-page/bytesForHumans';
 
 /* Function to fetch device info from the backend
  * and resolve validated data

--- a/kolibri/plugins/device_management/assets/src/state/actions/selectContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/selectContentActions.js
@@ -3,8 +3,8 @@ import urls from 'kolibri.urls';
 import { ContentNodeGranularResource } from 'kolibri.resources';
 import { ContentWizardPages, TransferTypes } from '../../constants';
 import { channelIsInstalled, wizardState } from '../getters';
-import { downloadChannelMetadata } from './contentTransferActions';
 import { navigateToTopicUrl } from '../../wizardTransitionRoutes';
+import { downloadChannelMetadata } from './contentTransferActions';
 
 /**
  * Transitions the import/export wizard to the 'select-content-page'

--- a/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
@@ -82,13 +82,13 @@
 
   import UiProgressLinear from 'keen-ui/src/UiProgressLinear';
   import kSelect from 'kolibri.coreVue.components.kSelect';
-  import channelListItem from '../manage-content-page/channel-list-item';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import uniqBy from 'lodash/uniqBy';
   import channelTokenModal from '../available-channels-page/channel-token-modal';
   import subpageContainer from '../containers/subpage-container';
-  import uniqBy from 'lodash/uniqBy';
+  import channelListItem from '../manage-content-page/channel-list-item';
   import {
     installedChannelList,
     installedChannelsWithResources,

--- a/kolibri/plugins/device_management/assets/src/views/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/index.vue
@@ -18,8 +18,8 @@
 
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
-  import { PageNames } from '../constants';
   import coreBase from 'kolibri.coreVue.components.coreBase';
+  import { PageNames } from '../constants';
   import topNavigation from './device-top-nav';
   import manageContentPage from './manage-content-page';
   import managePermissionsPage from './manage-permissions-page';

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -85,10 +85,10 @@
 
 <script>
 
-  import bytesForHumans from './bytesForHumans';
-  import { channelIsInstalled } from '../../state/getters';
   import kButton from 'kolibri.coreVue.components.kButton';
   import UiIcon from 'keen-ui/src/UiIcon';
+  import { channelIsInstalled } from '../../state/getters';
+  import bytesForHumans from './bytesForHumans';
 
   const Modes = {
     IMPORT: 'IMPORT',

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
@@ -46,13 +46,13 @@
 
 <script>
 
-  import { refreshChannelList } from '../../state/actions/manageContentActions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiProgressLinear from 'keen-ui/src/UiProgressLinear';
-  import deleteChannelModal from './delete-channel-modal';
-  import channelListItem from './channel-list-item';
+  import { refreshChannelList } from '../../state/actions/manageContentActions';
   import { triggerChannelDeleteTask } from '../../state/actions/taskActions';
   import { installedChannelsWithResources } from '../../state/getters';
+  import deleteChannelModal from './delete-channel-modal';
+  import channelListItem from './channel-list-item';
 
   export default {
     name: 'channelsGrid',

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
@@ -55,19 +55,19 @@
 <script>
 
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
+  import authMessage from 'kolibri.coreVue.components.authMessage';
+  import kButton from 'kolibri.coreVue.components.kButton';
   import { refreshTaskList, cancelTask } from '../../state/actions/taskActions';
   import { transitionWizardPage } from '../../state/actions/contentWizardActions';
   import { ContentWizardPages } from '../../constants';
-  import authMessage from 'kolibri.coreVue.components.authMessage';
-  import channelsGrid from './channels-grid';
-  import kButton from 'kolibri.coreVue.components.kButton';
   import availableChannelsPage from '../available-channels-page';
-  import selectImportSource from './wizards/select-import-source-modal';
   import subpageContainer from '../containers/subpage-container';
-  import taskProgress from './task-progress';
-  import selectDriveModal from './wizards/select-drive-modal';
   import selectContentPage from '../select-content-page';
   import { refreshChannelList } from '../../state/actions/manageContentActions';
+  import channelsGrid from './channels-grid';
+  import selectImportSource from './wizards/select-import-source-modal';
+  import taskProgress from './task-progress';
+  import selectDriveModal from './wizards/select-drive-modal';
 
   const pageNameComponentMap = {
     [ContentWizardPages.SELECT_IMPORT_SOURCE]: selectImportSource,

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-drive-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-drive-modal.vue
@@ -57,11 +57,11 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import UiAlert from 'keen-ui/src/UiAlert';
-  import driveList from './drive-list';
   import { refreshDriveList } from '../../../state/actions/taskActions';
   import { transitionWizardPage } from '../../../state/actions/contentWizardActions';
   import { wizardState } from '../../../state/getters';
   import { TransferTypes } from '../../../constants';
+  import driveList from './drive-list';
 
   export default {
     name: 'selectDriveModal',

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -44,8 +44,8 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import { transitionWizardPage } from '../../../state/actions/contentWizardActions';
   import { RemoteChannelResource } from 'kolibri.resources';
+  import { transitionWizardPage } from '../../../state/actions/contentWizardActions';
 
   export default {
     name: 'selectImportSourceModal',

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
@@ -30,8 +30,8 @@
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
-  import userGrid from './user-grid';
   import subpageContainer from '../containers/subpage-container';
+  import userGrid from './user-grid';
 
   export default {
     name: 'deviceManagementPage',

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
@@ -49,9 +49,9 @@
 
   import kButton from 'kolibri.coreVue.components.kButton';
   import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
-  import { userMatchesFilter, filterAndSortUsers } from '../../userSearchUtils';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
   import coreTable from 'kolibri.coreVue.components.coreTable';
+  import { userMatchesFilter, filterAndSortUsers } from '../../userSearchUtils';
 
   export default {
     name: 'userGrid',

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/channel-contents-summary.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/channel-contents-summary.vue
@@ -51,8 +51,8 @@
 
 <script>
 
-  import bytesForHumans from '../manage-content-page/bytesForHumans';
   import UiIcon from 'keen-ui/src/UiIcon';
+  import bytesForHumans from '../manage-content-page/bytesForHumans';
 
   export default {
     name: 'channelContentsSummary',

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
@@ -60,18 +60,18 @@
   import CoreTable from 'kolibri.coreVue.components.coreTable';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
-  import contentNodeRow from './content-node-row';
-  import { annotateNode, CheckboxTypes, transformBreadrumb } from './treeViewUtils';
+  import last from 'lodash/last';
+  import every from 'lodash/every';
+  import omit from 'lodash/omit';
+  import { wizardState, inExportMode } from '../../state/getters';
   import {
     addNodeForTransfer,
     removeNodeForTransfer,
   } from '../../state/actions/contentTreeViewerActions';
-  import { wizardState, inExportMode } from '../../state/getters';
-  import last from 'lodash/last';
-  import every from 'lodash/every';
-  import omit from 'lodash/omit';
   import { navigateToTopicUrl } from '../../wizardTransitionRoutes';
   import { TransferTypes } from '../../constants';
+  import { annotateNode, CheckboxTypes, transformBreadrumb } from './treeViewUtils';
+  import contentNodeRow from './content-node-row';
 
   // Removes annotations (except path) added to nodes in ContentTreeViewer before putting in store.
   function sanitizeNode(node) {

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -94,13 +94,10 @@
 
   import kButton from 'kolibri.coreVue.components.kButton';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
-  import selectedResourcesSize from './selected-resources-size';
-  import contentTreeViewer from './content-tree-viewer';
-  import channelContentsSummary from './channel-contents-summary';
   import uiAlert from 'keen-ui/src/UiAlert';
+  import isEmpty from 'lodash/isEmpty';
   import subpageContainer from '../containers/subpage-container';
   import { channelIsInstalled, wizardState, nodeTransferCounts } from '../../state/getters';
-  import isEmpty from 'lodash/isEmpty';
   import {
     getAvailableSpaceOnDrive,
     updateTreeViewTopic,
@@ -113,6 +110,9 @@
   import taskProgress from '../manage-content-page/task-progress';
   import { WizardTransitions } from '../../wizardTransitionRoutes';
   import { PageNames, TaskStatuses } from '../../constants';
+  import channelContentsSummary from './channel-contents-summary';
+  import contentTreeViewer from './content-tree-viewer';
+  import selectedResourcesSize from './selected-resources-size';
 
   export default {
     name: 'selectContentPage',

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/selected-resources-size.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/selected-resources-size.vue
@@ -44,9 +44,9 @@
 
 <script>
 
-  import bytesForHumans from '../manage-content-page/bytesForHumans';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiAlert from 'keen-ui/src/UiAlert.vue';
+  import bytesForHumans from '../manage-content-page/bytesForHumans';
 
   const RequiredNumber = { type: Number, required: true };
 

--- a/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
@@ -76,14 +76,14 @@
 <script>
 
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
-  import subpageContainer from './containers/subpage-container';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
+  import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
   import { addOrUpdateUserPermissions } from '../state/actions/managePermissionsActions';
   import { PageNames } from '../constants';
-  import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
+  import subpageContainer from './containers/subpage-container';
 
   const SUCCESS = 'SUCCESS';
   const IN_PROGRESS = 'IN_PROGRESS';

--- a/kolibri/plugins/document_pdf_render/assets/src/module.js
+++ b/kolibri/plugins/document_pdf_render/assets/src/module.js
@@ -1,5 +1,5 @@
-import ContentRendererModule from 'content_renderer_module';
 import PDFComponent from './views/index';
+import ContentRendererModule from 'content_renderer_module';
 
 class DocumentPDFModule extends ContentRendererModule {
   get rendererComponent() {

--- a/kolibri/plugins/facility_management/assets/src/app.js
+++ b/kolibri/plugins/facility_management/assets/src/app.js
@@ -1,5 +1,4 @@
 import store from 'kolibri.coreVue.vuex.store';
-import KolibriApp from 'kolibri_app';
 
 import RootVue from './views';
 
@@ -17,6 +16,7 @@ import { showFacilityConfigPage } from './state/actions/facilityConfig';
 
 import * as mutations from './state/mutations';
 import initialState from './state/initialState';
+import KolibriApp from 'kolibri_app';
 
 const routes = [
   {

--- a/kolibri/plugins/facility_management/assets/src/state/actions/class.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/class.js
@@ -8,10 +8,10 @@ import { samePageCheckGenerator, handleApiError } from 'kolibri.coreVue.vuex.act
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { PageNames } from '../../constants';
+import { filterAndSortUsers } from '../../userSearchUtils';
 import { _userState } from './helpers/mappers';
 import displayModal from './helpers/displayModal';
 import preparePage from './helpers/preparePage';
-import { filterAndSortUsers } from '../../userSearchUtils';
 
 /**
  * Do a POST to create new class

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/class-rename-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/class-rename-modal.vue
@@ -40,10 +40,11 @@
 
 <script>
 
-  import { updateClass, displayModal } from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
+  import { updateClass, displayModal } from '../../state/actions';
+
   export default {
     name: 'classRenameModal',
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -92,14 +92,14 @@
 
 <script>
 
+  import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
+  import kButton from 'kolibri.coreVue.components.kButton';
   import userTable from '../user-table';
   import { PageNames, Modals } from '../../constants';
   import { removeClassLearner, removeClassCoach } from '../../state/actions/class';
   import { displayModal } from '../../state/actions';
   import classRenameModal from './class-rename-modal';
   import userRemoveConfirmationModal from './user-remove-confirmation-modal';
-  import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
-  import kButton from 'kolibri.coreVue.components.kButton';
 
   export default {
     // TODO update component name after string freeze

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
@@ -28,9 +28,9 @@
 
 <script>
 
-  import { displayModal } from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
+  import { displayModal } from '../../state/actions';
 
   export default {
     name: 'userRemoveModal',

--- a/kolibri/plugins/facility_management/assets/src/views/class-enroll-form.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-enroll-form.vue
@@ -57,9 +57,7 @@
 
 <script>
 
-  import { Modals } from './../constants';
   import differenceWith from 'lodash/differenceWith';
-  import userTable from './user-table';
   import kGrid from 'kolibri.coreVue.components.kGrid';
   import kGridItem from 'kolibri.coreVue.components.kGridItem';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -68,6 +66,8 @@
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
   import { userMatchesFilter, filterAndSortUsers } from '../userSearchUtils';
+  import userTable from './user-table';
+  import { Modals } from './../constants';
 
   export default {
     name: 'managementClassEnroll',

--- a/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
@@ -15,9 +15,9 @@
 
 <script>
 
-  import classEnrollForm from './class-enroll-form';
   import { PageNames } from '../constants';
   import { assignCoachesToClass } from '../state/actions/class';
+  import classEnrollForm from './class-enroll-form';
 
   export default {
     name: 'coachClassAssignmentPage',

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/config-page-notifications.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/config-page-notifications.vue
@@ -31,8 +31,9 @@
 
 <script>
 
-  import { notificationTypes } from '../../constants';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
+  import { notificationTypes } from '../../constants';
+
   export default {
     name: 'configPageNotifications',
     components: { uiAlert },

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
@@ -35,6 +35,7 @@
 
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
+
   export default {
     name: 'confirmResetModal',
     components: {

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
@@ -67,6 +67,13 @@
 
 <script>
 
+  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+  import kButton from 'kolibri.coreVue.components.kButton';
+  import isEqual from 'lodash/isEqual';
+  import { saveFacilityConfig, resetFacilityConfig } from '../../state/actions';
+  import confirmResetModal from './confirm-reset-modal';
+  import notifications from './config-page-notifications';
+
   const settingsList = [
     'learnerCanEditUsername',
     'learnerCanEditName',
@@ -74,13 +81,6 @@
     'learnerCanLoginWithNoPassword',
     'showDownloadButtonInLearn',
   ];
-
-  import { saveFacilityConfig, resetFacilityConfig } from '../../state/actions';
-  import confirmResetModal from './confirm-reset-modal';
-  import notifications from './config-page-notifications';
-  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import isEqual from 'lodash/isEqual';
 
   export default {
     name: 'facilityConfigPage',

--- a/kolibri/plugins/facility_management/assets/src/views/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/index.vue
@@ -26,14 +26,14 @@
 
 <script>
 
-  import { PageNames } from '../constants';
   import { isAdmin, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
+  import coreBase from 'kolibri.coreVue.components.coreBase';
+  import { PageNames } from '../constants';
   import classEditPage from './class-edit-page';
   import coachClassAssignmentPage from './coach-class-assignment-page';
   import learnerClassEnrollmentPage from './learner-class-enrollment-page';
-  import coreBase from 'kolibri.coreVue.components.coreBase';
   import dataPage from './data-page';
   import facilitiesConfigPage from './facilities-config-page';
   import manageClassPage from './manage-class-page';

--- a/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
@@ -15,9 +15,9 @@
 
 <script>
 
-  import classEnrollForm from './class-enroll-form';
   import { PageNames } from '../constants';
   import { enrollLearnersInClass } from '../state/actions/class';
+  import classEnrollForm from './class-enroll-form';
 
   export default {
     name: 'learnerClassEnrollmentPage',

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-create-modal.vue
@@ -41,10 +41,11 @@
 
 <script>
 
-  import { createClass, displayModal } from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
+  import { createClass, displayModal } from '../../state/actions';
+
   export default {
     name: 'classCreateModal',
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -31,9 +31,10 @@
 
 <script>
 
-  import { deleteClass, displayModal } from '../../state/actions';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
+  import { deleteClass, displayModal } from '../../state/actions';
+
   export default {
     name: 'classDeleteModal',
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -79,14 +79,14 @@
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import UiIcon from 'keen-ui/src/UiIcon';
-  import { Modals, PageNames } from '../../constants';
-  import { displayModal } from '../../state/actions';
   import orderBy from 'lodash/orderBy';
-  import classCreateModal from './class-create-modal';
-  import classDeleteModal from './class-delete-modal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import { Modals, PageNames } from '../../constants';
+  import { displayModal } from '../../state/actions';
+  import classCreateModal from './class-create-modal';
+  import classDeleteModal from './class-delete-modal';
 
   function classEditLink(classId) {
     return {

--- a/kolibri/plugins/facility_management/assets/src/views/top-nav.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/top-nav.vue
@@ -32,9 +32,10 @@
 
 <script>
 
-  import { PageNames } from '../constants';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
+  import { PageNames } from '../constants';
+
   export default {
     name: 'topNav',
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
@@ -29,9 +29,9 @@
 
 <script>
 
-  import { deleteUser, displayModal } from '../../state/actions';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { deleteUser, displayModal } from '../../state/actions';
 
   export default {
     name: 'deleteUserModal',

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -86,7 +86,6 @@
 
 <script>
 
-  import { updateUser, displayModal } from '../../state/actions';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -96,6 +95,7 @@
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
+  import { updateUser, displayModal } from '../../state/actions';
 
   export default {
     name: 'editUserModal',

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
@@ -78,22 +78,22 @@
 
 <script>
 
-  import userTable from '../user-table';
   import UiIcon from 'keen-ui/src/UiIcon';
+  import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+  import kButton from 'kolibri.coreVue.components.kButton';
+  import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
+  import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
+  import { currentUserId, isSuperuser } from 'kolibri.coreVue.vuex.getters';
+  import kSelect from 'kolibri.coreVue.components.kSelect';
+  import userTable from '../user-table';
   import { Modals } from '../../constants';
   import { displayModal } from '../../state/actions';
-  import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+  import userRole from '../user-role';
+  import { userMatchesFilter, filterAndSortUsers } from '../../userSearchUtils';
   import userCreateModal from './user-create-modal';
   import editUserModal from './edit-user-modal';
   import resetUserPasswordModal from './reset-user-password-modal';
   import deleteUserModal from './delete-user-modal';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
-  import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
-  import userRole from '../user-role';
-  import { userMatchesFilter, filterAndSortUsers } from '../../userSearchUtils';
-  import { currentUserId, isSuperuser } from 'kolibri.coreVue.vuex.getters';
-  import kSelect from 'kolibri.coreVue.components.kSelect';
 
   const ALL_FILTER = 'all';
 

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
@@ -52,10 +52,10 @@
 
 <script>
 
-  import { updateUser, displayModal } from '../../state/actions';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { updateUser, displayModal } from '../../state/actions';
 
   export default {
     name: 'resetUserPasswordModal',

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -100,7 +100,6 @@
 
 <script>
 
-  import { createUser, displayModal } from '../../state/actions';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -110,6 +109,8 @@
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
+  import { createUser, displayModal } from '../../state/actions';
+
   export default {
     name: 'userCreateModal',
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-table.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-table.vue
@@ -89,9 +89,9 @@
 
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
-  import userRole from './user-role';
   import UiIcon from 'keen-ui/src/UiIcon';
   import difference from 'lodash/difference';
+  import userRole from './user-role';
 
   export default {
     name: 'userTable',

--- a/kolibri/plugins/html5_app_renderer/assets/src/module.js
+++ b/kolibri/plugins/html5_app_renderer/assets/src/module.js
@@ -1,5 +1,5 @@
-import ContentRendererModule from 'content_renderer_module';
 import HTML5AppComponent from './views/index';
+import ContentRendererModule from 'content_renderer_module';
 
 class HTML5AppModule extends ContentRendererModule {
   get rendererComponent() {

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -1,10 +1,10 @@
-import KolibriApp from 'kolibri_app';
 import RootVue from './views';
 import initialState from './state/initialState';
 import mutations from './state/mutations';
 import prepareLearnApp from './state/prepareLearnApp';
 import routes from './routes';
 import { setFacilitiesAndConfig } from './state/actions/main';
+import KolibriApp from 'kolibri_app';
 
 class LearnModule extends KolibriApp {
   get stateSetters() {

--- a/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
@@ -1,3 +1,4 @@
+import store from 'kolibri.coreVue.vuex.store';
 import { ClassesPageNames } from '../constants';
 import {
   showAllClassesPage,
@@ -6,7 +7,6 @@ import {
   showLessonResourceViewer,
 } from '../state/actions/classesActions';
 import { showExam, showExamReport } from '../state/actions/main';
-import store from 'kolibri.coreVue.vuex.store';
 
 export default [
   {

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -1,3 +1,4 @@
+import store from 'kolibri.coreVue.vuex.store';
 import {
   showRoot,
   showChannels,
@@ -16,7 +17,6 @@ import {
   showLearnContent,
 } from '../state/actions/recommended';
 import { PageNames } from '../constants';
-import store from 'kolibri.coreVue.vuex.store';
 import classesRoutes from './classesRoutes';
 
 export default [

--- a/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
@@ -1,8 +1,8 @@
-import { ClassesPageNames } from '../../constants';
-import { LearnerClassroomResource, LearnerLessonResource } from '../../apiResources';
 import { ContentNodeResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { handleApiError } from 'kolibri.coreVue.vuex.actions';
+import { LearnerClassroomResource, LearnerLessonResource } from '../../apiResources';
+import { ClassesPageNames } from '../../constants';
 
 const translator = createTranslator('classesPageTitles', {
   allClasses: 'All classes',

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -23,7 +23,6 @@ import {
   canViewExamReport,
 } from 'kolibri.utils.exams';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-import { PageNames, ClassesPageNames } from '../../constants';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { now } from 'kolibri.utils.serverClock';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
@@ -32,6 +31,7 @@ import seededShuffle from 'kolibri.lib.seededshuffle';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import tail from 'lodash/tail';
+import { PageNames, ClassesPageNames } from '../../constants';
 
 const translator = createTranslator('topicTreeExplorationPageTitles', {
   topicsForChannelPageTitle: 'Topics - { currentChannelTitle }',

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -5,11 +5,11 @@ import {
   setChannelInfo,
   handleApiError,
 } from 'kolibri.coreVue.vuex.actions';
-import { PageNames } from '../../constants';
-import { contentState, setAndCheckChannels } from './main';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import uniqBy from 'lodash/uniqBy';
 import { createTranslator } from 'kolibri.utils.i18n';
+import { PageNames } from '../../constants';
+import { contentState, setAndCheckChannels } from './main';
 
 const translator = createTranslator('learnerRecommendationPageTitles', {
   popularPageTitle: 'Popular',

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/exercise-attempts/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/exercise-attempts/index.vue
@@ -25,6 +25,7 @@
 <script>
 
   import answerIcon from './answer-icon';
+
   export default {
     components: { answerIcon },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -104,11 +104,11 @@ oriented data synchronization.
   import { InteractionTypes, MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import seededShuffle from 'kolibri.lib.seededshuffle';
   import { now } from 'kolibri.utils.serverClock';
-  import { updateContentNodeProgress } from '../../state/actions/main';
-  import exerciseAttempts from './exercise-attempts';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
+  import { updateContentNodeProgress } from '../../state/actions/main';
+  import exerciseAttempts from './exercise-attempts';
 
   export default {
     name: 'assessmentWrapper',

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
@@ -11,10 +11,11 @@
 
 <script>
 
+  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames, PageModes } from '../constants';
   import { pageMode } from '../state/getters';
-  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import classesBreadcrumbItems from './classes/classesBreadcrumbItems';
+
   export default {
     name: 'breadcrumbs',
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/channels-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page.vue
@@ -19,6 +19,7 @@
   import { PageNames } from '../constants';
   import pageHeader from './page-header';
   import contentCardGroupGrid from './content-card-group-grid';
+
   export default {
     name: 'channelsPage',
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -28,9 +28,9 @@
   import AuthMessage from 'kolibri.coreVue.components.authMessage';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import ContentCard from '../content-card';
   import { classAssignmentsLink } from './classPageLinks';
-  import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
 
   export default {
     name: 'allClassesPage',

--- a/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
@@ -28,10 +28,11 @@
 
 <script>
 
-  import ContentCard from '../content-card';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { examViewerLink, examReportViewerLink } from './classPageLinks';
   import { canViewExam } from 'kolibri.utils.exams';
+  import ContentCard from '../content-card';
+  import { examViewerLink, examReportViewerLink } from './classPageLinks';
+
   export default {
     name: 'assignedExamsCards',
     components: {

--- a/kolibri/plugins/learn/assets/src/views/classes/AssignedLessonsCards.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AssignedLessonsCards.vue
@@ -27,8 +27,8 @@
 
 <script>
 
-  import ContentCard from '../content-card';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import ContentCard from '../content-card';
   import { lessonPlaylistLink } from './classPageLinks';
 
   export default {

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -44,10 +44,10 @@
 
   import sumBy from 'lodash/sumBy';
   import ProgressIcon from 'kolibri.coreVue.components.progressIcon';
-  import ContentCard from '../content-card';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
-  import { lessonResourceViewerLink } from './classPageLinks';
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
+  import ContentCard from '../content-card';
+  import { lessonResourceViewerLink } from './classPageLinks';
 
   export default {
     name: 'lessonPlaylistPage',

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -23,10 +23,10 @@
 
 <script>
 
+  import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import ContentCard from '../content-card';
   import ContentPage from '../content-page';
   import { lessonResourceViewerLink } from './classPageLinks';
-  import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 
   export default {
     name: 'lessonResourceViewer',

--- a/kolibri/plugins/learn/assets/src/views/classes/classesBreadcrumbItems.js
+++ b/kolibri/plugins/learn/assets/src/views/classes/classesBreadcrumbItems.js
@@ -1,5 +1,5 @@
-import { ClassesPageNames } from '../../constants';
 import { createTranslator } from 'kolibri.utils.i18n';
+import { ClassesPageNames } from '../../constants';
 import { classAssignmentsLink, lessonPlaylistLink } from './classPageLinks';
 
 const translator = createTranslator('classesBreadcrumbItems', {

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
@@ -44,8 +44,8 @@
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
   import some from 'lodash/some';
   import kSelect from 'kolibri.coreVue.components.kSelect';
-  import contentCard from './content-card';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import contentCard from './content-card';
 
   export default {
     name: 'contentCardGroupGrid',

--- a/kolibri/plugins/learn/assets/src/views/content-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page.vue
@@ -142,22 +142,22 @@
     startTrackingProgress as startTracking,
     stopTrackingProgress as stopTracking,
   } from 'kolibri.coreVue.vuex.actions';
-  import { PageNames, PageModes, ClassesPageNames } from '../constants';
-  import { pageMode } from '../state/getters';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { isUserLoggedIn, facilityConfig } from 'kolibri.coreVue.vuex.getters';
-  import { updateContentNodeProgress } from '../state/actions/main';
-  import pageHeader from './page-header';
-  import contentCardGroupCarousel from './content-card-group-carousel';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import downloadButton from 'kolibri.coreVue.components.downloadButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { isAndroidWebView } from 'kolibri.utils.browser';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
+  import markdownIt from 'markdown-it';
+  import { PageNames, PageModes, ClassesPageNames } from '../constants';
+  import { pageMode } from '../state/getters';
+  import { updateContentNodeProgress } from '../state/actions/main';
+  import pageHeader from './page-header';
+  import contentCardGroupCarousel from './content-card-group-carousel';
   import assessmentWrapper from './assessment-wrapper';
   import pointsPopup from './points-popup';
   import pointsSlidein from './points-slidein';
-  import uiIconButton from 'keen-ui/src/UiIconButton';
-  import markdownIt from 'markdown-it';
   import { lessonResourceViewerLink } from './classes/classPageLinks';
 
   export default {

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -96,18 +96,19 @@
 
 <script>
 
-  import { ClassesPageNames } from '../../constants';
   import { InteractionTypes } from 'kolibri.coreVue.vuex.constants';
-  import { setAndSaveCurrentExamAttemptLog, closeExam } from '../../state/actions/main';
   import isEqual from 'lodash/isEqual';
   import { now } from 'kolibri.utils.serverClock';
   import throttle from 'lodash/throttle';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import answerHistory from './answer-history';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
+  import { setAndSaveCurrentExamAttemptLog, closeExam } from '../../state/actions/main';
+  import { ClassesPageNames } from '../../constants';
+  import answerHistory from './answer-history';
+
   export default {
     name: 'examPage',
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -24,8 +24,8 @@
 
 <script>
 
-  import { ClassesPageNames } from '../constants';
   import examReport from 'kolibri.coreVue.components.examReport';
+  import { ClassesPageNames } from '../constants';
 
   export default {
     name: 'learnExamReportViewer',

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -54,21 +54,21 @@
 
 <script>
 
-  import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import coreBase from 'kolibri.coreVue.components.coreBase';
+  import kNavbar from 'kolibri.coreVue.components.kNavbar';
+  import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
+  import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
   import channelsPage from './channels-page';
   import topicsPage from './topics-page';
   import contentPage from './content-page';
   import recommendedPage from './recommended-page';
   import recommendedSubpage from './recommended-subpage';
   import contentUnavailablePage from './content-unavailable-page';
-  import coreBase from 'kolibri.coreVue.components.coreBase';
   import breadcrumbs from './breadcrumbs';
   import searchPage from './search-page';
-  import kNavbar from 'kolibri.coreVue.components.kNavbar';
-  import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import examPage from './exam-page';
   import examReportViewer from './exam-report-viewer';
   import totalPoints from './total-points';

--- a/kolibri/plugins/learn/assets/src/views/page-header.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header.vue
@@ -13,6 +13,7 @@
 <script>
 
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
+
   export default {
     name: 'pageHeader',
     components: { progressIcon },

--- a/kolibri/plugins/learn/assets/src/views/recommended-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-page.vue
@@ -91,12 +91,12 @@
 
 <script>
 
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import { getChannels } from 'kolibri.coreVue.vuex.getters';
   import { PageNames } from '../constants';
   import contentCardGroupCarousel from './content-card-group-carousel';
   import contentCardGroupGrid from './content-card-group-grid';
   import contentCardGroupHeader from './content-card-group-header';
-  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
-  import { getChannels } from 'kolibri.coreVue.vuex.getters';
 
   const mobileCarouselLimit = 3;
   const desktopCarouselLimit = 15;

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
@@ -15,10 +15,10 @@
 
 <script>
 
+  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../constants';
   import contentCardGroupGrid from './content-card-group-grid';
   import contentCardGroupHeader from './content-card-group-header';
-  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
 
   export default {
     name: 'recommendedSubpage',

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -46,8 +46,8 @@
 
 <script>
 
-  import { PageNames } from '../constants';
   import uiIconButton from 'keen-ui/src/UiIconButton';
+  import { PageNames } from '../constants';
 
   export default {
     name: 'searchBox',

--- a/kolibri/plugins/learn/assets/src/views/search-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page.vue
@@ -35,6 +35,7 @@
   import contentCard from './content-card';
   import contentCardGroupGrid from './content-card-group-grid';
   import searchBox from './search-box';
+
   export default {
     name: 'searchPage',
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/topics-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page.vue
@@ -26,11 +26,12 @@
 
 <script>
 
-  import { PageNames } from '../constants';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { PageNames } from '../constants';
   import pageHeader from './page-header';
   import contentCard from './content-card';
   import contentCardGroupGrid from './content-card-group-grid';
+
   export default {
     name: 'topicsPage',
     $trs: {

--- a/kolibri/plugins/media_player/assets/src/module.js
+++ b/kolibri/plugins/media_player/assets/src/module.js
@@ -1,5 +1,5 @@
-import ContentRendererModule from 'content_renderer_module';
 import MediaPlayerComponent from './views/index';
+import ContentRendererModule from 'content_renderer_module';
 
 class MediaPlayerModule extends ContentRendererModule {
   get rendererComponent() {

--- a/kolibri/plugins/media_player/assets/src/views/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/index.vue
@@ -48,13 +48,13 @@
 
   import vue from 'kolibri.lib.vue';
   import videojs from 'video.js';
-  import { ReplayButton, ForwardButton, MimicFullscreenToggle } from './customButtons';
   import throttle from 'lodash/throttle';
   import Lockr from 'lockr';
   import loadingSpinner from 'kolibri.coreVue.components.loadingSpinner';
   import ResponsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
   import ScreenFull from 'screenfull';
+  import { ReplayButton, ForwardButton, MimicFullscreenToggle } from './customButtons';
   import audioIconPoster from './audio-icon-poster.svg';
 
   const GlobalLangCode = vue.locale;

--- a/kolibri/plugins/setup_wizard/assets/src/app.js
+++ b/kolibri/plugins/setup_wizard/assets/src/app.js
@@ -1,6 +1,6 @@
-import KolibriApp from 'kolibri_app';
 import RootVue from './views';
 import { initialState, mutations } from './state/store'; // attaching store to the root element
+import KolibriApp from 'kolibri_app';
 
 class OnboardingApp extends KolibriApp {
   get RootVue() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -35,8 +35,8 @@
 
 <script>
 
-  import { provisionDevice, goToNextStep, goToPreviousStep } from '../state/actions/main';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import { provisionDevice, goToNextStep, goToPreviousStep } from '../state/actions/main';
 
   import loadingPage from './submission-states/loading-page';
   import errorPage from './submission-states/error-page';

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
@@ -13,10 +13,10 @@
 
 <script>
 
+  import languageSwitcherList from 'kolibri.coreVue.components.languageSwitcherList';
   import { submitDefaultLanguage } from '../../../state/actions/forms';
 
   import onboardingForm from '../onboarding-form';
-  import languageSwitcherList from 'kolibri.coreVue.components.languageSwitcherList';
 
   export default {
     name: 'defaultLanguageForm',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
@@ -22,9 +22,9 @@
 
 <script>
 
+  import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import { submitFacilityName } from '../../../state/actions/forms';
 
-  import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import onboardingForm from '../onboarding-form';
 
   export default {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -123,12 +123,11 @@
 
 <script>
 
-  import { submitFacilityPermissions } from '../../../state/actions/forms';
-
-  import onboardingForm from '../onboarding-form';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
+  import onboardingForm from '../onboarding-form';
+  import { submitFacilityPermissions } from '../../../state/actions/forms';
 
   export default {
     name: 'selectPermissionsForm',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
@@ -58,9 +58,9 @@
 <script>
 
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
+  import { validateUsername } from 'kolibri.utils.validators';
   import { submitSuperuserCredentials } from '../../../state/actions/forms';
   import onboardingForm from '../onboarding-form';
-  import { validateUsername } from 'kolibri.utils.validators';
 
   export default {
     name: 'superuserCredentialsForm',

--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/error-page/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/error-page/index.vue
@@ -25,8 +25,8 @@
 
 <script>
 
-  import submissionStatePage from '../submission-state-page';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import submissionStatePage from '../submission-state-page';
 
   export default {
     name: 'onboardingErrorPage',

--- a/kolibri/plugins/style_guide/assets/src/app.js
+++ b/kolibri/plugins/style_guide/assets/src/app.js
@@ -1,9 +1,9 @@
-import KolibriModule from 'kolibri_module';
 import Vue from 'kolibri.lib.vue';
-import RootVue from './views';
 import router from 'kolibri.coreVue.router';
-import { navMenuRoutes } from './views/shell/nav-menu';
 import Vuep from 'vuep';
+import RootVue from './views';
+import { navMenuRoutes } from './views/shell/nav-menu';
+import KolibriModule from 'kolibri_module';
 
 Vue.use(Vuep, { lineNumbers: false });
 

--- a/kolibri/plugins/style_guide/assets/src/views/content/breadcrumbs/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/breadcrumbs/index.vue
@@ -31,6 +31,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -39,8 +41,6 @@
   import example from 'raw-loader!./example.html';
   import kBreadcrumbsApi from '!vue-doc!kolibri.coreVue.components.kBreadcrumbs';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   FullVue.component('k-breadcrumbs', kBreadcrumbs);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/buttons/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/buttons/index.vue
@@ -124,6 +124,10 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kButton from 'kolibri.coreVue.components.kButton';
+  import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
+  import kExternalLink from 'kolibri.coreVue.components.kExternalLink';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -134,10 +138,6 @@
   import kRouterLinkApi from '!vue-doc!kolibri.coreVue.components.kRouterLink';
   import kExternalLinkApi from '!vue-doc!kolibri.coreVue.components.kExternalLink';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kButton from 'kolibri.coreVue.components.kButton';
-  import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
-  import kExternalLink from 'kolibri.coreVue.components.kExternalLink';
   FullVue.component('k-button', kButton);
   FullVue.component('k-router-link', kRouterLink);
   FullVue.component('k-external-link', kExternalLink);

--- a/kolibri/plugins/style_guide/assets/src/views/content/checkboxes/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/checkboxes/index.vue
@@ -44,6 +44,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -52,8 +54,6 @@
   import example from 'raw-loader!./example.html';
   import kCheckboxApi from '!vue-doc!kolibri.coreVue.components.kCheckbox';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   FullVue.component('k-checkbox', kCheckbox);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/dropdown-menus/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/dropdown-menus/index.vue
@@ -17,6 +17,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -24,8 +26,6 @@
   import example from 'raw-loader!./example.html';
   import kDropdownMenuApi from '!vue-doc!kolibri.coreVue.components.kDropdownMenu';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
   FullVue.component('k-dropdown-menu', kDropdownMenu);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/filters/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/filters/index.vue
@@ -125,20 +125,21 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
 
-  import FullVue from 'vue/dist/vue.common';
-
   import kFilterTextboxExample from 'raw-loader!./k-filter-textbox-example.html';
   import kFilterTextboxApi from '!vue-doc!kolibri.coreVue.components.kFilterTextbox';
-  import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
+
   FullVue.component('k-filter-textbox', kFilterTextbox);
 
   import kSelectExample from 'raw-loader!./k-select-example.html';
   import kSelectApi from '!vue-doc!kolibri.coreVue.components.kSelect';
   import kSelect from 'kolibri.coreVue.components.kSelect';
+
   FullVue.component('k-select', kSelect);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/filters/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/filters/index.vue
@@ -127,19 +127,16 @@
 
   import FullVue from 'vue/dist/vue.common';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
+  import kSelect from 'kolibri.coreVue.components.kSelect';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
-
   import kFilterTextboxExample from 'raw-loader!./k-filter-textbox-example.html';
   import kFilterTextboxApi from '!vue-doc!kolibri.coreVue.components.kFilterTextbox';
-
-  FullVue.component('k-filter-textbox', kFilterTextbox);
-
   import kSelectExample from 'raw-loader!./k-select-example.html';
   import kSelectApi from '!vue-doc!kolibri.coreVue.components.kSelect';
-  import kSelect from 'kolibri.coreVue.components.kSelect';
 
+  FullVue.component('k-filter-textbox', kFilterTextbox);
   FullVue.component('k-select', kSelect);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/navbar/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/navbar/index.vue
@@ -59,6 +59,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -68,10 +70,9 @@
   import kNavbarApi from '!vue-doc!kolibri.coreVue.components.kNavbar';
   import kNavbarLinkApi from '!vue-doc!kolibri.coreVue.components.kNavbarLink';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kNavbar from 'kolibri.coreVue.components.kNavbar';
   FullVue.component('k-navbar', kNavbar);
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
+
   FullVue.component('k-navbar-link', kNavbarLink);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/navbar/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/navbar/index.vue
@@ -61,18 +61,16 @@
 
   import FullVue from 'vue/dist/vue.common';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
+  import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
   import show from '../../shell/show';
-
   import example from 'raw-loader!./example.html';
   import kNavbarApi from '!vue-doc!kolibri.coreVue.components.kNavbar';
   import kNavbarLinkApi from '!vue-doc!kolibri.coreVue.components.kNavbarLink';
 
   FullVue.component('k-navbar', kNavbar);
-  import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
-
   FullVue.component('k-navbar-link', kNavbarLink);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/radio-buttons/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/radio-buttons/index.vue
@@ -35,6 +35,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -42,8 +44,6 @@
   import example from 'raw-loader!./example.html';
   import kRadioButtonApi from '!vue-doc!kolibri.coreVue.components.kRadioButton';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   FullVue.component('k-radio-button', kRadioButton);
 
   export default {

--- a/kolibri/plugins/style_guide/assets/src/views/content/text-fields/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/text-fields/index.vue
@@ -129,6 +129,8 @@
 
 <script>
 
+  import FullVue from 'vue/dist/vue.common';
+  import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import componentDocs from '../../shell/component-docs';
   import vueExample from '../../shell/vue-example';
   import pageTemplate from '../../shell/page-template';
@@ -136,8 +138,6 @@
   import example from 'raw-loader!./example.html';
   import kTextboxApi from '!vue-doc!kolibri.coreVue.components.kTextbox';
 
-  import FullVue from 'vue/dist/vue.common';
-  import kTextbox from 'kolibri.coreVue.components.kTextbox';
   FullVue.component('k-textbox', kTextbox);
 
   export default {

--- a/kolibri/plugins/user/assets/src/app.js
+++ b/kolibri/plugins/user/assets/src/app.js
@@ -1,4 +1,6 @@
-import KolibriApp from 'kolibri_app';
+import store from 'kolibri.coreVue.vuex.store';
+import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
+import router from 'kolibri.coreVue.router';
 import RootVue from './views';
 import {
   showSignInPage,
@@ -9,9 +11,7 @@ import {
 import initialState from './state/initialState';
 import mutations from './state/mutations';
 import { PageNames } from './constants';
-import store from 'kolibri.coreVue.vuex.store';
-import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
-import router from 'kolibri.coreVue.router';
+import KolibriApp from 'kolibri_app';
 
 const routes = [
   {

--- a/kolibri/plugins/user/assets/src/state/actions.js
+++ b/kolibri/plugins/user/assets/src/state/actions.js
@@ -1,10 +1,10 @@
-import { PageNames } from '../constants';
 import { SIGNED_OUT_DUE_TO_INACTIVITY } from 'kolibri.coreVue.vuex.constants';
 import * as coreActions from 'kolibri.coreVue.vuex.actions';
 import { currentFacilityId, facilities } from 'kolibri.coreVue.vuex.getters';
 import { SignUpResource, FacilityUserResource, FacilityResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
 import Lockr from 'lockr';
+import { PageNames } from '../constants';
 
 const translator = createTranslator('userPageTitles', {
   userProfilePageTitle: 'User Profile',

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -19,9 +19,9 @@
 
 <script>
 
-  import { PageNames } from '../constants';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import coreBase from 'kolibri.coreVue.components.coreBase';
+  import { PageNames } from '../constants';
   import signInPage from './sign-in-page';
   import signUpPage from './sign-up-page';
   import profilePage from './profile-page';

--- a/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
@@ -50,10 +50,10 @@
 
 <script>
 
-  import { updateUserProfilePassword } from '../../state/actions';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import { updateUserProfilePassword } from '../../state/actions';
 
   export default {
     name: 'changeUserPasswordModal',

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -113,7 +113,6 @@
 
 <script>
 
-  import { updateUserProfile, resetProfileState } from '../../state/actions';
   import {
     facilityConfig,
     isSuperuser,
@@ -133,8 +132,9 @@
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
   import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
   import uiAlert from 'keen-ui/src/UiAlert';
-  import changeUserPasswordModal from './change-user-password-modal';
   import { PermissionTypes, UserKinds } from 'kolibri.coreVue.vuex.constants';
+  import { updateUserProfile, resetProfileState } from '../../state/actions';
+  import changeUserPasswordModal from './change-user-password-modal';
 
   export default {
     name: 'profilePage',

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -110,7 +110,6 @@
 <script>
 
   import { kolibriLogin } from 'kolibri.coreVue.vuex.actions';
-  import { PageNames } from '../../constants';
   import { facilityConfig } from 'kolibri.coreVue.vuex.getters';
   import { FacilityUsernameResource } from 'kolibri.resources';
   import { LoginErrors } from 'kolibri.coreVue.vuex.constants';
@@ -121,6 +120,7 @@
   import logo from 'kolibri.coreVue.components.logo';
   import uiAutocompleteSuggestion from 'keen-ui/src/UiAutocompleteSuggestion';
   import uiAlert from 'keen-ui/src/UiAlert';
+  import { PageNames } from '../../constants';
   import languageSwitcherFooter from '../language-switcher-footer';
   import facilityModal from './facility-modal';
 

--- a/kolibri/plugins/user/assets/src/views/sign-up-page.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page.vue
@@ -115,8 +115,6 @@
 
 <script>
 
-  import { signUpNewUser, resetSignUpState } from '../state/actions';
-  import { PageNames } from '../constants';
   import { validateUsername } from 'kolibri.utils.validators';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
@@ -124,6 +122,8 @@
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import logo from 'kolibri.coreVue.components.logo';
   import kSelect from 'kolibri.coreVue.components.kSelect';
+  import { PageNames } from '../constants';
+  import { signUpNewUser, resetSignUpState } from '../state/actions';
   import languageSwitcherFooter from './language-switcher-footer';
 
   export default {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^4.2.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-loader": "https://github.com/learningequality/eslint-loader/",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.10.0",
     "eslint-plugin-vue": "4.2.0",
     "esprima": "^4.0.0",
     "exports-loader": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,23 +1904,23 @@ eslint-import-resolver-node@^0.3.1:
     object-hash "^1.1.4"
     rimraf "^2.6.1"
 
-eslint-module-utils@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@^2.7.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz#26002efbfca5989b7288ac047508bd24f217b169"
+eslint-plugin-import@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.10.0.tgz#fa09083d5a75288df9c6c7d09fe12255985655e7"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
     debug "^2.6.8"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.1"
-    eslint-module-utils "^2.1.1"
+    eslint-module-utils "^2.2.0"
     has "^1.0.1"
     lodash "^4.17.4"
     minimatch "^3.0.3"


### PR DESCRIPTION
### Summary

Adds some linting rules to better organize imports.

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
