### PR TITLE
large improvement in annotation performance

### DIFF
--- a/kolibri/content/utils/annotation.py
+++ b/kolibri/content/utils/annotation.py
@@ -190,10 +190,9 @@ def recurse_availability_up_tree(channel_id):
         available_nodes = select([child.c.available]).where(
             and_(
                 child.c.available == True,  # noqa
-                child.c.level == level,
-                child.c.channel_id == channel_id,
+                ContentNodeTable.c.id == child.c.parent_id
             )
-        ).where(ContentNodeTable.c.id == child.c.parent_id)
+        )
 
         # Create an expression that will resolve a boolean value for all the available children
         # of a content node, whereby if they all have coach_content flagged on them, it will be true,
@@ -203,18 +202,16 @@ def recurse_availability_up_tree(channel_id):
             coach_content_nodes = select([func.min(child.c.coach_content)]).where(
                 and_(
                     child.c.available == True,  # noqa
-                    child.c.level == level,
-                    child.c.channel_id == channel_id,
+                    ContentNodeTable.c.id == child.c.parent_id
                 )
-            ).where(ContentNodeTable.c.id == child.c.parent_id)
+            )
         elif bridge.engine.name == 'postgresql':
             coach_content_nodes = select([func.bool_and(child.c.coach_content)]).where(
                 and_(
                     child.c.available == True,  # noqa
-                    child.c.level == level,
-                    child.c.channel_id == channel_id,
+                    ContentNodeTable.c.id == child.c.parent_id
                 )
-            ).where(ContentNodeTable.c.id == child.c.parent_id)
+            )
 
         logging.info('Setting availability of ContentNode objects with children for level {level}'.format(level=level))
         # Only modify topic availability here


### PR DESCRIPTION
### Summary
Removes extraneous queries from annotation lookups.
Gives a performance boost on the order of 200x.

### Reviewer guidance
Can test with the following snippet (make sure the Khan Academy content data is in your local DB):
```
import time
from kolibri.content.models import ContentNode
from kolibri.content.utils.annotation import recurse_availability_up_tree

start = time.time()
ContentNode.objects.filter(level=5).update(available=True)
recurse_availability_up_tree('1ceff53605e55bef987d88e0908658c5')
print(time.time()-start)
```
On my machine went from 629s on current release-v0.10.x to around 3s.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
