### PR TITLE
Path fix for node-js on Ubuntu (or Debian in general?)

### DIFF
--- a/frontend_build/src/read_webpack_json.js
+++ b/frontend_build/src/read_webpack_json.js
@@ -8,8 +8,24 @@ module.exports = function() {
   // the temporary path where the webpack_json json is stored
   var webpack_json_tempfile = temp.openSync({ suffix: '.json' }).path;
 
-  // Run the script below to extract the relevant information about the plugin configuration from the Python code.
-  execSync(`python ${webpack_json} --output_file  ${webpack_json_tempfile}`);
+  // Extract the relevant information about the plugin configuration from the Python code.
+
+  // For reasons unknown, there is an extra /usr/bin injected into PATH while running execSync, which
+  // by-passes the virtualenv!
+
+  // Refs: https://github.com/yarnpkg/yarn/issues/5874
+  // See PR: https://github.com/learningequality/kolibri/pull/3777
+
+  // You can debug it like this:
+  //     execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" which python >&2 && exit 1", {env: process.env});
+  // ..hence, we have manipulated the path in the shell command to remove Node's unwanted manipulation
+  if (process.platform !== 'win32') {
+    execSync(
+      `PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" python ${webpack_json} --output_file  ${webpack_json_tempfile}`
+    );
+  } else {
+    execSync(`python ${webpack_json} --output_file ${webpack_json_tempfile}`);
+  }
 
   var result = fs.readFileSync(webpack_json_tempfile);
 


### PR DESCRIPTION
### Summary

This was previously attempted in #1688 but I found a Node 6 upgrade fixed the issue back then.

However, now on Ubuntu 18.04, I find the issue occurring with the current official Debian pkg for Node.

@rtibbles does this work on your system as well?

If this get's merged, I'm fine that it get's quickly reverted if fellow devs report issues with it.

### Reviewer guidance

@rtibbles we've been here before...

### References

#1688

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually (on **MY SYSTEM**)
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
