### PR TITLE
Changed font for device info page as well as padding

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
@@ -12,7 +12,7 @@
           <th>
             {{ $tr('url', { count: info.urls.length }) }}
           </th>
-          <td>
+          <td class="urlSpace">
             <a
               v-for="(url, index) in info.urls"
               :key="index"
@@ -106,12 +106,14 @@
     padding-bottom: 24px
     padding-right: 24px
 
-  td
-    font-family: monospace
+  td:not(.urlSpace)
     padding-bottom: 24px
 
   .link
     display: block
     margin-bottom: 8px
+
+  .urlSpace
+    padding-bottom: 16px
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
@@ -12,7 +12,7 @@
           <th>
             {{ $tr('url', { count: info.urls.length }) }}
           </th>
-          <td class="urlSpace">
+          <td class="urlspace">
             <a
               v-for="(url, index) in info.urls"
               :key="index"
@@ -106,14 +106,14 @@
     padding-bottom: 24px
     padding-right: 24px
 
-  td:not(.urlSpace)
+  td:not(.urlspace)
     padding-bottom: 24px
 
   .link
     display: block
     margin-bottom: 8px
 
-  .urlSpace
+  .urlspace
     padding-bottom: 16px
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
@@ -12,7 +12,7 @@
           <th>
             {{ $tr('url', { count: info.urls.length }) }}
           </th>
-          <td class="urlspace">
+          <td>
             <a
               v-for="(url, index) in info.urls"
               :key="index"
@@ -106,14 +106,13 @@
     padding-bottom: 24px
     padding-right: 24px
 
-  td:not(.urlspace)
+  td
     padding-bottom: 24px
 
   .link
     display: block
-    margin-bottom: 8px
 
-  .urlspace
-    padding-bottom: 16px
+  .link:not(:last-child)
+    margin-bottom: 8px
 
 </style>


### PR DESCRIPTION
Before
![beforestyling](https://user-images.githubusercontent.com/18543718/40028024-9313ce58-5791-11e8-9fbc-008702ecec4c.png)


After
![afterstyling](https://user-images.githubusercontent.com/18543718/40028021-92d14aba-5791-11e8-9a77-b96bfd10ba3b.jpg)

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
See Issue #2675 
Fixed some spacing/padding issues according to spec in #2675 
Spacing between URLs is 8px, also added a class tag to that particular element to add a spacing of 16px (so that we can fit the 24px spacing across all entries in the table). 
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Go to the Device info page
-Inspect elements between the entries in the table
-The spacing between each URL should be 8px, +16px at the end of the last URL to get a padding of 24px.
-Font should no longer be monospace as well
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
#2675 
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
