### PR TITLE
fix changelog typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -263,7 +263,7 @@ See a `more detailed list <https://github.com/learningequality/kolibri/issues?q=
  - Updated Spanish translations
 
 
-0.3.2
+0.3.1
 -----
 
  - Portuguese and Kaswihili updates


### PR DESCRIPTION
### Summary

fixes a minor typo in the changelog



----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
