### PR TITLE
No heartbeat on setup wizard

### DIFF
--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -33,12 +33,22 @@ export class HeartBeat {
     this.setActive = this.setActive.bind(this);
     this.beat = this.beat.bind(this);
     this.setInactive();
+    this.enabled = false;
   }
   start() {
     logging.debug('Starting heartbeat');
+    this.enabled = true;
     this.setActivityListeners();
     // No need to start it straight away, can wait.
     this.beat();
+  }
+  stop() {
+    logging.debug('Stopping heartbeat');
+    this.enabled = false;
+    this.clearActivityListeners();
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
   }
   setActivityListeners() {
     this.events.forEach(event => {
@@ -181,8 +191,10 @@ export class HeartBeat {
       clearTimeout(this.timerId);
     }
     return this.checkSession().finally(() => {
-      this.setInactive();
-      this.wait();
+      if (this.enabled) {
+        this.setInactive();
+        this.wait();
+      }
     });
   }
   get events() {

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -63,7 +63,7 @@ export default class KolibriApp extends KolibriModule {
       state: this.initialState,
       mutations: this.mutations,
     });
-    getCurrentSession(store).then(() => {
+    return getCurrentSession(store).then(() => {
       Promise.all([
         // Invoke each of the state setters before initializing the app.
         ...this.stateSetters.map(setter => setter(this.store)),

--- a/kolibri/core/assets/test/heartbeat.js
+++ b/kolibri/core/assets/test/heartbeat.js
@@ -57,6 +57,7 @@ describe('HeartBeat', function() {
     beforeEach(function() {
       this.heartBeat = new HeartBeat();
       this.heartBeat.active = false;
+      this.heartBeat.enabled = true;
       this.store = coreStore.factory();
       this.checkSessionStub = sinon.stub(this.heartBeat, 'checkSession');
       this.checkSessionStub.resolves();

--- a/kolibri/plugins/setup_wizard/assets/src/app.js
+++ b/kolibri/plugins/setup_wizard/assets/src/app.js
@@ -1,3 +1,4 @@
+import heartbeat from 'kolibri.heartbeat';
 import RootVue from './views';
 import { initialState, mutations } from './state/store'; // attaching store to the root element
 import KolibriApp from 'kolibri_app';
@@ -11,6 +12,14 @@ class OnboardingApp extends KolibriApp {
   }
   get mutations() {
     return mutations;
+  }
+  ready() {
+    return super.ready().then(() => {
+      // Fix for https://github.com/learningequality/kolibri/issues/3852
+      // Don't call beat because it may cause a save in the session endpoint
+      // while the device provisioning is in progress
+      heartbeat.stop();
+    });
   }
 }
 


### PR DESCRIPTION
### Summary
Stops heartbeat in setup wizard to prevent writes to session db during device provisioning

### Reviewer guidance
Reduce heartbeat delay in constructor default value to 50ms. Note that the device provisioning still goes well without a 500.

### References
Fixes #3852

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
