### PR TITLE
Don't translate backend role kind strings

### DIFF
--- a/kolibri/auth/constants/role_kinds.py
+++ b/kolibri/auth/constants/role_kinds.py
@@ -3,14 +3,12 @@ This module contains constants representing the kinds of "roles" that a user can
 """
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
-
 ADMIN = "admin"
 COACH = "coach"
 ASSIGNABLE_COACH = "classroom assignable coach"
 
 choices = (
-    (ADMIN, _("Admin")),
-    (COACH, _("Coach")),
-    (ASSIGNABLE_COACH, _("Classroom Assignable Coach")),
+    (ADMIN, "Admin"),
+    (COACH, "Coach"),
+    (ASSIGNABLE_COACH, "Classroom Assignable Coach"),
 )


### PR DESCRIPTION
### Summary
Don't translate role kind strings on the backend.

### Reviewer guidance
Do role kinds still work? Does it think that migrations are needed?

### References
Resolves #3738 by removing the bone of contention.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
