### PR TITLE
Allow empty answers to persist in exams

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/exam-page/index.vue
@@ -178,12 +178,8 @@
         return this._throttledSaveAnswer(...args);
       },
       saveAnswer() {
-        const answer = this.checkAnswer() || {
-          answerState: null,
-          simpleAnswer: '',
-          correct: 0,
-        };
-        if (!isEqual(answer.answerState, this.currentAttempt.answer)) {
+        const answer = this.checkAnswer();
+        if (answer && !isEqual(answer.answerState, this.currentAttempt.answer)) {
           const attempt = Object.assign({}, this.currentAttempt);
           attempt.answer = answer.answerState;
           attempt.simple_answer = answer.simpleAnswer;


### PR DESCRIPTION
### Summary
We were creating null answerStates that are meaningless. This stops that.

### Reviewer guidance
Can you delete an answer in an exam numeric input question?

### References
Fixes final bug here: https://github.com/learningequality/kolibri/issues/4162#issuecomment-415308109

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
