### PR TITLE
Move vuex.{getters, actions} to computed, methods, respectively

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -87,6 +87,7 @@ import examReport from '../views/exam-report';
 import textTruncator from '../views/text-truncator';
 import kLinearLoader from '../views/k-linear-loader';
 import kCircularLoader from '../views/k-circular-loader';
+import * as vuexCompat from '../utils/vuexCompat';
 
 import * as client from './client';
 import urls from './urls';
@@ -180,5 +181,6 @@ export default {
     validators,
     serverClock,
     i18n,
+    vuexCompat,
   },
 };

--- a/kolibri/core/assets/src/utils/vuexCompat.js
+++ b/kolibri/core/assets/src/utils/vuexCompat.js
@@ -1,0 +1,35 @@
+import mapValues from 'lodash/mapValues';
+
+/**
+ * Use like vuex 3's mapGetters utility
+ * computed: {
+ * ...mapGetters({
+ *     getter1,
+ *     getter2,
+ *   })
+ * }
+ */
+export function mapGetters(getters) {
+  return mapValues(getters, fn => {
+    return function newGetter() {
+      return fn.call(this, this.$store.state);
+    };
+  });
+}
+
+/**
+ * Use like vuex 3's mapActions utility
+ * methods: {
+ *   ...mapActions({
+ *     action1,
+ *     action2,
+ *   })
+ * }
+ */
+export function mapActions(actions) {
+  return mapValues(actions, fn => {
+    return function newAction(...args) {
+      return fn.call(this, this.$store, ...args);
+    };
+  });
+}

--- a/kolibri/core/assets/src/utils/vuexCompat.js
+++ b/kolibri/core/assets/src/utils/vuexCompat.js
@@ -1,15 +1,15 @@
 import mapValues from 'lodash/mapValues';
 
 /**
- * Use like vuex 3's mapGetters utility
+ * Use like vuex 3's mapState utility
  * computed: {
- * ...mapGetters({
+ * ...mapState({
  *     getter1,
  *     getter2,
  *   })
  * }
  */
-export function mapGetters(getters) {
+export function mapState(getters) {
   return mapValues(getters, fn => {
     return function newGetter() {
       return fn.call(this, this.$store.state);

--- a/kolibri/core/assets/src/views/app-bar.vue
+++ b/kolibri/core/assets/src/views/app-bar.vue
@@ -114,6 +114,13 @@
       userMenuDropdownIsOpen: false,
     }),
     computed: {
+      ...mapGetters({
+        isUserLoggedIn,
+        isAdmin,
+        isCoach,
+        isLearner,
+        username: state => state.core.session.username,
+      }),
       userMenuOptions() {
         const changeLanguage = {
           id: 'language',
@@ -141,13 +148,6 @@
           changeLanguage,
         ];
       },
-      ...mapGetters({
-        isUserLoggedIn,
-        isAdmin,
-        isCoach,
-        isLearner,
-        username: state => state.core.session.username,
-      }),
     },
     created() {
       window.addEventListener('click', this.handleClick);

--- a/kolibri/core/assets/src/views/app-bar.vue
+++ b/kolibri/core/assets/src/views/app-bar.vue
@@ -64,7 +64,7 @@
 
   import { kolibriLogout } from 'kolibri.coreVue.vuex.actions';
   import { isUserLoggedIn, isAdmin, isCoach, isLearner } from 'kolibri.coreVue.vuex.getters';
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import uiIconButton from 'keen-ui/src/UiIconButton';
@@ -114,7 +114,7 @@
       userMenuDropdownIsOpen: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         isUserLoggedIn,
         isAdmin,
         isCoach,

--- a/kolibri/core/assets/src/views/app-bar.vue
+++ b/kolibri/core/assets/src/views/app-bar.vue
@@ -64,6 +64,7 @@
 
   import { kolibriLogout } from 'kolibri.coreVue.vuex.actions';
   import { isUserLoggedIn, isAdmin, isCoach, isLearner } from 'kolibri.coreVue.vuex.getters';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import uiIconButton from 'keen-ui/src/UiIconButton';
@@ -140,6 +141,13 @@
           changeLanguage,
         ];
       },
+      ...mapGetters({
+        isUserLoggedIn,
+        isAdmin,
+        isCoach,
+        isLearner,
+        username: state => state.core.session.username,
+      }),
     },
     created() {
       window.addEventListener('click', this.handleClick);
@@ -168,15 +176,8 @@
           this.userMenuDropdownIsOpen = false;
         }
       },
-    },
-    vuex: {
-      actions: { kolibriLogout },
-      getters: {
-        username: state => state.core.session.username,
-        isUserLoggedIn,
-        isAdmin,
-        isCoach,
-        isLearner,
+      kolibriLogout() {
+        kolibriLogout(this.$store);
       },
     },
   };

--- a/kolibri/core/assets/src/views/app-body.vue
+++ b/kolibri/core/assets/src/views/app-body.vue
@@ -20,7 +20,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import errorBox from './error-box';
@@ -47,7 +47,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         loading: state => state.core.loading,
         error: state => state.core.error,
         documentTitle: state => state.core.title,

--- a/kolibri/core/assets/src/views/app-body.vue
+++ b/kolibri/core/assets/src/views/app-body.vue
@@ -47,6 +47,11 @@
       },
     },
     computed: {
+      ...mapGetters({
+        loading: state => state.core.loading,
+        error: state => state.core.error,
+        documentTitle: state => state.core.title,
+      }),
       isMobile() {
         return this.windowSize.breakpoint < 2;
       },
@@ -60,11 +65,6 @@
           padding: `${this.padding}px`,
         };
       },
-      ...mapGetters({
-        loading: state => state.core.loading,
-        error: state => state.core.error,
-        documentTitle: state => state.core.title,
-      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/app-body.vue
+++ b/kolibri/core/assets/src/views/app-body.vue
@@ -20,6 +20,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import errorBox from './error-box';
@@ -59,13 +60,11 @@
           padding: `${this.padding}px`,
         };
       },
-    },
-    vuex: {
-      getters: {
+      ...mapGetters({
         loading: state => state.core.loading,
         error: state => state.core.error,
         documentTitle: state => state.core.title,
-      },
+      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/attempt-log-list.vue
+++ b/kolibri/core/assets/src/views/attempt-log-list.vue
@@ -56,6 +56,7 @@
 <script>
 
   import find from 'lodash/find';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coachContentLabel from 'kolibri.coreVue.components.coachContentLabel';
 
   export default {
@@ -81,16 +82,8 @@
         default: 1,
       },
     },
-    methods: {
-      setSelectedAttemptLog(questionNumber) {
-        this.$emit('select', questionNumber);
-      },
-      isSelected(questionNumber) {
-        return Number(this.selectedQuestionNumber) === questionNumber;
-      },
-    },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         numCoachContents(state) {
           return function getCoachContents(questionNumber) {
             const { questions, exerciseContentNodes } = state.pageState;
@@ -98,6 +91,14 @@
             return find(exerciseContentNodes, { id: questionId }).num_coach_contents;
           };
         },
+      }),
+    },
+    methods: {
+      setSelectedAttemptLog(questionNumber) {
+        this.$emit('select', questionNumber);
+      },
+      isSelected(questionNumber) {
+        return Number(this.selectedQuestionNumber) === questionNumber;
       },
     },
   };

--- a/kolibri/core/assets/src/views/attempt-log-list.vue
+++ b/kolibri/core/assets/src/views/attempt-log-list.vue
@@ -56,7 +56,7 @@
 <script>
 
   import find from 'lodash/find';
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coachContentLabel from 'kolibri.coreVue.components.coachContentLabel';
 
   export default {
@@ -83,7 +83,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         numCoachContents(state) {
           return function getCoachContents(questionNumber) {
             const { questions, exerciseContentNodes } = state.pageState;

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -128,6 +128,10 @@
     },
     data: () => ({ navShown: false }),
     computed: {
+      ...mapGetters({
+        documentTitle: state => state.core.title,
+        toolbarTitle: state => state.pageState.toolbarTitle,
+      }),
       mobile() {
         return this.windowSize.breakpoint < 2;
       },
@@ -137,10 +141,6 @@
       navWidth() {
         return this.headerHeight * 4;
       },
-      ...mapGetters({
-        documentTitle: state => state.core.title,
-        toolbarTitle: state => state.pageState.toolbarTitle,
-      }),
     },
     watch: {
       documentTitle: 'updateDocumentTitle',

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -56,6 +56,7 @@
 
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import values from 'lodash/values';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import appBar from 'kolibri.coreVue.components.appBar';
   import sideNav from 'kolibri.coreVue.components.sideNav';
@@ -125,13 +126,6 @@
         required: false,
       },
     },
-    vuex: {
-      getters: {
-        // set document title (window name)
-        documentTitle: state => state.core.title,
-        toolbarTitle: state => state.pageState.toolbarTitle,
-      },
-    },
     data: () => ({ navShown: false }),
     computed: {
       mobile() {
@@ -143,6 +137,10 @@
       navWidth() {
         return this.headerHeight * 4;
       },
+      ...mapGetters({
+        documentTitle: state => state.core.title,
+        toolbarTitle: state => state.pageState.toolbarTitle,
+      }),
     },
     watch: {
       documentTitle: 'updateDocumentTitle',

--- a/kolibri/core/assets/src/views/core-base.vue
+++ b/kolibri/core/assets/src/views/core-base.vue
@@ -56,7 +56,7 @@
 
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import values from 'lodash/values';
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import appBar from 'kolibri.coreVue.components.appBar';
   import sideNav from 'kolibri.coreVue.components.sideNav';
@@ -128,7 +128,7 @@
     },
     data: () => ({ navShown: false }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         documentTitle: state => state.core.title,
         toolbarTitle: state => state.pageState.toolbarTitle,
       }),

--- a/kolibri/core/assets/src/views/core-snackbar.vue
+++ b/kolibri/core/assets/src/views/core-snackbar.vue
@@ -25,6 +25,7 @@
 <script>
 
   import uiSnackbar from 'keen-ui/src/UiSnackbar';
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import { clearSnackbar } from 'kolibri.coreVue.vuex.actions';
 
   /* Snackbars are used to display notification. */
@@ -95,14 +96,12 @@
           this.$refs.snackbar.$el.focus();
         }
       },
-    },
-    vuex: {
-      actions: {
+      ...mapActions({
         hideSnackbar(store) {
           this.$emit('hide');
           clearSnackbar(store);
         },
-      },
+      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/core-snackbar.vue
+++ b/kolibri/core/assets/src/views/core-snackbar.vue
@@ -88,6 +88,12 @@
       }
     },
     methods: {
+      ...mapActions({
+        hideSnackbar(store) {
+          this.$emit('hide');
+          clearSnackbar(store);
+        },
+      }),
       containFocus(event) {
         if (event.target === window) {
           return;
@@ -96,12 +102,6 @@
           this.$refs.snackbar.$el.focus();
         }
       },
-      ...mapActions({
-        hideSnackbar(store) {
-          this.$emit('hide');
-          clearSnackbar(store);
-        },
-      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/custom-ui-menu/menu-option.vue
+++ b/kolibri/core/assets/src/views/custom-ui-menu/menu-option.vue
@@ -44,7 +44,6 @@
 <script>
 
   import config from 'keen-ui/src/config';
-
   import UiIcon from 'keen-ui/src/UiIcon.vue';
   import UiRippleInk from 'keen-ui/src/UiRippleInk.vue';
 
@@ -78,7 +77,6 @@
         default: false,
       },
     },
-
     computed: {
       classes() {
         return {
@@ -87,7 +85,6 @@
           'is-active': this.active,
         };
       },
-
       isDivider() {
         return this.type === 'divider';
       },

--- a/kolibri/core/assets/src/views/error-box.vue
+++ b/kolibri/core/assets/src/views/error-box.vue
@@ -17,7 +17,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
 
   export default {
     name: 'error',
@@ -31,7 +31,7 @@
       isHidden: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         error: state => state.core.error,
       }),
     },

--- a/kolibri/core/assets/src/views/error-box.vue
+++ b/kolibri/core/assets/src/views/error-box.vue
@@ -17,6 +17,8 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
+
   export default {
     name: 'error',
     $trs: {
@@ -25,14 +27,14 @@
       explanation: `Sorry, something went wrong. Please try refreshing the page`,
       errorLabel: `Error details:`,
     },
-    vuex: {
-      getters: {
-        error: state => state.core.error,
-      },
-    },
     data: () => ({
       isHidden: false,
     }),
+    computed: {
+      ...mapGetters({
+        error: state => state.core.error,
+      }),
+    },
     methods: {
       hideErrorbox() {
         this.isHidden = true;

--- a/kolibri/core/assets/src/views/global-snackbar.vue
+++ b/kolibri/core/assets/src/views/global-snackbar.vue
@@ -17,6 +17,7 @@
 <script>
 
   import coreSnackbar from 'kolibri.coreVue.components.coreSnackbar';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { snackbarIsVisible, snackbarOptions } from 'kolibri.coreVue.vuex.getters';
 
   export default {
@@ -36,18 +37,16 @@
         }
         return JSON.stringify(options) + new Date();
       },
+      ...mapGetters({
+        snackbarIsVisible,
+        snackbarOptions,
+      }),
     },
     methods: {
       hideCallback() {
         if (this.snackbarOptions.hideCallback) {
           this.snackbarOptions.hideCallback();
         }
-      },
-    },
-    vuex: {
-      getters: {
-        snackbarIsVisible,
-        snackbarOptions,
       },
     },
   };

--- a/kolibri/core/assets/src/views/global-snackbar.vue
+++ b/kolibri/core/assets/src/views/global-snackbar.vue
@@ -26,6 +26,10 @@
       coreSnackbar,
     },
     computed: {
+      ...mapGetters({
+        snackbarIsVisible,
+        snackbarOptions,
+      }),
       key() {
         const options = Object.assign({}, this.snackbarOptions);
         // The forceReuse option is used to force the reuse of the snackbar
@@ -37,10 +41,6 @@
         }
         return JSON.stringify(options) + new Date();
       },
-      ...mapGetters({
-        snackbarIsVisible,
-        snackbarOptions,
-      }),
     },
     methods: {
       hideCallback() {

--- a/kolibri/core/assets/src/views/global-snackbar.vue
+++ b/kolibri/core/assets/src/views/global-snackbar.vue
@@ -17,7 +17,7 @@
 <script>
 
   import coreSnackbar from 'kolibri.coreVue.components.coreSnackbar';
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { snackbarIsVisible, snackbarOptions } from 'kolibri.coreVue.vuex.getters';
 
   export default {
@@ -26,7 +26,7 @@
       coreSnackbar,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         snackbarIsVisible,
         snackbarOptions,
       }),

--- a/kolibri/core/assets/src/views/logo/index.vue
+++ b/kolibri/core/assets/src/views/logo/index.vue
@@ -3,10 +3,3 @@
   <img src="./icons/kolibri-logo.svg">
 
 </template>
-
-
-<script>
-
-  export default {};
-
-</script>

--- a/kolibri/core/assets/src/views/side-nav.vue
+++ b/kolibri/core/assets/src/views/side-nav.vue
@@ -133,6 +133,14 @@
       };
     },
     computed: {
+      ...mapGetters({
+        session: state => state.core.session,
+        isUserLoggedIn,
+        isSuperuser,
+        isAdmin,
+        isCoach,
+        canManageContent,
+      }),
       mobile() {
         return this.windowSize.breakpoint < 2;
       },
@@ -201,14 +209,6 @@
         options.push({ type: 'divider' });
         return options;
       },
-      ...mapGetters({
-        session: state => state.core.session,
-        isUserLoggedIn,
-        isSuperuser,
-        isAdmin,
-        isCoach,
-        canManageContent,
-      }),
     },
     watch: {
       navShown(isShown) {
@@ -225,6 +225,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        signOut: kolibriLogout,
+      }),
       navigate(option) {
         if (option.href) {
           window.location.href = option.href;
@@ -246,9 +249,6 @@
           this.$refs.toggleButton.$el.focus();
         }
       },
-      ...mapActions({
-        signOut: kolibriLogout,
-      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/side-nav.vue
+++ b/kolibri/core/assets/src/views/side-nav.vue
@@ -73,6 +73,7 @@
     isCoach,
     canManageContent,
   } from 'kolibri.coreVue.vuex.getters';
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { kolibriLogout } from 'kolibri.coreVue.vuex.actions';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -200,6 +201,14 @@
         options.push({ type: 'divider' });
         return options;
       },
+      ...mapGetters({
+        session: state => state.core.session,
+        isUserLoggedIn,
+        isSuperuser,
+        isAdmin,
+        isCoach,
+        canManageContent,
+      }),
     },
     watch: {
       navShown(isShown) {
@@ -237,17 +246,9 @@
           this.$refs.toggleButton.$el.focus();
         }
       },
-    },
-    vuex: {
-      actions: { signOut: kolibriLogout },
-      getters: {
-        session: state => state.core.session,
-        isUserLoggedIn,
-        isSuperuser,
-        isAdmin,
-        isCoach,
-        canManageContent,
-      },
+      ...mapActions({
+        signOut: kolibriLogout,
+      }),
     },
   };
 

--- a/kolibri/core/assets/src/views/side-nav.vue
+++ b/kolibri/core/assets/src/views/side-nav.vue
@@ -73,7 +73,7 @@
     isCoach,
     canManageContent,
   } from 'kolibri.coreVue.vuex.getters';
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { kolibriLogout } from 'kolibri.coreVue.vuex.actions';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -133,7 +133,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         session: state => state.core.session,
         isUserLoggedIn,
         isSuperuser,

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentCopyModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentCopyModal.vue
@@ -68,6 +68,7 @@
 
   import sortBy from 'lodash/sortBy';
   import find from 'lodash/find';
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import { error as logError } from 'kolibri.lib.logging';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -137,6 +138,9 @@
       this.selectedClassroomId = this.classId;
     },
     methods: {
+      ...mapActions({
+        handleApiError,
+      }),
       getLearnerGroupsForClassroom(classroomId) {
         return LearnerGroupResource.getCollection({ parent: classroomId }).fetch();
       },
@@ -171,11 +175,6 @@
       },
       isCurrentClassroom(classroom) {
         return classroom.id === this.classId;
-      },
-    },
-    vuex: {
-      actions: {
-        handleApiError,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -56,6 +56,7 @@
 <script>
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -84,6 +85,10 @@
       sortedClasses() {
         return orderBy(this.classList, [classroom => classroom.name.toUpperCase()], ['asc']);
       },
+      ...mapGetters({
+        classList: state => state.classList,
+        noClassesExist: state => state.classList.length === 0,
+      }),
     },
     methods: {
       learnerPageLink,
@@ -120,12 +125,6 @@
           return coach_names.join('\n');
         }
         return null;
-      },
-    },
-    vuex: {
-      getters: {
-        classList: state => state.classList,
-        noClassesExist: state => state.classList.length === 0,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -56,7 +56,7 @@
 <script>
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -81,7 +81,7 @@
       kRouterLink,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classList: state => state.classList,
         noClassesExist: state => state.classList.length === 0,
       }),

--- a/kolibri/plugins/coach/assets/src/views/class-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/class-list-page.vue
@@ -81,14 +81,14 @@
       kRouterLink,
     },
     computed: {
-      CLASSROOM: () => ContentNodeKinds.CLASSROOM,
-      sortedClasses() {
-        return orderBy(this.classList, [classroom => classroom.name.toUpperCase()], ['asc']);
-      },
       ...mapGetters({
         classList: state => state.classList,
         noClassesExist: state => state.classList.length === 0,
       }),
+      CLASSROOM: () => ContentNodeKinds.CLASSROOM,
+      sortedClasses() {
+        return orderBy(this.classList, [classroom => classroom.name.toUpperCase()], ['asc']);
+      },
     },
     methods: {
       learnerPageLink,

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -135,7 +135,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -218,7 +218,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.classId,
         topic: state => state.pageState.topic,
         subtopics: state => state.pageState.subtopics,

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -135,6 +135,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -217,6 +218,14 @@
       };
     },
     computed: {
+      ...mapGetters({
+        classId: state => state.classId,
+        topic: state => state.pageState.topic,
+        subtopics: state => state.pageState.subtopics,
+        exercises: state => state.pageState.exercises,
+        selectedExercises: state => state.pageState.selectedExercises,
+        examsModalSet: state => state.pageState.examsModalSet,
+      }),
       numCols() {
         return this.windowSize.breakpoint > 3 ? 2 : 1;
       },
@@ -341,6 +350,16 @@
       },
     },
     methods: {
+      ...mapActions({
+        goToTopic,
+        goToTopLevel,
+        createExamAndRoute,
+        addExercise,
+        removeExercise,
+        setExamsModal,
+        createSnackbar,
+        setSelectedExercises,
+      }),
       setDummyChannelId(id) {
         if (!this.dummyChannelId) {
           this.dummyChannelId = id;
@@ -446,26 +465,6 @@
       randomize() {
         this.seed = this.generateRandomSeed();
         this.setSelectedExercises(shuffle(this.selectedExercises));
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.classId,
-        topic: state => state.pageState.topic,
-        subtopics: state => state.pageState.subtopics,
-        exercises: state => state.pageState.exercises,
-        selectedExercises: state => state.pageState.selectedExercises,
-        examsModalSet: state => state.pageState.examsModalSet,
-      },
-      actions: {
-        goToTopic,
-        goToTopLevel,
-        createExamAndRoute,
-        addExercise,
-        removeExercise,
-        setExamsModal,
-        createSnackbar,
-        setSelectedExercises,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
@@ -46,12 +46,12 @@
       },
     },
     methods: {
-      close() {
-        this.setExamsModal(false);
-      },
       ...mapActions({
         setExamsModal,
       }),
+      close() {
+        this.setExamsModal(false);
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/preview-new-exam-modal.vue
@@ -19,6 +19,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { setExamsModal } from '../../../state/actions/exam';
   import previewExamModal from '../exams-page/preview-exam-modal';
@@ -48,8 +49,10 @@
       close() {
         this.setExamsModal(false);
       },
+      ...mapActions({
+        setExamsModal,
+      }),
     },
-    vuex: { actions: { setExamsModal } },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -34,15 +34,6 @@
       examReport,
     },
     computed: {
-      backPageLink() {
-        return {
-          name: PageNames.EXAM_REPORT,
-          params: {
-            classId: this.classId,
-            examId: this.exam.id,
-          },
-        };
-      },
       ...mapGetters({
         classId: state => state.classId,
         examAttempts: state => state.pageState.examAttempts,
@@ -59,6 +50,15 @@
         completionTimestamp: state => state.pageState.examLog.completion_timestamp,
         closed: state => state.pageState.examLog.closed,
       }),
+      backPageLink() {
+        return {
+          name: PageNames.EXAM_REPORT,
+          params: {
+            classId: this.classId,
+            examId: this.exam.id,
+          },
+        };
+      },
     },
     methods: {
       navigateToQuestion(questionNumber) {

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -24,7 +24,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import examReport from 'kolibri.coreVue.components.examReport';
   import { PageNames } from '../../../constants';
 
@@ -34,7 +34,7 @@
       examReport,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.classId,
         examAttempts: state => state.pageState.examAttempts,
         exam: state => state.pageState.exam,

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -24,6 +24,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import examReport from 'kolibri.coreVue.components.examReport';
   import { PageNames } from '../../../constants';
 
@@ -42,6 +43,22 @@
           },
         };
       },
+      ...mapGetters({
+        classId: state => state.classId,
+        examAttempts: state => state.pageState.examAttempts,
+        exam: state => state.pageState.exam,
+        userName: state => state.pageState.user.full_name,
+        userId: state => state.pageState.user.id,
+        currentAttempt: state => state.pageState.currentAttempt,
+        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
+        currentInteraction: state => state.pageState.currentInteraction,
+        selectedInteractionIndex: state => state.pageState.interactionIndex,
+        questionNumber: state => state.pageState.questionNumber,
+        exercise: state => state.pageState.exercise,
+        itemId: state => state.pageState.itemId,
+        completionTimestamp: state => state.pageState.examLog.completion_timestamp,
+        closed: state => state.pageState.examLog.closed,
+      }),
     },
     methods: {
       navigateToQuestion(questionNumber) {
@@ -61,24 +78,6 @@
             examId: this.exam.id,
           },
         });
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.classId,
-        examAttempts: state => state.pageState.examAttempts,
-        exam: state => state.pageState.exam,
-        userName: state => state.pageState.user.full_name,
-        userId: state => state.pageState.user.id,
-        currentAttempt: state => state.pageState.currentAttempt,
-        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
-        currentInteraction: state => state.pageState.currentInteraction,
-        selectedInteractionIndex: state => state.pageState.interactionIndex,
-        questionNumber: state => state.pageState.questionNumber,
-        exercise: state => state.pageState.exercise,
-        itemId: state => state.pageState.itemId,
-        completionTimestamp: state => state.pageState.examLog.completion_timestamp,
-        closed: state => state.pageState.examLog.closed,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
@@ -85,6 +85,14 @@
       AssignmentDeleteModal,
     },
     computed: {
+      ...mapGetters({
+        exam: state => state.pageState.exam,
+        examsModalSet: state => state.pageState.examsModalSet,
+        classId: state => state.classId,
+        className: state => state.className,
+        classList: state => state.classList,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
       AssignmentActions() {
         return AssignmentActions;
       },
@@ -94,14 +102,6 @@
       selectedCollectionIds() {
         return this.exam.assignments.map(assignment => assignment.collection);
       },
-      ...mapGetters({
-        exam: state => state.pageState.exam,
-        examsModalSet: state => state.pageState.examsModalSet,
-        classId: state => state.classId,
-        className: state => state.className,
-        classList: state => state.classList,
-        learnerGroups: state => state.pageState.learnerGroups,
-      }),
     },
     methods: {
       ...mapActions({

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
@@ -57,7 +57,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import xorWith from 'lodash/xorWith';
   import AssignmentChangeStatusModal from '../../assignments/AssignmentChangeStatusModal';
   import previewExamModal from '../exams-page/preview-exam-modal';
@@ -85,7 +85,7 @@
       AssignmentDeleteModal,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         exam: state => state.pageState.exam,
         examsModalSet: state => state.pageState.examsModalSet,
         classId: state => state.classId,

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/ManageExamModals.vue
@@ -57,6 +57,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import xorWith from 'lodash/xorWith';
   import AssignmentChangeStatusModal from '../../assignments/AssignmentChangeStatusModal';
   import previewExamModal from '../exams-page/preview-exam-modal';
@@ -93,8 +94,24 @@
       selectedCollectionIds() {
         return this.exam.assignments.map(assignment => assignment.collection);
       },
+      ...mapGetters({
+        exam: state => state.pageState.exam,
+        examsModalSet: state => state.pageState.examsModalSet,
+        classId: state => state.classId,
+        className: state => state.className,
+        classList: state => state.classList,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
     },
     methods: {
+      ...mapActions({
+        setExamsModal,
+        activateExam,
+        deactivateExam,
+        deleteExam,
+        copyExam,
+        updateExamDetails,
+      }),
       handleChangeStatus(isActive) {
         if (isActive === true) {
           this.activateExam(this.exam.id);
@@ -139,24 +156,6 @@
           assignments: selectedCollectionIds.map(id => ({ collection: id })),
         };
         this.copyExam(exam, this.className);
-      },
-    },
-    vuex: {
-      getters: {
-        exam: state => state.pageState.exam,
-        examsModalSet: state => state.pageState.examsModalSet,
-        classId: state => state.classId,
-        className: state => state.className,
-        classList: state => state.classList,
-        learnerGroups: state => state.pageState.learnerGroups,
-      },
-      actions: {
-        setExamsModal,
-        activateExam,
-        deactivateExam,
-        deleteExam,
-        copyExam,
-        updateExamDetails,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
@@ -135,6 +135,12 @@
       };
     },
     computed: {
+      ...mapGetters({
+        examTakers: state => state.pageState.examTakers,
+        classId: state => state.classId,
+        exam: state => state.pageState.exam,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
       viewByGroupsIsDisabled() {
         return !this.learnerGroups.length || this.examTakers.every(learner => !learner.group.id);
       },
@@ -172,12 +178,6 @@
           { label: this.$tr('delete') },
         ];
       },
-      ...mapGetters({
-        examTakers: state => state.pageState.examTakers,
-        classId: state => state.classId,
-        exam: state => state.pageState.exam,
-        learnerGroups: state => state.pageState.learnerGroups,
-      }),
     },
     methods: {
       ...mapActions({

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
@@ -102,7 +102,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import sumBy from 'lodash/sumBy';
@@ -135,7 +135,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         examTakers: state => state.pageState.examTakers,
         classId: state => state.classId,
         exam: state => state.pageState.exam,

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-page/index.vue
@@ -102,6 +102,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import sumBy from 'lodash/sumBy';
@@ -171,8 +172,17 @@
           { label: this.$tr('delete') },
         ];
       },
+      ...mapGetters({
+        examTakers: state => state.pageState.examTakers,
+        classId: state => state.classId,
+        exam: state => state.pageState.exam,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
     },
     methods: {
+      ...mapActions({
+        setExamsModal,
+      }),
       handleSelection(optionSelected) {
         const action = optionSelected.label;
         if (action === this.$tr('previewExam')) {
@@ -202,17 +212,6 @@
         return averageScore >= 0
           ? this.$tr('averageScore', { num: averageScore })
           : this.$tr('noAverageScore');
-      },
-    },
-    vuex: {
-      getters: {
-        examTakers: state => state.pageState.examTakers,
-        classId: state => state.classId,
-        exam: state => state.pageState.exam,
-        learnerGroups: state => state.pageState.learnerGroups,
-      },
-      actions: {
-        setExamsModal,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
@@ -73,7 +73,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import orderBy from 'lodash/orderBy';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
@@ -119,7 +119,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         exams: state => state.pageState.exams,
       }),
       examIcon() {

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/index.vue
@@ -73,6 +73,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import orderBy from 'lodash/orderBy';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
@@ -118,6 +119,9 @@
       };
     },
     computed: {
+      ...mapGetters({
+        exams: state => state.pageState.exams,
+      }),
       examIcon() {
         return ContentNodeKinds.EXAM;
       },
@@ -167,19 +171,12 @@
         }
       },
     },
-    vuex: {
-      getters: {
-        exams: state => state.pageState.exams,
-      },
-    },
   };
 
 </script>
 
 
 <style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
 
   .filter-and-button
     display: flex

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -76,7 +76,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import find from 'lodash/find';
   import { ContentNodeResource } from 'kolibri.resources';
   import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
@@ -131,7 +131,7 @@
       loading: true,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         exerciseContentNodes: state => state.pageState.exerciseContentNodes,
       }),
       questions() {

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -76,6 +76,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import find from 'lodash/find';
   import { ContentNodeResource } from 'kolibri.resources';
   import { createQuestionList, selectQuestionFromExercise } from 'kolibri.utils.exams';
@@ -130,6 +131,9 @@
       loading: true,
     }),
     computed: {
+      ...mapGetters({
+        exerciseContentNodes: state => state.pageState.exerciseContentNodes,
+      }),
       questions() {
         return Object.keys(this.exercises).length
           ? createQuestionList(this.examQuestionSources).map(question => ({
@@ -159,6 +163,9 @@
       this.setExercises();
     },
     methods: {
+      ...mapActions({
+        setExamsModal,
+      }),
       numCoachContents(exercise) {
         return find(this.exerciseContentNodes, { id: exercise.exercise_id }).num_coach_contents;
       },
@@ -200,14 +207,6 @@
       },
       getExerciseQuestions(exerciseId) {
         return this.questions.filter(q => q.contentId === exerciseId);
-      },
-    },
-    vuex: {
-      actions: {
-        setExamsModal,
-      },
-      getters: {
-        exerciseContentNodes: state => state.pageState.exerciseContentNodes,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -39,7 +39,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';

--- a/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/create-group-modal.vue
@@ -39,6 +39,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -102,6 +103,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+        createGroup,
+      }),
       callCreateGroup() {
         this.formSubmitted = true;
         if (this.formIsValid) {
@@ -113,12 +118,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        displayModal,
-        createGroup,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/delete-group-modal.vue
@@ -25,6 +25,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -55,14 +56,12 @@
       },
     },
     methods: {
-      close() {
-        this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
+      ...mapActions({
         displayModal,
         deleteGroup,
+      }),
+      close() {
+        this.displayModal(false);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -85,7 +85,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -142,7 +142,7 @@
       return { selectedUsers: [] };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         groupModalShown: state => state.pageState.groupModalShown,
       }),
       sortedGroupUsers() {

--- a/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/group-section.vue
@@ -85,6 +85,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -141,6 +142,9 @@
       return { selectedUsers: [] };
     },
     computed: {
+      ...mapGetters({
+        groupModalShown: state => state.pageState.groupModalShown,
+      }),
       sortedGroupUsers() {
         return sortBy(this.group.users, user => user.full_name.toLowerCase());
       },
@@ -163,6 +167,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+      }),
       handleSelection(selectedOption) {
         if (selectedOption === this.$tr('renameGroup')) {
           this.$emit('rename', this.group.name, this.group.id);
@@ -191,10 +198,6 @@
       emitMove() {
         this.$emit('move', this.group.name, this.group.id, this.selectedUsers, this.isUngrouped);
       },
-    },
-    vuex: {
-      getters: { groupModalShown: state => state.pageState.groupModalShown },
-      actions: { displayModal },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
@@ -63,6 +63,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import differenceWith from 'lodash/differenceWith';
   import orderBy from 'lodash/orderBy';
   import flatMap from 'lodash/flatMap';
@@ -102,6 +103,11 @@
       };
     },
     computed: {
+      ...mapGetters({
+        classUsers: state => state.pageState.classUsers,
+        groups: state => state.pageState.groups,
+        groupModalShown: state => state.pageState.groupModalShown,
+      }),
       showCreateGroupModal() {
         return this.groupModalShown === GroupModals.CREATE_GROUP;
       },
@@ -131,6 +137,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+      }),
       openCreateGroupModal() {
         this.displayModal(GroupModals.CREATE_GROUP);
       },
@@ -157,14 +166,6 @@
         this.isUngrouped = isUngrouped;
         this.displayModal(GroupModals.MOVE_LEARNERS);
       },
-    },
-    vuex: {
-      getters: {
-        classUsers: state => state.pageState.classUsers,
-        groups: state => state.pageState.groups,
-        groupModalShown: state => state.pageState.groupModalShown,
-      },
-      actions: { displayModal },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/index.vue
@@ -63,7 +63,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import differenceWith from 'lodash/differenceWith';
   import orderBy from 'lodash/orderBy';
   import flatMap from 'lodash/flatMap';
@@ -103,7 +103,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classUsers: state => state.pageState.classUsers,
         groups: state => state.pageState.groups,
         groupModalShown: state => state.pageState.groupModalShown,

--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -42,6 +42,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
@@ -100,6 +101,12 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+        addUsersToGroup,
+        removeUsersFromGroup,
+        moveUsersBetweenGroups,
+      }),
       moveUsers() {
         if (this.groupId) {
           if (this.groupSelected === 'ungrouped') {
@@ -113,14 +120,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        displayModal,
-        addUsersToGroup,
-        removeUsersFromGroup,
-        moveUsersBetweenGroups,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/rename-group-modal.vue
@@ -39,6 +39,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -114,6 +115,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        renameGroup,
+        displayModal,
+      }),
       callRenameGroup() {
         this.formSubmitted = true;
         if (this.formIsValid) {
@@ -125,12 +130,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        renameGroup,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { isAdmin, isCoach, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
@@ -124,7 +124,7 @@
       navTitle,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         toolbarRoute: state => state.pageState.toolbarRoute,
         pageName: state => state.pageName,
         isAdmin,

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -30,6 +30,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { isAdmin, isCoach, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
@@ -123,6 +124,17 @@
       navTitle,
     },
     computed: {
+      ...mapGetters({
+        toolbarRoute: state => state.pageState.toolbarRoute,
+        pageName: state => state.pageName,
+        isAdmin,
+        isCoach,
+        isSuperuser,
+        className,
+        classCoaches,
+        classList: state => state.classList,
+        classId: state => state.classId,
+      }),
       topLevelPageName: () => TopLevelPageNames.COACH,
       currentPage() {
         if (!this.userCanAccessPage) {
@@ -178,19 +190,6 @@
           return false;
         }
         return true;
-      },
-    },
-    vuex: {
-      getters: {
-        toolbarRoute: state => state.pageState.toolbarRoute,
-        pageName: state => state.pageName,
-        isAdmin,
-        isCoach,
-        isSuperuser,
-        className,
-        classCoaches,
-        classList: state => state.classList,
-        classId: state => state.classId,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/index.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { isAdmin, isCoach, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/SelectOptions.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/SelectOptions.vue
@@ -27,6 +27,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
 
   export default {
@@ -54,8 +55,8 @@
         return this.workingResources.includes(this.contentId);
       },
     },
-    vuex: {
-      actions: {
+    methods: {
+      ...mapActions({
         // Maybe break these out to actual actions.
         // Used by select page, summary page, and here
         addToWorkingResources(store) {
@@ -65,7 +66,7 @@
         removeFromWorkingResources(store) {
           store.dispatch('REMOVE_FROM_WORKING_RESOURCES', this.contentId);
         },
-      },
+      }),
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -39,6 +39,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
@@ -63,6 +64,12 @@
       };
     },
     computed: {
+      ...mapGetters({
+        content: state => state.pageState.currentContentNode,
+        questions: state => state.pageState.questions,
+        completionData: state => state.pageState.completionData,
+        workingResources: state => state.pageState.workingResources,
+      }),
       isPerseusExercise() {
         return this.content.kind === 'exercise';
       },
@@ -74,25 +81,17 @@
       },
     },
     methods: {
+      ...mapActions({
+        addToCache(store) {
+          store.dispatch('ADD_TO_RESOURCE_CACHE', this.content);
+        },
+      }),
       questionLabel(questionIndex) {
         if (!this.isPerseusExercise) {
           return '';
         }
         const questionNumber = questionIndex + 1;
         return this.$tr('questionLabel', { questionNumber });
-      },
-    },
-    vuex: {
-      getters: {
-        content: state => state.pageState.currentContentNode,
-        questions: state => state.pageState.questions,
-        completionData: state => state.pageState.completionData,
-        workingResources: state => state.pageState.workingResources,
-      },
-      actions: {
-        addToCache(store) {
-          store.dispatch('ADD_TO_RESOURCE_CACHE', this.content);
-        },
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -39,7 +39,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
@@ -64,7 +64,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         content: state => state.pageState.currentContentNode,
         questions: state => state.pageState.questions,
         completionData: state => state.pageState.completionData,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -61,6 +61,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -82,6 +83,16 @@
       searchTools,
     },
     computed: {
+      ...mapGetters({
+        currentLesson: state => state.pageState.currentLesson,
+        lessonId: state => state.pageState.currentLesson.id,
+        workingResources: state => state.pageState.workingResources,
+        // TODO remove since we don't need it in template; use actions
+        classId: state => state.classId,
+        contentList: state => state.pageState.contentList,
+        resourceCache: state => state.pageState.resourceCache,
+        ancestorCounts: state => state.pageState.ancestorCounts,
+      }),
       lessonPage() {
         return lessonSummaryLink(this.routerParams);
       },
@@ -90,6 +101,17 @@
       },
     },
     methods: {
+      ...mapActions({
+        saveLessonResources,
+        createSnackbar,
+        addToSelectedResources(store, contentId) {
+          store.dispatch('ADD_TO_RESOURCE_CACHE', this.contentList.find(n => n.id === contentId));
+          store.dispatch('ADD_TO_WORKING_RESOURCES', contentId);
+        },
+        removeFromSelectedResources(store, contentId) {
+          store.dispatch('REMOVE_FROM_WORKING_RESOURCES', contentId);
+        },
+      }),
       // IDEA refactor router logic into actions
       contentIsDirectoryKind({ kind }) {
         return kind === ContentNodeKinds.TOPIC || kind === ContentNodeKinds.CHANNEL;
@@ -135,29 +157,6 @@
         } else {
           this.removeFromSelectedResources(contentId);
         }
-      },
-    },
-    vuex: {
-      getters: {
-        currentLesson: state => state.pageState.currentLesson,
-        lessonId: state => state.pageState.currentLesson.id,
-        workingResources: state => state.pageState.workingResources,
-        // TODO remove since we don't need it in template; use actions
-        classId: state => state.classId,
-        contentList: state => state.pageState.contentList,
-        resourceCache: state => state.pageState.resourceCache,
-        ancestorCounts: state => state.pageState.ancestorCounts,
-      },
-      actions: {
-        saveLessonResources,
-        createSnackbar,
-        addToSelectedResources(store, contentId) {
-          store.dispatch('ADD_TO_RESOURCE_CACHE', this.contentList.find(n => n.id === contentId));
-          store.dispatch('ADD_TO_WORKING_RESOURCES', contentId);
-        },
-        removeFromSelectedResources(store, contentId) {
-          store.dispatch('REMOVE_FROM_WORKING_RESOURCES', contentId);
-        },
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -61,7 +61,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -83,7 +83,7 @@
       searchTools,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentLesson: state => state.pageState.currentLesson,
         lessonId: state => state.pageState.currentLesson.id,
         workingResources: state => state.pageState.workingResources,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/searchTools/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/searchTools/index.vue
@@ -1,21 +1,12 @@
 <template>
 
   <div>
-    <!-- TODO make search box work, sets content on page -->
-
-    <!-- TODO functionalize -->
-    <!-- <search-box /> -->
-
-    <!-- TODO add conditionalsearch exit button -->
-
     <k-breadcrumbs
       v-if="!noContentOnDevice"
       :items="selectionCrumbs"
       :showSingleItem="true"
     />
 
-    <!-- TODO add conditional filters for search -->
-    <!-- TODO add conditional search result strings -->
     <template v-if="contentListEmpty">
       {{ emptyStateString }}
     </template>
@@ -26,14 +17,13 @@
 
 <script>
 
-  // import searchBox from '../../../../../../../learn/assets/src/views/search-box/';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { selectionRootLink, topicListingLink } from '../../lessonsRouterUtils';
 
   export default {
     name: 'searchTools',
     components: {
-      // searchBox,
       kBreadcrumbs,
     },
     data() {
@@ -44,6 +34,12 @@
       };
     },
     computed: {
+      ...mapGetters({
+        ancestors: state => state.pageState.ancestors,
+        lessonId: state => state.pageState.currentLesson.id,
+        classId: state => state.classId,
+        contentList: state => state.pageState.contentList,
+      }),
       // TODO cleanup, classId and lessonId are included in these routes all of these routes
       routerParams() {
         return { classId: this.classId, lessonId: this.lessonId };
@@ -77,16 +73,6 @@
           return this.$tr('noResourcesInTopicStatus');
         }
       },
-    },
-    methods: {},
-    vuex: {
-      getters: {
-        ancestors: state => state.pageState.ancestors,
-        lessonId: state => state.pageState.currentLesson.id,
-        classId: state => state.classId,
-        contentList: state => state.pageState.contentList,
-      },
-      actions: {},
     },
     $trs: {
       noResourcesOnDeviceStatus: 'No Channels to select resources from',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/searchTools/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/searchTools/index.vue
@@ -17,7 +17,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { selectionRootLink, topicListingLink } from '../../lessonsRouterUtils';
 
@@ -34,7 +34,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         ancestors: state => state.pageState.ancestors,
         lessonId: state => state.pageState.currentLesson.id,
         classId: state => state.classId,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
@@ -160,6 +160,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -192,6 +193,13 @@
       };
     },
     computed: {
+      ...mapGetters({
+        resourceTitle: state => state.pageState.resourceTitle,
+        resourceKind: state => state.pageState.resourceKind,
+        channelTitle: state => state.pageState.channelTitle,
+        userData: state => state.pageState.userData,
+        contentNode: state => state.pageState.contentNode,
+      }),
       isExercise() {
         return this.resourceKind === ContentNodeKinds.EXERCISE;
       },
@@ -230,16 +238,6 @@
         this.sortBy = sortKey;
         this.invert = false;
       },
-    },
-    vuex: {
-      getters: {
-        resourceTitle: state => state.pageState.resourceTitle,
-        resourceKind: state => state.pageState.resourceKind,
-        channelTitle: state => state.pageState.channelTitle,
-        userData: state => state.pageState.userData,
-        contentNode: state => state.pageState.contentNode,
-      },
-      actions: {},
     },
     $trs: {
       channelTitleLabel: 'Channel',

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceUserSummaryPage.vue
@@ -160,7 +160,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -193,7 +193,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         resourceTitle: state => state.pageState.resourceTitle,
         resourceKind: state => state.pageState.resourceKind,
         channelTitle: state => state.pageState.channelTitle,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ManageLessonModals.vue
@@ -51,6 +51,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import AssignmentChangeStatusModal from '../../assignments/AssignmentChangeStatusModal';
   import AssignmentDetailsModal from '../../assignments/AssignmentDetailsModal';
   import AssignmentCopyModal from '../../assignments/AssignmentCopyModal';
@@ -73,6 +74,14 @@
       AssignmentDeleteModal,
     },
     computed: {
+      ...mapGetters({
+        currentLesson: state => state.pageState.currentLesson,
+        lessonsModalSet: state => state.pageState.lessonsModalSet,
+        classId: state => state.classId,
+        classList: state => state.classList,
+        className: state => state.className,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
       AssignmentActions() {
         return AssignmentActions;
       },
@@ -81,6 +90,13 @@
       },
     },
     methods: {
+      ...mapActions({
+        setLessonsModal,
+        updateLessonStatus,
+        deleteLesson,
+        copyLesson,
+        updateLesson,
+      }),
       handleChangeStatus(isActive) {
         this.updateLessonStatus(this.currentLesson.id, isActive);
       },
@@ -104,23 +120,6 @@
         })
           .then()
           .catch(() => this.$refs.detailsModal.handleSubmitFailure());
-      },
-    },
-    vuex: {
-      getters: {
-        currentLesson: state => state.pageState.currentLesson,
-        lessonsModalSet: state => state.pageState.lessonsModalSet,
-        classId: state => state.classId,
-        classList: state => state.classList,
-        className: state => state.className,
-        learnerGroups: state => state.pageState.learnerGroups,
-      },
-      actions: {
-        setLessonsModal,
-        updateLessonStatus,
-        deleteLesson,
-        copyLesson,
-        updateLesson,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ManageLessonModals.vue
@@ -51,7 +51,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import AssignmentChangeStatusModal from '../../assignments/AssignmentChangeStatusModal';
   import AssignmentDetailsModal from '../../assignments/AssignmentDetailsModal';
   import AssignmentCopyModal from '../../assignments/AssignmentCopyModal';
@@ -74,7 +74,7 @@
       AssignmentDeleteModal,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentLesson: state => state.pageState.currentLesson,
         lessonsModalSet: state => state.pageState.lessonsModalSet,
         classId: state => state.classId,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -102,7 +102,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
@@ -134,7 +134,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         lessonId: state => state.pageState.currentLesson.id,
         workingResources: state => state.pageState.workingResources,
         // consider loading this async?

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -116,6 +116,10 @@
 
   const removalSnackbarTime = 5000;
 
+  function workingResources(state) {
+    return state.pageState.workingResources;
+  }
+
   export default {
     name: 'resourceListTable',
     components: {
@@ -129,14 +133,14 @@
     },
     data() {
       return {
-        workingResourcesBackup: Array.from(this.workingResources),
+        workingResourcesBackup: Array.from(workingResources(this.$store.state)),
         firstRemovalTitle: '',
       };
     },
     computed: {
       ...mapState({
         lessonId: state => state.pageState.currentLesson.id,
-        workingResources: state => state.pageState.workingResources,
+        workingResources,
         // consider loading this async?
         resourceContentNodes: state => state.pageState.resourceCache,
         totalLearners: state => state.pageState.lessonReport.total_learners,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -102,6 +102,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
@@ -133,6 +134,27 @@
       };
     },
     computed: {
+      ...mapGetters({
+        lessonId: state => state.pageState.currentLesson.id,
+        workingResources: state => state.pageState.workingResources,
+        // consider loading this async?
+        resourceContentNodes: state => state.pageState.resourceCache,
+        totalLearners: state => state.pageState.lessonReport.total_learners,
+        getCachedResource(state) {
+          return function getter(resourceId) {
+            return state.pageState.resourceCache[resourceId] || {};
+          };
+        },
+        numLearnersCompleted(state) {
+          return function counter(contentNodeId) {
+            const report =
+              state.pageState.lessonReport.progress.find(p => p.contentnode_id === contentNodeId) ||
+              {};
+            // If progress couldn't be found, assume 0 learners completed
+            return report.num_learners_completed || 0;
+          };
+        },
+      }),
       removalMessage() {
         const numberOfRemovals = this.workingResourcesBackup.length - this.workingResources.length;
 
@@ -150,6 +172,18 @@
       },
     },
     methods: {
+      ...mapActions({
+        saveLessonResources,
+        updateCurrentLesson,
+        createSnackbar,
+        clearSnackbar,
+        removeFromWorkingResources(store, resourceId) {
+          store.dispatch('REMOVE_FROM_WORKING_RESOURCES', resourceId);
+        },
+        setWorkingResources(store, resourceArray) {
+          store.dispatch('SET_WORKING_RESOURCES', resourceArray);
+        },
+      }),
       resourceUserSummaryLink,
       resourceTitle(resourceId) {
         return this.resourceContentNodes[resourceId].title;
@@ -224,41 +258,6 @@
             );
           });
         });
-      },
-    },
-    vuex: {
-      getters: {
-        lessonId: state => state.pageState.currentLesson.id,
-        workingResources: state => state.pageState.workingResources,
-        // consider loading this async?
-        resourceContentNodes: state => state.pageState.resourceCache,
-        totalLearners: state => state.pageState.lessonReport.total_learners,
-        getCachedResource(state) {
-          return function getter(resourceId) {
-            return state.pageState.resourceCache[resourceId] || {};
-          };
-        },
-        numLearnersCompleted(state) {
-          return function counter(contentNodeId) {
-            const report =
-              state.pageState.lessonReport.progress.find(p => p.contentnode_id === contentNodeId) ||
-              {};
-            // If progress couldn't be found, assume 0 learners completed
-            return report.num_learners_completed || 0;
-          };
-        },
-      },
-      actions: {
-        saveLessonResources,
-        updateCurrentLesson,
-        createSnackbar,
-        clearSnackbar,
-        removeFromWorkingResources(store, resourceId) {
-          store.dispatch('REMOVE_FROM_WORKING_RESOURCES', resourceId);
-        },
-        setWorkingResources(store, resourceArray) {
-          store.dispatch('SET_WORKING_RESOURCES', resourceArray);
-        },
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -52,7 +52,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import map from 'lodash/map';
@@ -74,7 +74,7 @@
       AssignmentSummary,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         // IDEA refactor, make actions get all this information themselves.
         classId: state => state.classId,
         lessonId: state => state.pageState.currentLesson.id,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -52,6 +52,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import map from 'lodash/map';
@@ -73,6 +74,17 @@
       AssignmentSummary,
     },
     computed: {
+      ...mapGetters({
+        // IDEA refactor, make actions get all this information themselves.
+        classId: state => state.classId,
+        lessonId: state => state.pageState.currentLesson.id,
+        lessonTitle: state => state.pageState.currentLesson.title,
+        lessonActive: state => state.pageState.currentLesson.is_active,
+        lessonDescription: state => state.pageState.currentLesson.description,
+        lessonAssignments: state => state.pageState.currentLesson.lesson_assignments,
+        lessonResources: state => state.pageState.currentLesson.resources,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
       lessonOptions() {
         return map(this.actionsToLabelMap, (label, action) => ({
           label: this.$tr(label),
@@ -97,24 +109,11 @@
       },
     },
     methods: {
+      ...mapActions({
+        setLessonsModal,
+      }),
       handleSelectOption({ action }) {
         this.setLessonsModal(action);
-      },
-    },
-    vuex: {
-      actions: {
-        setLessonsModal,
-      },
-      getters: {
-        // IDEA refactor, make actions get all this information themselves.
-        classId: state => state.classId,
-        lessonId: state => state.pageState.currentLesson.id,
-        lessonTitle: state => state.pageState.currentLesson.title,
-        lessonActive: state => state.pageState.currentLesson.is_active,
-        lessonDescription: state => state.pageState.currentLesson.description,
-        lessonAssignments: state => state.pageState.currentLesson.lesson_assignments,
-        lessonResources: state => state.pageState.currentLesson.resources,
-        learnerGroups: state => state.pageState.learnerGroups,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -89,7 +89,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import countBy from 'lodash/countBy';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
@@ -123,7 +123,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         lessons: state => state.pageState.lessons,
         classId: state => state.classId,
         learnerGroups: state => state.pageState.learnerGroups,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -89,6 +89,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import countBy from 'lodash/countBy';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
@@ -122,6 +123,11 @@
       };
     },
     computed: {
+      ...mapGetters({
+        lessons: state => state.pageState.lessons,
+        classId: state => state.classId,
+        learnerGroups: state => state.pageState.learnerGroups,
+      }),
       filterOptions() {
         const filters = ['allLessons', 'activeLessons', 'inactiveLessons'];
         return filters.map(filter => ({
@@ -137,6 +143,9 @@
       this.filterSelection = this.filterOptions[0];
     },
     methods: {
+      ...mapActions({
+        createLesson,
+      }),
       showLesson(lesson) {
         switch (this.filterSelection.value) {
           case 'activeLessons':
@@ -167,16 +176,6 @@
         })
           .then()
           .catch(() => this.$refs.detailsModal.handleSubmitFailure());
-      },
-    },
-    vuex: {
-      actions: {
-        createLesson,
-      },
-      getters: {
-        lessons: state => state.pageState.lessons,
-        classId: state => state.classId,
-        learnerGroups: state => state.pageState.learnerGroups,
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
@@ -7,7 +7,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { getChannels, getChannelObject } from 'kolibri.coreVue.vuex.getters';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../../constants';
@@ -27,7 +27,7 @@
     },
     components: { kBreadcrumbs },
     computed: {
-      ...mapGetters({
+      ...mapState({
         channels: getChannels,
         classId: state => state.classId,
         pageName: state => state.pageName,

--- a/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/breadcrumbs.vue
@@ -7,6 +7,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { getChannels, getChannelObject } from 'kolibri.coreVue.vuex.getters';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../../constants';
@@ -26,6 +27,34 @@
     },
     components: { kBreadcrumbs },
     computed: {
+      ...mapGetters({
+        channels: getChannels,
+        classId: state => state.classId,
+        pageName: state => state.pageName,
+        pageState: state => state.pageState,
+        currentClassroom: state => state.currentClassroom,
+        isTopicPage,
+        isLearnerPage,
+        isRecentPage,
+        getChannelObject: state => getChannelObject.bind(null, state),
+        numberOfAssignedClassrooms,
+        currentLearnerForReport(state) {
+          if (state.pageState.userScope === 'user') {
+            return {
+              name: state.pageState.userScopeName,
+              id: state.pageState.userScopeId,
+            };
+          }
+        },
+        currentLearnerReportContentNode(state) {
+          if (state.pageState.contentScope) {
+            return {
+              name: state.pageState.contentScopeSummary.title,
+              ancestors: state.pageState.contentScopeSummary.ancestors,
+            };
+          }
+        },
+      }),
       channelTitle() {
         return this.pageState.channelId
           ? this.getChannelObject(this.pageState.channelId).title
@@ -194,36 +223,6 @@
             },
           })),
         ];
-      },
-    },
-    vuex: {
-      getters: {
-        channels: getChannels,
-        classId: state => state.classId,
-        pageName: state => state.pageName,
-        pageState: state => state.pageState,
-        currentClassroom: state => state.currentClassroom,
-        isTopicPage,
-        isLearnerPage,
-        isRecentPage,
-        getChannelObject: state => getChannelObject.bind(null, state),
-        numberOfAssignedClassrooms,
-        currentLearnerForReport(state) {
-          if (state.pageState.userScope === 'user') {
-            return {
-              name: state.pageState.userScopeName,
-              id: state.pageState.userScopeId,
-            };
-          }
-        },
-        currentLearnerReportContentNode(state) {
-          if (state.pageState.contentScope) {
-            return {
-              name: state.pageState.contentScopeSummary.title,
-              ancestors: state.pageState.contentScopeSummary.ancestors,
-            };
-          }
-        },
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
@@ -56,6 +56,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -91,6 +92,13 @@
       noChannels: 'You do not have any content yet',
     },
     computed: {
+      ...mapGetters({
+        channels: getChannels,
+        standardDataTable,
+        classId: state => state.classId,
+        pageName: state => state.pageName,
+        showRecentOnly: state => state.pageState.showRecentOnly,
+      }),
       CHANNEL() {
         return ContentNodeKinds.CHANNEL;
       },
@@ -115,15 +123,6 @@
             channelId,
           },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        channels: getChannels,
-        standardDataTable,
-        classId: state => state.classId,
-        pageName: state => state.pageName,
-        showRecentOnly: state => state.pageState.showRecentOnly,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/channel-list-page.vue
@@ -56,7 +56,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -92,7 +92,7 @@
       noChannels: 'You do not have any content yet',
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         channels: getChannels,
         standardDataTable,
         classId: state => state.classId,

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -77,7 +77,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -77,7 +77,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -116,7 +116,7 @@
       emptyTableMessage: 'No exercises or resources in this topic',
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.classId,
         pageName: state => state.pageName,
         pageState: state => state.pageState,

--- a/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/item-list-page.vue
@@ -77,6 +77,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -115,6 +116,14 @@
       emptyTableMessage: 'No exercises or resources in this topic',
     },
     computed: {
+      ...mapGetters({
+        classId: state => state.classId,
+        pageName: state => state.pageName,
+        pageState: state => state.pageState,
+        exerciseCount,
+        contentCount,
+        standardDataTable,
+      }),
       tableColumns() {
         return TableColumns;
       },
@@ -146,16 +155,6 @@
           }
         }
         return null;
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.classId,
-        pageName: state => state.pageName,
-        pageState: state => state.pageState,
-        exerciseCount,
-        contentCount,
-        standardDataTable,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -9,7 +9,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import { PageNames, LearnerReports } from '../../../constants';
   import learnerExerciseReport from './learner-exercise-report';
@@ -22,7 +22,7 @@
       learnerExerciseReport,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         channelId: state => state.pageState.channelId,
         user: state => state.pageState.user,
         exercise: state => state.pageState.exercise,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -9,6 +9,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import { PageNames, LearnerReports } from '../../../constants';
   import learnerExerciseReport from './learner-exercise-report';
@@ -21,6 +22,13 @@
       learnerExerciseReport,
     },
     computed: {
+      ...mapGetters({
+        channelId: state => state.pageState.channelId,
+        user: state => state.pageState.user,
+        exercise: state => state.pageState.exercise,
+        classId: state => state.classId,
+        pageName: state => state.pageName,
+      }),
       backPageLink() {
         if (this.pageName === PageNames.RECENT_LEARNER_ITEM_DETAILS) {
           return {
@@ -63,15 +71,6 @@
       },
       parentTopic() {
         return this.exercise.ancestors[this.exercise.ancestors.length - 1];
-      },
-    },
-    vuex: {
-      getters: {
-        channelId: state => state.pageState.channelId,
-        user: state => state.pageState.user,
-        exercise: state => state.pageState.exercise,
-        classId: state => state.classId,
-        pageName: state => state.pageName,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -51,6 +51,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import attemptLogList from 'kolibri.coreVue.components.attemptLogList';
@@ -67,6 +68,20 @@
       interactionList,
     },
     computed: {
+      ...mapGetters({
+        interactionIndex: state => state.pageState.interactionIndex,
+        currentAttemptLog: state => state.pageState.currentAttemptLog,
+        attemptLogs: state => state.pageState.attemptLogs,
+        currentInteraction: state => state.pageState.currentInteraction,
+        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
+        classId: state => state.classId,
+        channelId: state => state.pageState.channelId,
+        user: state => state.pageState.user,
+        exercise: state => state.pageState.exercise,
+        summaryLog: state => state.pageState.summaryLog,
+        pageName: state => state.pageName,
+        attemptLogIndex: state => state.pageState.attemptLogIndex,
+      }),
       isExercise() {
         return this.exercise.kind === ContentNodeKinds.EXERCISE;
       },
@@ -95,22 +110,6 @@
             interactionIndex,
           },
         });
-      },
-    },
-    vuex: {
-      getters: {
-        interactionIndex: state => state.pageState.interactionIndex,
-        currentAttemptLog: state => state.pageState.currentAttemptLog,
-        attemptLogs: state => state.pageState.attemptLogs,
-        currentInteraction: state => state.pageState.currentInteraction,
-        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
-        classId: state => state.classId,
-        channelId: state => state.pageState.channelId,
-        user: state => state.pageState.user,
-        exercise: state => state.pageState.exercise,
-        summaryLog: state => state.pageState.summaryLog,
-        pageName: state => state.pageName,
-        attemptLogIndex: state => state.pageState.attemptLogIndex,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -51,7 +51,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import attemptLogList from 'kolibri.coreVue.components.attemptLogList';
@@ -68,7 +68,7 @@
       interactionList,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         interactionIndex: state => state.pageState.interactionIndex,
         currentAttemptLog: state => state.pageState.currentAttemptLog,
         attemptLogs: state => state.pageState.attemptLogs,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
@@ -79,6 +79,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -122,6 +123,14 @@
       noLearners: 'There are no learners enrolled in this class',
     },
     computed: {
+      ...mapGetters({
+        classId: state => state.classId,
+        pageState: state => state.pageState,
+        pageName: state => state.pageName,
+        exerciseCount,
+        contentCount,
+        standardDataTable,
+      }),
       isExercisePage() {
         return this.pageState.contentScopeSummary.kind === ContentNodeKinds.EXERCISE;
       },
@@ -161,16 +170,6 @@
           };
         }
         return undefined;
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.classId,
-        pageState: state => state.pageState,
-        pageName: state => state.pageName,
-        exerciseCount,
-        contentCount,
-        standardDataTable,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-list-page.vue
@@ -79,7 +79,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -123,7 +123,7 @@
       noLearners: 'There are no learners enrolled in this class',
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.classId,
         pageState: state => state.pageState,
         pageName: state => state.pageName,

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -59,6 +59,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -98,6 +99,12 @@
       noRecentProgress: 'No activity in past {threshold} days',
     },
     computed: {
+      ...mapGetters({
+        classId: state => state.classId,
+        pageState: state => state.pageState,
+        userCount: classMemberCount,
+        standardDataTable: reportGetters.standardDataTable,
+      }),
       tableColumns() {
         return TableColumns;
       },
@@ -133,14 +140,6 @@
             contentId: row.id,
           },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.classId,
-        pageState: state => state.pageState,
-        userCount: classMemberCount,
-        standardDataTable: reportGetters.standardDataTable,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/recent-items-page.vue
@@ -59,7 +59,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import contentIcon from 'kolibri.coreVue.components.contentIcon';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -99,7 +99,7 @@
       noRecentProgress: 'No activity in past {threshold} days',
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.classId,
         pageState: state => state.pageState,
         userCount: classMemberCount,

--- a/kolibri/plugins/coach/assets/src/views/reports/table-cells/header-cell.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/table-cells/header-cell.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { sortColumn, sortOrder } from '../../../state/getters/reports';
   import { SortOrders } from '../../../constants/reportConstants';
   import { setReportSorting } from '../../../state/actions/reports';
@@ -56,7 +56,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         sortColumn,
         sortOrder,
       }),

--- a/kolibri/plugins/coach/assets/src/views/reports/table-cells/header-cell.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/table-cells/header-cell.vue
@@ -28,6 +28,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { sortColumn, sortOrder } from '../../../state/getters/reports';
   import { SortOrders } from '../../../constants/reportConstants';
   import { setReportSorting } from '../../../state/actions/reports';
@@ -55,6 +56,10 @@
       },
     },
     computed: {
+      ...mapGetters({
+        sortColumn,
+        sortOrder,
+      }),
       sorted() {
         return (
           this.column === this.sortColumn && (this.sortOrder && this.sortOrder !== SortOrders.NONE)
@@ -68,6 +73,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        setReportSorting,
+      }),
       setSortOrder() {
         let sortOrder;
         if (!this.sorted) {
@@ -79,15 +87,6 @@
           sortOrder = SortOrders.NONE;
         }
         this.setReportSorting(this.column, sortOrder);
-      },
-    },
-    vuex: {
-      getters: {
-        sortColumn,
-        sortOrder,
-      },
-      actions: {
-        setReportSorting,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/top-nav.vue
+++ b/kolibri/plugins/coach/assets/src/views/top-nav.vue
@@ -44,7 +44,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import { PageNames } from '../constants';
@@ -65,7 +65,7 @@
       kNavbarLink,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: state => state.pageName,
         classId: state => state.classId,
       }),

--- a/kolibri/plugins/coach/assets/src/views/top-nav.vue
+++ b/kolibri/plugins/coach/assets/src/views/top-nav.vue
@@ -44,6 +44,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import { PageNames } from '../constants';
@@ -64,6 +65,10 @@
       kNavbarLink,
     },
     computed: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+        classId: state => state.classId,
+      }),
       recentLink() {
         return {
           name: PageNames.RECENT_CHANNELS,
@@ -99,12 +104,6 @@
           name: LessonsPageNames.ROOT,
           params: { classId: this.classId },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: state => state.pageName,
-        classId: state => state.classId,
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
@@ -86,7 +86,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
@@ -131,7 +131,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         availableChannels: state => wizardState(state).availableChannels,
         selectedDrive: state => wizardState(state).selectedDrive,
         installedChannelsWithResources,

--- a/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/available-channels-page/index.vue
@@ -86,6 +86,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import kSelect from 'kolibri.coreVue.components.kSelect';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
@@ -130,6 +131,16 @@
       };
     },
     computed: {
+      ...mapGetters({
+        availableChannels: state => wizardState(state).availableChannels,
+        selectedDrive: state => wizardState(state).selectedDrive,
+        installedChannelsWithResources,
+        transferType: state => wizardState(state).transferType,
+        wizardStatus: state => wizardState(state).status,
+        inLocalImportMode,
+        inRemoteImportMode,
+        inExportMode,
+      }),
       channelsAreLoading() {
         return this.wizardStatus === 'LOADING_CHANNELS_FROM_KOLIBRI_STUDIO';
       },
@@ -170,6 +181,9 @@
       }
     },
     methods: {
+      ...mapActions({
+        setToolbarTitle,
+      }),
       toolbarTitle(transferType) {
         switch (transferType) {
           case TransferTypes.LOCALEXPORT:
@@ -209,21 +223,6 @@
           titleMatches = tokens.every(token => channel.name.toLowerCase().includes(token));
         }
         return languageMatches && titleMatches && isOnDevice;
-      },
-    },
-    vuex: {
-      getters: {
-        availableChannels: state => wizardState(state).availableChannels,
-        selectedDrive: state => wizardState(state).selectedDrive,
-        installedChannelsWithResources,
-        transferType: state => wizardState(state).transferType,
-        wizardStatus: state => wizardState(state).status,
-        inLocalImportMode,
-        inRemoteImportMode,
-        inExportMode,
-      },
-      actions: {
-        setToolbarTitle,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
@@ -61,6 +61,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import subpageContainer from './containers/subpage-container';
@@ -71,11 +72,11 @@
       authMessage,
       subpageContainer,
     },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         info: state => state.pageState.deviceInfo,
         canManageContent,
-      },
+      }),
     },
     $trs: {
       header: 'Device info',

--- a/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-info-page.vue
@@ -61,7 +61,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import subpageContainer from './containers/subpage-container';
@@ -73,7 +73,7 @@
       subpageContainer,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         info: state => state.pageState.deviceInfo,
         canManageContent,
       }),

--- a/kolibri/plugins/device_management/assets/src/views/device-top-nav.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-top-nav.vue
@@ -28,6 +28,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import { canManageContent, isSuperuser } from 'kolibri.coreVue.vuex.getters';
@@ -40,17 +41,15 @@
       kNavbarLink,
     },
     computed: {
+      ...mapGetters({
+        canManageContent,
+        isSuperuser,
+      }),
       PageNames: () => PageNames,
     },
     methods: {
       linkify(name) {
         return { name };
-      },
-    },
-    vuex: {
-      getters: {
-        canManageContent,
-        isSuperuser,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/device-top-nav.vue
+++ b/kolibri/plugins/device_management/assets/src/views/device-top-nav.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kNavbar from 'kolibri.coreVue.components.kNavbar';
   import kNavbarLink from 'kolibri.coreVue.components.kNavbarLink';
   import { canManageContent, isSuperuser } from 'kolibri.coreVue.vuex.getters';
@@ -41,7 +41,7 @@
       kNavbarLink,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         canManageContent,
         isSuperuser,
       }),

--- a/kolibri/plugins/device_management/assets/src/views/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/index.vue
@@ -25,6 +25,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import coreBase from 'kolibri.coreVue.components.coreBase';
@@ -56,6 +57,19 @@
       topNavigation,
     },
     computed: {
+      ...mapGetters({
+        pageName: ({ pageName }) => pageName,
+        welcomeModalVisible: ({ welcomeModalVisible }) => welcomeModalVisible,
+        canManageContent,
+        toolbarTitle: ({ pageState }) => pageState.toolbarTitle,
+        inContentManagementPage: ({ pageName }) => {
+          return [
+            ContentWizardPages.AVAILABLE_CHANNELS,
+            ContentWizardPages.SELECT_CONTENT,
+            PageNames.MANAGE_CONTENT_PAGE,
+          ].includes(pageName);
+        },
+      }),
       DEVICE: () => TopLevelPageNames.DEVICE,
       currentPage() {
         return pageNameComponentMap[this.pageName];
@@ -88,6 +102,12 @@
       this.stopTaskPolling();
     },
     methods: {
+      ...mapActions({
+        refreshTaskList,
+        hideWelcomeModal(store) {
+          store.dispatch('SET_WELCOME_MODAL_VISIBLE', false);
+        },
+      }),
       startTaskPolling() {
         if (!this.intervalId && this.canManageContent) {
           this.intervalId = setInterval(this.refreshTaskList, 1000);
@@ -97,27 +117,6 @@
         if (this.intervalId) {
           this.intervalId = clearInterval(this.intervalId);
         }
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: ({ pageName }) => pageName,
-        welcomeModalVisible: ({ welcomeModalVisible }) => welcomeModalVisible,
-        canManageContent,
-        toolbarTitle: ({ pageState }) => pageState.toolbarTitle,
-        inContentManagementPage: ({ pageName }) => {
-          return [
-            ContentWizardPages.AVAILABLE_CHANNELS,
-            ContentWizardPages.SELECT_CONTENT,
-            PageNames.MANAGE_CONTENT_PAGE,
-          ].includes(pageName);
-        },
-      },
-      actions: {
-        refreshTaskList,
-        hideWelcomeModal(store) {
-          store.dispatch('SET_WELCOME_MODAL_VISIBLE', false);
-        },
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/index.vue
@@ -25,7 +25,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import coreBase from 'kolibri.coreVue.components.coreBase';
@@ -57,7 +57,7 @@
       topNavigation,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: ({ pageName }) => pageName,
         welcomeModalVisible: ({ welcomeModalVisible }) => welcomeModalVisible,
         canManageContent,

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -90,7 +90,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import coachContentLabel from 'kolibri.coreVue.components.coachContentLabel';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
@@ -136,7 +136,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageState: ({ pageState }) => pageState,
         channelIsInstalled,
       }),

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channel-list-item.vue
@@ -90,6 +90,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import coachContentLabel from 'kolibri.coreVue.components.coachContentLabel';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kDropdownMenu from 'kolibri.coreVue.components.kDropdownMenu';
@@ -135,6 +136,10 @@
       },
     },
     computed: {
+      ...mapGetters({
+        pageState: ({ pageState }) => pageState,
+        channelIsInstalled,
+      }),
       manageChannelActions() {
         return [
           {
@@ -187,12 +192,6 @@
           return this.$emit('clickdelete');
         }
         return this.$emit('import_more', { ...this.channel });
-      },
-    },
-    vuex: {
-      getters: {
-        pageState: ({ pageState }) => pageState,
-        channelIsInstalled,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
@@ -47,7 +47,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import { refreshChannelList } from '../../state/actions/manageContentActions';
@@ -69,7 +69,7 @@
       selectedChannelId: null,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         installedChannelsWithResources,
         installedChannelListLoading,
         pageState: state => state.pageState,

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
@@ -47,6 +47,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import { refreshChannelList } from '../../state/actions/manageContentActions';
@@ -68,6 +69,11 @@
       selectedChannelId: null,
     }),
     computed: {
+      ...mapGetters({
+        installedChannelsWithResources,
+        installedChannelListLoading,
+        pageState: state => state.pageState,
+      }),
       channelIsSelected() {
         return this.selectedChannelId !== null;
       },
@@ -85,24 +91,17 @@
       },
     },
     methods: {
+      ...mapActions({
+        startImportWorkflow,
+        triggerChannelDeleteTask,
+        refreshChannelList,
+      }),
       handleDeleteChannel() {
         if (this.channelIsSelected) {
           const channelId = this.selectedChannelId;
           this.selectedChannelId = null;
           this.triggerChannelDeleteTask(channelId);
         }
-      },
-    },
-    vuex: {
-      getters: {
-        installedChannelsWithResources,
-        installedChannelListLoading,
-        pageState: state => state.pageState,
-      },
-      actions: {
-        startImportWorkflow,
-        triggerChannelDeleteTask,
-        refreshChannelList,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
@@ -51,7 +51,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -84,7 +84,7 @@
       taskProgress,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         canManageContent,
         pageState: ({ pageState }) => pageState,
         firstTask: ({ pageState }) => pageState.taskList[0],

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/index.vue
@@ -51,6 +51,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { canManageContent } from 'kolibri.coreVue.vuex.getters';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -82,6 +83,16 @@
       subpageContainer,
       taskProgress,
     },
+    computed: {
+      ...mapGetters({
+        canManageContent,
+        pageState: ({ pageState }) => pageState,
+        firstTask: ({ pageState }) => pageState.taskList[0],
+        tasksInQueue: ({ pageState }) => pageState.taskList.length > 0,
+        deviceHasChannels: ({ pageState }) => pageState.channelList.length > 0,
+        wizardPageName: ({ pageState }) => pageState.wizardState.pageName,
+      }),
+    },
     watch: {
       // If Tasks disappear from queue, assume that an addition/deletion has
       // completed and refresh list.
@@ -92,6 +103,12 @@
       },
     },
     methods: {
+      ...mapActions({
+        cancelTask,
+        refreshChannelList,
+        startImportWorkflow,
+        startExportWorkflow,
+      }),
       clearFirstTask(unblockCb) {
         this.cancelTask(this.firstTask.id)
           // Handle failures silently in case of near-simultaneous cancels.
@@ -99,22 +116,6 @@
           .then(() => {
             unblockCb();
           });
-      },
-    },
-    vuex: {
-      getters: {
-        canManageContent,
-        pageState: ({ pageState }) => pageState,
-        firstTask: ({ pageState }) => pageState.taskList[0],
-        tasksInQueue: ({ pageState }) => pageState.taskList.length > 0,
-        deviceHasChannels: ({ pageState }) => pageState.channelList.length > 0,
-        wizardPageName: ({ pageState }) => pageState.wizardState.pageName,
-      },
-      actions: {
-        cancelTask,
-        refreshChannelList,
-        startImportWorkflow,
-        startExportWorkflow,
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/index.vue
@@ -24,6 +24,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import { ContentWizardPages, TransferTypes } from '../../../constants';
   import { resetContentWizardState } from '../../../state/actions/contentWizardActions';
@@ -38,6 +39,10 @@
       selectDriveModal,
     },
     computed: {
+      ...mapGetters({
+        wizardPageName: ({ pageState }) => pageState.wizardState.pageName,
+        transferType: ({ pageState }) => pageState.wizardState.transferType,
+      }),
       atSelectImportSource() {
         return this.wizardPageName === ContentWizardPages.SELECT_IMPORT_SOURCE;
       },
@@ -56,6 +61,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        resetContentWizardState,
+      }),
       goForward() {
         if (this.atSelectImportSource) {
           return this.$refs.selectImportSourceModal.goForward();
@@ -65,15 +73,6 @@
       },
       cancel() {
         return this.resetContentWizardState();
-      },
-    },
-    vuex: {
-      getters: {
-        wizardPageName: ({ pageState }) => pageState.wizardState.pageName,
-        transferType: ({ pageState }) => pageState.wizardState.transferType,
-      },
-      actions: {
-        resetContentWizardState,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/index.vue
@@ -24,7 +24,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import { ContentWizardPages, TransferTypes } from '../../../constants';
   import { resetContentWizardState } from '../../../state/actions/contentWizardActions';
@@ -39,7 +39,7 @@
       selectDriveModal,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         wizardPageName: ({ pageState }) => pageState.wizardState.pageName,
         transferType: ({ pageState }) => pageState.wizardState.transferType,
       }),

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-drive-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-drive-modal.vue
@@ -47,6 +47,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import UiAlert from 'keen-ui/src/UiAlert';
   import { refreshDriveList } from '../../../state/actions/taskActions';
@@ -70,6 +71,13 @@
       };
     },
     computed: {
+      ...mapGetters({
+        driveList: state => wizardState(state).driveList,
+        transferType: state => wizardState(state).transferType,
+        transferredChannel: state => wizardState(state).transferredChannel,
+        driveCanBeUsedForTransfer,
+        isImportingMore,
+      }),
       inImportMode() {
         return this.transferType === TransferTypes.LOCALIMPORT;
       },
@@ -103,24 +111,15 @@
         });
     },
     methods: {
+      ...mapActions({
+        goForwardFromSelectDriveModal,
+        refreshDriveList,
+      }),
       goForward() {
         this.goForwardFromSelectDriveModal({
           driveId: this.selectedDriveId,
           forExport: !this.inImportMode,
         });
-      },
-    },
-    vuex: {
-      getters: {
-        driveList: state => wizardState(state).driveList,
-        transferType: state => wizardState(state).transferType,
-        transferredChannel: state => wizardState(state).transferredChannel,
-        driveCanBeUsedForTransfer,
-        isImportingMore,
-      },
-      actions: {
-        goForwardFromSelectDriveModal,
-        refreshDriveList,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-drive-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-drive-modal.vue
@@ -47,7 +47,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import UiAlert from 'keen-ui/src/UiAlert';
   import { refreshDriveList } from '../../../state/actions/taskActions';
@@ -71,7 +71,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         driveList: state => wizardState(state).driveList,
         transferType: state => wizardState(state).transferType,
         transferredChannel: state => wizardState(state).transferredChannel,

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-import-source-modal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/select-transfer-source-modal/select-import-source-modal.vue
@@ -37,6 +37,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { RemoteChannelResource } from 'kolibri.resources';
@@ -75,15 +76,13 @@
       localDrives: 'Attached drive or memory card',
     },
     methods: {
+      ...mapActions({
+        goForwardFromSelectImportSourceModal,
+      }),
       goForward() {
         if (!this.formIsDisabled) {
           this.goForwardFromSelectImportSourceModal(this.source);
         }
-      },
-    },
-    vuex: {
-      actions: {
-        goForwardFromSelectImportSourceModal,
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/task-progress.vue
@@ -55,6 +55,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kLinearLoader from 'kolibri.coreVue.components.kLinearLoader';
   import kCircularLoader from 'kolibri.coreVue.components.kCircularLoader';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -155,17 +156,15 @@
       },
     },
     methods: {
+      ...mapActions({
+        cancelTask,
+        refreshChannelList,
+      }),
       endTask() {
         this.uiBlocked = true;
         this.$emit('cleartask', () => {
           this.uiBlocked = false;
         });
-      },
-    },
-    vuex: {
-      actions: {
-        cancelTask,
-        refreshChannelList,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
@@ -27,6 +27,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
@@ -46,11 +47,11 @@
         searchFilterText: '',
       };
     },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         facilityUsers: state => state.pageState.facilityUsers,
         isSuperuser,
-      },
+      }),
     },
     $trs: {
       devicePermissionsHeader: 'Device permissions',

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
@@ -27,7 +27,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import authMessage from 'kolibri.coreVue.components.authMessage';
   import { isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import kFilterTextbox from 'kolibri.coreVue.components.kFilterTextbox';
@@ -48,7 +48,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         facilityUsers: state => state.pageState.facilityUsers,
         isSuperuser,
       }),

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
@@ -49,7 +49,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
@@ -69,7 +69,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         isCurrentUser: ({ core }) => username => core.session.username === username,
         facilityUsers: ({ pageState }) => pageState.facilityUsers,
         userPermissions: state => userid => state.pageState.permissions[userid],

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/user-grid.vue
@@ -49,6 +49,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import permissionsIcon from 'kolibri.coreVue.components.permissionsIcon';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
@@ -68,6 +69,11 @@
       },
     },
     computed: {
+      ...mapGetters({
+        isCurrentUser: ({ core }) => username => core.session.username === username,
+        facilityUsers: ({ pageState }) => pageState.facilityUsers,
+        userPermissions: state => userid => state.pageState.permissions[userid],
+      }),
       visibleUsers() {
         return filterAndSortUsers(this.facilityUsers, user =>
           userMatchesFilter(user, this.searchFilter)
@@ -96,13 +102,6 @@
           return PermissionTypes.LIMITED_PERMISSIONS;
         }
         return null;
-      },
-    },
-    vuex: {
-      getters: {
-        isCurrentUser: ({ core }) => username => core.session.username === username,
-        facilityUsers: ({ pageState }) => pageState.facilityUsers,
-        userPermissions: state => userid => state.pageState.permissions[userid],
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
@@ -57,7 +57,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import CoreTable from 'kolibri.coreVue.components.coreTable';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
@@ -93,7 +93,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         breadcrumbs: state => wizardState(state).path.map(transformBreadrumb),
         childNodes: state => wizardState(state).currentTopicNode.children,
         inExportMode,

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/content-tree-viewer.vue
@@ -57,6 +57,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import CoreTable from 'kolibri.coreVue.components.coreTable';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
@@ -92,6 +93,15 @@
       };
     },
     computed: {
+      ...mapGetters({
+        breadcrumbs: state => wizardState(state).path.map(transformBreadrumb),
+        childNodes: state => wizardState(state).currentTopicNode.children,
+        inExportMode,
+        path: state => wizardState(state).path,
+        nodesForTransfer: state => wizardState(state).nodesForTransfer,
+        topicNode: state => wizardState(state).currentTopicNode,
+        transferType: state => wizardState(state).transferType,
+      }),
       childNodesWithPath() {
         return this.childNodes.map(node => ({
           ...node,
@@ -133,6 +143,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        addNodeForTransfer,
+        removeNodeForTransfer,
+      }),
       nodeIsChecked(node) {
         return node.checkboxType === CheckboxTypes.CHECKED;
       },
@@ -175,21 +189,6 @@
           this.disableAll = false;
           this.$forceUpdate();
         });
-      },
-    },
-    vuex: {
-      getters: {
-        breadcrumbs: state => wizardState(state).path.map(transformBreadrumb),
-        childNodes: state => wizardState(state).currentTopicNode.children,
-        inExportMode,
-        path: state => wizardState(state).path,
-        nodesForTransfer: state => wizardState(state).nodesForTransfer,
-        topicNode: state => wizardState(state).currentTopicNode,
-        transferType: state => wizardState(state).transferType,
-      },
-      actions: {
-        addNodeForTransfer,
-        removeNodeForTransfer,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -97,7 +97,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import uiAlert from 'keen-ui/src/UiAlert';
@@ -139,7 +139,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         availableSpace: state => wizardState(state).availableSpace,
         transferredChannel: state => wizardState(state).transferredChannel || {},
         channelIsInstalled,

--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/index.vue
@@ -97,6 +97,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import uiAlert from 'keen-ui/src/UiAlert';
@@ -138,6 +139,21 @@
       };
     },
     computed: {
+      ...mapGetters({
+        availableSpace: state => wizardState(state).availableSpace,
+        transferredChannel: state => wizardState(state).transferredChannel || {},
+        channelIsInstalled,
+        databaseIsLoading: ({ pageState }) => pageState.databaseIsLoading,
+        firstTask: ({ pageState }) => pageState.taskList[0],
+        taskList: ({ pageState }) => pageState.taskList,
+        mode: state => (wizardState(state).transferType === 'localexport' ? 'export' : 'import'),
+        nodeTransferCounts,
+        onDeviceInfoIsReady: state => !isEmpty(wizardState(state).currentTopicNode),
+        selectedItems: state => wizardState(state).nodesForTransfer || {},
+        transferType: state => wizardState(state).transferType,
+        wizardStatus: state => wizardState(state).status,
+        topicNode: state => wizardState(state).currentTopicNode,
+      }),
       metadataDownloadTask() {
         return find(this.taskList, { type: TaskTypes.REMOTECHANNELIMPORT });
       },
@@ -195,6 +211,20 @@
       this.cancelMetadataDownloadTask();
     },
     methods: {
+      ...mapActions({
+        setToolbarTitle,
+        cancelMetadataDownloadTask(store) {
+          const { taskList } = store.state.pageState;
+          const task = find(taskList, { type: TaskTypes.REMOTECHANNELIMPORT });
+          // TODO can remove this guard once cancelTask resolves even if Task is not there
+          if (task) {
+            return TaskResource.cancelTask(task.id);
+          }
+          return Promise.resolve();
+        },
+        downloadChannelMetadata,
+        transferChannelContent,
+      }),
       updateChannelMetadata() {
         // NOTE: This only updates the metadata, not the underlying content.
         // This could produced unexpected behavior for users.
@@ -222,37 +252,6 @@
       },
       returnToChannelsList() {
         this.$router.push(manageContentPageLink());
-      },
-    },
-    vuex: {
-      getters: {
-        availableSpace: state => wizardState(state).availableSpace,
-        transferredChannel: state => wizardState(state).transferredChannel || {},
-        channelIsInstalled,
-        databaseIsLoading: ({ pageState }) => pageState.databaseIsLoading,
-        firstTask: ({ pageState }) => pageState.taskList[0],
-        taskList: ({ pageState }) => pageState.taskList,
-        mode: state => (wizardState(state).transferType === 'localexport' ? 'export' : 'import'),
-        nodeTransferCounts,
-        onDeviceInfoIsReady: state => !isEmpty(wizardState(state).currentTopicNode),
-        selectedItems: state => wizardState(state).nodesForTransfer || {},
-        transferType: state => wizardState(state).transferType,
-        wizardStatus: state => wizardState(state).status,
-        topicNode: state => wizardState(state).currentTopicNode,
-      },
-      actions: {
-        setToolbarTitle,
-        cancelMetadataDownloadTask(store) {
-          const { taskList } = store.state.pageState;
-          const task = find(taskList, { type: TaskTypes.REMOTECHANNELIMPORT });
-          // TODO can remove this guard once cancelTask resolves even if Task is not there
-          if (task) {
-            return TaskResource.cancelTask(task.id);
-          }
-          return Promise.resolve();
-        },
-        downloadChannelMetadata,
-        transferChannelContent,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
@@ -75,6 +75,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -108,6 +109,12 @@
       };
     },
     computed: {
+      ...mapGetters({
+        user: ({ pageState }) => pageState.user,
+        permissions: ({ pageState }) => pageState.permissions,
+        isCurrentUser: ({ core, pageState }) => core.session.username === pageState.user.username,
+        isSuperuser,
+      }),
       superuserDisabled() {
         return this.uiBlocked || this.isCurrentUser;
       },
@@ -161,6 +168,9 @@
         this.permissions.can_manage_content || this.permissions.is_superuser;
     },
     methods: {
+      ...mapActions({
+        addOrUpdateUserPermissions,
+      }),
       save() {
         this.uiBlocked = true;
         this.saveProgress = IN_PROGRESS;
@@ -179,17 +189,6 @@
       },
       goBack() {
         this.$router.push({ path: '/permissions' });
-      },
-    },
-    vuex: {
-      getters: {
-        user: ({ pageState }) => pageState.user,
-        permissions: ({ pageState }) => pageState.permissions,
-        isCurrentUser: ({ core, pageState }) => core.session.username === pageState.user.username,
-        isSuperuser,
-      },
-      actions: {
-        addOrUpdateUserPermissions,
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
+++ b/kolibri/plugins/device_management/assets/src/views/user-permissions-page.vue
@@ -75,7 +75,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import immersiveFullScreen from 'kolibri.coreVue.components.immersiveFullScreen';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
@@ -109,7 +109,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         user: ({ pageState }) => pageState.user,
         permissions: ({ pageState }) => pageState.permissions,
         isCurrentUser: ({ core, pageState }) => core.session.username === pageState.user.username,

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -9,7 +9,7 @@ import { wizardState } from '../../src/state/getters';
 import SelectedResourcesSize from '../../src/views/select-content-page/selected-resources-size';
 import { makeSelectContentPageStore } from '../utils/makeStore';
 
-SelectContentPage.vuex.actions.getAvailableSpaceOnDrive = () => {};
+SelectContentPage.methods.getAvailableSpaceOnDrive = () => {};
 
 const router = new VueRouter({
   routes: [],

--- a/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
@@ -9,7 +9,7 @@ import SelectDriveModal from '../../src/views/manage-content-page/select-transfe
 import { wizardState } from '../../src/state/getters';
 import { makeAvailableChannelsPageStore } from '../utils/makeStore';
 
-SelectDriveModal.vuex.actions.refreshDriveList = () => Promise.resolve();
+SelectDriveModal.methods.refreshDriveList = () => Promise.resolve();
 
 function makeWrapper(options = {}) {
   const { props = {}, store } = options;

--- a/kolibri/plugins/document_epub_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/index.vue
@@ -40,7 +40,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import Epub from 'epubjs/lib/epub';
   import manager from 'epubjs/lib/managers/default';
   import iFrameView from 'epubjs/lib/managers/views/iframe';
@@ -71,7 +71,7 @@
       totalPages: null,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         sessionTimeSpent,
       }),
       epubURL() {

--- a/kolibri/plugins/document_epub_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/index.vue
@@ -40,6 +40,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import Epub from 'epubjs/lib/epub';
   import manager from 'epubjs/lib/managers/default';
   import iFrameView from 'epubjs/lib/managers/views/iframe';
@@ -70,6 +71,9 @@
       totalPages: null,
     }),
     computed: {
+      ...mapGetters({
+        sessionTimeSpent,
+      }),
       epubURL() {
         return this.defaultFile.storage_url;
       },
@@ -133,11 +137,6 @@
     $trs: {
       exitFullscreen: 'Exit fullscreen',
       enterFullscreen: 'Enter fullscreen',
-    },
-    vuex: {
-      getters: {
-        sessionTimeSpent,
-      },
     },
   };
 

--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -67,7 +67,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import PDFJSLib from 'pdfjs-dist';
   import Lockr from 'lockr';
 
@@ -122,7 +122,7 @@
       recycleListIsMounted: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         sessionTimeSpent,
       }),
       pdfURL() {

--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -67,6 +67,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import PDFJSLib from 'pdfjs-dist';
   import Lockr from 'lockr';
 
@@ -121,6 +122,9 @@
       recycleListIsMounted: false,
     }),
     computed: {
+      ...mapGetters({
+        sessionTimeSpent,
+      }),
       pdfURL() {
         return this.defaultFile.storage_url;
       },
@@ -320,11 +324,6 @@
     $trs: {
       exitFullscreen: 'Exit fullscreen',
       enterFullscreen: 'Enter fullscreen',
-    },
-    vuex: {
-      getters: {
-        sessionTimeSpent,
-      },
     },
   };
 

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/class-rename-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/class-rename-modal.vue
@@ -40,6 +40,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
@@ -115,6 +116,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        updateClass,
+        displayModal,
+      }),
       updateName() {
         this.formSubmitted = true;
         if (this.formIsValid) {
@@ -126,12 +131,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        updateClass,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -93,7 +93,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -138,7 +138,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classLearners: state => state.pageState.classLearners,
         classCoaches: state => state.pageState.classCoaches,
         classes: state => state.pageState.classes,

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/index.vue
@@ -93,6 +93,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import kRouterLink from 'kolibri.coreVue.components.kRouterLink';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -137,6 +138,13 @@
       };
     },
     computed: {
+      ...mapGetters({
+        classLearners: state => state.pageState.classLearners,
+        classCoaches: state => state.pageState.classCoaches,
+        classes: state => state.pageState.classes,
+        currentClass: state => state.pageState.currentClass,
+        modalShown: state => state.pageState.modalShown,
+      }),
       Modals() {
         return Modals;
       },
@@ -152,24 +160,15 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+        removeClassLearner,
+        removeClassCoach,
+      }),
       confirmRemoval(user, removalAction) {
         this.userToBeRemoved = user;
         this.removalAction = removalAction;
         this.displayModal(Modals.REMOVE_USER);
-      },
-    },
-    vuex: {
-      getters: {
-        classLearners: state => state.pageState.classLearners,
-        classCoaches: state => state.pageState.classCoaches,
-        classes: state => state.pageState.classes,
-        currentClass: state => state.pageState.currentClass,
-        modalShown: state => state.pageState.modalShown,
-      },
-      actions: {
-        displayModal,
-        removeClassLearner,
-        removeClassCoach,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/class-edit-page/user-remove-confirmation-modal.vue
@@ -28,6 +28,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import { displayModal } from '../../state/actions';
@@ -56,16 +57,14 @@
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+      }),
       confirmRemoval() {
         this.$emit('confirm');
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
@@ -15,6 +15,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import { assignCoachesToClass } from '../state/actions/class';
   import classEnrollForm from './class-enroll-form';
@@ -24,23 +25,22 @@
     components: {
       classEnrollForm,
     },
-    computed: {},
+    computed: {
+      ...mapGetters({
+        className: state => state.pageState.class.name,
+        facilityUsers: state => state.pageState.facilityUsers,
+        classUsers: state => state.pageState.classUsers,
+      }),
+    },
     methods: {
+      ...mapActions({
+        assignCoachesToClass,
+      }),
       assignCoaches(coaches) {
         this.assignCoachesToClass(coaches).then(() => {
           // do this in action?
           this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE });
         });
-      },
-    },
-    vuex: {
-      getters: {
-        className: state => state.pageState.class.name,
-        facilityUsers: state => state.pageState.facilityUsers,
-        classUsers: state => state.pageState.classUsers,
-      },
-      actions: {
-        assignCoachesToClass,
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/coach-class-assignment-page.vue
@@ -15,7 +15,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import { assignCoachesToClass } from '../state/actions/class';
   import classEnrollForm from './class-enroll-form';
@@ -26,7 +26,7 @@
       classEnrollForm,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         className: state => state.pageState.class.name,
         facilityUsers: state => state.pageState.facilityUsers,
         classUsers: state => state.pageState.classUsers,

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
@@ -66,6 +66,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kButton from 'kolibri.coreVue.components.kButton';
   import isEqual from 'lodash/isEqual';
@@ -94,6 +95,11 @@
       settingsCopy: {},
     }),
     computed: {
+      ...mapGetters({
+        currentFacilityName: state => state.pageState.facilityName,
+        settings: state => state.pageState.settings,
+        notification: state => state.pageState.notification,
+      }),
       settingsList: () => settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);
@@ -103,26 +109,7 @@
       this.copySettings();
     },
     methods: {
-      resetToDefaultSettings() {
-        this.showModal = false;
-        this.resetFacilityConfig();
-      },
-      saveConfig() {
-        this.saveFacilityConfig().then(() => {
-          this.copySettings();
-        });
-      },
-      copySettings() {
-        this.settingsCopy = Object.assign({}, this.settings);
-      },
-    },
-    vuex: {
-      getters: {
-        currentFacilityName: state => state.pageState.facilityName,
-        settings: state => state.pageState.settings,
-        notification: state => state.pageState.notification,
-      },
-      actions: {
+      ...mapActions({
         toggleSetting(store, settingName) {
           store.dispatch('CONFIG_PAGE_MODIFY_SETTING', {
             name: settingName,
@@ -134,6 +121,18 @@
         dismissNotification(store) {
           store.dispatch('CONFIG_PAGE_NOTIFY', null);
         },
+      }),
+      resetToDefaultSettings() {
+        this.showModal = false;
+        this.resetFacilityConfig();
+      },
+      saveConfig() {
+        this.saveFacilityConfig().then(() => {
+          this.copySettings();
+        });
+      },
+      copySettings() {
+        this.settingsCopy = Object.assign({}, this.settings);
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/facilities-config-page/index.vue
@@ -66,7 +66,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import kButton from 'kolibri.coreVue.components.kButton';
   import isEqual from 'lodash/isEqual';
@@ -95,7 +95,7 @@
       settingsCopy: {},
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentFacilityName: state => state.pageState.facilityName,
         settings: state => state.pageState.settings,
         notification: state => state.pageState.notification,

--- a/kolibri/plugins/facility_management/assets/src/views/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/index.vue
@@ -26,6 +26,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { isAdmin, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
@@ -66,6 +67,12 @@
       topNav,
     },
     computed: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+        isEnrollmentPage: state => classEnrollmentPages.includes(state.pageName),
+        isAdmin,
+        isSuperuser,
+      }),
       topLevelPageName: () => TopLevelPageNames.MANAGE,
       currentPage() {
         return pageNameComponentMap[this.pageName] || null;
@@ -86,14 +93,6 @@
       },
       isImmersive() {
         return this.isEnrollmentPage;
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: state => state.pageName,
-        isEnrollmentPage: state => classEnrollmentPages.includes(state.pageName),
-        isAdmin,
-        isSuperuser,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/index.vue
@@ -26,7 +26,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { isAdmin, isSuperuser } from 'kolibri.coreVue.vuex.getters';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import authMessage from 'kolibri.coreVue.components.authMessage';
@@ -67,7 +67,7 @@
       topNav,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: state => state.pageName,
         isEnrollmentPage: state => classEnrollmentPages.includes(state.pageName),
         isAdmin,

--- a/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
@@ -15,6 +15,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import { enrollLearnersInClass } from '../state/actions/class';
   import classEnrollForm from './class-enroll-form';
@@ -24,23 +25,22 @@
     components: {
       classEnrollForm,
     },
-    computed: {},
+    computed: {
+      ...mapGetters({
+        className: state => state.pageState.class.name,
+        facilityUsers: state => state.pageState.facilityUsers,
+        classUsers: state => state.pageState.classUsers,
+      }),
+    },
     methods: {
+      ...mapActions({
+        enrollLearnersInClass,
+      }),
       enrollLearners(selectedUsers) {
         // do this in action?
         this.enrollLearnersInClass(selectedUsers).then(() => {
           this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE });
         });
-      },
-    },
-    vuex: {
-      getters: {
-        className: state => state.pageState.class.name,
-        facilityUsers: state => state.pageState.facilityUsers,
-        classUsers: state => state.pageState.classUsers,
-      },
-      actions: {
-        enrollLearnersInClass,
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/learner-class-enrollment-page.vue
@@ -15,7 +15,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import { enrollLearnersInClass } from '../state/actions/class';
   import classEnrollForm from './class-enroll-form';
@@ -26,7 +26,7 @@
       classEnrollForm,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         className: state => state.pageState.class.name,
         facilityUsers: state => state.pageState.facilityUsers,
         classUsers: state => state.pageState.classUsers,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-create-modal.vue
@@ -41,6 +41,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
@@ -104,6 +105,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        createClass,
+        displayModal,
+      }),
       createNewClass() {
         this.formSubmitted = true;
         if (this.formIsValid) {
@@ -115,12 +120,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        createClass,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -31,6 +31,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import { deleteClass, displayModal } from '../../state/actions';
@@ -60,17 +61,15 @@
       },
     },
     methods: {
+      ...mapActions({
+        deleteClass,
+        displayModal,
+      }),
       classDelete() {
         this.deleteClass(this.classid);
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        deleteClass,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/class-delete-modal.vue
@@ -31,7 +31,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import { deleteClass, displayModal } from '../../state/actions';

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -77,7 +77,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import UiIcon from 'keen-ui/src/UiIcon';
   import orderBy from 'lodash/orderBy';
@@ -109,7 +109,7 @@
     mixins: [responsiveWindow],
     data: () => ({ currentClassDelete: null }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         modalShown: state => state.pageState.modalShown,
         classes: state => state.pageState.classes,
         noClassesExist: state => state.pageState.classes.length === 0,

--- a/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/manage-class-page/index.vue
@@ -77,6 +77,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreTable from 'kolibri.coreVue.components.coreTable';
   import UiIcon from 'keen-ui/src/UiIcon';
   import orderBy from 'lodash/orderBy';
@@ -108,12 +109,20 @@
     mixins: [responsiveWindow],
     data: () => ({ currentClassDelete: null }),
     computed: {
+      ...mapGetters({
+        modalShown: state => state.pageState.modalShown,
+        classes: state => state.pageState.classes,
+        noClassesExist: state => state.pageState.classes.length === 0,
+      }),
       Modals: () => Modals,
       sortedClassrooms() {
         return orderBy(this.classes, [classroom => classroom.name.toUpperCase()], ['asc']);
       },
     },
     methods: {
+      ...mapActions({
+        displayModal,
+      }),
       // Duplicated in class-list-page
       coachNames(classroom) {
         const { coaches } = classroom;
@@ -150,16 +159,6 @@
       openDeleteClassModal(classModel) {
         this.currentClassDelete = classModel;
         this.displayModal(Modals.DELETE_CLASS);
-      },
-    },
-    vuex: {
-      getters: {
-        modalShown: state => state.pageState.modalShown,
-        classes: state => state.pageState.classes,
-        noClassesExist: state => state.pageState.classes.length === 0,
-      },
-      actions: {
-        displayModal,
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/delete-user-modal.vue
@@ -6,7 +6,7 @@
   >
     <p>{{ $tr('confirmation', { username: username }) }}</p>
     <p>{{ $tr('warning', { username: username }) }}</p>
-  
+
     <div class="core-modal-buttons">
       <k-button
         :text="$tr('cancel')"
@@ -29,6 +29,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import { deleteUser, displayModal } from '../../state/actions';
@@ -66,18 +67,16 @@
       };
     },
     methods: {
+      ...mapActions({
+        deleteUser,
+        displayModal,
+      }),
       handleDeleteUser() {
         this.submitting = true;
         this.deleteUser(this.id);
       },
       closeModal() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      actions: {
-        deleteUser,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -82,6 +82,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -151,6 +152,14 @@
       };
     },
     computed: {
+      ...mapGetters({
+        currentFacilityId,
+        currentUserId: state => state.core.session.user_id,
+        currentUserKind: state => state.core.session.kind[0],
+        facilityUsers: state => state.pageState.facilityUsers,
+        error: state => state.pageState.error,
+        isBusy: state => state.pageState.isBusy,
+      }),
       coachIsSelected() {
         return this.newKind.value === UserKinds.COACH;
       },
@@ -225,6 +234,10 @@
       }
     },
     methods: {
+      ...mapActions({
+        updateUser,
+        displayModal,
+      }),
       submitForm() {
         const roleUpdate = {
           collection: this.currentFacilityId,
@@ -259,20 +272,6 @@
             this.$refs.username.focus();
           }
         }
-      },
-    },
-    vuex: {
-      actions: {
-        updateUser,
-        displayModal,
-      },
-      getters: {
-        currentFacilityId,
-        currentUserId: state => state.core.session.user_id,
-        currentUserKind: state => state.core.session.kind[0],
-        facilityUsers: state => state.pageState.facilityUsers,
-        error: state => state.pageState.error,
-        isBusy: state => state.pageState.isBusy,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -82,7 +82,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -152,7 +152,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentFacilityId,
         currentUserId: state => state.core.session.user_id,
         currentUserKind: state => state.core.session.kind[0],

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
@@ -78,6 +78,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import UiIcon from 'keen-ui/src/UiIcon';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -118,6 +119,12 @@
       selectedUser: null,
     }),
     computed: {
+      ...mapGetters({
+        facilityUsers: state => state.pageState.facilityUsers,
+        modalShown: state => state.pageState.modalShown,
+        currentUserId,
+        isSuperuser,
+      }),
       Modals: () => Modals,
       userKinds() {
         return [
@@ -146,6 +153,9 @@
       this.roleFilter = this.userKinds[0];
     },
     methods: {
+      ...mapActions({
+        displayModal,
+      }),
       userMatchesRole(user) {
         const { value: filterKind } = this.roleFilter;
         if (filterKind === ALL_FILTER) {
@@ -175,17 +185,6 @@
         // If logged-in user is a superuser, then they can edit anybody (including other SUs).
         // Otherwise, only non-SUs can be edited.
         return this.isSuperuser || !user.is_superuser;
-      },
-    },
-    vuex: {
-      getters: {
-        facilityUsers: state => state.pageState.facilityUsers,
-        modalShown: state => state.pageState.modalShown,
-        currentUserId,
-        isSuperuser,
-      },
-      actions: {
-        displayModal,
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/index.vue
@@ -78,7 +78,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import UiIcon from 'keen-ui/src/UiIcon';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -119,7 +119,7 @@
       selectedUser: null,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         facilityUsers: state => state.pageState.facilityUsers,
         modalShown: state => state.pageState.modalShown,
         currentUserId,

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
@@ -52,7 +52,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -89,7 +89,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         isBusy: state => state.pageState.isBusy,
       }),
       passwordIsInvalidText() {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
@@ -52,6 +52,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -88,6 +89,9 @@
       };
     },
     computed: {
+      ...mapGetters({
+        isBusy: state => state.pageState.isBusy,
+      }),
       passwordIsInvalidText() {
         if (this.passwordBlurred || this.submittedForm) {
           if (this.password === '') {
@@ -118,6 +122,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        updateUser,
+        displayModal,
+      }),
       submitForm() {
         this.submittedForm = true;
         if (this.formIsValid) {
@@ -129,15 +137,6 @@
             this.$refs.confirmedPassword.focus();
           }
         }
-      },
-    },
-    vuex: {
-      actions: {
-        updateUser,
-        displayModal,
-      },
-      getters: {
-        isBusy: state => state.pageState.isBusy,
       },
     },
     $trs: {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -96,6 +96,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -162,6 +163,10 @@
       };
     },
     computed: {
+      ...mapGetters({
+        facilityUsers: state => state.pageState.facilityUsers,
+        currentFacilityId,
+      }),
       newUserRole() {
         if (this.coachIsSelected) {
           if (this.classCoach) {
@@ -259,6 +264,10 @@
       },
     },
     methods: {
+      ...mapActions({
+        createUser,
+        displayModal,
+      }),
       createNewUser() {
         this.errorMessage = '';
         this.formSubmitted = true;
@@ -299,16 +308,6 @@
       },
       close() {
         this.displayModal(false);
-      },
-    },
-    vuex: {
-      getters: {
-        facilityUsers: state => state.pageState.facilityUsers,
-        currentFacilityId,
-      },
-      actions: {
-        createUser,
-        displayModal,
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -96,7 +96,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
   import { currentFacilityId } from 'kolibri.coreVue.vuex.getters';
   import { validateUsername } from 'kolibri.utils.validators';
@@ -163,7 +163,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         facilityUsers: state => state.pageState.facilityUsers,
         currentFacilityId,
       }),

--- a/kolibri/plugins/facility_management/assets/src/views/user-table.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-table.vue
@@ -148,10 +148,6 @@
         return this.$emit('input', selected.filter(selectedId => selectedId !== id));
       },
     },
-    vuex: {
-      getters: {},
-      actions: {},
-    },
     $trs: {
       coachTableTitle: 'Coaches',
       learnerTableTitle: 'Learners',

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -104,7 +104,7 @@ oriented data synchronization.
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import {
     initMasteryLog,
@@ -202,7 +202,7 @@ oriented data synchronization.
       checkWasAttempted: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         isUserLoggedIn,
         mastered: state => state.core.logging.mastery.complete,
         totalattempts: state => state.core.logging.mastery.totalattempts,

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -104,6 +104,7 @@ oriented data synchronization.
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import {
     initMasteryLog,
@@ -201,6 +202,18 @@ oriented data synchronization.
       checkWasAttempted: false,
     }),
     computed: {
+      ...mapGetters({
+        isUserLoggedIn,
+        mastered: state => state.core.logging.mastery.complete,
+        totalattempts: state => state.core.logging.mastery.totalattempts,
+        pastattempts: state =>
+          (state.core.logging.mastery.pastattempts || []).filter(attempt => attempt.error !== true),
+        userid: state => state.core.session.user_id,
+        content: state => state.pageState.content,
+        assessmentIds: state => state.pageState.content.assessmentIds,
+        masteryModel: state => state.pageState.content.masteryModel,
+        randomize: state => state.pageState.content.randomize,
+      }),
       recentAttempts() {
         if (!this.pastattempts) {
           return [];
@@ -288,6 +301,19 @@ oriented data synchronization.
       this.saveAttemptLogMasterLog(false);
     },
     methods: {
+      ...mapActions({
+        initMasteryLog,
+        createDummyMasteryLog,
+        saveMasteryLog,
+        saveAndStoreMasteryLog,
+        setMasteryLogComplete,
+        createAttemptLog,
+        saveAttemptLog,
+        saveAndStoreAttemptLog,
+        updateMasteryAttemptState,
+        updateAttemptLogInteractionHistory,
+        updateExerciseProgress,
+      }),
       updateAttemptLogMasteryLog({
         correct,
         complete,
@@ -464,33 +490,6 @@ oriented data synchronization.
       },
       stopTracking(...args) {
         this.$emit('stopTracking', ...args);
-      },
-    },
-    vuex: {
-      actions: {
-        initMasteryLog,
-        createDummyMasteryLog,
-        saveMasteryLog,
-        saveAndStoreMasteryLog,
-        setMasteryLogComplete,
-        createAttemptLog,
-        saveAttemptLog,
-        saveAndStoreAttemptLog,
-        updateMasteryAttemptState,
-        updateAttemptLogInteractionHistory,
-        updateExerciseProgress,
-      },
-      getters: {
-        isUserLoggedIn,
-        mastered: state => state.core.logging.mastery.complete,
-        totalattempts: state => state.core.logging.mastery.totalattempts,
-        pastattempts: state =>
-          (state.core.logging.mastery.pastattempts || []).filter(attempt => attempt.error !== true),
-        userid: state => state.core.session.user_id,
-        content: state => state.pageState.content,
-        assessmentIds: state => state.pageState.content.assessmentIds,
-        masteryModel: state => state.pageState.content.masteryModel,
-        randomize: state => state.pageState.content.randomize,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
@@ -11,6 +11,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames, PageModes } from '../constants';
   import { pageMode } from '../state/getters';
@@ -25,6 +26,16 @@
     components: { kBreadcrumbs },
     mixins: [classesBreadcrumbItems],
     computed: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+        pageMode,
+        channelRootId: state => (state.pageState.channel || {}).root_id,
+        channelTitle: state => (state.pageState.channel || {}).title,
+        topicTitle: state => (state.pageState.topic || {}).title,
+        topicCrumbs: state => (state.pageState.topic || {}).breadcrumbs || [],
+        contentTitle: state => (state.pageState.content || {}).title,
+        contentCrumbs: state => (state.pageState.content || {}).breadcrumbs || [],
+      }),
       inLearn() {
         return this.pageMode === PageModes.RECOMMENDED && this.pageName !== PageNames.RECOMMENDED;
       },
@@ -97,18 +108,6 @@
             params: { id },
           },
         }));
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: state => state.pageName,
-        pageMode,
-        channelRootId: state => (state.pageState.channel || {}).root_id,
-        channelTitle: state => (state.pageState.channel || {}).title,
-        topicTitle: state => (state.pageState.topic || {}).title,
-        topicCrumbs: state => (state.pageState.topic || {}).breadcrumbs || [],
-        contentTitle: state => (state.pageState.content || {}).title,
-        contentCrumbs: state => (state.pageState.content || {}).breadcrumbs || [],
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
+++ b/kolibri/plugins/learn/assets/src/views/breadcrumbs.vue
@@ -11,7 +11,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames, PageModes } from '../constants';
   import { pageMode } from '../state/getters';
@@ -26,7 +26,7 @@
     components: { kBreadcrumbs },
     mixins: [classesBreadcrumbItems],
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: state => state.pageName,
         pageMode,
         channelRootId: state => (state.pageState.channel || {}).root_id,

--- a/kolibri/plugins/learn/assets/src/views/channels-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page.vue
@@ -16,6 +16,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import pageHeader from './page-header';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -29,17 +30,17 @@
       pageHeader,
       contentCardGroupGrid,
     },
+    computed: {
+      ...mapGetters({
+        channels: state => state.pageState.rootNodes,
+      }),
+    },
     methods: {
       genChannelLink(channel_id) {
         return {
           name: PageNames.TOPICS_CHANNEL,
           params: { channel_id },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        channels: state => state.pageState.rootNodes,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/channels-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/channels-page.vue
@@ -16,7 +16,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { PageNames } from '../constants';
   import pageHeader from './page-header';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -31,7 +31,7 @@
       contentCardGroupGrid,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         channels: state => state.pageState.rootNodes,
       }),
     },

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -25,7 +25,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import AuthMessage from 'kolibri.coreVue.components.authMessage';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -41,7 +41,7 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters({
+      ...mapState({
         classrooms: state => state.pageState.classrooms,
         isUserLoggedIn,
       }),

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -25,6 +25,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import AuthMessage from 'kolibri.coreVue.components.authMessage';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -40,6 +41,10 @@
     },
     mixins: [responsiveWindow],
     computed: {
+      ...mapGetters({
+        classrooms: state => state.pageState.classrooms,
+        isUserLoggedIn,
+      }),
       isMobile() {
         return this.windowSize.breakpoint <= 1;
       },
@@ -49,12 +54,6 @@
     },
     methods: {
       classAssignmentsLink,
-    },
-    vuex: {
-      getters: {
-        classrooms: state => state.pageState.classrooms,
-        isUserLoggedIn,
-      },
     },
     $trs: {
       allClassesHeader: 'Classes',

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -20,7 +20,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import AssignedExamsCards from './AssignedExamsCards';
   import AssignedLessonsCards from './AssignedLessonsCards';
@@ -33,7 +33,7 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters({
+      ...mapState({
         classroomName: state => state.pageState.currentClassroom.name,
         exams: state => state.pageState.currentClassroom.assignments.exams,
         lessons: state => state.pageState.currentClassroom.assignments.lessons,

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -20,6 +20,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import AssignedExamsCards from './AssignedExamsCards';
   import AssignedLessonsCards from './AssignedLessonsCards';
@@ -32,15 +33,13 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      isMobile() {
-        return this.windowSize.breakpoint <= 1;
-      },
-    },
-    vuex: {
-      getters: {
+      ...mapGetters({
         classroomName: state => state.pageState.currentClassroom.name,
         exams: state => state.pageState.currentClassroom.assignments.exams,
         lessons: state => state.pageState.currentClassroom.assignments.lessons,
+      }),
+      isMobile() {
+        return this.windowSize.breakpoint <= 1;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -43,7 +43,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import sumBy from 'lodash/sumBy';
   import ProgressIcon from 'kolibri.coreVue.components.progressIcon';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -59,7 +59,7 @@
       ProgressIcon,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         contentNodes: state => state.pageState.contentNodes,
         currentLesson: state => state.pageState.currentLesson,
       }),

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -43,6 +43,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import sumBy from 'lodash/sumBy';
   import ProgressIcon from 'kolibri.coreVue.components.progressIcon';
   import ContentIcon from 'kolibri.coreVue.components.contentIcon';
@@ -58,6 +59,10 @@
       ProgressIcon,
     },
     computed: {
+      ...mapGetters({
+        contentNodes: state => state.pageState.contentNodes,
+        currentLesson: state => state.pageState.currentLesson,
+      }),
       lessonHasResources() {
         return this.contentNodes.length > 0;
       },
@@ -76,12 +81,6 @@
     methods: {
       getContentNodeThumbnail,
       lessonResourceViewerLink,
-    },
-    vuex: {
-      getters: {
-        contentNodes: state => state.pageState.contentNodes,
-        currentLesson: state => state.pageState.currentLesson,
-      },
     },
     $trs: {
       noResourcesInLesson: 'There are no resources in this lesson',

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -24,7 +24,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import ContentCard from '../content-card';
   import ContentPage from '../content-page';
@@ -37,7 +37,7 @@
       ContentPage,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentLesson: state => state.pageState.currentLesson,
         currentLessonResource: state => state.pageState.content,
         nextLessonResource: state => state.pageState.content.next_content,

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -24,6 +24,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import ContentCard from '../content-card';
   import ContentPage from '../content-page';
@@ -36,19 +37,17 @@
       ContentPage,
     },
     computed: {
+      ...mapGetters({
+        currentLesson: state => state.pageState.currentLesson,
+        currentLessonResource: state => state.pageState.content,
+        nextLessonResource: state => state.pageState.content.next_content,
+      }),
       nextResourceLink() {
         return lessonResourceViewerLink(Number(this.$route.params.resourceNumber) + 1);
       },
     },
     methods: {
       getContentNodeThumbnail,
-    },
-    vuex: {
-      getters: {
-        currentLesson: state => state.pageState.currentLesson,
-        currentLessonResource: state => state.pageState.content,
-        nextLessonResource: state => state.pageState.content.next_content,
-      },
     },
     $trs: {
       nextInLesson: 'Next in lesson',

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
@@ -66,6 +66,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
@@ -135,6 +136,9 @@
       uniqueId: null,
     }),
     computed: {
+      ...mapGetters({
+        channels: getChannels,
+      }),
       isMobile() {
         return this.windowSize.breakpoint <= 1;
       },
@@ -183,11 +187,6 @@
         this.sharedContentId = contentId;
         this.uniqueId = this.contents.find(content => content.content_id === contentId).id;
         this.modalIsOpen = true;
-      },
-    },
-    vuex: {
-      getters: {
-        channels: getChannels,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-grid.vue
@@ -66,7 +66,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
@@ -136,7 +136,7 @@
       uniqueId: null,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         channels: getChannels,
       }),
       isMobile() {

--- a/kolibri/plugins/learn/assets/src/views/content-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page.vue
@@ -115,7 +115,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import {
     initContentSession as initSessionAction,
     updateProgress as updateProgressAction,
@@ -164,7 +164,7 @@
       licenceDescriptionIsVisible: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         content: state => state.pageState.content,
         contentId: state => state.pageState.content.content_id,
         contentNodeId: state => state.pageState.content.id,

--- a/kolibri/plugins/learn/assets/src/views/content-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page.vue
@@ -115,6 +115,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import {
     initContentSession as initSessionAction,
     updateProgress as updateProgressAction,
@@ -163,6 +164,20 @@
       licenceDescriptionIsVisible: false,
     }),
     computed: {
+      ...mapGetters({
+        content: state => state.pageState.content,
+        contentId: state => state.pageState.content.content_id,
+        contentNodeId: state => state.pageState.content.id,
+        channelId: state => state.pageState.content.channel_id,
+        pageName: state => state.pageName,
+        recommended: state => state.pageState.recommended,
+        summaryProgress: state => state.core.logging.summary.progress,
+        sessionProgress: state => state.core.logging.session.progress,
+        pageMode,
+        isUserLoggedIn,
+        facilityConfig,
+        contentPoints,
+      }),
       isTopic() {
         return this.content.kind === ContentNodeKinds.TOPIC;
       },
@@ -222,6 +237,12 @@
       this.stopTracking();
     },
     methods: {
+      ...mapActions({
+        initSessionAction,
+        updateProgressAction,
+        startTracking,
+        stopTracking,
+      }),
       setWasIncomplete() {
         this.wasIncomplete = this.progress < 1;
       },
@@ -243,28 +264,6 @@
               : PageNames.RECOMMENDED_CONTENT,
           params: { id },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        content: state => state.pageState.content,
-        contentId: state => state.pageState.content.content_id,
-        contentNodeId: state => state.pageState.content.id,
-        channelId: state => state.pageState.content.channel_id,
-        pageName: state => state.pageName,
-        recommended: state => state.pageState.recommended,
-        summaryProgress: state => state.core.logging.summary.progress,
-        sessionProgress: state => state.core.logging.session.progress,
-        pageMode,
-        isUserLoggedIn,
-        facilityConfig,
-        contentPoints,
-      },
-      actions: {
-        initSessionAction,
-        updateProgressAction,
-        startTracking,
-        stopTracking,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/copies-modal.vue
+++ b/kolibri/plugins/learn/assets/src/views/copies-modal.vue
@@ -49,6 +49,7 @@
 
 <script>
 
+  import { mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCircularLoader from 'kolibri.coreVue.components.kCircularLoader';
@@ -88,6 +89,9 @@
       });
     },
     methods: {
+      ...mapActions({
+        getCopies,
+      }),
       closeModal() {
         return this.$emit('cancel');
       },
@@ -101,11 +105,6 @@
     $trs: {
       copies: 'Locations',
       close: 'Close',
-    },
-    vuex: {
-      actions: {
-        getCopies,
-      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
@@ -30,6 +30,8 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
+
   export default {
     name: 'answerHistory',
     $trs: {
@@ -40,6 +42,12 @@
         type: Number,
         required: true,
       },
+    },
+    computed: {
+      ...mapGetters({
+        questions: state => state.pageState.questions,
+        attemptLogs: state => state.examAttemptLogs,
+      }),
     },
     methods: {
       daysElapsedText(daysElapsed) {
@@ -61,12 +69,6 @@
       },
       isAnswered(question) {
         return ((this.attemptLogs[question.contentId] || {})[question.itemId] || {}).answer;
-      },
-    },
-    vuex: {
-      getters: {
-        questions: state => state.pageState.questions,
-        attemptLogs: state => state.examAttemptLogs,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/answer-history.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
 
   export default {
     name: 'answerHistory',
@@ -44,7 +44,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         questions: state => state.pageState.questions,
         attemptLogs: state => state.examAttemptLogs,
       }),

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -96,6 +96,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { InteractionTypes } from 'kolibri.coreVue.vuex.constants';
   import isEqual from 'lodash/isEqual';
   import { now } from 'kolibri.utils.serverClock';
@@ -137,8 +138,8 @@
         submitModalOpen: false,
       };
     },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         exam: state => state.pageState.exam,
         channelId: state => state.pageState.channelId,
         content: state => state.pageState.content,
@@ -147,13 +148,7 @@
         attemptLogs: state => state.examAttemptLogs,
         currentAttempt: state => state.pageState.currentAttempt,
         questionsAnswered: state => state.pageState.questionsAnswered,
-      },
-      actions: {
-        setAndSaveCurrentExamAttemptLog,
-        closeExam,
-      },
-    },
-    computed: {
+      }),
       backPageLink() {
         return {
           name: ClassesPageNames.CLASS_ASSIGNMENTS,
@@ -169,6 +164,10 @@
       });
     },
     methods: {
+      ...mapActions({
+        setAndSaveCurrentExamAttemptLog,
+        closeExam,
+      }),
       checkAnswer() {
         if (this.$refs.contentRenderer) {
           return this.$refs.contentRenderer.checkAnswer();

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -96,7 +96,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { InteractionTypes } from 'kolibri.coreVue.vuex.constants';
   import isEqual from 'lodash/isEqual';
   import { now } from 'kolibri.utils.serverClock';
@@ -139,7 +139,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         exam: state => state.pageState.exam,
         channelId: state => state.pageState.channelId,
         content: state => state.pageState.content,

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -24,6 +24,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import examReport from 'kolibri.coreVue.components.examReport';
   import { ClassesPageNames } from '../constants';
 
@@ -33,6 +34,22 @@
       examReport,
     },
     computed: {
+      ...mapGetters({
+        classId: state => state.pageState.exam.collection,
+        examAttempts: state => state.pageState.examAttempts,
+        exam: state => state.pageState.exam,
+        userName: state => state.pageState.user.full_name,
+        userId: state => state.pageState.user.id,
+        currentAttempt: state => state.pageState.currentAttempt,
+        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
+        currentInteraction: state => state.pageState.currentInteraction,
+        selectedInteractionIndex: state => state.pageState.interactionIndex,
+        questionNumber: state => state.pageState.questionNumber,
+        exercise: state => state.pageState.exercise,
+        itemId: state => state.pageState.itemId,
+        completionTimestamp: state => state.pageState.examLog.completion_timestamp,
+        closed: state => state.pageState.examLog.closed,
+      }),
       backPageLink() {
         return {
           name: ClassesPageNames.CLASS_ASSIGNMENTS,
@@ -59,24 +76,6 @@
             examId: this.exam.id,
           },
         });
-      },
-    },
-    vuex: {
-      getters: {
-        classId: state => state.pageState.exam.collection,
-        examAttempts: state => state.pageState.examAttempts,
-        exam: state => state.pageState.exam,
-        userName: state => state.pageState.user.full_name,
-        userId: state => state.pageState.user.id,
-        currentAttempt: state => state.pageState.currentAttempt,
-        currentInteractionHistory: state => state.pageState.currentInteractionHistory,
-        currentInteraction: state => state.pageState.currentInteraction,
-        selectedInteractionIndex: state => state.pageState.interactionIndex,
-        questionNumber: state => state.pageState.questionNumber,
-        exercise: state => state.pageState.exercise,
-        itemId: state => state.pageState.itemId,
-        completionTimestamp: state => state.pageState.examLog.completion_timestamp,
-        closed: state => state.pageState.examLog.closed,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -24,7 +24,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import examReport from 'kolibri.coreVue.components.examReport';
   import { ClassesPageNames } from '../constants';
 
@@ -34,7 +34,7 @@
       examReport,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         classId: state => state.pageState.exam.collection,
         examAttempts: state => state.pageState.examAttempts,
         exam: state => state.pageState.exam,

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -54,6 +54,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -121,6 +122,14 @@
     },
     mixins: [responsiveWindow],
     computed: {
+      ...mapGetters({
+        memberships: state => state.learnAppState.memberships,
+        pageName: state => state.pageName,
+        searchTerm: state => state.pageState.searchTerm,
+        isUserLoggedIn,
+        content: state => state.pageState.content,
+        exam: state => state.pageState.exam,
+      }),
       topLevelPageName() {
         return TopLevelPageNames.LEARN;
       },
@@ -219,17 +228,6 @@
         const isAssessment = isContentPage && this.content && this.content.assessment;
         // height of .attempts-container in assessment-wrapper
         return isAssessment ? BOTTOM_SPACED_RESERVED : 0;
-      },
-    },
-
-    vuex: {
-      getters: {
-        memberships: state => state.learnAppState.memberships,
-        pageName: state => state.pageName,
-        searchTerm: state => state.pageState.searchTerm,
-        isUserLoggedIn,
-        content: state => state.pageState.content,
-        exam: state => state.pageState.exam,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/index.vue
@@ -54,7 +54,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -122,7 +122,7 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters({
+      ...mapState({
         memberships: state => state.learnAppState.memberships,
         pageName: state => state.pageName,
         searchTerm: state => state.pageState.searchTerm,

--- a/kolibri/plugins/learn/assets/src/views/mastered-snackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/mastered-snackbars/index.vue
@@ -73,7 +73,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
@@ -112,7 +112,7 @@
     }),
 
     computed: {
-      ...mapGetters({
+      ...mapState({
         isUserLoggedIn,
       }),
       SNACKBARS() {

--- a/kolibri/plugins/learn/assets/src/views/mastered-snackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/mastered-snackbars/index.vue
@@ -73,6 +73,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
@@ -111,6 +112,9 @@
     }),
 
     computed: {
+      ...mapGetters({
+        isUserLoggedIn,
+      }),
       SNACKBARS() {
         return SNACKBARS;
       },
@@ -163,11 +167,6 @@
       plusPoints: '+ { maxPoints, number } Points',
       next: 'Next:',
       signIn: 'Sign in or create an account to save points you earn',
-    },
-    vuex: {
-      getters: {
-        isUserLoggedIn,
-      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/page-header.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header.vue
@@ -12,14 +12,15 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
 
   export default {
     name: 'pageHeader',
     components: { progressIcon },
     props: { title: { type: String } },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         progress: state => {
           if (state.pageState.content) {
             if (
@@ -32,7 +33,7 @@
           }
           return null;
         },
-      },
+      }),
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/page-header.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header.vue
@@ -12,7 +12,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import progressIcon from 'kolibri.coreVue.components.progressIcon';
 
   export default {
@@ -20,7 +20,7 @@
     components: { progressIcon },
     props: { title: { type: String } },
     computed: {
-      ...mapGetters({
+      ...mapState({
         progress: state => {
           if (state.pageState.content) {
             if (

--- a/kolibri/plugins/learn/assets/src/views/recommended-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-page.vue
@@ -91,6 +91,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
   import { PageNames } from '../constants';
@@ -117,6 +118,13 @@
     },
     mixins: [responsiveWindow],
     computed: {
+      ...mapGetters({
+        channels: getChannels,
+        nextSteps: state => state.pageState.nextSteps,
+        popular: state => state.pageState.popular,
+        resume: state => state.pageState.resume,
+        featured: state => state.pageState.featured,
+      }),
       isMobile() {
         return this.windowSize.breakpoint <= 1;
       },
@@ -169,15 +177,6 @@
       },
       getChannelTitle(channel_id) {
         return this.channels.find(channel => channel.id === channel_id).title;
-      },
-    },
-    vuex: {
-      getters: {
-        channels: getChannels,
-        nextSteps: state => state.pageState.nextSteps,
-        popular: state => state.pageState.popular,
-        resume: state => state.pageState.resume,
-        featured: state => state.pageState.featured,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/recommended-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-page.vue
@@ -91,7 +91,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
   import { PageNames } from '../constants';
@@ -118,7 +118,7 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters({
+      ...mapState({
         channels: getChannels,
         nextSteps: state => state.pageState.nextSteps,
         popular: state => state.pageState.popular,

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
@@ -15,6 +15,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../constants';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -35,6 +36,11 @@
       kBreadcrumbs,
     },
     computed: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+        recommendations: state => state.pageState.recommendations,
+        channelTitle: state => state.pageState.channelTitle,
+      }),
       header() {
         switch (this.pageName) {
           case PageNames.RECOMMENDED_POPULAR:
@@ -69,13 +75,6 @@
           name: PageNames.RECOMMENDED_CONTENT,
           params: { id },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: state => state.pageName,
-        recommendations: state => state.pageState.recommendations,
-        channelTitle: state => state.pageState.channelTitle,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
@@ -15,7 +15,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
   import { PageNames } from '../constants';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -36,7 +36,7 @@
       kBreadcrumbs,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: state => state.pageName,
         recommendations: state => state.pageState.recommendations,
         channelTitle: state => state.pageState.channelTitle,

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -68,7 +68,7 @@
     },
     data() {
       return {
-        searchQuery: this.searchTerm,
+        searchQuery: this.$store.state.pageState.searchTerm,
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -46,6 +46,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import { PageNames } from '../constants';
 
@@ -70,6 +71,11 @@
         searchQuery: this.searchTerm,
       };
     },
+    computed: {
+      ...mapGetters({
+        searchTerm: state => state.pageState.searchTerm,
+      }),
+    },
     watch: {
       searchTerm(val) {
         this.searchQuery = val || '';
@@ -90,11 +96,6 @@
             query: { query: this.searchQuery },
           });
         }
-      },
-    },
-    vuex: {
-      getters: {
-        searchTerm: state => state.pageState.searchTerm,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -46,7 +46,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import { PageNames } from '../constants';
 
@@ -72,7 +72,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         searchTerm: state => state.pageState.searchTerm,
       }),
     },

--- a/kolibri/plugins/learn/assets/src/views/search-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page.vue
@@ -30,9 +30,9 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import sortBy from 'lodash/sortBy';
-
   import { PageNames } from '../constants';
   import contentCard from './content-card';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -52,6 +52,10 @@
       searchBox,
     },
     computed: {
+      ...mapGetters({
+        contents: state => state.pageState.contents,
+        searchTerm: state => state.pageState.searchTerm,
+      }),
       searchContents() {
         return sortBy(this.contents, content => content.channel_id !== content.content_id);
       },
@@ -72,12 +76,6 @@
             id: contentId,
           },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        contents: state => state.pageState.contents,
-        searchTerm: state => state.pageState.searchTerm,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/search-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-page.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import sortBy from 'lodash/sortBy';
   import { PageNames } from '../constants';
@@ -52,7 +52,7 @@
       searchBox,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         contents: state => state.pageState.contents,
         searchTerm: state => state.pageState.searchTerm,
       }),

--- a/kolibri/plugins/learn/assets/src/views/topics-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import textTruncator from 'kolibri.coreVue.components.textTruncator';
   import { PageNames } from '../constants';
@@ -49,7 +49,7 @@
       textTruncator,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         topic: state => state.pageState.topic,
         contents: state => state.pageState.contents,
         isRoot: state => state.pageState.isRoot,

--- a/kolibri/plugins/learn/assets/src/views/topics-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page.vue
@@ -28,6 +28,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import textTruncator from 'kolibri.coreVue.components.textTruncator';
   import { PageNames } from '../constants';
@@ -47,6 +48,14 @@
       contentCardGroupGrid,
       textTruncator,
     },
+    computed: {
+      ...mapGetters({
+        topic: state => state.pageState.topic,
+        contents: state => state.pageState.contents,
+        isRoot: state => state.pageState.isRoot,
+        channelId: state => state.pageState.channel.id,
+      }),
+    },
     methods: {
       genContentLink(id, kind) {
         if (kind === ContentNodeKinds.TOPIC) {
@@ -59,14 +68,6 @@
           name: PageNames.TOPICS_CONTENT,
           params: { channel_id: this.channelId, id },
         };
-      },
-    },
-    vuex: {
-      getters: {
-        topic: state => state.pageState.topic,
-        contents: state => state.pageState.contents,
-        isRoot: state => state.pageState.isRoot,
-        channelId: state => state.pageState.channel.id,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/total-points.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points.vue
@@ -15,7 +15,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { totalPoints, currentUserId, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { fetchPoints } from 'kolibri.coreVue.vuex.actions';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
@@ -29,7 +29,7 @@
       uiTooltip,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         totalPoints,
         currentUserId,
         isUserLoggedIn,

--- a/kolibri/plugins/learn/assets/src/views/total-points.vue
+++ b/kolibri/plugins/learn/assets/src/views/total-points.vue
@@ -15,6 +15,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { totalPoints, currentUserId, isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
   import { fetchPoints } from 'kolibri.coreVue.vuex.actions';
   import pointsIcon from 'kolibri.coreVue.components.pointsIcon';
@@ -27,17 +28,19 @@
       pointsIcon,
       uiTooltip,
     },
-    vuex: {
-      getters: {
+    computed: {
+      ...mapGetters({
         totalPoints,
         currentUserId,
         isUserLoggedIn,
-      },
-      actions: { fetchPoints },
+      }),
     },
     watch: { currentUserId: 'fetchPoints' },
     created() {
       this.fetchPoints();
+    },
+    methods: {
+      ...mapActions({ fetchPoints }),
     },
   };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -35,6 +35,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { provisionDevice, goToNextStep, goToPreviousStep } from '../state/actions/main';
 
@@ -61,6 +62,12 @@
       };
     },
     computed: {
+      ...mapGetters({
+        onboardingStep: state => state.onboardingStep,
+        onboardingData: state => state.onboardingData,
+        loading: state => state.loading,
+        error: state => state.error,
+      }),
       currentOnboardingForm() {
         switch (this.onboardingStep) {
           case 1:
@@ -88,25 +95,17 @@
       },
     },
     methods: {
+      ...mapActions({
+        goToNextStep,
+        goToPreviousStep,
+        provisionDevice,
+      }),
       continueOnboarding() {
         if (this.isLastStep) {
           this.provisionDevice(this.onboardingData);
         } else {
           this.goToNextStep();
         }
-      },
-    },
-    vuex: {
-      getters: {
-        onboardingStep: state => state.onboardingStep,
-        onboardingData: state => state.onboardingData,
-        loading: state => state.loading,
-        error: state => state.error,
-      },
-      actions: {
-        goToNextStep,
-        goToPreviousStep,
-        provisionDevice,
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/index.vue
@@ -35,7 +35,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { provisionDevice, goToNextStep, goToPreviousStep } from '../state/actions/main';
 
@@ -62,7 +62,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         onboardingStep: state => state.onboardingStep,
         onboardingData: state => state.onboardingData,
         loading: state => state.loading,

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
@@ -13,7 +13,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import languageSwitcherList from 'kolibri.coreVue.components.languageSwitcherList';
   import { submitDefaultLanguage } from '../../../state/actions/forms';
   import onboardingForm from '../onboarding-form';
@@ -38,7 +38,7 @@
       },
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentLanguageId: state => state.onboardingData.language_id,
       }),
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/default-language-form/index.vue
@@ -13,9 +13,9 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import languageSwitcherList from 'kolibri.coreVue.components.languageSwitcherList';
   import { submitDefaultLanguage } from '../../../state/actions/forms';
-
   import onboardingForm from '../onboarding-form';
 
   export default {
@@ -37,18 +37,18 @@
         required: false,
       },
     },
+    computed: {
+      ...mapGetters({
+        currentLanguageId: state => state.onboardingData.language_id,
+      }),
+    },
     methods: {
+      ...mapActions({
+        submitDefaultLanguage,
+      }),
       setLanguage() {
         this.submitDefaultLanguage(this.currentLanguageId);
         this.$emit('submit');
-      },
-    },
-    vuex: {
-      actions: {
-        submitDefaultLanguage,
-      },
-      getters: {
-        currentLanguageId: state => state.onboardingData.language_id,
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
@@ -22,9 +22,9 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import { submitFacilityName } from '../../../state/actions/forms';
-
   import onboardingForm from '../onboarding-form';
 
   export default {
@@ -54,6 +54,9 @@
       };
     },
     computed: {
+      ...mapGetters({
+        currentFacilityName: state => state.onboardingData.facility.name,
+      }),
       facilityNameErrorMessage() {
         if (this.facilityName === '') {
           return this.$tr('facilityNameFieldEmptyErrorMessage');
@@ -68,6 +71,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        submitFacilityName,
+      }),
       validateFacilityName() {
         this.fieldVisited = true;
       },
@@ -79,14 +85,6 @@
           this.submitFacilityName(this.facilityName);
           this.$emit('submit');
         }
-      },
-    },
-    vuex: {
-      actions: {
-        submitFacilityName,
-      },
-      getters: {
-        currentFacilityName: state => state.onboardingData.facility.name,
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
@@ -27,6 +27,10 @@
   import { submitFacilityName } from '../../../state/actions/forms';
   import onboardingForm from '../onboarding-form';
 
+  function currentFacilityName(state) {
+    return state.onboardingData.facility.name;
+  }
+
   export default {
     name: 'facilityNameForm',
     components: {
@@ -49,13 +53,13 @@
     },
     data() {
       return {
-        facilityName: this.currentFacilityName,
+        facilityName: currentFacilityName(this.$store.state),
         fieldVisited: false,
       };
     },
     computed: {
       ...mapGetters({
-        currentFacilityName: state => state.onboardingData.facility.name,
+        currentFacilityName,
       }),
       facilityNameErrorMessage() {
         if (this.facilityName === '') {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-name-form/index.vue
@@ -22,7 +22,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import { submitFacilityName } from '../../../state/actions/forms';
   import onboardingForm from '../onboarding-form';
@@ -58,7 +58,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentFacilityName,
       }),
       facilityNameErrorMessage() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -162,7 +162,7 @@
         permissionPresetDetailsModalShown: false,
       };
     },
-    computed:{
+    computed: {
       ...mapGetters({
         currentPermissionPreset: state => state.onboardingData.preset,
       }),

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -111,6 +111,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
@@ -161,10 +162,18 @@
         permissionPresetDetailsModalShown: false,
       };
     },
+    computed:{
+      ...mapGetters({
+        currentPermissionPreset: state => state.onboardingData.preset,
+      }),
+    },
     mounted() {
       this.$refs['first-button'].focus();
     },
     methods: {
+      ...mapActions({
+        submitFacilityPermissions,
+      }),
       setPermissions() {
         this.submitFacilityPermissions(this.selectedPreset);
         this.$emit('submit');
@@ -174,14 +183,6 @@
       },
       hideFacilityPermissionsDetails() {
         this.permissionPresetDetailsModalShown = false;
-      },
-    },
-    vuex: {
-      actions: {
-        submitFacilityPermissions,
-      },
-      getters: {
-        currentPermissionPreset: state => state.onboardingData.preset,
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -111,7 +111,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
@@ -167,7 +167,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentPermissionPreset,
       }),
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/facility-permissions-form/index.vue
@@ -118,6 +118,10 @@
   import onboardingForm from '../onboarding-form';
   import { submitFacilityPermissions } from '../../../state/actions/forms';
 
+  function currentPermissionPreset(state) {
+    return state.onboardingData.preset;
+  }
+
   export default {
     name: 'selectPermissionsForm',
     components: {
@@ -158,13 +162,13 @@
     },
     data() {
       return {
-        selectedPreset: this.currentPermissionPreset,
+        selectedPreset: currentPermissionPreset(this.$store.state),
         permissionPresetDetailsModalShown: false,
       };
     },
     computed: {
       ...mapGetters({
-        currentPermissionPreset: state => state.onboardingData.preset,
+        currentPermissionPreset,
       }),
     },
     mounted() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
@@ -63,6 +63,18 @@
   import { submitSuperuserCredentials } from '../../../state/actions/forms';
   import onboardingForm from '../onboarding-form';
 
+  function currentName(state) {
+    return state.onboardingData.superuser.full_name;
+  }
+
+  function currentUsername(state) {
+    return state.onboardingData.superuser.username;
+  }
+
+  function currentPassword(state) {
+    return state.onboardingData.superuser.password;
+  }
+
   export default {
     name: 'superuserCredentialsForm',
     components: {
@@ -94,9 +106,9 @@
     },
     data() {
       return {
-        name: this.currentName,
-        username: this.currentUsername,
-        password: this.currentPassword,
+        name: currentName(this.$store.state),
+        username: currentUsername(this.$store.state),
+        password: currentPassword(this.$store.state),
         passwordConfirm: this.currentPassword,
         visitedFields: {
           name: false,
@@ -108,9 +120,9 @@
     },
     computed: {
       ...mapGetters({
-        currentName: state => state.onboardingData.superuser.full_name,
-        currentUsername: state => state.onboardingData.superuser.username,
-        currentPassword: state => state.onboardingData.superuser.password,
+        currentName,
+        currentUsername,
+        currentPassword,
       }),
       nameErrorMessage() {
         if (this.name === '') {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
@@ -57,7 +57,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import { validateUsername } from 'kolibri.utils.validators';
   import { submitSuperuserCredentials } from '../../../state/actions/forms';
@@ -119,7 +119,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         currentName,
         currentUsername,
         currentPassword,

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/superuser-credentials-form/index.vue
@@ -57,6 +57,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import { validateUsername } from 'kolibri.utils.validators';
   import { submitSuperuserCredentials } from '../../../state/actions/forms';
@@ -106,6 +107,11 @@
       };
     },
     computed: {
+      ...mapGetters({
+        currentName: state => state.onboardingData.superuser.full_name,
+        currentUsername: state => state.onboardingData.superuser.username,
+        currentPassword: state => state.onboardingData.superuser.password,
+      }),
       nameErrorMessage() {
         if (this.name === '') {
           return this.$tr('nameFieldEmptyErrorMessage');
@@ -158,6 +164,9 @@
       },
     },
     methods: {
+      ...mapActions({
+        submitSuperuserCredentials,
+      }),
       setSuperuserCredentials() {
         for (const field in this.visitedFields) {
           this.visitedFields[field] = true;
@@ -175,16 +184,6 @@
         } else if (this.passwordConfirmIsInvalid) {
           this.$refs.passwordConfirm.focus();
         }
-      },
-    },
-    vuex: {
-      actions: {
-        submitSuperuserCredentials,
-      },
-      getters: {
-        currentName: state => state.onboardingData.superuser.full_name,
-        currentUsername: state => state.onboardingData.superuser.username,
-        currentPassword: state => state.onboardingData.superuser.password,
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -19,6 +19,7 @@
 
 <script>
 
+  import { mapGetters } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import coreBase from 'kolibri.coreVue.components.coreBase';
   import { PageNames } from '../constants';
@@ -35,6 +36,9 @@
   export default {
     name: 'userPlugin',
     components: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+      }),
       coreBase,
       signInPage,
       signUpPage,
@@ -53,11 +57,6 @@
       },
       navBarNeeded() {
         return this.pageName !== PageNames.SIGN_IN && this.pageName !== PageNames.SIGN_UP;
-      },
-    },
-    vuex: {
-      getters: {
-        pageName: state => state.pageName,
       },
     },
     $trs: {

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -19,7 +19,7 @@
 
 <script>
 
-  import { mapGetters } from 'kolibri.utils.vuexCompat';
+  import { mapState } from 'kolibri.utils.vuexCompat';
   import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import coreBase from 'kolibri.coreVue.components.coreBase';
   import { PageNames } from '../constants';
@@ -42,7 +42,7 @@
       profilePage,
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         pageName: state => state.pageName,
       }),
       appBarTitle() {

--- a/kolibri/plugins/user/assets/src/views/index.vue
+++ b/kolibri/plugins/user/assets/src/views/index.vue
@@ -36,15 +36,15 @@
   export default {
     name: 'userPlugin',
     components: {
-      ...mapGetters({
-        pageName: state => state.pageName,
-      }),
       coreBase,
       signInPage,
       signUpPage,
       profilePage,
     },
     computed: {
+      ...mapGetters({
+        pageName: state => state.pageName,
+      }),
       appBarTitle() {
         if (this.pageName === PageNames.PROFILE) {
           return this.$tr('userProfileTitle');

--- a/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
@@ -50,6 +50,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -72,6 +73,9 @@
       };
     },
     computed: {
+      ...mapActions({
+        updateUserProfilePassword,
+      }),
       newPasswordInvalidErrorText() {
         if (this.newPasswordBlurred || this.submittedForm) {
           if (this.newPassword === '') {
@@ -102,6 +106,9 @@
       },
     },
     methods: {
+      ...mapGetters({
+        isBusy: state => state.pageState.busy,
+      }),
       closeModal() {
         this.$emit('cancel');
       },
@@ -116,14 +123,6 @@
             this.$refs.confirmedNewPassword.focus();
           }
         }
-      },
-    },
-    vuex: {
-      actions: {
-        updateUserProfilePassword,
-      },
-      getters: {
-        isBusy: state => state.pageState.busy,
       },
     },
     $trs: {

--- a/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/change-user-password-modal.vue
@@ -50,7 +50,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -106,7 +106,7 @@
       },
     },
     methods: {
-      ...mapGetters({
+      ...mapState({
         isBusy: state => state.pageState.busy,
       }),
       closeModal() {

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -113,6 +113,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import {
     facilityConfig,
     isSuperuser,
@@ -178,6 +179,23 @@
       };
     },
     computed: {
+      ...mapGetters({
+        facilityConfig,
+        isSuperuser,
+        isAdmin,
+        isCoach,
+        isLearner,
+        totalPoints,
+        session: state => state.core.session,
+        busy: state => state.pageState.busy,
+        errorCode: state => state.pageState.errorCode,
+        backendErrorMessage: state => state.pageState.errorMessage,
+        success: state => state.pageState.success,
+        passwordModalVisible: state => state.pageState.passwordState.modal,
+        getUserKind,
+        getUserPermissions,
+        userHasPermissions,
+      }),
       role() {
         if (this.getUserKind === UserKinds.ADMIN) {
           return this.$tr('isAdmin');
@@ -267,6 +285,14 @@
       this.fetchPoints();
     },
     methods: {
+      ...mapActions({
+        updateUserProfile,
+        resetProfileState,
+        fetchPoints,
+        setPasswordModalVisible(store, visibility) {
+          store.dispatch('SET_PROFILE_PASSWORD_MODAL', visibility);
+        },
+      }),
       submitEdits() {
         this.formSubmitted = true;
         this.resetProfileState();
@@ -291,33 +317,6 @@
           return this.$tr('manageContent');
         }
         return permission;
-      },
-    },
-    vuex: {
-      getters: {
-        facilityConfig,
-        isSuperuser,
-        isAdmin,
-        isCoach,
-        isLearner,
-        totalPoints,
-        session: state => state.core.session,
-        busy: state => state.pageState.busy,
-        errorCode: state => state.pageState.errorCode,
-        backendErrorMessage: state => state.pageState.errorMessage,
-        success: state => state.pageState.success,
-        passwordModalVisible: state => state.pageState.passwordState.modal,
-        getUserKind,
-        getUserPermissions,
-        userHasPermissions,
-      },
-      actions: {
-        updateUserProfile,
-        resetProfileState,
-        fetchPoints,
-        setPasswordModalVisible(store, visibility) {
-          store.dispatch('SET_PROFILE_PASSWORD_MODAL', visibility);
-        },
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -113,7 +113,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import {
     facilityConfig,
     isSuperuser,
@@ -179,7 +179,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         facilityConfig,
         isSuperuser,
         isAdmin,

--- a/kolibri/plugins/user/assets/src/views/profile-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/profile-page/index.vue
@@ -171,8 +171,8 @@
     mixins: [responsiveWindow],
     data() {
       return {
-        username: this.session.username,
-        name: this.session.full_name,
+        username: this.$store.state.core.session.username,
+        name: this.$store.state.core.session.full_name,
         usernameBlurred: false,
         nameBlurred: false,
         formSubmitted: false,

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
@@ -26,6 +26,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -44,7 +45,23 @@
         selectedFacility: this.currentFacilityId,
       };
     },
+    computed: {
+      ...mapGetters({
+        // currentFacilityId uses session, with is anonymous in sign-in-page
+        currentFacilityId: state => state.facilityId,
+        facilities,
+      }),
+    },
     methods: {
+      ...mapActions({
+        getFacilityConfig,
+        setFacilityId(store) {
+          store.dispatch('SET_FACILITY_ID', this.selectedFacility);
+        },
+        clearLoginError(store) {
+          store.dispatch('CORE_SET_LOGIN_ERROR', '');
+        },
+      }),
       emitClose() {
         this.$emit('close');
       },
@@ -58,22 +75,6 @@
       facilitySelectionPrompt: 'Which facility do you want to sign in to?',
       submitFacilitySelectionButtonPrompt: 'Select',
       facilitySelectionModalHeader: 'Select a facility',
-    },
-    vuex: {
-      getters: {
-        // currentFacilityId uses session, with is anonymous in sign-in-page
-        currentFacilityId: state => state.facilityId,
-        facilities,
-      },
-      actions: {
-        getFacilityConfig,
-        setFacilityId(store) {
-          store.dispatch('SET_FACILITY_ID', this.selectedFacility);
-        },
-        clearLoginError(store) {
-          store.dispatch('CORE_SET_LOGIN_ERROR', '');
-        },
-      },
     },
   };
 

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
@@ -26,7 +26,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
   import kButton from 'kolibri.coreVue.components.kButton';
@@ -50,7 +50,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         // currentFacilityId uses session, with is anonymous in sign-in-page
         currentFacilityId,
         facilities,

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/facility-modal.vue
@@ -33,6 +33,10 @@
   import { getFacilityConfig } from 'kolibri.coreVue.vuex.actions';
   import { facilities } from 'kolibri.coreVue.vuex.getters';
 
+  function currentFacilityId(state) {
+    return state.facilityId;
+  }
+
   export default {
     name: 'facilityModal',
     components: {
@@ -42,13 +46,13 @@
     },
     data() {
       return {
-        selectedFacility: this.currentFacilityId,
+        selectedFacility: currentFacilityId(this.$store.state),
       };
     },
     computed: {
       ...mapGetters({
         // currentFacilityId uses session, with is anonymous in sign-in-page
-        currentFacilityId: state => state.facilityId,
+        currentFacilityId,
         facilities,
       }),
     },

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -117,7 +117,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { kolibriLogin } from 'kolibri.coreVue.vuex.actions';
   import { facilityConfig } from 'kolibri.coreVue.vuex.getters';
   import { FacilityUsernameResource } from 'kolibri.resources';
@@ -181,7 +181,7 @@
       };
     },
     computed: {
-      ...mapGetters({
+      ...mapState({
         // backend's default facility on load
         facilityId: state => state.facilityId,
         facilityConfig,

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -117,6 +117,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { kolibriLogin } from 'kolibri.coreVue.vuex.actions';
   import { facilityConfig } from 'kolibri.coreVue.vuex.getters';
   import { FacilityUsernameResource } from 'kolibri.resources';
@@ -176,6 +177,15 @@
       };
     },
     computed: {
+      ...mapGetters({
+        // backend's default facility on load
+        facilityId: state => state.facilityId,
+        facilityConfig,
+        hasMultipleFacilities: state => state.pageState.hasMultipleFacilities,
+        passwordMissing: state => state.core.loginError === LoginErrors.PASSWORD_MISSING,
+        invalidCredentials: state => state.core.loginError === LoginErrors.INVALID_CREDENTIALS,
+        busy: state => state.core.signInBusy,
+      }),
       simpleSignIn() {
         return this.facilityConfig.learnerCanLoginWithNoPassword;
       },
@@ -269,6 +279,9 @@
       }, 250);
     },
     methods: {
+      ...mapActions({
+        kolibriLogin,
+      }),
       closeFacilityModal() {
         this.facilityModalVisible = false;
       },
@@ -371,20 +384,6 @@
       },
       handlePasswordChanged() {
         this.autoFilledByChromeAndNotEdited = false;
-      },
-    },
-    vuex: {
-      getters: {
-        // backend's default facility on load
-        facilityId: state => state.facilityId,
-        facilityConfig,
-        hasMultipleFacilities: state => state.pageState.hasMultipleFacilities,
-        passwordMissing: state => state.core.loginError === LoginErrors.PASSWORD_MISSING,
-        invalidCredentials: state => state.core.loginError === LoginErrors.INVALID_CREDENTIALS,
-        busy: state => state.core.signInBusy,
-      },
-      actions: {
-        kolibriLogin,
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-in-page/index.vue
@@ -134,6 +134,10 @@
   import languageSwitcherFooter from '../language-switcher-footer';
   import facilityModal from './facility-modal';
 
+  function hasMultipleFacilities(state) {
+    return state.pageState.hasMultipleFacilities;
+  }
+
   export default {
     name: 'signInPage',
     $trs: {
@@ -166,7 +170,7 @@
         username: '',
         password: '',
         usernameSuggestions: [],
-        facilityModalVisible: this.hasMultipleFacilities,
+        facilityModalVisible: hasMultipleFacilities(this.$store.state),
         suggestionTerm: '',
         showDropdown: true,
         highlightedIndex: -1,
@@ -181,7 +185,7 @@
         // backend's default facility on load
         facilityId: state => state.facilityId,
         facilityConfig,
-        hasMultipleFacilities: state => state.pageState.hasMultipleFacilities,
+        hasMultipleFacilities,
         passwordMissing: state => state.core.loginError === LoginErrors.PASSWORD_MISSING,
         invalidCredentials: state => state.core.loginError === LoginErrors.INVALID_CREDENTIALS,
         busy: state => state.core.signInBusy,

--- a/kolibri/plugins/user/assets/src/views/sign-up-page.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page.vue
@@ -115,6 +115,7 @@
 
 <script>
 
+  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
   import { validateUsername } from 'kolibri.utils.validators';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
@@ -167,6 +168,13 @@
       formSubmitted: false,
     }),
     computed: {
+      ...mapGetters({
+        session: state => state.core.session,
+        errorCode: state => state.pageState.errorCode,
+        busy: state => state.pageState.busy,
+        backendErrorMessage: state => state.pageState.errorMessage,
+        facilities: state => state.core.facilities,
+      }),
       signInPage() {
         return { name: PageNames.SIGN_IN };
       },
@@ -274,6 +282,10 @@
       }
     },
     methods: {
+      ...mapActions({
+        signUpNewUser,
+        resetSignUpState,
+      }),
       signUp() {
         this.formSubmitted = true;
         const canSubmit = this.formIsValid && !this.busy;
@@ -298,19 +310,6 @@
         } else if (this.confirmedPasswordIsInvalid) {
           this.$refs.confirmedPassword.focus();
         }
-      },
-    },
-    vuex: {
-      getters: {
-        session: state => state.core.session,
-        errorCode: state => state.pageState.errorCode,
-        busy: state => state.pageState.busy,
-        backendErrorMessage: state => state.pageState.errorMessage,
-        facilities: state => state.core.facilities,
-      },
-      actions: {
-        signUpNewUser,
-        resetSignUpState,
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/sign-up-page.vue
+++ b/kolibri/plugins/user/assets/src/views/sign-up-page.vue
@@ -115,7 +115,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'kolibri.utils.vuexCompat';
+  import { mapState, mapActions } from 'kolibri.utils.vuexCompat';
   import { validateUsername } from 'kolibri.utils.validators';
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
@@ -168,7 +168,7 @@
       formSubmitted: false,
     }),
     computed: {
-      ...mapGetters({
+      ...mapState({
         session: state => state.core.session,
         errorCode: state => state.pageState.errorCode,
         busy: state => state.pageState.busy,

--- a/kolibri/plugins/user/assets/test/views/profile-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/profile-page.spec.js
@@ -5,7 +5,8 @@ import { mount } from '@vue/test-utils';
 import ProfilePage from '../../src/views/profile-page';
 import makeStore from '../util/makeStore';
 
-ProfilePage.vuex.actions.fetchPoints = () => {};
+ProfilePage.methods.fetchPoints = () => {};
+ProfilePage.mixins = [];
 
 function makeWrapper() {
   const store = makeStore();


### PR DESCRIPTION
### Summary

Following a strategy in #2022 , this moves some Vuex 1 options towards the Vuex 2+ style to make the current components Vuex 2 compatible.

After upgrading to Vuex 3, we'll probably need to update the implementation of the `mapAction` utility to match Vuex 3 API. `mapState` will probably still work.

After that, we can gradually adopt the proper Vuex idioms.

### Reviewer guidance

Make sure stuff still works.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
