### PR TITLE
Ignore kolibri/dist in test coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,5 @@ exclude_lines =
 	raise NotImplementedError
 
 	if __name__ == .__main__.:
+omit =
+	kolibri/dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ omit =
 	*/test_*.py
 	kolibri/core/webpack/management/commands/devserver.py
 	kolibri/utils/lru_cache.py
+	kolibri/dist/*
 
 [coverage:report]
 ignore_errors = True


### PR DESCRIPTION
### Summary

Test coverage in `develop` started being sensitive to the files in `kolibri/dist` - I'm not sure what caused the change.

@jonboiser 

### Reviewer guidance

n/a - just gonna merge if it works

### References


----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
