### PR TITLE
Fixes #3497: Change default: don't filter unrenderable content on import

### DIFF
--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -67,7 +67,7 @@ class Command(AsyncCommand):
         parser.add_argument(
             "--include-unrenderable-content",
             action='store_false',
-            default=True,
+            default=False,
             dest="renderable_only",
             help="Import all content, not just that which this Kolibri instance can render"
         )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Filtering by content types seems to make the `importcontent` command orders of magnitude slower. This commit simply switches the default for this option from `True` to `False`, so that it won't cause this performance penalty for end users until we can optimize it further.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try this with the new code, and note it takes a little while (30s?) before it kicks off the progress bar for the download:
`kolibri manage importcontent network 1ceff53605e55bef987d88e0908658c5`

Then try it again with the previous code, and note that it takes... forever, possibly?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Should address https://github.com/learningequality/kolibri/issues/3497

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
