### PR TITLE
Update wording in exam submission modal

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -112,14 +112,14 @@
   export default {
     name: 'examPage',
     $trs: {
-      submitExam: 'Submit',
+      submitExam: 'Submit exam',
       backToExamList: 'Back to exam list',
       questionsAnswered:
         '{numAnswered, number} of {numTotal, number} {numTotal, plural, one {question} other {questions}} answered',
       previousQuestion: 'Previous question',
       nextQuestion: 'Next question',
       goBack: 'Go back',
-      areYouSure: "Note: you can't change your answers after you submit",
+      areYouSure: 'You cannot change your answers after you submit',
       unanswered:
         'You have {numLeft, number} {numLeft, plural, one {question} other {questions}} unanswered',
       noItemId: 'This question has an error, please move on to the next question',

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -77,7 +77,7 @@
         </p>
         <div class="core-modal-buttons">
           <k-button
-            :text="$tr('cancel')"
+            :text="$tr('goBack')"
             appearance="flat-button"
             @click="toggleModal"
           />
@@ -118,7 +118,7 @@
         '{numAnswered, number} of {numTotal, number} {numTotal, plural, one {question} other {questions}} answered',
       previousQuestion: 'Previous question',
       nextQuestion: 'Next question',
-      cancel: 'Cancel',
+      goBack: 'Go back',
       areYouSure: "Note: you can't change your answers after you submit",
       unanswered:
         'You have {numLeft, number} {numLeft, plural, one {question} other {questions}} unanswered',


### PR DESCRIPTION
### Summary

* Update wording in exam submission modal
* Fixes #3404 

![localhost_8000_learn_ ipad](https://user-images.githubusercontent.com/7193975/38635944-bf66e358-3d7b-11e8-9ee2-7cddd34a5a50.png)

### Reviewer guidance

Attempt to submit an exam.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
