### PR TITLE
Only fetch the channelList once on landing on the manage content page.

### DIFF
--- a/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
@@ -6,10 +6,12 @@ import { canManageContent } from 'kolibri.coreVue.vuex.getters';
  *
  */
 export function refreshChannelList(store) {
+  store.dispatch('SET_CHANNEL_LIST_LOADING', true);
   return ChannelResource.getCollection()
     .fetch({ file_sizes: true }, true)
     .then(channels => {
       store.dispatch('SET_CHANNEL_LIST', channels);
+      store.dispatch('SET_CHANNEL_LIST_LOADING', false);
     });
 }
 

--- a/kolibri/plugins/device_management/assets/src/state/getters.js
+++ b/kolibri/plugins/device_management/assets/src/state/getters.js
@@ -29,6 +29,10 @@ export function installedChannelList(state) {
   return state.pageState.channelList;
 }
 
+export function installedChannelListLoading(state) {
+  return state.pageState.channelListLoading;
+}
+
 // Channels that are installed & also "available"
 export function installedChannelsWithResources(state) {
   return state.pageState.channelList.filter(channel => channel.available);

--- a/kolibri/plugins/device_management/assets/src/state/mutations/manageContentMutations.js
+++ b/kolibri/plugins/device_management/assets/src/state/mutations/manageContentMutations.js
@@ -15,3 +15,7 @@ export function SET_CONTENT_PAGE_TASKS(state, taskList) {
 export function SET_CHANNEL_LIST(state, channelList) {
   state.pageState.channelList = channelList;
 }
+
+export function SET_CHANNEL_LIST_LOADING(state, channelListLoading) {
+  state.pageState.channelListLoading = channelListLoading;
+}

--- a/kolibri/plugins/device_management/assets/src/state/wizardState.js
+++ b/kolibri/plugins/device_management/assets/src/state/wizardState.js
@@ -2,6 +2,7 @@
 export function manageContentPageState() {
   return {
     channelList: [],
+    channelListLoading: false,
     taskList: [],
     wizardState: importExportWizardState(),
   };

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
@@ -10,7 +10,7 @@
       </p>
 
       <ui-progress-linear
-        v-else-if="channelsLoading"
+        v-else-if="installedChannelListLoading"
         type="indefinite"
         color="primary"
       />
@@ -52,7 +52,7 @@
   import deleteChannelModal from './delete-channel-modal';
   import channelListItem from './channel-list-item';
   import { triggerChannelDeleteTask } from '../../state/actions/taskActions';
-  import { installedChannelsWithResources } from '../../state/getters';
+  import { installedChannelsWithResources, installedChannelListLoading } from '../../state/getters';
 
   export default {
     name: 'channelsGrid',
@@ -64,7 +64,6 @@
     },
     data: () => ({
       selectedChannelId: null,
-      channelsLoading: true,
     }),
     computed: {
       channelIsSelected() {
@@ -77,16 +76,11 @@
         return '';
       },
       noChannelsToShow() {
-        return this.sortedChannels.length === 0 && !this.channelsLoading;
+        return this.sortedChannels.length === 0 && !this.installedChannelListLoading;
       },
       sortedChannels() {
         return this.installedChannelsWithResources.slice().sort((c1, c2) => c1.name > c2.name);
       },
-    },
-    created() {
-      this.refreshChannelList().then(() => {
-        this.channelsLoading = false;
-      });
     },
     methods: {
       handleDeleteChannel() {
@@ -100,6 +94,7 @@
     vuex: {
       getters: {
         installedChannelsWithResources,
+        installedChannelListLoading,
         pageState: state => state.pageState,
       },
       actions: {

--- a/kolibri/plugins/device_management/assets/test/views/channels-grid.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/channels-grid.spec.js
@@ -82,7 +82,7 @@ describe('channelsGrid component', () => {
     return wrapper.vm
       .$nextTick()
       .then(() => {
-        wrapper.setData({ channelsLoading: true });
+        store.dispatch('SET_CHANNEL_LIST_LOADING', true);
         return wrapper.vm.$nextTick();
       })
       .then(() => {


### PR DESCRIPTION
### Summary
There were two separate calls to load the channel list on the manage content page. This reduces that to one.

### Reviewer guidance
Does the page still load correctly, and display correct loading behaviour?

### References
Fixes #3579 (or should mitigate it, at least).

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
