### PR TITLE
Hid back arrow in "<-- Select Content" when downloading channel

### DIFF
--- a/kolibri/core/assets/src/views/immersive-full-screen.vue
+++ b/kolibri/core/assets/src/views/immersive-full-screen.vue
@@ -2,7 +2,7 @@
 
   <div class="whole-page">
     <div class="top-bar">
-      <router-link class="back-btn" :to="backPageLink">
+      <router-link v-if="showLink" class="back-btn" :to="backPageLink">
         <mat-svg
           class="back svg-back"
           category="navigation"
@@ -34,6 +34,10 @@
       },
       backPageText: {
         type: String,
+      },
+      showLink: {
+        type: Boolean,
+        default: true,
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -3,6 +3,7 @@
   <immersive-full-screen
     :backPageText="$tr('selectContent')"
     :backPageLink="goBackLink"
+    :showLink="!taskInProgress"
   >
     <subpage-container withSideMargin>
       <task-progress


### PR DESCRIPTION


### Summary
See #2745 
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
![apr-05-2018 23-15-35](https://user-images.githubusercontent.com/18543718/38405940-648c137a-3927-11e8-8317-9ca914a18e9b.gif)

…

### Reviewer guidance
Go to imports and download a large channel like KA (en). You should not be able to exit from within the page
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
Fixed issue #2745 . 
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
