### PR TITLE
Changed kolibry CherryPy default_queue_size option

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -45,7 +45,7 @@ option_spec = {
         },
         "CHERRYPY_QUEUE_SIZE": {
             "type": "integer",
-            "default": 5,
+            "default": 30,
             "envvars": ("KOLIBRI_CHERRYPY_QUEUE_SIZE",),
         },
         "CHERRYPY_QUEUE_TIMEOUT": {


### PR DESCRIPTION
Changed kolibry CherryPy default_queue_size option to be usable in low profile hardware


### Reviewer guidance
Previous Kolibri setting was an infinite queue. It grew so much the clients didn't receive any response.
In #3736 the queue was set to a limit of 5 requests. After more checks it has become clear that parameter is fine for good computers but too short for low profile machines.
The new parameter is a tradeoff between the infinite queue (producing an unresponsive browser)  and the server rejecting requests with HTTP error code 0/load error.

### References
This change is related to previous PR #3736 and  issue #3720 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
