### PR TITLE
Adjust thumbnail style and add missing pdf content color

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/card-thumbnail.vue
@@ -100,9 +100,10 @@
 
   .card-thumbnail-wrapper
     position: absolute
-    background-size: cover
+    background-size: contain
+    background-repeat: no-repeat
     background-position: center
-    background-color: $core-grey
+    background-color: $core-bg-light
     width: $thumb-width
     height: $thumb-height
 

--- a/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/card-thumbnail.vue
@@ -127,6 +127,7 @@
           video: '#3938A5',
           audio: '#E65997',
           topic: '#262626',
+          document: '#ED2828',
           html5: '#FF8B41',
         };
         return { fill: kindToFillHex[this.kind] };
@@ -146,9 +147,10 @@
     width: $thumb-width-desktop
     height: $thumb-height-desktop
     position: relative
-    background-size: cover
+    background-size: contain
+    background-repeat: no-repeat
     background-position: center
-    background-color: $core-grey
+    background-color: $core-bg-light
 
   .type-icon
     position: absolute


### PR DESCRIPTION
### Summary

Switch from cover to contain to prevent stretching.
Make background white. Looks CLEAN.
Pdfs were missing their red color for some reason.

#### Before

![localhost_8000_learn_ ipad 4](https://user-images.githubusercontent.com/7193975/40960448-957a4176-6854-11e8-9cf7-c0a7e90e0359.png)

#### After

![localhost_8000_learn_ ipad 1](https://user-images.githubusercontent.com/7193975/40960459-9bf51a12-6854-11e8-950a-a810535ab408.png)

#### Before

![localhost_8000_learn_ ipad 3](https://user-images.githubusercontent.com/7193975/40960449-959481da-6854-11e8-8c7b-b15f652622a3.png)

#### After
![localhost_8000_learn_ ipad 2](https://user-images.githubusercontent.com/7193975/40960503-c2b553a6-6854-11e8-878b-59d1c60a31c2.png)

#### Before 
![localho
st_8000_learn_ ipad 5](https://user-images.githubusercontent.com/7193975/40960446-9560ae32-6854-11e8-9803-c1d95d1bed95.png)

#### After
![localhost_8000_learn_ ipad](https://user-images.githubusercontent.com/7193975/40960460-9c0da528-6854-11e8-8730-829babfe3823.png)

### Reviewer guidance

Thoughts?
Note that this is not meant to address the bigger issue of different sized images 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
