### PR TITLE
Fix password fields in modals.

### DIFF
--- a/kolibri/core/assets/src/views/core-modal.vue
+++ b/kolibri/core/assets/src/views/core-modal.vue
@@ -131,10 +131,11 @@
         if (!this.$refs.modal) {
           return;
         }
-        if (event.target === this.$refs.modal) {
-          return;
-        }
-        if (this.$refs.modal.contains(event.target.activeElement)) {
+        // addresses https://github.com/learningequality/kolibri/issues/3824
+        if (
+          event.target === this.$refs.modal ||
+          this.$refs.modal.contains(event.target.activeElement)
+        ) {
           return;
         }
         // focus has escaped the modal - put it back!

--- a/kolibri/core/assets/src/views/core-modal.vue
+++ b/kolibri/core/assets/src/views/core-modal.vue
@@ -131,6 +131,12 @@
         if (!this.$refs.modal) {
           return;
         }
+        if (event.target === this.$refs.modal) {
+          return;
+        }
+        if (this.$refs.modal.contains(event.target.activeElement)) {
+          return;
+        }
         // focus has escaped the modal - put it back!
         if (!this.$refs.modal.contains(event.target)) {
           this.focusModal();

--- a/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/user-page/user-create-modal.vue
@@ -292,10 +292,15 @@
         }
       },
       focusOnInvalidField() {
-        this.nameIsInvalid && this.$refs.name.focus();
-        this.usernameIsInvalid && this.$refs.username.focus();
-        this.passwordIsInvalid && this.$refs.password.focus();
-        this.confirmedPasswordIsInvalid && this.$refs.confirmedPassword.focus();
+        if (this.nameIsInvalid) {
+          this.$refs.name.focus();
+        } else if (this.usernameIsInvalid) {
+          this.$refs.username.focus();
+        } else if (this.passwordIsInvalid) {
+          this.$refs.password.focus();
+        } else if (this.confirmedPasswordIsInvalid) {
+          this.$refs.confirmedPassword.focus();
+        }
       },
       close() {
         this.displayModal(false);


### PR DESCRIPTION
### Summary

Fixes #3824 
There is a bug in password inputs in FF. (Try focusing on the password field using FF in [this demo](https://www.w3schools.com/html/tryit.asp?filename=tryhtml_inputpassword), and notice the lag.) After clicking on the input field the focus changes to the HTMLDocument before focusing back on the input field? So I had to adjust the focus event handler. Note that this does not fix the lag that exists when trying to focus on a password input in FF.

I also fixed the focus logic for the create user account modal.

#### Before

![before](https://user-images.githubusercontent.com/7193975/41800844-2d66ec0c-762c-11e8-8a8b-54e34b76f091.gif)

#### After

![after](https://user-images.githubusercontent.com/7193975/41800849-30ffe274-762c-11e8-9bc1-d01e7830bede.gif)

### Reviewer guidance

Test password fields within modals in FF.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
