### PR TITLE
Upgrade perseus renderer to core.content compatible API.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.11
-kolibri_exercise_perseus_plugin==0.9.3
+kolibri_exercise_perseus_plugin==1.1.0a1
 jsonfield==2.0.2
 morango==0.3.3
 requests-toolbelt==0.8.0


### PR DESCRIPTION
### Summary
Fix perseus renderer to use `kolibri.core.content`.

https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/release-v1.0.x...develop
