### PR TITLE
Ensure plugins are updated before loading Django settings

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+rom __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
@@ -146,6 +146,9 @@ def initialize(debug=False):
         version = version.strip() if version else ""
         change_version = kolibri.__version__ != version
         if change_version:
+            # dbbackup will load settings.INSTALLED_APPS.
+            # we need to ensure plugins are correct in conf.config before
+            enable_default_plugins()
             # Version changed, make a backup no matter what.
             from kolibri.core.deviceadmin.utils import dbbackup
             try:
@@ -156,7 +159,6 @@ def initialize(debug=False):
                 logger.warning(
                     "Skipped automatic database backup, not compatible with "
                     "this DB engine.")
-            enable_default_plugins()
 
         django.setup()
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -1,4 +1,4 @@
-rom __future__ import absolute_import
+from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 


### PR DESCRIPTION
### Summary
In the first run after a Kolibri version changes and plugins are updated the running server does not recognize the updated plugins.
This PR changes the order of the sentence upgrading the plugins to ensure is executed before Django settings is filled.

Notice that running Kolibri using `yarn django-devserver` the issue is not seen because the server reloads after  update_channel_metadata is executed. The issue appears only when running the production server.


### Reviewer guidance
To reproduce it:
- .kolibri folder from version 0.7.2 
- run new kolibri version (>0.8) not using the dev server mode


Then, if this PR is not applied:
- http://localhost:8080/facility/ will give a 404 error
- After login device and facility menus don't appear

### References
Closes #3805, closes #3806, closes #4021 


### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
