### PR TITLE
In Exam Report + Preview, handle when Exercises are not available

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -64,14 +64,22 @@ function getExamReport(store, examId, userId, questionNumber = 0, interactionInd
               contentNodeMap[node.pk] = node;
             });
 
-            const questions = questionList.map(question => ({
-              itemId: selectQuestionFromExercise(
-                question.assessmentItemIndex,
-                seed,
-                contentNodeMap[question.contentId]
-              ),
-              contentId: question.contentId,
-            }));
+            // Only pick questions that are still on server
+            const questions = questionList
+              .filter(question => contentNodeMap[question.contentId])
+              .map(question => ({
+                itemId: selectQuestionFromExercise(
+                  question.assessmentItemIndex,
+                  seed,
+                  contentNodeMap[question.contentId]
+                ),
+                contentId: question.contentId,
+              }));
+
+            // When all the Exercises are not available on the server
+            if (questions.length === 0) {
+              return resolve({ exam, examLog, user });
+            }
 
             const allQuestions = questions.map((question, index) => {
               const attemptLog = examAttempts.filter(

--- a/kolibri/core/assets/src/views/exam-report/index.vue
+++ b/kolibri/core/assets/src/views/exam-report/index.vue
@@ -96,14 +96,6 @@
         type: String,
         required: true,
       },
-      userId: {
-        type: String,
-        required: true,
-      },
-      currentAttempt: {
-        type: Object,
-        required: true,
-      },
       currentInteractionHistory: {
         type: Array,
         required: true,
@@ -136,10 +128,6 @@
       },
       closed: {
         type: Boolean,
-        required: true,
-      },
-      backPageLink: {
-        type: Object,
         required: true,
       },
       navigateToQuestion: {

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -1,23 +1,26 @@
 <template>
 
-  <exam-report
-    :examAttempts="examAttempts"
-    :exam="exam"
-    :userName="userName"
-    :userId="userId"
-    :currentAttempt="currentAttempt"
-    :currentInteractionHistory="currentInteractionHistory"
-    :currentInteraction="currentInteraction"
-    :selectedInteractionIndex="selectedInteractionIndex"
-    :questionNumber="questionNumber"
-    :exercise="exercise"
-    :itemId="itemId"
-    :completionTimestamp="completionTimestamp"
-    :closed="closed"
-    :backPageLink="backPageLink"
-    :navigateToQuestion="navigateToQuestion"
-    :navigateToQuestionAttempt="navigateToQuestionAttempt"
-  />
+  <div>
+    <exam-report
+      v-if="examAttempts"
+      :examAttempts="examAttempts"
+      :exam="exam"
+      :userName="userName"
+      :currentInteractionHistory="currentInteractionHistory"
+      :currentInteraction="currentInteraction"
+      :selectedInteractionIndex="selectedInteractionIndex"
+      :questionNumber="questionNumber"
+      :exercise="exercise"
+      :itemId="itemId"
+      :completionTimestamp="completionTimestamp"
+      :closed="closed"
+      :navigateToQuestion="navigateToQuestion"
+      :navigateToQuestionAttempt="navigateToQuestionAttempt"
+    />
+    <div v-else>
+      {{ $tr('reportsNotAvailableForExam') }}
+    </div>
+  </div>
 
 </template>
 
@@ -80,6 +83,9 @@
         completionTimestamp: state => state.pageState.examLog.completion_timestamp,
         closed: state => state.pageState.examLog.closed,
       },
+    },
+    $trs: {
+      reportsNotAvailableForExam: 'Reports are not available for this exam',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exam-report-detail-page/index.vue
@@ -17,8 +17,8 @@
       :navigateToQuestion="navigateToQuestion"
       :navigateToQuestionAttempt="navigateToQuestionAttempt"
     />
-    <div v-else>
-      {{ $tr('reportsNotAvailableForExam') }}
+    <div v-else class="no-exercise-x">
+      <mat-svg category="navigation" name="close" />
     </div>
   </div>
 
@@ -84,12 +84,17 @@
         closed: state => state.pageState.examLog.closed,
       },
     },
-    $trs: {
-      reportsNotAvailableForExam: 'Reports are not available for this exam',
-    },
   };
 
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .no-exercise-x
+    text-align: center
+    svg
+      height: 200px
+      width: 200px
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -17,7 +17,7 @@
       </div>
       <div v-else>
         <div ref="header">
-          <strong>{{ $tr('numQuestions', { num: examNumQuestions }) }}</strong>
+          <strong>{{ $tr('numQuestions', { num: availableExamQuestionSources.length }) }}</strong>
           <slot name="randomize-button"></slot>
         </div>
         <k-grid
@@ -25,7 +25,10 @@
           :style="{ maxHeight: `${maxHeight}px` }"
         >
           <k-grid-item size="1" cols="3" class="question-selector">
-            <div v-for="(exercise, exerciseIndex) in examQuestionSources" :key="exerciseIndex">
+            <div
+              v-for="(exercise, exerciseIndex) in availableExamQuestionSources"
+              :key="exerciseIndex"
+            >
               <h3 v-if="examCreation">{{ getExerciseName(exercise.exercise_id) }}</h3>
               <ol class="question-list">
                 <li
@@ -147,9 +150,14 @@
       debouncedSetMaxHeight() {
         return debounce(this.setMaxHeight, 250);
       },
+      availableExamQuestionSources() {
+        return this.examQuestionSources.filter(questionSource => {
+          return this.exercises[questionSource.exercise_id];
+        });
+      },
       questions() {
         return Object.keys(this.exercises).length
-          ? createQuestionList(this.examQuestionSources).map(question => ({
+          ? createQuestionList(this.availableExamQuestionSources).map(question => ({
               itemId: selectQuestionFromExercise(
                 question.assessmentItemIndex,
                 this.examSeed,

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -12,6 +12,9 @@
         v-if="loading"
         :delay="false"
       />
+      <div v-else-if="exerciseContentNodes.length === 0">
+        {{ $tr('previewNotAvailableForExam') }}
+      </div>
       <div v-else>
         <div ref="header">
           <strong>{{ $tr('numQuestions', { num: examNumQuestions }) }}</strong>
@@ -104,6 +107,7 @@
       question: 'Question { num }',
       numQuestions: '{num} {num, plural, one {question} other {questions}}',
       exercise: 'Exercise { num }',
+      previewNotAvailableForExam: 'Preview is not available for this exam',
     },
     components: {
       coachContentLabel,

--- a/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/exams-page/preview-exam-modal.vue
@@ -12,8 +12,8 @@
         v-if="loading"
         :delay="false"
       />
-      <div v-else-if="exerciseContentNodes.length === 0">
-        {{ $tr('previewNotAvailableForExam') }}
+      <div class="no-exercise-x" v-else-if="exerciseContentNodes.length === 0">
+        <mat-svg category="navigation" name="close" />
       </div>
       <div v-else>
         <div ref="header">
@@ -110,7 +110,6 @@
       question: 'Question { num }',
       numQuestions: '{num} {num, plural, one {question} other {questions}}',
       exercise: 'Exercise { num }',
-      previewNotAvailableForExam: 'Preview is not available for this exam',
     },
     components: {
       coachContentLabel,
@@ -292,5 +291,11 @@
   h3
     margin-top: 1em
     margin-bottom: 0.25em
+
+  .no-exercise-x
+    text-align: center
+    svg
+      height: 200px
+      width: 200px
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -17,8 +17,8 @@
       :navigateToQuestion="navigateToQuestion"
       :navigateToQuestionAttempt="navigateToQuestionAttempt"
     />
-    <div v-else>
-      {{ $tr('reportsNotAvailableForExam') }}
+    <div class="no-exercise-x" v-else>
+      <mat-svg category="navigation" name="close" />
     </div>
   </div>
 
@@ -82,12 +82,17 @@
         closed: state => state.pageState.examLog.closed,
       },
     },
-    $trs: {
-      reportsNotAvailableForExam: 'Reports are not available for this exam',
-    },
   };
 
 </script>
 
 
-<style lang="stylus" scoped></style>
+<style lang="stylus" scoped>
+
+  .no-exercise-x
+    text-align: center
+    svg
+      height: 200px
+      width: 200px
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -1,20 +1,26 @@
 <template>
 
-  <exam-report
-    :examAttempts="examAttempts"
-    :exam="exam"
-    :userName="userName"
-    :currentInteractionHistory="currentInteractionHistory"
-    :currentInteraction="currentInteraction"
-    :selectedInteractionIndex="selectedInteractionIndex"
-    :questionNumber="questionNumber"
-    :exercise="exercise"
-    :itemId="itemId"
-    :completionTimestamp="completionTimestamp"
-    :closed="closed"
-    :navigateToQuestion="navigateToQuestion"
-    :navigateToQuestionAttempt="navigateToQuestionAttempt"
-  />
+  <div>
+    <exam-report
+      v-if="examAttempts"
+      :examAttempts="examAttempts"
+      :exam="exam"
+      :userName="userName"
+      :currentInteractionHistory="currentInteractionHistory"
+      :currentInteraction="currentInteraction"
+      :selectedInteractionIndex="selectedInteractionIndex"
+      :questionNumber="questionNumber"
+      :exercise="exercise"
+      :itemId="itemId"
+      :completionTimestamp="completionTimestamp"
+      :closed="closed"
+      :navigateToQuestion="navigateToQuestion"
+      :navigateToQuestionAttempt="navigateToQuestionAttempt"
+    />
+    <div v-else>
+      {{ $tr('reportsNotAvailableForExam') }}
+    </div>
+  </div>
 
 </template>
 
@@ -75,6 +81,9 @@
         completionTimestamp: state => state.pageState.examLog.completion_timestamp,
         closed: state => state.pageState.examLog.closed,
       },
+    },
+    $trs: {
+      reportsNotAvailableForExam: 'Reports are not available for this exam',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-report-viewer.vue
@@ -4,8 +4,6 @@
     :examAttempts="examAttempts"
     :exam="exam"
     :userName="userName"
-    :userId="userId"
-    :currentAttempt="currentAttempt"
     :currentInteractionHistory="currentInteractionHistory"
     :currentInteraction="currentInteraction"
     :selectedInteractionIndex="selectedInteractionIndex"
@@ -14,7 +12,6 @@
     :itemId="itemId"
     :completionTimestamp="completionTimestamp"
     :closed="closed"
-    :backPageLink="backPageLink"
     :navigateToQuestion="navigateToQuestion"
     :navigateToQuestionAttempt="navigateToQuestionAttempt"
   />

--- a/kolibri/plugins/style_guide/assets/src/app.js
+++ b/kolibri/plugins/style_guide/assets/src/app.js
@@ -12,7 +12,7 @@ class StyleGuideModule extends KolibriModule {
     document.title = 'Kolibri Style Guide';
     this.rootvue = new Vue({
       el: 'rootvue',
-      name: 'styleGuideRoot',
+      name: 'StyleGuideRoot',
       render: createElement => createElement(RootVue),
       router: router.init(navMenuRoutes, {
         // Enable the anchor scrolling behavior (which requires the vue-router


### PR DESCRIPTION
### Summary

1. When hydrating Learner/Coach Exam Report pages, handle cases when some or all of the Exercises in an Exam are no longer installed on the server.
1. When displaying a Learner/Coach Exam Report page, show an empty state message when *all* Exercises are no longer on exam. If a subset of the Exercises are still available, they will appear in the Report.
1. Remove some unused props from `exam-report` component.

### Reviewer guidance

**Scenario: All Exercises available**

1. Create and active an Exam
1. Interact with Exam as a Learner
1. As a coach, check to see that Coach Reports + Preview work for Exam
1. As a Learner, check to see that Exam Reports work

**All Exercises Deleted**
1. Create and activate an Exam (select exercises from only one channel)
1. Interact with Exam as a Learner
1. Delete the Channel from which the Exam Exercises were taken
1. As a coach, check to see that Coach Reports + Preview work for Exam. You should see an empty state ("Preview not available...", "Reports not available...")
1. As a Learner, check to see that Exam Reports work

**Some Exercises Deleted**
1. Create and activate an Exam (select exercises from at least two channels)
1. Interact with Exam as a Learner
1. Delete one of the Channels from which the Exam Exercises were taken
1. As a coach, check to see that Coach Reports + Preview work for Exam. You should see only the exercises that remain on the server after deleting the one channel.
1. As a Learner, check to see that Exam Reports work

### References

#3947 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
