### PR TITLE
Fix for generating lessons when no channels present

### DIFF
--- a/kolibri/logger/utils/user_data.py
+++ b/kolibri/logger/utils/user_data.py
@@ -17,11 +17,11 @@ from kolibri.auth.models import Classroom
 from kolibri.auth.models import Facility
 from kolibri.auth.models import FacilityUser
 from kolibri.content.models import ContentNode
+from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import AttemptLog
 from kolibri.logger.models import ContentSessionLog
 from kolibri.logger.models import ContentSummaryLog
 from kolibri.logger.models import MasteryLog
-from kolibri.core.lessons.models import Lesson
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +328,9 @@ def create_lessons_for_classroom(**options):
     lessons = options['lessons']
     facility = options['facility']
     now = options['now']
+
+    if not channels:
+        return
 
     coaches = facility.get_coaches()
     if coaches:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Don't try to create lessons when there are no channels available.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

call `generateuserdata` with no channels.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
