### PR TITLE
Add fallback for first login if not redirect hook found.

### DIFF
--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -59,6 +59,13 @@ def logout_view(request):
 def get_url_by_role(role, first_login):
     obj = next((hook for hook in RoleBasedRedirectHook().registered_hooks
                 if hook.role == role and hook.first_login == first_login), None)
+
+    if obj is None and first_login:
+        # If it is the first_login, do a fallback to find the non-first login behaviour when it is
+        # not available
+        obj = next((hook for hook in RoleBasedRedirectHook().registered_hooks
+                    if hook.role == role and hook.first_login is False), None)
+
     if obj:
         return obj.url
 


### PR DESCRIPTION
### Summary
Rectifies a bug whereby the first login would not be properly handled if there was no first login redirect hook.

### Reviewer guidance
Create a new learner, login and see that you get redirected to learn.

### References
Fixes #3987

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
