### PR TITLE
Add python 3.4 cryptography for Windows 64 bit

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -25,6 +25,9 @@ def get_path_with_arch(platform, path, abi, implementation, python_version):
     # Windows 32-bit's machine name is x86.
     if platform_split[0] == 'win32':
         return os.path.join(path, 'Windows', 'x86')
+    # Windows 64-bit
+    elif platform_split[0] == 'win':
+        return os.path.join(path, 'Windows', 'AMD64')
 
     # Prior to CPython 3.3, there were two ABI-incompatible ways of building CPython
     # There could be abi tag 'm' for narrow-unicode and abi tag 'mu' for wide-unicode
@@ -96,7 +99,7 @@ def parse_package_page(files, pk_version, index_url):
                 file_name[1] != pk_version or
                 file_name[2][2:] == '26' or
                 'macosx' in file_name[4].split('.')[0] or
-                'win_amd64' in file_name[4].split('.')[0]):
+                ('win_amd64' in file_name[4].split('.')[0] and file_name[2][2:] != '34')):
 
             continue
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR adds back the python 3.4 cryptography for Windows 64bit. We add python 3.4 based on [this doc](https://github.com/learningequality/kolibri-installer-windows/blob/develop/README.md#release-history). 
The decision to add it back is originally from this discussion: https://learningequality.slack.com/archives/CB37UM23A/p1530199449000531

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test if cryptography exists on windows 64 bit by doing
```
kolibri shell
> import cryptography
> cryptography.__file__
```


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3852

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
