### PR TITLE
Localize texts in coach-content-label

### DIFF
--- a/kolibri/core/assets/src/views/coach-content-label.vue
+++ b/kolibri/core/assets/src/views/coach-content-label.vue
@@ -5,7 +5,7 @@
       <mat-svg name="local_library" category="maps" />
     </ui-icon>
     <span class="counter" v-if="isTopic">
-      {{ value }}
+      {{ $formatNumber(value) }}
     </span>
   </div>
 
@@ -42,7 +42,7 @@
     },
     $trs: {
       coachResourceLabel: 'Coach resource',
-      topicTitle: 'Contains {count} {count, plural, one {coach resource} other {coach resources}}',
+      topicTitle: 'Contains {count, number, integer} {count, plural, one {coach resource} other {coach resources}}',
     },
   };
 


### PR DESCRIPTION

### Summary

Localize the title meta and label text for coach-content-label.

![screen shot 2018-07-10 at 1 42 27 pm](https://user-images.githubusercontent.com/10248067/42536740-bdc53140-8447-11e8-95d9-08b4cc726e1e.png)

### Reviewer guidance

1. Install some coach content
1. Look in different UIs where label occurs in a RTL language.

### References

Fixes #3970
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
