### PR TITLE
Updates to response headers for ZIP endpoints for security and functionality

### DIFF
--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -91,3 +91,10 @@ class ZipContentTestCase(TestCase):
     def test_x_frame_options_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.get("X-Frame-Options", ""), "")
+
+    def test_access_control_allow_headers(self):
+        headerval = "X-Penguin-Dance-Party"
+        response = self.client.options(self.zip_file_base_url + self.test_name_1, HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval)
+        self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)
+        response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval)
+        self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)

--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -77,3 +77,17 @@ class ZipContentTestCase(TestCase):
         caching_client = Client(HTTP_IF_MODIFIED_SINCE="Sat, 10-Sep-2016 19:14:07 GMT")
         response = caching_client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.status_code, 304)
+
+    def test_content_security_policy_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+
+    def test_access_control_allow_origin_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Access-Control-Allow-Origin"), "*")
+        response = self.client.options(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Access-Control-Allow-Origin"), "*")
+
+    def test_x_frame_options_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("X-Frame-Options", ""), "")

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -19,6 +19,16 @@ mimetypes.init([os.path.join(os.path.dirname(__file__), 'constants', 'mime.types
 class ZipContentView(View):
 
     @xframe_options_exempt
+    def options(self, request, *args, **kwargs):
+        """
+        Handles OPTIONS requests which may be sent as "preflight CORS" requests to check permissions.
+        """
+        response = HttpResponse()
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        return response
+
+    @xframe_options_exempt
     def get(self, request, zipped_filename, embedded_filepath):
         """
         Handles GET requests and serves a static file from within the zip file.

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -2,8 +2,10 @@ import mimetypes
 import os
 import zipfile
 
-from django.http import Http404, HttpResponse
-from django.http.response import FileResponse, HttpResponseNotModified
+from django.http import Http404
+from django.http import HttpResponse
+from django.http.response import FileResponse
+from django.http.response import HttpResponseNotModified
 from django.views.generic.base import View
 from le_utils.constants import exercises
 
@@ -78,6 +80,11 @@ class ZipContentView(View):
         # Newer versions of Chrome block iframes from loading
         # solution is to override xframe options with any string (https://stackoverflow.com/a/6767901)
         response['X-Frame-Options'] = "GOFORIT"
+
+        # restrict CSP to only allow resources to be loaded from the Kolibri host, to prevent info leakage
+        # (e.g. via passing user info out as GET parameters to an attacker's server), or inadvertent data usage
+        host = request.build_absolute_uri('/').strip("/")
+        response["Content-Security-Policy"] = "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: " + host
 
         return response
 

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -6,6 +6,7 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.http.response import FileResponse
 from django.http.response import HttpResponseNotModified
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic.base import View
 from le_utils.constants import exercises
 
@@ -17,6 +18,7 @@ mimetypes.init([os.path.join(os.path.dirname(__file__), 'constants', 'mime.types
 
 class ZipContentView(View):
 
+    @xframe_options_exempt
     def get(self, request, zipped_filename, embedded_filepath):
         """
         Handles GET requests and serves a static file from within the zip file.
@@ -76,10 +78,6 @@ class ZipContentView(View):
 
         # allow all origins so that content can be read from within zips within sandboxed iframes
         response["Access-Control-Allow-Origin"] = "*"
-
-        # Newer versions of Chrome block iframes from loading
-        # solution is to override xframe options with any string (https://stackoverflow.com/a/6767901)
-        response['X-Frame-Options'] = "GOFORIT"
 
         # restrict CSP to only allow resources to be loaded from the Kolibri host, to prevent info leakage
         # (e.g. via passing user info out as GET parameters to an attacker's server), or inadvertent data usage


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes some issues we've been seeing, and proactively protects us against others.

1. Add "Content-Security-Policy" header: More aggressive protections against content being loaded from other servers (to highlight issues that might only show up offline, avoid unwanted bandwidth usage, and protect against data leakage once we add HTML5 app data access methods -- CC @kollivier).
1. Use Django decorator to block XFrameOptionsMiddleware instead of overwriting header, to avoid "Invalid 'X-Frame-Options' header encountered" JS error (which still worked, but caused unnecessary panic).
1. Add "Access-Control-Allow-Origin" header in response to OPTIONS requests: Prevent CORS errors when HTML5 apps make AJAX requests to read files from within zip.

Many (most? all?) of these changes should also be ported over [to Studio](https://github.com/learningequality/studio/blob/4ecb84457e78df35ac14c13eec7c5829c0aa0781/contentcuration/contentcuration/views/zip.py#L30) (CC @ivanistheone @jayoshih @micahscopes).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I made a zip file that tests all the edge cases, which I've used for doing fairly extensive cross-browser testing on BrowserStack:
[a0de2cf520524f207eed87cc7056ac6b.zip](https://github.com/learningequality/kolibri/files/2037706/a0de2cf520524f207eed87cc7056ac6b.zip)

You can overwrite one of your existing content folder zip files with that file (renaming appropriately) so as to load it in a Kolibri sandboxed iframe easily. Current filename matches the zip for ContentNode: "Channels > PhET Interactive Simulations (en) > Physics > Motion > Gravity And Orbits".

(More manual testing would also be good, on more actual content)

Screenshot of the test zip in action:

![image](https://user-images.githubusercontent.com/618416/40523074-58d00f56-5faa-11e8-98ff-1e70e5300505.png)

The main "failure" case is that in old old versions of some browsers, "Content-Security-Policy" is ignored. This just leads to it being possible to load external resources from other domains into the iframe -- doesn't compromise anything critical.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Related to (but different from) https://github.com/learningequality/kolibri/issues/877 -- which is about applying Content-Security-Policy externally to the iframes, in Kolibri itself -- CC @benjaoming.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
