### PR TITLE
Add creation of Lessons to the generateuserdata script

### DIFF
--- a/kolibri/logger/management/commands/generateuserdata.py
+++ b/kolibri/logger/management/commands/generateuserdata.py
@@ -34,6 +34,7 @@ class Command(BaseCommand):
         parser.add_argument('--facilities', type=int, default=1, dest="facilities", help="Number of facilities")
         parser.add_argument('--no-onboarding', action='store_true', dest="no_onboarding", help="Automatically create superusers and skip onboarding")
         parser.add_argument('--num-content-items', type=int, dest='num_content_items', help="Number of content interactions per user")
+        parser.add_argument('--num-lessons', type=int, default=5, dest='num_lessons', help="Number of lessons to be created per class")
 
     def handle(self, *args, **options):
         # Load in the user data from the csv file to give a predictable source of user data
@@ -44,6 +45,7 @@ class Command(BaseCommand):
         n_classes = options['classes']
         no_onboarding = options['no_onboarding']
         num_content_items = options['num_content_items']
+        num_lessons = options['num_lessons']
 
         # Set the random seed so that all operations will be randomized predictably
         random.seed(options['seed'])
@@ -97,3 +99,12 @@ class Command(BaseCommand):
                             user=user,
                             now=now
                         )
+
+                # create lessons
+                utils.create_lessons_for_classroom(
+                    classroom=classroom,
+                    facility=facility,
+                    channels=ChannelMetadata.objects.all(),
+                    lessons=num_lessons,
+                    now=now
+                )

--- a/kolibri/logger/test/test_generateuserdata.py
+++ b/kolibri/logger/test/test_generateuserdata.py
@@ -5,11 +5,13 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from kolibri.auth.models import Classroom, Facility, FacilityUser
+from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSessionLog, ContentSummaryLog
 
 n_users = 2
 n_classes = 2
 n_facilities = 2
+n_lessons = 2
 
 CONTENT_STORAGE_DIR_TEMP = tempfile.mkdtemp()
 CONTENT_DATABASE_DIR_TEMP = tempfile.mkdtemp()
@@ -26,7 +28,8 @@ class GenerateUserDataTest(TestCase):
     def setUpTestData(cls):
         # To save testing time, only run the management command once
         # Then make assertions in separate tests to isolate failures
-        call_command('generateuserdata', users=n_users, classes=n_classes, facilities=n_facilities)
+        call_command('generateuserdata', users=n_users, classes=n_classes, facilities=n_facilities,
+                     num_lessons=n_lessons)
 
     def test_facilities_created(self):
         self.assertEqual(Facility.objects.count(), n_facilities)
@@ -44,3 +47,6 @@ class GenerateUserDataTest(TestCase):
     def test_summary_logs_for_each_user(self):
         for user in FacilityUser.objects.all():
             self.assertTrue(ContentSummaryLog.objects.filter(user=user).exists())
+
+    def test_lessons_created(self):
+        self.assertEqual(Lesson.objects.count(), n_lessons * n_classes * n_facilities)

--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -365,4 +365,3 @@ def create_lessons_for_classroom(**options):
             date_created=now
 
         )
-

--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -344,7 +344,7 @@ def create_lessons_for_classroom(**options):
 
     for l in range(lessons):
 
-        channel = random.choice(options['channels'])
+        channel = random.choice(channels)
         channel_content = ContentNode.objects.filter(channel_id=channel.id)
         # don't add more than 10 resources per Lesson:
         n_content_items = min(random.randint(0, channel_content.count() - 1), 10)

--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -342,7 +342,7 @@ def create_lessons_for_classroom(**options):
             coach = random.choice(members)
             facility.add_coach(coach)
 
-    for l in range(lessons):
+    for lesson in range(lessons):
 
         channel = random.choice(channels)
         channel_content = ContentNode.objects.filter(channel_id=channel.id)
@@ -357,7 +357,7 @@ def create_lessons_for_classroom(**options):
             lesson_content.append(content)
 
         Lesson.objects.create(
-            title='Lesson {}-{a}'.format(l, a=random.choice('ABCDEF')),
+            title='Lesson {}-{a}'.format(lesson, a=random.choice('ABCDEF')),
             resources=lesson_content,
             is_active=True,
             collection=classroom,

--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -21,7 +21,7 @@ from kolibri.logger.models import AttemptLog
 from kolibri.logger.models import ContentSessionLog
 from kolibri.logger.models import ContentSummaryLog
 from kolibri.logger.models import MasteryLog
-
+from kolibri.core.lessons.models import Lesson
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def get_or_create_classroom_users(**options):
     )[0:n_users]
 
 
-def add_channel_activity_for_user(**options): # noqa: max-complexity=16
+def add_channel_activity_for_user(**options):  # noqa: max-complexity=16
     n_content_items = options['n_content_items']
     channel = options['channel']
     user = options['user']
@@ -319,3 +319,50 @@ def add_channel_activity_for_user(**options): # noqa: max-complexity=16
                         masterylog=mastery_log,
                         sessionlog=session_log,
                     )
+
+
+def create_lessons_for_classroom(**options):
+
+    classroom = options['classroom']
+    channels = options['channels']
+    lessons = options['lessons']
+    facility = options['facility']
+    now = options['now']
+
+    coaches = facility.get_coaches()
+    if coaches:
+        coach = random.choice(coaches)
+    else:
+        members = facility.get_members()
+        if not members:
+            coach = FacilityUser.objects.create(username='admin', facility=facility)
+            coach.set_password('password')
+            coach.save()
+        else:
+            coach = random.choice(members)
+            facility.add_coach(coach)
+
+    for l in range(lessons):
+
+        channel = random.choice(options['channels'])
+        channel_content = ContentNode.objects.filter(channel_id=channel.id)
+        # don't add more than 10 resources per Lesson:
+        n_content_items = min(random.randint(0, channel_content.count() - 1), 10)
+        lesson_content = []
+        for i in range(0, n_content_items):
+            # Use this to randomly select a content node to generate the interaction for
+            index = random.randint(0, channel_content.count() - 1)
+            random_node = channel_content[index]
+            content = {"contentnode_id": random_node.id, "channel_id": channel.id, "content_id": random_node.content_id}
+            lesson_content.append(content)
+
+        Lesson.objects.create(
+            title='Lesson {}-{a}'.format(l, a=random.choice('ABCDEF')),
+            resources=lesson_content,
+            is_active=True,
+            collection=classroom,
+            created_by=coach,
+            date_created=now
+
+        )
+


### PR DESCRIPTION
### Summary
generateuserdata script has not been updated in some time. 
Lessons are not been generated by this script. To make performance tests on the different pages of Kolibri we need to have them created.

### Reviewer guidance
From a  Kolibri installation, running generateuserdata  must create the classrooms and lessons for each classroom (5 lessons per classroom by default)

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
