### PR TITLE
Conditionally encode when reading stopword file

### DIFF
--- a/kolibri/content/utils/stopwords.py
+++ b/kolibri/content/utils/stopwords.py
@@ -1,10 +1,11 @@
 import json
 import os
 
+from kolibri.core.deviceadmin.utils import KWARGS_IO_READ
 
 # load stopwords file
 stopwords_path = os.path.join(os.path.dirname(__file__), os.path.pardir, 'constants', 'stopwords-all.json')
-with open(stopwords_path, 'r') as f:
+with open(stopwords_path, **KWARGS_IO_READ) as f:
     stopwords = json.load(f)
 
 # load into a set


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Specify encoding for reading stopwords file on python2/3.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Hopefully solves this problem https://github.com/learningequality/kolibri-installer-windows/issues/72#issuecomment-393454573

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
