### PR TITLE
Catch exceptions and raise them after setting availability (target 0.10.2)

### DIFF
--- a/kolibri/content/test/test_import_export.py
+++ b/kolibri/content/test/test_import_export.py
@@ -278,7 +278,7 @@ class ImportContentTestCase(TestCase):
             with self.assertRaises(OSError):
                 call_command('importcontent', 'disk', self.the_channel_id, 'destination')
                 self.assertTrue('Permission denied' in logging_mock.call_args_list[0][0][0])
-                annotation_mock.assert_not_called()
+            annotation_mock.set_availability.assert_not_called()
 
     @patch('kolibri.content.utils.transfer.os.path.getsize', return_value=0)
     @patch('kolibri.content.management.commands.importcontent.os.path.isfile', return_value=False)

--- a/kolibri/content/test/test_import_export.py
+++ b/kolibri/content/test/test_import_export.py
@@ -254,7 +254,7 @@ class ImportContentTestCase(TestCase):
         with self.assertRaises(HTTPError):
             call_command('importcontent', 'network', self.the_channel_id)
             self.assertTrue('500' in logging_mock.call_args_list[0][0][0])
-        annotation_mock.set_availability.assert_not_called()
+        annotation_mock.set_availability.assert_called()
 
     @patch('kolibri.content.management.commands.importcontent.logging.error')
     @patch('kolibri.content.management.commands.importcontent.AsyncCommand.start_progress')
@@ -278,7 +278,7 @@ class ImportContentTestCase(TestCase):
             with self.assertRaises(OSError):
                 call_command('importcontent', 'disk', self.the_channel_id, 'destination')
                 self.assertTrue('Permission denied' in logging_mock.call_args_list[0][0][0])
-            annotation_mock.set_availability.assert_not_called()
+            annotation_mock.set_availability.assert_called()
 
     @patch('kolibri.content.utils.transfer.os.path.getsize', return_value=0)
     @patch('kolibri.content.management.commands.importcontent.os.path.isfile', return_value=False)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I closed the PR #4167 to target 0.10.2 in this PR. I'm copying the summary from there:

This PR is to resolve the issue in #3883 that exceptions in the retry logic are raised before setting availabilities of the downloaded nodes.
I can't find a nice way to reproduce the error in the issue, so I'm going to use the fail+fix strategy to have a commit that contains failed tests first and then push another commit to fix the tests.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the first commit fails and second commit fixes the tests.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#3883 

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
