### PR TITLE
Handle esc key in fullscreen mixin

### DIFF
--- a/kolibri/core/assets/src/mixins/fullscreen.js
+++ b/kolibri/core/assets/src/mixins/fullscreen.js
@@ -11,6 +11,9 @@
 import ScreenFull from 'screenfull';
 import { isAndroidWebView } from 'kolibri.utils.browser';
 
+const NORMALIZE_FULLSCREEN_CLASS = 'normalize-fullscreen';
+const MIMIC_FULLSCREEN_CLASS = 'mimic-fullscreen';
+
 export default {
   data() {
     return {
@@ -31,9 +34,9 @@ export default {
     enterFullScreen(element) {
       if (this.fullscreenIsSupported) {
         ScreenFull.toggle(element);
-        element.classList.add('normalize-fullscreen');
+        element.classList.add(NORMALIZE_FULLSCREEN_CLASS);
       } else {
-        element.classList.add('mimic-fullscreen');
+        element.classList.add(MIMIC_FULLSCREEN_CLASS);
       }
       this.isInFullscreen = true;
     },
@@ -41,9 +44,9 @@ export default {
     exitFullscreen(element) {
       if (this.fullscreenIsSupported) {
         ScreenFull.toggle(element);
-        element.classList.remove('normalize-fullscreen');
+        element.classList.remove(NORMALIZE_FULLSCREEN_CLASS);
       } else {
-        element.classList.remove('mimic-fullscreen');
+        element.classList.remove(MIMIC_FULLSCREEN_CLASS);
       }
       this.isInFullscreen = false;
     },
@@ -51,5 +54,19 @@ export default {
 
   mounted() {
     this.fullscreenIsSupported = ScreenFull.enabled && !isAndroidWebView();
+
+    // Catch the use of the esc key to exit fullscreen
+    if (this.fullscreenIsSupported) {
+      ScreenFull.onchange(() => {
+        this.isInFullscreen = ScreenFull.isFullscreen;
+        // Just exited fullscreen
+        if (!this.isInFullscreen) {
+          const elementWithClass = this.$el.querySelector(NORMALIZE_FULLSCREEN_CLASS);
+          if (elementWithClass) {
+            elementWithClass.classList.remove(NORMALIZE_FULLSCREEN_CLASS);
+          }
+        }
+      });
+    }
   },
 };


### PR DESCRIPTION
### Summary

Forgot to handle the case where fullscreen is exited using the esc key.
Fixes #3644 

### Reviewer guidance

Toggle fullscreen using the button and esc and make sure everything works properly. 

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [x] Contributor is in AUTHORS.rst
