### PR TITLE
Add url smoke tests to Kolibri

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -314,11 +314,15 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         """
         Returns the number of node copies for each content id.
         """
-        content_ids = self.request.query_params.get('content_ids', []).split(',')
-        counts = models.ContentNode.objects.filter(content_id__in=content_ids, available=True) \
-                                           .values('content_id') \
-                                           .order_by() \
-                                           .annotate(count=Count('content_id'))
+        content_id_string = self.request.query_params.get('content_ids')
+        if content_id_string:
+            content_ids = content_id_string.split(',')
+            counts = models.ContentNode.objects.filter(content_id__in=content_ids, available=True) \
+                                               .values('content_id') \
+                                               .order_by() \
+                                               .annotate(count=Count('content_id'))
+        else:
+            counts = 0
         return Response(counts)
 
     @detail_route(methods=['get'])

--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -88,6 +88,9 @@ class ContentRendererHook(WebpackBundleHook):
 
         :returns: HTML of a script tag to insert into a page.
         """
+        # Note, while most plugins use sorted chunks to filter by text direction
+        # content renderers do not, as they may need to have styling for a different
+        # text direction than the interface due to the text direction of content
         urls = [chunk['url'] for chunk in self.bundle]
         tags = self.frontend_message_tag() +\
             ['<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -3,13 +3,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from django.urls.exceptions import NoReverseMatch
 from rest_framework.test import APITestCase
 
+from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
 from kolibri.core.auth.test.test_api import FacilityFactory
-
-DUMMY_PASSWORD = "password"
+from kolibri.core.auth.test.test_api import FacilityUserFactory
+from kolibri.deployment.default.urls import urlpatterns
 
 
 class KolibriTagNavigationTestCase(APITestCase):
@@ -39,3 +42,99 @@ class KolibriTagNavigationTestCase(APITestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.get("location"), reverse('kolibri:learnplugin:learn'))
+
+
+class AllUrlsTest(APITestCase):
+
+    allowed_http_codes = [200, 302, 400, 401, 403, 404, 405]
+
+    def setUp(self):
+        provision_device()
+
+    def check_responses(self, credentials=None): # noqa max-complexity=12
+        """
+        This is a very liberal test, we are mostly just concerned with making sure
+        that no pages throw errors (500).
+        Adapted from:
+        http://stackoverflow.com/questions/14454001/list-all-suburls-and-check-if-broken-in-python#answer-19162337
+        Test all pattern in root urlconf and included ones.
+        Do GET requests only.
+        A pattern is skipped if any of the conditions applies:
+            - pattern has no name in urlconf
+            - pattern expects any positinal parameters
+            - pattern expects keyword parameters that are not specified in @default_kwargs
+        If response code is not in @allowed_http_codes, fail the test.
+        if @credentials dict is specified (e.g. username and password),
+            login before run tests.
+        If @logout_url is specified, then check if we accidentally logged out
+            the client while testing, and login again
+        Specify @default_kwargs to be used for patterns that expect keyword parameters,
+            e.g. if you specify default_kwargs={'username': 'testuser'}, then
+            for pattern url(r'^accounts/(?P<username>[\.\w-]+)/$'
+            the url /accounts/testuser/ will be tested.
+        If @quiet=False, print all the urls checked. If status code of the response is not 200,
+            print the status code.
+        """
+        if not credentials:
+            credentials = {}
+
+        def check_urls(urlpatterns, prefix=''):
+            if credentials:
+                self.client.login(**credentials)
+            for pattern in urlpatterns:
+                if hasattr(pattern, 'url_patterns'):
+                    # this is an included urlconf
+                    new_prefix = prefix
+                    if pattern.namespace:
+                        new_prefix = prefix + (":" if prefix else "") + pattern.namespace
+                    check_urls(pattern.url_patterns, prefix=new_prefix)
+                skip = False
+                regex = pattern.regex
+                if regex.groups > 0:
+                    skip = True
+                if hasattr(pattern, "name") and pattern.name:
+                    name = pattern.name
+                else:
+                    # if pattern has no name, skip it
+                    skip = True
+                    name = ""
+                fullname = (prefix + ":" + name) if prefix else name
+                if not skip:
+                    try:
+                        url = reverse(fullname)
+                        print("testing url: {0}".format(url))
+                        response = self.client.get(url)
+                        self.assertIn(response.status_code, self.allowed_http_codes,
+                                      "{url} gave status code {status_code}".format(url=url, status_code=response.status_code))
+                        # print status code if it is not 200
+                        status = "" if response.status_code == 200 else str(response.status_code) + " "
+                        print(status + url)
+                        if url == reverse('kolibri:logout'):
+                            self.client.login(**credentials)
+                    except NoReverseMatch:
+                        pass
+                else:
+                    print("SKIP " + regex.pattern + " " + fullname)
+        check_urls(urlpatterns)
+
+    def test_anonymous_responses(self):
+        self.check_responses()
+
+    def test_learner_responses(self):
+        user = FacilityUserFactory.create()
+        self.check_responses(credentials={'username': user.username, 'password': DUMMY_PASSWORD})
+
+    def test_coach_responses(self):
+        user = FacilityUserFactory.create()
+        user.facility.add_role(user, role_kinds.COACH)
+        self.check_responses(credentials={'username': user.username, 'password': DUMMY_PASSWORD})
+
+    def test_admin_responses(self):
+        user = FacilityUserFactory.create()
+        user.facility.add_role(user, role_kinds.ADMIN)
+        self.check_responses(credentials={'username': user.username, 'password': DUMMY_PASSWORD})
+
+    def test_superuser_responses(self):
+        facility = FacilityFactory.create()
+        user = create_superuser(facility)
+        self.check_responses(credentials={'username': user.username, 'password': DUMMY_PASSWORD})


### PR DESCRIPTION
### Summary
This adds very minimal URL smoke tests to Kolibri (which only work for URLs that do not need supplied arguments).

Fixes one small issue that arose during testing.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
