### PR TITLE
Do not allow duplicate usernames

### DIFF
--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -43,7 +43,7 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         return super(FacilityUserSerializer, self).create(validated_data)
 
     def update(self, instance, validated_data):
-        if FacilityUser.objects.exclude(id__exact=instance.id).filter(username__iexact=validated_data['username']).exists():
+        if validated_data.get('username') and FacilityUser.objects.exclude(id__exact=instance.id).filter(username__iexact=validated_data['username']).exists():
             raise serializers.ValidationError(_('An account with that username already exists'))
         return super(FacilityUserSerializer, self).update(instance, validated_data)
 

--- a/kolibri/auth/serializers.py
+++ b/kolibri/auth/serializers.py
@@ -42,6 +42,11 @@ class FacilityUserSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(_('An account with that username already exists'))
         return super(FacilityUserSerializer, self).create(validated_data)
 
+    def update(self, instance, validated_data):
+        if FacilityUser.objects.exclude(id__exact=instance.id).filter(username__iexact=validated_data['username']).exists():
+            raise serializers.ValidationError(_('An account with that username already exists'))
+        return super(FacilityUserSerializer, self).update(instance, validated_data)
+
 
 class FacilityUserSignupSerializer(FacilityUserSerializer):
 


### PR DESCRIPTION
### Summary

Do not allow users to change their username to an existing one.
Allow users to change the case of their username.
Fixes #3391
Should also fix  #3476

![localhost_8000_user_ ipad 3](https://user-images.githubusercontent.com/7193975/38646368-8ad08f88-3d9c-11e8-817b-5de90633c358.png)

### Reviewer guidance

Attempt to change your username to an existing one.
Change the case of your username.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
