### PR TITLE
remove /run from the blacklist

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -25,9 +25,11 @@ RAW_MOUNT_PARSER = re.compile("^(?P<device>\S+) (?P<path>.+) (?P<filesystem>\S+)
 FILESYSTEM_BLACKLIST = set(["anon_inodefs", "bdev", "binfmt_misc", "cgroup", "cpuset", "debugfs", "devpts", "devtmpfs",
                             "ecryptfs", "fuse", "fuse.gvfsd-fuse", "fusectl", "hugetlbfs", "mqueue", "nfs", "nfs4", "nfsd",
                             "pipefs", "proc", "pstore", "ramfs", "rootfs", "rpc_pipefs", "securityfs", "sockfs", "sysfs",
-                            "tmpfs"])
+                            "tmpfs", "cgmfs"])
 
-PATH_PREFIX_BLACKLIST = ["/proc", "/sys", "/tmp", "/var", "/run", "/boot", "/dev"]
+# These paths can be mounted as separate drives/partitions,
+# so they should not be shown in the list of import/export drives.
+PATH_PREFIX_BLACKLIST = ["/proc", "/sys", "/tmp", "/var", "/boot", "/dev"]
 
 def get_drive_list():
     """


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to remove /run from the PATH_PREFIX_BLACKLIST so that the folder can be found by kolibri disk import/export.
I've tested on Ubuntu with
```
osboxes@osboxes:~$ cat /proc/mounts
......
/dev/sda4 /run/media/me ext4 rw,relatime,data=ordered 0 0
```
and 
```
osboxes@osboxes:~$ ls -l /run/media/
total 4
drwxr-xr-x 5 osboxes osboxes 4096 Jun 7 19:39 me
```

so now I can see `/run/media/me/` is listed in the 'export' drive list.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

test whether a folder under `/run` can be listed in the 'export' drive list

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3068

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
