### PR TITLE
increase line height in menu options

### DIFF
--- a/kolibri/core/assets/src/views/core-menu/option.vue
+++ b/kolibri/core/assets/src/views/core-menu/option.vue
@@ -140,6 +140,7 @@
   .ui-menu-option-text {
       @include text-truncation;
       flex-grow: 1;
+      line-height: 2em;
   }
 
   .ui-menu-option-secondary-text {


### PR DESCRIPTION

### Summary

Updates line height so that tall scripts fit.

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/41750482-0aea42a2-7571-11e8-8b5e-cab1e192d0f2.png) |  ![image](https://user-images.githubusercontent.com/2367265/41750309-120eebba-7570-11e8-903f-8ddea131e699.png) |
| ![image](https://user-images.githubusercontent.com/2367265/41750442-c8b5adea-7570-11e8-8948-a9177e28f586.png) | ![image](https://user-images.githubusercontent.com/2367265/41750436-b0eaff8a-7570-11e8-9c15-ad707e50b257.png) |



### Reviewer guidance

make sure this change makes sense

### References

NA

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
