### PR TITLE
Adjust fullscreen button in HTML5 renderer

### DIFF
--- a/kolibri/core/assets/src/views/content-renderer/index.vue
+++ b/kolibri/core/assets/src/views/content-renderer/index.vue
@@ -230,4 +230,11 @@
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .content-renderer-component
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2),
+                0 1px 1px 0 rgba(0, 0, 0, 0.14),
+                0 2px 1px -1px rgba(0, 0, 0, 0.12)
+
+</style>

--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -41,6 +41,8 @@
         class="controls button-fullscreen"
         aria-controls="pdf-container"
         :ariaLabel="isInFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+        color="primary"
+        size="large"
         @click="toggleFullscreen($refs.pdfRenderer)"
       >
         <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
@@ -177,15 +179,17 @@
             index: i,
           });
         }
-        return this.getPage(1).then(firstPage => {
+        // Is either the first page or the saved last page visited
+        const firstPageToRender = parseInt(this.getSavedPosition() * this.totalPages);
+        return this.getPage(firstPageToRender + 1).then(firstPage => {
           this.firstPageHeight = firstPage.view[3];
           this.firstPageWidth = firstPage.view[2];
-          this.scale = this.elSize.height / (this.firstPageHeight + MARGIN);
-          // Set the firstPage into the pdfPages object so that we do not refetch the page
+          this.scale = this.elSize.width / (this.firstPageWidth + MARGIN);
+          // Set the firstPageToRender into the pdfPages object so that we do not refetch the page
           // from PDFJS when we do our initial render
           // splice so changes are detected
-          this.pdfPages.splice(0, 1, {
-            ...this.pdfPages[0],
+          this.pdfPages.splice(firstPageToRender, 1, {
+            ...this.pdfPages[firstPageToRender],
             page: firstPage,
             resolved: true,
           });
@@ -324,8 +328,6 @@
 
   @require '~kolibri.styles.definitions'
 
-  $keen-button-height = 36px
-
   .pdf-renderer
     position: relative
     height: 500px
@@ -335,19 +337,20 @@
     position: absolute
     z-index: 6 // material spec - snackbar and FAB
 
-  .button-fullscreen,
-  .button-zoom-in,
-  .button-zoom-out
-    right: 21px
-
   .button-fullscreen
     top: 16px
+    right: 21px
+    fill: white
+
+  .button-zoom-in,
+  .button-zoom-out
+    right: 27px
 
   .button-zoom-in
-    top: $keen-button-height + 32
+    top: 80px
 
   .button-zoom-out
-    top: ($keen-button-height * 2) + 48
+    top: 132px
 
   .progress-bar
     top: 50%

--- a/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/index.vue
@@ -41,7 +41,6 @@
         class="controls button-fullscreen"
         aria-controls="pdf-container"
         :ariaLabel="isInFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
-        size="large"
         @click="toggleFullscreen($refs.pdfRenderer)"
       >
         <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
@@ -50,7 +49,6 @@
       <ui-icon-button
         class="controls button-zoom-in"
         aria-controls="pdf-container"
-        size="large"
         @click="zoomIn"
       >
         <mat-svg name="add" category="content" />
@@ -58,7 +56,6 @@
       <ui-icon-button
         class="controls button-zoom-out"
         aria-controls="pdf-container"
-        size="large"
         @click="zoomOut"
       >
         <mat-svg name="remove" category="content" />
@@ -327,7 +324,7 @@
 
   @require '~kolibri.styles.definitions'
 
-  $keen-button-height = 48px
+  $keen-button-height = 36px
 
   .pdf-renderer
     position: relative
@@ -341,7 +338,7 @@
   .button-fullscreen,
   .button-zoom-in,
   .button-zoom-out
-    right: 32px
+    right: 21px
 
   .button-fullscreen
     top: 16px

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -5,12 +5,14 @@
     class="html5-renderer"
     allowfullscreen
   >
-    <k-button
+    <ui-icon-button
       class="btn"
-      :text="isInFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+      :ariaLabel="isInFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
       @click="toggleFullscreen($refs.html5Renderer)"
-      :primary="true"
-    />
+    >
+      <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
+      <mat-svg v-else name="fullscreen" category="navigation" />
+    </ui-icon-button>
     <iframe
       class="iframe"
       sandbox="allow-scripts"
@@ -25,13 +27,15 @@
 
 <script>
 
-  import kButton from 'kolibri.coreVue.components.kButton';
   import contentRendererMixin from 'kolibri.coreVue.mixins.contentRenderer';
   import fullscreen from 'kolibri.coreVue.mixins.fullscreen';
+  import uiIconButton from 'keen-ui/src/UiIconButton';
 
   export default {
     name: 'html5Renderer',
-    components: { kButton },
+    components: {
+      uiIconButton,
+    },
     mixins: [contentRendererMixin, fullscreen],
     props: {
       defaultFile: {
@@ -70,8 +74,8 @@
 
   .btn
     position: absolute
-    left: 50%
-    transform: translateX(-50%)
+    right: 21px
+    top: 8px
 
   .html5-renderer
     position: relative

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/index.vue
@@ -8,6 +8,8 @@
     <ui-icon-button
       class="btn"
       :ariaLabel="isInFullscreen ? $tr('exitFullscreen') : $tr('enterFullscreen')"
+      color="primary"
+      size="large"
       @click="toggleFullscreen($refs.html5Renderer)"
     >
       <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
@@ -76,6 +78,7 @@
     position: absolute
     right: 21px
     top: 8px
+    fill: white
 
   .html5-renderer
     position: relative


### PR DESCRIPTION
### Summary

Temporary adjustment. Long term we need to handle toggling button visibility, which requires more design. Made button in HTML5 renderer right aligned. Made buttons smaller.

Before

![localhost_8000_learn_ nexus 7 8](https://user-images.githubusercontent.com/7193975/42057171-5a66fdce-7ad1-11e8-9ceb-6fa5f53143e9.png)

![localhost_8000_learn_ nexus 7 7](https://user-images.githubusercontent.com/7193975/42057173-5c161b14-7ad1-11e8-96b7-379d82589b53.png)

After

![localhost_8000_learn_ nexus 7 5](https://user-images.githubusercontent.com/7193975/42057180-6261a254-7ad1-11e8-8d4a-d2e63631d22a.png)

![localhost_8000_learn_ nexus 7 6](https://user-images.githubusercontent.com/7193975/42057176-5da74688-7ad1-11e8-9375-fb6be2d2cb66.png)

### Reviewer guidance

Thoughts?

### References

Related:: https://github.com/learningequality/kolibri/issues/3557

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
