### PR TITLE
Fix the error when OpenSSL version is incompatible with the system cryptography version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,15 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=npmbuild
-    - python: "3.4"
+    - python: "2.7"
       env:
-        - TOX_ENV=py3.4
-        - RUN_WITH_CEXT="y"
+        - TOX_ENV=nocext
       script:
-       - pip install -r requirements/build.txt
-       - make staticdeps-cext
+       - tox -e $TOX_ENV
+    - python: "2.7"
+      env:
+        - TOX_ENV=cext
+      script:
        - tox -e $TOX_ENV
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,59 +23,54 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=pythonbuild2.7
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.4"
       env:
         - TOX_ENV=pythonbuild3.4
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=pythonbuild3.5
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.6"
       env:
         - TOX_ENV=pythonbuild3.6
-        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint
-        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=licenses
-        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=py2.7
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=docs
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.4"
       env:
         - TOX_ENV=py3.4
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=py3.5
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.6"
       env:
         - TOX_ENV=py3.6
-        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=node6.x
-        - TRAVIS_NODE_VERSION="6"
     - python: "3.5"
       env:
         - TOX_ENV=postgres
-        - TRAVIS_NODE_VERSION="6"
     - python: "2.7"
       env:
         - TOX_ENV=npmbuild
-        - TRAVIS_NODE_VERSION="6"
+    - python: "3.4"
+      env:
+        - TOX_ENV=py3.4
+        - RUN_WITH_CEXT="y"
+      script:
+       - pip install -r requirements/build.txt
+       - make staticdeps-cext
+       - tox -e $TOX_ENV
+
 
 before_install:
   - git fetch
@@ -84,8 +79,8 @@ before_install:
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
   - pip install -U pip codecov tox
   - . $HOME/.nvm/nvm.sh
-  - nvm install $TRAVIS_NODE_VERSION
-  - nvm use $TRAVIS_NODE_VERSION
+  - nvm install 6
+  - nvm use 6
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ staticdeps:
 staticdeps-cext:
 	rm -rf kolibri/dist/cext || true # remove everything
 	python build_tools/install_cexts.py --file "requirements/cext.txt" # pip install c extensions
-	pip install -t kolibri/dist -r "requirements/cext_noarch.txt" --no-deps
+	pip install -t kolibri/dist/cext -r "requirements/cext_noarch.txt" --no-deps
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -rf kolibri/dist/cext/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	make test-namespaced-packages

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -13,7 +13,7 @@ def check_debian_user():
 
     with open("/etc/kolibri/username", "r") as f:
         kolibri_user = f.read().rstrip()
-    current_user = os.environ["USER"]
+    current_user = os.environ.get("USER")
     if not kolibri_user or kolibri_user == current_user:
         return
 

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -3,7 +3,7 @@ import os
 import platform
 import sys
 
-def get_cext_path(dist_path):
+def prepend_cext_path(dist_path):
     """
     Calculate the directory of C extensions and add it to sys.path if exists.
     """
@@ -22,11 +22,11 @@ def get_cext_path(dist_path):
             dirname = os.path.join(dirname, python_version+'mu')
 
     dirname = os.path.join(dirname, machine_name)
-    openssl_parent_dir = os.path.join(dist_path, 'cext')
+    noarch_dir = os.path.join(dist_path, 'cext')
     if os.path.exists(dirname):
-        # If the directory of cryptography exists, add it and the OpenSSL module's
-        # parent directory to sys.path
-        sys.path = [str(dirname), str(openssl_parent_dir)] + sys.path
+        # If the directory of platform-specific cextensions (cryptography) exists,
+        # add it + the matching noarch (OpenSSL) modules to sys.path
+        sys.path = [str(dirname), str(noarch_dir)] + sys.path
     else:
         logging.warning('No C Extensions available for this platform.\n')
 
@@ -43,7 +43,7 @@ def set_env():
     sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
 
     # Add path for c extensions to sys.path
-    get_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
+    prepend_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
 
     # This was added in
     # https://github.com/learningequality/kolibri/pull/580

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -5,7 +5,7 @@ import sys
 
 def get_cext_path(dist_path):
     """
-    Get the directory of dist/cext.
+    Calculate the directory of C extensions and add it to sys.path if exists.
     """
     python_version = 'cp' + str(sys.version_info.major) + str(sys.version_info.minor)
     system_name = platform.system()
@@ -22,8 +22,13 @@ def get_cext_path(dist_path):
             dirname = os.path.join(dirname, python_version+'mu')
 
     dirname = os.path.join(dirname, machine_name)
-    sys.path = [os.path.realpath(str(dirname))] + sys.path
-
+    openssl_parent_dir = os.path.join(dist_path, 'cext')
+    if os.path.exists(dirname):
+        # If the directory of cryptography exists, add it and the OpenSSL module's
+        # parent directory to sys.path
+        sys.path = [str(dirname), str(openssl_parent_dir)] + sys.path
+    else:
+        logging.warning('No C Extensions available for this platform.\n')
 
 def set_env():
     """
@@ -39,12 +44,6 @@ def set_env():
 
     # Add path for c extensions to sys.path
     get_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
-    try:
-        import cryptography  # noqa
-    except ImportError:
-        # Fallback
-        logging.warning('No C Extensions available for this platform.\n')
-        sys.path = sys.path[1:]
 
     # This was added in
     # https://github.com/learningequality/kolibri/pull/580

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
 testpaths = test/ kolibri/
-DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
 norecursedirs = dist tmp* .svn .*
+# Settings for pytest-django
+django_find_project = false
+DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
+# Settings for pytest-pythonpath
+python_paths = kolibri/dist

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
--r base.txt
 # These are for testing
 factory-boy==2.7.0  # pyup: ignore - Needs an update, called 'faker' now
 fake-factory==0.5.7  # pyup: ignore Needs an update
@@ -8,3 +7,4 @@ mixer==6.0.1
 pytest==3.5.1
 pytest-cov==2.5.1
 pytest-django==3.2.1
+pytest-pythonpath==0.7.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,4 @@
 -r base.txt
--r cext.txt
 # These are for testing
 factory-boy==2.7.0  # pyup: ignore - Needs an update, called 'faker' now
 fake-factory==0.5.7  # pyup: ignore Needs an update

--- a/test/test_cext.py
+++ b/test/test_cext.py
@@ -9,9 +9,12 @@ def test_cryptography_path():
     """
     try:
         import cryptography
-        assert "dist/cext" in cryptography.__file__
+        # If this is 'n' and we can import cryptography, there is a problem
+        assert os.environ.get('TOX_ENV') != 'nocext'
+        if os.environ.get('TOX_ENV') == 'cext':
+            assert "dist/cext" in cryptography.__file__
     except ImportError:
         # This variable is defined in .travis.yml and the intention is to fail
         # loudly when were unsuccessful when importing cryptography
-        if os.environ.get('RUN_WITH_CEXT') == 'y':
+        if os.environ.get('TOX_ENV') == 'cext':
             raise AssertionError("Expected c extesions")

--- a/test/test_cext.py
+++ b/test/test_cext.py
@@ -1,3 +1,4 @@
+import os
 
 
 def test_cryptography_path():
@@ -10,4 +11,7 @@ def test_cryptography_path():
         import cryptography
         assert "dist/cext" in cryptography.__file__
     except ImportError:
-        pass
+        # This variable is defined in .travis.yml and the intention is to fail
+        # loudly when were unsuccessful when importing cryptography
+        if os.environ.get('RUN_WITH_CEXT') == 'y':
+            raise AssertionError("Expected c extesions")

--- a/test/test_cext.py
+++ b/test/test_cext.py
@@ -1,0 +1,13 @@
+
+
+def test_cryptography_path():
+    """
+    Checks that an imported version of cryptography is actually from the
+    dist/cext folder. We can allow other versions, but for now, we want tests
+    to fail until we identify the right way to do this.
+    """
+    try:
+        import cryptography
+        assert "dist/cext" in cryptography.__file__
+    except ImportError:
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7, 3.4, 3.5, 3.6}
+envlist = py{2.7,3.4,3.5,3.6,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7, 3.4, 3.5, 3.6}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -8,7 +8,6 @@ whitelist_externals=
     make
     sh
 setenv =
-    PYTHONPATH = {toxinidir}
     KOLIBRI_HOME = {envtmpdir}/.kolibri
     DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
     KOLIBRI_RUN_MODE = tox
@@ -28,15 +27,13 @@ basepython =
     pythonlint: python2.7
     node6.x: python2.7
     npmbuild: python2.7
+    nocext: python2.7
+    cext: python2.7
 deps =
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/cext.txt
 commands =
-    # Until we have staged builds, we will be running this in each and every
-    # environment even though builds should be done in Py 2.7
-    make staticdeps  # install staticdeps for all envs
-    # Ensure that for this Python version, we can actually compile ALL files
-    # in the kolibri directory
-    python -m compileall -q kolibri -x py2only
     # Enable the plugins to ensure the configuration is read without error
     coverage run -p kolibri plugin kolibri.plugins.learn enable
     coverage run -p kolibri plugin kolibri.plugins.facility_management enable
@@ -45,11 +42,56 @@ commands =
     coverage run -p kolibri stop
     sh -c 'kolibri manage makemigrations --check'
     # Run the actual tests
-    py.test {posargs:--cov=kolibri --color=no}
+    py.test {posargs:--cov=kolibri --cov-report= --cov-append --color=no}
     # This is currently disabled because some process seems to be locking
     # the directory:
     # /bin/rm: cannot remove `/home/travis/build/learningequality/kolibri/.tox/py3.5/tmp/.kolibri': Directory not empty
     # rm -rf {env:KOLIBRI_HOME}
+
+# Running w/o C extensions is slow, so we just do a
+# limited amount of testing
+# This briefly tests our static deps etc w/o cexts
+[testenv:nocext]
+passenv = TOX_ENV
+setenv =
+     PYTHONPATH = "{toxinidir}:{toxinidir}/kolibri/dist"
+deps =
+    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/build.txt
+commands =
+    # Ensure that for this Python version, we can actually compile ALL files
+    # in the kolibri directory
+    python -m compileall -q kolibri -x py2only
+    # Until we have staged builds, we will be running this in each and every
+    # environment even though builds should be done in Py 2.7
+    make staticdeps
+    # Start and stop kolibri
+    coverage run -p kolibri start --port=8081
+    coverage run -p kolibri stop
+    # Run just tests in test/
+    py.test --cov=kolibri --cov-report= --cov-append --color=no test/
+
+# This briefly tests our static deps etc WITH cexts
+[testenv:cext]
+passenv = TOX_ENV
+setenv =
+     PYTHONPATH = "{toxinidir}:{toxinidir}/kolibri/dist"
+deps =
+    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/build.txt
+commands =
+    # Ensure that for this Python version, we can actually compile ALL files
+    # in the kolibri directory
+    python -m compileall -q kolibri -x py2only
+    # Until we have staged builds, we will be running this in each and every
+    # environment even though builds should be done in Py 2.7
+    make staticdeps
+    make staticdeps-cext
+    # Start and stop kolibri
+    coverage run -p kolibri start --port=8081
+    coverage run -p kolibri stop
+    # Run just tests in test/
+    py.test --cov=kolibri --cov-report= --cov-append --color=no test/
 
 [testenv:postgres]
 passenv = TOX_ENV
@@ -62,6 +104,8 @@ basepython =
     postgres: python3.5
 deps =
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/cext.txt
     -r{toxinidir}/requirements/postgres.txt
 commands =
     py.test {posargs:--cov=kolibri --color=no}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the error when we don't have bundled cryptography available for the platform, and a system cryptography exists in the machine but is not compatible with kolibri's bundled OpenSSL.
The error is described in #4058 
Basically, the change is that the paths of cryptography and OpenSSL are only added to PYTHONPATH when the path of cryptography exists. That means, when kolibri don't have cryptography that suits the user's platform available, the OpenSSL module bundled inside kolibri will not be imported. Whether users have an old version of cryptography in the system or not will not cause the error anymore.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The steps to reproduce the error are listed in the issue.
To test the PR, install cryptography 1.2.3 when the platform doesn't have available bundled cryptography in kolibri, and see if the error still occurs.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#4058 

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
