### PR TITLE
Handle when String::localeCompare extended arguments are not supported (IE, Edge)

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -228,3 +228,13 @@ export function setUpIntl() {
     }
   });
 }
+
+export function localeCompare(str1, str2) {
+  // Catch if browser does not support extended localeCompare arguments
+  try {
+    // use 'search' option to ignore case rather than use locale defaults
+    return String(str1).localeCompare(String(str2), 'default', { usage: 'search' });
+  } catch (e) {
+    return String(str1).localeCompare(String(str2));
+  }
+}

--- a/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
+++ b/kolibri/plugins/coach/assets/src/state/getters/reportUtils.js
@@ -1,4 +1,5 @@
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+import { localeCompare } from 'kolibri.utils.i18n';
 import { TableColumns, SortOrders } from '../../constants/reportConstants';
 
 /* given an array of objects sum the keys on those that pass the filter */
@@ -52,10 +53,6 @@ export function genCompareFunc(sortColumn, sortOrder) {
       return flipped(-1);
     }
     // standard comparisons
-    return flipped(
-      String(a[key]).localeCompare(String(b[key]), 'default', {
-        usage: 'search',
-      })
-    );
+    return localeCompare(a[key], b[key]);
   };
 }

--- a/kolibri/plugins/device_management/assets/src/userSearchUtils.js
+++ b/kolibri/plugins/device_management/assets/src/userSearchUtils.js
@@ -1,3 +1,5 @@
+import { localeCompare } from 'kolibri.utils.i18n';
+
 export function userMatchesFilter(user, searchFilter) {
   const searchTerms = searchFilter.split(/\s+/).map(val => val.toLowerCase());
   const fullName = user.full_name.toLowerCase();
@@ -6,12 +8,7 @@ export function userMatchesFilter(user, searchFilter) {
 }
 
 export function filterAndSortUsers(users, pred, sortByKey = 'username') {
-  return users.filter(pred).sort(
-    // use 'search' option to ignore case rather than use locale defaults
-    (a, b) => {
-      return String(a[sortByKey]).localeCompare(String(b[sortByKey]), 'default', {
-        usage: 'search',
-      });
-    }
-  );
+  return users.filter(pred).sort((a, b) => {
+    return localeCompare(a[sortByKey], b[sortByKey]);
+  });
 }

--- a/kolibri/plugins/facility_management/assets/src/userSearchUtils.js
+++ b/kolibri/plugins/facility_management/assets/src/userSearchUtils.js
@@ -1,3 +1,5 @@
+import { localeCompare } from 'kolibri.utils.i18n';
+
 export function userMatchesFilter(user, searchFilter) {
   const searchTerms = searchFilter.split(/\s+/).map(val => val.toLowerCase());
   const fullName = user.full_name.toLowerCase();
@@ -9,9 +11,7 @@ export function filterAndSortUsers(users, pred = () => true, sortByKey = 'full_n
   return users.filter(pred).sort(
     // use 'search' option to ignore case rather than use locale defaults
     (a, b) => {
-      return String(a[sortByKey]).localeCompare(String(b[sortByKey]), 'default', {
-        usage: 'search',
-      });
+      return localeCompare(a[sortByKey], b[sortByKey]);
     }
   );
 }


### PR DESCRIPTION
### Summary

Replaces instances of `String.prototype.localeCompare(str2, locale, options)` with a utility `localeCompare` that tries to gracefully handle cases when the browser does not support `locale` or `option` args.


Fixes #3804 

### Reviewer guidance

In IE11 and Microsoft Edge and other browsers, go to the pages mentioned in https://github.com/learningequality/kolibri/issues/3804#issuecomment-400030208

and make sure things still work.

### References

#3804 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#Check_browser_support_for_extended_arguments

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
