### PR TITLE
Fine tune Kolibri CherryPy params, allowing options

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -33,10 +33,10 @@ option_spec = {
         },
     },
     "Server": {
-        "THREADS_POOL": {
+        "THREAD_POOL": {
             "type": "integer",
             "default": 10,
-            "envvars": ("CHERRYPY_THREADS_POOL",),
+            "envvars": ("CHERRYPY_THREAD_POOL",),
         },
         "SOCKET_TIMEOUT": {
             "type": "integer",

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -32,6 +32,28 @@ option_spec = {
             "envvars": ("KOLIBRI_DATABASE_HOST",),
         },
     },
+    "Server": {
+        "THREADS_POOL": {
+            "type": "integer",
+            "default": 10,
+            "envvars": ("CHERRYPY_THREADS_POOL",),
+        },
+        "SOCKET_TIMEOUT": {
+            "type": "integer",
+            "default": 10,
+            "envvars": ("CHERRYPY_SOCKET_TIMEOUT",),
+        },
+        "QUEUE_SIZE": {
+            "type": "integer",
+            "default": 5,
+            "envvars": ("CHERRYPY_QUEUE_SIZE",),
+        },
+        "QUEUE_TIMEOUT": {
+            "type": "float",
+            "default": 0.1,
+            "envvars": ("CHERRYPY_QUEUE_TIMEOUT",),
+        },
+    },
     "Paths": {
         "CONTENT_DIR": {
             "type": "string",

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -33,25 +33,25 @@ option_spec = {
         },
     },
     "Server": {
-        "SERVER_THREAD_POOL": {
+        "CHERRYPY_THREAD_POOL": {
             "type": "integer",
             "default": 10,
-            "envvars": ("KOLIBRI_SERVER_THREAD_POOL",),
+            "envvars": ("KOLIBRI_CHERRYPY_THREAD_POOL",),
         },
-        "SERVER_SOCKET_TIMEOUT": {
+        "CHERRYPY_SOCKET_TIMEOUT": {
             "type": "integer",
             "default": 10,
-            "envvars": ("KOLIBRI_SERVER_SOCKET_TIMEOUT",),
+            "envvars": ("KOLIBRI_CHERRYPY_SOCKET_TIMEOUT",),
         },
-        "SERVER_QUEUE_SIZE": {
+        "CHERRYPY_QUEUE_SIZE": {
             "type": "integer",
             "default": 5,
-            "envvars": ("KOLIBRI_SERVER_QUEUE_SIZE",),
+            "envvars": ("KOLIBRI_CHERRYPY_QUEUE_SIZE",),
         },
-        "SERVER_QUEUE_TIMEOUT": {
+        "CHERRYPY_QUEUE_TIMEOUT": {
             "type": "float",
             "default": 0.1,
-            "envvars": ("KOLIBRI_SERVER_QUEUE_TIMEOUT",),
+            "envvars": ("KOLIBRI_CHERRYPY_QUEUE_TIMEOUT",),
         },
     },
     "Paths": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -33,25 +33,25 @@ option_spec = {
         },
     },
     "Server": {
-        "THREAD_POOL": {
+        "SERVER_THREAD_POOL": {
             "type": "integer",
             "default": 10,
-            "envvars": ("CHERRYPY_THREAD_POOL",),
+            "envvars": ("KOLIBRI_SERVER_THREAD_POOL",),
         },
-        "SOCKET_TIMEOUT": {
+        "SERVER_SOCKET_TIMEOUT": {
             "type": "integer",
             "default": 10,
-            "envvars": ("CHERRYPY_SOCKET_TIMEOUT",),
+            "envvars": ("KOLIBRI_SERVER_SOCKET_TIMEOUT",),
         },
-        "QUEUE_SIZE": {
+        "SERVER_QUEUE_SIZE": {
             "type": "integer",
             "default": 5,
-            "envvars": ("CHERRYPY_QUEUE_SIZE",),
+            "envvars": ("KOLIBRI_SERVER_QUEUE_SIZE",),
         },
-        "QUEUE_TIMEOUT": {
+        "SERVER_QUEUE_TIMEOUT": {
             "type": "float",
             "default": 0.1,
-            "envvars": ("CHERRYPY_QUEUE_TIMEOUT",),
+            "envvars": ("KOLIBRI_SERVER_QUEUE_TIMEOUT",),
         },
     },
     "Paths": {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -151,10 +151,10 @@ def run_server(port):
     # Configure the server
     server.socket_host = LISTEN_ADDRESS
     server.socket_port = port
-    server.thread_pool = conf.OPTIONS["Server"]["SERVER_THREAD_POOL"]
-    server.socket_timeout = conf.OPTIONS["Server"]["SERVER_SOCKET_TIMEOUT"]
-    server.accepted_queue_size = conf.OPTIONS["Server"]["SERVER_QUEUE_SIZE"]
-    server.accepted_queue_timeout = conf.OPTIONS["Server"]["SERVER_QUEUE_TIMEOUT"]
+    server.thread_pool = conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"]
+    server.socket_timeout = conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"]
+    server.accepted_queue_size = conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"]
+    server.accepted_queue_timeout = conf.OPTIONS["Server"]["CHERRYPY_QUEUE_TIMEOUT"]
 
     # Subscribe this server
     server.subscribe()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -151,10 +151,10 @@ def run_server(port):
     # Configure the server
     server.socket_host = LISTEN_ADDRESS
     server.socket_port = port
-    server.thread_pool = conf.OPTIONS["Server"]["THREAD_POOL"]
-    server.socket_timeout = conf.OPTIONS["Server"]["SOCKET_TIMEOUT"]
-    server.accepted_queue_size = conf.OPTIONS["Server"]["QUEUE_SIZE"]
-    server.accepted_queue_timeout = conf.OPTIONS["Server"]["QUEUE_TIMEOUT"]
+    server.thread_pool = conf.OPTIONS["Server"]["SERVER_THREAD_POOL"]
+    server.socket_timeout = conf.OPTIONS["Server"]["SERVER_SOCKET_TIMEOUT"]
+    server.accepted_queue_size = conf.OPTIONS["Server"]["SERVER_QUEUE_SIZE"]
+    server.accepted_queue_timeout = conf.OPTIONS["Server"]["SERVER_QUEUE_TIMEOUT"]
 
     # Subscribe this server
     server.subscribe()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -151,7 +151,7 @@ def run_server(port):
     # Configure the server
     server.socket_host = LISTEN_ADDRESS
     server.socket_port = port
-    server.thread_pool = conf.OPTIONS["Server"]["THREADS_POOL"]
+    server.thread_pool = conf.OPTIONS["Server"]["THREAD_POOL"]
     server.socket_timeout = conf.OPTIONS["Server"]["SOCKET_TIMEOUT"]
     server.accepted_queue_size = conf.OPTIONS["Server"]["QUEUE_SIZE"]
     server.accepted_queue_timeout = conf.OPTIONS["Server"]["QUEUE_TIMEOUT"]

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -12,7 +12,7 @@ from django.core.management import call_command
 from .system import kill_pid
 from .system import pid_exists
 from kolibri.content.utils import paths
-from kolibri.utils.conf import KOLIBRI_HOME
+from kolibri.utils import conf
 
 logger = logging.getLogger(__name__)
 
@@ -30,15 +30,15 @@ STATUS_PID_FILE_INVALID = 100
 STATUS_UNKNOWN = 101
 
 # Used to store PID and port number (both in foreground and daemon mode)
-PID_FILE = os.path.join(KOLIBRI_HOME, "server.pid")
+PID_FILE = os.path.join(conf.KOLIBRI_HOME, "server.pid")
 
 # Used to PID, port during certain exclusive startup process, before we fork
 # to daemon mode
-STARTUP_LOCK = os.path.join(KOLIBRI_HOME, "server.lock")
+STARTUP_LOCK = os.path.join(conf.KOLIBRI_HOME, "server.lock")
 
 # This is a special file with daemon activity. It logs ALL stderr output, some
 # might not have made it to the log file!
-DAEMON_LOG = os.path.join(KOLIBRI_HOME, "server.log")
+DAEMON_LOG = os.path.join(conf.KOLIBRI_HOME, "server.log")
 
 # Currently non-configurable until we know how to properly handle this
 LISTEN_ADDRESS = "0.0.0.0"
@@ -151,7 +151,10 @@ def run_server(port):
     # Configure the server
     server.socket_host = LISTEN_ADDRESS
     server.socket_port = port
-    server.thread_pool = 30
+    server.thread_pool = conf.OPTIONS["Server"]["THREADS_POOL"]
+    server.socket_timeout = conf.OPTIONS["Server"]["SOCKET_TIMEOUT"]
+    server.accepted_queue_size = conf.OPTIONS["Server"]["QUEUE_SIZE"]
+    server.accepted_queue_timeout = conf.OPTIONS["Server"]["QUEUE_TIMEOUT"]
 
     # Subscribe this server
     server.subscribe()


### PR DESCRIPTION
### Summary
This PR will change the options used to run kolibri server in production.
The options are configurable using the options.ini file

 fixes #3720

### Reviewer guidance
To check how these server options apply kolibri must be rebuilt.
I did it using `python setup.py install`

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
