### PR TITLE
add retry logic to importchannel and catch timeout/ssl exceptions

### DIFF
--- a/kolibri/content/test/test_import_export.py
+++ b/kolibri/content/test/test_import_export.py
@@ -75,7 +75,7 @@ class ImportChannelTestCase(TestCase):
         self.assertFalse(os.path.exists(local_dest_path))
 
     @patch('kolibri.content.management.commands.importchannel.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importchannel.AsyncCommand.is_cancelled', side_effect=[False, True])
+    @patch('kolibri.content.management.commands.importchannel.AsyncCommand.is_cancelled', return_value=True)
     def test_remote_import_sslerror(self, is_cancelled_mock, cancel_mock, start_progress_mock, import_channel_mock):
         SSLERROR = SSLError(['SSL routines', 'ssl3_get_record', 'decryption failed or bad record mac'])
 
@@ -89,7 +89,7 @@ class ImportChannelTestCase(TestCase):
 
     @patch('kolibri.content.utils.transfer.Transfer.next', side_effect=ReadTimeout('Read timed out.'))
     @patch('kolibri.content.management.commands.importchannel.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importchannel.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
+    @patch('kolibri.content.management.commands.importchannel.AsyncCommand.is_cancelled', return_value=True)
     def test_remote_import_readtimeout(self, is_cancelled_mock, cancel_mock, sslerror_mock, start_progress_mock, import_channel_mock):
         call_command('importchannel', 'network', '197934f144305350b5820c7c4dd8e194')
         cancel_mock.assert_called_with()
@@ -128,7 +128,7 @@ class ImportContentTestCase(TestCase):
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     @patch('kolibri.content.management.commands.importcontent.transfer.FileDownload')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True, True])
     def test_remote_cancel_during_transfer(self, is_cancelled_mock, cancel_mock, FileDownloadMock, local_path_mock, remote_path_mock, start_progress_mock,
                                            annotation_mock):
         # If transfer is cancelled during transfer of first file
@@ -194,7 +194,7 @@ class ImportContentTestCase(TestCase):
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     @patch('kolibri.content.management.commands.importcontent.transfer.FileCopy')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True, True])
     def test_local_cancel_during_transfer(self, is_cancelled_mock, cancel_mock, FileCopyMock, local_path_mock, start_progress_mock, annotation_mock):
         # Local version of test above
         local_dest_path = tempfile.mkstemp()[1]
@@ -222,7 +222,7 @@ class ImportContentTestCase(TestCase):
         len_mock.assert_not_called()
         annotation_mock.set_availability.assert_called()
 
-    @patch('kolibri.content.utils.import_export_content.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.start_progress')
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     def test_remote_import_httperror_404(self, path_mock, start_progress_mock, logging_mock, annotation_mock):
@@ -234,11 +234,11 @@ class ImportContentTestCase(TestCase):
         self.assertTrue(logging_mock.call_count == 3)
         self.assertTrue('404' in logging_mock.call_args_list[0][0][0])
 
-    @patch('kolibri.content.utils.import_export_content.sleep')
-    @patch('kolibri.content.utils.import_export_content.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.sleep')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_remote_url')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, False, True, True, True])
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
     def test_remote_import_httperror_502(self, is_cancelled_mock, cancel_mock, url_mock, logging_mock, sleep_mock, annotation_mock):
         url_mock.return_value = 'http://httpbin.org/status/502'
         call_command('importcontent', 'network', self.the_channel_id)
@@ -247,7 +247,7 @@ class ImportContentTestCase(TestCase):
         sleep_mock.assert_called_once()
         self.assertTrue('502' in logging_mock.call_args_list[0][0][0])
 
-    @patch('kolibri.content.utils.import_export_content.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_remote_url')
     def test_remote_import_httperror_500(self, url_mock, logging_mock, annotation_mock):
         url_mock.return_value = 'http://httpbin.org/status/500'
@@ -256,11 +256,11 @@ class ImportContentTestCase(TestCase):
             self.assertTrue('500' in logging_mock.call_args_list[0][0][0])
         annotation_mock.set_availability.assert_not_called()
 
-    @patch('kolibri.content.utils.import_export_content.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.start_progress')
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True])
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True, True])
     def test_local_import_oserror_dne(self, is_cancelled_mock, cancel_mock, path_mock, start_progress_mock, logging_mock, annotation_mock):
         dest_path = tempfile.mkstemp()[1]
         path_mock.side_effect = [dest_path, '/test/dne']
@@ -268,7 +268,7 @@ class ImportContentTestCase(TestCase):
         self.assertTrue('No such file or directory' in logging_mock.call_args_list[0][0][0])
         annotation_mock.set_availability.assert_called()
 
-    @patch('kolibri.content.utils.import_export_content.logging.error')
+    @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.utils.transfer.os.path.getsize')
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     def test_local_import_oserror_permission_denied(self, path_mock, getsize_mock, logging_mock, annotation_mock):
@@ -284,7 +284,7 @@ class ImportContentTestCase(TestCase):
     @patch('kolibri.content.management.commands.importcontent.os.path.isfile', return_value=False)
     @patch('kolibri.content.management.commands.importcontent.paths.get_content_storage_file_path')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.cancel')
-    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, True, True])
+    @patch('kolibri.content.management.commands.importcontent.AsyncCommand.is_cancelled', side_effect=[False, False, True, True])
     def test_local_import_source_corrupted(self, is_cancelled_mock, cancel_mock, path_mock, isfile_mock, getsize_mock, annotation_mock):
         local_src_path = tempfile.mkstemp()[1]
         local_dest_path = tempfile.mkstemp()[1]

--- a/kolibri/content/utils/import_export_content.py
+++ b/kolibri/content/utils/import_export_content.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 from django.db.models import Sum
 from le_utils.constants import content_kinds
 from requests.exceptions import ConnectionError
@@ -79,38 +77,35 @@ def get_num_coach_contents(contentnode, filter_available=True):
         return 1 if contentnode.coach_content else 0
 
 
-def retry_import(command, e, name, f=None, overall_progress_update=None):
-    logging.error("An error occured during channel import: {}".format(e))
+def retry_import(e, **kwargs):
+    """
+    When an exception occurs during channel/content import, if
+        * there is an Internet connection error or timeout error,
+          or HTTPError where the error code is one of the RETRY_STATUS_CODE,
+          return return True to retry the file transfer
+        * the file does not exist on the server or disk, skip the file and return False.
+          This only applies to content import not channel import.
+        * otherwise, raise the  exception.
+    return value:
+        * True - needs retry.
+        * False - file is skipped. Does not need retry.
+    """
 
-    # When there is an Internet connection error or timeout error,
-    # or HTTPError where the error code is one of the RETRY_STATUS_CODE,
-    # return False, 0 to retry the file transfer, or return True, 0 to
-    # indicate the cancellation
+    skip_404 = kwargs.pop('skip_404')
+
     if (
             isinstance(e, ConnectionError) or
             isinstance(e, Timeout) or
             (isinstance(e, HTTPError) and e.response.status_code in RETRY_STATUS_CODE) or
             (isinstance(e, SSLERROR) and 'decryption failed or bad record mac' in str(e))):
-        return sleep_before_retry(command), 0
+        return True
 
-    # Skip the file if it does not exist on the server or disk.
-    # This only applies to content import not channel import.
     elif (
-            name == 'content' and
+            skip_404 and
             (
                 (isinstance(e, HTTPError) and e.response.status_code == 404) or
                 (isinstance(e, OSError) and e.errno == 2))):
-        overall_progress_update(f.file_size)
-        return True, 1
+        return False
 
     else:
         raise e
-
-def sleep_before_retry(command):
-    logging.info('Waiting for 30 seconds before retrying...')
-    for i in range(30):
-        if command.is_cancelled():
-            command.cancel()
-            return True
-        sleep(1)
-    return False


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to add retry logic to `importchannel` command and catch additional exceptions in the retry logic - `Timeout` error and `OpenSSL.SSL.Error: [('SSL routines', 'ssl3_get_record', 'decryption failed or bad record mac')]`

I also clean up the code by moving the retry logic from `importcontent` into `utils/import_export_content.py` so we can reuse the code in `importchannel` to reduce redundancy.

Since some platforms won't have `OpenSSL` module after the fix in https://github.com/learningequality/kolibri/pull/4059, I have the code below to handle the case
```
try:
    import OpenSSL
    SSLERROR = OpenSSL.SSL.Error
except ImportError:
    import requests
    SSLERROR = requests.exceptions.SSLError
```

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

When the internet is not available, it's possible to reproduce the `ReadTimeout` error, which is a subclass of `Timeout` error.
I'm still not sure how to reproduce the `SSLError` in kolibri. But you can produce the error by the script here: https://github.com/requests/requests/issues/1906#issuecomment-201120959. I used it to see how the exception looks.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3963

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
