### PR TITLE
Add option to configure postgres database port

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Please feel free to add your name on this list if you do a PR!
 * Richard Amodia (mrpau-richard)
 * Eugene Oliveros (mrpau-eugene)
 * Geoff Rich (geoffrey1218)
+* Boni Đukić (bonidjukic)

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -143,6 +143,7 @@ elif conf.OPTIONS['Database']['DATABASE_ENGINE'] == "postgres":
             'PASSWORD': conf.OPTIONS['Database']['DATABASE_PASSWORD'],
             'USER': conf.OPTIONS['Database']['DATABASE_USER'],
             'HOST': conf.OPTIONS['Database']['DATABASE_HOST'],
+            'PORT': conf.OPTIONS['Database']['DATABASE_PORT'],
         }
     }
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -31,6 +31,10 @@ option_spec = {
             "type": "string",
             "envvars": ("KOLIBRI_DATABASE_HOST",),
         },
+        "DATABASE_PORT": {
+            "type": "string",
+            "envvars": ("KOLIBRI_DATABASE_PORT",),
+        },
     },
     "Server": {
         "CHERRYPY_THREAD_POOL": {


### PR DESCRIPTION
### Summary
Currently, we're not able to run Kolibri with Postgres database backend
if running Postgres server on port other than the default 5432.

This change simply adds ability to configure the port.

### Reviewer guidance
1) Checkout `develop` branch
1) Configure Kolibri to run with Postgres db backend (either by adding / editing `options.ini` in your `KOLIBRI_HOME` directory, or by using the environment variables)
2) Edit your `postgresql.conf` and set `port` to a value other than the default `5432` (e.g. `5433`)
3) Restart postresql service (e.g. `service postgresql restart`)
4) Try to run Kolibri and observe error stating that Kolibri can't find the postgres server running on port `5432`
5) Checkout to `configure-postgres-db-port` branch
6) Add `DATABASE_PORT = 5433` to your `options.ini` or start Kolibri with ` KOLIBRI_DATABASE_PORT=5433` environment variable
7) Observe that Kolibri is now able to connect to Postgres server on port `5433`

### References
https://github.com/learningequality/kolibri/pull/3607 - First pass at ini-based options file, for persistent user-accessible configuration

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Link to diff of internal dependency change is included
- [x] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
