### PR TITLE
Update local versions to conform with PEP 440

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -86,14 +86,14 @@ class TestKolibriVersion(unittest.TestCase):
         v = get_version((0, 1, 0, "alpha", 1))
         self.assertIn("0.1.0a1", v)
 
-    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git-2-gfd48a7a")
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git.2.gfd48a7a")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
     def test_version_file_local_git_version(self, describe_mock, file_mock):
         """
         Test that a version file with git describe output is correctly parsed
         """
         v = get_version((0, 7, 1, "beta", 1))
-        self.assertIn("0.7.1b1.dev+git-2-gfd48a7a", v)
+        self.assertIn("0.7.1b1.dev+git.2.gfd48a7a", v)
 
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
     @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
@@ -152,7 +152,7 @@ class TestKolibriVersion(unittest.TestCase):
         Tests that git describe data for an alpha-1 tag generates an a1 version
         string.
         """
-        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0a1.dev+git-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 0)) == "0.1.0a1.dev+git.123.abcdfe12"
 
     @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
     @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.1.0-alpha1-123-abcdfe12")
@@ -161,7 +161,7 @@ class TestKolibriVersion(unittest.TestCase):
         Tests that git describe data for an alpha-1 tag generates an a1 version
         string.
         """
-        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0a1.dev+git-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0a1.dev+git.123.abcdfe12"
 
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b2")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
@@ -173,7 +173,7 @@ class TestKolibriVersion(unittest.TestCase):
         """
         assert get_version((0, 1, 0, "beta", 1)) == "0.1.0b2"
 
-    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git-12-g2a8fe31")
+    @mock.patch('kolibri.utils.version.get_version_file', return_value="0.7.1b1.dev+git.12.g2a8fe31")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value=None)
     @mock.patch('kolibri.utils.version.get_git_changeset', return_value=None)
     def test_beta_1_consistent_dev_release_version_file(self, get_git_changeset_mock, describe_mock, file_mock):
@@ -181,7 +181,7 @@ class TestKolibriVersion(unittest.TestCase):
         Test that a VERSION file can overwrite an beta-1 state in case the
         version was bumped in ``kolibri.VERSION``.
         """
-        assert get_version((0, 7, 1, "alpha", 0)) == "0.7.1b1.dev+git-12-g2a8fe31"
+        assert get_version((0, 7, 1, "alpha", 0)) == "0.7.1b1.dev+git.12.g2a8fe31"
 
     @mock.patch('kolibri.utils.version.get_version_file', return_value="0.1.0b1")
     @mock.patch('kolibri.utils.version.get_git_describe', return_value="v0.0.1")
@@ -236,7 +236,7 @@ class TestKolibriVersion(unittest.TestCase):
         Test that a beta1 git tag can override kolibri.__version__ reading
         alpha0.
         """
-        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git.123.abcdfe12"
 
     @mock.patch('subprocess.Popen')
     def test_git_describe_parser(self, popen_mock):
@@ -247,7 +247,7 @@ class TestKolibriVersion(unittest.TestCase):
         attrs = {'communicate.return_value': ('v0.1.0-beta1-123-abcdfe12', '')}
         process_mock.configure_mock(**attrs)
         popen_mock.return_value = process_mock
-        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git-123-abcdfe12"
+        assert get_version((0, 1, 0, "alpha", 1)) == "0.1.0b1.dev+git.123.abcdfe12"
 
     @mock.patch('subprocess.Popen')
     @mock.patch('kolibri.utils.version.get_version_file', return_value=None)
@@ -330,7 +330,7 @@ class TestKolibriVersion(unittest.TestCase):
             ('00000001', '00000002', '00000003', '*a', '*final')
             >>> parse_version("1.2.3b1")
             ('00000001', '00000002', '00000003', '*b', '00000001', '*final')
-            >>> parse_version("1.2.3b1+git-123")
+            >>> parse_version("1.2.3b1+git.123")
             ('00000001', '00000002', '00000003', '*b', '00000001', '*+', '*git', '*final-', '00000123', '*final')
 
         """

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -38,7 +38,7 @@ Confused? Here's a table:
 | Final        | Canonical, only     | N/A                 | N/A                       | 0.1.0, 0.2.2,                       |
 |              | information used    |                     |                           | 0.2.post1                           |
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| dev release  | (1, 2, 3, 'alpha',  | Fallback            | timestamp of latest       | 0.4.0.dev020170605181124-f1234567   |
+| dev release  | (1, 2, 3, 'alpha',  | Fallback            | timestamp of latest       | 1.2.3.dev0+git.123.f1234567         |
 | (alpha0)     | 0), 0th alpha = a   |                     | commit + hash             |                                     |
 |              | dev release! Never  |                     |                           |                                     |
 |              | used as a canonical |                     |                           |                                     |
@@ -46,15 +46,15 @@ Confused? Here's a table:
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
 | alpha1+      | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
 |              | 1)                  |                     |                           | 1.2.3a1,                            |
-|              |                     |                     |                           | Changes                             |
+|              |                     |                     |                           | 4 changes                           |
 |              |                     |                     |                           | since tag:                          |
-|              |                     |                     |                           | 1.2.3a1.dev123-f1234567             |
+|              |                     |                     |                           | 1.2.3a1.dev+git.4.f1234567          |
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
 | beta1+       | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
 |              | 1)                  |                     |                           | 1.2.3b1,                            |
-|              |                     |                     |                           | Changes                             |
+|              |                     |                     |                           | 5 changes                           |
 |              |                     |                     |                           | since tag:                          |
-|              |                     |                     |                           | 1.2.3b1.dev123-f1234567             |
+|              |                     |                     |                           | 1.2.3b1.dev+git.5.f1234567          |
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
 | rc1+         | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
 | (release     | 1)                  |                     |                           | 1.2.3rc1,                           |
@@ -62,16 +62,8 @@ Confused? Here's a table:
 |              |                     |                     |                           | since tag:                          |
 |              |                     |                     |                           | 1.2.3rc1.dev123-f1234567            |
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| beta0, rc0,  | Not recommended,    | Fallback            | timestamp of latest       | 0.4.0b0.dev020170605181124-f1234567 |
-| post0, x.y.0 | but if you use it,  |                     | commit + hash             |                                     |
-|              | your release        |                     |                           |                                     |
-|              | transforms into a   |                     |                           |                                     |
-|              | X.Y.0b0.dev{suffix} |                     |                           |                                     |
-|              | release, which in   |                     |                           |                                     |
-|              | most cases should   |                     |                           |                                     |
-|              | be assigned to the  |                     |                           |                                     |
-|              | preceding release   |                     |                           |                                     |
-|              | type.               |                     |                           |                                     |
+| beta0, rc0,  | DO NOT USE          | Fallback            | timestamp of latest       | 1.2.3b0.dev+git.123.f1234567        |
+| post0, x.y.0 |                     |                     | commit + hash             |                                     |
 |              |                     |                     |                           |                                     |
 +--------------+---------------------+---------------------+---------------------------+-------------------------------------+
 
@@ -235,7 +227,10 @@ def get_version_from_git(get_git_describe_string):
     else:
         major, minor, patch = version_split
 
-    suffix = m.group('suffix')
+    # We need to replace "-" with ".". Namely, this is done automatically in
+    # the naming of source dist .whl and .tar.gz files produced by setup.py.
+    # See: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
+    suffix = m.group('suffix').replace("-", ".")
     suffix = ".dev+git" + suffix if suffix else ""
 
     return get_complete_version((


### PR DESCRIPTION
### Summary

Update to match [PEP 440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)

> Local version identifiers MUST comply with the following scheme:
> 
>      <public version identifier>[+<local version label>]
> 
> (...)
> 
> To ensure local version identifiers can be readily incorporated as part of filenames and URLs, and to avoid formatting inconsistencies in hexadecimal hash representations, local version labels MUST be limited to the following set of permitted characters:
> 
> * ASCII letters ([a-zA-Z])
> * ASCII digits ([0-9])
> * periods (.)

Working on a Docker build to create Debian builds, I had to be able to predict the file names in `dist/` output, created from `make dist`.

The file names were automatically altered to match PEP 440 conventions, which on one hand is great. On the other, it meant that `kolibri --version` would be `1.2.3+git-1-abcdef123` and the file name would be ``kolibri-1.2.3+git.1.abcdef123.tar.gz`` (dots instead of hyphens).

So the reasons for this PR:

1) Changing our automated version generation for consistency with PEP 440
2) Avoiding some ugly/fuzzy regular expression or file pattern `kolibri-*.tar.gz` match when writing Docker automation that uses output in `dist/`.

### Reviewer guidance

Trying to make gradual, positive improvements. Let me know, if there is something we might as well include here!

You can check the file names of the Buildkite artifacts :)

### References

n/a - came up while working on https://github.com/learningequality/kolibri-installer-debian/issues/3

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
