### PR TITLE
Fix logic for changing facility-level Roles when editing users

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/state/actions/rolesActions.js
+++ b/kolibri/plugins/facility_management/assets/src/state/actions/rolesActions.js
@@ -33,6 +33,11 @@ export function updateFacilityLevelRoles(facilityUser, newRoleKind) {
     return createFacilityRole();
   }
 
+  // If facility-wide Role has not changed, do nothing
+  if (currentFacilityRole.kind === newRoleKind) {
+    return Promise.resolve();
+  }
+
   // Downgrading Role to LEARNER
   if (newRoleKind === UserKinds.LEARNER) {
     const roleDeletionPromises = [

--- a/kolibri/plugins/facility_management/assets/src/state/mutations.js
+++ b/kolibri/plugins/facility_management/assets/src/state/mutations.js
@@ -51,6 +51,7 @@ export function UPDATE_USERS(state, users) {
         existingUser.username = user.username;
         existingUser.full_name = user.full_name;
         existingUser.kind = user.kind;
+        existingUser.roles = [...user.roles];
       }
     });
   });

--- a/kolibri/plugins/facility_management/assets/src/state/mutations.js
+++ b/kolibri/plugins/facility_management/assets/src/state/mutations.js
@@ -1,3 +1,5 @@
+import Vue from 'kolibri.lib.vue';
+
 // TODO move more mutations here so they can be tested
 export function SET_PAGE_NAME(state, name) {
   state.pageName = name;
@@ -44,17 +46,12 @@ export function SET_USER_JUST_CREATED(state, user) {
   state.pageState.userJustCreated = user;
 }
 
-export function UPDATE_USERS(state, users) {
-  users.forEach(user => {
-    state.pageState.facilityUsers.forEach(existingUser => {
-      if (existingUser.id === user.id.toString()) {
-        existingUser.username = user.username;
-        existingUser.full_name = user.full_name;
-        existingUser.kind = user.kind;
-        existingUser.roles = [...user.roles];
-      }
-    });
-  });
+export function UPDATE_USER(state, updatedUser) {
+  const match = state.pageState.facilityUsers.find(user => user.id === updatedUser.id);
+  Vue.set(match, 'username', updatedUser.username);
+  Vue.set(match, 'full_name', updatedUser.full_name);
+  Vue.set(match, 'kind', updatedUser.kind);
+  Vue.set(match, 'roles', [...updatedUser.roles]);
 }
 
 export function SET_ERROR(state, error) {

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -5,7 +5,7 @@
     @cancel="displayModal(false)"
     width="400px"
   >
-    <form @submit.prevent="submitForm">
+    <form class="edit-user-form" @submit.prevent="submitForm">
 
       <ui-alert
         v-if="error"
@@ -287,5 +287,8 @@
     margin: 0
     padding: 0
     border: none
+
+  .edit-user-form
+    min-height: 350px
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/edit-user-modal.vue
@@ -244,6 +244,8 @@
             username: this.newUsername,
             full_name: this.newName,
             role: roleUpdate,
+          }).then(() => {
+            this.displayModal(false);
           });
           if (
             this.currentUserId === this.id &&

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/reset-user-password-modal.vue
@@ -55,7 +55,9 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import { updateUser, displayModal } from '../../state/actions';
+  import { handleApiError } from 'kolibri.coreVue.vuex.actions';
+  import { displayModal } from '../../state/actions';
+  import { updateFacilityUser } from '../../state/actions/user';
 
   export default {
     name: 'resetUserPasswordModal',
@@ -121,7 +123,10 @@
       submitForm() {
         this.submittedForm = true;
         if (this.formIsValid) {
-          this.updateUser(this.id, { password: this.password });
+          // TODO handle the error within this modal (needs new strings)
+          this.updateFacilityUser({ userId: this.id, updates: { password: this.password } })
+            .catch(error => this.handleApiError(error))
+            .then(() => this.displayModal(false));
         } else {
           if (this.passwordIsInvalid) {
             this.$refs.password.focus();
@@ -133,8 +138,9 @@
     },
     vuex: {
       actions: {
-        updateUser,
+        updateFacilityUser,
         displayModal,
+        handleApiError,
       },
       getters: {
         isBusy: state => state.pageState.isBusy,

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -9,7 +9,7 @@
       {{ errorMessage }}
     </ui-alert>
 
-    <form @submit.prevent="createNewUser">
+    <form class="user-create-form" @submit.prevent="createNewUser">
       <section>
         <k-textbox
           ref="name"
@@ -317,6 +317,9 @@
 
 
 <style lang="stylus" scoped>
+
+  .user-create-form
+    min-height: 500px
 
   .coach-selector
     margin-bottom: 3em


### PR DESCRIPTION
### Summary
1. Fixes #3734 by removing `if` check with bad assumptions about `kind`
1. Implements proper short-circuiting logic if user details or roles or both have not been changed
1. Add a little bit of vertical space to the edit + create user forms so user kind drop down doesn't cause an overflow

The `kind` property in `state.pageState.facilityUsers` should probably be implemented as a getter, since it's even described in the code as presentational. The current logic, where `kind` is derived after receiving response from API requires a bunch of imperative updates to `kind` that might be removed.

### Reviewer guidance

Test:

1. Changing user details (name, username, password)
1. Change user facility-wide role (Learner, Facility Coach, Class Coach, Admin), esp. converting between all role kinds.
1. Test changing nothing
1. Test original issue (blurring the username field, then attempting to submit).

### References

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
