### PR TITLE
Add empty state for coach content item report

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -121,43 +121,27 @@
     },
     methods: {
       genRowLink(row) {
+        const rowIsTopic = row.kind === ContentNodeKinds.TOPIC;
+        const params = {
+          classId: this.classId,
+          channelId: this.pageState.channelId,
+          [rowIsTopic ? 'topicId' : 'contentId']: row.id,
+        };
         if (TopicReports.includes(this.pageName)) {
-          if (row.kind === ContentNodeKinds.TOPIC) {
-            return {
-              name: PageNames.TOPIC_ITEM_LIST,
-              params: {
-                classId: this.classId,
-                channelId: this.pageState.channelId,
-                topicId: row.id,
-              },
-            };
-          }
           return {
-            name: PageNames.TOPIC_LEARNERS_FOR_ITEM,
-            params: {
-              classId: this.classId,
-              channelId: this.pageState.channelId,
-              contentId: row.id,
-            },
+            name: rowIsTopic ? PageNames.TOPIC_ITEM_LIST : PageNames.TOPIC_LEARNERS_FOR_ITEM,
+            params,
           };
         } else if (LearnerReports.includes(this.pageName)) {
-          if (row.kind === ContentNodeKinds.TOPIC) {
+          if (rowIsTopic) {
             return {
               name: PageNames.LEARNER_ITEM_LIST,
-              params: {
-                classId: this.classId,
-                channelId: this.pageState.channelId,
-                topicId: row.id,
-              },
+              params,
             };
           } else if (row.kind === ContentNodeKinds.EXERCISE) {
             return {
               name: PageNames.LEARNER_ITEM_DETAILS_ROOT,
-              params: {
-                classId: this.classId,
-                channelId: this.pageState.channelId,
-                contentId: row.id,
-              },
+              params,
             };
           }
         }

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -67,7 +67,7 @@
       </tbody>
     </core-table>
     <p v-if="!standardDataTable.length">
-      {{ $tr('noItems') }}
+      {{ $tr('emptyTableMessage') }}
     </p>
 
   </div>
@@ -112,7 +112,7 @@
         '{count, number, integer} {count, plural, one {exercise} other {exercises}}',
       contentCountText:
         '{count, number, integer} {count, plural, one {resource} other {resources}}',
-      noItems: 'No Items',
+      emptyTableMessage: 'No exercises or resources in this topic',
     },
     computed: {
       tableColumns() {

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -66,6 +66,9 @@
         </tr>
       </tbody>
     </core-table>
+    <p v-if="!standardDataTable.length">
+      {{ $tr('noItems') }}
+    </p>
 
   </div>
 
@@ -109,6 +112,7 @@
         '{count, number, integer} {count, plural, one {exercise} other {exercises}}',
       contentCountText:
         '{count, number, integer} {count, plural, one {resource} other {resources}}',
+      noItems: 'No Items',
     },
     computed: {
       tableColumns() {


### PR DESCRIPTION
FOr #3554, adds a message if, in a coach content report, a topic somehow doesn't have any children.

![screen shot 2018-04-24 at 1 12 20 pm](https://user-images.githubusercontent.com/10248067/39211756-8121a678-47c1-11e8-8a60-b674e6270efa.png)
