### PR TITLE
Dry up kind property in session api

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -366,7 +366,8 @@ class SessionViewSet(viewsets.ViewSet):
                    'full_name': user.full_name,
                    'user_id': user.id,
                    'can_manage_content': user.can_manage_content}
-        roles = Role.objects.filter(user_id=user.id)
+
+        roles = list(Role.objects.filter(user_id=user.id).values_list('kind', flat=True).distinct())
 
         if len(roles) is 0:
             session.update({'facility_id': user.facility_id,
@@ -374,15 +375,8 @@ class SessionViewSet(viewsets.ViewSet):
                             'error': '200'})
         else:
             session.update({'facility_id': user.facility_id,
-                            'kind': [],
+                            'kind': roles,
                             'error': '200'})
-            for role in roles:
-                if role.kind == 'admin':
-                    session['kind'].append('admin')
-                elif role.kind == 'coach':
-                    session['kind'].append('coach')
-                elif role.kind == 'classroom assignable coach':
-                    session['kind'].append('classroom assignable coach')
 
         if user.is_superuser:
             session['kind'].insert(0, 'superuser')

--- a/kolibri/auth/test/test_api.py
+++ b/kolibri/auth/test/test_api.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase as BaseTestCase
 
 from .. import models
+from ..constants import role_kinds
 from .helpers import create_superuser
 from .helpers import provision_device
 
@@ -324,8 +325,8 @@ class LoginLogoutTestCase(APITestCase):
     def test_session_return_admin_and_coach_kind(self):
         self.client.post(reverse('session-list'), data={"username": self.admin.username, "password": "bar", "facility": self.facility.id})
         response = self.client.get(reverse('session-detail', kwargs={'pk': 'current'}))
-        self.assertTrue(response.data['kind'][0], 'admin')
-        self.assertTrue(response.data['kind'][1], 'coach')
+        self.assertIn(role_kinds.ADMIN, response.data['kind'])
+        self.assertIn(role_kinds.COACH, response.data['kind'])
 
     def test_session_return_anon_kind(self):
         response = self.client.get(reverse('session-detail', kwargs={'pk': 'current'}))


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Creates roles array in one shot. Now whenever we add a kind to roles, it will automatically appear in the session response, if the user has the new role.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does order matter in terms of the kind array?
ex. (['admin', 'coach'] as opposed to ['coach', 'admin'])

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Cleans up issue discussed here
https://trello.com/c/C2jQqcUQ/96-dry-up-the-kind-property-in-sessionserializer

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [N/A] If there are any front-end changes, before/after screenshots are included
- [N/A] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
