### PR TITLE
Coach contents post bug bash fixes

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -274,7 +274,23 @@ class ContentNodeFilter(IdFilter):
         if user.is_facility_user:  # exclude anon users
             if user.roles.exists() or user.is_superuser:  # must have coach role or higher
                 return queryset
-        return queryset.exclude(coach_content=True)
+
+        # In all other cases, exclude leaf nodes that are coach content
+        queryset = queryset.exclude(coach_content=True)
+
+        # Also exclude topics that are 100% coach content
+        def node_only_has_coach_content(contentnode):
+            if (contentnode.kind == content_kinds.TOPIC):
+                return not node.get_descendants() \
+                    .exclude(kind=content_kinds.TOPIC) \
+                    .exclude(coach_content=True) \
+                    .exists()
+            else:
+                return contentnode.coach_content
+
+        only_coach_content_node_ids = [node.id for node in queryset if node_only_has_coach_content(node)]
+
+        return queryset.exclude(id__in=only_coach_content_node_ids)
 
     def filter_in_lesson(self, queryset, name, value):
         """

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -281,7 +281,7 @@ class ContentNodeFilter(IdFilter):
         # Also exclude topics that are 100% coach content
         def node_only_has_coach_content(contentnode):
             if (contentnode.kind == content_kinds.TOPIC):
-                return not node.get_descendants() \
+                return not contentnode.get_descendants() \
                     .exclude(kind=content_kinds.TOPIC) \
                     .exclude(coach_content=True) \
                     .exists()

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -28,6 +28,8 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         value = super(ChannelMetadataSerializer, self).to_representation(instance)
 
+        value.update({"num_coach_contents": get_num_coach_contents(instance.root)})
+
         # if it has the file_size flag add extra file_size information
         if 'request' in self.context and self.context['request'].GET.get('file_sizes', False):
             # only count up currently renderable content types, as only these will be downloaded
@@ -41,16 +43,12 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
             on_device_resources = descendants.exclude(kind=content_kinds.TOPIC).filter(available=True).count()
             on_device_file_size = local_files.filter(available=True).aggregate(Sum('file_size'))['file_size__sum'] or 0
 
-            num_coach_contents = get_num_coach_contents(instance.root)
-
-            value.update(
-                {
-                    "total_resources": total_resources,
-                    "total_file_size": total_file_size,
-                    "on_device_resources": on_device_resources,
-                    "on_device_file_size": on_device_file_size,
-                    "num_coach_contents": num_coach_contents,
-                })
+            value.update({
+                "total_resources": total_resources,
+                "total_file_size": total_file_size,
+                "on_device_resources": on_device_resources,
+                "on_device_file_size": on_device_file_size,
+            })
 
         return value
 

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -9,7 +9,6 @@ import requests
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from django.test import TestCase
 from le_utils.constants import content_kinds
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -136,10 +135,6 @@ class ContentNodeTestBase(object):
         channel.delete_content_tree_and_files()
         self.assertFalse(content.ContentNode.objects.filter(channel_id=channel_id).exists())
         self.assertFalse(content.File.objects.all().exists())
-
-
-class ContentNodeTestCase(ContentNodeTestBase, TestCase):
-    fixtures = ['content_test.json']
 
 
 class ContentNodeAPITestCase(APITestCase):
@@ -591,8 +586,8 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_filtering_coach_content_anon(self):
         response = self.client.get(self._reverse_channel_url("contentnode-list"), data={"by_role": True})
-        expected_output = content.ContentNode.objects.exclude(coach_content=True).exclude(available=False).count()  # coach_content node should NOT be returned
-        self.assertEqual(len(response.data), expected_output)
+        # TODO make content_test.json fixture more organized. Here just, hardcoding the correct count
+        self.assertEqual(len(response.data), 6)
 
     def test_filtering_coach_content_admin(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -153,6 +153,7 @@ function _channelListState(data) {
     last_updated: channel.last_updated,
     version: channel.version,
     thumbnail: channel.thumbnail,
+    num_coach_contents: channel.num_coach_contents,
   }));
 }
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -42,6 +42,7 @@ function _currentTopicState(topic, ancestors = []) {
   return {
     id: topic.id,
     title: topic.title,
+    num_coach_contents: topic.num_coach_contents,
     breadcrumbs: [
       { id: null, title: translator.$tr('allChannels') },
       ...ancestors,

--- a/kolibri/plugins/coach/assets/src/state/actions/lessons.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/lessons.js
@@ -196,6 +196,7 @@ export function showLessonResourceSelectionRootPage(store, classId, lessonId) {
       description: channel.description,
       title: channel.title,
       thumbnail: channel.thumbnail,
+      num_coach_contents: channel.num_coach_contents,
       kind: ContentNodeKinds.CHANNEL,
     };
   });

--- a/kolibri/plugins/coach/assets/src/state/actions/reports.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/reports.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import { handleError } from 'kolibri.coreVue.vuex.actions';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { getChannels } from 'kolibri.coreVue.vuex.getters';
@@ -109,16 +108,14 @@ function getAllChannelsLastActivePromise(channels, userScope, userScopeId) {
   return Promise.all(promises);
 }
 
-function _channelReportState(data, channelRootNodes = []) {
+function _channelReportState(data) {
   if (!data) {
     return [];
   }
   return data.map(row => ({
     lastActive: row.last_active,
     id: row.channelId,
-    // merge ChannelMetdata with ContentNode to get num_coach_contents
-    num_coach_contents:
-      (find(channelRootNodes, { id: row.channelId }) || {}).num_coach_contents || 0,
+    num_coach_contents: row.num_coach_contents,
     progress: row.progress.map(progressData => ({
       kind: progressData.kind,
       nodeCount: progressData.node_count,

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -27,6 +27,7 @@
               <h3 v-if="examCreation">{{ getExerciseName(exercise.exercise_id) }}</h3>
               <ol class="question-list">
                 <li
+                  class="question-list-item"
                   v-for="(question, questionIndex) in getExerciseQuestions(exercise.exercise_id)"
                   :key="questionIndex"
                 >
@@ -218,8 +219,12 @@
 
   @require '~kolibri.styles.definitions'
 
+  .question-list-item
+    vertical-align: middle
+
   .coach-content-label
     display: inline-block
+    vertical-align: inherit
 
   .exam-preview-container
     padding-top: 1em

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/index.vue
@@ -93,7 +93,7 @@
     },
     computed: {
       isTopic() {
-        return this.kind === ContentNodeKinds.TOPIC;
+        return this.kind === ContentNodeKinds.CHANNEL || this.kind === ContentNodeKinds.TOPIC;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -290,7 +290,8 @@
 
   .resource-title
     display: inline-block
-    width: 75%
+    margin-right: 8px
+    max-width: 75%
 
   .coach-content-label
     display: inline-block

--- a/kolibri/plugins/device_management/assets/src/state/actions/availableChannelsActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/availableChannelsActions.js
@@ -64,12 +64,12 @@ export function getRemoteChannelByToken(token) {
  */
 export function getAllRemoteChannels(store, publicChannels) {
   const installedChannels = installedChannelList(store.state);
-  const potentiallyUnlisted = differenceBy(installedChannels, publicChannels, 'id').filter(
+  const privateChannels = differenceBy(installedChannels, publicChannels, 'id').filter(
     channel => channel.on_device_resources > 0
   );
-  const promises = potentiallyUnlisted.map(channel =>
-    getRemoteChannelByToken(channel.id)
-      .then(([channel]) => Promise.resolve(channel))
+  const promises = privateChannels.map(privateChannel =>
+    getRemoteChannelByToken(privateChannel.id)
+      .then(([channel]) => Promise.resolve({ ...channel, ...privateChannel }))
       .catch(() => Promise.resolve())
   );
   return Promise.all(promises).then(unlisted => {

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -133,11 +133,17 @@ export function showChannels(store) {
         .fetch()
         .then(channelCollection => {
           // we want them to be in the same order as the channels list
-          const rootNodes = channels.map(channel => {
-            const node = _collectionState(channelCollection).find(n => n.channel_id === channel.id);
-            node.thumbnail = channel.thumbnail;
-            return node;
-          });
+          const rootNodes = channels
+            .map(channel => {
+              const node = _collectionState(channelCollection).find(
+                n => n.channel_id === channel.id
+              );
+              if (node) {
+                node.thumbnail = channel.thumbnail;
+                return node;
+              }
+            })
+            .filter(Boolean);
           store.dispatch('SET_PAGE_STATE', { rootNodes });
           store.dispatch('CORE_SET_PAGE_LOADING', false);
           store.dispatch('CORE_SET_ERROR', null);

--- a/kolibri/plugins/learn/assets/src/views/content-card/card.styl
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card.styl
@@ -5,4 +5,4 @@ $thumb-width-desktop = 210px
 $thumb-height-desktop = round($thumb-width-desktop / $ratio)
 
 $thumb-width-mobile = 150px
-$thumb-height-mobile = round($thumb-width-mobile / $ratio)
+$thumb-height-mobile = max(round($thumb-width-mobile / $ratio), 92px)


### PR DESCRIPTION
### Summary

UI fixes for coach contents

1. Show coach content icon (hereafter "Icon") on Channels for Coach Reports (recent + all activity)
1. Show Icon on Channels during exam creation
1. Show Icon on Available Channels Page (import/export)
1. Show Icon on Channels during Lesson creation
1. Fix alignment of Icon next to Questions Button in Exam Preview
1. Increase height of mobile content cards so Icon isn't squashed
1. Fix `by_role` filter so it also filters out topics that are 100% coach content @ralphiee22 

### Reviewer guidance

1. Manually go to each of the above mentioned UIs as a learner, coach, facility coach, and admin

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
