### PR TITLE
remove global css helper classes

### DIFF
--- a/kolibri/core/assets/src/styles/main.styl
+++ b/kolibri/core/assets/src/styles/main.styl
@@ -74,12 +74,6 @@ svg:not(:root)
   position: absolute
   width: 1px
 
-.core-text-alert
-  color: $core-text-error
-
-.core-text-annotation
-  color: $core-text-annotation
-
 // Definitions for Google Material Design Icons
 // from http://google.github.io/material-design-icons/
 

--- a/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-content-page/channels-grid.vue
@@ -3,7 +3,7 @@
   <div>
     <transition mode="out-in">
       <p
-        class="core-text-alert no-channels"
+        class="no-channels"
         v-if="noChannelsToShow"
       >
         {{ $tr('emptyChannelListMessage') }}
@@ -125,5 +125,8 @@
 
   .channel-list-item:first-of-type
     border-top: 1px solid $core-grey
+
+  .no-channels
+    color: $core-text-error
 
 </style>


### PR DESCRIPTION

### Summary

removes two helper classes that were getting very little use, in favor of stylus variables which are more common in our codebase

### Reviewer guidance

check it out

### References

NA

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
