### PR TITLE
Fix manual provision device workflow

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -28,7 +28,7 @@ def create_facility(facility_name=None, preset=None, interactive=False):
     if facility_name is None and interactive:
         answer = get_user_response("Do you wish to create a facility? [yn] ", ["y", "n"])
         if answer == "y":
-            facility = get_user_response("What do you wish to name your facility? ")
+            facility_name = get_user_response("What do you wish to name your facility? ")
 
     if facility_name:
         facility, created = Facility.objects.get_or_create(name=facility_name)


### PR DESCRIPTION
### Summary
When running the provisiondevice command without any commandline arguments, it defaults to interactive mode. A misnamed variable in this interactive flow made it impossible to manually type in the command to provision the device. This PR fixes that.

### Reviewer guidance
Run `kolibri manage provisiondevice` - can you setup a facility?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
