### PR TITLE
Add multiPaneLayout

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -88,6 +88,7 @@ import textTruncator from '../views/text-truncator';
 import kLinearLoader from '../views/k-linear-loader';
 import kCircularLoader from '../views/k-circular-loader';
 
+import multiPaneLayout from '../views/multi-pane-layout';
 import * as client from './client';
 import urls from './urls';
 
@@ -156,6 +157,7 @@ export default {
       textTruncator,
       kLinearLoader,
       kCircularLoader,
+      multiPaneLayout,
     },
     router,
     mixins: {

--- a/kolibri/core/assets/src/views/attempt-log-list.vue
+++ b/kolibri/core/assets/src/views/attempt-log-list.vue
@@ -97,6 +97,9 @@
 
   @require '~kolibri.styles.definitions'
 
+  .attempt-log-list
+    background-color: $core-bg-light
+
   .title
     display: inline-block
 

--- a/kolibri/core/assets/src/views/exam-report/index.vue
+++ b/kolibri/core/assets/src/views/exam-report/index.vue
@@ -1,56 +1,52 @@
 <template>
 
-  <div>
-    <div class="summary-container">
-      <page-status
-        :contentName="exam.title"
-        :userName="userName"
-        :questions="examAttempts"
-        :completionTimestamp="completionTimestamp"
-        :completed="closed"
+  <multi-pane-layout ref="multiPaneLayout">
+    <page-status
+      slot="header"
+      :contentName="exam.title"
+      :userName="userName"
+      :questions="examAttempts"
+      :completionTimestamp="completionTimestamp"
+      :completed="closed"
+    />
+
+    <attempt-log-list
+      slot="aside"
+      :attemptLogs="attemptLogs"
+      :selectedQuestionNumber="questionNumber"
+      @select="handleNavigateToQuestion"
+    />
+
+    <div slot="main" class="exercise-container">
+      <h3>{{ $tr('question', {questionNumber: questionNumber + 1}) }}</h3>
+
+      <k-checkbox
+        :label="$tr('showCorrectAnswerLabel')"
+        :checked="showCorrectAnswer"
+        @change="toggleShowCorrectAnswer"
+      />
+      <interaction-list
+        v-if="!showCorrectAnswer"
+        :interactions="currentInteractionHistory"
+        :selectedInteractionIndex="selectedInteractionIndex"
+        @select="navigateToQuestionAttempt"
+      />
+      <content-renderer
+        :id="exercise.pk"
+        :itemId="itemId"
+        :allowHints="false"
+        :kind="exercise.kind"
+        :files="exercise.files"
+        :contentId="exercise.content_id"
+        :available="exercise.available"
+        :extraFields="exercise.extra_fields"
+        :interactive="false"
+        :assessment="true"
+        :answerState="currentInteraction"
+        :showCorrectAnswer="showCorrectAnswer"
       />
     </div>
-    <div class="details-container">
-      <div class="attempt-log-container">
-        <attempt-log-list
-          :attemptLogs="attemptLogs"
-          :selectedQuestionNumber="questionNumber"
-          @select="handleNavigateToQuestion"
-        />
-      </div>
-      <div class="exercise-container" ref ="exerciseContainer">
-        <h3>{{ $tr('question', {questionNumber: questionNumber + 1}) }}</h3>
-
-        <k-checkbox
-          :label="$tr('showCorrectAnswerLabel')"
-          :checked="showCorrectAnswer"
-          @change="toggleShowCorrectAnswer"
-        />
-        <interaction-list
-          v-if="!showCorrectAnswer"
-          :interactions="currentInteractionHistory"
-          :attemptNumber="currentAttempt.questionNumber"
-          :selectedInteractionIndex="selectedInteractionIndex"
-          @select="navigateToQuestionAttempt"
-        />
-
-        <content-renderer
-          :id="exercise.pk"
-          :itemId="itemId"
-          :allowHints="false"
-          :kind="exercise.kind"
-          :files="exercise.files"
-          :contentId="exercise.content_id"
-          :available="exercise.available"
-          :extraFields="exercise.extra_fields"
-          :interactive="false"
-          :assessment="true"
-          :answerState="currentInteraction && !showCorrectAnswer ? currentInteraction.answer : null"
-          :showCorrectAnswer="showCorrectAnswer"
-        />
-      </div>
-    </div>
-  </div>
+  </multi-pane-layout>
 
 </template>
 
@@ -64,6 +60,7 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import find from 'lodash/find';
+  import multiPaneLayout from 'kolibri.coreVue.components.multiPaneLayout';
   import pageStatus from './page-status';
 
   export default {
@@ -84,6 +81,7 @@
       interactionList,
       kButton,
       kCheckbox,
+      multiPaneLayout,
     },
     props: {
       examAttempts: {
@@ -171,7 +169,7 @@
     methods: {
       handleNavigateToQuestion(questionNumber) {
         this.navigateToQuestion(questionNumber);
-        this.$refs.exerciseContainer.scrollTop = 0;
+        this.$refs.multiPaneLayout.scrollMainToTop();
         this.showCorrectAnswer = false;
       },
       toggleShowCorrectAnswer() {
@@ -194,32 +192,11 @@
 
   @require '~kolibri.styles.definitions'
 
-  $container-side-padding = 16px
-  $max-height = calc(100vh - 290px)
-
-  .summary-container
-    height: 15%
-
-  .details-container
-    width: 100%
-    height: 85%
-    padding-top: $container-side-padding
-    clearfix()
-
-  .attempt-log-container
-    width: 30%
-    height: 100%
-    max-height: $max-height
-    overflow-y: auto
-    float: left
-
   .exercise-container
-    width: 70%
-    height: 100%
-    max-height: $max-height
-    padding-left: $container-side-padding
-    padding-right: $container-side-padding
-    float: left
-    overflow: auto
+    background-color: $core-bg-light
+    padding: 8px
+
+  h3
+    margin-top: 0
 
 </style>

--- a/kolibri/core/assets/src/views/exam-report/page-status.vue
+++ b/kolibri/core/assets/src/views/exam-report/page-status.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div class="page-status">
-    <div class="column pure-u-3-4">
+    <div class="pure-u-3-4">
       <div class="user-name-container">
         <mat-svg
           class="svg-item"
@@ -17,7 +17,7 @@
         {{ $tr('questionsCorrect', { correct: questionsCorrect, total: questions.length }) }}
       </div>
     </div>
-    <div class="column pure-u-1-4">
+    <div class="pure-u-1-4">
       <div class="inner-column">
         <progress-icon class="svg-icon" :progress="progress" />
         <span v-if="completed">
@@ -94,7 +94,7 @@
   @require '~kolibri.styles.definitions'
 
   .page-status
-    height: 130px
+    background-color: $core-bg-light
 
   .user-name-container
     display: block
@@ -113,9 +113,6 @@
     display: inline-block
     vertical-align: middle
     margin: 0
-
-  .column
-    float: left
 
   .inner-column
     float: right

--- a/kolibri/core/assets/src/views/immersive-full-screen.vue
+++ b/kolibri/core/assets/src/views/immersive-full-screen.vue
@@ -12,8 +12,13 @@
         <p class="back">{{ backPageText }}</p>
       </router-link>
     </div>
-    <div class="page-body">
-      <slot></slot>
+    <div class="wrapper">
+      <div
+        class="page-body"
+        :style="{ padding: windowSize.breakpoint < 2 ? '16px' : '32px' }"
+      >
+        <slot></slot>
+      </div>
     </div>
   </div>
 
@@ -23,9 +28,11 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
 
   export default {
     name: 'immersiveFullScreen',
+    mixins: [responsiveWindow],
     props: {
       backPageLink: {
         type: Object,
@@ -81,12 +88,15 @@
     margin: 0
 
   .page-body
-    width: 100%
+    max-width: 1000px
+    margin: auto
+
+  .wrapper
     position: absolute
-    margin-top:60px
-    top: 0
+    top: 60px
+    right: 0
     bottom: 0
+    left: 0
     overflow-y: auto
-    background-color: $core-bg-light
 
 </style>

--- a/kolibri/core/assets/src/views/interaction-list/index.vue
+++ b/kolibri/core/assets/src/views/interaction-list/index.vue
@@ -3,7 +3,6 @@
   <div class="interaction-list">
     <!--TODO-->
     <template v-if="interactions.length">
-      <h4 class="header">{{ $tr('questionHeader', {questionNumber: attemptNumber }) }}</h4>
       <p>{{ $tr('currAnswer', {ordinal: selectedInteractionIndex + 1 }) }}</p>
     </template>
 
@@ -35,7 +34,6 @@
     mixins: [responsiveElement],
     $trs: {
       currAnswer: '{ordinal, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} answer',
-      questionHeader: 'Question {questionNumber, number} attempts',
       noInteractions: 'No attempts made on this question',
     },
     props: {
@@ -44,10 +42,6 @@
         required: true,
       },
       selectedInteractionIndex: {
-        type: Number,
-        required: true,
-      },
-      attemptNumber: {
         type: Number,
         required: true,
       },

--- a/kolibri/core/assets/src/views/multi-pane-layout.vue
+++ b/kolibri/core/assets/src/views/multi-pane-layout.vue
@@ -44,35 +44,12 @@
 
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
-  import debounce from 'lodash/debounce';
 
   export default {
     name: 'multiPaneLayout',
     mixins: [responsiveWindow, responsiveElement],
-    data() {
-      return {
-        maxHeight: null,
-      };
-    },
-    watch: {
-      windowSize: {
-        handler() {
-          this.updateMaxHeight();
-        },
-        deep: true,
-      },
-      elSize: {
-        handler() {
-          this.updateMaxHeight();
-        },
-        deep: true,
-      },
-    },
-    methods: {
-      scrollMainToTop() {
-        this.$refs.main.scrollTop = 0;
-      },
-      updateMaxHeight: debounce(function() {
+    computed: {
+      maxHeight() {
         const APP_BAR_HEIGHT = this.windowSize.breakpoint < 2 ? 56 : 64;
         const PADDING = this.windowSize.breakpoint < 2 ? 16 : 32;
         const MARGIN = 16;
@@ -83,8 +60,13 @@
         if (this.$refs.footer) {
           maxHeight = maxHeight - this.$refs.footer.clientHeight;
         }
-        this.maxHeight = maxHeight;
-      }, 100),
+        return maxHeight;
+      },
+    },
+    methods: {
+      scrollMainToTop() {
+        this.$refs.main.scrollTop = 0;
+      },
     },
   };
 

--- a/kolibri/core/assets/src/views/multi-pane-layout.vue
+++ b/kolibri/core/assets/src/views/multi-pane-layout.vue
@@ -1,0 +1,115 @@
+<template>
+
+  <div>
+    <header
+      v-if="$slots.header"
+      ref="header"
+      class="header"
+    >
+      <slot name="header"></slot>
+    </header>
+
+    <div>
+      <aside
+        v-if="$slots.aside"
+        class="aside"
+        :style="{ maxHeight: `${maxHeight}px` }"
+      >
+        <slot name="aside"></slot>
+      </aside>
+
+      <main
+        ref="main"
+        class="main"
+        :class="{'main-with-aside': $slots.aside }"
+        :style="{ maxHeight: $slots.aside ? `${maxHeight}px` : '' }"
+      >
+        <slot name="main"></slot>
+      </main>
+
+    </div>
+    <footer
+      v-if="$slots.footer"
+      class="footer"
+      ref="footer"
+    >
+      <slot name="footer"></slot>
+    </footer>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
+  import debounce from 'lodash/debounce';
+
+  export default {
+    name: 'multiPaneLayout',
+    mixins: [responsiveWindow, responsiveElement],
+    data() {
+      return {
+        maxHeight: null,
+      };
+    },
+    watch: {
+      windowSize: {
+        handler() {
+          this.updateMaxHeight();
+        },
+        deep: true,
+      },
+      elSize: {
+        handler() {
+          this.updateMaxHeight();
+        },
+        deep: true,
+      },
+    },
+    methods: {
+      scrollMainToTop() {
+        this.$refs.main.scrollTop = 0;
+      },
+      updateMaxHeight: debounce(function() {
+        const APP_BAR_HEIGHT = this.windowSize.breakpoint < 2 ? 56 : 64;
+        const PADDING = this.windowSize.breakpoint < 2 ? 16 : 32;
+        const MARGIN = 16;
+        let maxHeight = this.windowSize.height - APP_BAR_HEIGHT - PADDING * 2 - MARGIN;
+        if (this.$refs.header) {
+          maxHeight = maxHeight - this.$refs.header.clientHeight;
+        }
+        if (this.$refs.footer) {
+          maxHeight = maxHeight - this.$refs.footer.clientHeight;
+        }
+        this.maxHeight = maxHeight;
+      }, 100),
+    },
+  };
+
+</script>
+
+
+<style scoped lang="stylus">
+
+  .header
+    margin-bottom: 8px
+
+  .aside, .main
+    overflow-y: auto
+
+  .aside
+    display: inline-block
+    width: 25%
+    margin-right: 8px
+
+  .main-with-aside
+    display: inline-block
+    width: calc(75% - 8px)
+    vertical-align: top
+
+  .footer
+    margin-top: 8px
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/ContentArea.vue
@@ -1,15 +1,11 @@
 <template>
 
-  <section
-    class="content-area"
-    :class="{perseus: isPerseusExercise}"
-  >
+  <section :class="{padding: isPerseusExercise}">
     <h2 v-if="isPerseusExercise" class="header">
       {{ header }}
     </h2>
     <content-renderer
-      class="content"
-      :class="{perseus: isPerseusExercise}"
+      :class="{ hof: isPerseusExercise}"
       :showCorrectAnswer="true"
       :id="content.pk"
       :itemId="selectedQuestion"
@@ -69,19 +65,11 @@
 
 <style scoped lang="stylus">
 
-  $perseus-padding = 15px
-  $header-height = 56px // dupe from question-list
+  .padding
+    padding-left: 8px // give same margin as question-list (16px)
 
-  .content-area
-    padding: 0
-    &.perseus
-      padding-left: 1px // give same margin as question-list (16px)
-
-  .content
-    // NOTE stylus exclusive. Variable/calc interpolation
-    &.perseus
-      max-height: 'calc(100% - %s)' % $header-height
-      overflow-x: hidden // .solutionarea's negative margin oversteps
+  .hof
+    overflow-x: hidden // .solutionarea's negative margin oversteps
 
   .header
     margin: 0

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/MetadataArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/MetadataArea.vue
@@ -2,7 +2,7 @@
 
   <!-- TODO if not breaking up into child components, use single .vue file -->
 
-  <div class="description-area">
+  <div>
     <!-- IDEA -a11y- add an invisible title entry in the dl below? -->
     <!-- h1's are technically not allowed within a dl -->
     <h1 class="header primary-data">
@@ -142,10 +142,6 @@
 
   $standard-data-spacing = 8px
 
-  .description-area
-    // safeguard against margin collapsing
-    overflow: auto
-
   .header
     margin-top: 0
     font-size: 28px // bumping half an increment
@@ -169,8 +165,8 @@
     &:not(.description)
       margin-left: 8px
 
-  .top-line
-    display: table
-    width: 100%
+  .description
+    >>>p
+      margin: 0
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/QuestionList.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/QuestionList.vue
@@ -68,12 +68,9 @@
 
   $item-content-height = 56px
   $item-division-height = 2px
-  $item-height = ($item-content-height + $item-division-height)
 
   .question-list
     background-color: white
-    // position: relative
-    padding: 0
 
   .header, .list, .item, .button
     display: block
@@ -83,9 +80,6 @@
 
   .list
     list-style: none
-    // NOTE stylus specific - calc + variable interpolation
-    max-height: 'calc(100% - %s)' % $item-height
-    overflow-y: auto
 
   // normalize styles for the 2
   .button, .header

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -1,23 +1,25 @@
 <template>
 
-  <div class="content-preview-page">
-    <metadata-area
-      class="top"
-      :class="{left: workingResources}"
-      :content="content"
-      :completionData="completionData"
-    />
-    <select-options
-      v-if="workingResources"
-      class="select-options"
-      :workingResources="workingResources"
-      :contentId="content.pk"
-      @addresource="addToCache"
-    />
+  <multi-pane-layout>
+    <template slot="header">
+      <metadata-area
+        class="ib"
+        :class="{left: workingResources}"
+        :content="content"
+        :completionData="completionData"
+      />
+      <select-options
+        v-if="workingResources"
+        class="select-options ib"
+        :workingResources="workingResources"
+        :contentId="content.pk"
+        @addresource="addToCache"
+      />
+    </template>
 
     <question-list
+      slot="aside"
       v-if="isPerseusExercise"
-      class="question-list bottom left"
       @select="selectedQuestionIndex = $event"
       :questions="questions"
       :questionLabel="questionLabel"
@@ -25,14 +27,13 @@
     />
 
     <content-area
-      class="content-area bottom"
-      :class="{right: isPerseusExercise}"
+      slot="main"
       :header="questionLabel(selectedQuestionIndex)"
       :selectedQuestion="selectedQuestion"
       :content="content"
       :isPerseusExercise="isPerseusExercise"
     />
-  </div>
+  </multi-pane-layout>
 
 </template>
 
@@ -40,6 +41,7 @@
 <script>
 
   import kButton from 'kolibri.coreVue.components.kButton';
+  import multiPaneLayout from 'kolibri.coreVue.components.multiPaneLayout';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
   import MetadataArea from './MetadataArea';
@@ -53,6 +55,7 @@
       MetadataArea,
       SelectOptions,
       kButton,
+      multiPaneLayout,
     },
     $trs: {
       questionLabel: 'Question { questionNumber, number }',
@@ -102,41 +105,15 @@
 
 <style lang="stylus" scoped>
 
-  $vertical-split = 30%
-  $horizontal-split = 25%
-
-  .content-preview-page
-    height: 100% // establish containing-blocks' height
-    position: relative // set the context for absolute elements within
-
   .select-options
-    max-width: 20%
-    position: absolute
-    // NOTE stylus specific - calc + variable interpolation
-    bottom: 'calc(100% - %s)' % 28px // should line up with header
-    margin-bottom: 0
-    right: 0
+    width: 20%
+    text-align: right
+    vertical-align: top
 
+  .ib
+    display: inline-block
 
-  .top
-    height: $horizontal-split
-    &.left
-      max-width: 80%
-
-  // went with this approach because of noscroll page. Not great on mobile
-  // might want to explore doing this with pure (original plan)
-  .bottom
-    position: absolute
-    bottom: 0
-    top: $horizontal-split
-    background-color: white
-    left: 0
-    right: 0
-
-    &.left
-      right: 100% - $vertical-split
-    &.right
-      margin-left: 8px
-      left: $vertical-split
+  .left
+    width: 80%
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/attempt-summary.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div class="attempt-summary">
-    <div class="column pure-u-3-4">
+    <div class="pure-u-3-4">
       <div class="summary-item">
         <div class="icon">
           <mat-svg
@@ -44,7 +44,7 @@
 
     </div>
 
-    <div class="column pure-u-1-4">
+    <div class="pure-u-1-4">
       <div class="status">
         <div class="status-text">
           <progress-icon
@@ -198,11 +198,7 @@
     display: inline-block
     vertical-align: middle
 
-  .column
-    float: left
-
   .status
-    float: right
     text-align: right
 
   .icon

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/index.vue
@@ -79,28 +79,4 @@
 </script>
 
 
-<style lang="stylus" scoped>
-
-  @require '~kolibri.styles.definitions'
-
-  $container-side-padding = 15px
-
-  .details-container
-    width: 100%
-    height: 85%
-    padding-top: $container-side-padding
-    clearfix()
-
-  .attempt-log-container
-    width: 30%
-    height: 100%
-    overflow-y: auto
-    float: left
-
-  .exercise-container
-    width: 70%
-    height: 100%
-    padding: $containerSidePadding
-    float: left
-
-</style>
+<style lang="stylus" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/learner-exercise-detail-page/learner-exercise-report.vue
@@ -1,50 +1,50 @@
 <template>
 
-  <div class="learner-exercise-report">
-    <div class="pure-u-1-1">
-      <attempt-summary
-        :exerciseTitle="exercise.title"
-        :userName="user.full_name"
+  <multi-pane-layout ref="multiPaneLayout">
+    <attempt-summary
+      slot="header"
+      :exerciseTitle="exercise.title"
+      :userName="user.full_name"
+      :kind="exercise.kind"
+      :summaryLog="summaryLog"
+    />
+    <attempt-log-list
+      slot="aside"
+      :attemptLogs="attemptLogs"
+      :selectedQuestionNumber="attemptLogIndex"
+      @select="navigateToNewAttempt($event)"
+    />
+    <div slot="main" class="exercise-section">
+      <h3>{{ $tr('question', {questionNumber: currentAttemptLog.questionNumber}) }}</h3>
+      <k-checkbox
+        :label="$tr('showCorrectAnswerLabel')"
+        :checked="showCorrectAnswer"
+        @change="toggleShowCorrectAnswer"
+      />
+      <interaction-list
+        v-if="!showCorrectAnswer"
+        :interactions="currentInteractionHistory"
+        :selectedInteractionIndex="interactionIndex"
+        @select="navigateToNewInteraction($event)"
+      />
+      <content-renderer
+        v-if="currentInteraction"
+        :id="exercise.pk"
+        :itemId="currentAttemptLog.item"
+        :assessment="true"
+        :allowHints="false"
         :kind="exercise.kind"
-        :summaryLog="summaryLog"
+        :files="exercise.files"
+        :contentId="exercise.content_id"
+        :channelId="channelId"
+        :available="exercise.available"
+        :answerState="currentInteraction"
+        :showCorrectAnswer="showCorrectAnswer"
+        :interactive="false"
+        :extraFields="exercise.extra_fields"
       />
     </div>
-    <div class="details-container">
-      <div class="attempt-log-container pure-u-1-3">
-        <attempt-log-list
-          v-if="isExercise"
-          :attemptLogs="attemptLogs"
-          :selectedQuestionNumber="attemptLogIndex"
-          @select="navigateToNewAttempt($event)"
-        />
-      </div>
-      <div class="exercise-container pure-u-2-3">
-        <interaction-list
-          v-if="isExercise"
-          :interactions="currentInteractionHistory"
-          :selectedInteractionIndex="interactionIndex"
-          :attemptNumber="currentAttemptLog.questionNumber || 0"
-          @select="navigateToNewInteraction($event)"
-        />
-
-        <content-renderer
-          v-if="currentInteraction"
-          :id="exercise.pk"
-          :itemId="currentAttemptLog.item"
-          :assessment="true"
-          :allowHints="false"
-          :kind="exercise.kind"
-          :files="exercise.files"
-          :contentId="exercise.content_id"
-          :channelId="channelId"
-          :available="exercise.available"
-          :answerState="currentInteraction.answer"
-          :interactive="false"
-          :extraFields="exercise.extra_fields"
-        />
-      </div>
-    </div>
-  </div>
+  </multi-pane-layout>
 
 </template>
 
@@ -52,27 +52,35 @@
 <script>
 
   import contentRenderer from 'kolibri.coreVue.components.contentRenderer';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import attemptLogList from 'kolibri.coreVue.components.attemptLogList';
   import interactionList from 'kolibri.coreVue.components.interactionList';
+  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
+  import multiPaneLayout from 'kolibri.coreVue.components.multiPaneLayout';
   import attemptSummary from './attempt-summary';
 
   export default {
     name: 'learnerExerciseReport',
-    $trs: { backPrompt: 'Back to { backTitle }' },
+    $trs: {
+      backPrompt: 'Back to { backTitle }',
+      showCorrectAnswerLabel: 'Show correct answer',
+      question: 'Question { questionNumber, number }',
+    },
     components: {
       contentRenderer,
       attemptSummary,
       attemptLogList,
       interactionList,
+      kCheckbox,
+      multiPaneLayout,
     },
-    computed: {
-      isExercise() {
-        return this.exercise.kind === ContentNodeKinds.EXERCISE;
-      },
+    data() {
+      return {
+        showCorrectAnswer: false,
+      };
     },
     methods: {
       navigateToNewAttempt(attemptLogIndex) {
+        this.showCorrectAnswer = false;
         this.$router.push({
           name: this.pageName,
           params: {
@@ -83,6 +91,7 @@
             attemptLogIndex,
           },
         });
+        this.$refs.multiPaneLayout.scrollMainToTop();
       },
       navigateToNewInteraction(interactionIndex) {
         this.$router.push({
@@ -95,6 +104,10 @@
             interactionIndex,
           },
         });
+      },
+      toggleShowCorrectAnswer() {
+        this.showCorrectAnswer = !this.showCorrectAnswer;
+        this.$forceUpdate();
       },
     },
     vuex: {
@@ -126,24 +139,10 @@
 
   @require '~kolibri.styles.definitions'
 
-  $container-side-padding = 15px
-
-  .details-container
-    width: 100%
-    height: 85%
-    padding-top: $container-side-padding
-    clearfix()
-
-  .attempt-log-container
-    width: 30%
-    height: 100%
-    overflow-y: auto
-    float: left
-
-  .exercise-container
-    width: 70%
-    height: 100%
-    padding: $containerSidePadding
-    float: left
+  .exercise-section
+    background-color: $core-bg-light
+    padding: 16px
+    h3
+      margin-top: 0
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/manage-permissions-page/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <subpage-container>
+  <subpage-container :withSideMargin="false">
 
     <auth-message v-if="!isSuperuser" authorizedRole="superuser" />
 

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -78,6 +78,7 @@
     text-align: center
     height: 500px
     overflow-x: auto
+    overflow-y: hidden
 
   .iframe
     height: 100%

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -251,7 +251,7 @@
     max-width: 400px
     text-align: right
     button
-      margin: 0
+      margin: 0 0 0 8px
 
   .exam-icon
     position: relative

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -5,67 +5,68 @@
     :backPageLink="backPageLink"
     :backPageText="$tr('backToExamList')"
   >
-    <template>
-      <div class="container">
-        <div class="exam-status-container">
-          <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment_late" />
-          <h1 class="exam-title">{{ exam.title }}</h1>
-          <div class="exam-status">
-            <p class="questions-answered">
-              {{
-                $tr(
-                  'questionsAnswered',
-                  { numAnswered: questionsAnswered, numTotal: exam.question_count }
-                )
-              }}
-            </p>
-            <k-button @click="toggleModal" :text="$tr('submitExam')" :primary="true" />
-          </div>
+    <multi-pane-layout ref="multiPaneLayout">
+      <div class="exam-status-container" slot="header">
+        <mat-svg class="exam-icon" slot="content-icon" category="action" name="assignment_late" />
+        <h1 class="exam-title">{{ exam.title }}</h1>
+        <div class="exam-status">
+          <p class="questions-answered">
+            {{
+              $tr(
+                'questionsAnswered',
+                { numAnswered: questionsAnswered, numTotal: exam.question_count }
+              )
+            }}
+          </p>
+          <k-button @click="toggleModal" :text="$tr('submitExam')" :primary="true" />
         </div>
-        <div class="question-container">
-          <div class="outer-container">
-            <div class="answer-history-container column">
-              <answer-history
-                :questionNumber="questionNumber"
-                @goToQuestion="goToQuestion"
-              />
-            </div>
-            <div class="exercise-container column">
-              <content-renderer
-                ref="contentRenderer"
-                v-if="itemId"
-                :id="content.id"
-                :kind="content.kind"
-                :files="content.files"
-                :contentId="content.content_id"
-                :channelId="channelId"
-                :available="content.available"
-                :extraFields="content.extra_fields"
-                :itemId="itemId"
-                :assessment="true"
-                :allowHints="false"
-                :answerState="currentAttempt.answer"
-                @interaction="throttledSaveAnswer"
-              />
-              <ui-alert v-else :dismissible="false" type="error">
-                {{ $tr('noItemId') }}
-              </ui-alert>
-              <div class="question-navbutton-container">
-                <k-button
-                  :disabled="questionNumber===0"
-                  @click="goToQuestion(questionNumber - 1)"
-                  :text="$tr('previousQuestion')"
-                />
-                <k-button
-                  :disabled="questionNumber===exam.question_count-1"
-                  @click="goToQuestion(questionNumber + 1)"
-                  :text="$tr('nextQuestion')"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
+        <div style="clear: both;"></div>
       </div>
+
+      <answer-history
+        slot="aside"
+        :questionNumber="questionNumber"
+        @goToQuestion="goToQuestion"
+      />
+
+      <div
+        slot="main"
+        class="question-container"
+      >
+        <content-renderer
+          ref="contentRenderer"
+          v-if="itemId"
+          :id="content.id"
+          :kind="content.kind"
+          :files="content.files"
+          :contentId="content.content_id"
+          :channelId="channelId"
+          :available="content.available"
+          :extraFields="content.extra_fields"
+          :itemId="itemId"
+          :assessment="true"
+          :allowHints="false"
+          :answerState="currentAttempt.answer"
+          @interaction="throttledSaveAnswer"
+        />
+        <ui-alert v-else :dismissible="false" type="error">
+          {{ $tr('noItemId') }}
+        </ui-alert>
+      </div>
+
+      <div class="question-navbutton-container" slot="footer">
+        <k-button
+          :disabled="questionNumber===0"
+          @click="goToQuestion(questionNumber - 1)"
+          :text="$tr('previousQuestion')"
+        />
+        <k-button
+          :disabled="questionNumber===exam.question_count-1"
+          @click="goToQuestion(questionNumber + 1)"
+          :text="$tr('nextQuestion')"
+        />
+      </div>
+
       <core-modal
         v-if="submitModalOpen"
         :title="$tr('submitExam')"
@@ -88,7 +89,7 @@
           />
         </div>
       </core-modal>
-    </template>
+    </multi-pane-layout>
   </immersive-full-screen>
 
 </template>
@@ -105,6 +106,7 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import uiAlert from 'kolibri.coreVue.components.uiAlert';
+  import multiPaneLayout from 'kolibri.coreVue.components.multiPaneLayout';
   import { setAndSaveCurrentExamAttemptLog, closeExam } from '../../state/actions/main';
   import { ClassesPageNames } from '../../constants';
   import answerHistory from './answer-history';
@@ -131,6 +133,7 @@
       answerHistory,
       coreModal,
       uiAlert,
+      multiPaneLayout,
     },
     data() {
       return {
@@ -212,6 +215,7 @@
               questionNumber,
             },
           });
+          this.$refs.multiPaneLayout.scrollMainToTop();
         });
       },
       submitExam() {
@@ -237,13 +241,8 @@
 
   @require '~kolibri.styles.definitions'
 
-  .container
-    width: 90%
-    margin: 30px auto
-    position: relative
-
   .exam-status-container
-    padding: 10px 25px
+    padding: 16px
     background: $core-bg-light
 
   .exam-status
@@ -251,7 +250,8 @@
     width: 50%
     max-width: 400px
     text-align: right
-    margin-top: 15px
+    button
+      margin: 0
 
   .exam-icon
     position: relative
@@ -265,28 +265,12 @@
   .questions-answered
     display: inline-block
     position: relative
-    top: 2px
+    margin-top: 0
 
   .question-container
-    height: 100%
-    width: 100%
-    padding: 10px
     background: $core-bg-light
-
-  .outer-container > div
-    float: left
-
-  .answer-history-container
-    width: 25%
-    height: 100%
-    max-height: 500px
-    overflow-y: auto
-
-  .exercise-container
-    width: 75%
 
   .question-navbutton-container
     text-align: right
-    margin-right: 15px
 
 </style>


### PR DESCRIPTION
### Summary

Attempt to bring consistency and dryness to these type of layouts by introducing a `<multi-pane-layout/>` component.
Fixes #3855

#### Sreenshots

| Before | After |
| --- | --- |
| ![localhost_8000_learn_ nexus 7 2](https://user-images.githubusercontent.com/7193975/41882147-19cabf30-789c-11e8-814e-ce4f07334fb4.png)  | ![localhost_8000_learn_ nexus 7 4](https://user-images.githubusercontent.com/7193975/41882459-d640b54c-789d-11e8-950b-9e3948455e1e.png) |
| ![localhost_8000_learn_ nexus 7 3](https://user-images.githubusercontent.com/7193975/41882146-199699b2-789c-11e8-918a-ca5d360cc23f.png)  | ![localhost_8000_learn_ nexus 7 1](https://user-images.githubusercontent.com/7193975/41882155-1a84b444-789c-11e8-9372-0c00da3439ad.png) |
| ![localhost_8000_coach_ nexus 7 7](https://user-images.githubusercontent.com/7193975/41882145-197f649a-789c-11e8-85a7-64f3c19902f7.png)  | ![localhost_8000_coach_ nexus 7](https://user-images.githubusercontent.com/7193975/41882154-1a6ed458-789c-11e8-97f3-c3a68010cb8b.png)   |
| ![localhost_8000_coach_ nexus 7 8](https://user-images.githubusercontent.com/7193975/41882144-1967da0a-789c-11e8-88d7-3d3ec10973cc.png)  | ![localhost_8000_coach_ nexus 7 1](https://user-images.githubusercontent.com/7193975/41882153-1a585c00-789c-11e8-9bf7-a39391abb715.png) |
| ![localhost_8000_coach_ nexus 7 9](https://user-images.githubusercontent.com/7193975/41882143-1948258e-789c-11e8-8542-5e8cd7f20867.png)  | ![localhost_8000_coach_ nexus 7 2](https://user-images.githubusercontent.com/7193975/41882152-1a412c88-789c-11e8-9708-f0c7d3fbd131.png) |
| ![localhost_8000_coach_ nexus 7 10](https://user-images.githubusercontent.com/7193975/41882142-19335b36-789c-11e8-8ca9-e71e84ef6392.png) | ![localhost_8000_coach_ nexus 7 3](https://user-images.githubusercontent.com/7193975/41882151-1a288638-789c-11e8-8a90-e9d8f73feb55.png) |
| ![localhost_8000_coach_ nexus 7 11](https://user-images.githubusercontent.com/7193975/41882141-191c38c0-789c-11e8-8cbc-3c5b42830b0f.png) | ![localhost_8000_coach_ nexus 7 4](https://user-images.githubusercontent.com/7193975/41882150-1a0f54e2-789c-11e8-951e-9eca3de0a781.png) |
| ![localhost_8000_coach_ nexus 7 12](https://user-images.githubusercontent.com/7193975/41882140-1906b6b2-789c-11e8-9b0a-1b6001adcb80.png) | ![localhost_8000_coach_ nexus 7 5](https://user-images.githubusercontent.com/7193975/41882149-19f7e71c-789c-11e8-9891-5c5b36268d1d.png) |
| ![localhost_8000_coach_ nexus 7 13](https://user-images.githubusercontent.com/7193975/41882139-18ef0ef4-789c-11e8-9f6d-08e4996a8746.png) | ![localhost_8000_coach_ nexus 7 6](https://user-images.githubusercontent.com/7193975/41882148-19e1926e-789c-11e8-9139-fac52b54309c.png) |
### Reviewer guidance

#### Strings added

2 strings were added to `learner-exercise-report.vue` that already exist in `exam-report/index.vue`

```
showCorrectAnswerLabel: 'Show correct answer',
question: 'Question { questionNumber, number }',
```

#### Pages to test

* Learn
  * Exam page
  * Exam report
* Coach
  * Exam report
  * Preview an exercise from lesson selection
  * Preview an non-exercise resource from lesson selection
  * Preview an exercise from lesson page
  * Preview a non-exercise resource from lesson page
  * Exercise report from Lessons
  * Exercise report from Reports

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
