### PR TITLE
Update of i18n names caused by automated 'node ./frontend_build/src/intl_code_gen.js' run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help clean clean-pyc clean-build list test test-all coverage docs release sdist
+# Specifies the targets that should ALWAYS have their recipies run
+.PHONY: help clean clean-pyc clean-build clean-assets writeversion lint test test-all coverage docs release translation-crowdin-upload translation-crowdin-download
 
 help:
 	@echo "Usage:"
@@ -163,7 +164,10 @@ dist: writeversion staticdeps staticdeps-cext buildconfig assets translation-dja
 pex: writeversion
 	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python; done
 
-translation-extract: assets
+translation-extract: clean-build
+	@echo ""
+	@echo "!! This assumes that you are running with latest assets. Run 'make assets' if in doubt !!"
+	@echo ""
 	python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*'
 
 translation-django-compilemessages:
@@ -177,7 +181,10 @@ translation-crowdin-install:
 translation-crowdin-upload:
 	java -jar build_tools/crowdin-cli.jar -c build_tools/crowdin.yaml upload sources -b ${branch}
 
-translation-crowdin-download:
+# This rule must depend on translation-extract, such that source files have been generated
+# for CrowdIn CLI's pattern matching. If they are not in place, stuff will break.
+# See: https://github.com/learningequality/kolibri/pull/4121
+translation-crowdin-download: translation-extract
 	@echo "\nWhen doing new releases: Remember to build the project on CrowdIn\n\n"
 	java -jar build_tools/crowdin-cli.jar -c build_tools/crowdin.yaml download -b ${branch}
 

--- a/kolibri/core/assets/src/utils/intl-locale-data.js
+++ b/kolibri/core/assets/src/utils/intl-locale-data.js
@@ -48,16 +48,22 @@ module.exports = function(locale) {
           resolve(() => require('intl/locale-data/jsonp/hi-IN.js'));
         });
       });
-    case 'ka':
+    case 'kn':
       return new Promise(function(resolve) {
-        require.ensure(['intl/locale-data/jsonp/ka.js'], function(require) {
-          resolve(() => require('intl/locale-data/jsonp/ka.js'));
+        require.ensure(['intl/locale-data/jsonp/kn.js'], function(require) {
+          resolve(() => require('intl/locale-data/jsonp/kn.js'));
         });
       });
     case 'mr':
       return new Promise(function(resolve) {
         require.ensure(['intl/locale-data/jsonp/mr.js'], function(require) {
           resolve(() => require('intl/locale-data/jsonp/mr.js'));
+        });
+      });
+    case 'my':
+      return new Promise(function(resolve) {
+        require.ensure(['intl/locale-data/jsonp/my.js'], function(require) {
+          resolve(() => require('intl/locale-data/jsonp/my.js'));
         });
       });
     case 'nyn':

--- a/kolibri/core/assets/src/utils/vue-intl-locale-data.js
+++ b/kolibri/core/assets/src/utils/vue-intl-locale-data.js
@@ -48,16 +48,22 @@ module.exports = function(locale) {
           resolve(require('vue-intl/locale-data/hi.js'));
         });
       });
-    case 'ka':
+    case 'kn':
       return new Promise(function(resolve) {
-        require.ensure(['vue-intl/locale-data/ka.js'], function(require) {
-          resolve(require('vue-intl/locale-data/ka.js'));
+        require.ensure(['vue-intl/locale-data/kn.js'], function(require) {
+          resolve(require('vue-intl/locale-data/kn.js'));
         });
       });
     case 'mr':
       return new Promise(function(resolve) {
         require.ensure(['vue-intl/locale-data/mr.js'], function(require) {
           resolve(require('vue-intl/locale-data/mr.js'));
+        });
+      });
+    case 'my':
+      return new Promise(function(resolve) {
+        require.ensure(['vue-intl/locale-data/my.js'], function(require) {
+          resolve(require('vue-intl/locale-data/my.js'));
         });
       });
     case 'nyn':


### PR DESCRIPTION
### Summary

Opening up this to know if these upgrades are deliberate? They were auto-generated.

```
node ./frontend_build/src/intl_code_gen.js
```

on `release-v0.10x`

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
