### PR TITLE
Ignore pytest cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ kolibri/VERSION
 
 # Ignore downloaded crowdin client
 build_tools/crowdin-cli.jar
+
+# Ignore pytest cache directory
+.pytest_cache/


### PR DESCRIPTION
### Summary
Add `.pytest_cache` directory to `.gitignore`

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
