### PR TITLE
update coach content tooltips

### DIFF
--- a/kolibri/core/assets/src/views/coach-content-label.vue
+++ b/kolibri/core/assets/src/views/coach-content-label.vue
@@ -1,8 +1,8 @@
 <template>
 
-  <div class="vab" v-if="value > 0">
-    <ui-tooltip trigger="icon" position="top center">
-      {{ $tr('coachLabel') }}
+  <div class="vab" v-if="value > 0" :title="titleText">
+    <ui-tooltip trigger="icon" position="bottom center" v-if="!isTopic">
+      {{ $tr('coachResourceLabel') }}
     </ui-tooltip>
     <ui-icon
       class="coach-mat-icon"
@@ -39,8 +39,17 @@
         default: false,
       },
     },
+    computed: {
+      titleText() {
+        if (this.isTopic) {
+          return this.$tr('topicTitle', { count: this.value });
+        }
+        return null;
+      },
+    },
     $trs: {
-      coachLabel: 'Coach',
+      coachResourceLabel: 'Coach resource',
+      topicTitle: 'Contains {count} {count, plural, one {story} other {stories}}',
     },
   };
 

--- a/kolibri/core/assets/src/views/coach-content-label.vue
+++ b/kolibri/core/assets/src/views/coach-content-label.vue
@@ -1,14 +1,7 @@
 <template>
 
   <div class="vab" v-if="value > 0" :title="titleText">
-    <ui-tooltip trigger="icon" position="bottom center" v-if="!isTopic">
-      {{ $tr('coachResourceLabel') }}
-    </ui-tooltip>
-    <ui-icon
-      class="coach-mat-icon"
-      ref="icon"
-      icon="local_library"
-    />
+    <ui-icon class="coach-mat-icon" icon="local_library" />
     <span class="counter" v-if="isTopic">
       {{ value }}
     </span>
@@ -20,13 +13,11 @@
 <script>
 
   import UiIcon from 'keen-ui/src/UiIcon';
-  import UiTooltip from 'keen-ui/src/UiTooltip';
 
   export default {
     name: 'coachContentLabel',
     components: {
       UiIcon,
-      UiTooltip,
     },
     props: {
       value: {
@@ -44,12 +35,12 @@
         if (this.isTopic) {
           return this.$tr('topicTitle', { count: this.value });
         }
-        return null;
+        return this.$tr('coachResourceLabel');
       },
     },
     $trs: {
       coachResourceLabel: 'Coach resource',
-      topicTitle: 'Contains {count} {count, plural, one {story} other {stories}}',
+      topicTitle: 'Contains {count} {count, plural, one {coach resource} other {coach resources}}',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/content-card/card.styl
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card.styl
@@ -4,5 +4,5 @@ $ratio = 16 / 9
 $thumb-width-desktop = 210px
 $thumb-height-desktop = round($thumb-width-desktop / $ratio)
 
-$thumb-width-mobile = 150px
-$thumb-height-mobile = max(round($thumb-width-mobile / $ratio), 92px)
+$thumb-height-mobile = 92px
+$thumb-width-mobile = round($thumb-height-mobile * $ratio)


### PR DESCRIPTION

### Summary

Follow-up on [this comment](https://github.com/learningequality/kolibri/pull/3655#issuecomment-389347282)

Changes:

* switched from `ui-tooltip` to a regular HTML tooltip to avoid obscuring text
* clarified meanings when used on topics vs contents



| old | new |
|--|--|
| ![old](https://user-images.githubusercontent.com/2367265/40570586-25b027ea-6041-11e8-9581-61bec91f2f3a.gif) | ![new](https://user-images.githubusercontent.com/2367265/40570655-df3acfb2-6041-11e8-9fdb-9ad5b7f51943.gif) |

Also, follow-up on [this comment](https://github.com/learningequality/kolibri/pull/3655#discussion_r188469546)

### Reviewer guidance

See what you think @jonboiser @khangmach




----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
