### PR TITLE
updated language switcher

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -42,7 +42,6 @@ import kTextbox from '../views/k-textbox';
 import kNavbar from '../views/k-navbar';
 import kNavbarLink from '../views/k-navbar/link';
 import logo from '../views/logo';
-import languageSwitcherMixin from '../views/language-switcher/mixin.js';
 import languageSwitcherList from '../views/language-switcher/list.vue';
 import immersiveFullScreen from '../views/immersive-full-screen';
 import elapsedTime from '../views/elapsed-time';
@@ -162,7 +161,6 @@ export default {
     mixins: {
       responsiveWindow,
       responsiveElement,
-      languageSwitcherMixin,
       contentRenderer: contentRendererMixin,
       fullscreen,
     },

--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -83,7 +83,8 @@
           .filter(lang => availableLanguages[lang] !== undefined)
           .filter(lang => lang !== currentLanguage)
           .map(lang => availableLanguages[lang])
-          .slice(0, this.numVisibleLanguages);
+          .slice(0, this.numVisibleLanguages)
+          .sort(this.compareLanguages);
       },
     },
   };

--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -46,7 +46,6 @@
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import kButton from 'kolibri.coreVue.components.kButton';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
-  import shuffle from 'lodash/shuffle';
   import uiIconButton from 'keen-ui/src/UiIconButton';
   import languageSwitcherMixin from './mixin';
   import languageSwitcherModal from './modal';
@@ -78,7 +77,7 @@
         return this.windowSize.breakpoint;
       },
       buttonLanguages() {
-        const prioritized_languages = shuffle(['ar', 'en', 'es-es', 'fr-fr', 'hi-in', 'sw-tz']);
+        const prioritized_languages = ['en', 'ar', 'es-es', 'hi-in', 'fr-fr', 'sw-tz'];
         return prioritized_languages
           .filter(lang => availableLanguages[lang] !== undefined)
           .filter(lang => lang !== currentLanguage)

--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -1,39 +1,33 @@
 <template>
 
   <div>
-    <label
-      :class="[
-        'language-list-selected',
-        'language-list-items',
-        (isMobile ? 'mobile' : '')
-      ]"
-    >
-      <div class="language-list-selected-label">
-        {{ $tr('selectedLanguageLabel') }}
-      </div>
-      <div>
-        {{ selectedLanguage }}
-      </div>
-    </label>
-
+    <mat-svg
+      slot="icon"
+      name="language"
+      category="action"
+      class="icon"
+    />
+    <span>
+      {{ selectedLanguage }}
+    </span>
     <k-button
       v-for="language in buttonLanguages"
-      class="language-list-button-option language-list-items"
       @click="switchLanguage(language.id)"
       :key="language.id"
       :raised="false"
       :text="language.lang_name"
       appearance="basic-link"
     />
-
-    <k-select
-      v-if="moreLanguages.length"
-      :label="$tr('showMoreLanguagesSelector')"
-      :options="moreLanguages"
-      :inline="true"
-      v-model="moreLanguagesSelection"
-      @change="switchLanguage($event.value)"
-      class="language-list-dropdown"
+    <k-button
+      :text="$tr('showMoreLanguagesSelector')"
+      :primary="false"
+      appearance="flat-button"
+      @click="showLanguageModal = true"
+    />
+    <language-switcher-modal
+      v-if="showLanguageModal"
+      @close="showLanguageModal = false"
+      class="override-ui-toolbar"
     />
   </div>
 
@@ -43,56 +37,28 @@
 <script>
 
   import { availableLanguages as allLanguages, currentLanguage } from 'kolibri.utils.i18n';
-  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
-  import languageSwitcherMixin from 'kolibri.coreVue.mixins.languageSwitcherMixin';
-
   import kButton from 'kolibri.coreVue.components.kButton';
-  import kSelect from 'kolibri.coreVue.components.kSelect';
-
-  const mobileNumberOfLanguageButtons = 5;
-  const desktopNumberOfLanguageButtons = 3;
+  import languageSwitcherMixin from './mixin';
+  import languageSwitcherModal from './modal';
 
   export default {
     name: 'languageSwitcherList',
     $trs: {
       showMoreLanguagesSelector: 'More languages',
-      selectedLanguageLabel: 'Selected language',
     },
-    components: { kButton, kSelect },
-    mixins: [responsiveWindow, languageSwitcherMixin],
+    components: {
+      kButton,
+      languageSwitcherModal,
+    },
+    mixins: [languageSwitcherMixin],
     data() {
       return {
-        selectedLanguageId: currentLanguage,
-        moreLanguagesSelection: {},
+        showLanguageModal: false,
       };
     },
     computed: {
-      isMobile() {
-        return this.windowSize.breakpoint < 4;
-      },
       selectedLanguage() {
         return allLanguages[currentLanguage].lang_name;
-      },
-      remainingLanguages() {
-        return this.languageOptions.filter(lang => lang.id !== currentLanguage);
-      },
-      numberOfLanguageButtons() {
-        let numBtns = this.isMobile
-          ? mobileNumberOfLanguageButtons
-          : desktopNumberOfLanguageButtons;
-        // prevent a case where the selector menu has just a single item
-        if (Object.keys(allLanguages).length === numBtns + 2) {
-          return numBtns + 1;
-        }
-        return numBtns;
-      },
-      buttonLanguages() {
-        return this.remainingLanguages.slice(0, this.numberOfLanguageButtons);
-      },
-      moreLanguages() {
-        return this.remainingLanguages.slice(this.numberOfLanguageButtons).map(lang => {
-          return { label: lang.lang_name, value: lang.id };
-        });
       },
     },
   };
@@ -104,47 +70,8 @@
 
   @require '~kolibri.styles.definitions'
 
-  $k-button-styles()
-    padding: 0 16px
-    min-width: 64px
-    min-height: 36px
-    border-radius: 2px
-    font-size: 14px
-    font-weight: bold
-    line-height: 36px
-    text-transform: uppercase
-    max-width: 100%
-
-  .language-list
-    &-items
-      margin: 0
-      display: inline-block
-      margin-right: 16px
-      margin-bottom: 8px
-
-    &-selected
-      display: inline-block
-      font-weight: bold
-      &.mobile
-        display: block
-
-      &-label
-        display: block
-        font-weight: normal
-        font-size: 10px
-        margin-bottom: 8px
-
-    &-button-option
-      color: $core-action-dark
-
-  .language-list-dropdown
-    margin-bottom: 8px
-
-  .language-list-dropdown.k-select-inline
-      width: auto
-
-  >>>.ui-select__label-text.is-inline
-    margin-right: 2em
-    width: auto
+  .icon
+    position: relative
+    top: 6px
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/list.vue
+++ b/kolibri/core/assets/src/views/language-switcher/list.vue
@@ -1,13 +1,18 @@
 <template>
 
   <div>
-    <mat-svg
-      slot="icon"
-      name="language"
-      category="action"
-      class="icon"
-    />
-    <span>
+    <ui-icon-button
+      type="secondary"
+      @click="showLanguageModal = true"
+      class="globe"
+    >
+      <mat-svg
+        name="language"
+        category="action"
+      />
+    </ui-icon-button>
+
+    <span class="selected">
       {{ selectedLanguage }}
     </span>
     <k-button
@@ -16,18 +21,20 @@
       :key="language.id"
       :raised="false"
       :text="language.lang_name"
+      class="lang"
       appearance="basic-link"
     />
     <k-button
       :text="$tr('showMoreLanguagesSelector')"
       :primary="false"
       appearance="flat-button"
+      class="more"
       @click="showLanguageModal = true"
     />
     <language-switcher-modal
       v-if="showLanguageModal"
       @close="showLanguageModal = false"
-      class="override-ui-toolbar"
+      class="modal"
     />
   </div>
 
@@ -36,8 +43,11 @@
 
 <script>
 
-  import { availableLanguages as allLanguages, currentLanguage } from 'kolibri.utils.i18n';
+  import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import kButton from 'kolibri.coreVue.components.kButton';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import shuffle from 'lodash/shuffle';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
   import languageSwitcherMixin from './mixin';
   import languageSwitcherModal from './modal';
 
@@ -49,8 +59,9 @@
     components: {
       kButton,
       languageSwitcherModal,
+      uiIconButton,
     },
-    mixins: [languageSwitcherMixin],
+    mixins: [responsiveWindow, languageSwitcherMixin],
     data() {
       return {
         showLanguageModal: false,
@@ -58,7 +69,21 @@
     },
     computed: {
       selectedLanguage() {
-        return allLanguages[currentLanguage].lang_name;
+        return availableLanguages[currentLanguage].lang_name;
+      },
+      numVisibleLanguages() {
+        if (this.windowSize.breakpoint <= 2) {
+          return 2;
+        }
+        return this.windowSize.breakpoint;
+      },
+      buttonLanguages() {
+        const prioritized_languages = shuffle(['ar', 'en', 'es-es', 'fr-fr', 'hi-in', 'sw-tz']);
+        return prioritized_languages
+          .filter(lang => availableLanguages[lang] !== undefined)
+          .filter(lang => lang !== currentLanguage)
+          .map(lang => availableLanguages[lang])
+          .slice(0, this.numVisibleLanguages);
       },
     },
   };
@@ -70,8 +95,24 @@
 
   @require '~kolibri.styles.definitions'
 
-  .icon
+  .globe
     position: relative
-    top: 6px
+    top: -2px
+    right: -4px
+
+  .selected
+    margin: 8px
+
+  .lang
+    margin-left: 8px
+    margin-right: 8px
+
+  .more
+    margin: 0
+    margin-top: 8px
+    margin-bottom: 8px
+
+  .modal
+    text-align: left
 
 </style>

--- a/kolibri/core/assets/src/views/language-switcher/mixin.js
+++ b/kolibri/core/assets/src/views/language-switcher/mixin.js
@@ -13,24 +13,25 @@ export default {
         global.location.reload(true);
       });
     },
+    compareLanguages(a, b) {
+      if (a.id === currentLanguage) {
+        return -1;
+      }
+      if (b.id === currentLanguage) {
+        return 1;
+      }
+      if (a.lang_name.toLowerCase() < b.lang_name.toLowerCase()) {
+        return -1;
+      }
+      if (b.lang_name.toLowerCase() < a.lang_name.toLowerCase()) {
+        return 1;
+      }
+      return 0;
+    },
   },
   computed: {
     languageOptions() {
-      return Object.values(availableLanguages).sort((a, b) => {
-        if (a.id === currentLanguage) {
-          return -1;
-        }
-        if (b.id === currentLanguage) {
-          return 1;
-        }
-        if (a.lang_name.toLowerCase() < b.lang_name.toLowerCase()) {
-          return -1;
-        }
-        if (b.lang_name.toLowerCase() < a.lang_name.toLowerCase()) {
-          return 1;
-        }
-        return 0;
-      });
+      return Object.values(availableLanguages).sort(this.compareLanguages);
     },
   },
 };

--- a/kolibri/core/assets/src/views/language-switcher/mixin.js
+++ b/kolibri/core/assets/src/views/language-switcher/mixin.js
@@ -16,23 +16,21 @@ export default {
   },
   computed: {
     languageOptions() {
-      return Object.keys(availableLanguages)
-        .sort((a, b) => {
-          if (a === currentLanguage) {
-            return -1;
-          }
-          if (b === currentLanguage) {
-            return 1;
-          }
-          if (a[0] < b[0]) {
-            return -1;
-          }
-          if (b[0] < a[0]) {
-            return 1;
-          }
-          return 0;
-        })
-        .map(key => availableLanguages[key]);
+      return Object.values(availableLanguages).sort((a, b) => {
+        if (a.id === currentLanguage) {
+          return -1;
+        }
+        if (b.id === currentLanguage) {
+          return 1;
+        }
+        if (a.lang_name.toLowerCase() < b.lang_name.toLowerCase()) {
+          return -1;
+        }
+        if (b.lang_name.toLowerCase() < a.lang_name.toLowerCase()) {
+          return 1;
+        }
+        return 0;
+      });
     },
   },
 };

--- a/kolibri/core/assets/src/views/language-switcher/modal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/modal.vue
@@ -36,8 +36,8 @@
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kButton from 'kolibri.coreVue.components.kButton';
   import kRadioButton from 'kolibri.coreVue.components.kRadioButton';
-  import languageSwitcherMixin from 'kolibri.coreVue.mixins.languageSwitcherMixin';
   import { currentLanguage } from 'kolibri.utils.i18n';
+  import languageSwitcherMixin from './mixin';
 
   export default {
     name: 'languageSwitcherModal',

--- a/kolibri/plugins/user/assets/src/views/language-switcher-footer.vue
+++ b/kolibri/plugins/user/assets/src/views/language-switcher-footer.vue
@@ -1,8 +1,6 @@
 <template>
 
-  <div class="footer-wrapper">
-    <language-switcher-list class="list" />
-  </div>
+  <language-switcher-list class="list" />
 
 </template>
 
@@ -23,13 +21,9 @@
 
 <style lang="stylus" scoped>
 
-  .footer-wrapper
+  .list
     margin-left: 36px
     margin-right: 36px
     text-align: center
-
-  .list
-    display: inline-block
-    text-align: left
 
 </style>


### PR DESCRIPTION
### Summary

As reported in #3652, the language switcher is kind of a mess.

This PR simplifies the UI drastically and makes it consistent with the other language switcher in the main app:

* use a globe icon to indicate the current language
* use a modal - more effective at handling a large number of languages than the select box

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/41690399-33768932-74aa-11e8-9389-1171da77599c.png) | ![image](https://user-images.githubusercontent.com/2367265/41690377-10fb03a6-74aa-11e8-809b-c7cfcdf8d327.png) |


| select 1 | select 2 | same modal for both |
|--|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/41690161-1231083e-74a9-11e8-82a3-5444f33e7dd4.png) | ![image](https://user-images.githubusercontent.com/2367265/41690159-0e220aa4-74a9-11e8-9283-b0f8f0a5d0ff.png) | ![image](https://user-images.githubusercontent.com/2367265/41690163-14f5eecc-74a9-11e8-8819-208fd30f5445.png) |

The main downside I can think of is that there's no longer a few other visible languages. However, I'd argue that this is a reasonable thing to give up...


### Reviewer guidance

Please review both the design and implementation

### References

#3652

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
