### PR TITLE
Refactor coach/exams actions

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -107,13 +107,11 @@ export function showExamsPage(store, classId) {
   return ConditionalPromise.all(promises).only(
     samePageCheckGenerator(store),
     ([exams]) => {
-      const pageState = {
+      store.dispatch('SET_PAGE_STATE', {
         exams: _examsState(exams),
         examsModalSet: false,
         busy: false,
-      };
-
-      store.dispatch('SET_PAGE_STATE', pageState);
+      });
       store.dispatch('CORE_SET_ERROR', null);
       store.dispatch('CORE_SET_TITLE', translator.$tr('coachExamListPageTitle'));
       store.dispatch('CORE_SET_PAGE_LOADING', false);
@@ -131,13 +129,8 @@ function updateExamStatus(store, examId, isActive) {
     .save({ active: isActive })
     .then(
       () => {
-        const exams = store.state.pageState.exams;
-        const examIndex = exams.findIndex(exam => exam.id === examId);
-        exams[examIndex].active = isActive;
-
-        store.dispatch('SET_EXAMS', exams);
+        store.dispatch('SET_EXAM_STATUS', { examId, isActive });
         setExamsModal(store, false);
-
         createSnackbar(store, {
           text: snackbarTranslator.$tr(isActive ? 'examIsNowActive' : 'examIsNowInactive'),
           autoDismiss: true,

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -22,22 +22,28 @@ import { PageNames } from '../../constants';
 import { setClassState, handleCoachPageError } from './main';
 
 const translator = createTranslator('coachExamPageTitles', {
+  allChannels: 'All channels',
   coachExamListPageTitle: 'Exams',
   coachExamCreationPageTitle: 'Create new exam',
   coachExamReportDetailPageTitle: 'Exam Report Detail',
   examReportTitle: '{examTitle} report',
 });
 
-const allChannels = createTranslator('allChannels', {
-  allChannels: 'All channels',
-}).$tr('allChannels');
+const snackbarTranslator = createTranslator('examPageSnackbarTexts', {
+  changesToExamSaved: 'Changes to exam saved',
+  copiedExamToClass: 'Copied exam to { className }',
+  examDeleted: 'Exam deleted',
+  examIsNowActive: 'Exam is now active',
+  examIsNowInactive: 'Exam is now inactive',
+  newExamCreated: 'New exam created',
+});
 
 function _currentTopicState(topic, ancestors = []) {
   return {
     id: topic.id,
     title: topic.title,
     breadcrumbs: [
-      { id: null, title: allChannels },
+      { id: null, title: translator.$tr('allChannels') },
       ...ancestors,
       { id: topic.id, title: topic.title },
     ],
@@ -133,9 +139,7 @@ export function activateExam(store, examId) {
         setExamsModal(store, false);
 
         createSnackbar(store, {
-          text: createTranslator('examActivateSnackbar', {
-            examIsNowActive: 'Exam is now active',
-          }).$tr('examIsNowActive'),
+          text: snackbarTranslator.$tr('examIsNowActive'),
           autoDismiss: true,
         });
       },
@@ -156,9 +160,7 @@ export function deactivateExam(store, examId) {
         setExamsModal(store, false);
 
         createSnackbar(store, {
-          text: createTranslator('examDeactivateSnackbar', {
-            examIsNowInactive: 'Exam is now inactive',
-          }).$tr('examIsNowInactive'),
+          text: snackbarTranslator.$tr('examIsNowInactive'),
           autoDismiss: true,
         });
       },
@@ -173,9 +175,7 @@ export function copyExam(store, exam, className) {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       setExamsModal(store, false);
       createSnackbar(store, {
-        text: createTranslator('copyExam', {
-          copiedExamToClass: 'Copied exam to { className }',
-        }).$tr('copiedExamToClass', { className }),
+        text: snackbarTranslator.$tr('copiedExamToClass', { className }),
         autoDismiss: true,
       });
     },
@@ -197,9 +197,7 @@ export function updateExamDetails(store, examId, payload) {
           store.dispatch('SET_EXAMS', exams);
           setExamsModal(store, false);
           createSnackbar(store, {
-            text: createTranslator('editExamDetailsSnackbar', {
-              changesToExamSaved: 'Changes to exam saved',
-            }).$tr('changesToExamSaved'),
+            text: snackbarTranslator.$tr('changesToExamSaved'),
             autoDismiss: true,
           });
           store.dispatch('CORE_SET_PAGE_LOADING', false);
@@ -224,9 +222,7 @@ export function deleteExam(store, examId) {
 
         router.replace({ name: PageNames.EXAMS });
         createSnackbar(store, {
-          text: createTranslator('examDeleted', {
-            examDeleted: 'Exam deleted',
-          }).$tr('examDeleted'),
+          text: snackbarTranslator.$tr('examDeleted'),
           autoDismiss: true,
         });
         setExamsModal(store, false);
@@ -304,7 +300,7 @@ export function goToTopLevel(store) {
                 []
               ),
               id: null,
-              title: allChannels,
+              title: translator.$tr('allChannels'),
             };
             store.dispatch('SET_TOPIC', topic);
             store.dispatch('SET_SUBTOPICS', subtopics);
@@ -427,9 +423,7 @@ export function createExamAndRoute(store, exam) {
     () => {
       router.getInstance().push({ name: PageNames.EXAMS });
       createSnackbar(store, {
-        text: createTranslator('newExamCreated', {
-          newExamCreated: 'New exam created',
-        }).$tr('newExamCreated'),
+        text: snackbarTranslator.$tr('newExamCreated'),
         autoDismiss: true,
       });
     },

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -126,20 +126,20 @@ export function setExamsModal(store, modalName) {
   store.dispatch('SET_EXAMS_MODAL', modalName);
 }
 
-export function activateExam(store, examId) {
+function updateExamStatus(store, examId, isActive) {
   return ExamResource.getModel(examId)
-    .save({ active: true })
+    .save({ active: isActive })
     .then(
       () => {
         const exams = store.state.pageState.exams;
         const examIndex = exams.findIndex(exam => exam.id === examId);
-        exams[examIndex].active = true;
+        exams[examIndex].active = isActive;
 
         store.dispatch('SET_EXAMS', exams);
         setExamsModal(store, false);
 
         createSnackbar(store, {
-          text: snackbarTranslator.$tr('examIsNowActive'),
+          text: snackbarTranslator.$tr(isActive ? 'examIsNowActive' : 'examIsNowInactive'),
           autoDismiss: true,
         });
       },
@@ -147,25 +147,12 @@ export function activateExam(store, examId) {
     );
 }
 
+export function activateExam(store, examId) {
+  return updateExamStatus(store, examId, true);
+}
+
 export function deactivateExam(store, examId) {
-  return ExamResource.getModel(examId)
-    .save({ active: false })
-    .then(
-      () => {
-        const exams = store.state.pageState.exams;
-        const examIndex = exams.findIndex(exam => exam.id === examId);
-        exams[examIndex].active = false;
-
-        store.dispatch('SET_EXAMS', exams);
-        setExamsModal(store, false);
-
-        createSnackbar(store, {
-          text: snackbarTranslator.$tr('examIsNowInactive'),
-          autoDismiss: true,
-        });
-      },
-      error => handleError(store, error)
-    );
+  return updateExamStatus(store, examId, false);
 }
 
 export function copyExam(store, exam, className) {

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -124,7 +124,7 @@ export function setExamsModal(store, modalName) {
   store.dispatch('SET_EXAMS_MODAL', modalName);
 }
 
-function updateExamStatus(store, examId, isActive) {
+function updateExamStatus(store, { examId, isActive }) {
   return ExamResource.getModel(examId)
     .save({ active: isActive })
     .then(
@@ -141,11 +141,11 @@ function updateExamStatus(store, examId, isActive) {
 }
 
 export function activateExam(store, examId) {
-  return updateExamStatus(store, examId, true);
+  return updateExamStatus(store, { examId, isActive: true });
 }
 
 export function deactivateExam(store, examId) {
-  return updateExamStatus(store, examId, false);
+  return updateExamStatus(store, { examId, isActive: false });
 }
 
 export function copyExam(store, exam, className) {
@@ -209,10 +209,6 @@ export function deleteExam(store, examId) {
       },
       error => handleError(store, error)
     );
-}
-
-export function previewExam(store) {
-  setExamsModal(store, false);
 }
 
 /**

--- a/kolibri/plugins/coach/assets/src/state/store.js
+++ b/kolibri/plugins/coach/assets/src/state/store.js
@@ -96,4 +96,11 @@ export const mutations = {
   SET_TOOLBAR_TITLE(state, title) {
     state.pageState.toolbarTitle = title;
   },
+  SET_EXAM_STATUS(state, payload) {
+    const { examId, isActive } = payload;
+    const exams = [...state.pageState.exams];
+    const examIndex = exams.findIndex(exam => exam.id === examId);
+    exams[examIndex].active = isActive;
+    state.pageState.exams = exams;
+  },
 };


### PR DESCRIPTION
Some refactors to cleanup and remove code

1. Combine all the one-off translators for snackbars messages into one object
1. Use `id` instead of `pk` when requesting ContentNodes (so we don't rename pk -> id anymore)
1. Consolidate the almost-the-same activate/deactivateExam actions
1. Move in-cache exam updater to a mutation
1. Mechanical refactors
1. remove unused `previewExam` function