### PR TITLE
Pass correct reversal string

### DIFF
--- a/kolibri/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/auth/management/commands/fullfacilitysync.py
@@ -35,7 +35,7 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        facility_url = urljoin(base_url, reverse('publicfacility'))
+        facility_url = urljoin(base_url, reverse('publicfacility-list'))
         facility_resp = requests.get(facility_url)
         facility_resp.raise_for_status()
         facilities = facility_resp.json()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We are supposed to pass `'publicfacility-list'` not `'publicfacility'` into the `reverse` function.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
