### PR TITLE
Radio button descriptions + cleanup

### DIFF
--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -14,6 +14,7 @@
           type="radio"
           class="input"
           :id="id"
+          :checked="isChecked"
           :value="radiovalue"
           :disabled="disabled"
           :autofocus="autofocus"
@@ -25,7 +26,7 @@
         >
 
         <mat-svg
-          v-if="isCurrentlySelected"
+          v-if="isChecked"
           category="toggle"
           name="radio_button_checked"
           class="radio-bubble selected"
@@ -117,8 +118,8 @@
           this.$emit('input', val);
         },
       },
-      isCurrentlySelected() {
-        return this.radiovalue.toString() === this.model.toString();
+      isChecked() {
+        return this.radiovalue.toString() === this.value.toString();
       },
       id() {
         return `${this._uid}`;

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -1,18 +1,18 @@
 <template>
 
   <div
-    class="k-radio-container"
-    :class="{ 'k-radio-disabled': disabled }"
+    class="container"
+    :class="{ 'disabled': disabled }"
     @click="select"
   >
 
     <label class="tr">
       <!-- TODO no block level within label -->
-      <div class="k-radio" :class="{ 'k-radio-active': isActive }">
+      <div class="input-section" :class="{ 'active': isActive }">
         <input
           ref="kRadioInput"
           type="radio"
-          class="k-radio-input"
+          class="input"
           :id="id"
           :value="radiovalue"
           :disabled="disabled"
@@ -28,22 +28,22 @@
           v-if="isCurrentlySelected"
           category="toggle"
           name="radio_button_checked"
-          class="k-radio-selected"
+          class="selected"
         />
         <mat-svg
           v-else
           category="toggle"
           name="radio_button_unchecked"
-          class="k-radio-unselected"
+          class="unselected"
         />
       </div>
 
-      <p class="k-radio-text">
-        <span class="k-radio-label">
+      <p class="text">
+        <span class="label">
           {{ label }}
         </span>
 
-        <span class="k-radio-description">
+        <span class="description">
           {{ description }}
         </span>
       </p>
@@ -119,7 +119,7 @@
         return this.radiovalue.toString() === this.model.toString();
       },
       id() {
-        return `k-radio-${this._uid}`;
+        return `${this._uid}`;
       },
     },
 
@@ -154,7 +154,7 @@
 
   $radio-height = 24px
 
-  .k-radio-container
+  .container
     display: table
     margin-top: 8px
     margin-bottom: 8px
@@ -162,7 +162,7 @@
   .tr
     display: table-row
 
-  .k-radio
+  .input-section
     display: table-cell
     position: relative
     vertical-align: top
@@ -170,7 +170,7 @@
     height: $radio-height
     cursor: pointer
 
-  .k-radio-input
+  .input
     position: absolute
     top: 50%
     left: 50%
@@ -178,41 +178,41 @@
     opacity: 0
     cursor: pointer
 
-  .k-radio-selected
+  .selected
     fill: $core-action-normal
 
-  .k-radio-unselected
+  .unselected
     fill: $core-text-annotation
 
-  .k-radio-active
-    .k-radio-selected
+  .active
+    .selected
       outline: $core-outline
 
-  .k-radio-text
+  .text
     display: table-cell
     padding-left: 8px
     cursor: pointer
     // user-select: none // why?
 
-  .k-radio-label
+  .label
     line-height: 24px
 
-  .k-radio-description
+  .description
     display: block
     color: $core-text-annotation
     font-size: 12px
 
-  .k-radio-disabled
+  .disabled
     svg
       fill: $core-grey-300
 
-    .k-radio, .k-radio-input, .k-radio-label
+    .input-section, .input, .label
       cursor: default
 
-    .k-radio-text
+    .text
       color: $core-text-disabled
 
-    .k-radio-description
+    .description
       // need it more specific
       color: $core-text-disabled
 

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!-- HTML makes clicking label apply to input by default -->
-  <label class="k-radio-button">
+  <label :class="['k-radio-button', {disabled}]">
     <!-- v-model listens for @input event by default -->
     <!-- @input has compatibility issues for input of type radio -->
     <!-- Here, manually listen for @change (no compatibility issues) -->
@@ -32,13 +32,12 @@
       :class="['unchecked', {disabled, active}]"
     />
 
-    <span :class="['text', {disabled}]">
+    <span class="text">
       {{ label }}
       <span
         v-if="description"
         :class="['description', {disabled}]"
       >
-        <br>
         {{ description }}
       </span>
     </span>
@@ -64,7 +63,7 @@
         required: true,
       },
       /**
-       * Description for Label
+       * Description for label
        */
       description: {
         type: String,
@@ -138,46 +137,53 @@
   $radio-height = 24px
 
   .k-radio-button
-    // give conditional classes higher priority
     &.disabled
-      cursor: default
+      color: $core-text-disabled
+    &:not(.disabled)
+      cursor: pointer
     position: relative
-    cursor: pointer
     display:block
     margin-top: 8px
     margin-bottom: 8px
-    line-height: $radio-height
+
+  .input, .text
+    // consistent look in inline and block displays
+    vertical-align: top
 
   .input
     // use opacity, not appearance:none because ie compatibility
     opacity: 0
-    // bring the invible HTML element on top of our custom radio-button
-    position: absolute
     width: $radio-height
     height: $radio-height
 
   .checked, .unchecked
-    vertical-align: top
     &.active
       // setting opacity to 0 hides input's default outline
       outline: $core-outline
     &.disabled
       fill: $core-grey-300
+    // lay our custom radio buttons on top of the actual element
+    width: $radio-height
+    height: $radio-height
+    position: absolute
+    left: 0
+    top:0
   .checked
     fill: $core-action-normal
   .unchecked
     fill: $core-text-annotation
 
-
   .text, .description
-    &.disabled
-      color: $core-text-disabled
-  .text
     display: inline-block
+  .text
     padding-left: 8px
+    line-height: $radio-height
     max-width: 'calc(100% - %s)' % $radio-height // stylus specific
   .description
-    color: $core-text-annotation
+    &:not(.disabled)
+      color: $core-text-annotation
+    width:100%
+    line-height: normal
     font-size: 12px
 
 </style>

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -11,7 +11,7 @@
       class="input"
       :id="id"
       :checked="isChecked"
-      :value="radiovalue"
+      :value="value"
       :disabled="disabled"
       :autofocus="autofocus"
       @focus="active = true"
@@ -54,6 +54,9 @@
    */
   export default {
     name: 'kRadioButton',
+    model: {
+      prop: 'currentValue',
+    },
     props: {
       /**
        * Label
@@ -70,16 +73,16 @@
         required: false,
       },
       /**
-       * v-model value - the data that is currently assigned
+       * Value that is currently assigned via v-model
        */
-      value: {
+      currentValue: {
         type: [String, Number, Boolean],
         required: true,
       },
       /**
-       * Unique value of the particular radio - the data that this button can assign
+       * Unique value of this particular radio button
        */
-      radiovalue: {
+      value: {
         type: [String, Number, Boolean],
         required: true,
       },
@@ -103,7 +106,7 @@
     }),
     computed: {
       isChecked() {
-        return this.radiovalue.toString() === this.value.toString();
+        return this.value.toString() === this.currentValue.toString();
       },
       id() {
         return `${this._uid}`;
@@ -122,7 +125,7 @@
 
         // emitting input, resolves browser compatibility issues
         // with v-model's @input default and <input type=radio>
-        this.$emit('input', this.radiovalue);
+        this.$emit('input', this.value);
       },
     },
   };

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -39,10 +39,10 @@
         v-if="description"
         :class="['description', { disabled}]"
       >
+        <br>
         {{ description }}
       </span>
     </span>
-
 
   </label>
 
@@ -175,9 +175,9 @@
       color: $core-text-disabled
   .text
     display: inline-block
-    margin-left: 8px
+    padding-left: 8px
+    max-width: 'calc(100% - %s)' % $radio-height // stylus specific
   .description
-    display: block
     color: $core-text-annotation
     font-size: 12px
 

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -3,14 +3,14 @@
   <div
     class="container"
     :class="{ 'disabled': disabled }"
-    @click="select"
   >
 
+    <!-- HTML makes clicking label apply to input by default -->
     <label class="tr">
       <!-- TODO no block level within label -->
       <div class="input-section">
         <input
-          ref="kRadioInput"
+          ref="input"
           type="radio"
           class="input"
           :id="id"
@@ -20,9 +20,7 @@
           :autofocus="autofocus"
           @focus="isActive = true"
           @blur="isActive = false"
-          @change="emitChange"
-          v-model="model"
-          @click.stop="select"
+          @change="update($event)"
         >
 
         <mat-svg
@@ -110,14 +108,6 @@
       isActive: false,
     }),
     computed: {
-      model: {
-        get() {
-          return this.value;
-        },
-        set(val) {
-          this.$emit('input', val);
-        },
-      },
       isChecked() {
         return this.radiovalue.toString() === this.value.toString();
       },
@@ -128,22 +118,17 @@
 
     methods: {
       focus() {
-        this.$refs.kRadioInput.focus();
+        this.$refs.input.focus();
       },
-      select() {
-        if (!this.disabled) {
-          this.focus();
-          this.model = this.radiovalue;
-          this.emitChange();
-        }
-      },
-      emitChange(event) {
-        if (this.model !== this.radiovalue) {
-          /**
-           * Emits change event
-           */
-          this.$emit('change', this.model, event);
-        }
+      update(event) {
+        /**
+         * Emits change event
+         */
+        this.$emit('change', this.isChecked, event);
+
+        // emitting input, resolves browser compatibility issues
+        // with v-model's @input default and <input type=radio>
+        this.$emit('input', this.radiovalue);
       },
     },
   };
@@ -181,14 +166,14 @@
     opacity: 0
     cursor: pointer
 
-  .selected
-    fill: $core-action-normal
+  .radio-bubble
+    &.active
+      outline: $core-outline
+    &.selected
+      fill: $core-action-normal
+    &.unselected
+      fill: $core-text-annotation
 
-  .unselected
-    fill: $core-text-annotation
-
-  .radio-bubble.active
-    outline: $core-outline
 
   .text
     display: table-cell

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -9,6 +9,9 @@
     <label class="tr">
       <!-- TODO no block level within label -->
       <div class="input-section">
+        <!-- v-model listens for @input event by default -->
+        <!-- @input has compatibility issues for input of type radio -->
+        <!-- Here, manually listen for @change (no compatibility issues) -->
         <input
           ref="input"
           type="radio"
@@ -76,14 +79,14 @@
         required: false,
       },
       /**
-       * v-model value
+       * v-model value - the data that is currently assigned
        */
       value: {
         type: [String, Number, Boolean],
         required: true,
       },
       /**
-       * Unique value of the particular radio
+       * Unique value of the particular radio - the data that this button can assign
        */
       radiovalue: {
         type: [String, Number, Boolean],

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -1,58 +1,50 @@
 <template>
 
-  <div class="container">
+  <!-- HTML makes clicking label apply to input by default -->
+  <label class="k-radio-button">
+    <!-- v-model listens for @input event by default -->
+    <!-- @input has compatibility issues for input of type radio -->
+    <!-- Here, manually listen for @change (no compatibility issues) -->
+    <input
+      ref="input"
+      type="radio"
+      class="input"
+      :id="id"
+      :checked="isChecked"
+      :value="radiovalue"
+      :disabled="disabled"
+      :autofocus="autofocus"
+      @focus="active = true"
+      @blur="active = false"
+      @change="update($event)"
+    >
+    <!-- the radio buttons the user sees -->
+    <mat-svg
+      v-if="isChecked"
+      category="toggle"
+      name="radio_button_checked"
+      :class="['checked', {disabled, active}]"
+    />
+    <mat-svg
+      v-else
+      category="toggle"
+      name="radio_button_unchecked"
+      :class="['unchecked', {disabled, active}
+      ]"
+    />
 
-    <!-- HTML makes clicking label apply to input by default -->
-    <label class="tr">
-      <span class="input-section">
-        <!-- v-model listens for @input event by default -->
-        <!-- @input has compatibility issues for input of type radio -->
-        <!-- Here, manually listen for @change (no compatibility issues) -->
-        <input
-          ref="input"
-          type="radio"
-          class="input"
-          :id="id"
-          :checked="isChecked"
-          :value="radiovalue"
-          :disabled="disabled"
-          :autofocus="autofocus"
-          @focus="active = true"
-          @blur="active = false"
-          @change="update($event)"
-        >
-
-        <mat-svg
-          v-if="isChecked"
-          category="toggle"
-          name="radio_button_checked"
-          :class="['checked', {disabled, active}]"
-        />
-        <mat-svg
-          v-else
-          category="toggle"
-          name="radio_button_unchecked"
-          :class="['unchecked', {disabled, active}
-          ]"
-        />
+    <span :class="['text', { disabled}]">
+      {{ label }}
+      <span
+        v-if="description"
+        :class="['description', { disabled}]"
+      >
+        {{ description }}
       </span>
+    </span>
 
-      <span :class="['text', { disabled }]">
-        <span class="label">
-          {{ label }}
-        </span>
 
-        <span
-          v-if="description"
-          :class="['description', { disabled}]"
-        >
-          {{ description }}
-        </span>
-      </span>
-
-    </label>
-
-  </div>
+  </label>
 
 </template>
 
@@ -72,6 +64,9 @@
         type: String,
         required: true,
       },
+      /**
+       * Description for Label
+       */
       description: {
         type: String,
         required: false,
@@ -143,33 +138,29 @@
 
   $radio-height = 24px
 
-  .container
-    display: table
-    margin-top: 8px
-    margin-bottom: 8px
-
-  label
+  .k-radio-button
+    // give conditional classes higher priority
     &.disabled
       cursor: default
-    cursor: pointer
-
-  .tr
-    display: table-row
-
-  .input-section
-    display: table-cell
     position: relative
-    vertical-align: top
+    cursor: pointer
+    display:block
+    margin-top: 8px
+    margin-bottom: 8px
+    line-height: $radio-height
+
   .input
-    // using this rather than appearance:none because ie compatibility
+    // use opacity, not appearance:none because ie compatibility
     opacity: 0
+    // bring the invible HTML element on top of our custom radio-button
     position: absolute
     width: $radio-height
     height: $radio-height
+
   .checked, .unchecked
-    // give conditional classes higher priority
-    // setting opacity to 0 hides input's default outline
+    vertical-align: top
     &.active
+      // setting opacity to 0 hides input's default outline
       outline: $core-outline
     &.disabled
       fill: $core-grey-300
@@ -178,16 +169,14 @@
   .unchecked
     fill: $core-text-annotation
 
-  .text
+
+  .text, .description
     &.disabled
       color: $core-text-disabled
-    display: table-cell
-    padding-left: 8px
-  .label
-    line-height: 24px
+  .text
+    display: inline-block
+    margin-left: 8px
   .description
-    &.disabled
-      color: inherit
     display: block
     color: $core-text-annotation
     font-size: 12px

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -7,8 +7,7 @@
 
     <!-- HTML makes clicking label apply to input by default -->
     <label class="tr">
-      <!-- TODO no block level within label -->
-      <div class="input-section">
+      <span class="input-section">
         <!-- v-model listens for @input event by default -->
         <!-- @input has compatibility issues for input of type radio -->
         <!-- Here, manually listen for @change (no compatibility issues) -->
@@ -40,9 +39,9 @@
           class="radio-bubble unselected"
           :class="{ 'active': isActive }"
         />
-      </div>
+      </span>
 
-      <p class="text">
+      <span class="text">
         <span class="label">
           {{ label }}
         </span>
@@ -50,7 +49,7 @@
         <span class="description">
           {{ description }}
         </span>
-      </p>
+      </span>
 
     </label>
 

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -29,15 +29,14 @@
       v-else
       category="toggle"
       name="radio_button_unchecked"
-      :class="['unchecked', {disabled, active}
-      ]"
+      :class="['unchecked', {disabled, active}]"
     />
 
-    <span :class="['text', { disabled}]">
+    <span :class="['text', {disabled}]">
       {{ label }}
       <span
         v-if="description"
-        :class="['description', { disabled}]"
+        :class="['description', {disabled}]"
       >
         <br>
         {{ description }}

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <div
-    class="container"
-    :class="{ 'disabled': disabled }"
-  >
+  <div class="container">
 
     <!-- HTML makes clicking label apply to input by default -->
     <label class="tr">
@@ -29,24 +26,26 @@
           v-if="isChecked"
           category="toggle"
           name="radio_button_checked"
-          class="radio-bubble selected"
-          :class="{ 'active': isActive }"
+          :class="['checked', {disabled, active: isActive}]"
         />
         <mat-svg
           v-else
           category="toggle"
           name="radio_button_unchecked"
-          class="radio-bubble unselected"
-          :class="{ 'active': isActive }"
+          :class="['unchecked', {disabled, 'active': isActive}
+          ]"
         />
       </span>
 
-      <span class="text">
+      <span :class="['text', { disabled }]">
         <span class="label">
           {{ label }}
         </span>
 
-        <span class="description">
+        <span
+          v-if="description"
+          :class="['description', { disabled}]"
+        >
           {{ description }}
         </span>
       </span>
@@ -150,6 +149,8 @@
     margin-bottom: 8px
 
   label
+    &.disabled
+      cursor: default
     cursor: pointer
 
   .tr
@@ -159,48 +160,36 @@
     display: table-cell
     position: relative
     vertical-align: top
-
   .input
     // using this rather than appearance:none because ie compatibility
     opacity: 0
     position: absolute
     width: $radio-height
     height: $radio-height
-
-  .radio-bubble
+  .checked, .unchecked
+    // give conditional classes higher priority
     // setting opacity to 0 hides input's default outline
     &.active
       outline: $core-outline
-    &.selected
-      fill: $core-action-normal
-    &.unselected
-      fill: $core-text-annotation
-
+    &.disabled
+      fill: $core-grey-300
+  .checked
+    fill: $core-action-normal
+  .unchecked
+    fill: $core-text-annotation
 
   .text
+    &.disabled
+      color: $core-text-disabled
     display: table-cell
     padding-left: 8px
-
   .label
     line-height: 24px
-
   .description
+    &.disabled
+      color: inherit
     display: block
     color: $core-text-annotation
     font-size: 12px
-
-  .disabled
-    label
-      cursor: default
-
-    svg
-      fill: $core-grey-300
-
-    .text
-      color: $core-text-disabled
-
-    .description
-      // need it more specific
-      color: $core-text-disabled
 
 </style>

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -150,6 +150,9 @@
     margin-top: 8px
     margin-bottom: 8px
 
+  label
+    cursor: pointer
+
   .tr
     display: table-row
 
@@ -157,19 +160,16 @@
     display: table-cell
     position: relative
     vertical-align: top
-    width: $radio-height
-    height: $radio-height
-    cursor: pointer
 
   .input
-    position: absolute
-    top: 50%
-    left: 50%
-    transform: translate(-50%, -50%)
+    // using this rather than appearance:none because ie compatibility
     opacity: 0
-    cursor: pointer
+    position: absolute
+    width: $radio-height
+    height: $radio-height
 
   .radio-bubble
+    // setting opacity to 0 hides input's default outline
     &.active
       outline: $core-outline
     &.selected
@@ -181,8 +181,6 @@
   .text
     display: table-cell
     padding-left: 8px
-    cursor: pointer
-    // user-select: none // why?
 
   .label
     line-height: 24px
@@ -193,11 +191,11 @@
     font-size: 12px
 
   .disabled
+    label
+      cursor: default
+
     svg
       fill: $core-grey-300
-
-    .input-section, .input, .label
-      cursor: default
 
     .text
       color: $core-text-disabled

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -17,8 +17,8 @@
           :value="radiovalue"
           :disabled="disabled"
           :autofocus="autofocus"
-          @focus="isActive = true"
-          @blur="isActive = false"
+          @focus="active = true"
+          @blur="active = false"
           @change="update($event)"
         >
 
@@ -26,13 +26,13 @@
           v-if="isChecked"
           category="toggle"
           name="radio_button_checked"
-          :class="['checked', {disabled, active: isActive}]"
+          :class="['checked', {disabled, active}]"
         />
         <mat-svg
           v-else
           category="toggle"
           name="radio_button_unchecked"
-          :class="['unchecked', {disabled, 'active': isActive}
+          :class="['unchecked', {disabled, active}
           ]"
         />
       </span>
@@ -106,7 +106,7 @@
       },
     },
     data: () => ({
-      isActive: false,
+      active: false,
     }),
     computed: {
       isChecked() {

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -5,8 +5,9 @@
     :class="{ 'k-radio-disabled': disabled }"
     @click="select"
   >
-    <div class="tr">
 
+    <label class="tr">
+      <!-- TODO no block level within label -->
       <div class="k-radio" :class="{ 'k-radio-active': isActive }">
         <input
           ref="kRadioInput"
@@ -35,12 +36,20 @@
           name="radio_button_unchecked"
           class="k-radio-unselected"
         />
-
       </div>
 
-      <label :for="id" class="k-radio-label" @click.prevent>{{ label }}</label>
+      <p class="k-radio-text">
+        <span class="k-radio-label">
+          {{ label }}
+        </span>
 
-    </div>
+        <span class="k-radio-description">
+          {{ description }}
+        </span>
+      </p>
+
+    </label>
+
   </div>
 
 </template>
@@ -60,6 +69,10 @@
       label: {
         type: String,
         required: true,
+      },
+      description: {
+        type: String,
+        required: false,
       },
       /**
        * v-model value
@@ -175,12 +188,19 @@
     .k-radio-selected
       outline: $core-outline
 
-  .k-radio-label
+  .k-radio-text
     display: table-cell
     padding-left: 8px
     cursor: pointer
+    // user-select: none // why?
+
+  .k-radio-label
     line-height: 24px
-    user-select: none
+
+  .k-radio-description
+    display: block
+    color: $core-text-annotation
+    font-size: 12px
 
   .k-radio-disabled
     svg
@@ -189,7 +209,11 @@
     .k-radio, .k-radio-input, .k-radio-label
       cursor: default
 
-    .k-radio-label
+    .k-radio-text
+      color: $core-text-disabled
+
+    .k-radio-description
+      // need it more specific
       color: $core-text-disabled
 
 </style>

--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -8,7 +8,7 @@
 
     <label class="tr">
       <!-- TODO no block level within label -->
-      <div class="input-section" :class="{ 'active': isActive }">
+      <div class="input-section">
         <input
           ref="kRadioInput"
           type="radio"
@@ -28,13 +28,15 @@
           v-if="isCurrentlySelected"
           category="toggle"
           name="radio_button_checked"
-          class="selected"
+          class="radio-bubble selected"
+          :class="{ 'active': isActive }"
         />
         <mat-svg
           v-else
           category="toggle"
           name="radio_button_unchecked"
-          class="unselected"
+          class="radio-bubble unselected"
+          :class="{ 'active': isActive }"
         />
       </div>
 
@@ -184,9 +186,8 @@
   .unselected
     fill: $core-text-annotation
 
-  .active
-    .selected
-      outline: $core-outline
+  .radio-bubble.active
+    outline: $core-outline
 
   .text
     display: table-cell

--- a/kolibri/core/assets/src/views/language-switcher/modal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/modal.vue
@@ -9,7 +9,7 @@
       <k-radio-button
         v-for="language in languageOptions"
         :key="language.id"
-        :radiovalue="language.id"
+        :value="language.id"
         :label="language.lang_name"
         v-model="selectedLanguage"
       />

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentChangeStatusModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentChangeStatusModal.vue
@@ -8,12 +8,12 @@
       <p>{{ modalDescription }}</p>
       <k-radio-button
         :label="$tr('activeOption')"
-        :radiovalue="true"
+        :value="true"
         v-model="activeIsSelected"
       />
       <k-radio-button
         :label="$tr('inactiveOption')"
-        :radiovalue="false"
+        :value="false"
         v-model="activeIsSelected"
       />
 

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentCopyModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentCopyModal.vue
@@ -12,7 +12,7 @@
           <k-radio-button
             :key="classroom.id"
             :label="classroomLabel(classroom)"
-            :radiovalue="classroom.id"
+            :value="classroom.id"
             v-model="selectedClassroomId"
           />
         </template>

--- a/kolibri/plugins/coach/assets/src/views/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/RecipientSelector.vue
@@ -2,9 +2,9 @@
 
   <div>
     <k-radio-button
-      :radiovalue="true"
+      :value="true"
       :label="$tr('entireClass')"
-      :value="entireClassIsSelected"
+      :currentValue="entireClassIsSelected"
       @change="selectEntireClass()"
       :disabled="disabled"
     />

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -8,7 +8,7 @@
     <k-radio-button
       v-for="group in groupsExcludingCurrent"
       :key="group.id"
-      :radiovalue="group.id"
+      :value="group.id"
       :label="group.name"
       v-model="groupSelected"
     />
@@ -16,7 +16,7 @@
     <div v-if="!isUngrouped">
       <hr>
       <k-radio-button
-        radiovalue="ungrouped"
+        value="ungrouped"
         :label="$tr('ungrouped')"
         v-model="groupSelected"
       />

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/drive-list.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/drive-list.vue
@@ -16,8 +16,8 @@
         v-for="drive in drives"
         :key="drive.id"
         :label="enabledDriveLabel(drive)"
-        :radiovalue="drive.id"
-        :value="value"
+        :value="drive.id"
+        :currentValue="value"
         @change="$emit('input', drive.id)"
       />
     </div>

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-import-source-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/wizards/select-import-source-modal.vue
@@ -9,14 +9,14 @@
       <k-radio-button
         :label="$tr('network')"
         v-model="source"
-        radiovalue="network"
+        value="network"
         :disabled="disableUi || kolibriStudioIsOffline"
         :autofocus="!kolibriStudioIsOffline"
       />
       <k-radio-button
         :label="$tr('localDrives')"
         v-model="source"
-        radiovalue="local"
+        value="local"
         :disabled="disableUi"
       />
     </div>

--- a/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
@@ -166,7 +166,7 @@ describe('selectDriveModal component', () => {
   it('when a drive is selected, "Continue" button is enabled', () => {
     const wrapper = makeWrapper({ store });
     const { continueButton, writableImportableRadio } = getElements(wrapper);
-    writableImportableRadio().trigger('click');
+    writableImportableRadio().trigger('change');
     return wrapper.vm.$nextTick().then(() => {
       assert.equal(continueButton().attributes().disabled, undefined);
     });
@@ -176,7 +176,7 @@ describe('selectDriveModal component', () => {
     const wrapper = makeWrapper({ store });
     const transitionStub = sinon.stub(wrapper.vm, 'transitionWizardPage');
     const { continueButton, writableImportableRadio } = getElements(wrapper);
-    writableImportableRadio().trigger('click');
+    writableImportableRadio().trigger('change');
     return wrapper.vm.$nextTick().then(() => {
       continueButton().trigger('click');
       // same parameters for import or export flow

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -48,13 +48,13 @@
         <k-radio-button
           :label="$tr('classCoachLabel')"
           :description="$tr('classCoachDescription')"
-          :radiovalue="true"
+          :value="true"
           v-model="classCoachIsSelected"
         />
         <k-radio-button
           :label="$tr('facilityCoachLabel')"
           :description="$tr('facilityCoachDescription')"
-          :radiovalue="false"
+          :value="false"
           v-model="classCoachIsSelected"
         />
       </fieldset>

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -45,22 +45,18 @@
       />
 
       <fieldset class="coach-selector" v-if="coachIsSelected">
-        <label>
-          <k-radio-button
-            :label="$tr('classCoachLabel')"
-            :radiovalue="true"
-            v-model="classCoachIsSelected"
-          />
-          {{ $tr('classCoachDescription') }}
-        </label>
-        <label>
-          <k-radio-button
-            :label="$tr('facilityCoachLabel')"
-            :radiovalue="false"
-            v-model="classCoachIsSelected"
-          />
-          {{ $tr('facilityCoachDescription') }}
-        </label>
+        <k-radio-button
+          :label="$tr('classCoachLabel')"
+          :description="$tr('classCoachDescription')"
+          :radiovalue="true"
+          v-model="classCoachIsSelected"
+        />
+        <k-radio-button
+          :label="$tr('facilityCoachLabel')"
+          :description="$tr('facilityCoachDescription')"
+          :radiovalue="false"
+          v-model="classCoachIsSelected"
+        />
       </fieldset>
 
       <div class="core-modal-buttons">

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -61,13 +61,13 @@
           <k-radio-button
             :label="$tr('classCoachLabel')"
             :description="$tr('classCoachDescription')"
-            :radiovalue="true"
+            :value="true"
             v-model="classCoach"
           />
           <k-radio-button
             :label="$tr('facilityCoachLabel')"
             :description="$tr('facilityCoachDescription')"
-            :radiovalue="false"
+            :value="false"
             v-model="classCoach"
           />
         </fieldset>

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -58,22 +58,18 @@
         />
 
         <fieldset class="coach-selector" v-if="coachIsSelected">
-          <label>
-            <k-radio-button
-              :label="$tr('classCoachLabel')"
-              :radiovalue="true"
-              v-model="classCoach"
-            />
-            {{ $tr('classCoachDescription') }}
-          </label>
-          <label>
-            <k-radio-button
-              :label="$tr('facilityCoachLabel')"
-              :radiovalue="false"
-              v-model="classCoach"
-            />
-            {{ $tr('facilityCoachDescription') }}
-          </label>
+          <k-radio-button
+            :label="$tr('classCoachLabel')"
+            :description="$tr('classCoachDescription')"
+            :radiovalue="true"
+            v-model="classCoach"
+          />
+          <k-radio-button
+            :label="$tr('facilityCoachLabel')"
+            :description="$tr('facilityCoachDescription')"
+            :radiovalue="false"
+            v-model="classCoach"
+          />
         </fieldset>
       </section>
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -73,7 +73,7 @@
         ref="first-button"
         class="permission-preset-radio-button"
         v-model="selectedPreset"
-        radiovalue="nonformal"
+        value="nonformal"
         :label="$tr('selfManagedSetupTitle')"
         :description="$tr('selfManagedSetupDescription')"
       />
@@ -81,7 +81,7 @@
       <k-radio-button
         class="permission-preset-radio-button"
         v-model="selectedPreset"
-        radiovalue="formal"
+        value="formal"
         :label="$tr('adminManagedSetupTitle')"
         :description="$tr('adminManagedSetupDescription')"
       />
@@ -89,7 +89,7 @@
       <k-radio-button
         class="permission-preset-radio-button"
         v-model="selectedPreset"
-        radiovalue="informal"
+        value="informal"
         :label="$tr('informalSetupTitle')"
         :description="$tr('informalSetupDescription')"
       />

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -69,42 +69,30 @@
       @submit="setPermissions"
     >
 
-      <label class="permission-preset">
-        <k-radio-button
-          ref="first-button"
-          class="permission-preset-radio-button"
-          v-model="selectedPreset"
-          radiovalue="nonformal"
-          :label="$tr('selfManagedSetupTitle')"
-        />
-        <span class="permission-preset-description">
-          {{ $tr('selfManagedSetupDescription') }}
-        </span>
-      </label>
+      <k-radio-button
+        ref="first-button"
+        class="permission-preset-radio-button"
+        v-model="selectedPreset"
+        radiovalue="nonformal"
+        :label="$tr('selfManagedSetupTitle')"
+        :description="$tr('selfManagedSetupDescription')"
+      />
 
-      <label class="permission-preset">
-        <k-radio-button
-          class="permission-preset-radio-button"
-          v-model="selectedPreset"
-          radiovalue="formal"
-          :label="$tr('adminManagedSetupTitle')"
-        />
-        <span class="permission-preset-description">
-          {{ $tr('adminManagedSetupDescription') }}
-        </span>
-      </label>
+      <k-radio-button
+        class="permission-preset-radio-button"
+        v-model="selectedPreset"
+        radiovalue="formal"
+        :label="$tr('adminManagedSetupTitle')"
+        :description="$tr('adminManagedSetupDescription')"
+      />
 
-      <label class="permission-preset">
-        <k-radio-button
-          class="permission-preset-radio-button"
-          v-model="selectedPreset"
-          radiovalue="informal"
-          :label="$tr('informalSetupTitle')"
-        />
-        <span class="permission-preset-description">
-          {{ $tr('informalSetupDescription') }}
-        </span>
-      </label>
+      <k-radio-button
+        class="permission-preset-radio-button"
+        v-model="selectedPreset"
+        radiovalue="informal"
+        :label="$tr('informalSetupTitle')"
+        :description="$tr('informalSetupDescription')"
+      />
 
       <k-button
         slot="footer"
@@ -210,18 +198,6 @@
 
   .permission-preset
     cursor: pointer
-
-    &-radio-button
-      margin: 0
-      margin-top: 16px
-      font-size: 14px
-      font-weight: bold
-
-    &-description
-      color: $core-text-annotation
-      font-size: 12px
-      display: inline-block
-      margin-left: $margin-of-radio-button-text
 
     &-modal
       &-dismiss-button

--- a/kolibri/plugins/style_guide/assets/src/views/content/radio-buttons/example.html
+++ b/kolibri/plugins/style_guide/assets/src/views/content/radio-buttons/example.html
@@ -3,32 +3,32 @@
   <div>
     <k-radio-button
       label="Radio 1"
-      :radiovalue="1"
+      :value="1"
       v-model="model1"
     >
     </k-radio-button>
     <k-radio-button
       label="Radio 2"
-      :radiovalue="2"
+      :value="2"
       v-model="model1"
     >
     </k-radio-button>
     <k-radio-button
       label="Radio 3"
-      :radiovalue="3"
+      :value="3"
       v-model="model1"
     >
     </k-radio-button>
     <k-radio-button
       label="Radio 4 Disabled"
-      :radiovalue="4"
+      :value="4"
       :disabled="true"
       v-model="model2"
     >
     </k-radio-button>
     <k-radio-button
       label="Radio 5 Disabled"
-      :radiovalue="5"
+      :value="5"
       :disabled="true"
       v-model="model2"
     >

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
@@ -9,7 +9,7 @@
         v-model="selectedFacility"
         :key="facility.id"
         :label="facility.name"
-        :radiovalue="facility.id"
+        :value="facility.id"
       />
       <div class="core-modal-buttons">
         <k-button


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
![setup wizard](https://user-images.githubusercontent.com/9877852/38394006-b6def05c-38e1-11e8-9d8c-4955008f7a78.png)
![create user modal](https://user-images.githubusercontent.com/9877852/38394017-c09c46a8-38e1-11e8-8982-374ad647e0d1.png)
![edit user modal](https://user-images.githubusercontent.com/9877852/38394028-c6a5c092-38e1-11e8-9dbe-9867cace8ce4.png)

Allows for descriptions to be added to radio button labels in a uniform way across the app.
- [x] Add new `description` prop
- [x] [Style new `description` prop according to work in setup wizard] (https://github.com/learningequality/kolibri/issues/3401#issuecomment-375490135)
- [x] Use new `description` prop in appropriate intances of `k-radio-button`
- [x] [Clean up class names](https://learningequality.slack.com/archives/C0LE9NLCE/p1518643740000442?thread_ts=1518638722.000471&cid=C0LE9NLCE)
- [x] Fix recurring bug of radio button selection not being directly reflective of the radio buttons's state
    - [x] Clean up logic, which is handling 2 different forms of state for `checked` and `selected` state
- [x] Fix `focus` accessibility issues (unchecked boxes are never highlighted, inconsistent with HTML behavior)
- [x] [Fix `v-model` behavior (cross-compatibility issues with the `@input` event on `<input type="radio">`)](https://developer.mozilla.org/en-US/docs/Web/Events/input#Browser_compatibility)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

First commit has the simplest way to build on top of current `k-radio-button` to include descriptions.

Subsequent commits include cleanup and logic simplifications to address some of the quirks/issues I've ran into while using the radio button.

If you all think it's necessary, I'll break the first commit out for quick merge and continue the radio button work later.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Fixes #3401
- https://github.com/learningequality/kolibri/issues/3401#issuecomment-375490135
- [Discussion around new CSS class naming standards](https://learningequality.slack.com/archives/C0LE9NLCE/p1518643740000442?thread_ts=1518638722.000471&cid=C0LE9NLCE)
- [MDN docs describing `@input` incompatibility issues](https://developer.mozilla.org/en-US/docs/Web/Events/input#Browser_compatibility)
- [Potential improvements to the API using newer Vue features](https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
