### PR TITLE
Add @enter handlers on core-modals

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/delete-channel-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/delete-channel-modal.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="$tr('title')"
     @cancel="handleClickCancel()"
+    @enter="handleClickConfirm()"
   >
     <p>{{ $tr('confirmationQuestion', { channelTitle }) }}</p>
 

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/confirm-reset-modal.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="$tr('title')"
     @cancel="handleCancel"
+    @enter="handleConfirm()"
   >
     <div>
       <p>{{ $tr('confirmationQuestion') }}</p>

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -4,6 +4,7 @@
     :title="$tr('modalTitle')"
     :hasError="false"
     @cancel="close"
+    @enter="classDelete"
   >
     <div>
       <p>{{ $tr('confirmation', { classname: classname }) }}</p>

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
@@ -3,10 +3,11 @@
   <core-modal
     :title="$tr('deleteUser')"
     @cancel="closeModal()"
+    @enter="handleDeleteUser()"
   >
     <p>{{ $tr('confirmation', { username: username }) }}</p>
     <p>{{ $tr('warning', { username: username }) }}</p>
-  
+
     <div class="core-modal-buttons">
       <k-button
         :text="$tr('cancel')"

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -70,6 +70,7 @@
         v-if="submitModalOpen"
         :title="$tr('submitExam')"
         @cancel="toggleModal"
+        @enter="finishExam"
       >
         <p>{{ $tr('areYouSure') }}</p>
         <p v-if="questionsUnanswered">

--- a/kolibri/plugins/learn/assets/src/views/points-popup.vue
+++ b/kolibri/plugins/learn/assets/src/views/points-popup.vue
@@ -3,6 +3,7 @@
   <core-modal
     :title="$tr('niceWork')"
     @cancel="closePopover"
+    @enter="closePopover"
   >
 
     <div class="progress-icon">


### PR DESCRIPTION
### Summary
Adds `@enter` handers to core-modals that didn't have them, nor had a `<form>` so that keypress-enter reacted somehow.

For #3548, but also for other modals with similar behavior.

### Reviewer guidance

Go through all the modals updated and check that keypress-enter and keypress-esc produce reasonable behavior.

### References

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
