### PR TITLE
Coach content filter

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -25,7 +25,6 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from .utils.search import fuzz
-from kolibri.auth.models import AnonymousUser
 from kolibri.content import models
 from kolibri.content import serializers
 from kolibri.content.permissions import CanManageContent
@@ -233,10 +232,10 @@ class ContentNodeFilter(IdFilter):
         :return: content nodes filtered by coach_content if appropiate
         """
         user = self.request.user
-        if isinstance(user, AnonymousUser) or not user.roles.exists():
-            if not user.is_superuser:
-                return queryset.exclude(coach_content=True)
-        return queryset
+        if user.is_facility_user:  # exclude anon users
+            if user.roles.exists() or user.is_superuser:  # must have coach role or higher
+                return queryset
+        return queryset.exclude(coach_content=True)
 
     def filter_in_lesson(self, queryset, name, value):
         """

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -25,6 +25,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from .utils.search import fuzz
+from kolibri.auth.models import AnonymousUser
 from kolibri.content import models
 from kolibri.content import serializers
 from kolibri.content.permissions import CanManageContent
@@ -89,6 +90,7 @@ class ContentNodeFilter(IdFilter):
     popular = CharFilter(method="filter_popular")
     resume = CharFilter(method="filter_resume")
     kind = ChoiceFilter(method="filter_kind", choices=(content_kinds.choices + (('content', _('Content')),)))
+    by_role = BooleanFilter(method="filter_by_role")
     in_lesson = CharFilter(method="filter_in_lesson")
     in_exam = CharFilter(method="filter_in_exam")
 
@@ -221,6 +223,20 @@ class ContentNodeFilter(IdFilter):
         if value == 'content':
             return queryset.exclude(kind=content_kinds.TOPIC).order_by("lft")
         return queryset.filter(kind=value).order_by("lft")
+
+    def filter_by_role(self, queryset, name, value):
+        """
+        Show coach_content if they have coach role or higher.
+
+        :param queryset: all content nodes for this channel
+        :param value: 'boolean'
+        :return: content nodes filtered by coach_content if appropiate
+        """
+        user = self.request.user
+        if isinstance(user, AnonymousUser) or not user.roles.exists():
+            if not user.is_superuser:
+                return queryset.exclude(coach_content=True)
+        return queryset
 
     def filter_in_lesson(self, queryset, name, value):
         """

--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -208,6 +208,29 @@
   },
   {
     "fields": {
+      "license_owner": "",
+      "parent": "c391bfeec8a458f89f013cf1ca9cf33a",
+      "title": "coach_content",
+      "license_name": "WTFPL",
+      "tags": [],
+      "kind": "topic",
+      "content_id": "f2332710c2fd483386cdeb5dcbdda81d",
+      "tree_id": 1,
+      "rght": 10,
+      "description": "balbla5",
+      "available": true,
+      "coach_content": true,
+      "lft": 9,
+      "sort_order": null,
+      "level": 2,
+      "author": "",
+      "channel_id": "6199dde695db4ee4ab392222d5af1e5c"
+    },
+    "pk": "d84923c45695424aa43100baeba0bd9f",
+    "model": "content.contentnode"
+  },
+  {
+    "fields": {
       "lang_code": "en",
       "lang_subcode": "01",
       "lang_name": "English-Test",

--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -197,28 +197,6 @@
       "rght": 10,
       "description": "balbla5",
       "available": true,
-      "lft": 9,
-      "sort_order": null,
-      "level": 2,
-      "author": "",
-      "channel_id": "6199dde695db4ee4ab392222d5af1e5c"
-    },
-    "pk": "c391bfeec8a458f89f013cf1ca9cf33a",
-    "model": "content.contentnode"
-  },
-  {
-    "fields": {
-      "license_owner": "",
-      "parent": "c391bfeec8a458f89f013cf1ca9cf33a",
-      "title": "coach_content",
-      "license_name": "WTFPL",
-      "tags": [],
-      "kind": "topic",
-      "content_id": "f2332710c2fd483386cdeb5dcbdda81d",
-      "tree_id": 1,
-      "rght": 10,
-      "description": "balbla5",
-      "available": true,
       "coach_content": true,
       "lft": 9,
       "sort_order": null,
@@ -226,7 +204,7 @@
       "author": "",
       "channel_id": "6199dde695db4ee4ab392222d5af1e5c"
     },
-    "pk": "d84923c45695424aa43100baeba0bd9f",
+    "pk": "c391bfeec8a458f89f013cf1ca9cf33a",
     "model": "content.contentnode"
   },
   {

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -187,7 +187,6 @@ class ContentNodeAPITestCase(APITestCase):
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
         content.ContentNode.objects.all().update(available=False)
-        # import ipdb; ipdb.set_trace()
         response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}))
         self.assertEqual(
             response.data,

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -187,6 +187,7 @@ class ContentNodeAPITestCase(APITestCase):
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
         content.ContentNode.objects.all().update(available=False)
+        # import ipdb; ipdb.set_trace()
         response = self.client.get(reverse("contentnode_granular-detail", kwargs={"pk": c1_id}))
         self.assertEqual(
             response.data,
@@ -200,7 +201,7 @@ class ContentNodeAPITestCase(APITestCase):
                 "on_device_resources": 0,
                 "coach_content": False,
                 "importable": True,
-                "num_coach_contents": 0,
+                "num_coach_contents": 1,
                 "children": [
                     {
                         "pk": c2_id,
@@ -224,7 +225,7 @@ class ContentNodeAPITestCase(APITestCase):
                         "on_device_resources": 0,
                         "importable": True,
                         "coach_content": False,
-                        "num_coach_contents": 0,
+                        "num_coach_contents": 1,
                     }
                 ]
             }
@@ -255,7 +256,7 @@ class ContentNodeAPITestCase(APITestCase):
                 "on_device_resources": 0,
                 "importable": True,
                 "coach_content": False,
-                "num_coach_contents": 0,
+                "num_coach_contents": 1,
                 "children": [
                     {
                         "pk": c2_id,
@@ -279,7 +280,7 @@ class ContentNodeAPITestCase(APITestCase):
                         "on_device_resources": 0,
                         "importable": True,
                         "coach_content": False,
-                        "num_coach_contents": 0,
+                        "num_coach_contents": 1,
                     }
                 ]
             }

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -21,8 +21,8 @@ from kolibri.auth.test.helpers import provision_device
 from kolibri.content import models as content
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
-from kolibri.core.lessons.models import Lesson
 from kolibri.core.exams.models import Exam
+from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSummaryLog
 
 DUMMY_PASSWORD = "password"
@@ -200,7 +200,7 @@ class ContentNodeAPITestCase(APITestCase):
                 "on_device_resources": 0,
                 "coach_content": False,
                 "importable": True,
-                "num_coach_contents": 1,
+                "num_coach_contents": 0,
                 "children": [
                     {
                         "pk": c2_id,
@@ -224,7 +224,7 @@ class ContentNodeAPITestCase(APITestCase):
                         "on_device_resources": 0,
                         "importable": True,
                         "coach_content": False,
-                        "num_coach_contents": 1,
+                        "num_coach_contents": 0,
                     }
                 ]
             }
@@ -255,7 +255,7 @@ class ContentNodeAPITestCase(APITestCase):
                 "on_device_resources": 0,
                 "importable": True,
                 "coach_content": False,
-                "num_coach_contents": 1,
+                "num_coach_contents": 0,
                 "children": [
                     {
                         "pk": c2_id,
@@ -279,7 +279,7 @@ class ContentNodeAPITestCase(APITestCase):
                         "on_device_resources": 0,
                         "importable": True,
                         "coach_content": False,
-                        "num_coach_contents": 1,
+                        "num_coach_contents": 0,
                     }
                 ]
             }

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -456,7 +456,6 @@ export function showExam(store, classId, examId, questionNumber) {
           const contentPromise = ContentNodeResource.getCollection({
             in_exam: exam.id,
           }).fetch();
-
           contentPromise.only(
             samePageCheckGenerator(store),
             contentNodes => {

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -127,7 +127,7 @@ export function showChannels(store) {
         return;
       }
       const channelRootIds = channels.map(channel => channel.root);
-      ContentNodeResource.getCollection({ ids: channelRootIds })
+      ContentNodeResource.getCollection({ ids: channelRootIds, by_role: true })
         .fetch()
         .then(channelCollection => {
           // we want them to be in the same order as the channels list
@@ -153,7 +153,10 @@ export function showTopicsTopic(store, id, isRoot = false) {
   store.dispatch('SET_PAGE_NAME', isRoot ? PageNames.TOPICS_CHANNEL : PageNames.TOPICS_TOPIC);
   const promises = [
     ContentNodeResource.getModel(id).fetch(), // the topic
-    ContentNodeResource.getCollection({ parent: id }).fetch(), // the topic's children
+    ContentNodeResource.getCollection({
+      parent: id,
+      by_role: true,
+    }).fetch(), // the topic's children
     ContentNodeResource.fetchAncestors(id), // the topic's ancestors
     setChannelInfo(store),
   ];

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -22,24 +22,33 @@ const translator = createTranslator('learnerRecommendationPageTitles', {
 
 // User-agnostic recommendations
 function _getPopular() {
-  return ContentNodeResource.getCollection({ popular: 'true' }).fetch();
+  return ContentNodeResource.getCollection({ popular: 'true', by_role: true }).fetch();
 }
 
 function _getFeatured(state, channelId) {
-  return ContentNodeResource.getAllContentCollection({ channel_id: channelId }).fetch();
+  return ContentNodeResource.getAllContentCollection({
+    channel_id: channelId,
+    by_role: true,
+  }).fetch();
 }
 
 // User-specific recommendations
 function _getNextSteps(state) {
   if (isUserLoggedIn(state)) {
-    return ContentNodeResource.getCollection({ next_steps: currentUserId(state) }).fetch();
+    return ContentNodeResource.getCollection({
+      next_steps: currentUserId(state),
+      by_role: true,
+    }).fetch();
   }
   return Promise.resolve([]);
 }
 
 function _getResume(state) {
   if (isUserLoggedIn(state)) {
-    return ContentNodeResource.getCollection({ resume: currentUserId(state) }).fetch();
+    return ContentNodeResource.getCollection({
+      resume: currentUserId(state),
+      by_role: true,
+    }).fetch();
   }
   return Promise.resolve([]);
 }
@@ -168,7 +177,10 @@ export function showLearnContent(store, id) {
     ContentNodeResource.fetchNextContent(id),
     setChannelInfo(store),
   ];
-  const recommendedPromise = ContentNodeResource.getCollection({ recommendations_for: id }).fetch();
+  const recommendedPromise = ContentNodeResource.getCollection({
+    recommendations_for: id,
+    by_role: true,
+  }).fetch();
   ConditionalPromise.all(promises).only(
     samePageCheckGenerator(store),
     ([content, nextContent]) => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Content items are now filtered by whether they are meant for coaches/teachers or not.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

_**Frontend**_: Download a channel that has coach content, log in as learner, should not be able to see said content.
**_Backend_**: run the tests!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
