### PR TITLE
Reduce label bottom margin in lesson and exam summaries

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -171,7 +171,7 @@
     color: $core-text-annotation // same as table header
     font-size: $table-header-size
     margin-top: 16px
-    margin-bottom: 16px
+    margin-bottom: 8px
 
   dd
     margin-left: 0


### PR DESCRIPTION
### Summary

Fix https://github.com/learningequality/kolibri/issues/3828

Before

![localhost_8000_coach_ iphone 5_se 1](https://user-images.githubusercontent.com/7193975/42185296-3969698e-7dfd-11e8-9d08-5572477894c7.png)

After

![localhost_8000_coach_ iphone 5_se](https://user-images.githubusercontent.com/7193975/42185295-388db664-7dfd-11e8-98fd-9df6be12cb1e.png)

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
