### PR TITLE
Don't try to create assessments results if the ContentNode does not h…

### DIFF
--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -227,7 +227,8 @@ def add_channel_activity_for_user(**options): # noqa: max-complexity=16
 
             # Get the list of assessment item ids from the assessment meta data
             assessment_item_ids = random_node.assessmentmetadata.first().assessment_item_ids
-
+            if not assessment_item_ids:
+                continue
             for i, session_log in enumerate(reversed(session_logs)):
                 # Always make students get 5 attempts correct in the most recent session
                 # if the exercise is complete


### PR DESCRIPTION
…ave AssessmentMetaData

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Running generateuserdata script fails for some channels that don't have assessments on the Content Nodes. The script checked the node is of kind content_kinds.EXERCISE, but that's not enough to warranty the existance of assessments.
This change just skip those nodes without assessments when running the script.

…

### Reviewer guidance
From a clean Kolibri installation, loaded the demo channel and ran generateuserdata

### References
n/a

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
