### PR TITLE
Include channel in search results

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -30,8 +30,8 @@ from kolibri.content import serializers
 from kolibri.content.permissions import CanManageContent
 from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_filter
 from kolibri.content.utils.paths import get_channel_lookup_url
-from kolibri.core.lessons.models import Lesson
 from kolibri.core.exams.models import Exam
+from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSessionLog
 from kolibri.logger.models import ContentSummaryLog
 
@@ -110,9 +110,7 @@ class ContentNodeFilter(IdFilter):
         if not fuzzed_tokens[0]:
             return []
         token_queries = [reduce(lambda x, y: x | y, [Q(stemmed_metaphone__contains=token) for token in tokens]) for tokens in fuzzed_tokens]
-        return queryset.filter(
-            Q(parent__isnull=False),
-            reduce(lambda x, y: x & y, token_queries))
+        return queryset.filter(reduce(lambda x, y: x & y, token_queries))
 
     def filter_recommendations_for(self, queryset, name, value):
         """

--- a/kolibri/plugins/learn/assets/src/views/search-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page.vue
@@ -51,7 +51,7 @@
     },
     methods: {
       genContentLink(contentId, contentKind) {
-        if (contentKind === ContentNodeKinds.TOPIC) {
+        if (contentKind === ContentNodeKinds.TOPIC || contentKind === ContentNodeKinds.CHANNEL) {
           return {
             name: PageNames.TOPICS_TOPIC,
             params: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When searching a channel name, the channel (root node) will now appear in the search results.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Search any channel name and it should appear in the results.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Implements this feature.
https://github.com/learningequality/kolibri/issues/3512

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [N/A] If there are any front-end changes, before/after screenshots are included
- [N/A] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
