### PR TITLE
Use public facility endpoint for fullfacilitysync

### DIFF
--- a/kolibri/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/auth/management/commands/fullfacilitysync.py
@@ -5,6 +5,7 @@ import requests
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.validators import URLValidator
+from django.urls import reverse
 from django.utils.six.moves import input
 from morango.certificates import Certificate
 from morango.certificates import Filter
@@ -34,7 +35,7 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        facility_url = urljoin(base_url, 'api/public/v1/facility/')
+        facility_url = urljoin(base_url, reverse('publicfacility'))
         facility_resp = requests.get(facility_url)
         facility_resp.raise_for_status()
         facilities = facility_resp.json()

--- a/kolibri/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/auth/management/commands/fullfacilitysync.py
@@ -6,16 +6,20 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.validators import URLValidator
 from django.utils.six.moves import input
-from kolibri.auth.constants.morango_scope_definitions import FULL_FACILITY
-from kolibri.auth.models import FacilityUser
-from kolibri.core.device.models import DevicePermissions, DeviceSettings
-from kolibri.core.device.utils import device_provisioned
-from kolibri.tasks.management.commands.base import AsyncCommand
-from morango.certificates import Certificate, Filter, ScopeDefinition
+from morango.certificates import Certificate
+from morango.certificates import Filter
+from morango.certificates import ScopeDefinition
 from morango.controller import MorangoProfileController
 from morango.models import InstanceIDModel
 from requests.exceptions import ConnectionError
 from six.moves.urllib.parse import urljoin
+
+from kolibri.auth.constants.morango_scope_definitions import FULL_FACILITY
+from kolibri.auth.models import FacilityUser
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.models import DeviceSettings
+from kolibri.core.device.utils import device_provisioned
+from kolibri.tasks.management.commands.base import AsyncCommand
 
 
 class Command(AsyncCommand):
@@ -30,7 +34,7 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        facility_url = urljoin(base_url, 'api/facility/')
+        facility_url = urljoin(base_url, 'api/public/v1/facility/')
         facility_resp = requests.get(facility_url)
         facility_resp.raise_for_status()
         facilities = facility_resp.json()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Use the public facility endpoint. It was using the internal facility endpoint which serialized the dataset object's attributes. This broke the api call that the management command `fullfacilitysync` calls. We update the endpoint because we do not serialize the facility dataset object and only return the ID.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Use the mgmnt command! 
cc: @jamalex and I tested this change though and it works.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
