### PR TITLE
Fix attempt log list

### DIFF
--- a/kolibri/core/assets/src/views/attempt-log-list.vue
+++ b/kolibri/core/assets/src/views/attempt-log-list.vue
@@ -42,7 +42,7 @@
           </div>
           <coach-content-label
             class="coach-content-label"
-            :value="numCoachContents(attemptLog.questionNumber)"
+            :value="attemptLog.num_coach_contents"
             :isTopic="false"
           />
         </li>
@@ -55,7 +55,6 @@
 
 <script>
 
-  import find from 'lodash/find';
   import coachContentLabel from 'kolibri.coreVue.components.coachContentLabel';
 
   export default {
@@ -87,17 +86,6 @@
       },
       isSelected(questionNumber) {
         return Number(this.selectedQuestionNumber) === questionNumber;
-      },
-    },
-    vuex: {
-      getters: {
-        numCoachContents(state) {
-          return function getCoachContents(questionNumber) {
-            const { questions, exerciseContentNodes } = state.pageState;
-            const questionId = questions[questionNumber - 1].contentId;
-            return find(exerciseContentNodes, { id: questionId }).num_coach_contents;
-          };
-        },
       },
     },
   };

--- a/kolibri/core/assets/src/views/exam-report/index.vue
+++ b/kolibri/core/assets/src/views/exam-report/index.vue
@@ -13,7 +13,7 @@
     <div class="details-container">
       <div class="attempt-log-container">
         <attempt-log-list
-          :attemptLogs="examAttempts"
+          :attemptLogs="attemptLogs"
           :selectedQuestionNumber="questionNumber"
           @select="handleNavigateToQuestion"
         />
@@ -63,6 +63,7 @@
   import interactionList from 'kolibri.coreVue.components.interactionList';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+  import find from 'lodash/find';
   import pageStatus from './page-status';
 
   export default {
@@ -157,6 +158,16 @@
         showCorrectAnswer: false,
       };
     },
+    computed: {
+      attemptLogs() {
+        return this.examAttempts.map(attempt => {
+          const questionId = this.questions[attempt.questionNumber - 1].contentId;
+          const num_coach_contents = find(this.exerciseContentNodes, { id: questionId })
+            .num_coach_contents;
+          return { ...attempt, num_coach_contents };
+        });
+      },
+    },
     methods: {
       handleNavigateToQuestion(questionNumber) {
         this.navigateToQuestion(questionNumber);
@@ -166,6 +177,12 @@
       toggleShowCorrectAnswer() {
         this.showCorrectAnswer = !this.showCorrectAnswer;
         this.$forceUpdate();
+      },
+    },
+    vuex: {
+      getters: {
+        questions: state => state.pageState.questions,
+        exerciseContentNodes: state => state.pageState.exerciseContentNodes,
       },
     },
   };

--- a/kolibri/core/assets/src/views/interaction-list/index.vue
+++ b/kolibri/core/assets/src/views/interaction-list/index.vue
@@ -30,7 +30,7 @@
   import interactionItem from './interaction-item';
 
   export default {
-    name: 'coachExerciseQuestionAttempt',
+    name: 'interactionList',
     components: { interactionItem },
     mixins: [responsiveElement],
     $trs: {
@@ -45,6 +45,7 @@
       },
       selectedInteractionIndex: {
         type: Number,
+        required: true,
       },
       attemptNumber: {
         type: Number,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -101,7 +101,11 @@
       getters: {
         interactionIndex: state => state.pageState.interactionIndex,
         currentAttemptLog: state => state.pageState.currentAttemptLog,
-        attemptLogs: state => state.pageState.attemptLogs,
+        attemptLogs: state =>
+          state.pageState.attemptLogs.map(attempt => ({
+            ...attempt,
+            num_coach_contents: state.pageState.exercise.num_coach_contents,
+          })),
         currentInteraction: state => state.pageState.currentInteraction,
         currentInteractionHistory: state => state.pageState.currentInteractionHistory,
         classId: state => state.classId,

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -23,7 +23,7 @@
           v-if="isExercise"
           :interactions="currentInteractionHistory"
           :selectedInteractionIndex="interactionIndex"
-          :attemptNumber="currentAttemptLog.questionNumber"
+          :attemptNumber="currentAttemptLog.questionNumber || 0"
           @select="navigateToNewInteraction($event)"
         />
 


### PR DESCRIPTION
### Summary

Pass in num_coach_contents as part of attemptLogs prop.

### Reviewer guidance

Check with content that is coach content.

### References

Fixes #3792

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
