### PR TITLE
Linking to topics page if a topic is recommended.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/recommended-page.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-page.vue
@@ -93,6 +93,7 @@
 
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { getChannels } from 'kolibri.coreVue.vuex.getters';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { PageNames } from '../constants';
   import contentCardGroupCarousel from './content-card-group-carousel';
   import contentCardGroupGrid from './content-card-group-grid';
@@ -152,9 +153,12 @@
       },
     },
     methods: {
-      genContentLink(id) {
+      genContentLink(id, kind) {
         return {
-          name: PageNames.RECOMMENDED_CONTENT,
+          name:
+            kind === ContentNodeKinds.TOPIC
+              ? PageNames.TOPICS_TOPIC
+              : PageNames.RECOMMENDED_CONTENT,
           params: { id },
         };
       },

--- a/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/recommended-subpage.vue
@@ -16,6 +16,7 @@
 <script>
 
   import kBreadcrumbs from 'kolibri.coreVue.components.kBreadcrumbs';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { PageNames } from '../constants';
   import contentCardGroupGrid from './content-card-group-grid';
   import contentCardGroupHeader from './content-card-group-header';
@@ -64,9 +65,12 @@
       },
     },
     methods: {
-      genContentLink(id) {
+      genContentLink(id, kind) {
         return {
-          name: PageNames.RECOMMENDED_CONTENT,
+          name:
+            kind === ContentNodeKinds.TOPIC
+              ? PageNames.TOPICS_TOPIC
+              : PageNames.RECOMMENDED_CONTENT,
           params: { id },
         };
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Before
![before](https://user-images.githubusercontent.com/9877852/41881841-77aa62ec-789a-11e8-93fa-7ac905761fa4.gif)

### After

![after](https://user-images.githubusercontent.com/9877852/41881772-18af1166-789a-11e8-9c1a-622e6adb49ff.gif)

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Links to the regular topic tree if a topic is recommended

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Complete a content node whose "next item" is a topic. Usually the last item in a KA topic.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Resolves #3847 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
