### PR TITLE
Fix the test errors introduced by the movedirectory command PR

### DIFF
--- a/kolibri/content/test/test_movedirectory.py
+++ b/kolibri/content/test/test_movedirectory.py
@@ -4,6 +4,8 @@ from mock import patch
 
 from kolibri.utils.conf import OPTIONS
 
+
+@patch('kolibri.content.management.commands.content.update_options_file')
 class ContentMoveDirectoryTestCase(TestCase):
     """
     Testcase for the command kolibri manage content movedirectory <destination>
@@ -17,37 +19,37 @@ class ContentMoveDirectoryTestCase(TestCase):
         return True
 
     def _listdir_side_effect(*args):
-        if args[0] == OPTIONS['Paths']['CONTENT_DIR']:
-            return ['databases', 'storage']
-        elif args[0] == OPTIONS['Paths']['CONTENT_DIR'] + '/databases':
+        if args[0] == OPTIONS['Paths']['CONTENT_DIR'] + '/databases':
             return ['test.sqlite3']
         elif args[0] == OPTIONS['Paths']['CONTENT_DIR'] + '/storage':
             return ['test.mp3']
-        elif args[0] == '/test/content_exists_yes/databases':
+        elif args[0] == '/test/content_exists_no/databases':
             return ['exists.sqlite3']
         return []
 
     @patch('kolibri.content.management.commands.content.Command.migrate')
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=False)
-    def test_current_content_dir_dne(self, path_exists_mock, migrate_mock):
+    def test_current_content_dir_dne(self, path_exists_mock, migrate_mock, update_mock):
         with self.assertRaises(SystemExit):
             call_command('content', 'movedirectory', 'test')
             migrate_mock.assert_not_called()
+            update_mock.assert_not_called()
 
     @patch('kolibri.content.management.commands.content.Command.migrate')
     @patch('kolibri.utils.server.get_status', return_value=True)
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=True)
-    def test_migrate_while_kolibri_running(self, path_exists_mock, server_mock, migrate_mock):
+    def test_migrate_while_kolibri_running(self, path_exists_mock, server_mock, migrate_mock, update_mock):
         with self.assertRaises(SystemExit):
             call_command('content', 'movedirectory', 'test')
             migrate_mock.assert_not_called()
+            update_mock.assert_not_called()
 
     @patch('kolibri.content.management.commands.content.shutil.rmtree')
     @patch('kolibri.content.management.commands.content.shutil.copy2')
     @patch('kolibri.content.management.commands.content.input', return_value='no')
     @patch('kolibri.content.management.commands.content.os.listdir', side_effect=_listdir_side_effect)
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=True)
-    def test_migrate_while_dest_content_exists_no(self, path_exists_mock, listdir_mock, input_mock, copyfile_mock, remove_mock):
+    def test_migrate_while_dest_content_exists_no(self, path_exists_mock, listdir_mock, input_mock, copyfile_mock, remove_mock, update_mock):
         destination = '/test/content_exists_no'
         call_command('content', 'movedirectory', destination)
         self.assertEqual(copyfile_mock.call_count, 2)
@@ -58,13 +60,12 @@ class ContentMoveDirectoryTestCase(TestCase):
     @patch('kolibri.content.management.commands.content.input', return_value='yes')
     @patch('kolibri.content.management.commands.content.os.listdir', return_value=['test'])
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=True)
-    def test_migrate_while_dest_content_exists_yes(self, path_exists_mock, listdir_mock, input_mock, remove_mock, copy_mock):
+    def test_migrate_while_dest_content_exists_yes(self, path_exists_mock, listdir_mock, input_mock, remove_mock, copy_mock, update_mock):
         destination = '/test/content_exists_yes'
         call_command('content', 'movedirectory', destination)
         copy_mock.assert_called()
         self.assertEqual(remove_mock.call_count, 4)
 
-    @patch('kolibri.content.management.commands.content.Command.update_config_content_directory')
     @patch('kolibri.content.management.commands.content.input', return_value='random')
     @patch('kolibri.content.management.commands.content.os.listdir', return_value=['test'])
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=True)
@@ -79,7 +80,7 @@ class ContentMoveDirectoryTestCase(TestCase):
     @patch('kolibri.content.management.commands.content.os.makedirs')
     @patch('kolibri.content.management.commands.content.os.listdir', return_value=[])
     @patch('kolibri.content.management.commands.content.os.path.exists', side_effect=_path_exists_side_effect)
-    def test_migrate_while_dest_dir_dne_success(self, path_exists_mock, listdir_mock, mkdir_mock, copystat_mock, remove_mock):
+    def test_migrate_while_dest_dir_dne_success(self, path_exists_mock, listdir_mock, mkdir_mock, copystat_mock, remove_mock, update_mock):
         destination = '/test/success'
         call_command('content', 'movedirectory', destination)
         remove_mock.assert_called()
@@ -88,7 +89,7 @@ class ContentMoveDirectoryTestCase(TestCase):
 
     @patch('kolibri.content.management.commands.content.Command.migrate')
     @patch('kolibri.content.management.commands.content.os.path.exists', return_value=True)
-    def test_current_dir_equals_destination(self, path_exists_mock, migrate_mock):
+    def test_current_dir_equals_destination(self, path_exists_mock, migrate_mock, update_mock):
         with self.assertRaises(SystemExit):
             call_command('content', 'movedirectory', OPTIONS['Paths']['CONTENT_DIR'])
             migrate_mock.assert_not_called()

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -26,7 +26,7 @@ class SanityCheckTestCase(TestCase):
             logging_mock.assert_called()
 
     @patch('kolibri.utils.sanity_checks.logging.error')
-    @patch('kolibri.utils.sanity_checks.os.path.exists', side_effect=[True, False])
+    @patch('kolibri.utils.sanity_checks.os.path.exists', return_value=False)
     def test_content_dir_dne(self, path_mock, logging_mock):
         with self.assertRaises(SystemExit):
             cli.main({'start': True})


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The tests for movedirectory command changed the values in options.ini originally in that PR, which makes other tests fail.
This PR fixes the issue by mocking the function `update_options_file` so that the values in `options.ini` will not be changed when running tests for movedirectory command.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check if the `options.ini` file is changed after running the tests.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Slack thread: https://learningequality.slack.com/archives/CB37UM23A/p1528903284000355

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
