### PR TITLE
Aligned user-dropdown with app bar

### DIFF
--- a/kolibri/core/assets/src/views/app-bar.vue
+++ b/kolibri/core/assets/src/views/app-bar.vue
@@ -196,6 +196,7 @@
 
   .user-menu-button
     text-transform: none
+    vertical-align: middle
     svg
       fill: white
 

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -110,7 +110,6 @@
     display: table
     width: 100%
     max-width: 450px
-    margin-top: 3px
     margin-right: 8px
     background-color: white
 

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -144,7 +144,7 @@
     width: 78px
     height: 36px
     vertical-align: middle
-    
+
   .search-clear-button
     visibility: hidden
     width: 24px

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -110,6 +110,8 @@
     display: table
     width: 100%
     max-width: 450px
+    margin-top: 3px
+    margin-right: 8px
     background-color: white
 
   .search-box-within-action-bar
@@ -143,7 +145,7 @@
     width: 78px
     height: 36px
     vertical-align: middle
-
+    
   .search-clear-button
     visibility: hidden
     width: 24px


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Before
![beforealign](https://user-images.githubusercontent.com/18543718/40210061-c30dfb7a-59f7-11e8-8dc2-dab125c98769.png)


After
![afteralign](https://user-images.githubusercontent.com/18543718/40210060-c2cf0f50-59f7-11e8-864e-a0a9a6c46baf.jpg)

Edit: This appears to have an effect on mobile devices (Screenshot taken on Samsung Galaxy S5)

Here is the before effect:
![mobilebefore](https://user-images.githubusercontent.com/18543718/40210229-989668d6-59f8-11e8-97e0-7cea8c5bc721.jpg)

Here is the after effect:
![mobileafter](https://user-images.githubusercontent.com/18543718/40210236-9f78c7d4-59f8-11e8-8159-7350c74258e5.jpg)

It is a bit subtle, however the search bar has moved down. These changes are from adding "margin-top: 3px" to the class ".search-bar" in kolibri/plugins/learn/assets/src/views/search-box.vue

Unsure how to change the search bar on desktop so it does not negatively affect the bar on mobile, advice would be appreciated. Thanks!
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
-Sign in as a user
-Hover over the user dropdown bar
-It should be aligned with the search bar and also have a space (8px) separating them
…

### References
See #3639 
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
