### PR TITLE
In exam filter

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -250,9 +250,12 @@ class ContentNodeFilter(IdFilter):
         :param value: id of target exam
         :return: content nodes for this exam
         """
-        question_sources = Exam.objects.get(id=value).question_sources
-        exercise_id_list = [node['exercise_id'] for node in question_sources]
-        return queryset.filter(pk__in=exercise_id_list)
+        try:
+            question_sources = Exam.objects.get(id=value).question_sources
+            exercise_id_list = [node['exercise_id'] for node in question_sources]
+            return queryset.filter(pk__in=exercise_id_list)
+        except (Exam.DoesNotExist, ValueError):  # also handles invalid uuid
+            return queryset.none()
 
 
 class OptionalPageNumberPagination(pagination.PageNumberPagination):

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -626,7 +626,7 @@ class ContentNodeAPITestCase(APITestCase):
         admin = FacilityUser.objects.create(username="admin", facility=facility)
         admin.set_password(DUMMY_PASSWORD)
         admin.save()
-        node = content.ContentNode.objects.get(title='c3c1').id
+        node = content.ContentNode.objects.get(title='c3c1')
         exam = Exam.objects.create(
             title="title",
             channel_id="test",

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -621,7 +621,7 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"in_lesson": '47385a6d4df3426db38ad0d20e113dce'})
         self.assertEqual(len(response.data), 0)
 
-    def test_in_exam_filter(self):
+    def _setup_exam(self):
         facility = Facility.objects.create(name="MyFac")
         admin = FacilityUser.objects.create(username="admin", facility=facility)
         admin.set_password(DUMMY_PASSWORD)
@@ -638,9 +638,25 @@ class ContentNodeAPITestCase(APITestCase):
                 {"exercise_id": node.id, "number_of_questions": 6}
             ]
         )
+
+        return exam, node
+
+    def test_in_exam_filter(self):
+        exam, node = self._setup_exam()
         response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"in_exam": exam.id})
         self.assertEqual(len(response.data), len(exam.question_sources))
         self.assertEqual(response.data[0]['id'], node.id)
+
+    def test_in_exam_filter_invalid_value(self):
+        self._setup_exam()
+
+        # request with invalid uuid
+        response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"in_exam": '123'})
+        self.assertEqual(len(response.data), 0)
+
+        # request with valid uuid
+        response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"in_exam": '47385a6d4df3426db38ad0d20e113dce'})
+        self.assertEqual(len(response.data), 0)
 
     def tearDown(self):
         """

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -52,7 +52,7 @@ function getExamReport(store, examId, userId, questionNumber = 0, interactionInd
         const questionList = createQuestionList(questionSources);
 
         const contentPromise = ContentNodeResource.getCollection({
-          ids: questionSources.map(item => item.exercise_id),
+          in_exam: exam.id,
         }).fetch();
 
         contentPromise.only(

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -9,6 +9,7 @@ from kolibri.auth.models import Collection
 from kolibri.auth.models import FacilityUser
 from kolibri.auth.permissions.base import RoleBasedPermissions
 
+
 class Exam(AbstractFacilityDataModel):
     """
     This class stores metadata about teacher created exams to test current student knowledge.
@@ -29,12 +30,12 @@ class Exam(AbstractFacilityDataModel):
     channel_id = models.CharField(max_length=32)
     # Number of total questions this exam has
     question_count = models.IntegerField()
-    # JSON blob describing content ids for the assessments this exam draws from, and how many
+    # JSON blob describing exercise node pks for the assessments this exam draws from, and how many
     # questions each assessment contributes to the exam. e.g.:
     #
     # [
-    #     {"exercise_id": <content_id1>, "number_of_questions": 6},
-    #     {"exercise_id": <content_id2>, "number_of_questions": 5}
+    #     {"exercise_id": <exercise_pk1>, "number_of_questions": 6},
+    #     {"exercise_id": <exercise_pk2>, "number_of_questions": 5}
     # ]
     question_sources = JSONField(default=[], blank=True)
     # The random seed we use to decide which questions are in the exam

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -486,7 +486,7 @@ export function showExamReportPage(store, classId, examId) {
         collection: classId,
       }).fetch({}, true);
       const contentNodesPromise = ContentNodeResource.getCollection({
-        ids: exam.question_sources.map(({ exercise_id }) => exercise_id),
+        in_exam: exam.id,
         fields: ['id', 'num_coach_contents'],
       }).fetch();
       ConditionalPromise.all([

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -451,7 +451,7 @@ export function showExam(store, classId, examId, questionNumber) {
           handleError(store, `Question number ${questionNumber} is not valid for this exam`);
         } else {
           const contentPromise = ContentNodeResource.getCollection({
-            ids: questionSources.map(item => item.exercise_id),
+            in_exam: exam.id,
           }).fetch();
 
           contentPromise.only(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We now filter content nodes based on the exam id.
They are not returned in any particular order.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

**_Backend:_** Create exam, add some exercises, then pass in that exam id into api/contentnode/in_exam={id}
Frontend: Things should look the same.

If reviewer can ensure I replaced the correct calls from `ids` to `in_exam`.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [N/A] If there are any front-end changes, before/after screenshots are included
- [N/A] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
