### PR TITLE
Display metadata in content-page component correctly 

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -95,7 +95,7 @@ export function contentState(data, nextContent, ancestors = []) {
     content_id: data.content_id,
     next_content: nextContent,
     author: data.author,
-    license: data.license_name,
+    license_name: data.license_name,
     license_description: data.license_description,
     license_owner: data.license_owner,
     parent: data.parent,

--- a/kolibri/plugins/learn/assets/src/views/content-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/content-page.vue
@@ -63,14 +63,14 @@
     <p v-html="description" dir="auto" class="ta-l"></p>
 
 
-    <section class="metadata" v-if="showMetadata">
+    <section class="metadata">
       <!-- TODO: RTL - Do not interpolate strings -->
       <p v-if="content.author">
         {{ $tr('author', {author: content.author}) }}
       </p>
 
-      <p v-if="content.license">
-        {{ $tr('license', {license: content.license}) }}
+      <p v-if="content.license_name">
+        {{ $tr('license', {license: content.license_name}) }}
 
         <template v-if="content.license_description">
           <ui-icon-button
@@ -239,10 +239,6 @@
       },
       downloadableFiles() {
         return this.content.files.filter(file => file.preset !== 'Thumbnail');
-      },
-      showMetadata() {
-        // Hide metadata when viewing Resource in a Lesson
-        return this.pageName !== ClassesPageNames.LESSON_RESOURCE_VIEWER;
       },
     },
     beforeDestroy() {


### PR DESCRIPTION
Display metadata in content-page component correctly. #3840 only fixed half the problem.

![localhost_8000_learn_ nexus 7](https://user-images.githubusercontent.com/7193975/41801870-f2335354-7631-11e8-8e82-0285fa9517c5.png)

![localhost_8000_learn_ nexus 7 1](https://user-images.githubusercontent.com/7193975/41801871-f31e9c6a-7631-11e8-905f-541565fa6773.png)

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
