### PR TITLE
Remove noqa because these imports are already ordered

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -2,25 +2,25 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import importlib  # noqa
-import logging  # noqa
-import os  # noqa
-import signal  # noqa
-import sys  # noqa
-from sqlite3 import DatabaseError as SQLite3DatabaseError  # noqa
+import importlib
+import logging
+import os
+import signal
+import sys
+from sqlite3 import DatabaseError as SQLite3DatabaseError
 
-import django  # noqa
-from django.core.exceptions import AppRegistryNotReady  # noqa
-from django.core.management import call_command  # noqa
-from django.db.utils import DatabaseError  # noqa
-from docopt import docopt  # noqa
+import django
+from django.core.exceptions import AppRegistryNotReady
+from django.core.management import call_command
+from django.db.utils import DatabaseError
+from docopt import docopt
 
-import kolibri  # noqa
-from . import server  # noqa
-from .conf import OPTIONS  # noqa
-from .sanity_checks import check_other_kolibri_running  # noqa
-from .system import become_daemon  # noqa
-from kolibri.core.deviceadmin.utils import IncompatibleDatabase  # noqa
+import kolibri
+from . import server
+from .conf import OPTIONS
+from .sanity_checks import check_other_kolibri_running
+from .system import become_daemon
+from kolibri.core.deviceadmin.utils import IncompatibleDatabase
 
 USAGE = """
 Kolibri


### PR DESCRIPTION
### Summary

Since `env.set_env()` is called in `kolibri.__init__`, we don't have to be cautious about this load order anymore. Besides, the modules were already ordered, and it would already seem impossible to use `kolibri.utils.cli` if for instance `django` wasn't importable from `kolibri/dist`.

### Reviewer guidance

Spot anything that I didn't?

### References

A small step towards.. #3422 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
