### PR TITLE
Prevent multiple group membership within a class

### DIFF
--- a/kolibri/plugins/coach/assets/src/state/actions/group.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/group.js
@@ -2,11 +2,8 @@ import { handleError, samePageCheckGenerator } from 'kolibri.coreVue.vuex.action
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { PageNames } from '../../constants';
 import { setClassState } from './main';
-import logger from 'kolibri.lib.logging';
 import { LearnerGroupResource, MembershipResource, FacilityUserResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
-
-const logging = logger.getLogger(__filename);
 
 const translator = createTranslator('groupManagementPageTitles', {
   groupManagementPageTitle: 'Groups',
@@ -200,37 +197,33 @@ function _removeMultipleUsersFromGroup(store, groupId, userIds) {
 
 export function addUsersToGroup(store, groupId, userIds) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  return _addMultipleUsersToGroup(store, groupId, userIds).then(
-    () => {
+  return _addMultipleUsersToGroup(store, groupId, userIds)
+    .catch(error => handleError(store, error))
+    .finally(() => {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       this.displayModal(false);
-    },
-    error => logging.error(error)
-  );
+    });
 }
 
 export function removeUsersFromGroup(store, groupId, userIds) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  return _removeMultipleUsersFromGroup(store, groupId, userIds).then(
-    () => {
+  return _removeMultipleUsersFromGroup(store, groupId, userIds)
+    .catch(error => handleError(store, error))
+    .finally(() => {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       this.displayModal(false);
-    },
-    error => logging.error(error)
-  );
+    });
 }
 
 export function moveUsersBetweenGroups(store, currentGroupId, newGroupId, userIds) {
   store.dispatch('CORE_SET_PAGE_LOADING', true);
-  const promises = [
-    _removeMultipleUsersFromGroup(store, currentGroupId, userIds),
-    _addMultipleUsersToGroup(store, newGroupId, userIds),
-  ];
-  return Promise.all(promises).then(
-    () => {
+  return _removeMultipleUsersFromGroup(store, currentGroupId, userIds)
+    .then(() => {
+      return _addMultipleUsersToGroup(store, newGroupId, userIds);
+    })
+    .catch(error => handleError(store, error))
+    .finally(() => {
       store.dispatch('CORE_SET_PAGE_LOADING', false);
       this.displayModal(false);
-    },
-    error => logging.error(error)
-  );
+    });
 }


### PR DESCRIPTION
### Summary
Enforces single group membership within a class for a learner.
Does this by raising a 400 error if a group membership is created when they already have a membership, and then catching the error in the frontend to prevent a perpetual loading state.

### Reviewer guidance
Open two tabs on the group page. Move a learner into one group on one page, then try to move the same learner into another group on the other page. It should show an error box (as opposed to the previous behaviour where it would just do it!)

### References
Fixes #3530

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
