### PR TITLE
Fixes a few bugs with lessons and attempt logging

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -690,10 +690,12 @@ export class Resource {
   /**
    * Find a model by its attributes - will return first model found that matches
    * @param  {Object} attrs Hash of attributes to search by
+   * @param  {string} endpointName name of endpoint to search model cache
    * @return {Model}       First matching Model
    */
-  findModel(attrs) {
-    return find(this.models, model => matches(attrs)(model.attributes));
+  findModel(attrs, endpointName) {
+    const cache = this.__modelCache(endpointName);
+    return find(cache, model => matches(attrs)(model.attributes));
   }
 
   /**

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -15,6 +15,7 @@ import { now } from 'kolibri.utils.serverClock';
 import urls from 'kolibri.urls';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { redirectBrowser } from 'kolibri.utils.browser';
+import Vue from 'kolibri.lib.vue';
 import intervalTimer from '../../../timer';
 import {
   MasteryLoggingMap,
@@ -723,4 +724,22 @@ export function createSnackbar(store, snackbarOptions) {
 
 export function clearSnackbar(store) {
   store.commit('CORE_CLEAR_SNACKBAR');
+}
+
+export function loading(store) {
+  return new Promise(resolve => {
+    store.commit('CORE_SET_PAGE_LOADING', true);
+    Vue.nextTick(() => {
+      resolve();
+    });
+  });
+}
+
+export function notLoading(store) {
+  return new Promise(resolve => {
+    store.commit('CORE_SET_PAGE_LOADING', false);
+    Vue.nextTick(() => {
+      resolve();
+    });
+  });
 }

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -33,7 +33,7 @@
           :checked="isSelected(content.id)"
           @change="toggleSelected($event, content.id)"
         />
-        <ContentCard
+        <LessonContentCard
           class="content-card"
           :title="content.title"
           :thumbnail="content.thumbnail"

--- a/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
@@ -17,85 +17,86 @@ function preparePage(store, params) {
 
 // Shows a list of all the Classrooms a Learner is enrolled in
 export function showAllClassesPage(store) {
-  store.commit('CORE_SET_PAGE_LOADING', true);
-
-  return ClassroomResource.fetchCollection()
-    .then(classrooms => {
-      // set pageState _after_ to allow the previous page (often `content-page`)
-      // to finish destruction with the expected state in place
-      preparePage(store, {
-        pageName: ClassesPageNames.ALL_CLASSES,
-        initialState: {
-          classrooms: [],
-        },
-      });
-      store.commit('SET_LEARNER_CLASSROOMS', classrooms);
-      store.commit('CORE_SET_PAGE_LOADING', false);
-    })
-    .catch(error => {
-      return store.dispatch('handleApiError', error);
+  return store.dispatch('loading').then(() => {
+    // set pageState _after_ to allow the previous page (often `content-page`)
+    // to finish destruction with the expected state in place
+    preparePage(store, {
+      pageName: ClassesPageNames.ALL_CLASSES,
+      initialState: {
+        classrooms: [],
+      },
     });
+
+    return ClassroomResource.fetchCollection()
+      .then(classrooms => {
+        store.commit('SET_LEARNER_CLASSROOMS', classrooms);
+        store.dispatch('notLoading');
+      })
+      .catch(error => {
+        return store.dispatch('handleApiError', error);
+      });
+  });
 }
 
 // For a given Classroom, shows a list of all Exams and Lessons assigned to the Learner
 export function showClassAssignmentsPage(store, classId) {
-  store.commit('CORE_SET_PAGE_LOADING', true);
-  // Force fetch, so it doesn't re-use the assignments-less version in the cache
-  return LearnerClassroomResource.fetchModel({ id: classId })
-    .then(classroom => {
-      // set pageState _after_ to allow the previous page (often `content-page`)
-      // to finish destruction with the expected state in place
-      preparePage(store, {
-        pageName: ClassesPageNames.CLASS_ASSIGNMENTS,
-        initialState: {
-          currentClassroom: {},
-        },
-      });
-      store.commit('SET_CURRENT_CLASSROOM', classroom);
-      store.commit('CORE_SET_PAGE_LOADING', false);
-    })
-    .catch(error => {
-      return store.dispatch('handleApiError', error);
+  return store.dispatch('loading').then(() => {
+    // set pageState _after_ to allow the previous page (often `content-page`)
+    // to finish destruction with the expected state in place
+    preparePage(store, {
+      pageName: ClassesPageNames.CLASS_ASSIGNMENTS,
+      initialState: {
+        currentClassroom: {},
+      },
     });
+    return LearnerClassroomResource.fetchModel({ id: classId })
+      .then(classroom => {
+        store.commit('SET_CURRENT_CLASSROOM', classroom);
+        store.dispatch('notLoading');
+      })
+      .catch(error => {
+        return store.dispatch('handleApiError', error);
+      });
+  });
 }
 
 // For a given Lesson, shows a "playlist" of all the resources in the Lesson
 export function showLessonPlaylist(store, { lessonId }) {
-  store.commit('CORE_SET_PAGE_LOADING', true);
-
-  return LearnerLessonResource.fetchModel({ id: lessonId })
-    .then(lesson => {
-      // set pageState _after_ to allow the previous page (often `content-page`)
-      // to finish destruction with the expected state in place
-      preparePage(store, {
-        pageName: ClassesPageNames.LESSON_PLAYLIST,
-        initialState: {
-          currentLesson: {},
-          contentNodes: [],
-        },
-      });
-      store.commit('SET_CURRENT_LESSON', lesson);
-      return ContentNodeSlimResource.fetchCollection({ getParams: { in_lesson: lesson.id } });
-    })
-    .then(contentNodes => {
-      store.commit('SET_LESSON_CONTENTNODES', contentNodes);
-      // Only load contentnode progress if the user is logged in
-      if (store.getters.isUserLoggedIn) {
-        const contentNodeIds = contentNodes.map(({ id }) => id);
-
-        if (contentNodeIds.length > 0) {
-          ContentNodeProgressResource.fetchCollection({ getParams: { ids: contentNodeIds } }).then(
-            progresses => {
-              store.commit('SET_LESSON_CONTENTNODES_PROGRESS', progresses);
-            }
-          );
-        }
-      }
-      store.commit('CORE_SET_PAGE_LOADING', false);
-    })
-    .catch(error => {
-      return store.dispatch('handleApiError', error);
+  return store.dispatch('loading').then(() => {
+    // set pageState _after_ to allow the previous page (often `content-page`)
+    // to finish destruction with the expected state in place
+    preparePage(store, {
+      pageName: ClassesPageNames.LESSON_PLAYLIST,
+      initialState: {
+        currentLesson: {},
+        contentNodes: [],
+      },
     });
+    return LearnerLessonResource.fetchModel({ id: lessonId })
+      .then(lesson => {
+        store.commit('SET_CURRENT_LESSON', lesson);
+        return ContentNodeSlimResource.fetchCollection({ getParams: { in_lesson: lesson.id } });
+      })
+      .then(contentNodes => {
+        store.commit('SET_LESSON_CONTENTNODES', contentNodes);
+        // Only load contentnode progress if the user is logged in
+        if (store.getters.isUserLoggedIn) {
+          const contentNodeIds = contentNodes.map(({ id }) => id);
+
+          if (contentNodeIds.length > 0) {
+            ContentNodeProgressResource.fetchCollection({
+              getParams: { ids: contentNodeIds },
+            }).then(progresses => {
+              store.commit('SET_LESSON_CONTENTNODES_PROGRESS', progresses);
+            });
+          }
+        }
+        store.dispatch('notLoading');
+      })
+      .catch(error => {
+        return store.dispatch('handleApiError', error);
+      });
+  });
 }
 
 /**
@@ -107,39 +108,42 @@ export function showLessonPlaylist(store, { lessonId }) {
  *
  */
 export function showLessonResourceViewer(store, { lessonId, resourceNumber }) {
-  store.commit('CORE_SET_PAGE_LOADING', true);
-  return LearnerLessonResource.fetchModel({ id: lessonId })
-    .then(lesson => {
-      // set pageState _after_ to allow the previous page (often `content-page`)
-      // to finish destruction with the expected state in place
-      preparePage(store, {
-        pageName: ClassesPageNames.LESSON_RESOURCE_VIEWER,
-        initialState: {
-          currentLesson: {},
-          // To match expected shape for content-page
-          content: {},
-        },
-      });
-      const index = Number(resourceNumber);
-      store.commit('SET_CURRENT_LESSON', lesson);
-      const currentResource = lesson.resources[index];
-      if (!currentResource) {
-        return Promise.reject(`Lesson does not have a resource at index ${index}.`);
-      }
-      const nextResource = lesson.resources[index + 1];
-      return Promise.all([
-        ContentNodeResource.fetchModel({ id: currentResource.contentnode_id }),
-        ContentNodeSlimResource.fetchModel({
-          id: nextResource.contentnode_id,
-          getParams: { in_lesson: lesson.id },
-        }),
-      ]);
-    })
-    .then(resources => {
-      store.commit('SET_CURRENT_AND_NEXT_LESSON_RESOURCES', resources);
-      store.commit('CORE_SET_PAGE_LOADING', false);
-    })
-    .catch(error => {
-      return store.dispatch('handleApiError', error);
+  return store.dispatch('loading').then(() => {
+    // set pageState _after_ to allow the previous page (often `content-page`)
+    // to finish destruction with the expected state in place
+    preparePage(store, {
+      pageName: ClassesPageNames.LESSON_RESOURCE_VIEWER,
+      initialState: {
+        currentLesson: {},
+        // To match expected shape for content-page
+        content: {},
+      },
     });
+    return LearnerLessonResource.fetchModel({ id: lessonId })
+      .then(lesson => {
+        const index = Number(resourceNumber);
+        store.commit('SET_CURRENT_LESSON', lesson);
+        const currentResource = lesson.resources[index];
+        if (!currentResource) {
+          return Promise.reject(`Lesson does not have a resource at index ${index}.`);
+        }
+        const nextResource = lesson.resources[index + 1];
+        const nextResourcePromise = nextResource
+          ? ContentNodeSlimResource.fetchModel({
+              id: nextResource.contentnode_id,
+              getParams: { in_lesson: lesson.id },
+            })
+          : Promise.resolve();
+        return Promise.all([
+          ContentNodeResource.fetchModel({ id: currentResource.contentnode_id }),
+          nextResourcePromise,
+        ]).then(resources => {
+          store.commit('SET_CURRENT_AND_NEXT_LESSON_RESOURCES', resources);
+          store.dispatch('notLoading');
+        });
+      })
+      .catch(error => {
+        return store.dispatch('handleApiError', error);
+      });
+  });
 }

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -195,10 +195,11 @@
         return false;
       },
       description() {
-        if (this.content) {
+        if (this.content && this.content.description) {
           const md = new markdownIt('zero', { breaks: true });
           return md.render(this.content.description);
         }
+        return '';
       },
       recommendedText() {
         return this.$tr('recommended');


### PR DESCRIPTION
### Summary
1. Fixes an issue with the `findModel` method of the API Resource layer where the model cache it was referencing was not updated in #4048.
2. Fixes a (merge conflict resolution? oversight?) issue in the LessonResourceSelection component, where the content card component was being referred to by the wrong name in the template.
3. Adds `loading` and `notLoading` core actions that return a Promise that only resolves after `Vue.nextTick`. These bugs surfaced mostly in the learn lesson viewing actions because previously these had been doing forced fetches, so by the time the fetches had completed the `nextTick` had already occurred. Changes in #4048 allowed more of these fetches to rely on the API Resource cache, and hence were returning immediately, before `nextTick` could occur, this resulted in the previously displayed component throwing an error due to the change in the pageState that was incompatible with its expectations.

### Reviewer guidance
* Check that lesson rendering works.
* Check that lesson creation works.
* Check that you can answer exercise questions without it erroring out when trying to save the attempt.
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
