### PR TITLE
replace 'KA Lite' with 'Kolibri'

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -380,8 +380,8 @@ status.codes = {
     server.STATUS_FAILED_TO_START:
         'Failed to start (check log file: {0})'.format(server.DAEMON_LOG),
     server.STATUS_UNCLEAN_SHUTDOWN: 'Unclean shutdown',
-    server.STATUS_UNKNOWN_INSTANCE: 'Unknown KA Lite running on port',
-    server.STATUS_SERVER_CONFIGURATION_ERROR: 'KA Lite server configuration error',
+    server.STATUS_UNKNOWN_INSTANCE: 'Unknown Kolibri running on port',
+    server.STATUS_SERVER_CONFIGURATION_ERROR: 'Kolibri server configuration error',
     server.STATUS_PID_FILE_READ_ERROR: 'Could not read PID file',
     server.STATUS_PID_FILE_INVALID: 'Invalid PID file',
     server.STATUS_UNKNOWN: 'Could not determine status',

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -109,7 +109,7 @@ def stop(pid=None, force=False):
     """
 
     if not force:
-        # Kill the KA lite server
+        # Kill the Kolibri server
         kill_pid(pid)
     else:
         try:
@@ -253,7 +253,7 @@ def get_status():  # noqa: max-complexity=16
 
     try:
         # Timeout is 3 seconds, we don't want the status command to be slow
-        # TODO: Using 127.0.0.1 is a hardcode default from KA Lite, it could
+        # TODO: Using 127.0.0.1 is a hardcode default from Kolibri, it could
         # be configurable
         # TODO: HTTP might not be the protocol if server has SSL
         response = requests.get(


### PR DESCRIPTION
### Summary

Like it says on the box

### Reviewer guidance

Noticed in travis errors on https://github.com/learningequality/kolibri/pull/3461


----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
