### PR TITLE
Port #3707 to 0.9.x: Updates to response headers for ZIP endpoints for security and functionality

### DIFF
--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -93,3 +93,10 @@ class ZipContentTestCase(TestCase):
     def test_x_frame_options_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.get("X-Frame-Options", ""), "")
+
+    def test_access_control_allow_headers(self):
+        headerval = "X-Penguin-Dance-Party"
+        response = self.client.options(self.zip_file_base_url + self.test_name_1, HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval)
+        self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)
+        response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval)
+        self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)

--- a/kolibri/content/test/test_zipcontent.py
+++ b/kolibri/content/test/test_zipcontent.py
@@ -79,3 +79,17 @@ class ZipContentTestCase(TestCase):
         caching_client = Client(HTTP_IF_MODIFIED_SINCE="Sat, 10-Sep-2016 19:14:07 GMT")
         response = caching_client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.status_code, 304)
+
+    def test_content_security_policy_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+
+    def test_access_control_allow_origin_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Access-Control-Allow-Origin"), "*")
+        response = self.client.options(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("Access-Control-Allow-Origin"), "*")
+
+    def test_x_frame_options_header(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1)
+        self.assertEqual(response.get("X-Frame-Options", ""), "")

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -19,6 +19,16 @@ mimetypes.init([os.path.join(os.path.dirname(__file__), 'constants', 'mime.types
 class ZipContentView(View):
 
     @xframe_options_exempt
+    def options(self, request, *args, **kwargs):
+        """
+        Handles OPTIONS requests which may be sent as "preflight CORS" requests to check permissions.
+        """
+        response = HttpResponse()
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        return response
+
+    @xframe_options_exempt
     def get(self, request, zipped_filename, embedded_filepath):
         """
         Handles GET requests and serves a static file from within the zip file.

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -2,8 +2,10 @@ import mimetypes
 import os
 import zipfile
 
-from django.http import Http404, HttpResponse
-from django.http.response import FileResponse, HttpResponseNotModified
+from django.http import Http404
+from django.http import HttpResponse
+from django.http.response import FileResponse
+from django.http.response import HttpResponseNotModified
 from django.views.generic.base import View
 from le_utils.constants import exercises
 
@@ -78,6 +80,11 @@ class ZipContentView(View):
         # Newer versions of Chrome block iframes from loading
         # solution is to override xframe options with any string (https://stackoverflow.com/a/6767901)
         response['X-Frame-Options'] = "GOFORIT"
+
+        # restrict CSP to only allow resources to be loaded from the Kolibri host, to prevent info leakage
+        # (e.g. via passing user info out as GET parameters to an attacker's server), or inadvertent data usage
+        host = request.build_absolute_uri('/').strip("/")
+        response["Content-Security-Policy"] = "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: " + host
 
         return response
 

--- a/kolibri/content/views.py
+++ b/kolibri/content/views.py
@@ -6,6 +6,7 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.http.response import FileResponse
 from django.http.response import HttpResponseNotModified
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic.base import View
 from le_utils.constants import exercises
 
@@ -17,6 +18,7 @@ mimetypes.init([os.path.join(os.path.dirname(__file__), 'constants', 'mime.types
 
 class ZipContentView(View):
 
+    @xframe_options_exempt
     def get(self, request, zipped_filename, embedded_filepath):
         """
         Handles GET requests and serves a static file from within the zip file.
@@ -76,10 +78,6 @@ class ZipContentView(View):
 
         # allow all origins so that content can be read from within zips within sandboxed iframes
         response["Access-Control-Allow-Origin"] = "*"
-
-        # Newer versions of Chrome block iframes from loading
-        # solution is to override xframe options with any string (https://stackoverflow.com/a/6767901)
-        response['X-Frame-Options'] = "GOFORIT"
 
         # restrict CSP to only allow resources to be loaded from the Kolibri host, to prevent info leakage
         # (e.g. via passing user info out as GET parameters to an attacker's server), or inadvertent data usage


### PR DESCRIPTION
Backports https://github.com/learningequality/kolibri/pull/3707 from develop, to be included in 0.9.3