### PR TITLE
Use update instead of save when PATCH is used in http requests

### DIFF
--- a/kolibri/core/serializers.py
+++ b/kolibri/core/serializers.py
@@ -23,3 +23,4 @@ serializer_field_mapping.update(ModelSerializer.serializer_field_mapping)
 class KolibriModelSerializer(ModelSerializer):
 
     serializer_field_mapping = serializer_field_mapping
+

--- a/kolibri/core/serializers.py
+++ b/kolibri/core/serializers.py
@@ -24,3 +24,12 @@ class KolibriModelSerializer(ModelSerializer):
 
     serializer_field_mapping = serializer_field_mapping
 
+    def update(self, instance, validated_data):
+        skipped_fields = ['user', 'start_timestamp']
+        for attr, value in validated_data.items():
+
+            if attr not in skipped_fields and self.data[attr] != validated_data[attr]:
+                setattr(instance, attr, value)
+        instance.save()
+
+        return instance


### PR DESCRIPTION
### Summary
This modification will make Kolibri update only the changes fields when PATCH is being used. Theorically this should improve logging performance, however tests done using velox demonstrate the change has not noticeable impact in performance [https://docs.google.com/spreadsheets/d/1QNHI554kXaa0CoKrHzVcb3UhfYRsjUa0X87-7Ep9AjE/edit#gid=336877881](url)
![patch](https://user-images.githubusercontent.com/1008178/41549735-13d4f2e6-7327-11e8-8494-dae9120fd9ce.png)

I am adding this PR to leave documentation of the attempt, but I don't think the change is worth



----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
