### PR TITLE
fix link in styleguide

### DIFF
--- a/kolibri/plugins/style_guide/assets/src/views/content/writing.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/content/writing.vue
@@ -4,7 +4,7 @@
     <h1>Writing style</h1>
 
     <p>
-      In general, we follow <a href="https://material.io/guidelines/style/writing.html">Material Design's writing guidelines</a>. Our slightly adapted version is below.
+      In general, we follow <a href="https://material.io/archive/guidelines/style/writing.html">Material Design's writing guidelines</a>. Our slightly adapted version is below.
     </p>
 
     <h2>Language &amp; tone</h2>


### PR DESCRIPTION

### Summary

Material design was updated. The old one is now archived here: https://material.io/archive/guidelines/

Updated a link to continue pointing at that

### Reviewer guidance

check it out



----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
