### PR TITLE
Fix layout of selected-resources-size

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/select-content-page/selected-resources-size.vue
+++ b/kolibri/plugins/device_management/assets/src/views/select-content-page/selected-resources-size.vue
@@ -1,34 +1,36 @@
 <template>
 
-  <section class="selected-resources-size">
-    <div class="choose-message">
-      <span v-if="isInImportMode">
-        {{ $tr('chooseContentToImport') }}
-      </span>
-      <span v-else>
-        {{ $tr('chooseContentToExport') }}
-      </span>
+  <section>
+    <div class="counters">
+      <div class="choose-message">
+        <span v-if="isInImportMode">
+          {{ $tr('chooseContentToImport') }}
+        </span>
+        <span v-else>
+          {{ $tr('chooseContentToExport') }}
+        </span>
+      </div>
+
+      <div class="table-row">
+        <span class="remaining-space">
+          {{ $tr('remainingSpace', { space: bytesForHumans(remainingSpaceAfterTransfer) }) }}
+        </span>
+
+        <div class="resources-selected">
+          <span class="resources-selected-message">
+            {{ fileSizeText }}
+          </span>
+
+          <k-button
+            class="confirm-button"
+            :text="buttonText"
+            :primary="true"
+            :disabled="buttonIsDisabled"
+            @click="$emit('clickconfirm')"
+          />
+        </div>
+      </div>
     </div>
-
-    <span class="remaining-space">
-      {{ $tr('remainingSpace', { space: bytesForHumans(remainingSpaceAfterTransfer) }) }}
-    </span>
-
-    <div class="resources-selected">
-      <span class="resources-selected-message">
-        {{
-          $tr('resourcesSelected', { fileSize: bytesForHumans(fileSize), resources: resourceCount })
-        }}
-      </span>
-
-      <k-button
-        :text="buttonText"
-        :primary="true"
-        :disabled="buttonIsDisabled"
-        @click="$emit('clickconfirm')"
-      />
-    </div>
-
 
     <ui-alert
       v-if="remainingSpaceAfterTransfer<=0"
@@ -81,6 +83,12 @@
       remainingSpaceAfterTransfer() {
         return Math.max(this.spaceOnDrive - this.fileSize, 0);
       },
+      fileSizeText() {
+        return this.$tr('resourcesSelected', {
+          fileSize: bytesForHumans(this.fileSize),
+          resources: this.resourceCount,
+        });
+      },
     },
     methods: {
       bytesForHumans,
@@ -101,7 +109,7 @@
 
 <style lang="scss" scoped>
 
-  .selected-resources-size {
+  .counters {
     // using table to separate element by alignment while keeping them on the same line
     // avoids magic numbers, keeps text lined up.
     display: table;
@@ -123,6 +131,14 @@
   .resources-selected {
     display: table-cell;
     text-align: right;
+  }
+
+  .table-row {
+    display: table-row;
+  }
+
+  .confirm-button {
+    margin-right: 0;
   }
 
 </style>


### PR DESCRIPTION
### Summary

Fixes positioning of 'no remaining space' error by moving that error outside of the table containing the remaining space/resources selected message.

<img width="778" alt="screen shot 2018-07-09 at 4 03 23 pm" src="https://user-images.githubusercontent.com/10248067/42480495-89ed2b30-8392-11e8-9a24-754d2cd75150.png">

### Reviewer guidance

Make the no remaining space error appear. It should appear below the counters, not next to them.

### References

Fixes #4003 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
