### PR TITLE
Add loaders to style guide

### DIFF
--- a/kolibri/core/assets/src/views/k-circular-loader.vue
+++ b/kolibri/core/assets/src/views/k-circular-loader.vue
@@ -12,12 +12,18 @@
 
   import UiProgressCircular from 'keen-ui/src/UiProgressCircular';
 
+  /**
+   * Used to show indeterminate loading
+   */
   export default {
     name: 'kCircularLoader',
     components: {
       UiProgressCircular,
     },
     props: {
+      /**
+       * Whether there should be a delay before the loader displays
+       */
       delay: {
         type: Boolean,
         required: true,

--- a/kolibri/core/assets/src/views/k-linear-loader.vue
+++ b/kolibri/core/assets/src/views/k-linear-loader.vue
@@ -14,16 +14,25 @@
 
   import uiProgressLinear from 'keen-ui/src/UiProgressLinear';
 
+  /**
+   * Used to show determinate or indeterminate loading
+   */
   export default {
     name: 'kLinearLoader',
     components: {
       uiProgressLinear,
     },
     props: {
+      /**
+       * Whether there should be a delay before the loader displays
+       */
       delay: {
         type: Boolean,
         required: true,
       },
+      /**
+       * Determinate or indeterminate
+       */
       type: {
         type: String,
         required: true,
@@ -31,9 +40,13 @@
           return val === 'determinate' || val === 'indeterminate';
         },
       },
+      /**
+       * If type is determinate, a number between 0 - 100
+       */
       progress: {
         type: Number,
         required: false,
+        default: 0,
       },
     },
   };

--- a/kolibri/plugins/style_guide/assets/src/views/content/loaders/index.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/loaders/index.vue
@@ -1,0 +1,61 @@
+<template>
+
+  <page-template title="Loaders" :completed="false">
+
+    <h3><code>{{ kCircularLoaderApi.name }}</code> API</h3>
+    <component-docs :api="kCircularLoaderApi" />
+    <h3>Code Example</h3>
+    <vue-example :code="kCircularLoaderExample" />
+
+
+    <h3><code>{{ kLinearLoaderApi.name }}</code> API</h3>
+    <component-docs :api="kLinearLoaderApi" />
+    <h3>Code Example</h3>
+    <vue-example :code="kLinearLoaderExample" />
+
+
+    <h3>Guidelines</h3>
+    <p>TODO</p>
+
+  </page-template>
+
+</template>
+
+
+<script>
+
+  import FullVue from 'vue/dist/vue.common';
+  import pageTemplate from '../../shell/page-template';
+  import componentDocs from '../../shell/component-docs';
+  import vueExample from '../../shell/vue-example';
+
+  import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
+  import kCircularLoader from 'kolibri.coreVue.components.kCircularLoader';
+
+  import kLinearLoaderExample from 'raw-loader!./k-linear-loader-example.html';
+  import kCircularLoaderExample from 'raw-loader!./k-circular-loader-example.html';
+
+  import kLinearLoaderApi from '!vue-doc!kolibri.coreVue.components.kLinearLoader';
+  import kCircularLoaderApi from '!vue-doc!kolibri.coreVue.components.kCircularLoader';
+
+  FullVue.component('k-linear-loader', kLinearLoader);
+  FullVue.component('k-circular-loader', kCircularLoader);
+
+  export default {
+    components: {
+      pageTemplate,
+      componentDocs,
+      vueExample,
+    },
+    data: () => ({
+      kCircularLoaderExample,
+      kLinearLoaderExample,
+      kCircularLoaderApi,
+      kLinearLoaderApi,
+    }),
+  };
+
+</script>
+
+
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/style_guide/assets/src/views/content/loaders/k-circular-loader-example.html
+++ b/kolibri/plugins/style_guide/assets/src/views/content/loaders/k-circular-loader-example.html
@@ -1,0 +1,15 @@
+<template>
+
+  <div>
+    <k-circular-loader :delay="false"></k-circular-loader>
+    <k-circular-loader :delay="true"></k-circular-loader>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {};
+
+</script>

--- a/kolibri/plugins/style_guide/assets/src/views/content/loaders/k-linear-loader-example.html
+++ b/kolibri/plugins/style_guide/assets/src/views/content/loaders/k-linear-loader-example.html
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    <k-linear-loader :delay="false" type="indeterminate"></k-linear-loader>
+    <br>
+    <k-linear-loader :delay="true" type="indeterminate"></k-linear-loader>
+    <br>
+    <k-linear-loader :delay="false" type="determinate" :progress="progress"></k-linear-loader>
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {
+    data: () => ({
+      progress: 50,
+    }),
+  };
+
+</script>

--- a/kolibri/plugins/style_guide/assets/src/views/shell/nav-menu.js
+++ b/kolibri/plugins/style_guide/assets/src/views/shell/nav-menu.js
@@ -14,6 +14,7 @@ import radioButtonsPage from '../content/radio-buttons';
 import textFieldsPage from '../content/text-fields';
 import filtersPage from '../content/filters';
 import dropdownMenusPage from '../content/dropdown-menus';
+import loadersPage from '../content/loaders';
 
 function sortSectionItems(items) {
   return sortBy(items, [item => item.itemName]);
@@ -107,6 +108,13 @@ const navMenu = [
         itemRoute: {
           path: `/components/dropdown-menus`,
           component: dropdownMenusPage,
+        },
+      },
+      {
+        itemName: 'Loaders',
+        itemRoute: {
+          path: `/components/loaders`,
+          component: loadersPage,
         },
       },
     ]),


### PR DESCRIPTION
### Summary

Documents usage of loaders in style guide. 
Guidelines will come later.

![localhost_8000_style_guide](https://user-images.githubusercontent.com/7193975/38634031-43a35882-3d76-11e8-95bd-ca77aa584448.png)

### Reviewer guidance

Check out [http://localhost:8000/style_guide#/components/loaders](http://localhost:8000/style_guide#/components/loaders)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
