### PR TITLE
Add "deprovision" management command to clear out user data from the DB

### DIFF
--- a/kolibri/auth/management/commands/deprovision.py
+++ b/kolibri/auth/management/commands/deprovision.py
@@ -1,0 +1,73 @@
+import logging as logger
+import sys
+
+from django.db.models.signals import post_delete
+from django.utils.six.moves import input
+from morango.certificates import Certificate
+from morango.models import Buffer
+from morango.models import DatabaseIDModel
+from morango.models import DeletedModels
+from morango.models import Store
+
+from kolibri.auth.models import FacilityDataset
+from kolibri.auth.models import FacilityUser
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.models import DeviceSettings
+from kolibri.logger.models import AttemptLog
+from kolibri.logger.models import ContentSessionLog
+from kolibri.logger.models import ContentSummaryLog
+from kolibri.tasks.management.commands.base import AsyncCommand
+from kolibri.utils.cli import server
+
+logging = logger.getLogger(__name__)
+
+MODELS_TO_DELETE = [
+    AttemptLog, ContentSessionLog, ContentSummaryLog, FacilityUser, FacilityDataset, Certificate,
+    DatabaseIDModel, Store, Buffer, DevicePermissions, DeletedModels, DeviceSettings
+]
+
+# we want to disable the post_delete signal temporarily when deleting, so morango doesn't create DeletedModels objects
+class DisablePostDeleteSignal(object):
+
+    def __enter__(self):
+        self.receivers = post_delete.receivers
+        post_delete.receivers = []
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        post_delete.receivers = self.receivers
+        self.receivers = None
+
+
+def confirm_or_exit(message):
+    answer = ""
+    while answer not in ["yes", "n", "no"]:
+        answer = input("{} [Type 'yes' or 'no'.] ".format(message)).lower()
+    if answer != "yes":
+        print("Canceled! Exiting without touching the database.")
+        sys.exit(1)
+
+
+class Command(AsyncCommand):
+    help = "Delete all facility user data from the local database, and put it back to a clean state (but leaving content as-is)."
+
+    def deprovision(self):
+        with DisablePostDeleteSignal(), self.start_progress(total=len(MODELS_TO_DELETE)) as progress_update:
+            for Model in MODELS_TO_DELETE:
+                Model.objects.all().delete()
+                progress_update(1)
+
+    def handle_async(self, *args, **options):
+
+        # safest not to run this command while the server is running
+        status_code, _ = server.get_urls()
+        if status_code == server.STATUS_RUNNING:
+            logging.error("The Kolibri server is currently running. Please stop it and then re-run this command.")
+            sys.exit(1)
+
+        # ensure the user REALLY wants to do this!
+        confirm_or_exit("Are you sure you wish to deprovision your database? This will DELETE ALL USER DATA!")
+        confirm_or_exit("ARE YOU SURE? If you do this, there is no way to recover the user data on this device.")
+
+        print("Proceeding with deprovisioning. Deleting all user data.")
+        self.deprovision()
+        print("Deprovisioning complete. All user data has been deleted.")

--- a/kolibri/auth/test/test_deprovisioning.py
+++ b/kolibri/auth/test/test_deprovisioning.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+from mock import patch
+
+from .. import models as auth_models
+from ..management.commands import deprovision
+from .helpers import setup_device
+from .test_api import ClassroomFactory
+from .test_api import LearnerGroupFactory
+from kolibri.content import models as content_models
+from kolibri.logger.test.factory_logger import ContentSessionLogFactory
+from kolibri.logger.test.factory_logger import ContentSummaryLogFactory
+from kolibri.logger.test.factory_logger import FacilityUserFactory
+from kolibri.logger.test.factory_logger import UserSessionLogFactory
+
+
+def count_instances(models):
+    return sum([model.objects.count() for model in models])
+
+class UserImportCommandTestCase(TestCase):
+    """
+    Tests for the deprovision command.
+    """
+
+    fixtures = ['content_test.json']
+
+    def setUp(self):
+        facility, superuser = setup_device()
+        ContentSessionLogFactory.create(content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+        for classroom in [ClassroomFactory.create(parent=facility) for _ in range(3)]:
+            for group in [LearnerGroupFactory.create(parent=classroom) for _ in range(3)]:
+                user = FacilityUserFactory.create(facility=facility)
+                auth_models.Membership.objects.create(collection=group, user=user)
+                ContentSessionLogFactory.create(user=user, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+                ContentSummaryLogFactory.create(user=user, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+                UserSessionLogFactory.create(user=user)
+
+    @patch('django.utils.six.moves.input', new=lambda x: "yes")
+    def test_setup_no_headers_bad_user_good_user(self):
+        deprovision.input = mock.MagicMock(name='input', return_value='yes')
+        models_that_should_get_deleted = deprovision.MODELS_TO_DELETE + [auth_models.FacilityUser, auth_models.Facility]
+        models_that_should_remain = [content_models.LocalFile, content_models.ContentNode, content_models.File, content_models.AssessmentMetaData]
+        assert count_instances(models_that_should_get_deleted) > 0
+        assert count_instances(models_that_should_remain) > 0
+        call_command('deprovision')
+        assert count_instances(models_that_should_get_deleted) == 0
+        assert count_instances(models_that_should_remain) > 0

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -309,7 +309,7 @@ def stop():
         pid, __, __ = server.get_status()
         server.stop(pid=pid)
         stopped = True
-        logger.info("Kolibri server has successfully been stoppped.")
+        logger.info("Kolibri server has successfully been stopped.")
     except server.NotRunning as e:
         verbose_status = "{msg:s} ({code:d})".format(
             code=e.status_code,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Needed for when an implementing or hardware partner (Nalanda, World Possible, etc) provisions a device or device image with content, but then wants to clear out the temporary facility and user data and allow the end user to provision the device from scratch (but without needing to re-import content).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test, make sure to back up your database (if it has anything you care about). Then, run `kolibri manage deprovision` and answer the prompts. Then start the server back up and check that you're taken to the onboarding wizard. After you complete the wizard, the content page should still show whatever content you had in there before.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
