### PR TITLE
Fix logging race condition in assessment-wrapper

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
@@ -142,5 +142,5 @@
     border: none;
     font-size: 1em;
   }
-  
+
 </style>

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -175,19 +175,24 @@ oriented data synchronization.
         default: () => Promise.resolve(),
       },
     },
-    data: () => ({
-      ready: false,
-      itemId: '',
-      shake: false,
-      firstAttemptAtQuestion: true,
-      complete: false,
-      correct: 0,
-      itemError: false,
-      hintWasTaken: false,
-      // Attempted fix for #1725
-      checkingAnswer: false,
-      checkWasAttempted: false,
-    }),
+    data() {
+      return {
+        ready: false,
+        itemId: '',
+        shake: false,
+        firstAttemptAtQuestion: true,
+        complete: false,
+        correct: 0,
+        itemError: false,
+        hintWasTaken: false,
+        // Attempted fix for #1725
+        checkingAnswer: false,
+        checkWasAttempted: false,
+        // Placing these here so they are available at beforeDestroy
+        masteryModel: this.$store.state.pageState.content.masteryModel,
+        assessmentIds: this.$store.state.pageState.content.assessmentIds,
+      };
+    },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       ...mapState({
@@ -197,8 +202,6 @@ oriented data synchronization.
           (state.core.logging.mastery.pastattempts || []).filter(attempt => attempt.error !== true),
         userid: state => state.core.session.user_id,
         content: state => state.pageState.content,
-        assessmentIds: state => state.pageState.content.assessmentIds,
-        masteryModel: state => state.pageState.content.masteryModel,
         randomize: state => state.pageState.content.randomize,
       }),
       recentAttempts() {

--- a/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/assessment-wrapper/index.vue
@@ -197,6 +197,7 @@ oriented data synchronization.
       ...mapGetters(['isUserLoggedIn']),
       ...mapState({
         mastered: state => state.core.logging.mastery.complete,
+        currentInteractions: state => state.core.logging.attempt.interaction_history.length,
         totalattempts: state => state.core.logging.mastery.totalattempts,
         pastattempts: state =>
           (state.core.logging.mastery.pastattempts || []).filter(attempt => attempt.error !== true),
@@ -288,7 +289,9 @@ oriented data synchronization.
     },
     watch: { exerciseProgress: 'updateExerciseProgressMethod' },
     beforeDestroy() {
-      this.saveAttemptLogMasterLog(false);
+      if (this.currentInteractions > 0) {
+        this.saveAttemptLogMasterLog(false);
+      }
     },
     methods: {
       ...mapActions([


### PR DESCRIPTION
### Summary

Fixes issue where the `success` getter in `assessment-wrapper` errored out because of incompatible `pageState` at the `beforeDestroy` hook.

### Reviewer guidance

1. As a Learner, Interact with an exercise
1. Leave the exercise
1. You should not see any errors in the console

### References


### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
