### PR TITLE
Add triggered android apk build pipeline

### DIFF
--- a/.buildkite/build_apk.sh
+++ b/.buildkite/build_apk.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 yes y | rm -r kolibri-kivy/ || true 2> /dev/null
 git clone https://github.com/learningequality/kolibri-kivy.git
 cd kolibri-kivy
-git checkout v0.1.0-beta1
+git checkout develop
 cd ..
 
 # copy in the latest whl to make it available to the Docker build script

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,10 +14,10 @@ steps:
 
   - wait
 
-  # - label: Build the Android APK file
-  #   command: mkdir -p dist && .buildkite/build_apk.sh
-
-  # - wait
-
   - label: Upload artifacts
     command: .buildkite/setup_and_upload_artifact.sh && docker image prune -f -a
+
+  - block: "Create release artifacts?"
+
+  - label: Build the Android APK file
+    command: mkdir -p dist && .buildkite/build_apk.sh


### PR DESCRIPTION
### Summary
Re-enables Android builds as a triggered pipeline so as not to hold up builds.

Testing PR

This seems like a useful model as we try to automate building of more and more installation targets? Also, we could restrict the branches to just release branches if needed.

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
