### PR TITLE
Optimize contentnode endpoint for faster browsing

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNodeSlim.js
+++ b/kolibri/core/assets/src/api-resources/contentNodeSlim.js
@@ -1,0 +1,40 @@
+import logger from 'kolibri.lib.logging';
+import { Resource } from '../api-resource';
+
+const logging = logger.getLogger(__filename);
+
+/**
+ * TODO
+ */
+export default class ContentNodeSlimResource extends Resource {
+  static resourceName() {
+    return 'contentnode_slim';
+  }
+
+  static idKey() {
+    return 'pk';
+  }
+
+  fetchAncestors(id) {
+    if (!id) {
+      throw TypeError('An id must be specified');
+    }
+    let promise;
+    this.ancestor_cache = this.ancestor_cache || {};
+    const key = this.cacheKey({ id });
+    if (!this.ancestor_cache[key]) {
+      const url = this.urls[`${this.name}-ancestors`](id);
+      promise = this.client({ path: url }).then(response => {
+        if (Array.isArray(response.entity)) {
+          this.ancestor_cache[key] = response.entity;
+          return Promise.resolve(response.entity);
+        }
+        logging.debug('Data appears to be malformed', response.entity);
+        return Promise.reject(response);
+      });
+    } else {
+      promise = Promise.resolve(this.ancestor_cache[key]);
+    }
+    return promise;
+  }
+}

--- a/kolibri/core/assets/src/api-resources/index.js
+++ b/kolibri/core/assets/src/api-resources/index.js
@@ -1,6 +1,7 @@
 import ClassroomResource from './classroom';
 import ContentNodeResource from './contentNode';
 import ContentNodeGranular from './contentNodeGranular';
+import ContentNodeSlim from './contentNodeSlim';
 import FacilityUserResource from './facilityUser';
 import FacilityUsernameResource from './facilityUsername';
 import LearnerGroupResource from './learnerGroup';
@@ -56,6 +57,7 @@ const deviceProvisionResource = new DeviceProvisionResource();
 const devicePermissionsResource = new DevicePermissionsResource();
 const newDevicePermissionsResource = new NewDevicePermissionsResource();
 const ContentNodeGranularResource = new ContentNodeGranular();
+const ContentNodeSlimResource = new ContentNodeSlim();
 const RemoteChannelResource = new RemoteChannel();
 const LessonResource = new Lesson();
 
@@ -63,6 +65,7 @@ export {
   classroomResource as ClassroomResource,
   contentNodeResource as ContentNodeResource,
   ContentNodeGranularResource,
+  ContentNodeSlimResource,
   RemoteChannelResource,
   LessonResource,
   facilityUserResource as FacilityUserResource,

--- a/kolibri/core/assets/src/state/mappers.js
+++ b/kolibri/core/assets/src/state/mappers.js
@@ -18,7 +18,7 @@ function assessmentMetaDataState(data) {
     randomize: false,
   };
   if (typeof data.assessmentmetadata === 'undefined') {
-    return blankState
+    return blankState;
   }
   // Data is from a serializer for a one to many key, so it will return an array of length 0 or 1
   const assessmentMetaData = data.assessmentmetadata[0];

--- a/kolibri/core/assets/src/state/mappers.js
+++ b/kolibri/core/assets/src/state/mappers.js
@@ -17,7 +17,10 @@ function assessmentMetaDataState(data) {
     masteryModel: null,
     randomize: false,
   };
-  // Data is from a serializer for a one to many key, so it will return a array of length 0 or 1
+  if (typeof data.assessmentmetadata === 'undefined') {
+    return blankState
+  }
+  // Data is from a serializer for a one to many key, so it will return an array of length 0 or 1
   const assessmentMetaData = data.assessmentmetadata[0];
   if (!assessmentMetaData) {
     return blankState;

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -480,9 +480,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
     pagination_class = OptionalPageNumberPagination
 
     def prefetch_related(self, queryset):
-        return queryset.prefetch_related(
-            'files',
-        ).select_related('lang')
+        return queryset.prefetch_related('files')
 
     def get_queryset(self, prefetch=True):
         queryset = models.ContentNode.objects.filter(available=True)

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -473,6 +473,64 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         return Response(serializer.data)
 
 
+class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
+    serializer_class = serializers.ContentNodeSlimSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = ContentNodeFilter
+    pagination_class = OptionalPageNumberPagination
+
+    def prefetch_related(self, queryset):
+        return queryset.prefetch_related(
+            'files',
+        ).select_related('lang')
+
+    def get_queryset(self, prefetch=True):
+        queryset = models.ContentNode.objects.filter(available=True)
+        if prefetch:
+            return self.prefetch_related(queryset)
+        return queryset
+
+    def get_object(self, prefetch=True):
+        """
+        Returns the object the view is displaying.
+        You may want to override this if you need to provide non-standard
+        queryset lookups.  Eg if objects are referenced using multiple
+        keyword arguments in the url conf.
+        """
+        queryset = self.filter_queryset(self.get_queryset(prefetch=prefetch))
+
+        # Perform the lookup filtering.
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+
+        assert lookup_url_kwarg in self.kwargs, (
+            'Expected view %s to be called with a URL keyword argument '
+            'named "%s". Fix your URL conf, or set the `.lookup_field` '
+            'attribute on the view correctly.' %
+            (self.__class__.__name__, lookup_url_kwarg)
+        )
+
+        filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
+        obj = get_object_or_404(queryset, **filter_kwargs)
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, obj)
+
+        return obj
+
+    @detail_route(methods=['get'])
+    def ancestors(self, request, **kwargs):
+        cache_key = 'contentnode_ancestors_{pk}'.format(pk=kwargs.get('pk'))
+
+        if cache.get(cache_key) is not None:
+            return Response(cache.get(cache_key))
+
+        ancestors = list(self.get_object(prefetch=False).get_ancestors().values('pk', 'title'))
+
+        cache.set(cache_key, ancestors, 60 * 10)
+
+        return Response(ancestors)
+
+
 class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.ContentNodeGranularSerializer
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -71,7 +71,9 @@ class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
     filter_class = ChannelMetadataFilter
 
     def get_queryset(self):
-        return models.ChannelMetadata.objects.all().order_by('-last_updated')
+        return models.ChannelMetadata.objects.all() \
+            .order_by('-last_updated') \
+            .prefetch_related('root__lang')
 
 
 class IdFilter(FilterSet):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -494,7 +494,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
         """
         Returns the object the view is displaying.
         You may want to override this if you need to provide non-standard
-        queryset lookups.  Eg if objects are referenced using multiple
+        queryset lookups. Eg if objects are referenced using multiple
         keyword arguments in the url conf.
         """
         queryset = self.filter_queryset(self.get_queryset(prefetch=prefetch))

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -482,7 +482,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
     pagination_class = OptionalPageNumberPagination
 
     def prefetch_related(self, queryset):
-        return queryset.prefetch_related('files')
+        return queryset.prefetch_related('files__local_file')
 
     def get_queryset(self, prefetch=True):
         queryset = models.ContentNode.objects.filter(available=True)

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -519,7 +519,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
 
     @detail_route(methods=['get'])
     def ancestors(self, request, **kwargs):
-        cache_key = 'contentnode_ancestors_{pk}'.format(pk=kwargs.get('pk'))
+        cache_key = 'contentnode_slim_ancestors_{pk}'.format(pk=kwargs.get('pk'))
 
         if cache.get(cache_key) is not None:
             return Response(cache.get(cache_key))

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -73,7 +73,7 @@ class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         return models.ChannelMetadata.objects.all() \
             .order_by('-last_updated') \
-            .prefetch_related('root__lang')
+            .select_related('root__lang')
 
 
 class IdFilter(FilterSet):

--- a/kolibri/core/content/api_urls.py
+++ b/kolibri/core/content/api_urls.py
@@ -6,6 +6,7 @@ from .api import ChannelMetadataViewSet
 from .api import ContentNodeFileSizeViewSet
 from .api import ContentNodeGranularViewset
 from .api import ContentNodeProgressViewset
+from .api import ContentNodeSlimViewset
 from .api import ContentNodeViewset
 from .api import FileViewset
 from .api import RemoteChannelViewSet
@@ -14,6 +15,7 @@ router = routers.SimpleRouter()
 router.register('channel', ChannelMetadataViewSet, base_name="channel")
 
 router.register(r'contentnode', ContentNodeViewset, base_name='contentnode')
+router.register(r'contentnode_slim', ContentNodeSlimViewset, base_name='contentnode_slim')
 router.register(r'file', FileViewset, base_name='file')
 router.register(r'contentnodeprogress', ContentNodeProgressViewset, base_name='contentnodeprogress')
 router.register(r'contentnode_granular', ContentNodeGranularViewset, base_name='contentnode_granular')

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -160,6 +160,10 @@ class FileThumbnailSerializer(serializers.ModelSerializer):
     storage_url = serializers.SerializerMethodField()
 
     def get_storage_url(self, target_node):
+        # Avoid doing an extra db query if the file is not even a thumbnail
+        if not target_node.thumbnail:
+            return None
+
         return target_node.get_storage_url()
 
     class Meta:

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -366,8 +366,10 @@ class ContentNodeSerializer(serializers.ModelSerializer):
 
     def get_num_coach_contents(self, instance):
         user = self.context["request"].user
+        if not getattr(self, "user_roles_exist", None):
+            self.user_roles_exist = user.roles.exists()
         if user.is_facility_user:  # exclude anon users
-            if user.roles.exists() or user.is_superuser:  # must have coach role or higher
+            if self.user_roles_exist or user.is_superuser:  # must have coach role or higher
                 return get_num_coach_contents(instance)
         # all other conditions return 0
         return 0

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -153,6 +153,10 @@ class FileSerializer(serializers.ModelSerializer):
 
 
 class FileThumbnailSerializer(serializers.ModelSerializer):
+    """
+    Serializer used only in ContentNodeSlimSerializer (at the moment) to return minimum data
+    for frontend to be able to render thumbnails for content browsing
+    """
     storage_url = serializers.SerializerMethodField()
 
     def get_storage_url(self, target_node):
@@ -386,8 +390,11 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         return 0
 
 class ContentNodeSlimSerializer(serializers.ModelSerializer):
+    """
+    Lighter version of the ContentNodeSerializer whose purpose is to provide a minimum
+    subset of ContentNode fields necessary for functional content browsing
+    """
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
-    assessmentmetadata = AssessmentMetaDataSerializer(read_only=True, allow_null=True, many=True)
     files = FileThumbnailSerializer(many=True, read_only=True)
 
     class Meta:
@@ -399,7 +406,6 @@ class ContentNodeSlimSerializer(serializers.ModelSerializer):
             'channel_id',
             'content_id',
             'kind',
-            'assessmentmetadata',
             'files',
             'pk',  # TODO remove after UI standardizes on 'id'
             'title',

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -394,6 +394,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
         # all other conditions return 0
         return 0
 
+
 class ContentNodeSlimSerializer(serializers.ModelSerializer):
     """
     Lighter version of the ContentNodeSerializer whose purpose is to provide a minimum

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -385,9 +385,10 @@ class ContentNodeSerializer(serializers.ModelSerializer):
 
     def get_num_coach_contents(self, instance):
         user = self.context["request"].user
-        if not getattr(self, "user_roles_exist", None):
-            self.user_roles_exist = user.roles.exists()
         if user.is_facility_user:  # exclude anon users
+            # cache the user roles query on the instance
+            if not getattr(self, "user_roles_exist", None):
+                self.user_roles_exist = user.roles.exists()
             if self.user_roles_exist or user.is_superuser:  # must have coach role or higher
                 return get_num_coach_contents(instance)
         # all other conditions return 0

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -152,6 +152,17 @@ class FileSerializer(serializers.ModelSerializer):
                   'supplementary', 'thumbnail', 'download_url')
 
 
+class FileThumbnailSerializer(serializers.ModelSerializer):
+    storage_url = serializers.SerializerMethodField()
+
+    def get_storage_url(self, target_node):
+        return target_node.get_storage_url()
+
+    class Meta:
+        model = File
+        fields = ('storage_url', 'available', 'thumbnail',)
+
+
 class AssessmentMetaDataSerializer(serializers.ModelSerializer):
 
     assessment_item_ids = serializers.JSONField(default='[]')
@@ -373,6 +384,26 @@ class ContentNodeSerializer(serializers.ModelSerializer):
                 return get_num_coach_contents(instance)
         # all other conditions return 0
         return 0
+
+class ContentNodeSlimSerializer(serializers.ModelSerializer):
+    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+    assessmentmetadata = AssessmentMetaDataSerializer(read_only=True, allow_null=True, many=True)
+    files = FileThumbnailSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = ContentNode
+        fields = (
+            'id',
+            'parent',
+            'description',
+            'channel_id',
+            'content_id',
+            'kind',
+            'assessmentmetadata',
+            'files',
+            'pk',  # TODO remove after UI standardizes on 'id'
+            'title',
+        )
 
 
 class ContentNodeGranularSerializer(serializers.ModelSerializer):

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -367,6 +367,31 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(self._reverse_channel_url("contentnode-all-content"))
         self.assertEqual(len(response.data), nodes)
 
+    def test_contentnodeslim_ids(self):
+        titles = ["c2c2", "c2c3"]
+        nodes = [content.ContentNode.objects.get(title=title) for title in titles]
+        response = self.client.get(self._reverse_channel_url("contentnode_slim-list"), data={"ids": ','.join([n.id for n in nodes])})
+        self.assertEqual(len(response.data), 2)
+        for i in range(len(titles)):
+            self.assertEqual(response.data[i]["title"], titles[i])
+
+    def test_contentnodeslim_parent(self):
+        parent = content.ContentNode.objects.get(title="c2")
+        children = parent.get_children()
+        response = self.client.get(self._reverse_channel_url("contentnode_slim-list"), data={"parent": parent.id, "by_role": True})
+        self.assertEqual(len(response.data), children.count())
+        for i in range(len(children)):
+            self.assertEqual(response.data[i]['title'], children[i].title)
+
+    def test_contentnodeslim_ancestors(self):
+        node = content.ContentNode.objects.get(title="c2c2")
+        ancestors = node.get_ancestors()
+        ancestors_titles = {n.title for n in ancestors}
+        response = self.client.get(self._reverse_channel_url("contentnode_slim-ancestors", kwargs={"pk": node.id}))
+        response_titles = {n['title'] for n in response.data}
+        self.assertEqual(len(response.data), ancestors.count())
+        self.assertEqual(ancestors_titles, response_titles)
+
     def test_channelmetadata_list(self):
         response = self.client.get(reverse("channel-list", kwargs={}))
         self.assertEqual(response.data[0]['name'], 'testing')

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -498,7 +498,7 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(len(no_filter_response.data), 2)
         with_filter_response = self.client.get(reverse("channel-list"), {"has_exercise": True})
         self.assertEqual(len(with_filter_response.data), 1)
-        self.assertEqual(no_filter_response.data[0]["name"], "testing")
+        self.assertEqual(with_filter_response.data[0]["name"], "testing")
 
     def test_file_list(self):
         response = self.client.get(self._reverse_channel_url("file-list"))

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -49,15 +49,22 @@ def get_num_coach_contents(contentnode, filter_available=True):
     """
     Given a ContentNode model, return the number of Coach Contents underneath it
     """
-    if contentnode.kind == content_kinds.TOPIC:
-        queryset = contentnode.get_descendants().filter(coach_content=True)
+    if contentnode.coach_content:
+        if contentnode.kind == content_kinds.TOPIC:
+            queryset = contentnode.get_descendants().filter(coach_content=True)
 
-        if filter_available:
-            queryset = queryset.filter(available=True)
+            if filter_available:
+                queryset = queryset.filter(available=True)
 
-        return queryset \
-            .exclude(kind=content_kinds.TOPIC) \
-            .distinct() \
-            .count()
+            return queryset \
+                .exclude(kind=content_kinds.TOPIC) \
+                .distinct() \
+                .count()
+        else:
+            # if the content kind is not a topic but it is marked as coach content the total
+            # coach content count has to be 1 since this is the last node in the tree
+            return 1
     else:
-        return 1 if contentnode.coach_content else 0
+        # if this node is not marked as coach content, then all its descendants cannot be marked
+        # as coach content as well, which is made sure by content annotation at import time
+        return 0

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -1,5 +1,6 @@
 import {
   ContentNodeResource,
+  ContentNodeSlimResource,
   ContentNodeProgressResource,
   UserExamResource,
   ExamLogResource,
@@ -66,7 +67,7 @@ export function updateContentNodeProgress(channelId, contentId, progressFraction
    * to cache bust the model (and hence the entire collection), because some progress was
    * made on this ContentNode.
    */
-  ContentNodeResource.getModel(contentId).set({ progress_fraction: progressFraction });
+  ContentNodeSlimResource.getModel(contentId).set({ progress_fraction: progressFraction });
 }
 
 export function setAndCheckChannels(store) {
@@ -107,7 +108,7 @@ export function showChannels(store) {
         return;
       }
       const channelRootIds = channels.map(channel => channel.root);
-      ContentNodeResource.getCollection({ ids: channelRootIds, by_role: true })
+      ContentNodeSlimResource.getCollection({ ids: channelRootIds, by_role: true })
         .fetch()
         .then(channelCollection => {
           // we want them to be in the same order as the channels list
@@ -146,12 +147,12 @@ export function showTopicsTopic(store, { id, isRoot = false }) {
   store.commit('CORE_SET_PAGE_LOADING', true);
   store.commit('SET_PAGE_NAME', isRoot ? PageNames.TOPICS_CHANNEL : PageNames.TOPICS_TOPIC);
   const promises = [
-    ContentNodeResource.getModel(id).fetch(), // the topic
-    ContentNodeResource.getCollection({
+    ContentNodeSlimResource.getModel(id).fetch(), // the topic
+    ContentNodeSlimResource.getCollection({
       parent: id,
       by_role: true,
     }).fetch(), // the topic's children
-    ContentNodeResource.fetchAncestors(id), // the topic's ancestors
+    ContentNodeSlimResource.fetchAncestors(id), // the topic's ancestors
     store.dispatch('setChannelInfo'),
   ];
 

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -178,17 +178,15 @@ export function showTopicsTopic(store, { id, isRoot = false }) {
       }
       store.commit('SET_PAGE_STATE', pageState);
 
-      // Only load subtopic progress if the user is logged in
+      // Only load contentnode progress if the user is logged in
       if (store.getters.isUserLoggedIn) {
-        const subtopicIds = children
-          .filter(({ kind }) => kind === ContentNodeKinds.TOPIC)
-          .map(({ id }) => id);
+        const contentNodeIds = children.map(({ id }) => id);
 
-        if (subtopicIds.length > 0) {
-          ContentNodeProgressResource.getCollection({ ids: subtopicIds })
+        if (contentNodeIds.length > 0) {
+          ContentNodeProgressResource.getCollection({ ids: contentNodeIds })
             .fetch()
             .then(progresses => {
-              store.commit('SET_TOPIC_PROGRESS', progresses);
+              store.commit('SET_NODE_PROGRESS', progresses);
             });
         }
       }

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -1,4 +1,4 @@
-import { ContentNodeResource } from 'kolibri.resources';
+import { ContentNodeResource, ContentNodeSlimResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import uniqBy from 'lodash/uniqBy';
@@ -7,13 +7,13 @@ import { contentState, setAndCheckChannels } from './main';
 
 // User-agnostic recommendations
 function _getPopular() {
-  return ContentNodeResource.getCollection({ popular: 'true', by_role: true }).fetch();
+  return ContentNodeSlimResource.getCollection({ popular: 'true', by_role: true }).fetch();
 }
 
 // User-specific recommendations
 function _getNextSteps(store) {
   if (store.getters.isUserLoggedIn) {
-    return ContentNodeResource.getCollection({
+    return ContentNodeSlimResource.getCollection({
       next_steps: store.getters.currentUserId,
       by_role: true,
     }).fetch();
@@ -23,7 +23,7 @@ function _getNextSteps(store) {
 
 function _getResume(store) {
   if (store.getters.isUserLoggedIn) {
-    return ContentNodeResource.getCollection({
+    return ContentNodeSlimResource.getCollection({
       resume: store.getters.currentUserId,
       by_role: true,
     }).fetch();

--- a/kolibri/plugins/learn/assets/src/state/actions/recommended.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/recommended.js
@@ -1,6 +1,11 @@
-import { ContentNodeResource, ContentNodeSlimResource } from 'kolibri.resources';
+import {
+  ContentNodeResource,
+  ContentNodeSlimResource,
+  ContentNodeProgressResource,
+} from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
+import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
 import { PageNames } from '../../constants';
 import { contentState, setAndCheckChannels } from './main';
@@ -96,6 +101,21 @@ export function showLearn(store) {
       };
 
       store.commit('SET_PAGE_STATE', pageState);
+
+      // Only load contentnodes progress if the user is logged in
+      if (store.getters.isUserLoggedIn) {
+        const contentNodeIds = uniq([
+          ...nextSteps, ...popular, ...resume
+        ].map(({ id }) => id));
+
+        if (contentNodeIds.length > 0) {
+          ContentNodeProgressResource.getCollection({ ids: contentNodeIds })
+            .fetch()
+            .then(progresses => {
+              store.commit('SET_RECOMMENDED_NODES_PROGRESS', progresses);
+            });
+        }
+      }
 
       store.commit('CORE_SET_PAGE_LOADING', false);
       store.commit('CORE_SET_ERROR', null);

--- a/kolibri/plugins/learn/assets/src/state/mutations/index.js
+++ b/kolibri/plugins/learn/assets/src/state/mutations/index.js
@@ -44,7 +44,7 @@ export default {
     });
   },
   SET_RECOMMENDED_NODES_PROGRESS(state, progressArray) {
-    Object.keys(state.pageState).forEach(function(key) {
+    ['nextSteps', 'popular', 'resume'].forEach(function(key) {
       progressArray.forEach(progress => {
         const contentNode = state.pageState[key].find(node => node.id === progress.pk);
         if (contentNode) {

--- a/kolibri/plugins/learn/assets/src/state/mutations/index.js
+++ b/kolibri/plugins/learn/assets/src/state/mutations/index.js
@@ -43,4 +43,14 @@ export default {
       }
     });
   },
+  SET_RECOMMENDED_NODES_PROGRESS(state, progressArray) {
+    Object.keys(state.pageState).forEach(function(key) {
+      progressArray.forEach(progress => {
+        const contentNode = state.pageState[key].find(node => node.id === progress.pk);
+        if (contentNode) {
+          contentNode.progress = progress.progress_fraction;
+        }
+      });
+    });
+  },
 };

--- a/kolibri/plugins/learn/assets/src/state/mutations/index.js
+++ b/kolibri/plugins/learn/assets/src/state/mutations/index.js
@@ -35,11 +35,11 @@ export default {
   LEARN_SET_MEMBERSHIPS(state, memberships) {
     state.learnAppState.memberships = memberships;
   },
-  SET_TOPIC_PROGRESS(state, progressArray) {
+  SET_NODE_PROGRESS(state, progressArray) {
     progressArray.forEach(progress => {
-      const topic = state.pageState.contents.find(subtopic => subtopic.id === progress.pk);
-      if (topic) {
-        topic.progress = progress.progress_fraction;
+      const contentNode = state.pageState.contents.find(node => node.id === progress.pk);
+      if (contentNode) {
+        contentNode.progress = progress.progress_fraction;
       }
     });
   },


### PR DESCRIPTION
### Summary
Most of the work in this PR is focused on improving the `contentnode` endpoint by splitting it into two endpoints, creating a new, lighter option, `contentnode_slim`, to be used for content browsing.

Additional optimizations have also been added with a goal to increase the content browsing speed, such as:
- ORM prefetching to avoid additional db queries
- caching results to avoid additional db queries
- reducing the number of queries being done to get the number of nodes flagged as `coach_content`
- moved `ContentNode` progress annotation to the frontend (lazy-loaded)

### Graphs

![slim_total_requests](https://user-images.githubusercontent.com/2150991/42650490-cf6d065e-860c-11e8-825e-a301d6567dbe.png)

![slim_requests_per_s](https://user-images.githubusercontent.com/2150991/42650492-d29f7488-860c-11e8-8466-07685f1d1902.png)


### Reviewer guidance
- A couple of tests have been added to test the `contentnode_slim` endpoint, but I'm open to suggestions on how to increase test coverage if necessary
- Check if _Learn_ and _Recommended_ pages are working properly
- Keep in mind that this PR should not remove any of the existing functionalities, but strictly optimize

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
