### PR TITLE
block double clicks

### DIFF
--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -64,7 +64,7 @@ export default class KolibriApp extends KolibriModule {
       mutations: this.mutations,
     });
     return getCurrentSession(store).then(() => {
-      Promise.all([
+      return Promise.all([
         // Invoke each of the state setters before initializing the app.
         ...this.stateSetters.map(setter => setter(this.store)),
       ]).then(() => {

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -174,6 +174,22 @@ function handleApiError(store, errorObject) {
 }
 
 /**
+ * Used to prevent inadvertent actions if a user double-clicks to navigate
+ *
+ * Something of a hack. A better strategy would be to create a new
+ * `setLoading` action which handles both `state.core.loading` and
+ * `state.core.blockDoubleClicks` with a single function.
+ */
+function blockDoubleClicks(store) {
+  if (!store.state.core.blockDoubleClicks) {
+    store.dispatch('CORE_BLOCK_CLICKS', true);
+    setTimeout(() => {
+      store.dispatch('CORE_BLOCK_CLICKS', false);
+    }, 500);
+  }
+}
+
+/**
  * Signs in user.
  *
  * @param {object} store The store.
@@ -764,6 +780,7 @@ function clearSnackbar(store) {
 export {
   handleError,
   handleApiError,
+  blockDoubleClicks,
   kolibriLogin,
   kolibriLogout,
   getCurrentSession,

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -30,6 +30,7 @@ const baseConnectionState = {
 export const initialState = {
   core: {
     error: '',
+    blockDoubleClicks: false,
     loading: true,
     title: '',
     pageSessionId: 0,
@@ -79,6 +80,9 @@ export const coreMutations = {
   },
   CORE_SET_ERROR(state, error) {
     state.core.error = error;
+  },
+  CORE_BLOCK_CLICKS(state, blocked) {
+    state.core.blockDoubleClicks = blocked;
   },
   CORE_SET_TITLE(state, title) {
     state.core.title = title;

--- a/kolibri/core/assets/src/views/app-body.vue
+++ b/kolibri/core/assets/src/views/app-body.vue
@@ -2,6 +2,7 @@
 
   <!-- class unused, used as identifier when debugging from DOM -->
   <div class="app-body" :style="contentStyle">
+    <div v-if="blockDoubleClicks" class="click-mask"></div>
     <k-linear-loader
       v-if="loading"
       class="toolbar-loader"
@@ -63,6 +64,7 @@
     vuex: {
       getters: {
         loading: state => state.core.loading,
+        blockDoubleClicks: state => state.core.blockDoubleClicks,
         error: state => state.core.error,
         documentTitle: state => state.core.title,
       },
@@ -88,5 +90,13 @@
     position: fixed
     right: 0
     left: 0
+
+  .click-mask
+    position: fixed
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+    z-index: 24
 
 </style>

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -1,3 +1,6 @@
+import router from 'kolibri.coreVue.router';
+import store from 'kolibri.coreVue.vuex.store';
+import { blockDoubleClicks } from 'kolibri.coreVue.vuex.actions';
 import RootVue from './views';
 import initialState from './state/initialState';
 import mutations from './state/mutations';
@@ -21,6 +24,14 @@ class LearnModule extends KolibriApp {
   }
   get mutations() {
     return mutations;
+  }
+  ready() {
+    // after every navigation, block double-clicks
+    return super.ready().then(() => {
+      router.getInstance().afterEach(() => {
+        blockDoubleClicks(store);
+      });
+    });
   }
 }
 


### PR DESCRIPTION

### Summary

In Kakuma it was observed that some learners thought they needed to double-tap on content cards in order to navigate. This caused them to jump two levels deep in the tree.

This change adds a blocking layer for half a second after navigating to a new page, which has the effect of absorbing the second click in a double-click.

Quoting a comment from the code:

It's something of a hack. A better strategy would be to create a new `setLoading` action which handles both `state.core.loading` and `state.core.blockDoubleClicks` with a single function.

### Reviewer guidance

does this make sense?

### References

fixes #3914 which was observed by @jamalex 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
