### PR TITLE
Turn setup wizard redirect into an HTTP META refresh to avoid load.

### DIFF
--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -17,7 +17,12 @@ class KolibriTagNavigationTestCase(APITestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         url = reverse('kolibri:setupwizardplugin:setupwizard')
-        self.assertTrue('<meta http-equiv="refresh" content="0;URL=\'{url}\'" />'.format(url=url) in response.content)
+        try:
+            content = str(response.content, 'utf-8')
+        except TypeError:
+            # Will throw TypeError on Py2 as str does not take additional argument
+            content = response.content
+        self.assertTrue('<meta http-equiv="refresh" content="0;URL=\'{url}\'" />'.format(url=url) in content)
 
     def test_redirect_root_to_user_if_not_logged_in(self):
         provision_device()

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -1,11 +1,13 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 
+from kolibri.auth.test.helpers import create_superuser
+from kolibri.auth.test.helpers import provision_device
 from kolibri.auth.test.test_api import FacilityFactory
-
-from kolibri.auth.test.helpers import create_superuser, provision_device
 
 DUMMY_PASSWORD = "password"
 
@@ -13,8 +15,9 @@ class KolibriTagNavigationTestCase(APITestCase):
 
     def test_redirect_to_setup_wizard(self):
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.get("location"), reverse('kolibri:setupwizardplugin:setupwizard'))
+        self.assertEqual(response.status_code, 200)
+        url = reverse('kolibri:setupwizardplugin:setupwizard')
+        self.assertTrue('<meta http-equiv="refresh" content="0;URL=\'{url}\'" />'.format(url=url) in response.content)
 
     def test_redirect_root_to_user_if_not_logged_in(self):
         provision_device()

--- a/kolibri/plugins/setup_wizard/middleware.py
+++ b/kolibri/plugins/setup_wizard/middleware.py
@@ -14,6 +14,8 @@ ALLOWED_PATH_LIST = [
 
 SETUP_WIZARD_URL = reverse("kolibri:setupwizardplugin:setupwizard")
 
+# Workaround for https://github.com/learningequality/kolibri/issues/3852
+# Uses a meta tag redirect rather than a 302 to prevent extra load by Windows GUI polling
 redirect_page_content = """
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>

--- a/kolibri/plugins/setup_wizard/middleware.py
+++ b/kolibri/plugins/setup_wizard/middleware.py
@@ -1,6 +1,8 @@
 from django.core.urlresolvers import reverse
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
+
 from kolibri.core.device.utils import device_provisioned
 
 ALLOWED_PATH_LIST = [
@@ -9,6 +11,16 @@ ALLOWED_PATH_LIST = [
     "kolibri:set_language",
     "session-list"
 ]
+
+SETUP_WIZARD_URL = reverse("kolibri:setupwizardplugin:setupwizard")
+
+redirect_page_content = """
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="refresh" content="0;URL='{url}'" />
+  </head>
+</html>
+""".format(url=SETUP_WIZARD_URL)
 
 
 class SetupWizardMiddleware(MiddlewareMixin):
@@ -21,7 +33,7 @@ class SetupWizardMiddleware(MiddlewareMixin):
         # If a DevicePermissions with is_superuser has already been created, no need to do anything here
         self.device_provisioned = self.device_provisioned or device_provisioned()
         if self.device_provisioned:
-            if request.path.startswith(reverse("kolibri:setupwizardplugin:setupwizard")):
+            if request.path.startswith(SETUP_WIZARD_URL):
                 return redirect(reverse("kolibri:learnplugin:learn"))
             return
 
@@ -31,4 +43,4 @@ class SetupWizardMiddleware(MiddlewareMixin):
             return
 
         # If we've gotten this far, we want to redirect to the setup wizard
-        return redirect(reverse("kolibri:setupwizardplugin:setupwizard"))
+        return HttpResponse(redirect_page_content)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The Windows GUI pings the server repeatedly as a status check, and pre-provisioning this puts extra load and triggers redirects/session creation, which then causes database lockup on lower-end devices when attempting to provision.

This PR turns the redirect into a simple static HTML page that uses the HTTP META tag redirect method to send to the setup wizard instead.

I tested manually to make sure it still does all the right things in the browser, and also tested that it fixes the bug (as seen on Windows) that I can replicate on my own Ubuntu machine with running a bash script containing:

```
kolibri stop > /dev/null 2> /dev/null
yes yes | kolibri manage deprovision  > /dev/null 2> /dev/null
kolibri start  > /dev/null 2> /dev/null
sleep 3
siege http://127.0.0.1:8080/learn/ > /dev/null 2> /dev/null & 
sleep 3
echo
curl 'http://127.0.0.1:8080/api/deviceprovision/' -H 'Pragma: no-cache' -H 'Origin: http://127.0.0.1:8080' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7,es;q=0.6' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36' -H 'Content-Type: application/json' -H 'Accept: application/json, application/json;q=0.8, text/plain;q=0.5, */*;q=0.2' -H 'Cache-Control: no-cache' -H 'X-CSRFToken: 06GfDHzdCE0i3LvP4GELuqQ8MJxZ1dbvKhlo80yJRBheQK0ML1RVgr9nOH4jXEKt' -H 'Referer: http://127.0.0.1:8080/setup_wizard/' -H 'Cookie: visitor=fwAAAVruV5VfISoFAwMDAg==; django_language=en; csrftoken=06GfDHzdCE0i3LvP4GELuqQ8MJxZ1dbvKhlo80yJRBheQK0ML1RVgr9nOH4jXEKt; sessionid=1n4uynllnfh9ugmr54niqjo20ext9pc8' -H 'Connection: keep-alive' -H 'DNT: 1' --data-binary '{"language_id":"en","facility":{"name":"f"},"superuser":{"full_name":"f","username":"f","password":"f"},"preset":"nonformal"}' --compressed
echo
echo
```

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Can test regular behavior manually and using the script above test that it avoids the database lockup issue.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
