### PR TITLE
Content import was too slow. Now it is less slow.

### DIFF
--- a/kolibri/content/fixtures/content_test.json
+++ b/kolibri/content/fixtures/content_test.json
@@ -313,7 +313,7 @@
       "lang": 3,
       "local_file": "e00699f859624e0f875ac6fe1e13d648",
       "thumbnail": false,
-      "available": true,
+      "available": false,
       "preset": "vector_video",
       "contentnode": "2b6926ed22025518a8b9da91745b51d3",
       "supplementary": false
@@ -326,7 +326,7 @@
       "lang": null,
       "local_file": "4c30dc7619f74f97ae2ccd4fffd09bf2",
       "thumbnail": false,
-      "available": true,
+      "available": false,
       "preset": "low_res_video",
       "contentnode": "2b6926ed22025518a8b9da91745b51d3",
       "supplementary": false
@@ -339,7 +339,7 @@
       "lang": null,
       "local_file": "8ad3fffedf144cba9492e16daec1e39a",
       "thumbnail": false,
-      "available": true,
+      "available": false,
       "preset": "caption",
       "contentnode": "2b6926ed22025518a8b9da91745b51d3",
       "supplementary": true
@@ -368,7 +368,7 @@
   {
     "fields": {
       "file_size": null,
-      "available": true,
+      "available": false,
       "extension": ""
     },
     "pk": "e00699f859624e0f875ac6fe1e13d648",

--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -2,6 +2,7 @@ import logging as logger
 import os
 from time import sleep
 
+import requests
 from django.core.management.base import CommandError
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -128,6 +129,9 @@ class Command(AsyncCommand):
 
         with self.start_progress(total=total_bytes_to_transfer) as overall_progress_update:
 
+            if method == DOWNLOAD_METHOD:
+                session = requests.Session()
+
             for f in files_to_download:
 
                 if self.is_cancelled():
@@ -145,7 +149,7 @@ class Command(AsyncCommand):
                 # determine where we're downloading/copying from, and create appropriate transfer object
                 if method == DOWNLOAD_METHOD:
                     url = paths.get_content_storage_remote_url(filename, baseurl=baseurl)
-                    filetransfer = transfer.FileDownload(url, dest)
+                    filetransfer = transfer.FileDownload(url, dest, session=session)
                 elif method == COPY_METHOD:
                     srcpath = paths.get_content_storage_file_path(filename, datafolder=path)
                     filetransfer = transfer.FileCopy(srcpath, dest)

--- a/kolibri/content/test/test_channel_import.py
+++ b/kolibri/content/test/test_channel_import.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import pickle
+import tempfile
 import uuid
 
 from django.core.management import call_command
@@ -31,6 +32,7 @@ from kolibri.content.utils.channel_import import import_channel_from_local_db
 from kolibri.content.utils.channels import read_channel_metadata_from_db_file
 from kolibri.content.utils.paths import get_content_database_file_path
 from kolibri.content.utils.sqlalchemybridge import get_default_db_string
+
 
 @patch('kolibri.content.utils.channel_import.Bridge')
 @patch('kolibri.content.utils.channel_import.ChannelImport.find_unique_tree_id')
@@ -209,7 +211,6 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock.__table__.columns.items.return_value = [('test_attr', MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
         channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}]*100, 0)
-        channel_import.destination.session.bulk_insert_mappings.assert_has_calls([call(record_mock, [{'test_attr': 'test_val'}]*100)])
         channel_import.destination.session.flush.assert_not_called()
 
     def test_no_merge_records_bulk_insert_flush(self, apps_mock, tree_id_mock, BridgeMock):
@@ -218,7 +219,6 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock.__table__.columns.items.return_value = [('test_attr', MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
         channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}]*10000, 0)
-        channel_import.destination.session.bulk_insert_mappings.assert_has_calls([call(record_mock, [{'test_attr': 'test_val'}]*10000)])
         channel_import.destination.session.flush.assert_called_once_with()
 
     @patch('kolibri.content.utils.channel_import.merge_models', new=[])
@@ -231,6 +231,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         model_mock = MagicMock()
         model_mock._meta.pk.name = 'test_attr'
         merge_models.append(model_mock)
+        channel_import.merge_record = Mock()
         channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}]*100, 0)
         channel_import.destination.session.flush.assert_not_called()
 
@@ -244,6 +245,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         model_mock = Mock()
         model_mock._meta.pk.name = 'test_attr'
         merge_models.append(model_mock)
+        channel_import.merge_record = Mock()
         channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}]*10000, 0)
         channel_import.destination.session.flush.assert_called_once_with()
 
@@ -356,8 +358,11 @@ class ContentImportTestBase(TransactionTestCase):
 
         super(ContentImportTestBase, self).setUp()
 
-    def set_content_fixture(self):
-        self.content_engine = create_engine('sqlite:///:memory:', convert_unicode=True)
+    @patch('kolibri.content.utils.channel_import.get_content_database_file_path')
+    def set_content_fixture(self, db_path_mock):
+        _, self.content_db_path = tempfile.mkstemp(suffix='.sqlite3')
+        db_path_mock.return_value = self.content_db_path
+        self.content_engine = create_engine('sqlite:///' + self.content_db_path, convert_unicode=True)
 
         with open(SCHEMA_PATH_TEMPLATE.format(name=self.schema_name), 'rb') as f:
             metadata = pickle.load(f)

--- a/kolibri/content/test/test_import_export.py
+++ b/kolibri/content/test/test_import_export.py
@@ -5,11 +5,20 @@ from django.core.management import call_command
 from django.test import TestCase
 from mock import call
 from mock import patch
+from requests import Session
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 
 from kolibri.content.models import LocalFile
 from kolibri.utils.tests.helpers import override_option
+
+
+# helper class for mocking that is equal to anything
+def Any(cls):
+    class Any(cls):
+        def __eq__(self, other):
+            return True
+    return Any()
 
 
 @patch('kolibri.content.management.commands.importchannel.channel_import.import_channel_from_local_db')
@@ -108,7 +117,7 @@ class ImportContentTestCase(TestCase):
         # is_cancelled should be called thrice.
         is_cancelled_mock.assert_has_calls([call(), call(), call()])
         # Should be set to the local path we mocked
-        FileDownloadMock.assert_called_with('notest', local_path)
+        FileDownloadMock.assert_called_with('notest', local_path, session=Any(Session))
         # Check that it was cancelled when the command was cancelled, this ensures cleanup
         FileDownloadMock.assert_has_calls([call().cancel()])
         # Check that the command itself was also cancelled.

--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -343,6 +343,12 @@ class ChannelImport(object):
             # Check that the engine being used is sqlite
             can_use_attach = can_use_attach and self.destination.engine.name == "sqlite"
 
+        # if the table is not found in the source DB, we can't use the sqlite ATTACH method
+        try:
+            self.source.get_class(model)
+        except ClassNotFoundError:
+            can_use_attach = False
+
         if can_use_attach:
             return self.raw_attached_sqlite_table_import(model, row_mapper, table_mapper, unflushed_rows)
         else:

--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -340,10 +340,9 @@ class ChannelImport(object):
                         can_use_attach = False
                 else:
                     can_use_attach = False
-            # Check that the engine being used is sqlite
-            can_use_attach = can_use_attach and self.destination.engine.name == "sqlite"
-
-        # if the table is not found in the source DB, we can't use the sqlite ATTACH method
+        # Check that the engine being used is sqlite
+        can_use_attach = can_use_attach and self.destination.engine.name == "sqlite"
+        # Check that the table is in the source database (otherwise we can't use the ATTACH method)
         try:
             self.source.get_class(model)
         except ClassNotFoundError:

--- a/kolibri/content/utils/content_types_tools.py
+++ b/kolibri/content/utils/content_types_tools.py
@@ -1,10 +1,11 @@
 from django.db.models import Q
 from le_utils.constants import content_kinds
 
-from kolibri.content.hooks import ContentRendererHook
+from ..hooks import ContentRendererHook
+from ..models import ContentNode
 
-# Regardless of which renderers are installed, we can render topics!
-renderable_contentnodes_q_filter = Q(kind=content_kinds.TOPIC)
+# Start with an empty queryset, as we'll be using OR to add conditions
+renderable_contentnodes_without_topics_q_filter = ContentNode.objects.none()
 
 # loop through all the registered content renderer hooks
 for hook in ContentRendererHook().registered_hooks:
@@ -12,4 +13,7 @@ for hook in ContentRendererHook().registered_hooks:
         # iterate through each of the content types that each hook can handle
         for extension in obj['extensions']:
             # Extend the q filter by ORing with a q filter for this content kind, and this file extension
-            renderable_contentnodes_q_filter |= Q(kind=obj['name'], files__local_file__extension=extension)
+            renderable_contentnodes_without_topics_q_filter |= Q(kind=obj['name'], files__local_file__extension=extension)
+
+# Regardless of which renderers are installed, we can render topics!
+renderable_contentnodes_q_filter = Q(kind=content_kinds.TOPIC) | renderable_contentnodes_without_topics_q_filter

--- a/kolibri/content/utils/transfer.py
+++ b/kolibri/content/utils/transfer.py
@@ -130,9 +130,6 @@ class FileDownload(Transfer):
 
     def __init__(self, *args, **kwargs):
 
-        # Set block size to None, to always get the largest chunk available from the socket
-        kwargs["block_size"] = None
-
         # allow an existing requests.Session instance to be passed in, so it can be reused for speed
         if "session" in kwargs:
             self.session = kwargs.pop("session")

--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -4,18 +4,21 @@ import os
 import time
 from datetime import datetime
 
-import kolibri
 import requests
 from django.core.management.base import BaseCommand
-from kolibri.core.device.models import DeviceSettings
 from morango.models import InstanceIDModel
-from requests.exceptions import ConnectionError, RequestException, Timeout
+from requests.exceptions import ConnectionError
+from requests.exceptions import RequestException
+from requests.exceptions import Timeout
+
+import kolibri
+from kolibri.core.device.models import DeviceSettings
 
 logging = logger.getLogger(__name__)
 
 DEFAULT_PING_INTERVAL = 24 * 60
 DEFAULT_PING_CHECKRATE = 15
-DEFAULT_PING_SERVER_URL = "http://telemetry.learningequality.org/api/v1/pingback"
+DEFAULT_PING_SERVER_URL = "https://telemetry.learningequality.org/api/v1/pingback"
 
 
 class Command(BaseCommand):

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
@@ -38,8 +38,12 @@ export function downloadChannelMetadata(store) {
       if (taskId && !cancelled) {
         return TaskResource.cancelTask(taskId).then(() => {
           return ChannelResource.getModel(transferredChannel.id).fetch({
-            include_fields:
-              'total_resources,total_file_size,on_device_resources,on_device_file_size',
+            include_fields: [
+              'total_resources',
+              'total_file_size',
+              'on_device_resources',
+              'on_device_file_size',
+            ],
           })._promise;
         });
       }

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
@@ -37,8 +37,10 @@ export function downloadChannelMetadata(store) {
       const { taskId, cancelled } = completedTask;
       if (taskId && !cancelled) {
         return TaskResource.cancelTask(taskId).then(() => {
-          return ChannelResource.getModel(transferredChannel.id).fetch({ file_sizes: true })
-            ._promise;
+          return ChannelResource.getModel(transferredChannel.id).fetch({
+            include_fields:
+              'total_resources,total_file_size,on_device_resources,on_device_file_size',
+          })._promise;
         });
       }
       return Promise.reject({ errorType: ErrorTypes.CHANNEL_TASK_ERROR });

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
@@ -251,7 +251,14 @@ export function showSelectContentPage(store, params) {
   // eslint-disable-next-line
   const installedChannelPromise = ChannelResource.getModel(params.channel_id)
     .fetch(
-      { include_fields: 'total_resources,total_file_size,on_device_resources,on_device_file_size' },
+      {
+        include_fields: [
+          'total_resources',
+          'total_file_size',
+          'on_device_resources',
+          'on_device_file_size',
+        ],
+      },
       true
     )
     .then(channel => {

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
@@ -248,8 +248,12 @@ export function showSelectContentPage(store, params) {
   // HACK if going directly to URL, we make sure channelList has this channel at the minimum.
   // We only get the one channel, since GETing /api/channel with file sizes is slow.
   // We let it fail silently, since it is only used to show "on device" files/resources.
+  // eslint-disable-next-line
   const installedChannelPromise = ChannelResource.getModel(params.channel_id)
-    .fetch({ file_sizes: true }, true)
+    .fetch(
+      { include_fields: 'total_resources,total_file_size,on_device_resources,on_device_file_size' },
+      true
+    )
     .then(channel => {
       if (store.state.pageState.channelList.length === 0) {
         store.dispatch('SET_CHANNEL_LIST', [channel]);

--- a/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
@@ -8,7 +8,7 @@ import { canManageContent } from 'kolibri.coreVue.vuex.getters';
 export function refreshChannelList(store) {
   store.dispatch('SET_CHANNEL_LIST_LOADING', true);
   return ChannelResource.getCollection()
-    .fetch({ file_sizes: true }, true)
+    .fetch({ include_fields: 'on_device_file_size' }, true)
     .then(channels => {
       store.dispatch('SET_CHANNEL_LIST', [...channels]);
       store.dispatch('SET_CHANNEL_LIST_LOADING', false);

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -64,7 +64,7 @@ option_spec = {
     "Urls": {
         "CENTRAL_CONTENT_BASE_URL": {
             "type": "string",
-            "default": "http://studio.learningequality.org",
+            "default": "https://studio.learningequality.org",
             "envvars": ("KOLIBRI_CENTRAL_CONTENT_BASE_URL", "CENTRAL_CONTENT_DOWNLOAD_BASE_URL",),
         },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Speeds up the following operations:
- Loading the content page (the list of existing channels): 6x SPEEDUP
- Importing channel metadata ("preparing channel listing"): 10x SPEEDUP
- Importing the content itself (downloading content files): 23x SPEEDUP

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test the process of importing new channels and content, and compare speeds between doing so with the current 0.10 branch and this code. Will be especially noticeable with large channels like Khan Academy (English).

Most commits are logical units (with meaningful names), so that may be a good way to review it.

Note: need to resolve some issues (related to old DBs) raised by tests, will take a look with @rtibbles tomorrow.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

```
Channel listing page for import (with several channels loaded):

    Before:
        Calculating all 4 values: 12s <- what we currently do on channel list page
        Calculating size on disk: 3.5s

    After:
        Calculating all 4 values: 7s
        Calculating size on disk: 2s <- what we do now on the channel list page

=============================

Old Metadata Import  <- what we did before
-------------------
Khan Academy: 2m44s
Engage NY: 18.5s

New Metadata Import  <- what we do now
-------------------
Khan Academy: 20s (8x speedup)
Engage NY: 1.5s (12x speedup)

=============================

Downloading Channel over HTTP
-----------------------------
3m45s, 4m3s, 2m54s, 4m42s, 5m41s
Average: 253s (slowdown due to 301 redirects)  <- what we did before
(When done through UI: 199s)

Downloading Channel over HTTPS
------------------------------
2m12s, 2m5s, 1m0s, 1m46s, 1m45s
Average: 106s (2.4x speedup)
(When done through UI: 117s)

Downloading Channel over HTTPS with Shared Session
--------------------------------------------------
12s, 10s, 10s, 11s, 11s
Average: 11s (23x speedup)  <- what we do now
(When done through UI: 12s)
```


### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
