### PR TITLE
Allow vue devtools to open in editor.

### DIFF
--- a/frontend_build/src/webpackdevserver.js
+++ b/frontend_build/src/webpackdevserver.js
@@ -9,6 +9,7 @@ process.argv.forEach(function(val) {
 var WebpackDevServer = require('webpack-dev-server');
 var webpack = require('webpack');
 var devServerConfig = require('./webpackdevserverconfig');
+var openInEditor = require('launch-editor-middleware');
 
 var bundles = require('./webpack.config.dev');
 var compiler = webpack(bundles);
@@ -37,4 +38,6 @@ var server = new WebpackDevServer(compiler, {
     'Access-Control-Allow-Origin': '*',
   },
 });
+server.use('/__open-in-editor', openInEditor());
+
 server.listen(devServerConfig.port, devServerConfig.address, function() {});

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -1,7 +1,11 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .base import *  # noqa isort:skip @UnusedWildImport
 
 INSTALLED_APPS += ['rest_framework_swagger']  # noqa
 
 REST_SWAGGER = True
+
+REDIRECT_WEBPACK = True

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -17,10 +17,13 @@ Including another URLconf
 .. moduleauthor:: Learning Equality <info@learningequality.org>
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.conf.urls import url
 from django.contrib import admin
 from morango import urls as morango_urls
 
@@ -56,4 +59,14 @@ if getattr(settings, 'REST_SWAGGER', False):
 
     urlpatterns += [
         url(r'^api_explorer/', schema_view)
+    ]
+
+if getattr(settings, 'REDIRECT_WEBPACK', False):
+    from django.http.response import HttpResponseRedirect
+
+    def webpack_redirect_view(request):
+        return HttpResponseRedirect('http://127.0.0.1:3000/__open-in-editor?{query}'.format(query=request.GET.urlencode()))
+
+    urlpatterns += [
+        url(r'^__open-in-editor/', webpack_redirect_view)
     ]

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.2",
+    "launch-editor-middleware": "^2.2.1",
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.1",
     "node-sass": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,6 +3706,19 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+launch-editor-middleware@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz#e14b07e6c7154b0a4b86a0fd345784e45804c157"
+  dependencies:
+    launch-editor "^2.2.1"
+
+launch-editor@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.2.1.tgz#871b5a3ee39d6680fcc26d37930b6eeda89db0ca"
+  dependencies:
+    chalk "^2.3.0"
+    shell-quote "^1.6.1"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"


### PR DESCRIPTION
### Summary
Adds a redirect and enables 'open in editor' on the webpack dev server.

### Reviewer guidance
Try to 'open in editor' on vue devtools.

### References
Fixes #3692
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
