### PR TITLE
Dont bother checking for coach content stats if user is learner

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -1,10 +1,12 @@
 import os
+
 from django.core.cache import cache
 from django.db.models import Manager
 from django.db.models import Sum
 from django.db.models.query import RawQuerySet
 from le_utils.constants import content_kinds
 from rest_framework import serializers
+
 from kolibri.content.models import AssessmentMetaData
 from kolibri.content.models import ChannelMetadata
 from kolibri.content.models import ContentNode
@@ -329,16 +331,21 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         return value
 
     def get_num_coach_contents(self, instance):
-        # TODO return 0 by default if user is logged in as Learner
-        if instance.kind == content_kinds.TOPIC:
-            # get_descendants is weird for channels
-            return instance.get_descendants() \
-                .filter(coach_content=True, available=True) \
-                .exclude(kind=content_kinds.TOPIC) \
-                .distinct() \
-                .count()
-        else:
-            return 1 if instance.coach_content else 0
+        user = self.context["request"].user
+        if user.is_facility_user:  # must be facility user
+            if user.roles.exists() or user.is_superuser:  # must have coach role or higher
+                if instance.kind == content_kinds.TOPIC:
+                    # get_descendants is weird for channels
+                    return instance.get_descendants() \
+                        .filter(coach_content=True, available=True) \
+                        .exclude(kind=content_kinds.TOPIC) \
+                        .distinct() \
+                        .count()
+                else:
+                    return 1 if instance.coach_content else 0
+
+        # all other conditions return 0
+        return 0
 
 
 class ContentNodeGranularSerializer(serializers.ModelSerializer):
@@ -378,15 +385,21 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
             .count()
 
     def get_num_coach_contents(self, instance):
-        # TODO return 0 by default if user is logged in as a Learner
-        if instance.kind == content_kinds.TOPIC:
-            return instance.get_descendants() \
-                .filter(coach_content=True, available=True) \
-                .exclude(kind=content_kinds.TOPIC) \
-                .distinct() \
-                .count()
-        else:
-            return 1 if instance.coach_content else 0
+        user = self.context["request"].user
+        if user.is_facility_user:  # must be facility user
+            if user.roles.exists() or user.is_superuser:  # must have coach role or higher
+                if instance.kind == content_kinds.TOPIC:
+                    # get_descendants is weird for channels
+                    return instance.get_descendants() \
+                        .filter(coach_content=True, available=True) \
+                        .exclude(kind=content_kinds.TOPIC) \
+                        .distinct() \
+                        .count()
+                else:
+                    return 1 if instance.coach_content else 0
+
+        # all other conditions return 0
+        return 0
 
     def get_importable(self, instance):
         drive_id = self.context['request'].query_params.get('importing_from_drive_id', None)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

If logged in person does not have coach role or higher, then we don't bother calculating the number of coach content items.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Look at some coach content under different accounts (learner, coach, admin, etc.) and see if coach content indicator appears.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Implements this feature
https://trello.com/c/uWcwlNB8/48-dont-bother-checking-for-coach-content-stats-if-logged-in-as-a-learner
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [N/A] If there are any front-end changes, before/after screenshots are included
- [N/A] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
