### PR TITLE
Use min aggregation function instead of all_ to give bool AND behaviour.

### DIFF
--- a/kolibri/content/utils/annotation.py
+++ b/kolibri/content/utils/annotation.py
@@ -3,7 +3,6 @@ import logging as logger
 import os
 
 from le_utils.constants import content_kinds
-from sqlalchemy import all_
 from sqlalchemy import and_
 from sqlalchemy import exists
 from sqlalchemy import func
@@ -201,7 +200,7 @@ def recurse_availability_up_tree(channel_id):
         # but otherwise false.
         # Everything after the select statement should be identical to the available_nodes expression above.
         if bridge.engine.name == 'sqlite':
-            coach_content_nodes = select([all_(child.c.coach_content)]).where(
+            coach_content_nodes = select([func.min(child.c.coach_content)]).where(
                 and_(
                     child.c.available == True,  # noqa
                     child.c.level == level,


### PR DESCRIPTION
### Summary
A weird edge case arose whereby sibling-less topics would seem to apply *any* behaviour when determining their coach_content status from their children, as opposed to *all*. This fixes that.

### Reviewer guidance
Import channel 95a52b386f2c485cb97dd60901674a98 and verify that the channel is visible to a learner.

### References
Fixes #3939.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
