### PR TITLE
Re-style Coach Content Indicator

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -98,7 +98,7 @@ class ContentNodeFilter(IdFilter):
     class Meta:
         model = models.ContentNode
         fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related',
-                  'recommendations_for', 'next_steps', 'popular', 'resume', 'ids', 'content_id', 'channel_id', 'kind']
+                  'recommendations_for', 'next_steps', 'popular', 'resume', 'ids', 'content_id', 'channel_id', 'kind', 'by_role']
 
     def title_description_filter(self, queryset, name, value):
         """

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -222,11 +222,10 @@ class ContentNodeListSerializer(serializers.ListSerializer):
         # ensure that we are filtering by the parent only
         # this allows us to only cache results on the learn page
         from .api import ContentNodeFilter
-        pure_parent_query = "parent" in self.context['request'].GET and \
-            not any(field in self.context['request'].GET for field in ContentNodeFilter.Meta.fields if field != "parent")
+        parent_filter_only = set(self.context['request'].GET.keys()).intersection(ContentNodeFilter.Meta.fields) == set(['parent'])
 
         # Cache parent look ups only
-        if pure_parent_query:
+        if parent_filter_only:
             cache_key = 'contentnode_list_{parent}'.format(
                 parent=self.context['request'].GET.get('parent'))
 
@@ -263,7 +262,7 @@ class ContentNodeListSerializer(serializers.ListSerializer):
         # This has the happy side effect of not caching our dynamically calculated
         # recommendation queries, which might change for the same user over time
         # because they do not return topics
-        if topic_only and pure_parent_query:
+        if topic_only and parent_filter_only:
             cache.set(cache_key, result, 60 * 10)
 
         return result

--- a/kolibri/core/assets/src/views/coach-content-label.vue
+++ b/kolibri/core/assets/src/views/coach-content-label.vue
@@ -1,15 +1,8 @@
 <template>
 
-  <div v-if="value > 0">
-    <mat-svg
-      category="maps"
-      name="local_library"
-      class="coach-icon"
-    />
-    <span v-if="!isTopic">
-      {{ $tr('coachLabel') }}
-    </span>
-    <span v-else>
+  <div class="vab" v-if="value > 0">
+    <ui-icon icon="local_library" />
+    <span class="counter" v-if="isTopic">
       {{ value }}
     </span>
   </div>
@@ -19,8 +12,13 @@
 
 <script>
 
+  import UiIcon from 'keen-ui/src/UiIcon';
+
   export default {
     name: 'coachContentLabel',
+    components: {
+      UiIcon,
+    },
     props: {
       value: {
         type: Number,
@@ -44,9 +42,15 @@
 
   @require '~kolibri.styles.theme'
 
-  .coach-icon
-    fill: $core-status-progress
-    vertical-align: text-bottom
-    margin-right: 4px
+  .vab
+    vertical-align: bottom
+
+  .counter
+    font-size: 11px
+    vertical-align: inherit
+
+  >>>.ui-icon
+    font-size: 16px
+    color: $core-status-progress
 
 </style>

--- a/kolibri/core/assets/src/views/coach-content-label.vue
+++ b/kolibri/core/assets/src/views/coach-content-label.vue
@@ -1,7 +1,14 @@
 <template>
 
   <div class="vab" v-if="value > 0">
-    <ui-icon icon="local_library" />
+    <ui-tooltip trigger="icon" position="top center">
+      {{ $tr('coachLabel') }}
+    </ui-tooltip>
+    <ui-icon
+      class="coach-mat-icon"
+      ref="icon"
+      icon="local_library"
+    />
     <span class="counter" v-if="isTopic">
       {{ value }}
     </span>
@@ -13,18 +20,20 @@
 <script>
 
   import UiIcon from 'keen-ui/src/UiIcon';
+  import UiTooltip from 'keen-ui/src/UiTooltip';
 
   export default {
     name: 'coachContentLabel',
     components: {
       UiIcon,
+      UiTooltip,
     },
     props: {
       value: {
         type: Number,
         default: 0,
       },
-      // Show number next to label if a topic, otherwise show simple label
+      // Show number next to label if a topic
       isTopic: {
         type: Boolean,
         default: false,
@@ -49,7 +58,7 @@
     font-size: 11px
     vertical-align: inherit
 
-  >>>.ui-icon
+  .coach-mat-icon.ui-icon
     font-size: 16px
     color: $core-status-progress
 

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
@@ -205,5 +205,7 @@
 
   .select-all
     white-space: nowrap
+    .k-checkbox-container
+      margin-right: -70px
 
 </style>


### PR DESCRIPTION
Fixes #3611 

1. Replaces "Coach" text with tooltip when item is a leaf node
1. Resize icon to 16x16; resize counter to 11px
1. Add negative margin to "Select All" checkbox to the first column in import export is not so wide
1. Fix bug where `?parent` filter responses were getting cached even with `?by_role` filter. This meant that Anonymous users would see Coach Indicators and Coaches would see no indicators if a user viewed a certain page twice in both roles.

**Topic Node**
![screen shot 2018-05-08 at 3 05 36 pm](https://user-images.githubusercontent.com/10248067/39785541-6cbf1aba-52d1-11e8-92a6-e3c8505b8c48.png)

**Leaf Node**
![screen shot 2018-05-08 at 3 05 18 pm](https://user-images.githubusercontent.com/10248067/39785542-6ceb5b48-52d1-11e8-96a4-ffbe578bd274.png)

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
