### PR TITLE
Automate Kolibri Windows Installer signing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,3 +21,8 @@ steps:
 
   - label: Upload artifacts
     command: .buildkite/setup_and_upload_artifact.sh && docker image prune -f -a
+
+  - label: Sign Windows installer
+    command: .buildkite/sign_windows_installer.bat
+    agents:
+      queue: "windows-sign"

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -5,4 +5,4 @@ rem After the installer successfully sign it will upload the signed installer at
 set current_path=%cd%
 
 buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
-%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "%current_path%\installer\*.exe"
+%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && cd "%current_path%\installer\" && buildkite-agent.exe artifact upload "*.exe"

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -11,6 +11,6 @@ buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri 
 GOTO END
 
 :DONT_SIGN
-echo Don't sign the Windows installer.
+echo Set the SIGN_WINDOWS_INSTALLER=true environment variable to sign the Windows installer.
 
 :END

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -1,8 +1,16 @@
 @echo off
 rem This will download the Kolibri windows installer artifact at the windows-2016 buildkite agent.
 rem After the installer successfully sign it will upload the signed installer at the Sign Windows installer pipeline artifact.
+rem To sign the Windows installer set the `SIGN_WINDOWS_INSTALLER=true` environment variable.
+
+IF NOT "%SIGN_WINDOWS_INSTALLER%" == "true" (GOTO DONT_SIGN)
 
 set current_path=%cd%
-
 buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
 %WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && cd "%current_path%\installer\" && buildkite-agent.exe artifact upload "*.exe"
+GOTO END
+
+:DONT_SIGN
+echo Don't sign the Windows installer.
+
+:END

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -1,0 +1,8 @@
+@echo off
+rem This will download the Kolibri windows installer artifact at the windows-2016 buildkite agent.
+rem After the installer successfully sign it will upload the signed installer at the Sign Windows installer pipeline artifact.
+
+set current_path=%cd%
+
+buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
+%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "installer/*.exe"

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -5,4 +5,4 @@ rem After the installer successfully sign it will upload the signed installer at
 set current_path=%cd%
 
 buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
-%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "%current_path%\*.exe"
+%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "%current_path%\installer\*.exe"

--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -5,4 +5,4 @@ rem After the installer successfully sign it will upload the signed installer at
 set current_path=%cd%
 
 buildkite-agent.exe artifact download "installer/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
-%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "installer/*.exe"
+%WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\installer" && buildkite-agent.exe artifact upload "%current_path%\*.exe"


### PR DESCRIPTION
### Summary
I created a script to automate Kolibri windows installer signing at buildkite.

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
