### PR TITLE
Fix alignment of radios in move-learners-modal

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/groups-page/move-learners-modal.vue
@@ -130,11 +130,6 @@
 
 <style lang="stylus" scoped>
 
-  label
-    display: block
-    padding-bottom: 0.5em
-    padding-top: 0.5em
-
   .button-section
     margin-top: 1em
 


### PR DESCRIPTION
### Summary

Fix alignment of radios in move-learners-modal

#### Before

![localhost_8000_coach_ nexus 7 18](https://user-images.githubusercontent.com/7193975/41929725-dbda2822-792d-11e8-9e16-7e67c9a95e47.png)

#### After

![localhost_8000_coach_ nexus 7 17](https://user-images.githubusercontent.com/7193975/41929720-d9ed42d8-792d-11e8-9703-549c2c64d3fc.png)

### Reviewer guidance

Open move learners modal

### References

Fixes #3832 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
