### PR TITLE
Fix the issue that progress bar could reach over 100%

### DIFF
--- a/kolibri/content/management/commands/importcontent.py
+++ b/kolibri/content/management/commands/importcontent.py
@@ -183,9 +183,10 @@ class Command(AsyncCommand):
             * False, 0 - the transfer fails and needs to retry.
         """
         try:
-            # Save the current progress value
-            original_value = self.progresstrackers[0].progress
-            original_progress = self.progresstrackers[0].get_progress()
+            if self.progresstrackers:
+                # Save the current progress value
+                original_value = self.progresstrackers[0].progress
+                original_progress = self.progresstrackers[0].get_progress()
 
             with filetransfer, self.start_progress(total=filetransfer.total_size) as file_dl_progress_update:
                 # If size of the source file is smaller than the the size


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to resolve the issue reported by @laurenlichtman that the progress bar could reach over 100% when downloading content.
The problem behind it is that the Internet becomes unreachable in the middle of downloading one file. For example, it could be 20% of this file. Since we implemented the retry logic, the file will be downloaded again starting from 0%. So when the program finishes downloading the content, the progress bar will be shown as 100%+20% = 120%.
To fix the issue, I restore the previous progress bar value to make the progress bar go back to the state before the failed file download so that it reflects the real procedure when the program starts downloading this file from 0%. 

Before the fix:
https://slack-files.com/T0KT5DC58-FCBQ8AHN0-62858c08bf

After the fix:
https://slack-files.com/T0KT5DC58-FCC1PTVKL-3d49150cf8

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I have a testing channel `vijaz-tapuz` that only contains one large video file. 
To test the PR, we can turn off the Internet in the middle of downloading this file, and then turn it on again.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://learningequality.slack.com/archives/C0KSZ9FEG/p1533704314000091

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
