### PR TITLE
Move loading morango fixtures to kolibri

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -172,6 +172,9 @@ def initialize(debug=False):
             )
             update()
 
+        # load morango fixtures needed for certificate related operations
+        call_command("loaddata", "scopedefinitions")
+
 def _migrate_databases():
     """
     Try to migrate all active databases. This should not be called unless Django has

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -1,18 +1,21 @@
 """
 Tests for `kolibri` module.
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 import logging
 import os
 from functools import wraps
 
-import kolibri
 import pytest
+from mock import patch
+
+import kolibri
 from kolibri.core.deviceadmin.tests.test_dbrestore import is_sqlite_settings
 from kolibri.utils import cli
-from mock import patch
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +237,7 @@ def test_update(update, version_file=None, orig_version=None):
     update.assert_called_once()
 
 
+@pytest.mark.django_db
 @patch('kolibri.utils.cli.update')
 @patch('kolibri.core.deviceadmin.utils.dbbackup')
 def test_update_no_version_change(dbbackup, update, orig_version=None):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Move the job of loading morango-specific fixtures to the calling application.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Start kolibri server, and ensure `morango_scopedefinition` is filled in the database.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Attempts to address this issue.
https://github.com/learningequality/morango/issues/48

And in morango we reflect these changes.
https://github.com/learningequality/morango/pull/49

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
