### PR TITLE
Only count coach contents that are not topics and available

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -332,7 +332,11 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         # TODO return 0 by default if user is logged in as Learner
         if instance.kind == content_kinds.TOPIC:
             # get_descendants is weird for channels
-            return instance.get_descendants().filter(coach_content=True).count()
+            return instance.get_descendants() \
+                .filter(coach_content=True, available=True) \
+                .exclude(kind=content_kinds.TOPIC) \
+                .distinct() \
+                .count()
         else:
             return 1 if instance.coach_content else 0
 
@@ -374,8 +378,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
             .count()
 
     def get_num_coach_contents(self, instance):
+        # TODO return 0 by default if user is logged in as a Learner
         if instance.kind == content_kinds.TOPIC:
-            return instance.get_descendants().filter(coach_content=True).count()
+            return instance.get_descendants() \
+                .filter(coach_content=True, available=True) \
+                .exclude(kind=content_kinds.TOPIC) \
+                .distinct() \
+                .count()
         else:
             return 1 if instance.coach_content else 0
 


### PR DESCRIPTION
Original implementation was over counting coach contents because it was including topics (in Firki, topics were manually changed to have coach_Content = true, although this technically cannot happen on Studio UI), as well as content that was not installed.

