### PR TITLE
Multi pane layout follow up

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -734,7 +734,9 @@ export class Resource {
     }
     const filteredResourceIds = this.filterAndCheckResourceIds(resourceIds);
     const cacheKey = this.cacheKey(getParams, filteredResourceIds);
-    this.collections[cacheKey].synced = false;
+    if (this.collections[cacheKey]) {
+      this.collections[cacheKey].synced = false;
+    }
   }
 
   removeModel(model) {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/ContentArea.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <section :class="{padding: isPerseusExercise}">
+  <section :class="{'content-area-perseus': isPerseusExercise}">
     <h2 v-if="isPerseusExercise" class="header">
       {{ header }}
     </h2>
@@ -65,17 +65,17 @@
 
 <style scoped lang="stylus">
 
-  .padding
-    padding-left: 8px // give same margin as question-list (16px)
+  @require '~kolibri.styles.definitions'
+
+  .content-area-perseus
+    padding: 16px
+    background-color: $core-bg-light
 
   .hof
     overflow-x: hidden // .solutionarea's negative margin oversteps
 
   .header
     margin: 0
-    margin-left: $perseus-padding
-    line-height: $header-height
-    vertical-align: middle
     font-size: 16px // same as question-list
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -1,7 +1,10 @@
 <template>
 
   <multi-pane-layout>
-    <template slot="header">
+    <div
+      slot="header"
+      class="header"
+    >
       <metadata-area
         class="ib"
         :class="{left: workingResources}"
@@ -15,7 +18,7 @@
         :contentId="content.pk"
         @addresource="addToCache"
       />
-    </template>
+    </div>
 
     <question-list
       slot="aside"
@@ -104,6 +107,12 @@
 
 
 <style lang="stylus" scoped>
+
+  @require '~kolibri.styles.definitions'
+
+  .header
+    background-color: $core-bg-light
+    padding: 16px
 
   .select-options
     width: 20%

--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -66,30 +66,30 @@
           :text="$tr('nextQuestion')"
         />
       </div>
-
-      <core-modal
-        v-if="submitModalOpen"
-        :title="$tr('submitExam')"
-        @cancel="toggleModal"
-      >
-        <p>{{ $tr('areYouSure') }}</p>
-        <p v-if="questionsUnanswered">
-          {{ $tr('unanswered', { numLeft: questionsUnanswered } ) }}
-        </p>
-        <div class="core-modal-buttons">
-          <k-button
-            :text="$tr('goBack')"
-            appearance="flat-button"
-            @click="toggleModal"
-          />
-          <k-button
-            :text="$tr('submitExam')"
-            @click="finishExam"
-            :primary="true"
-          />
-        </div>
-      </core-modal>
     </multi-pane-layout>
+
+    <core-modal
+      v-if="submitModalOpen"
+      :title="$tr('submitExam')"
+      @cancel="toggleModal"
+    >
+      <p>{{ $tr('areYouSure') }}</p>
+      <p v-if="questionsUnanswered">
+        {{ $tr('unanswered', { numLeft: questionsUnanswered } ) }}
+      </p>
+      <div class="core-modal-buttons">
+        <k-button
+          :text="$tr('goBack')"
+          appearance="flat-button"
+          @click="toggleModal"
+        />
+        <k-button
+          :text="$tr('submitExam')"
+          @click="finishExam"
+          :primary="true"
+        />
+      </div>
+    </core-modal>
   </immersive-full-screen>
 
 </template>


### PR DESCRIPTION
### Summary

Moved the submit exam modal outside the multi pane layout. :mood:

Missed this one.

#### Before

![localhost_8000_coach_ nexus 7 16](https://user-images.githubusercontent.com/7193975/41895233-4cb5fa42-78d6-11e8-81fe-4e2719336d58.png)

#### After

![localhost_8000_coach_ nexus 7 15](https://user-images.githubusercontent.com/7193975/41895235-4dcbd65e-78d6-11e8-9070-78f7eb401987.png)

### Reviewer guidance

Preview a lesson resource.
Submit an exam

### References

Original PR: #3890 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
