### PR TITLE
Fix core tables with empty tbodys in IE and Edge

### DIFF
--- a/kolibri/core/assets/src/views/core-table.vue
+++ b/kolibri/core/assets/src/views/core-table.vue
@@ -33,6 +33,7 @@
 
   .core-table-container
     overflow-x: auto
+    overflow-y: hidden
 
   .core-table
     width: 100%


### PR DESCRIPTION
### Summary

Fix core tables with empty tbodys in IE and Edge
Fixes #3908 

Before
![bs_win10_edge_17 0 1](https://user-images.githubusercontent.com/7193975/42054243-af403f1c-7ac8-11e8-8285-540bdc9306b2.jpg)

After
![bs_win10_edge_17 0](https://user-images.githubusercontent.com/7193975/42054241-ae19c96e-7ac8-11e8-97e7-007b6695db69.jpg)

### Reviewer guidance

View empty tables in IE 11 or Edge

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
