### PR TITLE
Fix error during local import when channel metadata only has root_id

### DIFF
--- a/kolibri/content/utils/channels.py
+++ b/kolibri/content/utils/channels.py
@@ -2,11 +2,10 @@ import fnmatch
 import logging as logger
 import os
 
-from kolibri.core.discovery.utils.filesystem import enumerate_mounted_disk_partitions
-from kolibri.utils.uuids import is_valid_uuid
-
 from .paths import get_content_database_folder_path
 from .sqlalchemybridge import Bridge
+from kolibri.core.discovery.utils.filesystem import enumerate_mounted_disk_partitions
+from kolibri.utils.uuids import is_valid_uuid
 
 logging = logger.getLogger(__name__)
 
@@ -62,6 +61,11 @@ def read_channel_metadata_from_db_file(channeldbpath):
 
     source.end()
 
+    # Adds an attribute `root_id` when `root_id` does not exist to match with
+    # the latest schema.
+    if not hasattr(source_channel_metadata, 'root_id'):
+        setattr(source_channel_metadata, 'root_id', getattr(source_channel_metadata, 'root_pk'))
+
     return source_channel_metadata
 
 def get_channels_for_data_folder(datafolder):
@@ -75,7 +79,7 @@ def get_channels_for_data_folder(datafolder):
             "description": channel.description,
             "thumbnail": channel.thumbnail,
             "version": channel.version,
-            "root": channel.root_pk,
+            "root": channel.root_id,
             "author": channel.author,
             "last_updated": getattr(channel, 'last_updated', None),
             "lang_code": getattr(channel, 'lang_code', None),


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR fixes the error that some of the channel database file contain `root_pk` for channel metadata, and some contain `root_id`. This causes an error during the local import when we try to get the id of the root through `channel.root_pk`. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

try to import two channels, where one uses `root_id` and the other uses `root_pk`.
example channels:
03ff778aac984323a2a23216871022b5 (root_id)
d0ef6f71e4fe4e54bb87d7dab5eeaae2 (root_pk)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3641#issuecomment-388966190

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
