### PR TITLE
Bump to 0.10.1 dev series

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -15,7 +15,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 10, 0, 'final', 0)
+VERSION = (0, 10, 1, 'alpha', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION
Current builds are being released as 0.10.0

Will consolidate release process, so we catch this in the future subsequent to final releases.