### PR TITLE
Fix coach reports learner view

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -145,7 +145,7 @@ function _showChannelList(store, classId, userId = null, showRecentOnly = false)
   }
 
   return Promise.all(promises).then(
-    ([allChannelLastActive, , user]) => {
+    ([allChannelLastActive, , , user]) => {
       const defaultSortCol = showRecentOnly ? TableColumns.DATE : TableColumns.NAME;
       setReportSorting(store, defaultSortCol, SortOrders.DESCENDING);
       // HACK: need to append this to make pageState more consistent between pages


### PR DESCRIPTION
### Summary
Fixes the coach reports learner view.

### Reviewer guidance
Does the coach reports learner view display?

### References
Fixes #3622, a regression introduced by #3535.

Before
![image](https://user-images.githubusercontent.com/1680573/39783095-da948664-52c8-11e8-9d42-377a23ef5a46.png)


After
![image](https://user-images.githubusercontent.com/1680573/39783066-c88a7cd0-52c8-11e8-8a39-83f231c4b94e.png)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
