### PR TITLE
Do not show invalid credentials alert if pw is blank and simple sign-in is on

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -329,7 +329,7 @@ class SessionViewSet(viewsets.ViewSet):
             login(request, user)
             # Success!
             return Response(self.get_session(request))
-        elif not password and FacilityUser.objects.filter(username=username, facility=facility_id).exists():
+        elif not password and FacilityUser.objects.filter(username__iexact=username, facility=facility_id).exists():
             # Password was missing, but username is valid, prompt to give password
             return Response({
                 "message": "Please provide password for user",

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -223,8 +223,7 @@
         return Boolean(this.passwordMissing || this.invalidCredentials);
       },
       needPasswordField() {
-        const isSimpleButHasError = this.simpleSignIn && this.hasServerError;
-        return !this.simpleSignIn || isSimpleButHasError;
+        return !this.simpleSignIn || this.hasServerError;
       },
     },
     watch: {


### PR DESCRIPTION
### Summary

For #3582, Re-implements `invalidCredential` prop in `sign-in-page` to return `false` if password is blank and facility uses simple sign-on.

1. This means if a non-learner tries to login, they will not see an "invalid credentials" error above login form (as they would if non-simple sign-on is used).
1. If the non-learner provides an incorrect pw, they will see the "invalid credentials" error

In screencap, noticed weird behavior where pw field disappears after clearing it, but have not been able to reproduce.

![simple signon](https://user-images.githubusercontent.com/10248067/39152525-85d8e466-46fd-11e8-8e0b-eb63061b1a85.gif)

### Reviewer guidance
1. Test that login behavior works as usual with regular sign-on
1. Test that non-learner login behaves as described in #3582 with simple sign-on

### References

#3582 


----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
