### PR TITLE
Learners coaches

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -36,7 +36,7 @@
       </k-grid-item>
     </k-grid>
 
-    <core-table v-if="group.users.length">
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-checkbox-col">
@@ -73,7 +73,11 @@
         </tr>
       </tbody>
     </core-table>
-    <p v-else>{{ $tr('noLearners') }}</p>
+
+    <p v-if="!group.users.length">
+      {{ $tr('noLearners') }}
+    </p>
+
   </div>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
@@ -28,7 +28,7 @@
 
     <!-- TODO consolidate with facility_management user-list -->
     <section>
-      <core-table v-if="userData.length">
+      <core-table>
         <thead>
           <tr>
             <th class="visuallyhidden core-table-icon-col">
@@ -141,7 +141,7 @@
         </tbody>
       </core-table>
 
-      <p v-else>
+      <p v-if="!userData.length">
         {{ $tr('userTableEmptyMessage') }}
       </p>
 

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -4,8 +4,8 @@
 
     <breadcrumbs />
     <h1>{{ $tr('title') }}</h1>
-    <p v-if="!standardDataTable.length">{{ noProgressText }}</p>
-    <core-table v-if="standardDataTable.length">
+
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -47,6 +47,9 @@
       </tbody>
     </core-table>
 
+    <p v-if="!standardDataTable.length">
+      {{ noProgressText }}
+    </p>
 
   </div>
 
@@ -97,7 +100,7 @@
         return TableColumns;
       },
       noProgressText() {
-        return this.$tr('noRecentProgress', { treshold: RECENCY_THRESHOLD_IN_DAYS });
+        return this.$tr('noRecentProgress', { threshold: RECENCY_THRESHOLD_IN_DAYS });
       },
     },
     methods: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
@@ -2,10 +2,7 @@
 
   <div>
 
-    <div v-if="visibleUsers.length === 0">
-      {{ $tr('noUsersMatching', { searchFilter }) }}
-    </div>
-    <core-table v-else>
+    <core-table>
       <thead slot="thead">
         <tr>
           <th class="core-table-icon-col"></th>
@@ -40,6 +37,11 @@
         </tr>
       </tbody>
     </core-table>
+
+    <p v-if="!visibleUsers.length">
+      {{ $tr('noUsersMatching', { searchFilter }) }}
+    </p>
+
   </div>
 
 </template>

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -59,7 +59,7 @@
       </template>
     </user-table>
 
-    <k-grid>
+    <k-grid class="top-margin">
       <k-grid-item size="3" cols="4">
         <h2>{{ $tr('learnerTableTitle') }}</h2>
       </k-grid-item>
@@ -190,6 +190,9 @@
 
   .right
     text-align: right
+
+  .top-margin
+    margin-top: 24px
 
   // overwrite global styling
   // TODO - find a better way of doing this

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -59,8 +59,9 @@
       :username="userToBeRemoved.username"
     />
 
+    <h3 class="section-header">{{ $tr('coachTableTitle') }}</h3>
+
     <user-table
-      :title="$tr('coachTableTitle')"
       :users="classCoaches"
       :emptyMessage="$tr('noCoachesInClassMessge')"
     >
@@ -73,8 +74,9 @@
       </template>
     </user-table>
 
+    <h3 class="section-header">{{ $tr('learnerTableTitle') }}</h3>
+
     <user-table
-      :title="$tr('learnerTableTitle')"
       :users="classLearners"
       :emptyMessage="$tr('noLearnersInClassMessage')"
     >
@@ -212,6 +214,10 @@
 
   .header
     font-weight: normal
+
+  .section-header
+    margin-top: 32px
+    font-size: 18px
 
   .user-roster
     overflow-x: auto

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -4,29 +4,21 @@
 
     <!-- TODO use grid -->
 
-    <!-- TODO use an icon button for click rather than a div. Accessibility -->
-    <div
-      id="name-edit-box"
-      @click="displayModal(Modals.EDIT_CLASS_NAME)"
-    >
-      <div
-        id="edit-name"
-        class="name-edit"
-      >
+    <div>
+      <h1 class="title-header">
         {{ currentClass.name }}
-      </div>
-      <mat-svg
-        id="edit-icon"
-        class="name-edit"
-        category="image"
-        name="edit"
-        aria-hidden="true"
+      </h1>
+      <ui-icon-button
+        icon="mode_edit"
+        type="secondary"
+        color="primary"
+        class="edit-button"
+        :ariaLabel="$tr('edit')"
+        @click="displayModal(Modals.EDIT_CLASS_NAME)"
       />
     </div>
 
-    <h2 class="header">
-      {{ $tr('coachEnrollmentPageTitle') }}
-    </h2>
+    <p>{{ $tr('coachEnrollmentPageTitle') }}</p>
 
     <div class="toolbar">
       <div class="enroll">
@@ -100,6 +92,7 @@
   import { displayModal } from '../../state/actions';
   import classRenameModal from './class-rename-modal';
   import userRemoveConfirmationModal from './user-remove-confirmation-modal';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kButton from 'kolibri.coreVue.components.kButton';
 
@@ -116,11 +109,13 @@
       noLearnersInClassMessage: "You don't have any enrolled learners",
       remove: 'Remove',
       noUsersExist: 'No users in this class',
+      edit: 'Edit class name',
     },
     components: {
       userTable,
       classRenameModal,
       userRemoveConfirmationModal,
+      uiIconButton,
       kRouterLink,
       kButton,
     },
@@ -175,49 +170,18 @@
 
   @require '~kolibri.styles.definitions'
 
-  .toolbar
-    margin-bottom: 32px
-
-  .searchbar
-    margin-top: 5px
-
-  #name-edit-box
-    display: inline-block
-    cursor: pointer
-    margin: 15px 0 5px
-
-  .name-edit
-    float: left
-
-  #edit-name
-    font-size: 1.5em
-    font-weight: bold
-
-  #edit-icon
-    fill: $core-action-normal
-    margin: 2px 0 0 5px
-
-  .toolbar:after
-    content: ''
-    display: table
-    clear: both
-
-  .enroll-user-button
-    width: 100%
-
-  .enroll
-    float: right
-
-  .empty-list
-    color: $core-text-annotation
-    margin-left: 10px
-
-  .header
-    font-weight: normal
-
   .section-header
     margin-top: 32px
     font-size: 18px
+
+  .title-header
+    display: inline-block
+
+  .edit-button
+    display: inline-block
+    position: relative
+    left: 10px
+    top: -4px
 
   .user-roster
     overflow-x: auto

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -1,8 +1,6 @@
 <template>
 
-  <div class="user-roster">
-
-    <!-- TODO use grid -->
+  <div>
 
     <div>
       <h1 class="title-header">
@@ -20,22 +18,6 @@
 
     <p>{{ $tr('coachEnrollmentPageTitle') }}</p>
 
-    <div class="toolbar">
-      <div class="enroll">
-        <k-router-link
-          :text="$tr('assignCoachesButtonLabel')"
-          :to="coachAssignmentLink"
-          appearance="raised-button"
-        />
-        <k-router-link
-          :text="$tr('enrollLearnerButtonLabel')"
-          :to="learnerEnrollmentLink"
-          :primary="true"
-          appearance="raised-button"
-        />
-      </div>
-    </div>
-
     <!-- Modals -->
     <class-rename-modal
       v-if="modalShown===Modals.EDIT_CLASS_NAME"
@@ -43,15 +25,26 @@
       :classid="currentClass.id"
       :classes="classes"
     />
-
     <user-remove-confirmation-modal
       v-if="modalShown===Modals.REMOVE_USER"
       @confirm="removalAction(currentClass.id, userToBeRemoved.id)"
       :classname="currentClass.name"
       :username="userToBeRemoved.username"
     />
+    <!-- /Modals -->
 
-    <h3 class="section-header">{{ $tr('coachTableTitle') }}</h3>
+    <k-grid>
+      <k-grid-item size="3" cols="4">
+        <h2>{{ $tr('coachTableTitle') }}</h2>
+      </k-grid-item>
+      <k-grid-item size="1" cols="4" class="right">
+        <k-router-link
+          :text="$tr('assignCoachesButtonLabel')"
+          :to="coachAssignmentLink"
+          appearance="raised-button"
+        />
+      </k-grid-item>
+    </k-grid>
 
     <user-table
       :users="classCoaches"
@@ -66,7 +59,19 @@
       </template>
     </user-table>
 
-    <h3 class="section-header">{{ $tr('learnerTableTitle') }}</h3>
+    <k-grid>
+      <k-grid-item size="3" cols="4">
+        <h2>{{ $tr('learnerTableTitle') }}</h2>
+      </k-grid-item>
+      <k-grid-item size="1" cols="4" class="right">
+        <k-router-link
+          :text="$tr('enrollLearnerButtonLabel')"
+          :to="learnerEnrollmentLink"
+          :primary="true"
+          appearance="raised-button"
+        />
+      </k-grid-item>
+    </k-grid>
 
     <user-table
       :users="classLearners"
@@ -93,6 +98,8 @@
   import classRenameModal from './class-rename-modal';
   import userRemoveConfirmationModal from './user-remove-confirmation-modal';
   import uiIconButton from 'keen-ui/src/UiIconButton';
+  import kGrid from 'kolibri.coreVue.components.kGrid';
+  import kGridItem from 'kolibri.coreVue.components.kGridItem';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kButton from 'kolibri.coreVue.components.kButton';
 
@@ -116,6 +123,8 @@
       classRenameModal,
       userRemoveConfirmationModal,
       uiIconButton,
+      kGrid,
+      kGridItem,
       kRouterLink,
       kButton,
     },
@@ -170,10 +179,6 @@
 
   @require '~kolibri.styles.definitions'
 
-  .section-header
-    margin-top: 32px
-    font-size: 18px
-
   .title-header
     display: inline-block
 
@@ -183,8 +188,12 @@
     left: 10px
     top: -4px
 
-  .user-roster
-    overflow-x: auto
-    overflow-y: hidden
+  .right
+    text-align: right
+
+  // overwrite global styling
+  // TODO - find a better way of doing this
+  .gutter-24 [class *= 'pure-u'], .gutter-16 [class *= 'pure-u']
+    padding: 0
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/class-enroll-form.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-enroll-form.vue
@@ -9,10 +9,11 @@
       />
     </div>
 
+    <h2>{{ $tr('userTableLabel') }}</h2>
+
     <user-table
       v-model="selectedUsers"
       :users="visibleFilteredUsers"
-      :title="$tr('userTableLabel')"
       :selectable="true"
       :selectAllLabel="$tr('selectAllOnPage')"
       :userCheckboxLabel="$tr('selectUser')"

--- a/kolibri/plugins/facility_management/assets/src/views/user-table.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-table.vue
@@ -1,14 +1,7 @@
 <template>
 
   <div>
-    <core-table class="user-table">
-      <caption v-if="title" class="title">
-        {{ title }}
-      </caption>
-      <caption v-else class="visuallyhidden">
-        {{ $tr('users') }}
-      </caption>
-
+    <core-table>
 
       <thead slot="thead">
         <tr>
@@ -160,7 +153,6 @@
       actions: {},
     },
     $trs: {
-      users: 'Users',
       coachTableTitle: 'Coaches',
       learnerTableTitle: 'Learners',
       fullName: 'Full name',
@@ -178,13 +170,8 @@
 
 <style lang="stylus" scoped>
 
-  .title, .empty-message
+  .empty-message
     margin-bottom: 16px
-
-  .title
-    font-size: 24px
-    text-align: left
-    font-weight: bold
 
   .user-action-button
     text-align: right


### PR DESCRIPTION

### Summary

Addresses comment in #3400:

>  it might aid discovery of the action buttons if they were contextualized to their sections -- so, "Assign coaches" button next to the "Coaches" section, and "Enroll learners" next to the "Learners" section

| Old | New |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/38910354-c09d9b66-427d-11e8-9bd3-db77940693c6.png) |  ![image](https://user-images.githubusercontent.com/2367265/38910357-c6e09eb0-427d-11e8-9921-91aaad719392.png) |


### Reviewer guidance

look good? work right?

### References

https://github.com/learningequality/kolibri/issues/3400

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
