### PR TITLE
Use environment variables to build database connections

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -127,10 +127,22 @@ WSGI_APPLICATION = 'kolibri.deployment.default.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
+_db_engine = os.environ.get('KOLIBRI_DB_ENGINE', 'sqlite3')
+if _db_engine == "sqlite3":
+    _db_name = os.path.join(KOLIBRI_HOME, os.environ.get('KOLIBRI_DB_NAME', 'db.sqlite3'))
+elif _db_engine == "postgresql":
+    _db_name = os.environ.get('KOLIBRI_DB_NAME', 'kolibri')
+_db_password = os.environ.get('KOLIBRI_DB_PASSWORD', '')
+_db_user = os.environ.get('KOLIBRI_DB_USER', 'postgres')
+_db_host = os.environ.get('KOLIBRI_DB_HOST', '')
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(KOLIBRI_HOME, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.{engine}'.format(engine=_db_engine),
+        'NAME': _db_name,
+        'PASSWORD': _db_password,
+        'USER': _db_user,
+        'HOST': _db_host,
         'OPTIONS': {
             'timeout': 100,
         }


### PR DESCRIPTION
### Summary
Use environment variables to build database connections.
With these changes we'll be able to define a Postgresql configuration using env variables when running kolibri.
This is specially needed to run performance tests.

### Reviewer guidance
Set the variables and checked postgresql and sqlite keep on working as usual


### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
