### PR TITLE
Redirected Coach user to "Coach" page

### DIFF
--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -3,6 +3,7 @@ import {
   currentUserId,
   isSuperuser,
   isAdmin,
+  isCoach,
   currentFacilityId,
   facilities,
 } from 'kolibri.coreVue.vuex.getters';
@@ -187,13 +188,17 @@ function kolibriLogin(store, sessionPayload, isFirstDeviceSignIn) {
       store.dispatch('CORE_SET_SESSION', _sessionState(session));
       const facilityURL = urls['kolibri:facilitymanagementplugin:facility_management']();
       const deviceURL = urls['kolibri:devicemanagementplugin:device_management']();
+      const coachURL = urls['kolibri:coach:coach']();
       if (isFirstDeviceSignIn) {
         // Hacky way to redirect to content import page after completing setup wizard
         redirectBrowser(`${window.location.origin}${deviceURL}#/welcome`);
       } else if (isSuperuser(store.state) || isAdmin(store.state)) {
         /* Very hacky solution to redirect an admin or superuser to Manage tab on login*/
         redirectBrowser(window.location.origin + facilityURL);
-      } else {
+      } else if (isCoach(store.state)) {
+        /* Even more hacky solution to redirect a coach to Coach tab on login*/
+        redirectBrowser(window.location.origin + coachURL);
+      }else {
         redirectBrowser();
       }
     })

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -198,7 +198,7 @@ function kolibriLogin(store, sessionPayload, isFirstDeviceSignIn) {
       } else if (isCoach(store.state)) {
         /* Even more hacky solution to redirect a coach to Coach tab on login*/
         redirectBrowser(window.location.origin + coachURL);
-      }else {
+      } else {
         redirectBrowser();
       }
     })

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
+import assert from 'assert';
 import Vue from 'vue';
 import Vuex from 'vuex';
-import assert from 'assert';
-import coreStore from '../../src/state/store';
-import * as coreActions from '../../src/state/actions';
-import * as constants from '../../src/constants';
 import sinon from 'sinon';
 import urls from 'kolibri.urls';
 import { SessionResource, AttemptLogResource } from 'kolibri.resources';
+import coreStore from '../../src/state/store';
+import * as coreActions from '../../src/state/actions';
+import * as constants from '../../src/constants';
 import * as browser from '../../src/utils/browser';
 import ConditionalPromise from '../../src/conditionalPromise';
 
@@ -51,6 +51,7 @@ describe('Vuex store/actions for core module', () => {
     it('successful login', done => {
       urls['kolibri:facilitymanagementplugin:facility_management'] = () => '';
       urls['kolibri:devicemanagementplugin:device_management'] = () => '';
+      urls['kolibri:coach:coach'] = () => '';
       Object.assign(SessionResource, {
         createModel: () => ({
           save: () =>

--- a/kolibri/plugins/coach/urls.py
+++ b/kolibri/plugins/coach/urls.py
@@ -5,5 +5,5 @@ from .api_urls import urlpatterns
 
 urlpatterns = [
     url('^api/', include(urlpatterns)),
-    url('^$', views.CoachView.as_view()),
+    url('^$', views.CoachView.as_view(), name='coach'),
 ]


### PR DESCRIPTION


### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Changed it so that a URL is created for the coach section at login and added an
additional if statement to actions.js to verify if user logged in is a coach
![pullrequest2](https://user-images.githubusercontent.com/18543718/38710198-e77b0f56-3e73-11e8-8853-608ce21e9c7e.gif)

…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Login with a coach profile.
2. You should be immediately redirected to coach page.
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
From issue #3407 
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
