### PR TITLE
Fixed displays for RTL languages

### DIFF
--- a/kolibri/core/assets/src/views/k-radio-button.vue
+++ b/kolibri/core/assets/src/views/k-radio-button.vue
@@ -32,7 +32,7 @@
       :class="['unchecked', {disabled, active}]"
     />
 
-    <span class="text">
+    <span class="text" dir="auto">
       {{ label }}
       <span
         v-if="description"

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -36,11 +36,11 @@
             v-if="inExportMode || inManageMode"
             class="resources-size"
           >
-            <span>{{ resourcesSizeText }}</span>
+            <span dir="auto">{{ resourcesSizeText }}</span>
           </div>
         </div>
         <div class="channel-title">
-          <div class="title">
+          <div class="title" dir="auto">
             {{ channel.name }}
           </div>
           <ui-icon
@@ -55,7 +55,7 @@
       </div>
 
       <div class="details-bottom">
-        <div class="description">
+        <div class="description" dir="auto">
           {{ channel.description || $tr('defaultDescription') }}
         </div>
 
@@ -199,6 +199,7 @@
   .description
     width: 66%
     padding: 1em 0
+    text-align: left
 
   .thumbnail
     width: 10%

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -197,9 +197,7 @@
     color: $core-text-annotation
 
   .description
-    width: 66%
     padding: 1em 0
-    text-align: left
 
   .thumbnail
     width: 10%


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Before -> Channel List 
![beforechannelrtl](https://user-images.githubusercontent.com/18543718/40334154-ffbff318-5d10-11e8-81a6-be1f56f2b03f.png)

After -> Channel List
![channelafterrtl](https://user-images.githubusercontent.com/18543718/40334157-0036a350-5d11-11e8-867d-ed1cfb23c46b.jpg)

Before -> Language Switching Modal
![beforebarrtl](https://user-images.githubusercontent.com/18543718/40334155-fff333e0-5d10-11e8-82f7-d7d51304563f.png)

After -> Language Switching Modal
![afterbarrtl](https://user-images.githubusercontent.com/18543718/40334156-00168ca0-5d11-11e8-9595-33a34133ab60.jpg)


…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
-Go to Device -> Content to see the list of channels
-If viewing in an LTR language (such as English), it should look like this:
![screenshot 2018-05-21 16 11 24](https://user-images.githubusercontent.com/18543718/40334258-aa52aaf0-5d11-11e8-8aab-366b0ef9a8ba.jpg)

-If viewing in an RTL language, it should look like the after screenshot posted in the 'Summary' section. It should essentially mirror what the English view looks like.

For the language modal
- When logged in, click on the user dropdown and change languages
- Whether you are already viewing in a LTR or RTL language, the languages in this change language box should be displayed correctly (see after picture in summary)
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
See #3568 
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
