### PR TITLE
Don't make names with extraneous spaces

### DIFF
--- a/kolibri/logger/test/test_generateuserdata.py
+++ b/kolibri/logger/test/test_generateuserdata.py
@@ -50,3 +50,7 @@ class GenerateUserDataTest(TestCase):
 
     def test_lessons_created(self):
         self.assertEqual(Lesson.objects.count(), n_lessons * n_classes * n_facilities)
+
+    def test_no_spacey_names(self):
+        for user in FacilityUser.objects.all():
+            self.assertEqual(user.full_name.strip(), user.full_name)

--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -83,7 +83,7 @@ def get_or_create_classroom_users(**options):
             # Get the first base data that does not have a matching user already
             base_data = user_data[n_in_classroom + i]
             # Randomly create the name from 1 to 3 of the three user name fields
-            name = " ".join([base_data[key] for key in random.sample(user_data_name_fields, random.randint(1, 3))])
+            name = " ".join([base_data[key] for key in random.sample(user_data_name_fields, random.randint(1, 3)) if base_data[key]])
             user = FacilityUser.objects.create(
                 facility=facility,
                 full_name=name,


### PR DESCRIPTION
### Summary
Fixes #3347 by not including empty names in the concatenation.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
