### PR TITLE
0.9 into develop again

### DIFF
--- a/kolibri/content/utils/sqlalchemybridge.py
+++ b/kolibri/content/utils/sqlalchemybridge.py
@@ -45,7 +45,7 @@ def get_engine(connection_string):
     engine = create_engine(
         connection_string,
         echo=False,
-        connect_args={'check_same_thread': False},
+        connect_args={'check_same_thread': False} if connection_string.startswith('sqlite') else {},
         poolclass=NullPool,
         convert_unicode=True,
     )

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,9 +3,9 @@
 # These are for testing
 factory-boy==2.7.0  # pyup: ignore - Needs an update, called 'faker' now
 fake-factory==0.5.7  # pyup: ignore Needs an update
-coverage
-mock
-pytest
-mixer
-pytest-cov
-pytest-django
+coverage==4.5.1
+mock==2.0.0
+mixer==6.0.1
+pytest==3.5.0
+pytest-cov==2.5.1
+pytest-django==3.2.1


### PR DESCRIPTION
### Summary
Dependencies upgraded automatically again and broke the build.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
