### PR TITLE
Search improvements

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -311,16 +311,17 @@ export class Collection {
                   this.new = false;
                 } else if (typeof (response.entity || {}).results !== 'undefined') {
                   // If it's not, there are two possibilities - something is awry,
-                  // or we have received paginated data! Check to see if it is paginated.
+                  // or we have received data with additional metadata!
                   this.clearCache();
-                  // Paginated objects have 'results' as their results object so interpret this as
-                  // such.
+                  // Collections with additional metadata have 'results' as their results
+                  // object so interpret this as such.
                   this.set(response.entity.results);
-                  this.pageCount = Math.ceil(response.entity.count / this.pageSize);
-                  this.hasNext = Boolean(response.entity.next);
-                  this.hasPrev = Boolean(response.entity.previous);
-                  this.next = response.entity.next;
-                  this.previous = response.entity.previous;
+                  this.metadata = {};
+                  Object.keys(response.entity).forEach(key => {
+                    if (key !== 'results') {
+                      this.metadata[key] = response.entity[key];
+                    }
+                  });
                   // Mark that the fetch has completed.
                   this.synced = true;
                   // Flag that the collection exists on the server.
@@ -330,7 +331,6 @@ export class Collection {
                   logging.debug('Data appears to be malformed', response.entity);
                   reject(response);
                 }
-                // Return the data from the models, not the models themselves.
                 resolve(this.data);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -516,7 +516,17 @@ export class Collection {
   }
 
   get data() {
-    return this.models.filter(model => !model.deleted).map(model => model.data);
+    const data = this.models.filter(model => !model.deleted).map(model => model.data);
+    // Return the data from the models, not the models themselves.
+    if (!this.metadata) {
+      // If no additional metadata just return the results directly.
+      return data;
+    }
+    // Otherwise resolve the data in the form it was received originally
+    return {
+      results: data,
+      ...cloneDeep(this.metadata),
+    };
   }
 
   get synced() {
@@ -654,22 +664,6 @@ export class Resource {
     const key = this.__cacheKey(getParams, { detailId });
     const collection = new Collection(getParams, data, this, url);
     cache[key] = collection;
-    return collection;
-  }
-
-  /**
-   * Get a Collection with pagination settings.
-   * @param {Object} [getParams={}] - default parameters to use for Collection fetching.
-   * @param {Number} [pageSize=20] - The number of items to return in a page.
-   * @param {Number} [page=1] - Which page to return.
-   * @returns {Collection} - Returns an instantiated Collection object.
-   */
-  getPagedCollection(getParams = {}, pageSize = 20, page = 1) {
-    const pagedParams = { page, page_size: pageSize };
-    Object.assign(pagedParams, getParams);
-    const collection = this.getCollection(pagedParams);
-    collection.page = page;
-    collection.pageSize = pageSize;
     return collection;
   }
 

--- a/kolibri/core/assets/src/api-resources/contentNodeSearch.js
+++ b/kolibri/core/assets/src/api-resources/contentNodeSearch.js
@@ -1,0 +1,5 @@
+import { Resource } from '../api-resource';
+
+export default new Resource({
+  name: 'contentnode_search',
+});

--- a/kolibri/core/assets/src/api-resources/index.js
+++ b/kolibri/core/assets/src/api-resources/index.js
@@ -3,6 +3,7 @@ export { default as ContentNodeFileSizeResource } from './contentNodeFileSize';
 export { default as ContentNodeResource } from './contentNode';
 export { default as ContentNodeGranularResource } from './contentNodeGranular';
 export { default as ContentNodeSlimResource } from './contentNodeSlim';
+export { default as ContentNodeSearchResource } from './contentNodeSearch';
 export { default as FacilityUserResource } from './facilityUser';
 export { default as FacilityUsernameResource } from './facilityUsername';
 export { default as LearnerGroupResource } from './learnerGroup';

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -152,12 +152,19 @@ function _channelListState(data) {
  */
 
 export function handleError(store, errorString) {
+  logging.debug(errorString);
   store.commit('CORE_SET_ERROR', errorString);
   store.commit('CORE_SET_PAGE_LOADING', false);
 }
 
 export function handleApiError(store, errorObject) {
-  handleError(store, JSON.stringify(errorObject, null, 2));
+  let error = errorObject;
+  if (typeof errorObject === 'object' && !(errorObject instanceof Error)) {
+    error = JSON.stringify(errorObject, null, 2);
+  } else if (errorObject instanceof Error) {
+    error = errorObject.toString();
+  }
+  handleError(store, error);
 }
 
 /**

--- a/kolibri/core/assets/src/views/KSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect.vue
@@ -133,7 +133,6 @@
     methods: {
       handleChange(newSelection) {
         this.selection = newSelection;
-        this.$emit('change', newSelection);
       },
     },
   };

--- a/kolibri/core/assets/src/views/KSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect.vue
@@ -2,7 +2,10 @@
 
   <UiSelect
     class="k-select"
-    :class="{'k-select-inline': inline}"
+    :class="{
+      'k-select-inline': inline,
+      'k-select-disabled': disabled,
+    }"
     :value="selection"
     :options="options"
     :label="label"
@@ -144,6 +147,10 @@
     width: 150px;
     margin-right: 16px;
     vertical-align: bottom;
+  }
+
+  .k-select-disabled /deep/ .ui-select__label-text.is-inline {
+    cursor: default;
   }
 
   /deep/ .ui-select__display-value {

--- a/kolibri/core/assets/src/views/KSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect.vue
@@ -133,6 +133,7 @@
     methods: {
       handleChange(newSelection) {
         this.selection = newSelection;
+        this.$emit('change', newSelection);
       },
     },
   };

--- a/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
@@ -152,4 +152,8 @@ a.button {
   &:hover:focus {
     outline: $core-outline;
   }
+  &:disabled {
+    color: $primary-flat-disabled-color;
+    cursor: default;
+  }
 }

--- a/kolibri/core/assets/test/api-resource.spec.js
+++ b/kolibri/core/assets/test/api-resource.spec.js
@@ -400,24 +400,24 @@ describe('Collection', function() {
               done();
             });
           });
-          it('should set the pageCount property to 1', function(done) {
+          it('should set the count property to 1', function(done) {
             collection.synced = false;
             collection.fetch().then(() => {
-              expect(collection.pageCount).toEqual(1);
+              expect(collection.data.count).toEqual(1);
               done();
             });
           });
-          it('should set the hasNext property to false', function(done) {
+          it('should set the next property to false', function(done) {
             collection.synced = false;
             collection.fetch().then(() => {
-              expect(collection.hasNext).toEqual(false);
+              expect(collection.data.next).toEqual(false);
               done();
             });
           });
-          it('should set the hasPrev property to false', function(done) {
+          it('should set the previous property to false', function(done) {
             collection.synced = false;
             collection.fetch().then(() => {
-              expect(collection.hasPrev).toEqual(false);
+              expect(collection.data.previous).toEqual(false);
               done();
             });
           });

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -581,9 +581,9 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
         # Use unfiltered queryset to collect channel_ids and kinds metadata.
         unfiltered_queryset = self.get_queryset()
 
-        channel_ids = unfiltered_queryset.filter(all_queries_filter).values_list('channel_id', flat=True).distinct()
+        channel_ids = unfiltered_queryset.filter(all_queries_filter).values_list('channel_id', flat=True).order_by('channel_id').distinct()
 
-        content_kinds = unfiltered_queryset.filter(all_queries_filter).values_list('kind', flat=True).distinct()
+        content_kinds = unfiltered_queryset.filter(all_queries_filter).values_list('kind', flat=True).order_by('kind').distinct()
 
         serializer = self.get_serializer(results, many=True)
         return Response({

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -576,14 +576,14 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
         # If no queries, just use an empty Q.
         all_queries_filter = union(all_queries) or Q()
 
-        total_results = len(set(queryset.filter(all_queries_filter).values_list('content_id', flat=True)))
+        total_results = queryset.filter(all_queries_filter).values_list('content_id', flat=True).distinct().count()
 
         # Use unfiltered queryset to collect channel_ids and kinds metadata.
         unfiltered_queryset = self.get_queryset()
 
-        channel_ids = set(unfiltered_queryset.filter(all_queries_filter).values_list('channel_id', flat=True))
+        channel_ids = unfiltered_queryset.filter(all_queries_filter).values_list('channel_id', flat=True).distinct()
 
-        content_kinds = set(unfiltered_queryset.filter(all_queries_filter).values_list('kind', flat=True))
+        content_kinds = unfiltered_queryset.filter(all_queries_filter).values_list('kind', flat=True).distinct()
 
         serializer = self.get_serializer(results, many=True)
         return Response({

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -573,14 +573,17 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
             if len(results) >= MAX_RESULTS:
                 break
 
-        total_results = len(set(queryset.filter(union(all_queries)).values_list('content_id', flat=True)))
+        # If no queries, just use an empty Q.
+        all_queries_filter = union(all_queries) or Q()
+
+        total_results = len(set(queryset.filter(all_queries_filter).values_list('content_id', flat=True)))
 
         # Use unfiltered queryset to collect channel_ids and kinds metadata.
         unfiltered_queryset = self.get_queryset()
 
-        channel_ids = set(unfiltered_queryset.filter(union(all_queries)).values_list('channel_id', flat=True))
+        channel_ids = set(unfiltered_queryset.filter(all_queries_filter).values_list('channel_id', flat=True))
 
-        content_kinds = set(unfiltered_queryset.filter(union(all_queries)).values_list('kind', flat=True))
+        content_kinds = set(unfiltered_queryset.filter(all_queries_filter).values_list('kind', flat=True))
 
         serializer = self.get_serializer(results, many=True)
         return Response({

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -33,6 +33,7 @@ from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.content.utils.content_types_tools import renderable_contentnodes_q_filter
 from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.stopwords import stopwords_set
+from kolibri.core.decorators import query_params_required
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import ContentSessionLog
@@ -87,7 +88,6 @@ class IdFilter(FilterSet):
 
 
 class ContentNodeFilter(IdFilter):
-    search = CharFilter(method='filter_search')
     recommendations_for = CharFilter(method="filter_recommendations_for")
     next_steps = CharFilter(method="filter_next_steps")
     popular = CharFilter(method="filter_popular")
@@ -96,71 +96,12 @@ class ContentNodeFilter(IdFilter):
     by_role = BooleanFilter(method="filter_by_role")
     in_lesson = CharFilter(method="filter_in_lesson")
     in_exam = CharFilter(method="filter_in_exam")
+    exclude_content_ids = CharFilter(method="filter_exclude_content_ids")
 
     class Meta:
         model = models.ContentNode
-        fields = ['parent', 'search', 'prerequisite_for', 'has_prerequisite', 'related',
+        fields = ['parent', 'prerequisite_for', 'has_prerequisite', 'related', 'exclude_content_ids',
                   'recommendations_for', 'next_steps', 'popular', 'resume', 'ids', 'content_id', 'channel_id', 'kind', 'by_role']
-
-    def filter_search(self, queryset, name, value):
-        """
-        Implement various filtering strategies in order to get a wide range of search results.
-        """
-        # return the result of and-ing a list of queries
-        def intersection(queries):
-            if queries:
-                return reduce(lambda x, y: x & y, queries)
-            return None
-
-        # all words with punctuation removed
-        all_words = [w for w in re.split('[?.,!";: ]', value) if w]
-        # words in all_words that are not stopwords
-        critical_words = [w for w in all_words if w not in stopwords_set]
-        # queries ordered by relevance priority
-        all_queries = [
-            # all words in title
-            intersection([Q(title__icontains=w) for w in all_words]),
-            # all critical words in title
-            intersection([Q(title__icontains=w) for w in critical_words]),
-            # all words in description
-            intersection([Q(description__icontains=w) for w in all_words]),
-            # all critical words in description
-            intersection([Q(description__icontains=w) for w in critical_words]),
-        ]
-        # any critical word in title, reverse-sorted by word length
-        for w in sorted(critical_words, key=len, reverse=True):
-            all_queries.append(Q(title__icontains=w))
-        # any critical word in description, reverse-sorted by word length
-        for w in sorted(critical_words, key=len, reverse=True):
-            all_queries.append(Q(description__icontains=w))
-
-        results = []
-        content_ids = set()
-        MAX_RESULTS = 30
-        BUFFER_SIZE = MAX_RESULTS * 2  # grab some extras, but not too many
-
-        # iterate over each query type, and build up search results
-        for query in all_queries:
-
-            # only execute if query is meaningful
-            if query:
-                # in each pass, don't take any items already in the result set
-                matches = queryset.exclude(content_id__in=list(content_ids)).filter(query)[:BUFFER_SIZE]
-
-                for match in matches:
-                    # filter the dupes
-                    if match.content_id in content_ids:
-                        continue
-                    # add new, unique results
-                    content_ids.add(match.content_id)
-                    results.append(match)
-
-                    # bail out as soon as we reach the quota
-                    if len(results) >= MAX_RESULTS:
-                        return results
-
-        # we've tried all the queries and still have fewer than MAX_RESULTS results
-        return results
 
     def filter_kind(self, queryset, name, value):
         """
@@ -221,6 +162,9 @@ class ContentNodeFilter(IdFilter):
             return queryset.filter(pk__in=exercise_id_list)
         except (Exam.DoesNotExist, ValueError):  # also handles invalid uuid
             return queryset.none()
+
+    def filter_exclude_content_ids(self, queryset, name, value):
+        return queryset.exclude(content_id__in=value.split(','))
 
 
 class OptionalPageNumberPagination(pagination.PageNumberPagination):
@@ -551,6 +495,100 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+
+# return the result of and-ing a list of queries
+def intersection(queries):
+    if queries:
+        return reduce(lambda x, y: x & y, queries)
+    return None
+
+
+def union(queries):
+    if queries:
+        return reduce(lambda x, y: x | y, queries)
+    return None
+
+
+@query_params_required(search=str, max_results=int, max_results__default=30)
+class ContentNodeSearchViewset(ContentNodeSlimViewset):
+
+    def list(self, request, **kwargs):
+        """
+        Implement various filtering strategies in order to get a wide range of search results.
+        """
+
+        value = self.kwargs['search']
+        MAX_RESULTS = self.kwargs['max_results']
+
+        queryset = self.filter_queryset(self.get_queryset())
+
+        # all words with punctuation removed
+        all_words = [w for w in re.split('[?.,!";: ]', value) if w]
+        # words in all_words that are not stopwords
+        critical_words = [w for w in all_words if w not in stopwords_set]
+        # queries ordered by relevance priority
+        all_queries = [
+            # all words in title
+            intersection([Q(title__icontains=w) for w in all_words]),
+            # all critical words in title
+            intersection([Q(title__icontains=w) for w in critical_words]),
+            # all words in description
+            intersection([Q(description__icontains=w) for w in all_words]),
+            # all critical words in description
+            intersection([Q(description__icontains=w) for w in critical_words]),
+        ]
+        # any critical word in title, reverse-sorted by word length
+        for w in sorted(critical_words, key=len, reverse=True):
+            all_queries.append(Q(title__icontains=w))
+        # any critical word in description, reverse-sorted by word length
+        for w in sorted(critical_words, key=len, reverse=True):
+            all_queries.append(Q(description__icontains=w))
+
+        # only execute if query is meaningful
+        all_queries = [query for query in all_queries if query]
+
+        results = []
+        content_ids = set()
+        BUFFER_SIZE = MAX_RESULTS * 2  # grab some extras, but not too many
+
+        # iterate over each query type, and build up search results
+        for query in all_queries:
+
+            # in each pass, don't take any items already in the result set
+            matches = queryset.exclude(content_id__in=list(content_ids)).filter(query)[:BUFFER_SIZE]
+
+            for match in matches:
+                # filter the dupes
+                if match.content_id in content_ids:
+                    continue
+                # add new, unique results
+                content_ids.add(match.content_id)
+                results.append(match)
+
+                # bail out as soon as we reach the quota
+                if len(results) >= MAX_RESULTS:
+                    break
+            # bail out as soon as we reach the quota
+            if len(results) >= MAX_RESULTS:
+                break
+
+        total_results = len(set(queryset.filter(union(all_queries)).values_list('content_id', flat=True)))
+
+        # Use unfiltered queryset to collect channel_ids and kinds metadata.
+        unfiltered_queryset = self.get_queryset()
+
+        channel_ids = set(unfiltered_queryset.filter(union(all_queries)).values_list('channel_id', flat=True))
+
+        content_kinds = set(unfiltered_queryset.filter(union(all_queries)).values_list('kind', flat=True))
+
+        serializer = self.get_serializer(results, many=True)
+        return Response({
+            'channel_ids': channel_ids,
+            'content_kinds': content_kinds,
+            'results': serializer.data,
+            'total_results': total_results,
+        })
 
 
 class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):

--- a/kolibri/core/content/api_urls.py
+++ b/kolibri/core/content/api_urls.py
@@ -6,6 +6,7 @@ from .api import ChannelMetadataViewSet
 from .api import ContentNodeFileSizeViewSet
 from .api import ContentNodeGranularViewset
 from .api import ContentNodeProgressViewset
+from .api import ContentNodeSearchViewset
 from .api import ContentNodeSlimViewset
 from .api import ContentNodeViewset
 from .api import FileViewset
@@ -16,6 +17,7 @@ router.register('channel', ChannelMetadataViewSet, base_name="channel")
 
 router.register(r'contentnode', ContentNodeViewset, base_name='contentnode')
 router.register(r'contentnode_slim', ContentNodeSlimViewset, base_name='contentnode_slim')
+router.register(r'contentnode_search', ContentNodeSearchViewset, base_name='contentnode_search')
 router.register(r'file', FileViewset, base_name='file')
 router.register(r'contentnodeprogress', ContentNodeProgressViewset, base_name='contentnodeprogress')
 router.register(r'contentnode_granular', ContentNodeGranularViewset, base_name='contentnode_granular')

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -749,7 +749,23 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_search_channels(self):
         response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
-        self.assertEqual(list(response.data['channel_ids']), [self.the_channel_id])
+        self.assertEqual(response.data['content_kinds'][:], [content_kinds.TOPIC])
+
+    def test_search_repeated_kinds(self):
+        # Ensure that each kind is only returned once.
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'c'})
+        kinds = response.data['content_kinds'][:]
+        self.assertEqual(len(kinds), len(set(kinds)))
+
+    def test_search_channels(self):
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
+        self.assertEqual(response.data['channel_ids'][:], [self.the_channel_id])
+
+    def test_search_repeated_channels(self):
+        # Ensure that each channel_id is only returned once.
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'c'})
+        channel_ids = response.data['channel_ids'][:]
+        self.assertEqual(len(channel_ids), len(set(channel_ids)))
 
     def test_search(self):
         # ensure search works when there are no words not defined

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -741,14 +741,14 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_search(self):
         # ensure search works when there are no words not defined
-        response = self.client.get(reverse('kolibri:core:contentnode-list'), data={'search': '!?,'})
-        self.assertEqual(len(response.data), 0)
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': '!?,'})
+        self.assertEqual(len(response.data['results']), 0)
         # ensure search words when there is only stopwords
-        response = self.client.get(reverse('kolibri:core:contentnode-list'), data={'search': 'or'})
-        self.assertEqual(len(response.data), 0)
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'or'})
+        self.assertEqual(len(response.data['results']), 0)
         # regular search
-        response = self.client.get(reverse('kolibri:core:contentnode-list'), data={'search': 'root'})
-        self.assertEqual(len(response.data), 1)
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
+        self.assertEqual(len(response.data['results']), 1)
 
     def _create_session_logs(self):
         content_ids = ('f2332710c2fd483386cdeb5ecbdda81f', 'ce603df7c46b424b934348995e1b05fb', '481e1bda1faa445d801ceb2afbd2f42f')

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -747,10 +747,6 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
         self.assertEqual(list(response.data['content_kinds']), [content_kinds.TOPIC])
 
-    def test_search_channels(self):
-        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
-        self.assertEqual(response.data['content_kinds'][:], [content_kinds.TOPIC])
-
     def test_search_repeated_kinds(self):
         # Ensure that each kind is only returned once.
         response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'c'})

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -739,6 +739,18 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['count'],
                          content.ContentNode.objects.filter(content_id='f2332710c2fd483386cdeb5dcbdda81f').count())
 
+    def test_search_total_results(self):
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
+        self.assertEqual(response.data['total_results'], 1)
+
+    def test_search_kinds(self):
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
+        self.assertEqual(list(response.data['content_kinds']), [content_kinds.TOPIC])
+
+    def test_search_channels(self):
+        response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': 'root'})
+        self.assertEqual(list(response.data['channel_ids']), [self.the_channel_id])
+
     def test_search(self):
         # ensure search works when there are no words not defined
         response = self.client.get(reverse('kolibri:core:contentnode_search-list'), data={'search': '!?,'})

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -97,13 +97,14 @@ class ParamValidator(object):
             param = query_set.get(**{self.field: param})
         else:
             raise InvalidQueryParamsException("Invalid param type: %s" % self.param_type.____name__)
+        return param
 
     def check_type(self, param):
         """ Check that the type of param is valid, or raise an Exception. This doesn't take self.many into account. """
         if isinstance(self.param_type, TUPLE_TYPES):
             self.check_tuple_type(param)
         else:
-            self.check_non_tuple_types(param)
+            param = self.check_non_tuple_types(param)
         return param
 
     def check_value(self, param):

--- a/kolibri/plugins/learn/assets/src/modules/search/actions.js
+++ b/kolibri/plugins/learn/assets/src/modules/search/actions.js
@@ -1,4 +1,4 @@
-import { ContentNodeResource } from 'kolibri.resources';
+import { ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { _collectionState } from '../coreLearn/utils';
 
@@ -7,46 +7,77 @@ export function clearSearch(store, searchTerm = '') {
   store.commit('SET_SEARCH_TERM', searchTerm);
 }
 
-export function triggerSearch(store, searchTerm) {
+function setCopiesCount(store, contents) {
+  const contentIds = contents
+    .filter(
+      content =>
+        content.kind !== ContentNodeKinds.TOPIC && content.kind !== ContentNodeKinds.CHANNEL
+    )
+    .map(content => content.content_id);
+  if (contentIds.length) {
+    ContentNodeResource.fetchCopiesCount({
+      content_ids: contentIds,
+    })
+      .then(copiesCount => {
+        store.commit('SET_CONTENT_COPIES', copiesCount);
+      })
+      .catch(error => store.dispatch('handleApiError', error, { root: true }));
+  }
+}
+
+export function triggerSearch(
+  store,
+  { searchTerm = '', kindFilter = null, channelFilter = null } = {}
+) {
   if (!searchTerm) {
     return store.dispatch('clearSearch');
   }
 
-  return ContentNodeResource.getPagedCollection({ search: searchTerm })
+  const getParams = {
+    search: searchTerm,
+    kind: kindFilter,
+    channel_id: channelFilter,
+  };
+
+  return ContentNodeSearchResource.getCollection(getParams)
     .fetch()
-    .then(results => {
+    .then(({ results, channel_ids, content_kinds, total_results }) => {
       const contents = _collectionState(results);
       store.commit('SET_STATE', {
         contents,
         searchTerm,
+        channel_ids,
+        content_kinds,
+        kindFilter,
+        channelFilter,
+        total_results,
       });
       store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
+      setCopiesCount(store, contents);
+    })
+    .catch(error => {
+      store.dispatch('handleApiError', error, { root: true });
+    });
+}
 
-      const contentIds = contents
-        .filter(
-          content =>
-            content.kind !== ContentNodeKinds.TOPIC && content.kind !== ContentNodeKinds.CHANNEL
-        )
-        .map(content => content.content_id);
-      if (contentIds.length) {
-        ContentNodeResource.fetchCopiesCount({
-          content_ids: contentIds,
-        })
-          .then(copiesCount => {
-            const updatedContents = contents.map(content => {
-              const updatedContent = content;
-              const matchingContent = copiesCount.find(
-                copyCount => copyCount.content_id === content.content_id
-              );
-              if (matchingContent) {
-                updatedContent.copies_count = matchingContent.count;
-              }
-              return updatedContent;
-            });
-            store.commit('SET_CONTENT', updatedContents);
-          })
-          .catch(error => store.dispatch('handleApiError', error), { root: true });
-      }
+export function loadMore(store) {
+  const search = store.state.searchTerm;
+  const kind = store.state.kindFilter;
+  const channel_id = store.state.channelFilter;
+  const exclude_content_ids = store.state.contents.map(content => content.content_id);
+  const getParams = {
+    search,
+    kind,
+    channel_id,
+    exclude_content_ids,
+  };
+  return ContentNodeSearchResource.getCollection(getParams)
+    .fetch()
+    .then(({ results }) => {
+      const contents = _collectionState(results);
+      store.commit('SET_ADDITIONAL_CONTENTS', contents);
+      store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
+      setCopiesCount(store, contents);
     })
     .catch(error => {
       store.dispatch('handleApiError', error, { root: true });

--- a/kolibri/plugins/learn/assets/src/modules/search/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/search/handlers.js
@@ -1,6 +1,6 @@
 import { PageNames } from '../../constants';
 
-export function showSearch(store, searchTerm) {
+export function showSearch(store, { searchTerm, kind, channel_id }) {
   store.commit('SET_PAGE_NAME', PageNames.SEARCH);
   store.commit('CORE_SET_PAGE_LOADING', true);
   store.commit('CORE_SET_ERROR', null);
@@ -10,7 +10,11 @@ export function showSearch(store, searchTerm) {
       return;
     }
     if (searchTerm) {
-      store.dispatch('search/triggerSearch', searchTerm);
+      store.dispatch('search/triggerSearch', {
+        searchTerm,
+        kindFilter: kind,
+        channelFilter: channel_id,
+      });
     } else {
       store.commit('CORE_SET_PAGE_LOADING', false);
     }

--- a/kolibri/plugins/learn/assets/src/modules/search/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/search/index.js
@@ -3,24 +3,42 @@ import * as actions from './actions';
 export default {
   namespaced: true,
   state: {
-    content: [],
     contents: [],
     searchTerm: '',
+    channelFilter: null,
+    kindFilter: null,
+    channel_ids: [],
+    content_kinds: [],
+    total_results: null,
   },
   mutations: {
     SET_STATE(state, payload) {
       Object.assign(state, payload);
     },
     RESET_STATE(state) {
-      state.content = [];
       state.contents = [];
       state.searchTerm = '';
+      state.content_ids = [];
+      state.content_kinds = [];
+      state.channelFilter = null;
+      state.kindFilter = null;
+      state.total_results = null;
     },
     SET_SEARCH_TERM(state, searchTerm) {
       state.searchTerm = searchTerm;
     },
-    SET_CONTENT(state, content) {
-      state.content = content;
+    SET_ADDITIONAL_CONTENTS(state, contents) {
+      state.contents.push(...contents);
+    },
+    SET_CONTENT_COPIES(state, copiesCount) {
+      copiesCount.forEach(copyCount => {
+        const matchingContent = state.contents.find(
+          content => copyCount.content_id === content.content_id
+        );
+        if (matchingContent) {
+          matchingContent.copies_count = copyCount.count;
+        }
+      });
     },
   },
   actions,

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -47,7 +47,7 @@ export default [
     name: PageNames.SEARCH,
     path: '/search',
     handler: toRoute => {
-      showSearch(store, toRoute.query.query);
+      showSearch(store, { ...toRoute.query });
     },
   },
   {

--- a/kolibri/plugins/learn/assets/src/views/ChannelsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelsPage.vue
@@ -10,7 +10,6 @@
       :contents="channels"
       :genContentLink="genChannelLink"
       v-if="channels.length"
-      :showContentKindFilter="false"
     />
   </div>
 

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
@@ -1,45 +1,8 @@
 <template>
 
   <div class="content-grid">
-    <div class="filters">
-      <div
-        v-if="showContentKindFilter"
-        class="ib"
-      >
-        <mat-svg
-          category="content"
-          name="filter_list"
-          class="filter-icon"
-        />
-        <KSelect
-          :label="$tr('resourceType')"
-          :options="contentKindFilterOptions"
-          :inline="true"
-          class="filter"
-          v-model="contentKindFilterSelection"
-        />
-      </div>
-      <div
-        v-if="showChannelFilter"
-        class="ib"
-      >
-        <mat-svg
-          category="navigation"
-          name="apps"
-          class="filter-icon"
-        />
-        <KSelect
-          :label="$tr('channels')"
-          :options="channelFilterOptions"
-          :inline="true"
-          class="filter"
-          v-model="channelFilterSelection"
-        />
-      </div>
-    </div>
     <ContentCard
       v-for="content in contents"
-      v-show="showContentCard(content)"
       class="grid-item"
       :isMobile="windowIsSmall"
       :key="content.id"
@@ -66,42 +29,15 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import some from 'lodash/some';
-  import KSelect from 'kolibri.coreVue.components.KSelect';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import ContentCard from './ContentCard';
   import CopiesModal from './CopiesModal';
 
-  const ALL_FILTER = 'all';
-
-  const kindFilterToLabelMap = {
-    [ContentNodeKinds.TOPIC]: 'topics',
-    [ContentNodeKinds.EXERCISE]: 'exercises',
-    [ContentNodeKinds.VIDEO]: 'videos',
-    [ContentNodeKinds.AUDIO]: 'audio',
-    [ContentNodeKinds.DOCUMENT]: 'documents',
-    [ContentNodeKinds.HTML5]: 'html5',
-  };
-
   export default {
     name: 'ContentCardGroupGrid',
-    $trs: {
-      resourceType: 'Type',
-      all: 'All',
-      topics: 'Topics',
-      exercises: 'Exercises',
-      videos: 'Videos',
-      audio: 'Audio',
-      documents: 'Documents',
-      html5: 'Apps',
-      channels: 'Channels',
-    },
     components: {
       ContentCard,
-      KSelect,
       CopiesModal,
     },
     mixins: [responsiveWindow],
@@ -118,67 +54,13 @@
         default: () => {},
         required: false,
       },
-      showContentKindFilter: {
-        type: Boolean,
-        default: true,
-      },
-      showChannelFilter: {
-        type: Boolean,
-        default: false,
-      },
     },
     data: () => ({
-      contentKindFilterSelection: {},
-      channelFilterSelection: {},
       modalIsOpen: false,
       sharedContentId: null,
       uniqueId: null,
     }),
-    computed: {
-      ...mapGetters({
-        channels: 'getChannels',
-      }),
-      allFilter() {
-        return { label: this.$tr('all'), value: ALL_FILTER };
-      },
-      contentKindFilterOptions() {
-        const options = Object.keys(kindFilterToLabelMap)
-          .filter(kind => this.resultsIncludeContentKind(kind))
-          .map(kind => ({
-            label: this.$tr(kindFilterToLabelMap[kind]),
-            value: kind,
-          }));
-        return [this.allFilter, ...options];
-      },
-      channelFilterOptions() {
-        const options = this.channels
-          .filter(channel => this.resultsIncludeChannel(channel.id))
-          .map(channel => ({
-            label: channel.title,
-            value: channel.id,
-          }));
-        return [this.allFilter, ...options];
-      },
-    },
-    beforeMount() {
-      this.contentKindFilterSelection = this.contentKindFilterOptions[0];
-      this.channelFilterSelection = this.channelFilterOptions[0];
-    },
     methods: {
-      resultsIncludeContentKind(kindFilter) {
-        return some(this.contents, { kind: kindFilter });
-      },
-      resultsIncludeChannel(channelId) {
-        return some(this.contents, { channel_id: channelId });
-      },
-      showContentCard(content) {
-        const kindFilter = this.contentKindFilterSelection.value;
-        const channelFilter = this.channelFilterSelection.value;
-        return (
-          (kindFilter === ALL_FILTER || kindFilter === content.kind) &&
-          (channelFilter === ALL_FILTER || channelFilter === content.channel_id)
-        );
-      },
       openCopiesModal(contentId) {
         this.sharedContentId = contentId;
         this.uniqueId = this.contents.find(content => content.content_id === contentId).id;
@@ -199,27 +81,6 @@
   .grid-item {
     margin-right: $gutters;
     margin-bottom: $gutters;
-  }
-
-  .filter-icon {
-    margin-right: 12px;
-    vertical-align: middle;
-  }
-
-  .filter:nth-of-type(1) {
-    margin-right: 32px;
-  }
-
-  .filter {
-    margin-bottom: 0;
-  }
-
-  .filters {
-    margin-bottom: 24px;
-  }
-
-  .ib {
-    display: inline-block;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
@@ -14,7 +14,6 @@
         v-if="windowIsSmall"
         :genContentLink="genContentLink"
         :contents="trimmedPopular"
-        :showContentKindFilter="false"
       />
       <ContentCardGroupCarousel
         v-else
@@ -33,7 +32,6 @@
         v-if="windowIsSmall"
         :genContentLink="genContentLink"
         :contents="trimmedNextSteps"
-        :showContentKindFilter="false"
       />
       <ContentCardGroupCarousel
         v-else
@@ -52,7 +50,6 @@
         v-if="windowIsSmall"
         :genContentLink="genContentLink"
         :contents="trimmedResume"
-        :showContentKindFilter="false"
       />
       <ContentCardGroupCarousel
         v-else

--- a/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
@@ -6,7 +6,6 @@
     <ContentCardGroupGrid
       :contents="recommendations"
       :genContentLink="genContentLink"
-      :showContentKindFilter="false"
     />
   </div>
 

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -71,8 +71,10 @@
           :options="contentKindFilterOptions"
           :inline="true"
           :disabled="!contentKindFilterOptions.length"
+          :value="contentKindFilterSelection"
+          @change="updateFilter"
+          ref="contentKindFilter"
           class="filter"
-          v-model="contentKindFilterSelection"
         />
       </div>
       <div
@@ -88,8 +90,10 @@
           :options="channelFilterOptions"
           :inline="true"
           :disabled="!channelFilterOptions.length"
+          :value="channelFilterSelection"
+          @change="updateFilter"
+          ref="channelFilter"
           class="filter"
-          v-model="channelFilterSelection"
         />
       </div>
     </div>
@@ -155,6 +159,8 @@
     data() {
       return {
         searchQuery: this.$store.state.search.searchTerm,
+        contentKindFilterSelection: {},
+        channelFilterSelection: {},
       };
     },
     computed: {
@@ -195,38 +201,30 @@
         }
         return [];
       },
-      searchUpdate() {
+      filterUpdate() {
         return (
-          this.searchQuery !== this.searchTerm ||
           this.contentKindFilterSelection.value !== this.kindFilter ||
           this.channelFilterSelection.value !== this.channelFilter
         );
+      },
+      searchUpdate() {
+        return this.searchQuery !== this.searchTerm || this.filterUpdate;
       },
     },
     watch: {
       searchTerm(val) {
         this.searchQuery = val || '';
       },
-      contentKindFilterSelection() {
-        this.search(true);
-      },
-      channelFilterSelection() {
-        this.search(true);
-      },
     },
     beforeMount() {
-      this.contentKindFilterSelection = Object.assign(
-        {},
+      this.contentKindFilterSelection =
         this.contentKindFilterOptions.find(
           option => option.value === this.$store.state.search.kindFilter
-        ) || this.allFilter
-      );
-      this.channelFilterSelection = Object.assign(
-        {},
+        ) || this.allFilter;
+      this.channelFilterSelection =
         this.channelFilterOptions.find(
           option => option.value === this.$store.state.search.channelFilter
-        ) || this.allFilter
-      );
+        ) || this.allFilter;
     },
     methods: {
       handleEscKey() {
@@ -236,17 +234,20 @@
           this.searchQuery = '';
         }
       },
+      updateFilter() {
+        this.search(true);
+      },
       search(filterUpdate = false) {
         if (this.searchQuery !== '') {
           const query = {
             searchTerm: this.searchQuery,
           };
           if (filterUpdate === true) {
-            if (this.contentKindFilterSelection.value) {
-              query.kind = this.contentKindFilterSelection.value;
+            if (this.$refs.contentKindFilter.selection.value) {
+              query.kind = this.$refs.contentKindFilter.selection.value;
             }
-            if (this.channelFilterSelection.value) {
-              query.channel_id = this.channelFilterSelection.value;
+            if (this.$refs.channelFilter.selection.value) {
+              query.channel_id = this.$refs.channelFilter.selection.value;
             }
           }
           this.$router.push({

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -90,12 +90,6 @@
           v-model="channelFilterSelection"
         />
       </div>
-      <KButton
-        appearance="basic-link"
-        :disabled="!searchUpdate"
-        :text="$tr('updateSearch')"
-        @click="search"
-      />
     </div>
   </form>
 
@@ -128,7 +122,6 @@
       searchBoxLabel: 'Search',
       clearButtonLabel: 'Clear',
       startSearchButtonLabel: 'Start search',
-      updateSearch: 'Update search',
       resourceType: 'Type',
       all: 'All',
       topics: 'Topics',
@@ -196,26 +189,33 @@
           }));
         return [this.allFilter, ...options];
       },
-      searchUpdate() {
+      filterUpdate() {
         return (
-          this.searchQuery !== this.searchTerm ||
           this.contentKindFilterSelection.value !== this.kindFilter ||
           this.channelFilterSelection.value !== this.channelFilter
         );
+      },
+      searchUpdate() {
+        return this.searchQuery !== this.searchTerm || this.filterUpdate;
       },
     },
     watch: {
       searchTerm(val) {
         this.searchQuery = val || '';
       },
+      filterUpdate() {
+        this.search();
+      },
     },
     beforeMount() {
-      this.contentKindFilterSelection = this.contentKindFilterOptions.find(
-        option => option.value === this.$store.state.search.kindFilter
-      );
-      this.channelFilterSelection = this.channelFilterOptions.find(
-        option => option.value === this.$store.state.search.channelFilter
-      );
+      this.contentKindFilterSelection =
+        this.contentKindFilterOptions.find(
+          option => option.value === this.$store.state.search.kindFilter
+        ) || {};
+      this.channelFilterSelection =
+        this.channelFilterOptions.find(
+          option => option.value === this.$store.state.search.channelFilter
+        ) || {};
     },
     methods: {
       handleEscKey() {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -8,7 +8,7 @@
     <div class="search-box-row">
       <label class="visuallyhidden" for="searchfield">{{ $tr('searchBoxLabel') }}</label>
       <input
-        v-model="searchQuery"
+        v-model.trim="searchQuery"
         id="searchfield"
         type="search"
         class="search-input"
@@ -324,16 +324,20 @@
   }
 
   .filter-icon {
-    margin-right: 12px;
-    vertical-align: middle;
+    position: absolute;
+    top: 50%;
+    bottom: 50%;
+    margin-left: 12px;
+    transform: translate(-50%, -50%);
   }
 
   .filter:nth-of-type(1) {
-    margin-right: 32px;
+    margin-right: 16px;
   }
 
   .filter {
-    margin-bottom: 0;
+    margin-bottom: 16px;
+    margin-left: 28px;
   }
 
   .filters {
@@ -341,6 +345,7 @@
   }
 
   .ib {
+    position: relative;
     display: inline-block;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -155,8 +155,6 @@
     data() {
       return {
         searchQuery: this.$store.state.search.searchTerm,
-        contentKindFilterSelection: {},
-        channelFilterSelection: {},
       };
     },
     computed: {
@@ -197,33 +195,38 @@
         }
         return [];
       },
-      filterUpdate() {
+      searchUpdate() {
         return (
+          this.searchQuery !== this.searchTerm ||
           this.contentKindFilterSelection.value !== this.kindFilter ||
           this.channelFilterSelection.value !== this.channelFilter
         );
-      },
-      searchUpdate() {
-        return this.searchQuery !== this.searchTerm || this.filterUpdate;
       },
     },
     watch: {
       searchTerm(val) {
         this.searchQuery = val || '';
       },
-      filterUpdate() {
+      contentKindFilterSelection() {
+        this.search(true);
+      },
+      channelFilterSelection() {
         this.search(true);
       },
     },
     beforeMount() {
-      this.contentKindFilterSelection =
+      this.contentKindFilterSelection = Object.assign(
+        {},
         this.contentKindFilterOptions.find(
           option => option.value === this.$store.state.search.kindFilter
-        ) || {};
-      this.channelFilterSelection =
+        ) || this.allFilter
+      );
+      this.channelFilterSelection = Object.assign(
+        {},
         this.channelFilterOptions.find(
           option => option.value === this.$store.state.search.channelFilter
-        ) || {};
+        ) || this.allFilter
+      );
     },
     methods: {
       handleEscKey() {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -35,6 +35,7 @@
             type="secondary"
             color="white"
             class="search-submit-button"
+            :disabled="!searchUpdate"
             :class="{ 'rtl-icon': icon === 'arrow_forward' && isRtl }"
             :ariaLabel="$tr('startSearchButtonLabel')"
             @click="search"
@@ -89,6 +90,12 @@
           v-model="channelFilterSelection"
         />
       </div>
+      <KButton
+        appearance="basic-link"
+        :disabled="!searchUpdate"
+        :text="$tr('updateSearch')"
+        @click="search"
+      />
     </div>
   </form>
 
@@ -100,6 +107,7 @@
   import { mapGetters, mapState } from 'vuex';
   import UiIconButton from 'keen-ui/src/UiIconButton';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import KButton from 'kolibri.coreVue.components.KButton';
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import { PageNames } from '../constants';
 
@@ -120,6 +128,7 @@
       searchBoxLabel: 'Search',
       clearButtonLabel: 'Clear',
       startSearchButtonLabel: 'Start search',
+      updateSearch: 'Update search',
       resourceType: 'Type',
       all: 'All',
       topics: 'Topics',
@@ -132,6 +141,7 @@
     },
     components: {
       UiIconButton,
+      KButton,
       KSelect,
     },
     props: {
@@ -185,6 +195,13 @@
             value: channel.id,
           }));
         return [this.allFilter, ...options];
+      },
+      searchUpdate() {
+        return (
+          this.searchQuery !== this.searchTerm ||
+          this.contentKindFilterSelection.value !== this.kindFilter ||
+          this.channelFilterSelection.value !== this.channelFilter
+        );
       },
     },
     watch: {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -70,6 +70,7 @@
           :label="$tr('resourceType')"
           :options="contentKindFilterOptions"
           :inline="true"
+          :disabled="!contentKindFilterOptions.length"
           class="filter"
           v-model="contentKindFilterSelection"
         />
@@ -86,6 +87,7 @@
           :label="$tr('channels')"
           :options="channelFilterOptions"
           :inline="true"
+          :disabled="!channelFilterOptions.length"
           class="filter"
           v-model="channelFilterSelection"
         />
@@ -172,22 +174,28 @@
         return { label: this.$tr('all'), value: ALL_FILTER };
       },
       contentKindFilterOptions() {
-        const options = Object.keys(kindFilterToLabelMap)
-          .filter(kind => !this.content_kinds.length || this.content_kinds.includes(kind))
-          .map(kind => ({
-            label: this.$tr(kindFilterToLabelMap[kind]),
-            value: kind,
-          }));
-        return [this.allFilter, ...options];
+        if (this.content_kinds.length) {
+          const options = Object.keys(kindFilterToLabelMap)
+            .filter(kind => this.content_kinds.includes(kind))
+            .map(kind => ({
+              label: this.$tr(kindFilterToLabelMap[kind]),
+              value: kind,
+            }));
+          return [this.allFilter, ...options];
+        }
+        return [];
       },
       channelFilterOptions() {
-        const options = this.channels
-          .filter(channel => this.channel_ids.includes(channel.id))
-          .map(channel => ({
-            label: channel.title,
-            value: channel.id,
-          }));
-        return [this.allFilter, ...options];
+        if (this.channel_ids.length) {
+          const options = this.channels
+            .filter(channel => this.channel_ids.includes(channel.id))
+            .map(channel => ({
+              label: channel.title,
+              value: channel.id,
+            }));
+          return [this.allFilter, ...options];
+        }
+        return [];
       },
       filterUpdate() {
         return (
@@ -204,7 +212,7 @@
         this.searchQuery = val || '';
       },
       filterUpdate() {
-        this.search();
+        this.search(true);
       },
     },
     beforeMount() {
@@ -225,16 +233,18 @@
           this.searchQuery = '';
         }
       },
-      search() {
+      search(filterUpdate = false) {
         if (this.searchQuery !== '') {
           const query = {
             searchTerm: this.searchQuery,
           };
-          if (this.contentKindFilterSelection.value) {
-            query.kind = this.contentKindFilterSelection.value;
-          }
-          if (this.channelFilterSelection.value) {
-            query.channel_id = this.channelFilterSelection.value;
+          if (filterUpdate === true) {
+            if (this.contentKindFilterSelection.value) {
+              query.kind = this.contentKindFilterSelection.value;
+            }
+            if (this.channelFilterSelection.value) {
+              query.channel_id = this.channelFilterSelection.value;
+            }
           }
           this.$router.push({
             name: PageNames.SEARCH,

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -4,25 +4,36 @@
 
     <h3>{{ $tr('searchPageHeader') }}</h3>
 
-    <SearchBox />
+    <SearchBox :filters="true" />
 
     <p v-if="!searchTerm">{{ $tr('noSearch') }}</p>
 
     <template v-else>
-      <h1 class="search-results">{{ $tr('showingResultsFor', { searchTerm }) }}</h1>
+      <h1 class="search-results">{{ $tr('showingResultsFor', {
+        searchTerm,
+          results: contents.length,
+        totalResults: total_results
+      }) }}</h1>
 
       <p v-if="contents.length === 0">{{ $tr('noResultsMsg', { searchTerm }) }}</p>
 
       <ContentCardGroupGrid
-        v-else
         :genContentLink="genContentLink"
-        :contents="searchContents"
-        :showContentKindFilter="true"
-        :showChannelFilter="true"
+        :contents="contents"
+      />
+
+      <KButton
+        v-if="contents.length < total_results && !loading"
+        appearance="basic-link"
+        :text="$tr('viewMore')"
+        @click="loadMore"
+      />
+      <KCircularLoader
+        v-else-if="contents.length < total_results && loading"
+        :delay="false"
       />
 
     </template>
-
   </div>
 
 </template>
@@ -32,7 +43,8 @@
 
   import { mapState } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import sortBy from 'lodash/sortBy';
+  import KButton from 'kolibri.coreVue.components.KButton';
+  import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
   import { PageNames } from '../constants';
   import ContentCard from './ContentCard';
   import ContentCardGroupGrid from './ContentCardGroupGrid';
@@ -43,9 +55,10 @@
     $trs: {
       searchPageHeader: 'Search',
       noSearch: 'Search by typing in the box above',
-      showingResultsFor: "Results for '{searchTerm}'",
+      showingResultsFor: "Results for '{searchTerm}' ({results} of {totalResults})",
       noResultsMsg: "No results for '{searchTerm}'",
       documentTitle: 'Search',
+      viewMore: 'View more',
     },
     metaInfo() {
       return {
@@ -55,13 +68,17 @@
     components: {
       ContentCard,
       ContentCardGroupGrid,
+      KButton,
+      KCircularLoader,
       SearchBox,
     },
+    data() {
+      return {
+        loading: false,
+      };
+    },
     computed: {
-      ...mapState('search', ['contents', 'searchTerm']),
-      searchContents() {
-        return sortBy(this.contents, content => content.channel_id !== content.content_id);
-      },
+      ...mapState('search', ['contents', 'searchTerm', 'total_results']),
     },
     methods: {
       genContentLink(contentId, contentKind) {
@@ -79,6 +96,14 @@
             id: contentId,
           },
         };
+      },
+      loadMore() {
+        if (!this.loading) {
+          this.loading = true;
+          this.$store.dispatch('search/loadMore').then(() => {
+            this.loading = false;
+          });
+        }
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -15,8 +15,7 @@
       <h1 v-else class="search-results">
         {{ $tr('showingResultsFor', {
           searchTerm,
-            results: contents.length,
-          totalResults: total_results
+            totalResults: total_results
         }) }}
       </h1>
 
@@ -28,7 +27,6 @@
 
       <KButton
         v-if="contents.length < total_results && !loading"
-        appearance="basic-link"
         :text="$tr('viewMore')"
         @click="loadMore"
       />
@@ -59,7 +57,7 @@
     $trs: {
       searchPageHeader: 'Search',
       noSearch: 'Search by typing in the box above',
-      showingResultsFor: "Results for '{searchTerm}' ({results} of {totalResults})",
+      showingResultsFor: "{totalResults} results for '{searchTerm}'",
       noResultsMsg: "No results for '{searchTerm}'",
       documentTitle: 'Search',
       viewMore: 'View more',

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -9,13 +9,17 @@
     <p v-if="!searchTerm">{{ $tr('noSearch') }}</p>
 
     <template v-else>
-      <h1 class="search-results">{{ $tr('showingResultsFor', {
-        searchTerm,
-          results: contents.length,
-        totalResults: total_results
-      }) }}</h1>
+      <h1 v-if="contents.length === 0" class="search-results">
+        {{ $tr('noResultsMsg', { searchTerm }) }}
+      </h1>
+      <h1 v-else class="search-results">
+        {{ $tr('showingResultsFor', {
+          searchTerm,
+            results: contents.length,
+          totalResults: total_results
+        }) }}
+      </h1>
 
-      <p v-if="contents.length === 0">{{ $tr('noResultsMsg', { searchTerm }) }}</p>
 
       <ContentCardGroupGrid
         :genContentLink="genContentLink"

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -57,7 +57,8 @@
     $trs: {
       searchPageHeader: 'Search',
       noSearch: 'Search by typing in the box above',
-      showingResultsFor: "{totalResults} results for '{searchTerm}'",
+      showingResultsFor:
+        "{totalResults, plural, one {{totalResults} result} other {{totalResults} results}} for '{searchTerm}'",
       noResultsMsg: "No results for '{searchTerm}'",
       documentTitle: 'Search',
       viewMore: 'View more',

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -18,7 +18,6 @@
       v-if="contents.length"
       :contents="contents"
       :genContentLink="genContentLink"
-      :showContentKindFilter="false"
     />
 
   </div>

--- a/kolibri/plugins/style_guide/assets/src/views/content/Buttons/example.html
+++ b/kolibri/plugins/style_guide/assets/src/views/content/Buttons/example.html
@@ -23,6 +23,7 @@
     <br>
     <k-button text="disabled button" :primary="true" :disabled="true"></k-button>
     <k-button text="disabled button" appearance="flat-button" :primary="true" :disabled="true"></k-button>
+    <k-button text="disabled button" appearance="basic-link" :disabled="true"></k-button>
     <br>
     <k-button text="disabled button" :disabled="true"></k-button>
     <k-button text="disabled button" appearance="flat-button" :disabled="true"></k-button>


### PR DESCRIPTION
### Summary
* Make search a separate list endpoint.
* Return additional metadata with search results to allow filtering by channel_ids, and kinds
* Return total available search results
* Generalize the unused pagination logic in api-resource.js to allow this arbitrary metadata storage.
* Add 'view more' to search results to allow loading of additional search results, 30 at a time.
* Add 'update search' button to trigger new search based on change search string or altered filters
* Add disabled state for simple link KButton

### Reviewer guidance
Can you still search?
Can you find things you want?
Can you filter and still find things?

![image](https://user-images.githubusercontent.com/1680573/44546210-1b846200-a6cc-11e8-813f-e41732dc8f5c.png)

![image](https://user-images.githubusercontent.com/1680573/44546229-250dca00-a6cc-11e8-9b09-51b4b93d40ac.png)

![image](https://user-images.githubusercontent.com/1680573/44546246-3525a980-a6cc-11e8-8d4d-f21436026596.png)


----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
