### PR TITLE
Localize strings in user permissions and exam report page

### DIFF
--- a/kolibri/core/assets/src/views/exam-report/index.vue
+++ b/kolibri/core/assets/src/views/exam-report/index.vue
@@ -22,7 +22,7 @@
         <h3>{{ $tr('question', {questionNumber: questionNumber + 1}) }}</h3>
 
         <k-checkbox
-          label="Show correct answer"
+          :label="$tr('showCorrectAnswerLabel')"
           :checked="showCorrectAnswer"
           @change="toggleShowCorrectAnswer"
         />
@@ -73,6 +73,7 @@
       yourAnswer: 'Your answer',
       correctAnswerCannotBeDisplayed: 'Correct answer cannot be displayed',
       question: 'Question { questionNumber, number }',
+      showCorrectAnswerLabel: 'Show correct answer',
     },
     components: {
       immersiveFullScreen,

--- a/kolibri/plugins/device_management/assets/src/state/actions/managePermissionsActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/managePermissionsActions.js
@@ -8,6 +8,11 @@ import { handleApiError, samePageCheckGenerator } from 'kolibri.coreVue.vuex.act
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import head from 'lodash/head';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const translator = createTranslator('managePermissionsPageTitles', {
+  userPermissionsPageTitle: "{name}'s Device Permissions",
+});
 
 function fetchFacilityUsers() {
   return FacilityUserResource.getCollection().fetch();
@@ -88,7 +93,10 @@ export function showUserPermissionsPage(store, userId) {
   )._promise;
   return promise
     .then(function onUserSuccess([data]) {
-      store.dispatch('CORE_SET_TITLE', `${data.user.full_name}'s Device Permissions`);
+      store.dispatch(
+        'CORE_SET_TITLE',
+        translator.$tr('userPermissionsPageTitle', { name: data.user.full_name })
+      );
       return store.dispatch('SET_USER_PERMISSIONS_PAGE_STATE', data);
     })
     .catch(function onUserFailure(error) {


### PR DESCRIPTION
### Summary

Localize some strings that weren't being localized

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
#3441 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
