### PR TITLE
add max-width to exercise attempts bar

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -45,54 +45,55 @@ oriented data synchronization.
       class="attempts-container"
       :class="{ 'mobile': windowSize.breakpoint < 2}"
     >
-
-      <div class="overall-status">
-        <mat-svg
-          name="stars"
-          category="action"
-          :class="success ? 'mastered' : 'not-mastered'"
-        />
-        <div class="overall-status-text">
-          <div v-if="success" class="completed">
-            {{ $tr('completed') }}
-          </div>
-          <div>
-            {{ $tr('goal', {count: totalCorrectRequiredM}) }}
+      <div class="margin-wrapper">
+        <div class="overall-status">
+          <mat-svg
+            name="stars"
+            category="action"
+            :class="success ? 'mastered' : 'not-mastered'"
+          />
+          <div class="overall-status-text">
+            <div v-if="success" class="completed">
+              {{ $tr('completed') }}
+            </div>
+            <div>
+              {{ $tr('goal', {count: totalCorrectRequiredM}) }}
+            </div>
           </div>
         </div>
-      </div>
-      <div class="table">
-        <div class="row">
-          <div class="left">
-            <transition mode="out-in">
-              <k-button
-                v-if="!complete"
-                appearance="raised-button"
-                class="question-btn"
-                :text="$tr('check')"
-                :primary="true"
-                :class="{shaking: shake}"
-                :disabled="checkingAnswer"
-                @click="checkAnswer"
-              />
-              <k-button
-                v-else
-                appearance="raised-button"
-                class="question-btn"
-                :text="$tr('next')"
-                :primary="true"
-                @click="nextQuestion"
-              />
-            </transition>
-          </div>
+        <div class="table">
+          <div class="row">
+            <div class="left">
+              <transition mode="out-in">
+                <k-button
+                  v-if="!complete"
+                  appearance="raised-button"
+                  class="question-btn"
+                  :text="$tr('check')"
+                  :primary="true"
+                  :class="{shaking: shake}"
+                  :disabled="checkingAnswer"
+                  @click="checkAnswer"
+                />
+                <k-button
+                  v-else
+                  appearance="raised-button"
+                  class="question-btn"
+                  :text="$tr('next')"
+                  :primary="true"
+                  @click="nextQuestion"
+                />
+              </transition>
+            </div>
 
-          <div class="right">
-            <exercise-attempts
-              :waitingForAttempt="firstAttemptAtQuestion || itemError"
-              :numSpaces="attemptsWindowN"
-              :log="recentAttempts"
-            />
-            <p class="current-status">{{ currentStatus }}</p>
+            <div class="right">
+              <exercise-attempts
+                :waitingForAttempt="firstAttemptAtQuestion || itemError"
+                :numSpaces="attemptsWindowN"
+                :log="recentAttempts"
+              />
+              <p class="current-status">{{ currentStatus }}</p>
+            </div>
           </div>
         </div>
       </div>
@@ -517,6 +518,10 @@ oriented data synchronization.
     box-shadow: 0 8px 10px -5px rgba(0, 0, 0, 0.2),
                 0 16px 24px 2px rgba(0, 0, 0, 0.14),
                 0 6px 30px 5px rgba(0, 0, 0, 0.12)
+
+  .margin-wrapper
+    max-width: 1000px - 64px // account for page padding
+    margin: auto
 
   .mobile
       padding: 8px


### PR DESCRIPTION
### Summary

In #3782 we added a max-width to the page contents. However, this left the exercise attempts bar in an awkward state. This PR helps with that.

Before:

![image](https://user-images.githubusercontent.com/2367265/41245095-e8273904-6d5b-11e8-888c-e6f33e618882.png)

After:

![image](https://user-images.githubusercontent.com/2367265/41245066-d5d3673c-6d5b-11e8-9314-0f19b08d55d7.png)


### Reviewer guidance

Make sure this works as intended

### References

...

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
