### PR TITLE
Remove ignored flake8 rules; fix violations

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -11,6 +11,7 @@ from kolibri.core.sqlite.pragmas import START_PRAGMAS
 
 logger = logging.getLogger(__name__)
 
+
 class KolibriCoreConfig(AppConfig):
     name = 'kolibri.core'
 

--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -27,6 +27,8 @@ MODELS_TO_DELETE = [
 ]
 
 # we want to disable the post_delete signal temporarily when deleting, so morango doesn't create DeletedModels objects
+
+
 class DisablePostDeleteSignal(object):
 
     def __enter__(self):

--- a/kolibri/core/auth/management/commands/importusers.py
+++ b/kolibri/core/auth/management/commands/importusers.py
@@ -16,10 +16,12 @@ logging = logger.getLogger(__name__)
 
 DEFAULT_PASSWORD = "kolibri"
 
+
 def validate_username(user):
     # Check if username is specified, if not, throw an error
     if 'username' not in user or user['username'] is None:
         raise CommandError('No usernames specified, this is required for user creation')
+
 
 def infer_facility(user, default_facility):
     if 'facility' in user and user['facility']:
@@ -34,6 +36,7 @@ def infer_facility(user, default_facility):
     else:
         return default_facility
 
+
 def infer_and_create_class(user, facility):
     if 'class' in user and user['class']:
         try:
@@ -45,6 +48,7 @@ def infer_and_create_class(user, facility):
             except Classroom.DoesNotExist:
                 classroom = Classroom.objects.create(name=user['class'], parent=facility)
         return classroom
+
 
 def create_user(i, user, default_facility=None):
     validate_username(user)

--- a/kolibri/core/auth/management/commands/syncdata.py
+++ b/kolibri/core/auth/management/commands/syncdata.py
@@ -9,6 +9,7 @@ DB_PATH = settings.DATABASES["default"]["NAME"]
 
 CENTRAL_SERVER_DB_UPLOAD_URL = "http://kolibridataupload.learningequality.org/upload/"
 
+
 def create_callback(encoder):
     encoder_len = encoder.len
     bar = ProgressBar(expected_size=encoder_len, filled_char="=")
@@ -17,6 +18,7 @@ def create_callback(encoder):
         bar.show(monitor.bytes_read)
 
     return callback
+
 
 class Command(BaseCommand):
     help = "Uploads the local database to a central server for backup and reporting"

--- a/kolibri/core/auth/test/test_data_migrations.py
+++ b/kolibri/core/auth/test/test_data_migrations.py
@@ -9,6 +9,7 @@ from kolibri.core.auth.models import FacilityUser
 
 # Modified from https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 
+
 class TestMigrations(TestCase):
 
     migrate_from = None

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -10,6 +10,7 @@ from ..models import FacilityDataset
 from ..models import FacilityUser
 from ..models import LearnerGroup
 
+
 class FacilityDatasetTestCase(TestCase):
 
     def setUp(self):

--- a/kolibri/core/auth/test/test_deprovisioning.py
+++ b/kolibri/core/auth/test/test_deprovisioning.py
@@ -24,6 +24,7 @@ from kolibri.core.logger.test.factory_logger import UserSessionLogFactory
 def count_instances(models):
     return sum([model.objects.count() for model in models])
 
+
 class UserImportCommandTestCase(TestCase):
     """
     Tests for the deprovision command.

--- a/kolibri/core/auth/test/test_middleware.py
+++ b/kolibri/core/auth/test/test_middleware.py
@@ -8,9 +8,11 @@ from ..middleware import _get_user
 from ..middleware import CustomAuthenticationMiddleware
 from ..models import KolibriAnonymousUser
 
+
 class DummyRequestObject(object):
     def __init__(self):
         self.session = {}
+
 
 class AuthMiddlewareTestCase(TestCase):
 

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -345,6 +345,7 @@ class SuperuserTestCase(TestCase):
         self.assertTrue(superuser.has_perms(["someperm"], object()))
         self.assertTrue(superuser.has_module_perms("module.someapp"))
 
+
 class StringMethodTestCase(TestCase):
 
     def setUp(self):

--- a/kolibri/core/auth/test/test_permissions.py
+++ b/kolibri/core/auth/test/test_permissions.py
@@ -789,6 +789,7 @@ class MembershipPermissionsTestCase(TestCase):
         self.assertTrue(self.superuser.can_delete(membership))
         self.assertFalse(self.anon_user.can_delete(membership))
 
+
 class FacilityDatasetCertificateNamespacingTestCase(TestCase):
 
     def test_unsaved_facility_validation_only_create_one_dataset(self):

--- a/kolibri/core/auth/test/test_permissions_classes.py
+++ b/kolibri/core/auth/test/test_permissions_classes.py
@@ -14,6 +14,7 @@ from ..permissions.general import AllowAll
 from ..permissions.general import DenyAll
 from .helpers import create_superuser
 
+
 class BasePermissionsThrowExceptionsTestCase(TestCase):
 
     def setUp(self):

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -16,10 +16,12 @@ from ..models import Classroom
 from ..models import FacilityUser
 from .helpers import setup_device
 
+
 class UserImportTestCase(TestCase):
     """
     Tests for functions used in userimport command.
     """
+
     def setUp(self):
         self.facility, self.superuser = setup_device()
 
@@ -128,6 +130,7 @@ class UserImportCommandTestCase(TestCase):
     """
     Tests for userimport command.
     """
+
     def setUp(self):
         self.csvfile, self.csvpath = tempfile.mkstemp(suffix='csv')
 

--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 _JSON_CONTENT_TYPES_CACHE = {}
 
+
 class ContentRendererHook(WebpackBundleHook):
     """
     An inheritable hook that allows special behaviour for a frontend module that defines

--- a/kolibri/core/content/legacy_models.py
+++ b/kolibri/core/content/legacy_models.py
@@ -6,6 +6,7 @@ All models in here must have Meta property abstract = True so that they are avai
 but otherwise have no impact on the content app models
 """
 
+
 class License(models.Model):
     """
     Normalize the license of ContentNode model

--- a/kolibri/core/content/management/commands/deletechannel.py
+++ b/kolibri/core/content/management/commands/deletechannel.py
@@ -10,6 +10,7 @@ from kolibri.core.tasks.management.commands.base import AsyncCommand
 
 logging = logger.getLogger(__name__)
 
+
 class Command(AsyncCommand):
 
     def add_arguments(self, parser):

--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -16,6 +16,7 @@ from kolibri.core.content.utils.sqlalchemybridge import SCHEMA_PATH_TEMPLATE
 
 DATA_PATH_TEMPLATE = os.path.join(os.path.dirname(__file__), '../../fixtures/{name}_content_data.json')
 
+
 class Command(BaseCommand):
     """
     This management command produces SQLAlchemy schema reflections of the content database app.

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -87,6 +87,7 @@ CONTENT_DB_SCHEMA_VERSIONS = [
 # The schema version for this version of Kolibri
 CONTENT_SCHEMA_VERSION = VERSION_2
 
+
 class UUIDField(models.CharField):
     """
     Adaptation of Django's UUIDField, but with 32-char hex representation as Python representation rather than a UUID instance.

--- a/kolibri/core/content/templatetags/content_tags.py
+++ b/kolibri/core/content/templatetags/content_tags.py
@@ -23,6 +23,7 @@ from kolibri.core.webpack.utils import webpack_asset_render
 
 register = template.Library()
 
+
 @register.simple_tag()
 def content_renderer_assets():
     """

--- a/kolibri/core/content/test/sqlalchemytesting.py
+++ b/kolibri/core/content/test/sqlalchemytesting.py
@@ -6,15 +6,21 @@ from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 # get_conn and SharingPool code modified from:
 # http://nathansnoggin.blogspot.com/2013/11/integrating-sqlalchemy-into-django.html
 
-# custom connection factory, so we can share with django
+
 def get_conn(self):
+    """
+    custom connection factory, so we can share with django
+    """
     from django.db import connections
     conn = connections['default']
     return conn.connection
 
-# custom connection pool that doesn't close connections, and uses our
-# custom connection factory
+
 class SharingPool(NullPool):
+    """
+    custom connection pool that doesn't close connections, and uses our
+    custom connection factory
+    """
     def __init__(self, get_connection, **kwargs):
         kwargs['reset_on_return'] = False
         super(SharingPool, self).__init__(get_conn, **kwargs)
@@ -33,6 +39,7 @@ class SharingPool(NullPool):
 
     def dispose(self):
         pass
+
 
 def django_connection_engine():
     if get_default_db_string().startswith('sqlite'):

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -33,6 +33,7 @@ from kolibri.core.content.utils.channels import read_channel_metadata_from_db_fi
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 
+
 @patch('kolibri.core.content.utils.channel_import.Bridge')
 @patch('kolibri.core.content.utils.channel_import.ChannelImport.find_unique_tree_id')
 @patch('kolibri.core.content.utils.channel_import.apps')
@@ -68,6 +69,7 @@ class BaseChannelImportClassMethodUniqueTreeIdTestCase(TestCase):
     """
     Testcase for the base channel import class unique tree id generator
     """
+
     def test_empty(self, apps_mock, tree_ids_mock, BridgeMock):
         tree_ids_mock.return_value = []
         channel_import = ChannelImport('test')
@@ -209,7 +211,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock = MagicMock(spec=['__table__'])
         record_mock.__table__.columns.items.return_value = [('test_attr', MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
-        channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}]*100, 0)
+        channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}] * 100, 0)
         channel_import.destination.session.flush.assert_not_called()
 
     def test_no_merge_records_bulk_insert_flush(self, apps_mock, tree_id_mock, BridgeMock):
@@ -217,7 +219,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock = MagicMock(spec=['__table__'])
         record_mock.__table__.columns.items.return_value = [('test_attr', MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
-        channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}]*10000, 0)
+        channel_import.table_import(MagicMock(), lambda x, y: 'test_val', lambda x: [{}] * 10000, 0)
         channel_import.destination.session.flush.assert_called_once_with()
 
     @patch('kolibri.core.content.utils.channel_import.merge_models', new=[])
@@ -231,7 +233,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         model_mock._meta.pk.name = 'test_attr'
         merge_models.append(model_mock)
         channel_import.merge_record = Mock()
-        channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}]*100, 0)
+        channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}] * 100, 0)
         channel_import.destination.session.flush.assert_not_called()
 
     @patch('kolibri.core.content.utils.channel_import.merge_models', new=[])
@@ -245,7 +247,7 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         model_mock._meta.pk.name = 'test_attr'
         merge_models.append(model_mock)
         channel_import.merge_record = Mock()
-        channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}]*10000, 0)
+        channel_import.table_import(model_mock, lambda x, y: 'test_val', lambda x: [{}] * 10000, 0)
         channel_import.destination.session.flush.assert_called_once_with()
 
 
@@ -300,6 +302,7 @@ class BaseChannelImportClassOtherMethodsTestCase(TestCase):
             call.session.query(class_mock),
             call.session.query().all()
         ])
+
 
 class MaliciousDatabaseTestCase(TestCase):
 

--- a/kolibri/core/content/test/test_deletechannel.py
+++ b/kolibri/core/content/test/test_deletechannel.py
@@ -5,6 +5,7 @@ from mock import patch
 
 from kolibri.core.content import models as content
 
+
 class DeleteChannelTestCase(TestCase):
     """
     Testcase for delete channel management command
@@ -56,4 +57,4 @@ class DeleteChannelTestCase(TestCase):
         content_file_path.return_value = path
         num_files = content.LocalFile.objects.filter(available=True).count()
         self.delete_channel()
-        os_remove_mock.assert_has_calls([call(path)]*num_files)
+        os_remove_mock.assert_has_calls([call(path)] * num_files)

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -13,6 +13,8 @@ from kolibri.core.content.models import LocalFile
 from kolibri.utils.tests.helpers import override_option
 
 # helper class for mocking that is equal to anything
+
+
 def Any(cls):
     class Any(cls):
         def __eq__(self, other):
@@ -240,13 +242,13 @@ class ImportContentTestCase(TestCase):
     @patch('kolibri.core.content.utils.transfer.os.path.getsize')
     @patch('kolibri.core.content.management.commands.importcontent.paths.get_content_storage_file_path')
     def test_local_import_oserror_permission_denied(self, path_mock, getsize_mock, logging_mock, annotation_mock):
-            dest_path = tempfile.mkstemp()[1]
-            path_mock.side_effect = [dest_path, '/test/dne']
-            getsize_mock.side_effect = ['1', OSError('Permission denied')]
-            with self.assertRaises(OSError):
-                call_command('importcontent', 'disk', self.the_channel_id, 'destination')
-                self.assertTrue('Permission denied' in logging_mock.call_args_list[0][0][0])
-                annotation_mock.assert_not_called()
+        dest_path = tempfile.mkstemp()[1]
+        path_mock.side_effect = [dest_path, '/test/dne']
+        getsize_mock.side_effect = ['1', OSError('Permission denied')]
+        with self.assertRaises(OSError):
+            call_command('importcontent', 'disk', self.the_channel_id, 'destination')
+            self.assertTrue('Permission denied' in logging_mock.call_args_list[0][0][0])
+            annotation_mock.assert_not_called()
 
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())

--- a/kolibri/core/content/test/test_sqlalchemy_bridge.py
+++ b/kolibri/core/content/test/test_sqlalchemy_bridge.py
@@ -15,6 +15,7 @@ from kolibri.core.content.utils.sqlalchemybridge import make_session
 from kolibri.core.content.utils.sqlalchemybridge import set_all_class_defaults
 from kolibri.core.content.utils.sqlalchemybridge import sqlite_connection_string
 
+
 @patch('kolibri.core.content.utils.sqlalchemybridge.db_matches_schema')
 @patch('kolibri.core.content.utils.sqlalchemybridge.make_session', return_value=(0, 0))
 @patch('kolibri.core.content.utils.sqlalchemybridge.sqlite_connection_string', return_value='test')
@@ -74,6 +75,7 @@ class SQLAlchemyBridgeClassTestCase(TestCase):
         session_mock.close.assert_called_once_with()
         connection.close.assert_called_once_with()
 
+
 class SQLAlchemyBridgeSQLAlchemyFunctionsTestCase(TestCase):
 
     def test_sqlite_string(self):
@@ -126,6 +128,7 @@ def setUp(self, apps_mock, get_class_mock):
     self.DjangoModelMock = MagicMock()
     self.DjangoModelMock._meta.fields = []
     apps_mock.get_models.return_value = [self.DjangoModelMock]
+
 
 @patch('kolibri.core.content.utils.sqlalchemybridge.get_class')
 @patch('kolibri.core.content.utils.sqlalchemybridge.apps')

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -119,6 +119,7 @@ def set_leaf_node_availability_from_local_file_availability(channel_id):
 
     bridge.end()
 
+
 def mark_local_files_as_available(checksums):
     """
     Shortcut method to update database if we are sure that the files are available.
@@ -134,12 +135,13 @@ def mark_local_files_as_available(checksums):
         bridge.session.bulk_update_mappings(LocalFileClass, ({
             'id': checksum,
             'available': True
-        } for checksum in checksums[i:i+CHUNKSIZE]))
+        } for checksum in checksums[i:i + CHUNKSIZE]))
         bridge.session.flush()
 
     bridge.session.commit()
 
     bridge.end()
+
 
 def set_local_file_availability_from_disk(checksums=None):
     bridge = Bridge(app_name=CONTENT_APP_NAME)
@@ -164,6 +166,7 @@ def set_local_file_availability_from_disk(checksums=None):
     bridge.end()
 
     mark_local_files_as_available(checksums_to_update)
+
 
 def recurse_availability_up_tree(channel_id):
     bridge = Bridge(app_name=CONTENT_APP_NAME)
@@ -241,6 +244,7 @@ def recurse_availability_up_tree(channel_id):
     logging.debug("Availability annotation took {} seconds".format(elapsed.seconds))
 
     bridge.end()
+
 
 def set_availability(channel_id, checksums=None):
     if checksums is None:

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -148,7 +148,7 @@ class ChannelImport(object):
         # Do a binary search to find the lowest unused tree_id
         def find_hole_in_list(ids):
             last = len(ids) - 1
-            middle = int(last/2 + 1)
+            middle = int(last / 2 + 1)
             # Check if the lower half of ids has a hole in it
             if ids[middle] - ids[0] != middle:
                 # List is only two ids, so hole must be between them

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -9,6 +9,7 @@ from kolibri.utils.uuids import is_valid_uuid
 
 logging = logger.getLogger(__name__)
 
+
 def get_channel_ids_for_content_database_dir(content_database_dir):
     """
     Returns a list of channel IDs for the channel databases that exist in a content database directory.
@@ -44,10 +45,12 @@ def get_channel_ids_for_content_database_dir(content_database_dir):
 
     return valid_dbs
 
+
 def enumerate_content_database_file_paths(content_database_dir):
     full_dir_template = os.path.join(content_database_dir, "{}.sqlite3")
     channel_ids = get_channel_ids_for_content_database_dir(content_database_dir)
     return [full_dir_template.format(f) for f in channel_ids]
+
 
 def read_channel_metadata_from_db_file(channeldbpath):
     # import here to avoid circular imports whenever kolibri.core.content.models imports utils too
@@ -73,6 +76,7 @@ def read_channel_metadata_from_db_file(channeldbpath):
 
     return source_channel_metadata
 
+
 def get_channels_for_data_folder(datafolder):
     channels = []
     for path in enumerate_content_database_file_paths(get_content_database_dir_path(datafolder)):
@@ -93,11 +97,13 @@ def get_channels_for_data_folder(datafolder):
         channels.append(channel_data)
     return channels
 
+
 def get_mounted_drives_with_channel_info():
     drives = enumerate_mounted_disk_partitions()
     for drive in drives.values():
         drive.metadata["channels"] = get_channels_for_data_folder(drive.datafolder) if drive.datafolder else []
     return drives
+
 
 def get_current_or_first_channel(request):
     # import here to avoid circular imports whenever kolibri.core.content.models imports utils too

--- a/kolibri/core/content/utils/check_schema_db.py
+++ b/kolibri/core/content/utils/check_schema_db.py
@@ -4,8 +4,10 @@ from sqlalchemy.orm import RelationshipProperty
 
 # Modified from https://gist.github.com/miohtama/278fd4eeb9e5272d061c
 
+
 class DBSchemaError(Exception):
     pass
+
 
 def db_matches_schema(Base, session):
     """

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -18,6 +18,7 @@ VALID_STORAGE_FILENAME = re.compile("[0-9a-f]{32}(-data)?\.[0-9a-z]+")
 POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".perseus", ".zip"])
 # TODO: add ".epub" and ".epub3" if epub-equivalent of ZipContentView implemented
 
+
 def get_content_file_name(obj):
     return '{checksum}.{extension}'.format(checksum=obj.id, extension=obj.extension)
 
@@ -29,6 +30,7 @@ def get_content_dir_path(datafolder=None):
         datafolder,
         "content",
     ) if datafolder else conf.OPTIONS["Paths"]["CONTENT_DIR"]
+
 
 def get_content_database_dir_path(datafolder=None):
     """
@@ -48,6 +50,7 @@ def get_content_database_dir_path(datafolder=None):
             pass
     return path
 
+
 def get_content_database_file_path(channel_id, datafolder=None):
     """
     Given a channel_id, returns the path to the sqlite3 file
@@ -58,6 +61,7 @@ def get_content_database_file_path(channel_id, datafolder=None):
         "{}.sqlite3".format(channel_id),
     )
 
+
 def get_content_storage_dir_path(datafolder=None):
     path = os.path.join(
         get_content_dir_path(datafolder),
@@ -66,6 +70,7 @@ def get_content_storage_dir_path(datafolder=None):
     if not os.path.isdir(path):
         os.makedirs(path)
     return path
+
 
 def get_content_storage_file_path(filename, datafolder=None):
     assert VALID_STORAGE_FILENAME.match(filename), "'{}' is not a valid content storage filename".format(filename)
@@ -85,11 +90,13 @@ def get_content_url(baseurl=None):
         "content/",
     )
 
+
 def get_content_database_url(baseurl=None):
     return urljoin(
         get_content_url(baseurl),
         "databases/",
     )
+
 
 def get_content_database_file_url(channel_id, baseurl=None):
     return urljoin(
@@ -97,14 +104,17 @@ def get_content_database_file_url(channel_id, baseurl=None):
         "{}.sqlite3".format(channel_id),
     )
 
+
 def get_content_storage_url(baseurl=None):
     return urljoin(
         get_content_url(baseurl),
         "storage/",
     )
 
+
 def get_content_storage_remote_url(filename, baseurl=None):
     return "{}{}/{}/{}".format(get_content_storage_url(baseurl), filename[0], filename[1], filename)
+
 
 def get_channel_lookup_url(identifier=None, baseurl=None):
     studio_url = "/api/public/v1/channels"
@@ -114,6 +124,7 @@ def get_channel_lookup_url(identifier=None, baseurl=None):
         baseurl or conf.OPTIONS['Urls']['CENTRAL_CONTENT_BASE_URL'],
         studio_url
     )
+
 
 def get_content_storage_file_url(filename, baseurl=None):
     """

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -3,6 +3,7 @@ from porter2stemmer import Porter2Stemmer
 
 stemmer = Porter2Stemmer()
 
+
 def fuzz(text):
     """
     Apply porter stemming algorithm then double metaphone algorithm to the passed in String

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -32,12 +32,15 @@ logger = logging.getLogger(__name__)
 
 BASES = {}
 
+
 class ClassNotFoundError(Exception):
     pass
+
 
 def sqlite_connection_string(db_path):
     # Call normpath to ensure that Windows paths are properly formatted
     return 'sqlite:///{db_path}'.format(db_path=os.path.normpath(db_path))
+
 
 def get_engine(connection_string):
     """
@@ -59,6 +62,7 @@ def get_engine(connection_string):
 
     return engine
 
+
 def make_session(connection_string):
     """
     Make a session for a particular SQLAlchemy database, this handles opening a connection
@@ -69,6 +73,7 @@ def make_session(connection_string):
     engine = get_engine(connection_string)
     Session = scoped_session(sessionmaker(bind=engine, autoflush=False))
     return Session(), engine
+
 
 def get_class(DjangoModel, Base):
     """
@@ -82,6 +87,7 @@ def get_class(DjangoModel, Base):
         return Base.classes[DjangoModel._meta.db_table]
     except KeyError:
         raise ClassNotFoundError('No SQL Alchemy ORM Mapping for this Django model found in this database')
+
 
 def set_all_class_defaults(Base):
     """
@@ -118,6 +124,7 @@ def set_all_class_defaults(Base):
 
 
 SCHEMA_PATH_TEMPLATE = os.path.join(os.path.dirname(__file__), '../fixtures/{name}_content_schema')
+
 
 def prepare_bases():
 
@@ -185,8 +192,10 @@ def get_default_db_string():
             dbname=destination_db['NAME'],
         )
 
+
 class SchemaNotFoundError(Exception):
     pass
+
 
 class Bridge(object):
 

--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -27,6 +27,7 @@ browser_requirements = [
     },
 ]
 
+
 def pass_browser_entry(agent, entry):
     if agent.browser.family == entry['family']:
         if 'blacklist' in entry and entry['blacklist']:

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -14,6 +14,7 @@ from kolibri.core.device.models import DeviceSettings
 
 logging = logger.getLogger(__name__)
 
+
 def get_user_response(prompt, valid_answers=None):
     answer = None
     while not answer or (valid_answers is not None and answer.lower() not in valid_answers):

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -26,6 +26,7 @@ from kolibri.core.device.models import DeviceSettings
 
 DUMMY_PASSWORD = "password"
 
+
 class DeviceProvisionTestCase(APITestCase):
 
     superuser_data = {"username": "superuser", "password": "password"}
@@ -165,7 +166,7 @@ class DevicePermissionsTestCase(APITestCase):
 
     def test_superuser_update_own_permissions(self):
         response = self.client.patch(reverse('devicepermissions-detail',
-                                     kwargs={'pk': self.superuser.devicepermissions.pk}),
+                                             kwargs={'pk': self.superuser.devicepermissions.pk}),
                                      {'is_superuser': False},
                                      format="json")
         self.assertEqual(response.status_code, 403)

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -60,10 +60,12 @@ class DeviceProvisionTestCase(TestCase):
         create_device_settings(language_id='en', facility=facility)
         self.assertEqual(DeviceSettings.objects.get().default_facility, facility)
 
+
 class DeviceProvisionCommandTestCase(TestCase):
     """
     Tests for provisiondevice command.
     """
+
     def setUp(self):
         self.preset = list(presets.keys())[0]
         call_command(

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -1,15 +1,21 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from django.test import TestCase
-from mock import patch
 import ntpath
 import os
 import posixpath
 import sys
 
-from .dummydata import windows_data, osx_data, linux_data
+from django.test import TestCase
+from mock import patch
 
-from ..utils.filesystem import enumerate_mounted_disk_partitions, EXPORT_FOLDER_NAME
+from ..utils.filesystem import enumerate_mounted_disk_partitions
+from ..utils.filesystem import EXPORT_FOLDER_NAME
+from .dummydata import linux_data
+from .dummydata import osx_data
+from .dummydata import windows_data
+
 
 def _get_mocked_popen(cmd_resp):
 
@@ -72,6 +78,7 @@ class patch_disk_usage(object):
         else:
             return patch("os.statvfs", self.mocked_disk_usage)(f)
 
+
 def patch_os_access(readable, writable):
 
     def wrapper(f):
@@ -91,6 +98,7 @@ def patch_os_access(readable, writable):
         return patch("os.access", check_os_access)(f)
 
     return wrapper
+
 
 def patch_os_path_exists_for_kolibri_folder(folder_lookup):
 

--- a/kolibri/core/discovery/utils/filesystem/__init__.py
+++ b/kolibri/core/discovery/utils/filesystem/__init__.py
@@ -28,6 +28,7 @@ DriveData = namedtuple(
     ]
 )
 
+
 def enumerate_mounted_disk_partitions():
     """
     Searches the local device for attached partitions/drives, and computes metadata about each one.

--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -31,6 +31,7 @@ FILESYSTEM_BLACKLIST = set(["anon_inodefs", "bdev", "binfmt_misc", "cgroup", "cp
 # so they should not be shown in the list of import/export drives.
 PATH_PREFIX_BLACKLIST = ["/proc", "/sys", "/tmp", "/var", "/boot", "/dev"]
 
+
 def get_drive_list():
     """
     Gets a list of drives and metadata by parsing the output of `mount`, and adding additional info from various commands.
@@ -84,6 +85,7 @@ def get_drive_list():
 
     return drives
 
+
 def _get_drive_usage(path):
     """
     Use Python libraries to get drive space/usage statistics. Prior to v3.3, use `os.statvfs`;
@@ -106,6 +108,7 @@ def _get_drive_usage(path):
             "free": free,
             "used": total - free,
         }
+
 
 def _try_to_get_drive_info_from_dbus(device):
     """
@@ -152,6 +155,7 @@ def _try_to_get_drive_info_from_dbus(device):
     except dbus.exceptions.DBusException:
         return {}
 
+
 def _get_drivetype_from_dbus_drive_properties(drive_props):
     """
     Read the block and drive properties from dbus drive props object to determine our best guess at the drive type.
@@ -166,6 +170,7 @@ def _get_drivetype_from_dbus_drive_properties(drive_props):
         return drivetypes.USB_DEVICE
     else:
         return drivetypes.UNKNOWN
+
 
 def _try_to_get_drive_info_from_diskutil(device):
     """

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 _DRIVE_TYPES = [drivetypes.UNKNOWN, "#noroot", drivetypes.USB_DEVICE, drivetypes.INTERNAL_DRIVE, drivetypes.NETWORK_DRIVE, drivetypes.OPTICAL_DRIVE, "#ram"]
 
+
 def get_drive_list():
 
     drives = []
@@ -91,6 +92,7 @@ def _wmic_output():
     os.remove(OUTPUT_PATH)
 
     return output
+
 
 def _parse_wmic_csv_output(text):
     """

--- a/kolibri/core/errors.py
+++ b/kolibri/core/errors.py
@@ -8,6 +8,7 @@ class KolibriError(Exception):
 class KolibriValidationError(ValidationError, KolibriError):
     pass
 
+
 class KolibriUpgradeError(KolibriError):
     """
     Should be used whenever an error arises that is due to an anticipated future incompatible change,

--- a/kolibri/core/exams/api.py
+++ b/kolibri/core/exams/api.py
@@ -23,11 +23,13 @@ class OptionalPageNumberPagination(pagination.PageNumberPagination):
     page_size = None
     page_size_query_param = "page_size"
 
+
 class ExamFilter(FilterSet):
 
     class Meta:
         model = models.Exam
         fields = ['collection', ]
+
 
 def _ensure_raw_dict(d):
     if hasattr(d, "dict"):
@@ -45,6 +47,7 @@ class ExamPermissions(KolibriAuthPermissions):
         # so this doesn't try to validate the Exam with a non-empty assignments list
         validated_data.pop('assignments')
         return request.user.can_create(model, validated_data)
+
 
 class ExamViewset(viewsets.ModelViewSet):
     serializer_class = serializers.ExamSerializer

--- a/kolibri/core/exams/permissions.py
+++ b/kolibri/core/exams/permissions.py
@@ -25,6 +25,7 @@ class UserCanReadExamAssignmentData(DenyAll):
             ancestor_collection=F("collection"),
         ).filter(Q(exam__active=True) | Q(exam__examlogs__user=user))
 
+
 class UserCanReadExamData(DenyAll):
 
     def user_can_read_object(self, user, obj):

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -19,6 +19,7 @@ class NestedCollectionSerializer(serializers.ModelSerializer):
             'id', 'name', 'kind',
         )
 
+
 class NestedExamAssignmentSerializer(serializers.ModelSerializer):
 
     collection = NestedCollectionSerializer(read_only=True)

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -13,6 +13,7 @@ from kolibri.core.auth.test.helpers import provision_device
 
 DUMMY_PASSWORD = "password"
 
+
 class UserExamAPITestCase(APITestCase):
 
     def setUp(self):

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -12,6 +12,7 @@ tz_format = "({tz})"
 tz_regex = re.compile("\(([^\)]+)\)")
 db_storage_string = "{date_time_string}{tz_string}"
 
+
 def parse_timezonestamp(value):
     if tz_regex.search(value):
         tz = pytz.timezone(tz_regex.search(value).groups()[0])
@@ -23,6 +24,7 @@ def parse_timezonestamp(value):
         # Naive datetime, make aware
         value = timezone.make_aware(value, pytz.utc)
     return value.astimezone(tz)
+
 
 def create_timezonestamp(value):
     if value.tzinfo and hasattr(value.tzinfo, 'zone'):
@@ -42,6 +44,7 @@ def create_timezonestamp(value):
     tz_string = tz_format.format(tz=tz)
     value = db_storage_string.format(date_time_string=date_time_string, tz_string=tz_string)
     return value
+
 
 class DateTimeTzField(Field):
     """

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -11,6 +11,7 @@ from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.fields import DateTimeTzField
 from kolibri.utils.time import local_now
 
+
 class Lesson(AbstractFacilityDataModel):
     """
     A Lesson is a collection of non-topic ContentNodes that is linked to

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -13,6 +13,7 @@ from kolibri.core.auth.test.helpers import provision_device
 
 DUMMY_PASSWORD = "password"
 
+
 class LessonAPITestCase(APITestCase):
 
     def setUp(self):

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -117,6 +117,7 @@ class MasteryFilter(FilterSet):
         model = MasteryLog
         fields = ['summarylog']
 
+
 class MasteryLogViewSet(viewsets.ModelViewSet):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend)
@@ -124,6 +125,7 @@ class MasteryLogViewSet(viewsets.ModelViewSet):
     serializer_class = MasteryLogSerializer
     pagination_class = OptionalPageNumberPagination
     filter_class = MasteryFilter
+
 
 class AttemptFilter(FilterSet):
     content = CharFilter(method="filter_content")
@@ -134,6 +136,7 @@ class AttemptFilter(FilterSet):
     class Meta:
         model = AttemptLog
         fields = ['masterylog', 'complete', 'user', 'content']
+
 
 class AttemptLogViewSet(viewsets.ModelViewSet):
     permission_classes = (KolibriAuthPermissions,)
@@ -160,6 +163,7 @@ class ExamAttemptFilter(FilterSet):
         model = ExamAttemptLog
         fields = ['examlog', 'exam', 'user']
 
+
 class ExamAttemptLogViewSet(viewsets.ModelViewSet):
     permission_classes = (ExamActivePermissions, KolibriAuthPermissions, )
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend, filters.OrderingFilter)
@@ -167,6 +171,7 @@ class ExamAttemptLogViewSet(viewsets.ModelViewSet):
     serializer_class = ExamAttemptLogSerializer
     pagination_class = OptionalPageNumberPagination
     filter_class = ExamAttemptFilter
+
 
 class ExamLogFilter(BaseLogFilter):
 
@@ -181,6 +186,7 @@ class ExamLogFilter(BaseLogFilter):
     class Meta:
         model = ExamLog
         fields = ['user', 'exam']
+
 
 class ExamLogViewSet(viewsets.ModelViewSet):
     permission_classes = (KolibriAuthPermissions,)

--- a/kolibri/core/logger/serializers.py
+++ b/kolibri/core/logger/serializers.py
@@ -22,6 +22,7 @@ class ContentSessionLogSerializer(KolibriModelSerializer):
         fields = ('pk', 'user', 'content_id', 'channel_id', 'start_timestamp',
                   'end_timestamp', 'time_spent', 'kind', 'extra_fields', 'progress')
 
+
 class ExamLogSerializer(KolibriModelSerializer):
     progress = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
@@ -43,6 +44,7 @@ class ExamLogSerializer(KolibriModelSerializer):
             instance.completion_timestamp = now()
         return super(ExamLogSerializer, self).update(instance, validated_data)
 
+
 class MasteryLogSerializer(KolibriModelSerializer):
 
     pastattempts = serializers.SerializerMethodField()
@@ -61,6 +63,7 @@ class MasteryLogSerializer(KolibriModelSerializer):
     def get_totalattempts(self, obj):
         return AttemptLog.objects.filter(masterylog__summarylog=obj.summarylog).count()
 
+
 class AttemptLogSerializer(KolibriModelSerializer):
     answer = serializers.JSONField(default='{}')
     interaction_history = serializers.JSONField(default='[]')
@@ -70,6 +73,7 @@ class AttemptLogSerializer(KolibriModelSerializer):
         fields = ('id', 'masterylog', 'start_timestamp', 'sessionlog',
                   'end_timestamp', 'completion_timestamp', 'item', 'time_spent', 'user',
                   'complete', 'correct', 'hinted', 'answer', 'simple_answer', 'interaction_history', 'error')
+
 
 class ExamAttemptLogSerializer(KolibriModelSerializer):
     answer = serializers.JSONField(default='{}', allow_null=True)
@@ -92,6 +96,7 @@ class ExamAttemptLogSerializer(KolibriModelSerializer):
                 raise serializers.ValidationError('Invalid exam log')
         return data
 
+
 class ContentSummaryLogSerializer(KolibriModelSerializer):
 
     currentmasterylog = serializers.SerializerMethodField()
@@ -109,11 +114,13 @@ class ContentSummaryLogSerializer(KolibriModelSerializer):
         except MasteryLog.DoesNotExist:
             return None
 
+
 class UserSessionLogSerializer(KolibriModelSerializer):
 
     class Meta:
         model = UserSessionLog
         fields = ('pk', 'user', 'channels', 'start_timestamp', 'last_interaction_timestamp', 'pages')
+
 
 class TotalContentProgressSerializer(serializers.ModelSerializer):
 

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -33,6 +33,7 @@ from kolibri.core.exams.models import Exam
 from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
 
+
 class ContentSessionLogAPITestCase(APITestCase):
 
     def setUp(self):

--- a/kolibri/core/logger/test/test_permissions.py
+++ b/kolibri/core/logger/test/test_permissions.py
@@ -38,6 +38,7 @@ class ContentSessionLogPermissionsTestCase(TestCase):
         self.assertTrue(learner.can_update(self.data['interaction_log']))
         self.assertTrue(learner.can_delete(self.data['interaction_log']))
 
+
 class ContentSummaryLogPermissionsTestCase(TestCase):
 
     def setUp(self):

--- a/kolibri/core/serializers.py
+++ b/kolibri/core/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.serializers import ModelSerializer
 
 from .fields import DateTimeTzField as DjangoDateTimeTzField
 
+
 class DateTimeTzField(DateTimeField):
 
     def to_internal_value(self, data):
@@ -20,6 +21,7 @@ serializer_field_mapping = {
 }
 
 serializer_field_mapping.update(ModelSerializer.serializer_field_mapping)
+
 
 class KolibriModelSerializer(ModelSerializer):
 

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -96,6 +96,7 @@ def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
                                json.dumps(url_params)))
     return mark_safe(html)
 
+
 @register.simple_tag(takes_context=True)
 def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
     response, kwargs, url_params = _kolibri_bootstrap_helper(context, base_name, api_resource, 'list', **kwargs)
@@ -110,10 +111,12 @@ def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
                                ))
     return mark_safe(html)
 
+
 def _replace_dict_values(check, replace, dict):
     for (key, value) in iteritems(dict):
         if dict[key] is check:
             dict[key] = replace
+
 
 def _kolibri_bootstrap_helper(context, base_name, api_resource, route, **kwargs):
     reversal = dict()

--- a/kolibri/core/test/test_datetimetzfield.py
+++ b/kolibri/core/test/test_datetimetzfield.py
@@ -14,8 +14,10 @@ from kolibri.core.fields import DateTimeTzField
 from kolibri.core.fields import parse_timezonestamp
 from kolibri.core.serializers import DateTimeTzField as DateTimeTzSerializerField
 
+
 def aware_datetime():
     return timezone.get_current_timezone().localize(datetime.datetime(2000, 12, 11, 10, 9, 8))
+
 
 class DateTimeTzModel(models.Model):
     timestamp = DateTimeTzField(null=True)

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -11,6 +11,7 @@ from kolibri.core.auth.test.test_api import FacilityFactory
 
 DUMMY_PASSWORD = "password"
 
+
 class KolibriTagNavigationTestCase(APITestCase):
 
     def test_redirect_to_setup_wizard(self):

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -49,6 +49,7 @@ class WebpackError(EnvironmentError):
 
 logger = logging.getLogger(__name__)
 
+
 def filter_by_bidi(bidi, chunk):
     if chunk['name'].split('.')[-1] != 'css':
         return True

--- a/kolibri/plugins/coach/serializers.py
+++ b/kolibri/plugins/coach/serializers.py
@@ -77,6 +77,7 @@ class UserReportSerializer(serializers.ModelSerializer):
 def sum_progress_dicts(total_progress, progress_dict):
     return total_progress + progress_dict.get('total_progress', 0.0)
 
+
 def get_progress_and_last_active(target_nodes, **kwargs):
     # Prepare dictionaries to output the progress and last active, keyed by content_id
     output_progress_dict = {}

--- a/kolibri/plugins/coach/test/test_lesson_report.py
+++ b/kolibri/plugins/coach/test/test_lesson_report.py
@@ -17,6 +17,7 @@ from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
 from kolibri.core.logger.models import ContentSummaryLog
 
+
 class LessonReportTestCase(APITestCase):
 
     def setUp(self):
@@ -81,12 +82,12 @@ class LessonReportTestCase(APITestCase):
         learner_user.set_password('password')
         learner_user.save()
         self.client.login(username='learner', password='password')
-        get_response = self.client.get(reverse(self.lessonreport_basename+'-detail', kwargs={'pk': self.lesson.id}))
+        get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         self.assertEqual(get_response.status_code, 403)
 
     def test_no_progress_logged(self):
         self.client.login(username='admin', password='password')
-        get_response = self.client.get(reverse(self.lessonreport_basename+'-detail', kwargs={'pk': self.lesson.id}))
+        get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(len(progress), 1)
         self.assertEqual(progress[0], {
@@ -104,7 +105,7 @@ class LessonReportTestCase(APITestCase):
             start_timestamp=datetime.datetime.now(),
         )
         self.client.login(username='admin', password='password')
-        get_response = self.client.get(reverse(self.lessonreport_basename+'-detail', kwargs={'pk': self.lesson.id}))
+        get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(progress[0], {
             'num_learners_completed': 0,
@@ -121,7 +122,7 @@ class LessonReportTestCase(APITestCase):
             start_timestamp=datetime.datetime.now(),
         )
         self.client.login(username='admin', password='password')
-        get_response = self.client.get(reverse(self.lessonreport_basename+'-detail', kwargs={'pk': self.lesson.id}))
+        get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(progress[0], {
             'num_learners_completed': 1,
@@ -130,5 +131,5 @@ class LessonReportTestCase(APITestCase):
 
     def test_total_learners_value(self):
         self.client.login(username='admin', password='password')
-        get_response = self.client.get(reverse(self.lessonreport_basename+'-detail', kwargs={'pk': self.lesson.id}))
+        get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         self.assertEqual(get_response.data['total_learners'], 1)

--- a/kolibri/plugins/learn/hooks.py
+++ b/kolibri/plugins/learn/hooks.py
@@ -12,6 +12,7 @@ class LearnSyncHook(webpack_hooks.WebpackInclusionHook):
     class Meta:
         abstract = True
 
+
 class LearnAsyncHook(webpack_hooks.WebpackInclusionHook):
     """
     Inherit a hook defining assets to be loaded sychronously in learn/learn.html

--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -79,6 +79,7 @@ class LessonProgressSerializer(ModelSerializer):
             'total_resources': len(instance.resources),
         }
 
+
 class LearnerClassroomSerializer(ModelSerializer):
     assignments = SerializerMethodField()
 

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -8,5 +8,6 @@ from django.views.generic.base import TemplateView
 
 logging = logger.getLogger(__name__)
 
+
 class LearnView(TemplateView):
     template_name = "learn/learn.html"

--- a/kolibri/plugins/setup_wizard/hooks.py
+++ b/kolibri/plugins/setup_wizard/hooks.py
@@ -12,6 +12,7 @@ class SetupWizardSyncHook(webpack_hooks.WebpackInclusionHook):
     class Meta:
         abstract = True
 
+
 class SetupWizardAsyncHook(webpack_hooks.WebpackInclusionHook):
     """
     Inherit a hook defining assets to be loaded sychronously in setup_wizard/setup_wizard.html

--- a/kolibri/plugins/setup_wizard/views.py
+++ b/kolibri/plugins/setup_wizard/views.py
@@ -4,5 +4,6 @@ from __future__ import unicode_literals
 
 from django.views.generic.base import TemplateView
 
+
 class SetupWizardView(TemplateView):
     template_name = "setup_wizard/setup_wizard.html"

--- a/kolibri/plugins/user/management/commands/background.py
+++ b/kolibri/plugins/user/management/commands/background.py
@@ -11,6 +11,7 @@ from django.core.management.base import BaseCommand
 
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
 
     def add_arguments(self, parser):

--- a/kolibri/plugins/user/views.py
+++ b/kolibri/plugins/user/views.py
@@ -4,5 +4,6 @@ from __future__ import unicode_literals
 
 from django.views.generic.base import TemplateView
 
+
 class UserView(TemplateView):
     template_name = "user/user.html"

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 
+
 def get_cext_path(dist_path):
     """
     Get the directory of dist/cext.
@@ -16,10 +17,10 @@ def get_cext_path(dist_path):
     if system_name == 'Linux' and int(python_version[2:]) < 33:
         # encode with ucs2
         if sys.maxunicode == 65535:
-            dirname = os.path.join(dirname, python_version+'m')
+            dirname = os.path.join(dirname, python_version + 'm')
         # encode with ucs4
         else:
-            dirname = os.path.join(dirname, python_version+'mu')
+            dirname = os.path.join(dirname, python_version + 'mu')
 
     dirname = os.path.join(dirname, machine_name)
     sys.path = [os.path.realpath(str(dirname))] + sys.path

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -9,6 +9,7 @@ from .server import NotRunning
 
 logger = logging.getLogger(__name__)
 
+
 def check_other_kolibri_running(port):
     try:
         # Check if there are other kolibri instances running

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -135,10 +135,13 @@ def _windows_become_daemon(our_home_dir='.', out_log=None, err_log=None, umask=0
     old_stderr.flush()
     old_stdout.flush()
 
+
 class _WindowsNullDevice:
     "A writeable object that writes to nowhere -- like /dev/null."
+
     def write(self, s):
         pass
+
 
 def get_free_space(path=KOLIBRI_HOME):
     if sys.platform.startswith('win'):

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -2,6 +2,7 @@ from django.test.utils import TestContextDecorator
 
 from kolibri.utils import conf
 
+
 class override_option(TestContextDecorator):
     """
     Acts as either a decorator or a context manager. If it's a decorator it
@@ -11,6 +12,7 @@ class override_option(TestContextDecorator):
 
     Note: adapted from django.test.utils.override_settings
     """
+
     def __init__(self, section, key, value):
         self.section = section
         self.key = key

--- a/kolibri/utils/time.py
+++ b/kolibri/utils/time.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
 
+
 def local_now():
     return timezone.localtime(timezone.now())

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -204,6 +204,7 @@ def get_git_describe(version):
     except EnvironmentError:
         return None
 
+
 def get_version_from_git(get_git_describe_string):
     """
     Fetches the latest git tag (NB! broken behavior!)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ universal = 1
 test = pytest
 
 [flake8]
-ignore = E226,E302,E41
 max-line-length = 160
 max-complexity = 10
 exclude = kolibri/*/migrations/*,kolibri/dist/*
@@ -21,7 +20,7 @@ skip = wsgi.py,docs,env,cli.py,test,.eggs,build,setup.py
 [coverage:run]
 branch = true
 source = kolibri
-omit = 
+omit =
 	*/migrations/*
 	*/tests/*
 	*/test_*.py
@@ -32,10 +31,9 @@ omit =
 ignore_errors = True
 show_missing = True
 precision = 2
-exclude_lines = 
+exclude_lines =
 	raise NotImplementedError
 	raise AssertionError
 	raise NotImplementedError
-	
-	if __name__ == .__main__.:
 
+	if __name__ == .__main__.:


### PR DESCRIPTION
### Summary

1. Removes the `ignore` configuration from setup.cfg's flake8 section.
1. Fixes the resulting violations (mostly E302, 2 spaces between classes)

### Reviewer guidance

Look at the changes. It's mostly adding newlines.

### References

#3609 

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
