### PR TITLE
updates to tables

### DIFF
--- a/kolibri/core/assets/src/views/core-table.vue
+++ b/kolibri/core/assets/src/views/core-table.vue
@@ -37,8 +37,6 @@
   .core-table
     width: 100%
     font-size: 14px
-    // without this, we get inconsistent column widths
-    table-layout: fixed
 
   >>>thead
     border-bottom: solid 1px $core-grey

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
@@ -28,7 +28,7 @@
 
     <!-- TODO consolidate with facility_management user-list -->
     <section>
-      <core-table v-if="userData.length">
+      <core-table>
         <thead>
           <tr>
             <th class="visuallyhidden core-table-icon-col">
@@ -141,7 +141,7 @@
         </tbody>
       </core-table>
 
-      <p v-else>
+      <p v-if="!userData.length">
         {{ $tr('userTableEmptyMessage') }}
       </p>
 

--- a/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
@@ -1,20 +1,16 @@
 <template>
 
   <div>
+
     <breadcrumbs />
     <template v-if="showRecentOnly">
       <h1>{{ $tr('recentTitle') }}</h1>
       <p v-if="standardDataTable.length">{{ $tr('showingRecent', { threshold }) }}</p>
-      <p v-else>{{ $tr('noRecent', { threshold }) }}</p>
     </template>
     <template v-else>
       <h1>{{ $tr('topicsTitle') }}</h1>
-      <p v-if="!standardDataTable.length">{{ $tr('noChannels') }}</p>
     </template>
-    <core-table
-      v-if="standardDataTable.length"
-      :caption="$tr('channelList')"
-    >
+    <core-table :caption="$tr('channelList')">
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -46,6 +42,12 @@
         </tr>
       </tbody>
     </core-table>
+
+    <template v-if="!standardDataTable.length">
+      <p v-if="showRecentOnly">{{ $tr('noRecent', { threshold }) }}</p>
+      <p v-else>{{ $tr('noChannels') }}</p>
+    </template>
+
   </div>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
@@ -12,9 +12,7 @@
     </h1>
     <h1 v-else>{{ $tr('learners') }}</h1>
 
-    <p v-if="!standardDataTable.length">{{ $tr('noLearners') }}</p>
-
-    <core-table v-if="standardDataTable.length">
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -65,6 +63,8 @@
         </tr>
       </tbody>
     </core-table>
+
+    <p v-if="!standardDataTable.length">{{ $tr('noLearners') }}</p>
 
   </div>
 

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -4,8 +4,8 @@
 
     <breadcrumbs />
     <h1>{{ $tr('title') }}</h1>
-    <p v-if="!standardDataTable.length">{{ noProgressText }}</p>
-    <core-table v-if="standardDataTable.length">
+
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -47,6 +47,9 @@
       </tbody>
     </core-table>
 
+    <p v-if="!standardDataTable.length">
+      {{ noProgressText }}
+    </p>
 
   </div>
 
@@ -97,7 +100,7 @@
         return TableColumns;
       },
       noProgressText() {
-        return this.$tr('noRecentProgress', { treshold: RECENCY_THRESHOLD_IN_DAYS });
+        return this.$tr('noRecentProgress', { threshold: RECENCY_THRESHOLD_IN_DAYS });
       },
     },
     methods: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
@@ -2,10 +2,7 @@
 
   <div>
 
-    <div v-if="visibleUsers.length === 0">
-      {{ $tr('noUsersMatching', { searchFilter }) }}
-    </div>
-    <core-table v-else>
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -40,6 +37,11 @@
         </tr>
       </tbody>
     </core-table>
+
+    <p v-if="!visibleUsers.length">
+      {{ $tr('noUsersMatching', { searchFilter }) }}
+    </p>
+
   </div>
 
 </template>

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -16,7 +16,7 @@
         :primary="true"
       />
     </div>
-    <core-table v-if="!noClassesExist">
+    <core-table>
       <caption class="visuallyhidden">{{ $tr('tableCaption') }}</caption>
       <thead slot="thead">
         <tr>
@@ -58,7 +58,7 @@
       </tbody>
     </core-table>
 
-    <p v-else>{{ $tr('noClassesExist') }}</p>
+    <p v-if="noClassesExist">{{ $tr('noClassesExist') }}</p>
 
     <class-delete-modal
       v-if="modalShown===Modals.DELETE_CLASS"

--- a/kolibri/plugins/facility_management/assets/src/views/user-table.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-table.vue
@@ -186,10 +186,6 @@
     text-align: left
     font-weight: bold
 
-  .empty-message
-    text-align: center
-    font-weight: bold
-
   .user-action-button
     text-align: right
 


### PR DESCRIPTION
### Summary

re #3400 and #3549

* makes the empty states consistent:
  * consistent typography
  * always show header
* removes empty header space

Old - see screenshots in  #3549

new:

| ![image](https://user-images.githubusercontent.com/2367265/38838107-9a52072a-4189-11e8-8683-4456aa3fdd1a.png) |
|--|
| ![image](https://user-images.githubusercontent.com/2367265/38838148-c585d624-4189-11e8-9051-f264e5aefac2.png) |
| ![image](https://user-images.githubusercontent.com/2367265/38838167-d4295e4e-4189-11e8-94e8-0baa6ee7a07c.png) |
| ![image](https://user-images.githubusercontent.com/2367265/38838178-e0026f26-4189-11e8-92e8-c14a03c6852e.png) |
| ![image](https://user-images.githubusercontent.com/2367265/38838192-ea64f10a-4189-11e8-9ae1-a08c1a2cd486.png) |


### Reviewer guidance

Make sure this all looks okay


----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
