### PR TITLE
Fix Python2 compatibility in generate_schema cmd

### DIFF
--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import pickle
+import sys
 
 from django.apps import apps
 from django.core.management import call_command
@@ -62,5 +63,11 @@ class Command(BaseCommand):
             pickle.dump(metadata, f, protocol=2)
 
         data_path = DATA_PATH_TEMPLATE.format(name=options['version'])
-        with io.open(data_path, mode='w', encoding='utf-8') as f:
-            json.dump(data, f)
+        # Handle Python 2 unicode issue by opening the file in binary mode
+        # with no encoding as the data has already been encoded
+        if sys.version[0] == '2':
+            with io.open(data_path, mode='wb') as f:
+                json.dump(data, f)
+        else:
+            with io.open(data_path, mode='w', encoding='utf-8') as f:
+                json.dump(data, f)


### PR DESCRIPTION
### Summary
This fix adds special case handling the Python 2 version by opening the
json schema file in binary mode with no encoding (as the data has
already been encoded)

I'm not entirely sure why this issue arises, but from what I researched
it could be coming from the fact that some string literal which is
being used to populate the schema data has been decoded using the wrong
codec, e.g. if the text editor used to save it used different codec than
what we're using here.

In any case, this fix produces the same schema on Python 2 and 3
(tested with Python 2.7 and Python 3.6).

### Reviewer guidance
- Set up Python 2 virtualenv for Kolibri (optionally Python 3 as well)
- Run `kolibri manage generate_schema 3` using Python 2 virtualenv
- Verify that it throws a `TypeError` exception
- (Optionally, verify that it works as expected using Python 3)
- Pull this PR
- Run `generate_schema` command again and verify that it works as expected

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
