### PR TITLE
Inject copyright year at build time

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     __coreAPISpec: true,
     __filename: true,
     __publicPath: true,
+    __copyrightYear: true,
   },
   extends: [
     'eslint:recommended',

--- a/frontend_build/src/read_bundle_plugins.js
+++ b/frontend_build/src/read_bundle_plugins.js
@@ -104,6 +104,7 @@ var readBundlePlugins = function() {
         bundle.plugins.push(
           new webpack.DefinePlugin({
             __coreAPISpec: '{}',
+            __copyrightYear: new Date().getFullYear(),
           })
         );
       }

--- a/jest_config/jest.conf.js
+++ b/jest_config/jest.conf.js
@@ -15,6 +15,7 @@ module.exports = {
     __version: 'testversion',
     __events: {},
     __once: {},
+    __copyrightYear: '2018',
   },
   rootDir: path.resolve(__dirname, '../'),
   moduleFileExtensions: ['js', 'json', 'vue'],

--- a/kolibri/core/assets/src/views/side-nav.vue
+++ b/kolibri/core/assets/src/views/side-nav.vue
@@ -52,7 +52,7 @@
             <div class="side-nav-scrollable-area-footer-info">
               <p>{{ footerMsg }}</p>
               <!-- Not translated -->
-              <p>© 2018 Learning Equality</p>
+              <p>© {{ copyrightYear }} Learning Equality</p>
             </div>
           </div>
         </div>
@@ -133,6 +133,8 @@
     data() {
       return {
         previouslyFocusedElement: null,
+        // __copyrightYear is injected by Webpack DefinePlugin
+        copyrightYear: __copyrightYear,
       };
     },
     computed: {


### PR DESCRIPTION
### Summary

Uses Webpack DefinePlugin to hard-code the copyright year as the year when the bundle is created.

### Reviewer guidance

Check that the copyright year on the side-nav is correct.

Move your system clock forward or back in time and see that copyright year is correct then too.

### References

Fixes #3841 

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
