### PR TITLE
Exam lag fixes

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -54,6 +54,7 @@ class ChannelMetadataFilter(FilterSet):
 
         for channel in queryset:
             channel_has_exercise = channel.root.get_descendants() \
+                .filter(available=True) \
                 .filter(kind=content_kinds.EXERCISE) \
                 .exists()
             if channel_has_exercise:

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -268,6 +268,7 @@ export function goToTopLevel(store) {
                 (acc, subtopic) => acc.concat(subtopic.allExercisesWithinTopic),
                 channel.exercises
               );
+              subtopic.channel = true;
               return subtopic;
             });
 

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -89,6 +89,7 @@
               <topic-row
                 v-for="topic in subtopics"
                 :key="topic.id"
+                :channel="topic.channel"
                 :topicId="topic.id"
                 :topicTitle="topic.title"
                 :numCoachContents="topic.num_coach_contents"

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -88,6 +88,7 @@
               />
               <topic-row
                 v-for="topic in subtopics"
+                v-if="topic.allExercisesWithinTopic.length"
                 :key="topic.id"
                 :channel="topic.channel"
                 :topicId="topic.id"

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/index.vue
@@ -62,6 +62,7 @@
               <tr>
                 <th class="core-table-checkbox-col">
                   <k-checkbox
+                    v-if="exercises.length || !subtopics.every(subtopic => subtopic.channel)"
                     :label="$tr('selectAll')"
                     :showLabel="false"
                     :checked="allExercisesWithinCurrentTopicSelected"

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
@@ -3,6 +3,7 @@
   <tr>
     <th class="core-table-checkbox-col">
       <k-checkbox
+        v-if="!channel"
         :label="$tr('selectTopic')"
         :showLabel="false"
         :checked="allExercisesWithinTopicSelected"
@@ -62,6 +63,10 @@
       kCheckbox,
     },
     props: {
+      channel: {
+        type: Boolean,
+        default: false,
+      },
       topicId: {
         type: String,
         requires: true,

--- a/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/create-exam-page/topic-row.vue
@@ -8,17 +8,15 @@
         :showLabel="false"
         :checked="allExercisesWithinTopicSelected"
         :indeterminate="someExercisesWithinTopicSelected"
-        :disabled="!topicHasExercises"
         @change="changeSelection"
       />
     </th>
     <td class="core-table-main-col">
       <div class="topic-title">
         <content-icon :kind="topic" :class="{ disabled: !topicHasExercises }" />
-        <button v-if="topicHasExercises" class="title" @click="$emit('goToTopic', topicId)">
+        <button class="title" @click="$emit('goToTopic', topicId)">
           {{ topicTitle }}
         </button>
-        <span v-else class="disabled">{{ topicTitle }}</span>
       </div>
       <coach-content-label
         class="coach-content-label"
@@ -156,6 +154,8 @@
     padding: 0
     border: none
     font-size: 1em
+    color: $core-action-normal
+    text-decoration: underline
 
   .disabled
     color: $core-text-disabled


### PR DESCRIPTION
### Summary
Mitigates issues caused by adding large number of exercises to an exam by not allowing adding whole channels, and making navigable topics look more linky.

### Reviewer guidance
Can you create exams?
Can you still add whole topics?
Can you not add whole channels?
Do topics without any exercises get hidden?
Do channels without any exercises get hidden?

### References
Fixes #4159 

Before:
![image](https://user-images.githubusercontent.com/1680573/44412794-a45d9b00-a51e-11e8-9a25-4a012f6423a5.png)

![image](https://user-images.githubusercontent.com/1680573/44412821-ae7f9980-a51e-11e8-87ef-a223ac84cb8a.png)

After:
![image](https://user-images.githubusercontent.com/1680573/44412696-6e201b80-a51e-11e8-885d-48e5db8fc915.png)

![image](https://user-images.githubusercontent.com/1680573/44412718-78dab080-a51e-11e8-8500-6af1bfc5c9f7.png)


----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
