### PR TITLE
Test case and fix for versioning error spotted by @ivanistheone

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -1,12 +1,15 @@
 """
 Tests for `kolibri` module.
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import unittest
 
-import kolibri
 import mock
+
+import kolibri
 from kolibri.utils import version
 
 #: Because we don't want to call the original (decorated function), it uses
@@ -142,6 +145,24 @@ class TestKolibriVersion(unittest.TestCase):
         """
         assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0b1"
 
+    @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.1.0-alpha1-123-abcdfe12")
+    def test_alpha_0_consistent_git(self, describe_mock, file_mock):
+        """
+        Tests that git describe data for an alpha-1 tag generates an a1 version
+        string.
+        """
+        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0a1.dev+git-123-abcdfe12"
+
+    @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
+    @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.1.0-alpha1-123-abcdfe12")
+    def test_alpha_1_consistent_git(self, describe_mock, file_mock):
+        """
+        Tests that git describe data for an alpha-1 tag generates an a1 version
+        string.
+        """
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0a1.dev+git-123-abcdfe12"
+
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b2")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
     @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
@@ -210,9 +231,10 @@ class TestKolibriVersion(unittest.TestCase):
             version.get_git_describe = git_describe
 
     @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.1.0-beta1-123-abcdfe12")
-    def test_alpha_1_consistent_git(self, describe_mock):
+    def test_alpha_1_beta_1_consistent_git(self, describe_mock):
         """
-        Test that we get the git describe data when it's there
+        Test that a beta1 git tag can override kolibri.__version__ reading
+        alpha0.
         """
         assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git-123-abcdfe12"
 

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -265,8 +265,6 @@ def get_prerelease_version(version):
     """
 
     mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
-    if version[4] == 0 and version[3] == 'alpha':
-        mapping['alpha'] = '.dev'
 
     major = get_major_version(version)
     major_and_release = major + mapping[version[3]] + str(version[4])
@@ -366,6 +364,12 @@ def get_prerelease_version(version):
                 )
             )
         return version_file
+
+    # Finally, if there was no git data or VERSION file, map the alpha-0 to
+    # .dev
+    if version[4] == 0 and version[3] == 'alpha':
+        mapping['alpha'] = '.dev'
+        major_and_release = major + mapping[version[3]] + str(version[4])
 
     # In all circumstances, return the initial findings
     return major_and_release


### PR DESCRIPTION
### Summary

Proves and fixes the error that an `alpha-4` tag suffix becomes `.dev4` in the release.

* [x] Test case proof for error spotted by @ivanistheone
* [x] Fix

### Reviewer guidance

I targeted this for 0.11 instead, then we can (almost) start over with the release process and see if it works.

### References

#3678 #3764

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
