### PR TITLE
Update texts on facility settings page

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
@@ -22,7 +22,6 @@
 
       <div class="mb">
         <div class="settings">
-          <h2>{{ $tr('settingsHeader') }}</h2>
           <template v-for="setting in settingsList">
             <k-checkbox
               :label="$tr(setting)"
@@ -138,7 +137,7 @@
       },
     },
     $trs: {
-      currentFacilityHeader: 'Your current facility',
+      currentFacilityHeader: 'Facility',
       learnerCanEditName: 'Allow learners and coaches to edit their full name',
       learnerCanEditPassword: 'Allow learners and coaches to change their password when signed in',
       learnerCanEditUsername: 'Allow learners and coaches to edit their username',
@@ -149,7 +148,6 @@
       pageHeader: 'Facility settings',
       resetToDefaultSettings: 'Reset to default settings',
       saveChanges: 'Save changes',
-      settingsHeader: 'Facility settings',
     },
   };
 


### PR DESCRIPTION
### Summary
Fixes #3587 

1. Removes extra "Facility Settings" header above the settings
1. Changes "Current Facility" to just "Facility"

![screen shot 2018-05-09 at 12 07 41 pm](https://user-images.githubusercontent.com/10248067/39834430-c21a7b02-5381-11e8-9d78-c242d70ffe74.png)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
