### PR TITLE
HOTFIX: Ensure paths in options file are resolved and expanded

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -181,7 +181,18 @@ def read_options_file(KOLIBRI_HOME, ini_filename="options.ini"):
     # run validation once again to fill in any default values for options we deleted due to issues
     conf.validate(Validator())
 
+    # ensure all arguments under section "Paths" are fully resolved and expanded, relative to KOLIBRI_HOME
+    _expand_paths(KOLIBRI_HOME, conf.get("Paths", {}))
+
     return conf
+
+
+def _expand_paths(basepath, pathdict):
+    """
+    Resolve all paths in a dict, relative to a base path, and after expanding "~" into the user's home directory.
+    """
+    for key, path in pathdict.items():
+        pathdict[key] = os.path.join(basepath, os.path.expanduser(path))
 
 
 def update_options_file(section, key, value, KOLIBRI_HOME, ini_filename="options.ini"):

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -155,3 +155,24 @@ def test_option_writing():
         OPTIONS = options.read_options_file(conf.KOLIBRI_HOME, ini_filename=tmp_ini_path)
         assert OPTIONS["Paths"]["CONTENT_DIR"] == _NEW_CONTENT_DIR
         assert OPTIONS["Deployment"]["HTTP_PORT"] == _HTTP_PORT_GOOD
+
+
+def test_path_expansion():
+    """
+    Checks that options under [Path] have "~" expanded, and are relativized to the KOLIBRI_HOME directory.
+    """
+    KOLIBRI_HOME_TEMP = tempfile.mkdtemp()
+
+    _, tmp_ini_path = tempfile.mkstemp(prefix='options', suffix='.ini')
+
+    with mock.patch.dict(os.environ, {'KOLIBRI_CONTENT_DIR': "/absolute"}):
+        OPTIONS = options.read_options_file(KOLIBRI_HOME_TEMP, ini_filename=tmp_ini_path)
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == "/absolute"
+
+    with mock.patch.dict(os.environ, {'KOLIBRI_CONTENT_DIR': "relative"}):
+        OPTIONS = options.read_options_file(KOLIBRI_HOME_TEMP, ini_filename=tmp_ini_path)
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == os.path.join(KOLIBRI_HOME_TEMP, "relative")
+
+    with mock.patch.dict(os.environ, {'KOLIBRI_CONTENT_DIR': "~/homeiswherethecatis"}):
+        OPTIONS = options.read_options_file(KOLIBRI_HOME_TEMP, ini_filename=tmp_ini_path)
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == os.path.expanduser("~/homeiswherethecatis")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes an issue where relative (or home-relative) paths in options.ini file are not expanded and relativized to KOLIBRI_HOME.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try setting the CONTENT_DIR option to relative paths, and it should end up being set relative to KOLIBRI_HOME. If it starts with ~, it should be expanded to be under the user's home directory. And if it's an absolute path, it should remain the same.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes some of the logic introduced in https://github.com/learningequality/kolibri/pull/3607

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
