### PR TITLE
Security upgrade: Bump to latest cryptography 2.3. CVE-2018-10903

### DIFF
--- a/requirements/cext.txt
+++ b/requirements/cext.txt
@@ -1,1 +1,1 @@
-cryptography==2.0.3
+cryptography==2.3

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -1,4 +1,4 @@
 # These are unique requirements for C extensions, but the
 # ones that don't need to be shipped in one version per
 # arch/OS/pyVesion
-pyOpenSSL==17.4.0  # pyup: >=17.4.0,<17.5.0
+pyOpenSSL==18.0.0


### PR DESCRIPTION
### Summary

Will also make changes to Morango's test matrix.

### Reviewer guidance

n/a

### References

https://nvd.nist.gov/vuln/detail/CVE-2018-10903
----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
