### PR TITLE
Small fixes

### DIFF
--- a/docs/architecture/frontend_architecture.rst
+++ b/docs/architecture/frontend_architecture.rst
@@ -34,7 +34,7 @@ For example:
           core-modal.vue        # example of another shared component
           core-global.scss      # globally defined styles, indluded in head
           core-theme.scss       # style variable values
-          font-NotoSans.css     # embedded font
+          font-noto-sans.css     # embedded font
         test/
           ...                   # tests for core assets
     plugins/

--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -1,6 +1,6 @@
 // include global styles
 require('purecss/build/base-min.css');
-require('../styles/font-NotoSans.scss');
+require('../styles/font-noto-sans.scss');
 require('../styles/main.scss');
 
 // Required to setup Keen UI, should be imported only once in your project

--- a/kolibri/core/assets/src/keen-config/variables.scss
+++ b/kolibri/core/assets/src/keen-config/variables.scss
@@ -1,3 +1,3 @@
 $brand-primary-color: #996189;
-$font-stack: 'NotoSans';
+$font-stack: 'Noto Sans';
 $ui-input-border-width: 2px !default;

--- a/kolibri/core/assets/src/styles/core-theme.scss
+++ b/kolibri/core/assets/src/styles/core-theme.scss
@@ -2,7 +2,7 @@
   Define the (preferably limited) subset of values that can be overridden.
 */
 
-$core-font: 'NotoSans' 'sans-serif';
+$core-font: 'Noto Sans', sans-serif;
 
 $core-action-normal: #996189;
 $core-action-light: #e2d1e0;

--- a/kolibri/core/assets/src/styles/font-noto-sans.scss
+++ b/kolibri/core/assets/src/styles/font-noto-sans.scss
@@ -1,12 +1,12 @@
 @font-face {
-  font-family: 'NotoSans';
+  font-family: 'Noto Sans';
   src: url('~typeface-noto-sans/files/noto-sans-latin-400.woff') format('woff');
   font-style: normal;
   font-weight: normal;
 }
 
 @font-face {
-  font-family: 'NotoSans';
+  font-family: 'Noto Sans';
   src: url('~typeface-noto-sans/files/noto-sans-latin-700.woff') format('woff');
   font-style: normal;
   font-weight: bold;

--- a/kolibri/core/assets/src/styles/main.scss
+++ b/kolibri/core/assets/src/styles/main.scss
@@ -42,8 +42,7 @@ html,
 button,
 input,
 select,
-textarea,
-.pure-g [class*='pure-u'] {
+textarea {
   font-family: $core-font;
 }
 

--- a/kolibri/core/assets/src/views/KGrid/Overlay.vue
+++ b/kolibri/core/assets/src/views/KGrid/Overlay.vue
@@ -100,7 +100,7 @@
     top: 0;
     height: 100%;
     pointer-events: none;
-    background-color: #0064ff24;
+    background-color: rgba(0, 100, 255, 0.14);
   }
 
 </style>

--- a/kolibri/core/assets/src/views/KGrid/extra-units.css
+++ b/kolibri/core/assets/src/views/KGrid/extra-units.css
@@ -40,10 +40,10 @@
 .pure-u-11-11 {
   display: inline-block;
   *display: inline;
-  zoom: 1;
   letter-spacing: normal;
-  word-spacing: normal;
   vertical-align: top;
+  zoom: 1;
+  word-spacing: normal;
   text-rendering: auto;
 }
 

--- a/kolibri/core/assets/src/views/KGrid/index.vue
+++ b/kolibri/core/assets/src/views/KGrid/index.vue
@@ -16,7 +16,6 @@
 
 </template>
 
-
 <script>
 
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -120,13 +119,16 @@
 </script>
 
 
-<style lang="scss">
+<style lang="scss" scoped>
 
   @import '~purecss/build/grids-core.css';
   @import '~purecss/build/grids-units.css';
   @import './extra-units.css';
+  @import '~kolibri.styles.definitions';
+
+  /deep/ .pure-g,
+  /deep/ .pure-g [class*='pure-u'] {
+    font-family: $core-font;
+  }
 
 </style>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
@@ -33,7 +33,7 @@
     <LanguageSwitcherModal
       v-if="showLanguageModal"
       @close="showLanguageModal = false"
-      class="modal"
+      class="ta-l"
     />
   </div>
 
@@ -47,7 +47,7 @@
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiIconButton from 'keen-ui/src/UiIconButton';
   import languageSwitcherMixin from './mixin';
-  import LanguageSwitcherModal from './LanguageSwitcherList';
+  import LanguageSwitcherModal from './LanguageSwitcherModal';
 
   export default {
     name: 'LanguageSwitcherList',
@@ -115,7 +115,7 @@
     margin-bottom: 8px;
   }
 
-  .modal {
+  .ta-l {
     text-align: left;
   }
 

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -44,16 +44,16 @@
 
     .flapping-kolibri {
       position: absolute;
-      width: 125px;
-      height: 125px;
       top: 50%;
       left: 50%;
-      transform: translate(-50%, -50%);
+      width: 125px;
+      height: 125px;
       background: url("{% static 'images/loading-spinner.gif' %}") no-repeat center;
       background-size: contain;
+      transform: translate(-50%, -50%);
       animation: fadeIn;
-      animation-delay: 1s;
       animation-duration: 1s;
+      animation-delay: 1s;
       animation-fill-mode: both;
     }
 

--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -1,20 +1,20 @@
 {% load i18n %}
 <style>
   body {
-    font-family: sans-serif;
     margin: 0;
+    font-family: sans-serif;
     background-color: white;
   }
   .topbar {
-    background-color: #996189;
     width: 100%;
     color: white;
+    background-color: #996189;
   }
   .topbar h1 {
-    font-size: x-large;
     display: inline-block;
-    padding-left: 32px;
     padding-right: 32px;
+    padding-left: 32px;
+    font-size: x-large;
   }
   .content-container {
     padding: 32px;

--- a/kolibri/plugins/style_guide/assets/src/views/StyleGuideIndex.vue
+++ b/kolibri/plugins/style_guide/assets/src/views/StyleGuideIndex.vue
@@ -77,7 +77,7 @@
     display: initial;
     height: initial;
     // TODO: vuep pullutes the font-family
-    font-family: NotoSans;
+    font-family: 'Noto Sans';
 
     .vuep-preview,
     .vuep-editor {


### PR DESCRIPTION
### Summary

Resets font for k-grid.
Fix lint warnings.
Clean up references to font family
Fixes https://github.com/learningequality/kolibri/issues/3988

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
