### PR TITLE
Fix setup.py for pip 10.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
+	rm -r kolibri/dist/man kolibri/dist/bin || true # remove the two folders introduced by pip 10
 	# Remove unnecessary python2-syntax'ed file
 	# https://github.com/learningequality/kolibri/issues/3152
 	rm -f kolibri/dist/kolibri_exercise_perseus_plugin/static/mathjax/kathjax.py
@@ -188,4 +189,3 @@ dockerenvbuild: writeversion
 
 dockerenvdist: writeversion
 	docker run --env-file ./env.list -v $$PWD/dist:/kolibridist "learningequality/kolibri:$$(cat kolibri/VERSION | sed 's/+/_/g')"
-

--- a/kolibri/content/test/test_channel_import.py
+++ b/kolibri/content/test/test_channel_import.py
@@ -406,6 +406,10 @@ class Version1ImportTestCase(NaiveImportTestCase):
 
     name = VERSION_1
 
+    @classmethod
+    def tearDownClass(cls):
+        super(Version1ImportTestCase, cls).tearDownClass()
+
 
 class NoVersionImportTestCase(NaiveImportTestCase):
     """
@@ -413,6 +417,10 @@ class NoVersionImportTestCase(NaiveImportTestCase):
     """
 
     name = NO_VERSION
+
+    @classmethod
+    def tearDownClass(cls):
+        super(NoVersionImportTestCase, cls).tearDownClass()
 
 
 class NoVersionv020ImportTestCase(NoVersionImportTestCase):
@@ -428,6 +436,11 @@ class NoVersionv020ImportTestCase(NoVersionImportTestCase):
         p = content.Language.objects.get(lang_code="en")
         self.assertEqual(str(p), '')
 
+    @classmethod
+    def tearDownClass(cls):
+        super(NoVersionv020ImportTestCase, cls).tearDownClass()
+
+
 class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
     """
     Integration test for import from no version import
@@ -435,3 +448,7 @@ class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
     """
 
     legacy_schema = V040BETA3
+
+    @classmethod
+    def tearDownClass(cls):
+        super(NoVersionv040ImportTestCase, cls).tearDownClass()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ import logging
 import os
 import sys
 
-from pip.req import parse_requirements
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup
 from setuptools.command.install_scripts import install_scripts
 


### PR DESCRIPTION
### Summary
Travis stealth upgraded to pip 10, where the import paths are different.
This fixes that by introducing import that is agnostic to pip 10 vs 9.

### Reviewer guidance
Does Travis build?

### References
Fix from here: https://stackoverflow.com/questions/49837301/pip-10-no-module-named-pip-req/49837302#49837302

We may need to cherry pick this change to release-v0.9.x also.
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
