### PR TITLE
Don't overwrite localfile availability on channel metadata import.

### DIFF
--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -66,6 +66,11 @@ class ChannelImport(object):
                 'tree_id': 'get_tree_id',
             },
         },
+        LocalFile: {
+            'per_row': {
+                'available': 'get_none',
+            },
+        },
     }
 
     def __init__(self, channel_id, channel_version=None):
@@ -88,6 +93,9 @@ class ChannelImport(object):
 
     def get_tree_id(self, source_object):
         return self.tree_id
+
+    def get_none(self, source_object):
+        return None
 
     def get_all_destination_tree_ids(self):
         ContentNodeRecord = self.destination.get_class(ContentNode)
@@ -297,9 +305,6 @@ class NoVersionChannelImport(ChannelImport):
     }
 
     licenses = {}
-
-    def get_none(self, source_object):
-        return None
 
     def infer_channel_id_from_source(self, source_object):
         return self.channel_id


### PR DESCRIPTION
### Summary
Copies fix from https://github.com/learningequality/kolibri/commit/5777ea862b3eebeb1dd9a496c77d4655996b4c8b#diff-0ec475598a891a7cec7aba5496a508f3R79 to prevent LocalFile objects having their availability overwritten on import.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
