### PR TITLE
Add filtering content nodes by lesson id

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -221,6 +221,13 @@ class ContentNodeFilter(IdFilter):
         return queryset.filter(kind=value).order_by("lft")
 
     def filter_in_lesson(self, queryset, name, value):
+        """
+        Show only content associated with this lesson
+
+        :param queryset: all content nodes
+        :param value: id of target lesson
+        :return: content nodes for this lesson
+        """
         resources = Lesson.objects.get(id=value).resources
         contentnode_id_list = [node['contentnode_id'] for node in resources]
         return queryset.filter(pk__in=contentnode_id_list)

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -30,8 +30,10 @@ from kolibri.content import serializers
 from kolibri.content.permissions import CanManageContent
 from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
 from kolibri.content.utils.paths import get_channel_lookup_url
+from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSessionLog
 from kolibri.logger.models import ContentSummaryLog
+
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +88,7 @@ class ContentNodeFilter(IdFilter):
     popular = CharFilter(method="filter_popular")
     resume = CharFilter(method="filter_resume")
     kind = ChoiceFilter(method="filter_kind", choices=(content_kinds.choices + ('content', _('Content'))))
+    in_lesson = CharFilter(method="filter_in_lesson")
 
     class Meta:
         model = models.ContentNode
@@ -216,6 +219,11 @@ class ContentNodeFilter(IdFilter):
         if value == 'content':
             return queryset.exclude(kind=content_kinds.TOPIC).order_by("lft")
         return queryset.filter(kind=value).order_by("lft")
+
+    def filter_in_lesson(self, queryset, name, value):
+        resources = Lesson.objects.get(id=value).resources
+        contentnode_id_list = [node['contentnode_id'] for node in resources]
+        return queryset.filter(pk__in=contentnode_id_list)
 
 
 class OptionalPageNumberPagination(pagination.PageNumberPagination):

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -87,7 +87,7 @@ class ContentNodeFilter(IdFilter):
     next_steps = CharFilter(method="filter_next_steps")
     popular = CharFilter(method="filter_popular")
     resume = CharFilter(method="filter_resume")
-    kind = ChoiceFilter(method="filter_kind", choices=(content_kinds.choices + ('content', _('Content'))))
+    kind = ChoiceFilter(method="filter_kind", choices=(content_kinds.choices + (('content', _('Content')),)))
     in_lesson = CharFilter(method="filter_in_lesson")
 
     class Meta:

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -588,23 +588,22 @@ class ContentNodeAPITestCase(APITestCase):
         admin = FacilityUser.objects.create(username="admin", facility=facility)
         admin.set_password(DUMMY_PASSWORD)
         admin.save()
+        nodes = []
+        nodes.append(content.ContentNode.objects.get(title='c3c1'))
+        nodes.append(content.ContentNode.objects.get(title='c2c3'))
+        nodes.append(content.ContentNode.objects.get(title='c2c2'))
+        json_resource = [{"contentnode_id": node.id, "content_id": node.content_id, "channel_id": node.channel_id} for node in nodes]
         lesson = Lesson.objects.create(
             title="title",
             is_active=True,
             collection=facility,
             created_by=admin,
-            resources=[
-                {
-                  "contentnode_id": "c391bfeec8a458f89f013cf1ca9cf33a",
-                  "content_id": "content",
-                  "channel_id": "channel"
-                }
-            ]
+            resources=json_resource
         )
         response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"in_lesson": lesson.id})
-        expected_output = content.ContentNode.objects.get(title='c3c1').id
         self.assertEqual(len(response.data), len(lesson.resources))
-        self.assertEqual(response.data[0]['id'], expected_output)
+        for counter, node in enumerate(nodes):
+            self.assertEqual(response.data[counter]['id'], node.id)
 
     def tearDown(self):
         """


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We now filter content nodes based on the lesson that they are in, given the lesson id.
Nodes are returned in order that they were put into lesson.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

**_Backend_**: Create lesson, add some content, then pass in that lesson id into `api/contentnode/in_lesson={id}`
**_Frontend_**: (No frontend UI currently for this)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Implemented feature discussed in this card. 
https://trello.com/c/AQRuiJ3e/12-inlesson-filter-for-contentnode-api

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [N/A] If there are any front-end changes, before/after screenshots are included
- [N/A] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
