### PR TITLE
Pre-release kolibri/VERSION with git suffix fails?

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -1,12 +1,15 @@
 """
 Tests for `kolibri` module.
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import unittest
 
-import kolibri
 import mock
+
+import kolibri
 from kolibri.utils import version
 
 #: Because we don't want to call the original (decorated function), it uses
@@ -170,6 +173,17 @@ class TestKolibriVersion(unittest.TestCase):
         Test that the VERSION file is NOT used where git data is available
         """
         assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0.dev+git123"
+
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.10.0.dev4.dev+git-29-ga99e882")
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
+    def test_version_file_prerelease_git(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION specifying a pre-release with git info works
+
+        Data from @ivan
+        """
+        assert get_version((0, 10, 0, u'alpha', 0)) == "0.10.0.dev4.dev+git-29-ga99e882"
 
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)


### PR DESCRIPTION
### Summary

There was a problem with a Docker build by @ivanistheone that was dependent on `kolibri/VERSION` with a development name.

Firstly, let's see if the reported error will also reproduce with a test case...

```
AssertionError: kolibri/VERSION file inconsistent with kolibri.__version__.
__version__ is: (0, 10, 0, u'alpha', 0), file says: 0.10.0.dev4.dev+git-29-ga99e882
```

* [x] Test case proof for error spotted by @ivanistheone
* [ ] Fix

### Reviewer guidance

Not ready

### References

Ivan DM'ed me :)

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
