### PR TITLE
remove vestigial py_modules code dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,6 @@ output/*/index.html
 # Sphinx
 docs/_build
 
-# api-docs
-docs/py_modules/kolibri*rst
-docs/py_modules/modules.rst
-
 # node
 node_modules
 npm-debug.log

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 clean-docs:
-	rm -f docs/py_modules/kolibri*rst
-	rm -f docs/py_modules/modules.rst
 	$(MAKE) -C docs clean
 
 lint:
@@ -90,7 +88,6 @@ coverage:
 	coverage report -m
 
 docs: clean-docs
-	sphinx-apidoc -d 10 -H "Python Reference" -o docs/py_modules/ kolibri kolibri/test kolibri/deployment/ kolibri/dist/
 	$(MAKE) -C docs html
 
 release:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,9 +133,6 @@ html_theme = 'default'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
-if on_rtd:
-    os.system("sphinx-apidoc --doc-project='Python Reference' -f -o . ../kolibri ../kolibri/test ../kolibri/deployment/ ../kolibri/dist/")
-
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'


### PR DESCRIPTION

### Summary

Currently, our dev docs dump a lot of code into the search results, which makes searching less useful:

![image](https://user-images.githubusercontent.com/2367265/40568623-943f8de2-6030-11e8-8897-2a93cca85c0e.png)

It appears this is just a dump of code, which is super unhelpful when better tools exist on github or in editors:

![image](https://user-images.githubusercontent.com/2367265/40568647-bf83cf4a-6030-11e8-9e02-1d6bdbbb59a5.png)

It also doesn't address anything on the front-end side, so the inconsistency is confusing.


### Reviewer guidance

Make sure this change makes sense


----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
