### PR TITLE
Fix search box clear button horizontal overflow

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/search-box.vue
+++ b/kolibri/plugins/learn/assets/src/views/search-box.vue
@@ -166,8 +166,8 @@
     visibility: hidden
     width: 24px
     height: 24px
-    margin-right: 8px
-    margin-left: 8px
+    margin-right: 6px
+    margin-left: 6px
     vertical-align: middle
     color: $core-text-default
 


### PR DESCRIPTION
### Summary
Clear button had left and right margin values of 8px which was taking up too much horizontal space thus causing an overflow and pushing the search submit button to a new row.

It is possible that this regression surfaced now due to a new css extraction/compilation workflow being put in place.

Before:

![selection_320](https://user-images.githubusercontent.com/2150991/41545565-be6779c4-731b-11e8-9a33-33cf8fcbec3d.png)

After:

![selection_321](https://user-images.githubusercontent.com/2150991/41545574-c31a6bac-731b-11e8-988d-964b94f9a2c9.png)

### Reviewer guidance
Keep an eye on the search box with and without the changes.

### References
Regression possibly introduced with this PR: https://github.com/learningequality/kolibri/pull/3757

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
