### PR TITLE
Remove useless channel data bootstrapping

### DIFF
--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -6,12 +6,6 @@
 {% block content %}
   <!-- Bootstrapping the initial information for all channels. -->
   {% kolibri_bootstrap_collection 'channel' 'ChannelResource' available="true" %}
-  {% if currentChannel %}
-    <!-- Bootstrapping the root node for the current channel in Explore tab. -->
-    {% kolibri_bootstrap_model 'contentnode' 'ContentNodeResource' kwargs_pk=currentChannel.root_id %}
-    <!-- Bootstrapping the top level topics for current channel in Explore tab. -->
-    {% kolibri_bootstrap_collection 'contentnode' 'ContentNodeResource' parent=currentChannel.root_id %}
-  {% endif %}
 
   {% if request.user.is_facility_user %}
     <!-- Bootstrapping the the user's memberships. -->

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -1,21 +1,12 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import logging as logger
 
 from django.views.generic.base import TemplateView
-from kolibri.content.utils.channels import get_current_or_first_channel
 
 logging = logger.getLogger(__name__)
 
 class LearnView(TemplateView):
     template_name = "learn/learn.html"
-
-    def get_context_data(self, **kwargs):
-        context = super(LearnView, self).get_context_data(**kwargs)
-
-        context['currentChannel'] = []
-        channel = get_current_or_first_channel(context['view'].request)
-        if channel:
-            context['currentChannel'] = channel
-
-        return context


### PR DESCRIPTION
### Summary
Some residual bootstrapping of channel data remains from... 0.4, I think. This removes it.

### Reviewer guidance
Stops queries that may well not be made from being made.

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
