### PR TITLE
Handle single-card carousel.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/content-card-group-carousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-card-group-carousel.vue
@@ -4,11 +4,14 @@
 
     <div :style="contentControlsContainerStyles">
 
-      <div class="content-carousel-previous-control" @click="previousSet">
+      <div
+        class="content-carousel-previous-control"
+        @click="previousSet"
+        v-show="!isFirstSet"
+      >
         <ui-icon-button
           class="content-carousel-previous-control-button"
           :style="buttonTransforms"
-          v-show="!isFirstSet"
           :disabled="isFirstSet"
           :disableRipple="true"
           size="large"
@@ -40,11 +43,14 @@
         />
       </transition-group>
 
-      <div class="content-carousel-next-control" @click="nextSet">
+      <div
+        class="content-carousel-next-control"
+        @click="nextSet"
+        v-show="!isLastSet"
+      >
         <ui-icon-button
           class="content-carousel-next-control-button"
           :style="buttonTransforms"
-          v-show="!isLastSet"
           :disabled="isLastSet"
           :disableRipple="true"
           size="large"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Removing ability to shift pages if none exists.

There is logic to handle a click that goes past the range of the current array... but I figured this would be simpler. 

Note to @christianmemije: This actually doesn't have to do with the `:key` value? Tried setting it to a constant value, and all cards still loaded initially. I think `:key` is only checked when Vue is evaluating whether or not it needs to replace an element? Not sure where these would be getting deduped, though? 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
