### PR TITLE
Fix exam creation breadcrumbs

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -415,7 +415,8 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         if cache.get(cache_key) is not None:
             return Response(cache.get(cache_key))
 
-        ancestors = list(self.get_object(prefetch=False).get_ancestors().values('pk', 'title'))
+        # TODO remove 'pk' once UI standardizes to 'id'
+        ancestors = list(self.get_object(prefetch=False).get_ancestors().values('pk', 'id', 'title'))
 
         cache.set(cache_key, ancestors, 60 * 10)
 


### PR DESCRIPTION
### Summary

Fixes the exam creation breadcrumbs by making sure the `ancestors` array contains an `id` field (before it only had `pk` #typescriptwouldhavecaughtthis).


### Reviewer guidance

1. Create an exam and navigate through the topics
1. Make sure the breadcrumbs at the top of the topics list go to the correct place

### References

Fixes #3998 
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
