### PR TITLE
Re-enable filtering content-to-import by renderability, but faster!

### DIFF
--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -67,7 +67,7 @@ class Command(AsyncCommand):
         parser.add_argument(
             "--include-unrenderable-content",
             action='store_false',
-            default=False,
+            default=True,
             dest="renderable_only",
             help="Import all content, not just that which this Kolibri instance can render"
         )

--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -6,31 +6,31 @@ from kolibri.content.utils.content_types_tools import renderable_contentnodes_q_
 
 
 def get_files_to_transfer(channel_id, node_ids, exclude_node_ids, available, renderable_only=True):
-    files_to_transfer = LocalFile.objects.filter(files__contentnode__channel_id=channel_id, available=available)
 
+    # build initial file and node querysets, which will be further filtered below
+    files_to_transfer = LocalFile.objects.filter(available=available)
+    nodes_to_include = ContentNode.objects.filter(channel_id=channel_id)
+
+    # if requested, filter down to only include particular topics/nodes
     if node_ids:
-        node_ids = _get_node_ids(node_ids)
-        files_to_transfer = files_to_transfer.filter(files__contentnode__in=node_ids)
+        nodes_to_include = nodes_to_include.filter(pk__in=node_ids).get_descendants(include_self=True)
 
-    if exclude_node_ids:
-        exclude_node_ids = _get_node_ids(exclude_node_ids)
-        files_to_transfer = files_to_transfer.exclude(files__contentnode__in=exclude_node_ids)
-
+    # if requested, filter out nodes we're not able to render
     if renderable_only:
-        files_to_transfer = files_to_transfer.filter(files__contentnode__in=ContentNode.objects.filter(
-            channel_id=channel_id).filter(renderable_contentnodes_q_filter).distinct())
+        nodes_to_include = nodes_to_include.filter(renderable_contentnodes_q_filter)
+
+    # filter down the files query to only include files associated with the nodes we care about
+    files_to_transfer = files_to_transfer.filter(files__contentnode__in=nodes_to_include)
+
+    # filter down the query to remove files associated with nodes we've specifically been asked to exclude
+    if exclude_node_ids:
+        nodes_to_exclude = ContentNode.objects.filter(pk__in=exclude_node_ids).get_descendants(include_self=True)
+        files_to_transfer = files_to_transfer.exclude(files__contentnode__in=nodes_to_exclude)
 
     # Make sure the files are unique, to avoid duplicating downloads
     files_to_transfer = files_to_transfer.distinct()
 
+    # calculate the total file sizes across all files being returned in the queryset
     total_bytes_to_transfer = files_to_transfer.aggregate(Sum('file_size'))['file_size__sum'] or 0
 
     return files_to_transfer, total_bytes_to_transfer
-
-
-def _get_node_ids(node_ids):
-
-    return ContentNode.objects \
-        .filter(pk__in=node_ids) \
-        .get_descendants(include_self=True) \
-        .values_list('id', flat=True)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In #3563, we addressed #3497 by simply disabling "filter by renderability" completely. This PR reintroduces this as the default behavior, but approximately infinitely faster. :)

Performance tests for the old code (pre-#3563, so with "filter by renderability" still enabled) and the updated code can be found here, for 2 channels of different sizes:
https://docs.google.com/document/d/1yNo_Abd_Dz6NBtMIiQ_WXbbYl6oUC8jlx8g3e85PLuU/edit

tl;dr, performance for *all* combinations of filters is improved, including going from ∞ (forever) down to 3.5s with all filters enabled on the KA channel, and 4.5s to 180ms on the African Storybook channel. For KA, the current filtered solution also outperforms the temporary fix in #3563, which still took 47s. Even performance when not filtering at all is substantially improved.

The main thing causing performance issues in the original code was the chaining of multiple filter calls using the same related lookup. This resulted in multiple parallel joins to the same table within the generated SQL query, which grows n^2 as a function of the number of content nodes.

See: https://docs.djangoproject.com/en/1.8/topics/db/queries/#spanning-multi-valued-relationships for how such lookups are handled.

Additional gains came from doing `ContentNode.objects.filter(channel_id=channel_id)` instead of `files_to_transfer.filter(files__contentnode__in=node_ids)`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try importing content. See if you can still see the "Preparing..." step before it disappears, after selecting content for import and starting the process!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses #3497 more efficiently (and with fuller functionality) than the temp fix in #3563.

Benchmark reference: https://docs.google.com/document/d/1yNo_Abd_Dz6NBtMIiQ_WXbbYl6oUC8jlx8g3e85PLuU/edit

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
