### PR TITLE
updates to coach column strings

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -39,7 +39,9 @@
                 :to="learnerPageLink(classroom.id)"
               />
             </td>
-            <td>{{ coachNames(classroom) }}</td>
+            <td :title="formattedCoachNamesTooltip(classroom)">
+              {{ formattedCoachNames(classroom) }}
+            </td>
             <td>{{ classroom.learner_count }}</td>
           </tr>
         </tbody>
@@ -88,20 +90,36 @@
       // Duplicated in manage-classroom-page
       coachNames(classroom) {
         const { coaches } = classroom;
-        const coach_names = filterAndSortUsers(coaches, () => true, 'full_name').map(
+        return filterAndSortUsers(coaches, () => true, 'full_name').map(
           ({ full_name }) => full_name
         );
+      },
+      formattedCoachNames(classroom) {
+        const coach_names = this.coachNames(classroom);
         if (coach_names.length === 0) {
           return '–';
         }
-        if (coach_names.length <= 2) {
-          return coach_names.join(', ');
+        if (coach_names.length === 1) {
+          return coach_names[0];
         }
-        return this.$tr('truncatedCoachNames', {
+        if (coach_names.length === 2) {
+          return this.$tr('twoCoachNames', {
+            name1: coach_names[0],
+            name2: coach_names[1],
+          });
+        }
+        return this.$tr('manyCoachNames', {
           name1: coach_names[0],
           name2: coach_names[1],
           numRemaining: coach_names.length - 2,
         });
+      },
+      formattedCoachNamesTooltip(classroom) {
+        const coach_names = this.coachNames(classroom);
+        if (coach_names.length > 2) {
+          return coach_names.join('\n');
+        }
+        return null;
       },
     },
     vuex: {
@@ -121,8 +139,8 @@
       coachesColumnHeader: 'Coaches',
       learnerColumnHeader: 'Learners',
       classIconTableDescription: 'Class icon',
-      truncatedCoachNames:
-        '{name1}, {name2}, {numRemaining, number} {numRemaining, plural, one {other} other {others}}',
+      twoCoachNames: '{name1}, {name2}',
+      manyCoachNames: '{name1}, {name2}... (+{numRemaining, number})',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -140,7 +140,7 @@
       learnerColumnHeader: 'Learners',
       classIconTableDescription: 'Class icon',
       twoCoachNames: '{name1}, {name2}',
-      manyCoachNames: '{name1}, {name2}... (+{numRemaining, number})',
+      manyCoachNames: '{name1}, {name2}… (+{numRemaining, number})',
     },
   };
 

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -41,8 +41,8 @@
               :to="classEditLink(classroom.id)"
             />
           </td>
-          <td>
-            {{ coachNames(classroom) }}
+          <td :title="formattedCoachNamesTooltip(classroom)">
+            {{ formattedCoachNames(classroom) }}
           </td>
           <td>
             {{ classroom.learner_count }}
@@ -114,20 +114,37 @@
       },
     },
     methods: {
+      // Duplicated in class-list-page
       coachNames(classroom) {
         const { coaches } = classroom;
-        const coach_names = coaches.map(({ full_name }) => full_name);
+        return coaches.map(({ full_name }) => full_name);
+      },
+      formattedCoachNames(classroom) {
+        const coach_names = this.coachNames(classroom);
         if (coach_names.length === 0) {
           return '–';
         }
-        if (coach_names.length <= 2) {
-          return coach_names.join(', ');
+        if (coach_names.length === 1) {
+          return coach_names[0];
         }
-        return this.$tr('truncatedCoachNames', {
+        if (coach_names.length === 2) {
+          return this.$tr('twoCoachNames', {
+            name1: coach_names[0],
+            name2: coach_names[1],
+          });
+        }
+        return this.$tr('manyCoachNames', {
           name1: coach_names[0],
           name2: coach_names[1],
           numRemaining: coach_names.length - 2,
         });
+      },
+      formattedCoachNamesTooltip(classroom) {
+        const coach_names = this.coachNames(classroom);
+        if (coach_names.length > 2) {
+          return coach_names.join('\n');
+        }
+        return null;
       },
       classEditLink,
       openDeleteClassModal(classModel) {
@@ -154,8 +171,8 @@
       tableCaption: 'List of classes',
       learnersColumnHeader: 'Learners',
       coachesColumnHeader: 'Coaches',
-      truncatedCoachNames:
-        '{name1}, {name2}, {numRemaining, number} {numRemaining, plural, one {other} other {others}}',
+      twoCoachNames: '{name1}, {name2}',
+      manyCoachNames: '{name1}, {name2}... (+{numRemaining, number})',
       actions: 'Actions',
       noClassesExist: 'No classes exist.',
     },

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -172,7 +172,7 @@
       learnersColumnHeader: 'Learners',
       coachesColumnHeader: 'Coaches',
       twoCoachNames: '{name1}, {name2}',
-      manyCoachNames: '{name1}, {name2}... (+{numRemaining, number})',
+      manyCoachNames: '{name1}, {name2}… (+{numRemaining, number})',
       actions: 'Actions',
       noClassesExist: 'No classes exist.',
     },


### PR DESCRIPTION
### Summary

* properly internationalize the name list: cannot use `join(', ')`
* switch from "N others" to "(+N)" notation for simpler translation
* added tooltip

### Reviewer guidance

please review code and test

### References

fixes #3703

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
