### PR TITLE
Add showDownloadButtonInLearn to default config

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/constants.js
+++ b/kolibri/plugins/facility_management/assets/src/constants.js
@@ -28,6 +28,7 @@ export const defaultFacilityConfig = {
   learnerCanSignUp: true,
   learnerCanDeleteAccount: true,
   learnerCanLoginWithNoPassword: false,
+  showDownloadButtonInLearn: false,
 };
 
 export const notificationTypes = {

--- a/kolibri/plugins/facility_management/assets/src/state/actions/facilityConfig.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/facilityConfig.js
@@ -18,7 +18,7 @@ function showNotification(store, notificationType) {
   store.dispatch('CONFIG_PAGE_NOTIFY', notificationType);
 }
 
-function showFacilityConfigPage(store) {
+export function showFacilityConfigPage(store) {
   const FACILITY_ID = store.state.core.session.facility_id;
   preparePage(store.dispatch, {
     name: PageNames.FACILITY_CONFIG_PAGE,
@@ -53,7 +53,7 @@ function showFacilityConfigPage(store) {
     });
 }
 
-function saveFacilityConfig(store) {
+export function saveFacilityConfig(store) {
   showNotification(store, null);
   const { facilityDatasetId, settings } = store.state.pageState;
   const resourceRequests = [
@@ -70,9 +70,7 @@ function saveFacilityConfig(store) {
     });
 }
 
-function resetFacilityConfig(store) {
+export function resetFacilityConfig(store) {
   store.dispatch('CONFIG_PAGE_MODIFY_ALL_SETTINGS', defaultFacilityConfig);
   return saveFacilityConfig(store);
 }
-
-export { resetFacilityConfig, saveFacilityConfig, showFacilityConfigPage };


### PR DESCRIPTION
### Summary
Cherry pick of commit from #3561

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
