### PR TITLE
Resource Removal Autosave Deoptimization

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/lessons.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/lessons.js
@@ -251,7 +251,8 @@ export function showLessonResourceSelectionTopicPage(store, classId, lessonId, t
 }
 
 function getResourceCache(store, resourceIds) {
-  const { resourceCache } = store.state.pageState;
+  // duplicate data to remove reliance on pageState throughout the entire method
+  const { resourceCache } = Object.assign({}, store.state.pageState);
   const nonCachedResourceIds = [];
 
   if (resourceCache) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Quick fix for #3515 

After talks with @indirectlylit, thought it'd be best to just remove all server call optimizations until we have a more bulletproof solution or a new design.

----
#### Notes on the original fix 

`SaveTime = snackbar dismissal time + debounce time`
Removes a resource after `SaveTime` as long as one stays inside the coach plugin. 

If someone moves to a page that _is *not*_ scoped by a lesson before `SaveTime`, the temporary "optimistic" state they were just looking at is reset to its server representation. This could be confusing, and I'm thinking through the best way to avoid the issue.

The solution I'm leaning towards (if getting the `onRouteLeave` guard is out of the question) it to hold a persistent representation of the lesson's "working" state at a higher level than `pageState` within the coach app. But then we're maintaining yet another representation or resources. 

The reason `SaveTime` has to include both times: 

The snackbar is what allows a user the opportunity to "undo" their removal. The amount of time the snackbar is up represents the app's "uncertainty" as to whether or not the user _really_ wants to remove the resource.

The debounced `save` function is included because it holds any other actions happening to the `workingState`: reorders, removals, additions, etc. The most recent save is the one that happens and it carries the state of all the previous ones. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
