### PR TITLE
Catch exceptions and raise them after setting availability

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -125,6 +125,7 @@ class Command(AsyncCommand):
         file_checksums_to_annotate = []
 
         with self.start_progress(total=total_bytes_to_transfer) as overall_progress_update:
+            exception = None  # Exception that is not caught by the retry logic
 
             if method == DOWNLOAD_METHOD:
                 session = requests.Session()
@@ -152,16 +153,21 @@ class Command(AsyncCommand):
                     filetransfer = transfer.FileCopy(srcpath, dest)
 
                 finished = False
-                while not finished:
-                    finished, increment = self._start_file_transfer(
-                        f, filetransfer, overall_progress_update)
-                    if self.is_cancelled():
-                        self.cancel()
-                        break
-                    if increment == 2:
-                        file_checksums_to_annotate.append(f.id)
-                    else:
-                        number_of_skipped_files += increment
+                try:
+                    while not finished:
+                        finished, increment = self._start_file_transfer(
+                            f, filetransfer, overall_progress_update)
+
+                        if self.is_cancelled():
+                            break
+
+                        if increment == 2:
+                            file_checksums_to_annotate.append(f.id)
+                        else:
+                            number_of_skipped_files += increment
+                except Exception as e:
+                    exception = e
+                    break
 
             annotation.set_availability(channel_id, file_checksums_to_annotate)
 
@@ -169,6 +175,9 @@ class Command(AsyncCommand):
                 logger.warning(
                     "{} files are skipped, because errors occured during the import.".format(
                         number_of_skipped_files))
+
+            if exception:
+                raise exception
 
             if self.is_cancelled():
                 self.cancel()

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -280,7 +280,7 @@ class ImportContentTestCase(TestCase):
         with self.assertRaises(OSError):
             call_command('importcontent', 'disk', self.the_channel_id, 'destination')
             self.assertTrue('Permission denied' in logger_mock.call_args_list[0][0][0])
-            annotation_mock.assert_not_called()
+        annotation_mock.set_availability.assert_not_called()
 
     @patch('kolibri.core.content.utils.transfer.os.path.getsize', return_value=0)
     @patch('kolibri.core.content.management.commands.importcontent.os.path.isfile', return_value=False)

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -256,7 +256,7 @@ class ImportContentTestCase(TestCase):
         with self.assertRaises(HTTPError):
             call_command('importcontent', 'network', self.the_channel_id)
             self.assertTrue('500' in logger_mock.call_args_list[0][0][0])
-        annotation_mock.set_availability.assert_not_called()
+        annotation_mock.set_availability.assert_called()
 
     @patch('kolibri.core.content.management.commands.importcontent.logger.error')
     @patch('kolibri.core.content.management.commands.importcontent.AsyncCommand.start_progress')
@@ -280,7 +280,7 @@ class ImportContentTestCase(TestCase):
         with self.assertRaises(OSError):
             call_command('importcontent', 'disk', self.the_channel_id, 'destination')
             self.assertTrue('Permission denied' in logger_mock.call_args_list[0][0][0])
-        annotation_mock.set_availability.assert_not_called()
+        annotation_mock.set_availability.assert_called()
 
     @patch('kolibri.core.content.utils.transfer.os.path.getsize', return_value=0)
     @patch('kolibri.core.content.management.commands.importcontent.os.path.isfile', return_value=False)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to resolve the issue in https://github.com/learningequality/kolibri/issues/3883 that exceptions in the retry logic are raised before setting availabilities of the downloaded nodes. 
I can't find a nice way to reproduce the error in the issue, so I'm going to use the `fail+fix` strategy to have a commit that contains failed tests first and then push another commit to fix the tests.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the first commit fails and second commit fixes the tests.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3883

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
