### PR TITLE
Only use check_same_thread for sqlite

### DIFF
--- a/kolibri/content/utils/sqlalchemybridge.py
+++ b/kolibri/content/utils/sqlalchemybridge.py
@@ -4,14 +4,22 @@ import pickle
 
 from django.apps import apps
 from django.conf import settings
-from kolibri.content.models import CONTENT_SCHEMA_VERSION, NO_VERSION, V020BETA1, V040BETA3
-from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS, START_PRAGMAS
-from sqlalchemy import ColumnDefault, create_engine, event
+from sqlalchemy import ColumnDefault
+from sqlalchemy import create_engine
+from sqlalchemy import event
 from sqlalchemy.ext.automap import automap_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
-from .check_schema_db import DBSchemaError, db_matches_schema
+from .check_schema_db import db_matches_schema
+from .check_schema_db import DBSchemaError
+from kolibri.content.models import CONTENT_SCHEMA_VERSION
+from kolibri.content.models import NO_VERSION
+from kolibri.content.models import V020BETA1
+from kolibri.content.models import V040BETA3
+from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
+from kolibri.core.sqlite.pragmas import START_PRAGMAS
 
 
 def set_sqlite_connection_pragma(dbapi_connection, connection_record):
@@ -46,7 +54,7 @@ def get_engine(connection_string):
     engine = create_engine(
         connection_string,
         echo=False,
-        connect_args={'check_same_thread': False},
+        connect_args={'check_same_thread': False} if connection_string.startswith('sqlite') else {},
         poolclass=NullPool,
         convert_unicode=True,
     )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The `check_same_thread` is not available when connecting to a postgres database, so we will only use it if the backend is sqlite.

**_NOTE:_** This behavior is only observed when using the management commands or switching out a sqlite database for a postgres database, when content databases have already been downloaded.
This behavior is not observed when downloading through the UI. In other words, everything works fine when done through the frontend.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try downloading a channel with a settings file that points to a postgres database.
ex. `kolibri manage importchannel -- network be289bf750de4468bf51c2c164f1f973`
Before the change, it should error out.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
