### PR TITLE
Have router scroll to top after each page transition

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -33,7 +33,18 @@ class Router {
         delete route.handler;
       }
     });
-    this._vueRouter = new VueRouter(Object.assign({ routes }));
+    this._vueRouter = new VueRouter(
+      Object.assign({
+        routes,
+        scrollBehavior(to, from, savedPosition) {
+          if (savedPosition) {
+            return savedPosition;
+          } else {
+            return { x: 0, y: 0 };
+          }
+        },
+      })
+    );
     this._vueRouter.beforeEach(this._hook.bind(this));
     return this.getInstance();
   }


### PR DESCRIPTION
### Summary

Sets the scroll-behavior for vue-router. When going to a new route, the browser will scroll to very top by default. Fixes #3629.

Copied from [these docs](https://router.vuejs.org/en/advanced/scroll-behavior.html)

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
