### PR TITLE
Update cached model properly

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -150,7 +150,7 @@ export function updateContentNodeProgress(channelId, contentId, progressFraction
    * to cache bust the model (and hence the entire collection), because some progress was
    * made on this ContentNode.
    */
-  const model = ContentNodeSlimResource.getModel(contentId);
+  const model = ContentNodeProgressResource.getModel(contentId);
   model.set({ progress_fraction: progressFraction });
 }
 


### PR DESCRIPTION
### Summary
Previously we fetched the content node progress with the content node. We now fetch it solely from the content node progress endpoint.

This PR updates the client side cache updating behaviour to set it on the content node progress model rather than the content node model (which is no longer used as a source of the progress data).

### Reviewer guidance
Make sure that content node progress on the recommended and channels pages after engaging with a piece of content.

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
