### PR TITLE
Remove a possible copy-paste artifact in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     curl
-RUN add-apt-repository ppa:voronov84/andreyv
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 
 # add yarn ppa
@@ -13,7 +12,6 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 
 RUN apt-get update && apt-get install -y \
     python2.7 \
-    python3.6 \
     python-pip \
     git \
     nodejs \


### PR DESCRIPTION
### Summary

~If this doesn't pass for some reason of needing Python 3.6 that I didn't spot, then please disregard and close this PR.~ it passed!

[Searching Google](https://www.google.com/search?hl=en&q=voronov84%2Fandreyv), I find that the removed PPA is something that was due to a copy-paste from KA Lite? @aronasorman 

The following errors are showing up on Buildkite:

``` 
Step 3/10 : RUN add-apt-repository ppa:voronov84/andreyv
 ---> Running in 40dfe5a1c9b0
 Contains various, fresh packages (ansible, git, duplicity)). AMD64 only
 More info: https://launchpad.net/~voronov84/+archive/ubuntu/andreyv
gpg: keyring `/tmp/tmp21c3g61o/secring.gpg' created
gpg: keyring `/tmp/tmp21c3g61o/pubring.gpg' created
gpg: requesting key 12946919 from hkp server keyserver.ubuntu.com
gpgkeys: key C134CC0C8D12402AA77B5B7AD60C209B12946919 can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver helper general error
gpg: keyserver communications error: unknown pubkey algorithm
gpg: keyserver receive failed: unknown pubkey algorithm
Failed to add key.
The command '/bin/sh -c add-apt-repository ppa:voronov84/andreyv' returned a non-zero code: 1
```

### Reviewer guidance

Check build out-puts

### References

Check recent Buildkite error logs

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
