### PR TITLE
Fixes #4117: Do not overwrite LocalFiles on import, so annotation works successfully

### DIFF
--- a/kolibri/content/utils/channel_import.py
+++ b/kolibri/content/utils/channel_import.py
@@ -38,6 +38,9 @@ merge_models = [
     Language,
 ]
 
+models_not_to_overwrite = [
+    LocalFile,
+]
 
 class ImportCancelError(Exception):
     pass
@@ -267,8 +270,14 @@ class ChannelImport(object):
                 val = convert_to_sqlite_value(model._meta.get_field(col).get_default())
             source_vals.append(val)
 
+        if model in models_not_to_overwrite:
+            method = "INSERT OR IGNORE"
+        else:
+            method = "REPLACE"
+
         # build and execute a raw SQL query to transfer the data in one fell swoop
-        query = """REPLACE INTO {table} ({destcols}) SELECT {sourcevals} FROM sourcedb.{table} AS source""".format(
+        query = """{method} INTO {table} ({destcols}) SELECT {sourcevals} FROM sourcedb.{table} AS source""".format(
+            method=method,
             table=dest_table.name,
             destcols=", ".join(dest_columns),
             sourcevals=", ".join(source_vals),
@@ -298,13 +307,14 @@ class ChannelImport(object):
         columns = [column_name for column_name, column_obj in dest_table.columns.items() if column_not_auto_integer_pk(column_obj)]
         data_to_insert = []
         merge = model in merge_models
+        do_not_overwrite = model in models_not_to_overwrite
         for record in table_mapper(SourceRecord):
             self.check_cancelled()
             data = {
                 str(column): row_mapper(record, column) for column in columns if row_mapper(record, column) is not None
             }
             if merge:
-                self.merge_record(data, model, DestinationRecord)
+                self.merge_record(data, model, DestinationRecord, do_not_overwrite=do_not_overwrite)
             else:
                 data_to_insert.append(data)
             unflushed_rows += 1
@@ -359,13 +369,16 @@ class ChannelImport(object):
 
         return result
 
-    def merge_record(self, data, model, DestinationRecord):
+    def merge_record(self, data, model, DestinationRecord, do_not_overwrite=False):
         # Models that should be merged (see list above) need to be individually merged into the session
         # as SQL Alchemy ORM does not support INSERT ... ON DUPLICATE KEY UPDATE style queries,
         # as not available in SQLite, only MySQL as far as I can tell:
         # http://hackthology.com/how-to-compile-mysqls-on-duplicate-key-update-in-sql-alchemy.html
         RowEntry = self.destination.session.query(DestinationRecord).get(data[model._meta.pk.name])
         if RowEntry:
+            # record already exists, so if we don't want to overwrite, abort here
+            if do_not_overwrite:
+                return
             for key, value in data.items():
                 setattr(RowEntry, key, value)
         else:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

See https://github.com/learningequality/kolibri/issues/4117 for symptoms. We were overwriting LocalFile on reimport of the metadata for a channel, and then not setting availability again, so previously downloaded content wouldn't show up anymore.

This PR only inserts new LocalFile records, skipping any that already exist, to avoid clearing the availability on existing files.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Follow the replication instructions in the last comment in the issue, and it should no longer clear availability of already downloaded files.

If you don't want to go back and forth to Studio, and don't really care about what's in your DB, you can also just run:
`echo "from kolibri.content.models import *; ChannelMetadata.objects.all().update(version=0)" | kolibri shell`
after importing something from the channel the first time, and then go and update the channel version to the latest. It should leave your existing downloads there, showing as available.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/4117

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
