### PR TITLE
return first x attemptlogs depending on exercise type

### DIFF
--- a/kolibri/core/logger/constants/exercise_attempts.py
+++ b/kolibri/core/logger/constants/exercise_attempts.py
@@ -1,0 +1,8 @@
+from le_utils.constants import exercises
+
+MAPPING = {
+    exercises.NUM_CORRECT_IN_A_ROW_2: 2,
+    exercises.NUM_CORRECT_IN_A_ROW_3: 3,
+    exercises.NUM_CORRECT_IN_A_ROW_5: 5,
+    exercises.NUM_CORRECT_IN_A_ROW_10: 10,
+}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

PR  returns the last `x` attempt logs depending on the exercise type for the mastery log serializer.
**_Note: Would like to add regression tests before merging._**

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Not sure how to manually test this...

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#3763 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
