### PR TITLE
Improve build time (theoretically)  by compiling messages *before* populating kolibri/dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ buildconfig:
 	git checkout -- kolibri/utils/build_config # restore __init__.py
 	python build_tools/customize_build.py
 
-dist: writeversion staticdeps staticdeps-cext buildconfig assets translation-django-compilemessages
+dist: writeversion translation-django-compilemessages staticdeps staticdeps-cext buildconfig assets
 	python setup.py sdist --format=gztar --static > /dev/null # silence the sdist output! Too noisy!
 	python setup.py bdist_wheel --static
 	ls -l dist


### PR DESCRIPTION
### Summary

There's no immediate way to exclude child folders when running `compilemessages` (that would be an interesting upstream fix).

However, by moving the call to `compilemessages` in before calling `staticdeps`, then `kolibri/dist` will be empty provided that it's a clean environment. Otherwise run `make clean`.

### Reviewer guidance

n/a - if builds work I say go?

### References

#3384

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
