### PR TITLE
Change sinon .reset() to .resetHistory()

### DIFF
--- a/karma_config/testUtils.js
+++ b/karma_config/testUtils.js
@@ -10,8 +10,8 @@ class MockResource {
   }
 
   __resetMocks() {
-    this.getCollection.reset();
-    this.getModel.reset();
+    this.getCollection.resetHistory();
+    this.getModel.resetHistory();
   }
 
   __getFetchable(payload, willReject = false) {

--- a/kolibri/plugins/coach/assets/test/showPageActions.spec.js
+++ b/kolibri/plugins/coach/assets/test/showPageActions.spec.js
@@ -152,7 +152,7 @@ describe('showPage actions for coach exams section', () => {
     ClassroomResource.__resetMocks();
     ContentNodeResource.__resetMocks();
     ExamResource.__resetMocks();
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
   });
 
   describe('showExamsPage', () => {

--- a/kolibri/plugins/device_management/assets/test/actions/contentTreeViewerActions.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/contentTreeViewerActions.spec.js
@@ -84,7 +84,7 @@ describe('contentTreeViewer actions', () => {
   });
 
   afterEach(() => {
-    ContentNodeGranularResource.getFileSizes.reset();
+    ContentNodeGranularResource.getFileSizes.resetHistory();
   });
 
   function addFileSizes(node) {

--- a/kolibri/plugins/device_management/assets/test/actions/contentWizardActions.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/contentWizardActions.spec.js
@@ -80,7 +80,7 @@ describe('transitionWizardPage action', () => {
 
   afterEach(() => {
     showSelectContentPageStub.restore();
-    TaskResource.localDrives.reset();
+    TaskResource.localDrives.resetHistory();
   });
 
   it('REMOTEIMPORT flow correctly updates wizardState', () => {

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -78,9 +78,9 @@ describe('showSelectContentPage action', () => {
     ChannelResource.__resetMocks();
     ContentNodeGranularResource.__resetMocks();
     TaskResource.__resetMocks();
-    TaskResource.startRemoteChannelImport.reset();
-    TaskResource.startDiskChannelImport.reset();
-    TaskResource.cancelTask.reset();
+    TaskResource.startRemoteChannelImport.resetHistory();
+    TaskResource.startDiskChannelImport.resetHistory();
+    TaskResource.cancelTask.resetHistory();
   });
 
   function setUpStateForTransferType(transferType) {

--- a/kolibri/plugins/facility_management/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility_management/assets/test/state/facilityConfig.spec.js
@@ -42,7 +42,7 @@ describe('facility config page actions', () => {
   beforeEach(() => {
     FacilityResource.__resetMocks();
     FacilityDatasetResource.__resetMocks();
-    dispatchStub.reset();
+    dispatchStub.resetHistory();
     storeMock.state.pageState = {};
   });
 


### PR DESCRIPTION
Fixes #3462 by changing `.reset()` to `.resetHistory()` for various sinon test doubles.

