### PR TITLE
fix PyPi description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dist_name = 'kolibri'
 readme = read_file('README.rst')
 
 # Default description of the distributed package
-description = ("""Kolibri education platform for offline environments""")
+description = ("""Kolibri - the offline app for universal education""")
 
 # Decide if the invoked command is a request to do building
 is_building_dist = any([
@@ -50,7 +50,6 @@ dependency_links, install_requires, static_requirements = [], [], []
 if is_building_dist or '--static' in sys.argv:
     sys.argv.remove('--static')
     dist_name = 'kolibri'
-    description += " This static version bundles all dependencies."
     static_build = True
 # TODO:
 # `pip -e .` should work in a source dir, however since it doesn't


### PR DESCRIPTION

### Summary

Updates the description from

> Kolibri education platform for offline environments This static version bundles all dependencies.

to

> Kolibri - the offline app for universal education

fixes [ugliness on PyPi](https://pypi.org/project/kolibri/) and makes description consistent with [website](https://learningequality.org/kolibri/)

| PyPi | Website |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/40131710-96e700ae-58ef-11e8-947e-1a33fdc74b6a.png) | ![image](https://user-images.githubusercontent.com/2367265/40131813-d7694fb0-58ef-11e8-8be5-9e496b99d8ed.png) |




### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
