### PR TITLE
auto-resume for content importing from network

### DIFF
--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -285,6 +285,19 @@
   {
     "fields": {
       "lang": 1,
+      "local_file": "6bdfea4a01830fdd4a585181c0b8068c",
+      "thumbnail": false,
+      "available": true,
+      "preset": "high_res_video",
+      "contentnode": "32a941fb77c2576e8f6b294cde4c3b0c",
+      "supplementary": false
+    },
+    "pk": "6bdfea4a01830fdd4a585181c0b8068c",
+    "model": "content.file"
+  },
+  {
+    "fields": {
+      "lang": 1,
       "local_file": "9f9438fe6b0d42dd8e913d7d04cfb2b2",
       "thumbnail": false,
       "available": true,
@@ -354,6 +367,15 @@
       "extension": "mp4"
     },
     "pk": "9f9438fe6b0d42dd8e913d7d04cfb2b2",
+    "model": "content.localfile"
+  },
+  {
+    "fields": {
+      "file_size": null,
+      "available": true,
+      "extension": "mp4"
+    },
+    "pk": "6bdfea4a01830fdd4a585181c0b8068c",
     "model": "content.localfile"
   },
   {

--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -298,27 +298,14 @@
   {
     "fields": {
       "lang": 1,
-      "local_file": "9f9438fe6b0d42dd8e913d7d04cfb2b2",
-      "thumbnail": false,
-      "available": true,
-      "preset": "high_res_video",
-      "contentnode": "32a941fb77c2576e8f6b294cde4c3b0c",
-      "supplementary": false
-    },
-    "pk": "9f9438fe6b0d42dd8e913d7d04cfb2b1",
-    "model": "content.file"
-  },
-  {
-    "fields": {
-      "lang": 1,
-      "local_file": "725257a0570044acbd59f8cf6a68b2be",
+      "local_file": "211523265f53825b82f70ba19218a02e",
       "thumbnail": false,
       "available": true,
       "preset": "low_res_video",
       "contentnode": "32a941fb77c2576e8f6b294cde4c3b0c",
       "supplementary": false
     },
-    "pk": "725257a0570044acbd59f8cf6a68b2bf",
+    "pk": "211523265f53825b82f70ba19218a02e",
     "model": "content.file"
   },
   {
@@ -366,15 +353,6 @@
       "available": true,
       "extension": "mp4"
     },
-    "pk": "9f9438fe6b0d42dd8e913d7d04cfb2b2",
-    "model": "content.localfile"
-  },
-  {
-    "fields": {
-      "file_size": null,
-      "available": true,
-      "extension": "mp4"
-    },
     "pk": "6bdfea4a01830fdd4a585181c0b8068c",
     "model": "content.localfile"
   },
@@ -384,7 +362,7 @@
       "available": true,
       "extension": "mp4"
     },
-    "pk": "725257a0570044acbd59f8cf6a68b2be",
+    "pk": "211523265f53825b82f70ba19218a02e",
     "model": "content.localfile"
   },
   {

--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -200,10 +200,10 @@ class LocalFileByDisk(TransactionTestCase):
         set_local_file_availability_from_disk()
         self.assertEqual(LocalFile.objects.exclude(available=True).count(), 0)
 
-    @patch('kolibri.content.utils.annotation.get_content_storage_file_path', side_effect=[mock_content_file[1]]*2 + ['']*3)
+    @patch('kolibri.content.utils.annotation.get_content_storage_file_path', side_effect=[mock_content_file[1]]*3 + ['']*4)
     def test_set_all_files_two_exist(self, path_mock):
         set_local_file_availability_from_disk()
-        self.assertEqual(LocalFile.objects.filter(available=True).count(), 2)
+        self.assertEqual(LocalFile.objects.filter(available=True).count(), 3)
         self.assertEqual(LocalFile.objects.exclude(available=True).count(), 3)
 
     def tearDown(self):

--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -47,7 +47,7 @@ class AnnotationFromLocalFileAvailability(TransactionTestCase):
 
     def test_one_local_file_available(self):
         LocalFile.objects.all().update(available=False)
-        LocalFile.objects.filter(id='9f9438fe6b0d42dd8e913d7d04cfb2b2').update(available=True)
+        LocalFile.objects.filter(id='6bdfea4a01830fdd4a585181c0b8068c').update(available=True)
         set_leaf_node_availability_from_local_file_availability(test_channel_id)
         self.assertTrue(ContentNode.objects.get(id='32a941fb77c2576e8f6b294cde4c3b0c').available)
         self.assertFalse(all(
@@ -112,13 +112,13 @@ class LocalFileByChecksum(TransactionTestCase):
         LocalFile.objects.all().update(available=False)
 
     def test_set_one_file(self):
-        file_id = '9f9438fe6b0d42dd8e913d7d04cfb2b2'
+        file_id = '6bdfea4a01830fdd4a585181c0b8068c'
         mark_local_files_as_available([file_id])
         self.assertEqual(LocalFile.objects.filter(available=True).count(), 1)
         self.assertTrue(LocalFile.objects.get(id=file_id).available)
 
     def test_set_two_files(self):
-        file_id_1 = '9f9438fe6b0d42dd8e913d7d04cfb2b2'
+        file_id_1 = '6bdfea4a01830fdd4a585181c0b8068c'
         file_id_2 = 'e00699f859624e0f875ac6fe1e13d648'
         mark_local_files_as_available([file_id_1, file_id_2])
         self.assertEqual(LocalFile.objects.filter(available=True).count(), 2)
@@ -138,7 +138,7 @@ class LocalFileByDisk(TransactionTestCase):
 
     fixtures = ['content_test.json']
 
-    file_id_1 = '9f9438fe6b0d42dd8e913d7d04cfb2b2'
+    file_id_1 = '6bdfea4a01830fdd4a585181c0b8068c'
     file_id_2 = 'e00699f859624e0f875ac6fe1e13d648'
 
     def setUp(self):
@@ -200,10 +200,10 @@ class LocalFileByDisk(TransactionTestCase):
         set_local_file_availability_from_disk()
         self.assertEqual(LocalFile.objects.exclude(available=True).count(), 0)
 
-    @patch('kolibri.content.utils.annotation.get_content_storage_file_path', side_effect=[mock_content_file[1]]*3 + ['']*4)
+    @patch('kolibri.content.utils.annotation.get_content_storage_file_path', side_effect=[mock_content_file[1]]*2 + ['']*3)
     def test_set_all_files_two_exist(self, path_mock):
         set_local_file_availability_from_disk()
-        self.assertEqual(LocalFile.objects.filter(available=True).count(), 3)
+        self.assertEqual(LocalFile.objects.filter(available=True).count(), 2)
         self.assertEqual(LocalFile.objects.exclude(available=True).count(), 3)
 
     def tearDown(self):

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -321,15 +321,15 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_contentnodefilesize_resourcenode(self):
         c1_id = content.ContentNode.objects.get(title="c1").id
-        content.LocalFile.objects.filter(pk="9f9438fe6b0d42dd8e913d7d04cfb2b2").update(file_size=2)
-        content.LocalFile.objects.filter(pk="725257a0570044acbd59f8cf6a68b2be").update(file_size=1, available=False)
+        content.LocalFile.objects.filter(pk="6bdfea4a01830fdd4a585181c0b8068c").update(file_size=2)
+        content.LocalFile.objects.filter(pk="211523265f53825b82f70ba19218a02e").update(file_size=1, available=False)
         response = self.client.get(reverse("contentnodefilesize-detail", kwargs={"pk": c1_id}))
         self.assertEqual(response.data, {"total_file_size": 3, "on_device_file_size": 2})
 
     def test_contentnodefilesize_topicnode(self):
         root_id = content.ContentNode.objects.get(title="root").id
-        content.LocalFile.objects.filter(pk="9f9438fe6b0d42dd8e913d7d04cfb2b2").update(file_size=2)
-        content.LocalFile.objects.filter(pk="725257a0570044acbd59f8cf6a68b2be").update(file_size=1, available=False)
+        content.LocalFile.objects.filter(pk="6bdfea4a01830fdd4a585181c0b8068c").update(file_size=2)
+        content.LocalFile.objects.filter(pk="211523265f53825b82f70ba19218a02e").update(file_size=1, available=False)
         content.LocalFile.objects.filter(pk="e00699f859624e0f875ac6fe1e13d648").update(file_size=3)
         response = self.client.get(reverse("contentnodefilesize-detail", kwargs={"pk": root_id}))
         self.assertEqual(response.data, {"total_file_size": 6, "on_device_file_size": 5})
@@ -421,7 +421,7 @@ class ContentNodeAPITestCase(APITestCase):
     def test_channelmetadata_file_sizes_filter_has_total_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(file_size=1)
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
-        self.assertEqual(response.data[0]["total_file_size"], 3)
+        self.assertEqual(response.data[0]["total_file_size"], 2)
 
     def test_channelmetadata_file_sizes_filter_has_on_device_resources(self):
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
@@ -430,7 +430,7 @@ class ContentNodeAPITestCase(APITestCase):
     def test_channelmetadata_file_sizes_filter_has_on_device_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(file_size=1)
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
-        self.assertEqual(response.data[0]["on_device_file_size"], 3)
+        self.assertEqual(response.data[0]["on_device_file_size"], 2)
 
     def test_channelmetadata_file_sizes_filter_has_no_on_device_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(available=True)
@@ -465,10 +465,10 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
-        self.assertEqual(len(response.data), 6)
+        self.assertEqual(len(response.data), 5)
 
     def test_file_retrieve(self):
-        response = self.client.get(self._reverse_channel_url("file-detail", {'pk': "9f9438fe6b0d42dd8e913d7d04cfb2b1"}))
+        response = self.client.get(self._reverse_channel_url("file-detail", {'pk': "6bdfea4a01830fdd4a585181c0b8068c"}))
         self.assertEqual(response.data['preset'], 'High Resolution')
 
     def _setup_contentnode_progress(self):

--- a/kolibri/content/test/test_content_app.py
+++ b/kolibri/content/test/test_content_app.py
@@ -421,7 +421,7 @@ class ContentNodeAPITestCase(APITestCase):
     def test_channelmetadata_file_sizes_filter_has_total_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(file_size=1)
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
-        self.assertEqual(response.data[0]["total_file_size"], 2)
+        self.assertEqual(response.data[0]["total_file_size"], 3)
 
     def test_channelmetadata_file_sizes_filter_has_on_device_resources(self):
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
@@ -430,7 +430,7 @@ class ContentNodeAPITestCase(APITestCase):
     def test_channelmetadata_file_sizes_filter_has_on_device_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(file_size=1)
         response = self.client.get(reverse("channel-list"), {"file_sizes": True})
-        self.assertEqual(response.data[0]["on_device_file_size"], 2)
+        self.assertEqual(response.data[0]["on_device_file_size"], 3)
 
     def test_channelmetadata_file_sizes_filter_has_no_on_device_file_size(self):
         content.LocalFile.objects.filter(files__contentnode__channel_id=self.the_channel_id).update(available=True)
@@ -465,7 +465,7 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))
-        self.assertEqual(len(response.data), 5)
+        self.assertEqual(len(response.data), 6)
 
     def test_file_retrieve(self):
         response = self.client.get(self._reverse_channel_url("file-detail", {'pk': "9f9438fe6b0d42dd8e913d7d04cfb2b1"}))

--- a/kolibri/content/test/test_import_export.py
+++ b/kolibri/content/test/test_import_export.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from mock import call
 from mock import patch
 from requests.exceptions import ConnectionError
+from requests.exceptions import HTTPError
 
 from kolibri.content.models import LocalFile
 from kolibri.utils.tests.helpers import override_option
@@ -171,14 +172,72 @@ class ImportContentTestCase(TestCase):
         annotation_mock.set_availability.assert_called()
 
     @patch('kolibri.content.management.commands.importcontent.len')
-    @patch('kolibri.content.utils.transfer.Transfer.next', side_effect=ConnectionError)
+    @patch('kolibri.content.utils.transfer.Transfer.next', side_effect=ConnectionError('connection error'))
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
     def test_remote_cancel_during_connect_error(self, is_cancelled_mock, cancel_mock, next_mock, len_mock, annotation_mock):
-        call_command("importcontent", "network", self.the_channel_id, node_ids=['32a941fb77c2576e8f6b294cde4c3b0c'])
+        call_command('importcontent', 'network', self.the_channel_id, node_ids=['32a941fb77c2576e8f6b294cde4c3b0c'])
         cancel_mock.assert_called_with()
         len_mock.assert_not_called()
         annotation_mock.set_availability.assert_called()
+
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.start_progress')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
+    def test_remote_import_httperror_404(self, path_mock, logging_mock, start_progress_mock, annotation_mock):
+        local_dest_path_1 = tempfile.mkstemp()[1]
+        local_dest_path_2 = tempfile.mkstemp()[1]
+        local_dest_path_3 = tempfile.mkstemp()[1]
+        path_mock.side_effect = [local_dest_path_1, local_dest_path_2, local_dest_path_3]
+        call_command('importcontent', 'network', self.the_channel_id, node_ids=['2b6926ed22025518a8b9da91745b51d3'], renderable_only=False)
+        self.assertTrue(logging_mock.call_count == 3)
+        self.assertTrue('404' in logging_mock.call_args_list[0][0][0])
+
+    @patch('kolibri.content.management.commands.importcontent.sleep')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_remote_url')
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, False, True, True, True])
+    def test_remote_import_httperror_502(self, is_cancelled_mock, cancel_mock, url_mock, logging_mock, sleep_mock, annotation_mock):
+        url_mock.return_value = 'http://httpbin.org/status/502'
+        call_command('importcontent', 'network', self.the_channel_id)
+        cancel_mock.assert_called_with()
+        annotation_mock.set_availability.assert_called()
+        sleep_mock.assert_called_once()
+        self.assertTrue('502' in logging_mock.call_args_list[0][0][0])
+
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_remote_url')
+    def test_remote_import_httperror_500(self, url_mock, logging_mock, annotation_mock):
+        url_mock.return_value = 'http://httpbin.org/status/500'
+        with self.assertRaises(HTTPError):
+            call_command('importcontent', 'network', self.the_channel_id)
+            self.assertTrue('500' in logging_mock.call_args_list[0][0][0])
+        annotation_mock.set_availability.assert_not_called()
+
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.start_progress')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True])
+    def test_local_import_oserror_dne(self, is_cancelled_mock, cancel_mock, path_mock, logging_mock, start_progress_mock, annotation_mock):
+        dest_path = tempfile.mkstemp()[1]
+        path_mock.side_effect = [dest_path, '/test/dne']
+        call_command('importcontent', 'disk', self.the_channel_id, 'destination')
+        self.assertTrue('No such file or directory' in logging_mock.call_args_list[0][0][0])
+        annotation_mock.set_availability.assert_called()
+
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
+    @patch('kolibri.content.utils.transfer.os.path.getsize')
+    @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
+    def test_local_import_oserror_permission_denied(self, path_mock, getsize_mock, logging_mock, annotation_mock):
+            dest_path = tempfile.mkstemp()[1]
+            path_mock.side_effect = [dest_path, '/test/dne']
+            getsize_mock.side_effect = ['1', OSError('Permission denied')]
+            with self.assertRaises(OSError):
+                call_command('importcontent', 'disk', self.the_channel_id, 'destination')
+                self.assertTrue('Permission denied' in logging_mock.call_args_list[0][0][0])
+                annotation_mock.assert_not_called()
 
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())

--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -136,9 +136,9 @@ class FileDownload(Transfer):
 
     def start(self):
         # If a file download was stopped by Internet connection error,
-        # then reopen the temp file to write to it
+        # then open the temp file again.
         if self.started:
-            self.dest_file_obj = open(self.dest_tmp, "ab")
+            self.dest_file_obj = open(self.dest_tmp, "wb")
 
         # initialize the requests session
         self.session = requests.Session()

--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -5,15 +5,8 @@ import shutil
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
-from requests.packages.urllib3.util.retry import Retry
 
 logging = logger.getLogger(__name__)
-
-
-# policy for retrying downloads with exponential backoff delay
-retries = Retry(total=5,
-                backoff_factor=0.1,
-                status_forcelist=[500, 502, 503, 504])
 
 
 class ExistingTransferInProgress(Exception):
@@ -147,10 +140,10 @@ class FileDownload(Transfer):
         if self.started:
             self.dest_file_obj = open(self.dest_tmp, "ab")
 
-        # initialize the requests session, with backoff-retries enabled
+        # initialize the requests session
         self.session = requests.Session()
-        self.session.mount('http://', HTTPAdapter(max_retries=retries))
-        self.session.mount('https://', HTTPAdapter(max_retries=retries))
+        self.session.mount('http://', HTTPAdapter())
+        self.session.mount('https://', HTTPAdapter())
 
         # initiate the download, check for status errors, and calculate download size
         self.response = self.session.get(

--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -1,6 +1,7 @@
 import logging as logger
 import os
 import shutil
+
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
@@ -141,7 +142,10 @@ class FileDownload(Transfer):
         super(FileDownload, self).__init__(*args, **kwargs)
 
     def start(self):
-        assert not self.started, "File download has already been started, and cannot be started again"
+        # If a file download was stopped by Internet connection error,
+        # then reopen the temp file to write to it
+        if self.started:
+            self.dest_file_obj = open(self.dest_tmp, "ab")
 
         # initialize the requests session, with backoff-retries enabled
         self.session = requests.Session()

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
@@ -149,7 +149,7 @@
       },
       progressMessage() {
         if (this.percentage > 0) {
-          return this.formattedPercentage.toFixed(1) + '%';
+          return this.formattedPercentage.toFixed(2) + '%';
         }
         return '';
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR implements auto-resume for network content import. When there is an connection error or timeout error, it will wait for 30 seconds to retry. 
I edited the file `content_test.json` to have two content files that exist on studio server so that I can access the FileDownload.next() instead of only mocking the FileDownload. Please feel free to let me know if there's a better way to handle the unit test. Thank you!

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test it, please start a network content import, and then turn off the wifi. After some time, turn the wifi back on to continue the import.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3510

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
