### PR TITLE
Check if current user is the `kolibri` user when running kolibri

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -16,6 +16,11 @@ from django.db.utils import DatabaseError  # noqa
 from docopt import docopt  # noqa
 
 import kolibri  # noqa
+from .debian_check import check_debian_user
+# Check if the current user is the kolibri user when running kolibri from .deb.
+# Putting it here because importing server module creates KOLIBRI_HOME directory.
+check_debian_user()
+
 from . import server  # noqa
 from .conf import OPTIONS  # noqa
 from .sanity_checks import check_content_directory_exists_and_writable  # noqa

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+from builtins import input
+
+
+def check_debian_user():
+    # Check whether the current user is the kolibri user when running kolibri
+    # that is installed from .deb package.
+    # The code is mainly from https://github.com/learningequality/ka-lite/blob/master/bin/kalite#L53
+    if os.name == "posix" and os.path.isfile("/etc/kolibri/username"):
+        kolibri_user = open("/etc/kolibri/username", "r").read().rstrip()
+        current_user = os.environ["USER"]
+        if kolibri_user and kolibri_user != current_user:
+            kolibri_home = os.environ.get("KOLIBRI_HOME", os.path.expanduser("~/.kolibri"))
+            if not os.path.exists(kolibri_home) or not os.listdir(kolibri_home):
+                sys.stderr.write((
+                    "You are not running kolibri as the default user {}. "
+                    "This is recommended unless you want to re-create the database "
+                    "and start storing new videos/exercises etc. for a different "
+                    "user account\n\n"
+                ).format(kolibri_user))
+                sys.stderr.write((
+                    "To run the command as the default user, run this instead:\n\n"
+                    "    sudo su {} -c '<command>'\n\n"
+                ).format(kolibri_user))
+                cont = input("Do you wish to continue? [y/N] ")
+                if not cont.strip().lower() == "y":
+                    sys.exit(0)

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -8,26 +8,32 @@ def check_debian_user():
     # Check whether the current user is the kolibri user when running kolibri
     # that is installed from .deb package.
     # The code is mainly from https://github.com/learningequality/ka-lite/blob/master/bin/kalite#L53
-    if os.name == "posix" and os.path.isfile("/etc/kolibri/username"):
-        with open("/etc/kolibri/username", "r") as f:
-            kolibri_user = f.read().rstrip()
-        current_user = os.environ["USER"]
-        if kolibri_user and kolibri_user != current_user:
-            kolibri_home = os.environ.get(
-                "KOLIBRI_HOME", os.path.expanduser("~/.kolibri"))
-            if not os.path.exists(kolibri_home) or not os.listdir(kolibri_home):
-                sys.stderr.write((
-                    "You are running this command as the user '{current_user}', "
-                    "but Kolibri was originally installed to run as the user '{kolibri_user}'.\n"
-                    "This may result in unexpected behavior, "
-                    "because the two users will each use their own local databases and content.\n\n"
-                ).format(current_user=current_user, kolibri_user=kolibri_user))
-                sys.stderr.write((
-                    "If you'd like to run the command as '{}', you can try:\n\n"
-                    "    sudo su {} -c '<command>'\n\n"
-                ).format(kolibri_user, kolibri_user))
-                cont = input(
-                    "Alternatively, would you like to continue and "
-                    "run the command as '{}'? [y/N] ".format(current_user))
-                if not cont.strip().lower() == "y":
-                    sys.exit(0)
+    if not os.name == "posix" or not os.path.isfile("/etc/kolibri/username"):
+        return
+
+    with open("/etc/kolibri/username", "r") as f:
+        kolibri_user = f.read().rstrip()
+    current_user = os.environ["USER"]
+    if not kolibri_user or kolibri_user == current_user:
+        return
+
+    kolibri_home = os.path.expanduser(os.environ.get(
+        "KOLIBRI_HOME", "~/.kolibri"))
+    if os.path.exists(kolibri_home) and os.listdir(kolibri_home):
+        return
+
+    sys.stderr.write((
+        "You are running this command as the user '{current_user}', "
+        "but Kolibri was originally installed to run as the user '{kolibri_user}'.\n"
+        "This may result in unexpected behavior, "
+        "because the two users will each use their own local databases and content.\n\n"
+    ).format(current_user=current_user, kolibri_user=kolibri_user))
+    sys.stderr.write((
+        "If you'd like to run the command as '{}', you can try:\n\n"
+        "    sudo su {} -c '<command>'\n\n"
+    ).format(kolibri_user, kolibri_user))
+    cont = input(
+        "Alternatively, would you like to continue and "
+        "run the command as '{}'? [y/N] ".format(current_user))
+    if not cont.strip().lower() == "y":
+        sys.exit(0)

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -9,21 +9,25 @@ def check_debian_user():
     # that is installed from .deb package.
     # The code is mainly from https://github.com/learningequality/ka-lite/blob/master/bin/kalite#L53
     if os.name == "posix" and os.path.isfile("/etc/kolibri/username"):
-        kolibri_user = open("/etc/kolibri/username", "r").read().rstrip()
+        with open("/etc/kolibri/username", "r") as f:
+            kolibri_user = f.read().rstrip()
         current_user = os.environ["USER"]
         if kolibri_user and kolibri_user != current_user:
-            kolibri_home = os.environ.get("KOLIBRI_HOME", os.path.expanduser("~/.kolibri"))
+            kolibri_home = os.environ.get(
+                "KOLIBRI_HOME", os.path.expanduser("~/.kolibri"))
             if not os.path.exists(kolibri_home) or not os.listdir(kolibri_home):
                 sys.stderr.write((
-                    "You are not running kolibri as the default user {}. "
-                    "This is recommended unless you want to re-create the database "
-                    "and start storing new videos/exercises etc. for a different "
-                    "user account\n\n"
-                ).format(kolibri_user))
+                    "You are running this command as the user '{current_user}', "
+                    "but Kolibri was originally installed to run as the user '{kolibri_user}'.\n"
+                    "This may result in unexpected behavior, "
+                    "because the two users will each use their own local databases and content.\n\n"
+                ).format(current_user=current_user, kolibri_user=kolibri_user))
                 sys.stderr.write((
-                    "To run the command as the default user, run this instead:\n\n"
+                    "If you'd like to run the command as '{}', you can try:\n\n"
                     "    sudo su {} -c '<command>'\n\n"
-                ).format(kolibri_user))
-                cont = input("Do you wish to continue? [y/N] ")
+                ).format(kolibri_user, kolibri_user))
+                cont = input(
+                    "Alternatively, would you like to continue and "
+                    "run the command as '{}'? [y/N] ".format(current_user))
                 if not cont.strip().lower() == "y":
                     sys.exit(0)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to check whether the current user who tries to run kolibri is the `kolibri` user. And users are free to choose if they want to continue as the current user even though it's not the `kolibri` user. 
The code is from https://github.com/learningequality/ka-lite/blob/master/bin/kalite#L53

I put the function `check_debian_user()` in the front of the file `kolibri/utils/cli.py` because the module import `from . import server` goes into the file `kolibri/utils/conf.py`, which creates a kolibri home directory under the current user. This contradicts our intention to ask users before creating a kolibri home directory. Please feel free to let me know if you think there is a better place to put this function `check_debian_user()`. Thank you! 

This PR will not be working on Debian until we merge https://github.com/learningequality/kolibri-installer-debian/pull/43. 

<img width="452" alt="screen shot 2018-06-29 at 10 15 08 am" src="https://user-images.githubusercontent.com/19424916/42105501-5fc62998-7b85-11e8-95e1-a4abbd82b081.png">


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Testing installer's link is in the comment below

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3881

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
