### PR TITLE
Only count coach contents that are not topics and available

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -332,7 +332,11 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         # TODO return 0 by default if user is logged in as Learner
         if instance.kind == content_kinds.TOPIC:
             # get_descendants is weird for channels
-            return instance.get_descendants().filter(coach_content=True).count()
+            return instance.get_descendants() \
+                .filter(coach_content=True, available=True) \
+                .exclude(kind=content_kinds.TOPIC) \
+                .distinct() \
+                .count()
         else:
             return 1 if instance.coach_content else 0
 
@@ -375,7 +379,11 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
 
     def get_num_coach_contents(self, instance):
         if instance.kind == content_kinds.TOPIC:
-            return instance.get_descendants().filter(coach_content=True).count()
+            return instance.get_descendants() \
+                .filter(coach_content=True, available=True) \
+                .exclude(kind=content_kinds.TOPIC) \
+                .distinct() \
+                .count()
         else:
             return 1 if instance.coach_content else 0
 


### PR DESCRIPTION
Original implementation was over counting coach contents because it was including topics (in Firki, topics were manually changed to have coach_Content = true), as well as content that was not installed.

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
