### PR TITLE
Fix implicit derived dependencies that occur at build-time dep bundling

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,8 @@ djangorestframework-csv==1.4.1
 tqdm==4.8.3                     # progress bars
 requests==2.18.4
 https://github.com/cherrypy/cherrypy/archive/v6.2.0.zip#egg=cherrypy
+tempora<1.13  # derived no-upper-bounds dependency of cherrypy causing issues  # pyup: <1.13
+cheroot<6.2.0  # 6.2.0 introduced a namespaced pkg # pyup: <6.2.0
 iceqube==0.0.3
 porter2stemmer==1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
### Summary

Fixes severe regression. It is detected through our little Makefile filter at build time, but would otherwise cause issues in the PEX distribution, which doesn't support namespaced packages. Moreover, our `kolibri/dist` bundling, AFAIK also has issues.

```
# This expression checks that everything in kolibri/dist has an __init__.py
# To prevent namespaced packages from suddenly showing up
# https://github.com/learningequality/kolibri/pull/2972
! find kolibri/dist -mindepth 1 -maxdepth 1 -type d -not -name __pycache__ -not -name cext -not -name py2only -exec ls {}/__init__.py \; 2>&1 | grep  "No such file"
ls: cannot access 'kolibri/dist/jaraco/__init__.py': No such file or directory
Makefile:116: recipe for target 'test-namespaced-packages' failed
make[1]: Leaving directory '/kolibri'
make[1]: *** [test-namespaced-packages] Error 1
make: *** [staticdeps] Error 2
Makefile:122: recipe for target 'staticdeps' failed
make: *** [dockerenvdist] Error 2
```

### Reviewer guidance

How far back should this go? I'm worried that because cherrypy doesn't seem to carry upper bounds, we may see this error repeated at all subsequent patch releases in our branches.

We don't have to release this, just because we push it into a release branch. It just ensures that we don't release anything broken later in life...

See: https://github.com/cherrypy/cherrypy/issues/1722#issuecomment-402695776

### References

#2978 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
