### PR TITLE
Ignore case when creating/updating username

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -110,6 +110,7 @@
       save: 'Save',
       cancel: 'Cancel',
       required: 'This field is required',
+      usernameAlreadyExists: 'Username already exists',
       usernameNotAlphaNumUnderscore: 'Username can only contain letters, numbers, and underscores',
       classCoachLabel: 'Class coach',
       classCoachDescription: "Can only instruct classes that they're assigned to",
@@ -184,10 +185,21 @@
       nameIsInvalid() {
         return Boolean(this.nameIsInvalidText);
       },
+      usernameAlreadyExists() {
+        return this.facilityUsers.find(
+          ({ username }) => username.toLowerCase() === this.newUsername.toLowerCase()
+        );
+      },
       usernameIsInvalidText() {
         if (this.usernameBlurred || this.formSubmitted) {
+          if (this.username.toLowerCase() === this.newUsername.toLowerCase()) {
+            return '';
+          }
           if (this.newUsername === '') {
             return this.$tr('required');
+          }
+          if (this.usernameAlreadyExists) {
+            return this.$tr('usernameAlreadyExists');
           }
           if (!validateUsername(this.newUsername)) {
             return this.$tr('usernameNotAlphaNumUnderscore');
@@ -260,6 +272,7 @@
         currentFacilityId,
         currentUserId: state => state.core.session.user_id,
         currentUserKind: state => state.core.session.kind[0],
+        facilityUsers: state => state.pageState.facilityUsers,
         error: state => state.pageState.error,
         isBusy: state => state.pageState.isBusy,
       },

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -186,15 +186,17 @@
         return Boolean(this.nameIsInvalidText);
       },
       usernameAlreadyExists() {
+        // Just return if it's the same username with a different case
+        if (this.username.toLowerCase() === this.newUsername.toLowerCase()) {
+          return false;
+        }
+
         return this.facilityUsers.find(
           ({ username }) => username.toLowerCase() === this.newUsername.toLowerCase()
         );
       },
       usernameIsInvalidText() {
         if (this.usernameBlurred || this.formSubmitted) {
-          if (this.username.toLowerCase() === this.newUsername.toLowerCase()) {
-            return '';
-          }
           if (this.newUsername === '') {
             return this.$tr('required');
           }

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -191,7 +191,9 @@
         return Boolean(this.nameIsInvalidText);
       },
       usernameAlreadyExists() {
-        return this.facilityUsers.find(({ username }) => username === this.username);
+        return this.facilityUsers.find(
+          ({ username }) => username.toLowerCase() === this.username.toLowerCase()
+        );
       },
       usernameIsInvalidText() {
         if (this.usernameBlurred || this.formSubmitted) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Admin can create and update a username and considers `admin` and `ADMIN` to be different

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create 2 users (`a` and `b`)
2. Update username `a` to `B` or `b` to `A`
3. Create username `A`.
3. Error message should display

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#3477 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
