### PR TITLE
First pass optimization of exam creation

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -419,6 +419,15 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         data = descendants.aggregate(Sum('assessmentmetadata__number_of_assessments'))['assessmentmetadata__number_of_assessments__sum'] or 0
         return Response(data)
 
+    @list_route(methods=['get'])
+    def node_assessments(self, request):
+        ids = self.request.query_params.get('ids', '').split(',')
+        data = 0
+        if ids and ids[0]:
+            nodes = models.ContentNode.objects.filter(id__in=ids).prefetch_related('assessmentmetadata')
+            data = nodes.aggregate(Sum('assessmentmetadata__number_of_assessments'))['assessmentmetadata__number_of_assessments__sum'] or 0
+        return Response(data)
+
     @detail_route(methods=['get'])
     def ancestors(self, request, **kwargs):
         cache_key = 'contentnode_ancestors_{pk}'.format(pk=kwargs.get('pk'))

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -409,6 +409,17 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         return Response(serializer.data)
 
     @detail_route(methods=['get'])
+    def descendants_assessments(self, request, **kwargs):
+        node = self.get_object(prefetch=False)
+        kind = self.request.query_params.get('descendant_kind', None)
+        descendants = node.get_descendants().filter(available=True).prefetch_related('assessmentmetadata')
+        if kind:
+            descendants = descendants.filter(kind=kind)
+
+        data = descendants.aggregate(Sum('assessmentmetadata__number_of_assessments'))['assessmentmetadata__number_of_assessments__sum'] or 0
+        return Response(data)
+
+    @detail_route(methods=['get'])
     def ancestors(self, request, **kwargs):
         cache_key = 'contentnode_ancestors_{pk}'.format(pk=kwargs.get('pk'))
 

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -46,6 +46,24 @@ export default class ContentNodeResource extends Resource {
     }
     return promise;
   }
+  fetchNodeAssessments(ids) {
+    if (!Array.isArray(ids)) {
+      throw TypeError('Ids must be an Array');
+    }
+    let promise;
+    this.nodeAssessments = this.nodeAssessments || {};
+    const key = this.cacheKey({ ids });
+    if (!this.nodeAssessments[key]) {
+      const url = this.urls[`${this.name}-node-assessments`]();
+      promise = this.client({ path: url, params: { ids } }).then(response => {
+        this.nodeAssessments[key] = response.entity;
+        return Promise.resolve(response.entity);
+      });
+    } else {
+      promise = Promise.resolve(this.nodeAssessments[key]);
+    }
+    return promise;
+  }
   fetchAncestors(id) {
     if (!id) {
       throw TypeError('An id must be specified');

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -14,17 +14,37 @@ export default class ContentNodeResource extends Resource {
     if (!id) {
       throw TypeError('An id must be specified');
     }
+    this.descendantsCache = this.descendantsCache || {};
     // Add the id to the getParams for cache identification
     getParams.modelId = id;
     let collection;
     const key = this.cacheKey(getParams);
-    if (!this.collections[key]) {
+    if (!this.descendantsCache[key]) {
       collection = this.createCollection({}, getParams, []);
       collection.url = (...args) => this.urls[`${this.name}-descendants`](...args, id);
+      this.descendantsCache[key] = collection;
     } else {
-      collection = this.collections[key];
+      collection = this.descendantsCache[key];
     }
     return collection;
+  }
+  fetchDescendantsAssessments(id) {
+    if (!id) {
+      throw TypeError('An id must be specified');
+    }
+    let promise;
+    this.descendantsAssessments = this.descendantsAssessments || {};
+    const key = this.cacheKey({ id });
+    if (!this.descendantsAssessments[key]) {
+      const url = this.urls[`${this.name}-descendants-assessments`](id);
+      promise = this.client({ path: url }).then(response => {
+        this.descendantsAssessments[key] = response.entity;
+        return Promise.resolve(response.entity);
+      });
+    } else {
+      promise = Promise.resolve(this.descendantsAssessments[key]);
+    }
+    return promise;
   }
   fetchAncestors(id) {
     if (!id) {

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -296,14 +296,14 @@ export function getAllExercisesWithinTopic(store, topicId) {
   return new Promise((resolve, reject) => {
     const exercisesPromise = ContentNodeResource.getDescendantsCollection(topicId, {
       descendant_kind: ContentNodeKinds.EXERCISE,
-      fields: ['id', 'title', 'assessmentmetadata', 'num_coach_contents'],
+      fields: ['id', 'title'],
     }).fetch();
+    const assessmentNumbersPromise = ContentNodeResource.fetchDescendantsAssessments(topicId);
 
-    ConditionalPromise.all([exercisesPromise]).only(
+    ConditionalPromise.all([exercisesPromise, assessmentNumbersPromise]).only(
       samePageCheckGenerator(store),
-      ([exercisesCollection]) => {
-        const exercises = _exercisesState(exercisesCollection);
-        resolve(exercises);
+      ([exercisesCollection, assessmentNumbers]) => {
+        resolve([exercisesCollection, assessmentNumbers]);
       },
       error => reject(error)
     );
@@ -347,7 +347,8 @@ function fetchTopic(store, topicId) {
           samePageCheckGenerator(store),
           subtopicsExercises => {
             subtopics = subtopics.map((subtopic, index) => {
-              subtopic.allExercisesWithinTopic = subtopicsExercises[index];
+              subtopic.allExercisesWithinTopic = subtopicsExercises[index][0];
+              subtopics.numAssessments = subtopicsExercises[index][1];
               return subtopic;
             });
 

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -406,6 +406,11 @@ export function removeExercise(store, exercise) {
 
 export function setSelectedExercises(store, selectedExercises) {
   store.dispatch('SET_SELECTED_EXERCISES', selectedExercises);
+  return ContentNodeResource.fetchNodeAssessments(selectedExercises.map(ex => ex.id)).then(
+    number => {
+      store.dispatch('SET_AVAILABLE_QUESTIONS', number);
+    }
+  );
 }
 
 export function createExamAndRoute(store, exam) {

--- a/kolibri/plugins/coach/assets/src/state/store.js
+++ b/kolibri/plugins/coach/assets/src/state/store.js
@@ -79,6 +79,9 @@ export const mutations = {
       selectedExercises
     );
   },
+  SET_AVAILABLE_QUESTIONS(state, availableQuestions) {
+    Vue.set(state.pageState, 'availableQuestions', availableQuestions);
+  },
   SET_EXAMS(state, exams) {
     state.pageState.exams = exams;
   },

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -235,7 +235,7 @@
         return Boolean(this.titleIsInvalidText);
       },
       maxQuestionsFromSelection() {
-        // in case numAssestments is null, return 0
+        // in case num_assestments is null, return 0
         return this.selectedExercises.reduce(
           (sum, exercise) => sum + (exercise.numAssessments || 0),
           0

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -234,13 +234,6 @@
       titleIsInvalid() {
         return Boolean(this.titleIsInvalidText);
       },
-      maxQuestionsFromSelection() {
-        // in case num_assestments is null, return 0
-        return this.selectedExercises.reduce(
-          (sum, exercise) => sum + (exercise.numAssessments || 0),
-          0
-        );
-      },
       numQuestExceedsSelection() {
         return this.inputNumQuestions > this.maxQuestionsFromSelection;
       },
@@ -458,6 +451,7 @@
         subtopics: state => state.pageState.subtopics,
         exercises: state => state.pageState.exercises,
         selectedExercises: state => state.pageState.selectedExercises,
+        maxQuestionsFromSelection: state => state.pageState.availableQuestions,
         examsModalSet: state => state.pageState.examsModalSet,
       },
       actions: {


### PR DESCRIPTION
### Summary
Currently if you have all of Khan Academy English imported, and attempt to create an exam, it can either take a very long time (~40s on my dev machine) for the longest running requests to complete, or timeout completely due to cherrypy on lower performance machines.

This PR reduces the time required by no longer counting the number of assessments by aggregating over all the descendants, and instead does a database level sum to retrieve this data for a particular topic.

### Reviewer guidance
Check that you can still create exams.
Check that it is quicker when you have lots of exercises.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
