### PR TITLE
add max-width to pages and update some text-alignment

### DIFF
--- a/kolibri/core/assets/src/views/app-body.vue
+++ b/kolibri/core/assets/src/views/app-body.vue
@@ -79,6 +79,8 @@
     right: 0
     position: absolute
     overflow-x: hidden
+    max-width: 1000px
+    margin: auto
 
   .toolbar-loader
     position: fixed

--- a/kolibri/plugins/learn/assets/src/views/content-card/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card/index.vue
@@ -162,7 +162,6 @@
                 0 3px 1px -2px rgba(0, 0, 0, 0.2),
                 0 1px 5px 0 rgba(0, 0, 0, 0.12)
     transition: box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)
-    text-align: left
     &:hover, &:focus
       box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
                   0 3px 14px 2px rgba(0, 0, 0, 0.12),

--- a/kolibri/plugins/learn/assets/src/views/content-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page.vue
@@ -2,8 +2,7 @@
 
   <div>
 
-    <!-- TODO: RTL - Remove ta-l -->
-    <page-header :title="content.title" dir="auto" class="ta-l" />
+    <page-header :title="content.title" dir="auto" />
     <coach-content-label
       class="coach-content-label"
       :value="content.coach_content ? 1 : 0"
@@ -45,8 +44,7 @@
     />
 
     <!-- TODO consolidate this metadata table with coach/lessons -->
-    <!-- TODO: RTL - Remove ta-l -->
-    <p v-html="description" dir="auto" class="ta-l"></p>
+    <p v-html="description" dir="auto"></p>
 
 
     <section class="metadata" v-if="showMetadata">
@@ -68,7 +66,7 @@
             <mat-svg v-if="licenceDescriptionIsVisible" name="expand_less" category="navigation" />
             <mat-svg v-else name="expand_more" category="navigation" />
           </ui-icon-button>
-          <p v-if="licenceDescriptionIsVisible" dir="auto" class="ta-l">
+          <p v-if="licenceDescriptionIsVisible" dir="auto">
             {{ content.license_description }}
           </p>
         </template>
@@ -290,8 +288,5 @@
 
   .download-button
     display: block
-
-  .ta-l
-    text-align: left
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/page-header.vue
+++ b/kolibri/plugins/learn/assets/src/views/page-header.vue
@@ -1,7 +1,7 @@
 <template>
 
-  <div class="header-wrapper">
-    <h1 class="title" dir="auto">
+  <div dir="auto">
+    <h1 class="title">
       {{ title }}
       <progress-icon :progress="progress" />
     </h1>

--- a/kolibri/plugins/learn/assets/src/views/topics-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/topics-page.vue
@@ -11,7 +11,7 @@
       :showTooltip="false"
       :showViewMore="true"
       dir="auto"
-      class="page-description ta-l"
+      class="page-description"
     />
 
     <content-card-group-grid
@@ -80,8 +80,5 @@
     margin-top: 1em
     margin-bottom: 1em
     line-height: 1.5em
-
-  .ta-l
-    text-align: left
 
 </style>


### PR DESCRIPTION


### Summary

* Adds a max-width of 1000px to pages
* Updates text alignment of content and cards

Before:

![image](https://user-images.githubusercontent.com/2367265/41184157-44f94a6c-6b33-11e8-889b-141c80a3e72b.png)


After:

![image](https://user-images.githubusercontent.com/2367265/41184168-5a642dea-6b33-11e8-8063-7021bb8b344a.png)



### Reviewer guidance

Please make sure this looks right and doesn't break anything

### References

* fixes #2771
* fixes #2768
* refs #3781 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
