### PR TITLE
Add test and annotate per channel correctly.

### DIFF
--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -1,4 +1,5 @@
 import tempfile
+import uuid
 
 from django.core.management import call_command
 from django.test import TransactionTestCase
@@ -48,6 +49,17 @@ class AnnotationFromLocalFileAvailability(TransactionTestCase):
         self.assertFalse(all(
             ContentNode.objects.exclude(
                 kind=content_kinds.TOPIC).exclude(id='32a941fb77c2576e8f6b294cde4c3b0c').values_list('available', flat=True)))
+
+    def test_other_channel_node_still_available(self):
+        test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
+        test.id = uuid.uuid4().hex
+        test.channel_id = uuid.uuid4().hex
+        test.available = True
+        test.parent = None
+        test.save()
+        set_leaf_node_availability_from_local_file_availability(test_channel_id)
+        test.refresh_from_db()
+        self.assertTrue(test.available)
 
     def tearDown(self):
         call_command('flush', interactive=False)

--- a/kolibri/content/utils/annotation.py
+++ b/kolibri/content/utils/annotation.py
@@ -66,16 +66,17 @@ def set_leaf_node_availability_from_local_file_availability(channel_id):
             FileTable.c.supplementary == False
         )
     ).where(
-        and_(
-            ContentNodeTable.c.id == FileTable.c.contentnode_id,
-            ContentNodeTable.c.channel_id == channel_id,
-        )
+        ContentNodeTable.c.id == FileTable.c.contentnode_id,
     )
 
     logging.info('Setting availability of non-topic ContentNode objects based on File availability')
 
     connection.execute(ContentNodeTable.update().where(
-        ContentNodeTable.c.kind != content_kinds.TOPIC).values(available=exists(contentnode_statement)).execution_options(autocommit=True))
+        and_(
+            ContentNodeTable.c.kind != content_kinds.TOPIC,
+            ContentNodeTable.c.channel_id == channel_id,
+        )
+    ).values(available=exists(contentnode_statement)).execution_options(autocommit=True))
 
     bridge.end()
 


### PR DESCRIPTION
### Summary
Fix a regression introduced by #3538 which failed to properly annotate content nodes only for a particular channel.

Adds a test and fixes the issue.

### Reviewer guidance
Import content for one channel, import content for a second channel. The content for the first channel should still be available.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
