### PR TITLE
Show different ClassListPage empty states based on user + other fixes

### DIFF
--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -22,6 +22,12 @@ export default {
         state.kind.includes(UserKinds.COACH) || state.kind.includes(UserKinds.ASSIGNABLE_COACH)
       );
     },
+    isClassCoach(state) {
+      return state.kind.includes(UserKinds.ASSIGNABLE_COACH);
+    },
+    isFacilityCoach(state) {
+      return state.kind.includes(UserKinds.COACH);
+    },
     isLearner(state) {
       return state.kind.includes(UserKinds.LEARNER);
     },

--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -5,7 +5,9 @@
       {{ header }}
     </h1>
     <p>
-      {{ details || defaultDetails }}
+      <slot name="details">
+        {{ details || defaultDetails }}
+      </slot>
     </p>
   </div>
 

--- a/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
@@ -170,7 +170,7 @@
       noAssignedClassesHeader: "You aren't assigned to any classes",
       noAssignedClassesDetails:
         'Please consult your Kolibri administrator to be assigned to a class',
-      noClassesDetailsForAdmin: 'Create classes and enroll students in Facility',
+      noClassesDetailsForAdmin: 'Create a class and enroll learners',
       noClassesDetailsForFacilityCoach: 'Please consult your Kolibri administrator',
       coachesColumnHeader: 'Coaches',
       noClassesInFacility: 'There are no classes yet',

--- a/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
@@ -4,8 +4,8 @@
 
     <AuthMessage
       v-if="noClassesExist"
-      :header="$tr('noAssignedClassesHeader')"
-      :details="$tr('noAssignedClassesDetails')"
+      :header="authMessageHeader"
+      :details="authMessageDetails"
     />
 
     <template v-else>
@@ -55,7 +55,7 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
@@ -86,6 +86,7 @@
       KRouterLink,
     },
     computed: {
+      ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach']),
       ...mapState(['classList']),
       noClassesExist() {
         return this.classList.length === 0;
@@ -93,6 +94,26 @@
       CLASSROOM: () => ContentNodeKinds.CLASSROOM,
       sortedClasses() {
         return orderBy(this.classList, [classroom => classroom.name.toUpperCase()], ['asc']);
+      },
+      authMessageHeader() {
+        if (this.isClassCoach) {
+          return this.$tr('noAssignedClassesHeader');
+        }
+        if (this.isAdmin || this.isFacilityCoach) {
+          return this.$tr('noClassesInFacility');
+        }
+        return '';
+      },
+      authMessageDetails() {
+        if (this.isClassCoach) {
+          return this.$tr('noAssignedClassesDetails');
+        }
+        if (this.isAdmin) {
+          return this.$tr('noClassesDetailsForAdmin');
+        }
+        if (this.isFacilityCoach) {
+          return this.$tr('noClassesDetailsForFacilityCoach');
+        }
       },
     },
     methods: {
@@ -139,8 +160,11 @@
       tableCaption: 'List of classes',
       noAssignedClassesHeader: "You aren't assigned to any classes",
       noAssignedClassesDetails:
-        'To start coaching a class, please consult your Kolibri administrator',
+        'Please consult your Kolibri administrator to be assigned to a class',
+      noClassesDetailsForAdmin: 'Create classes and enroll students in Facility',
+      noClassesDetailsForFacilityCoach: 'Please consult your Kolibri administrator',
       coachesColumnHeader: 'Coaches',
+      noClassesInFacility: 'There are no classes yet',
       learnerColumnHeader: 'Learners',
       classIconTableDescription: 'Class icon',
       twoCoachNames: '{name1}, {name2}',

--- a/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
@@ -46,7 +46,7 @@
                 :to="learnerPageLink(classroom.id)"
               />
             </td>
-            <td :title="formattedCoachNamesTooltip(classroom)">
+            <td data-test="coach-names" :title="formattedCoachNamesTooltip(classroom)">
               {{ formattedCoachNames(classroom) }}
             </td>
             <td>{{ classroom.learner_count }}</td>

--- a/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
@@ -6,7 +6,14 @@
       v-if="noClassesExist"
       :header="authMessageHeader"
       :details="authMessageDetails"
-    />
+    >
+      <KExternalLink
+        slot="details"
+        v-if="isAdmin"
+        :text="$tr('noClassesDetailsForAdmin')"
+        href="/facility"
+      />
+    </AuthMessage>
 
     <template v-else>
       <section>
@@ -62,6 +69,7 @@
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import orderBy from 'lodash/orderBy';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
+  import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
   import { PageNames } from '../constants';
   import { filterAndSortUsers } from '../../../../facility_management/assets/src/userSearchUtils';
 
@@ -84,6 +92,7 @@
       CoreTable,
       ContentIcon,
       KRouterLink,
+      KExternalLink,
     },
     computed: {
       ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach']),

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -19,7 +19,7 @@
         {{ $tr('status') }}
         <CoreInfoIcon
           :iconAriaLabel="$tr('statusDescription')"
-          :tooltipText="$tr('statusTooltipText')"
+          :tooltipText="tooltipText"
           tooltipPosition="bottom left"
         />
       </dt>
@@ -77,7 +77,7 @@
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import KButton from 'kolibri.coreVue.components.KButton';
-  import { CollectionKinds } from 'kolibri.coreVue.vuex.constants';
+  import { CollectionKinds, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import StatusIcon from './StatusIcon';
 
   export default {
@@ -118,7 +118,8 @@
     $trs: {
       status: 'Status',
       statusDescription: 'Status description',
-      statusTooltipText: 'Active: visible to learners. Inactive: hidden from learners.',
+      statusTooltipTextExams: 'Learners can only see active exams',
+      statusTooltipTextLessons: 'Learners can only see active lessons',
       changeStatus: 'Change',
       description: 'Description',
       noDescription: 'No description',
@@ -154,6 +155,14 @@
             ).name;
             return recipientGroup;
           });
+      },
+      tooltipText() {
+        if (this.kind === ContentNodeKinds.EXAM) {
+          return this.$tr('statusTooltipTextExams');
+        }
+        if (this.kind === ContentNodeKinds.LESSON) {
+          return this.$tr('statusTooltipTextLessons');
+        }
       },
     },
   };

--- a/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
@@ -13,6 +13,7 @@ function makeWrapper() {
   };
   return { wrapper, els, store };
 }
+
 describe('ClassListPage', () => {
   describe('it shows correct empty message', () => {
     // prettier-ignore
@@ -39,6 +40,7 @@ describe('ClassListPage', () => {
         headerText: 'There are no classes yet',
         bodyText: 'Create classes and enroll students in Facility',
       });
+      expect(els.AuthMessage().find('a').attributes().href).toEqual('/facility');
     });
 
     it('when a facility coach and no classes in facility', () => {

--- a/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
@@ -38,7 +38,7 @@ describe('ClassListPage', () => {
       store.state.core.session.kind = ['admin'];
       testAuthMessage(els, {
         headerText: 'There are no classes yet',
-        bodyText: 'Create classes and enroll students in Facility',
+        bodyText: 'Create a class and enroll learners',
       });
       // prettier-ignore
       expect(els.AuthMessage().find('a').attributes().href).toEqual('/facility');

--- a/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
@@ -40,6 +40,7 @@ describe('ClassListPage', () => {
         headerText: 'There are no classes yet',
         bodyText: 'Create classes and enroll students in Facility',
       });
+      // prettier-ignore
       expect(els.AuthMessage().find('a').attributes().href).toEqual('/facility');
     });
 

--- a/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils';
+import makeStore from '../makeStore';
+import ClassListPage from '../../src/views/ClassListPage';
+
+function makeWrapper() {
+  const store = makeStore();
+  const wrapper = mount(ClassListPage, {
+    store,
+    stubs: ['router-link'],
+  });
+  const els = {
+    AuthMessage: () => wrapper.find({ name: 'AuthMessage' }),
+  };
+  return { wrapper, els, store };
+}
+describe('ClassListPage', () => {
+  describe('it shows correct empty message', () => {
+    // prettier-ignore
+    function testAuthMessage(els, expectedText) {
+      const headerText = els.AuthMessage().find('h1').text();
+      const bodyText = els.AuthMessage().find('p').text();
+      expect(headerText).toEqual(expectedText.headerText);
+      expect(bodyText).toEqual(expectedText.bodyText);
+    }
+
+    it('when a class coach and no classes in facility (or no assignments)', () => {
+      const { els, store } = makeWrapper();
+      store.state.core.session.kind = ['classroom assignable coach'];
+      testAuthMessage(els, {
+        headerText: "You aren't assigned to any classes",
+        bodyText: 'Please consult your Kolibri administrator to be assigned to a class',
+      });
+    });
+
+    it('when an admin and no classes in facility', () => {
+      const { els, store } = makeWrapper();
+      store.state.core.session.kind = ['admin'];
+      testAuthMessage(els, {
+        headerText: 'There are no classes yet',
+        bodyText: 'Create classes and enroll students in Facility',
+      });
+    });
+
+    it('when a facility coach and no classes in facility', () => {
+      const { els, store } = makeWrapper();
+      store.state.core.session.kind = ['coach'];
+      testAuthMessage(els, {
+        headerText: 'There are no classes yet',
+        bodyText: 'Please consult your Kolibri administrator',
+      });
+    });
+
+    it('does not show an empty message if there are classes', () => {
+      const { els, store } = makeWrapper();
+      store.commit('SET_CLASS_INFO', {
+        classList: [{ coaches: [], name: 'Class 1' }],
+      });
+      expect(els.AuthMessage().exists()).toEqual(false);
+    });
+  });
+});

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/index.vue
@@ -6,15 +6,13 @@
       <h1 class="title-header">
         {{ currentClass.name }}
       </h1>
-      <UiIconButton
-        type="secondary"
-        color="primary"
-        class="edit-button"
+      <KButton
+        :text="$tr('renameButtonLabel')"
+        appearance="basic-link"
+        :primary="true"
         :ariaLabel="$tr('edit')"
         @click="displayModal(Modals.EDIT_CLASS_NAME)"
-      >
-        <mat-svg name="edit" category="image" />
-      </UiIconButton>
+      />
     </div>
 
     <p>{{ $tr('coachEnrollmentPageTitle') }}</p>
@@ -95,7 +93,6 @@
 <script>
 
   import { mapState, mapActions } from 'vuex';
-  import UiIconButton from 'keen-ui/src/UiIconButton';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KGrid from 'kolibri.coreVue.components.KGrid';
@@ -119,6 +116,7 @@
       noUsersExist: 'No users in this class',
       edit: 'Edit class name',
       documentTitle: 'Edit Class',
+      renameButtonLabel: 'Edit',
     },
     metaInfo() {
       return {
@@ -129,7 +127,6 @@
       UserTable,
       ClassRenameModal,
       UserRemoveConfirmationModal,
-      UiIconButton,
       KGrid,
       KGridItem,
       KRouterLink,
@@ -186,6 +183,7 @@
 
   .title-header {
     display: inline-block;
+    margin-right: 8px;
   }
 
   .edit-button {

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "seededshuffle": "^0.1.1",
     "shave": "^2.1.3",
     "typeface-noto-sans": "^0.0.54",
-    "vue": "2.5.17-beta.0",
+    "vue": "^2.5.17",
     "vue-intl": "2.1.1",
     "vue-markdown": "^2.1.3",
     "vue-meta": "^1.5.0",
     "vue-router": "^2.1.1",
-    "vuex": "3.0.1"
+    "vuex": "^3.0.1"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.13",
@@ -122,7 +122,7 @@
     "vue-jest": "^2.6.0",
     "vue-loader": "15.0.0",
     "vue-style-loader": "^3.0.3",
-    "vue-template-compiler": "^2.5.17-beta.0",
+    "vue-template-compiler": "^2.5.17",
     "webpack": "^4.6.0",
     "webpack-bundle-size-analyzer": "^2.0.2",
     "webpack-bundle-tracker": "https://github.com/learningequality/webpack-bundle-tracker",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,9 +9791,9 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.5.17-beta.0:
-  version "2.5.17-beta.0"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.17-beta.0.tgz#6653d4029bd6fc427de616ce626e7f1db63e615c"
+vue-template-compiler@^2.5.17:
+  version "2.5.17"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz#52a4a078c327deb937482a509ae85c06f346c3cb"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -9802,11 +9802,11 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue@2.5.17-beta.0:
-  version "2.5.17-beta.0"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17-beta.0.tgz#b9985447818827306beee146923a1bd64f1bb834"
+vue@^2.5.17:
+  version "2.5.17"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
 
-vuex@3.0.1:
+vuex@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.0.1.tgz#e761352ebe0af537d4bb755a9b9dc4be3df7efd2"
 


### PR DESCRIPTION
### Summary

1. Shows different messages on Coach > ClassListPage depending on user role: Fixes #3780
1. Also changes the rename button on the ClassEditPage Fixes #3838 
1. Updates tooltips shown on ExamsRoot and LessonsRoot pages Fixes #4087 and Fixes #3877
1. Fixes Vue version to 2.5.17 Fixes #4075

![screen shot 2018-08-02 at 12 41 21 pm](https://user-images.githubusercontent.com/10248067/43607111-25f5493c-9652-11e8-9ded-37d6af322eaa.png)

**Learner**

![screen shot 2018-08-02 at 12 07 39 pm](https://user-images.githubusercontent.com/10248067/43605332-d100ada4-964c-11e8-99fb-ef624797d7a7.png)

**Facility Coach**

![screen shot 2018-08-02 at 12 07 25 pm](https://user-images.githubusercontent.com/10248067/43605333-d11fe570-964c-11e8-975b-0975b670428d.png)

**Admin**

(Link text changed to "Create a class and enroll learners")

![screen shot 2018-08-02 at 12 07 13 pm](https://user-images.githubusercontent.com/10248067/43605334-d13baaee-964c-11e8-8759-5150393175a8.png)

**Class Coach**

![screen shot 2018-08-02 at 12 07 02 pm](https://user-images.githubusercontent.com/10248067/43605335-d15329c6-964c-11e8-835b-9b2d57f856d8.png)

### Reviewer guidance

1. Manually test the various scenarios for Coach Pages
1. Check other pages that use AuthMessage to see it is still working

### References

Fixes #3780 
Fixes #3838 
Fixes #3877 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
