### PR TITLE
Filter requests by facility to prevent facility leaking.

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -247,6 +247,7 @@ class PublicFacilityViewSet(viewsets.ReadOnlyModelViewSet):
 class ClassroomFilter(FilterSet):
 
     role = CharFilter(method="filter_has_role_for")
+    parent = ModelChoiceFilter(queryset=Facility.objects.all())
 
     def filter_has_role_for(self, queryset, name, value):
         requesting_user = get_user(self.request)
@@ -266,7 +267,7 @@ class ClassroomFilter(FilterSet):
 
     class Meta:
         model = Classroom
-        fields = ['role', ]
+        fields = ['role', 'parent', ]
 
 
 class ClassroomViewSet(viewsets.ModelViewSet):

--- a/kolibri/plugins/device_management/assets/src/state/actions/managePermissionsActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/managePermissionsActions.js
@@ -5,6 +5,7 @@ import {
 } from 'kolibri.resources';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { handleApiError, samePageCheckGenerator } from 'kolibri.coreVue.vuex.actions';
+import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import head from 'lodash/head';
@@ -14,8 +15,9 @@ const translator = createTranslator('managePermissionsPageTitles', {
   userPermissionsPageTitle: "{name}'s Device Permissions",
 });
 
-function fetchFacilityUsers() {
-  return FacilityUserResource.getCollection().fetch();
+function fetchFacilityUsers(store) {
+  const facilityId = currentFacilityId(store.state);
+  return FacilityUserResource.getCollection({ member_of: facilityId }).fetch();
 }
 
 function fetchDevicePermissions() {
@@ -65,9 +67,10 @@ function fetchUserPermissions(userId) {
  * @returns Promise<void>
  */
 export function showManagePermissionsPage(store) {
-  const promises = ConditionalPromise.all([fetchFacilityUsers(), fetchDevicePermissions()]).only(
-    samePageCheckGenerator(store)
-  )._promise;
+  const promises = ConditionalPromise.all([
+    fetchFacilityUsers(store),
+    fetchDevicePermissions(),
+  ]).only(samePageCheckGenerator(store))._promise;
   return promises
     .then(function onSuccess([users, permissions]) {
       store.dispatch('SET_PERMISSIONS_PAGE_STATE', {

--- a/kolibri/plugins/facility_management/assets/src/state/actions/class.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/class.js
@@ -5,6 +5,7 @@ import {
   RoleResource,
 } from 'kolibri.resources';
 import { samePageCheckGenerator, handleApiError } from 'kolibri.coreVue.vuex.actions';
+import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { PageNames } from '../../constants';
@@ -160,7 +161,8 @@ export function showClassesPage(store) {
     name: PageNames.CLASS_MGMT_PAGE,
     title: 'Classes',
   });
-  return ClassroomResource.getCollection()
+  const facilityId = currentFacilityId(store.state);
+  return ClassroomResource.getCollection({ parent: facilityId })
     .fetch({}, true)
     .only(
       samePageCheckGenerator(store),
@@ -183,11 +185,11 @@ export function showClassEditPage(store, classId) {
     name: PageNames.CLASS_EDIT_MGMT_PAGE,
     title: 'Edit Class',
   });
-
+  const facilityId = currentFacilityId(store.state);
   const promises = [
     FacilityUserResource.getCollection({ member_of: classId }).fetch({}, true),
     ClassroomResource.getModel(classId).fetch(),
-    ClassroomResource.getCollection().fetch({}, true),
+    ClassroomResource.getCollection({ parent: facilityId }).fetch({}, true),
   ];
 
   const transformResults = ([facilityUsers, classroom, classrooms]) => ({
@@ -212,8 +214,9 @@ export function showClassEditPage(store, classId) {
 
 export function showLearnerClassEnrollmentPage(store, classId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
+  const facilityId = currentFacilityId(store.state);
   // all users in facility
-  const userPromise = FacilityUserResource.getCollection().fetch();
+  const userPromise = FacilityUserResource.getCollection({ member_of: facilityId }).fetch();
   // current class
   const classPromise = ClassroomResource.getModel(classId).fetch();
   // users in current class
@@ -240,8 +243,9 @@ export function showLearnerClassEnrollmentPage(store, classId) {
 }
 export function showCoachClassAssignmentPage(store, classId) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
+  const facilityId = currentFacilityId(store.state);
   // all users in facility
-  const userPromise = FacilityUserResource.getCollection().fetch();
+  const userPromise = FacilityUserResource.getCollection({ member_of: facilityId }).fetch();
   // current class
   const classPromise = ClassroomResource.getModel(classId).fetch({}, true);
 

--- a/kolibri/plugins/facility_management/assets/src/state/actions/user.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/user.js
@@ -5,7 +5,7 @@ import {
   handleApiError,
 } from 'kolibri.coreVue.vuex.actions';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
-import { currentUserId, isSuperuser } from 'kolibri.coreVue.vuex.getters';
+import { currentUserId, isSuperuser, currentFacilityId } from 'kolibri.coreVue.vuex.getters';
 import { PageNames } from '../../constants';
 import { _userState, _managePageTitle } from './helpers/mappers';
 import preparePage from './helpers/preparePage';
@@ -156,7 +156,9 @@ export function showUserPage(store) {
     title: _managePageTitle('Users'),
   });
 
-  FacilityUserResource.getCollection()
+  const facilityId = currentFacilityId(store.state);
+
+  FacilityUserResource.getCollection({ member_of: facilityId })
     .fetch({}, true)
     .only(
       samePageCheckGenerator(store),


### PR DESCRIPTION
### Summary
Fixes #3469 by adding filtering by facility id.
Currently even super users can only log in to the facility that they are a part of, so it just reads the current facility id from the logged in user's session.

### Reviewer guidance
Create a user in another facility, and see if it shows up on user page, and class enrollment page.

Create a classroom in another facility and see if it shows up in the classes list on facility management.

### References
#3469 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
