### PR TITLE
Recursively annotate coach_content up topic trees.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -305,23 +305,8 @@ class ContentNodeFilter(IdFilter):
             if user.roles.exists() or user.is_superuser:  # must have coach role or higher
                 return queryset
 
-        # In all other cases, exclude leaf nodes that are coach content
-        queryset = queryset.exclude(coach_content=True)
-
-        # Also exclude topics that are 100% coach content
-        def node_only_has_coach_content(contentnode):
-            if (contentnode.kind == content_kinds.TOPIC):
-                return not contentnode.get_descendants() \
-                    .exclude(kind=content_kinds.TOPIC) \
-                    .exclude(coach_content=True) \
-                    .exclude(available=False) \
-                    .exists()
-            else:
-                return contentnode.coach_content
-
-        only_coach_content_node_ids = [node.id for node in queryset if node_only_has_coach_content(node)]
-
-        return queryset.exclude(id__in=only_coach_content_node_ids)
+        # In all other cases, exclude nodes that are coach content
+        return queryset.exclude(coach_content=True)
 
     def filter_in_lesson(self, queryset, name, value):
         """

--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -97,6 +97,26 @@ class AnnotationTreeRecursion(TransactionTestCase):
         # Check parent is available
         self.assertTrue(ContentNode.objects.get(id='da7ecc42e62553eebc8121242746e88a').available)
 
+    def test_all_content_nodes_available_coach_content(self):
+        ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(available=True)
+        ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(coach_content=True)
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
+        self.assertTrue(ContentNode.objects.get(id="da7ecc42e62553eebc8121242746e88a").coach_content)
+        self.assertTrue(ContentNode.objects.get(id="2e8bac07947855369fe2d77642dfc870").coach_content)
+
+    def test_no_content_nodes_coach_content(self):
+        ContentNode.objects.filter(kind=content_kinds.TOPIC).update(available=True)
+        ContentNode.objects.all().update(coach_content=False)
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
+        self.assertEqual(ContentNode.objects.filter(coach_content=True).count(), 0)
+
+    def test_one_content_node_many_siblings_coach_content(self):
+        ContentNode.objects.filter(kind=content_kinds.TOPIC).update(available=True)
+        ContentNode.objects.filter(id='32a941fb77c2576e8f6b294cde4c3b0c').update(coach_content=True)
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
+        # Check parent is not marked as coach_content True because there are non-coach_content siblings
+        self.assertFalse(ContentNode.objects.get(id='da7ecc42e62553eebc8121242746e88a').coach_content)
+
     def tearDown(self):
         call_command('flush', interactive=False)
         super(AnnotationTreeRecursion, self).tearDown()

--- a/kolibri/content/test/test_annotation.py
+++ b/kolibri/content/test/test_annotation.py
@@ -98,8 +98,7 @@ class AnnotationTreeRecursion(TransactionTestCase):
         self.assertTrue(ContentNode.objects.get(id='da7ecc42e62553eebc8121242746e88a').available)
 
     def test_all_content_nodes_available_coach_content(self):
-        ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(available=True)
-        ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(coach_content=True)
+        ContentNode.objects.exclude(kind=content_kinds.TOPIC).update(available=True, coach_content=True)
         recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
         self.assertTrue(ContentNode.objects.get(id="da7ecc42e62553eebc8121242746e88a").coach_content)
         self.assertTrue(ContentNode.objects.get(id="2e8bac07947855369fe2d77642dfc870").coach_content)
@@ -116,6 +115,56 @@ class AnnotationTreeRecursion(TransactionTestCase):
         recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
         # Check parent is not marked as coach_content True because there are non-coach_content siblings
         self.assertFalse(ContentNode.objects.get(id='da7ecc42e62553eebc8121242746e88a').coach_content)
+
+    def test_two_channels_no_annotation_collision_child_false(self):
+        root_node = ContentNode.objects.create(
+            title='test',
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            kind=content_kinds.TOPIC,
+            available=True,
+            coach_content=True,
+        )
+        ContentNode.objects.create(
+            title='test1',
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=root_node.channel_id,
+            parent=root_node,
+            kind=content_kinds.VIDEO,
+            available=False,
+            coach_content=False,
+        )
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
+        root_node.refresh_from_db()
+        self.assertTrue(root_node.available)
+        self.assertTrue(root_node.coach_content)
+
+    def test_two_channels_no_annotation_collision_child_true(self):
+        root_node = ContentNode.objects.create(
+            title='test',
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            kind=content_kinds.TOPIC,
+            available=False,
+            coach_content=False,
+        )
+        ContentNode.objects.create(
+            title='test1',
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=root_node.channel_id,
+            parent=root_node,
+            kind=content_kinds.VIDEO,
+            available=True,
+            coach_content=True,
+        )
+        recurse_availability_up_tree(channel_id="6199dde695db4ee4ab392222d5af1e5c")
+        root_node.refresh_from_db()
+        self.assertFalse(root_node.available)
+        self.assertFalse(root_node.coach_content)
 
     def tearDown(self):
         call_command('flush', interactive=False)


### PR DESCRIPTION
### Summary
We are currently doing a check on every descendant of every topic to see whether it only has coach_content descendants that are available.
This removes that approach in favour of annotating this information on the topic tree whenever the availability of the topic tree is updated.
This should remove n-1 queries for getting topic tree information of non-leaf nodes.

### Reviewer guidance
Import a channel with coach content. Check that topics with only coach content are not shown to Learners.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
