### PR TITLE
Add a middleware to ignore the "kolibri session" user agent

### DIFF
--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -30,5 +30,6 @@ class IgnoreGUIMiddleware(object):
         return response
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if request.META["HTTP_USER_AGENT"] == "Kolibri session":
+        if request.META.get("HTTP_USER_AGENT", None) == "Kolibri session":
             return HttpResponse('')
+        return None

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.middleware.locale import LocaleMiddleware
 from django.utils import translation
 
@@ -10,3 +11,24 @@ class KolibriLocaleMiddleware(LocaleMiddleware):
         language = get_language_from_request(request)
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
+
+
+class IgnoreGUIMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if request.META["HTTP_USER_AGENT"] == "Kolibri session":
+            return HttpResponse('')

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -84,6 +84,7 @@ LOCALE_PATHS += [
 ]
 
 MIDDLEWARE = [
+    'kolibri.core.device.middleware.IgnoreGUIMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'kolibri.core.device.middleware.KolibriLocaleMiddleware',


### PR DESCRIPTION
### Summary
Adds a middleware to ignore the user agent that the Windows GUI uses when it repeatedly pings the Kolibri server.

### Reviewer guidance
Does it still work? Does the Windows installer work?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
