### PR TITLE
Bump to 0.10.3.dev

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -15,7 +15,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 10, 2, 'final', 0)
+VERSION = (0, 10, 3, 'alpha', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION
Maintainer PR - although 0.10.3 isn't definitely a release yet, we still need to version whatever is build on this branch, _not_ as 0.10.2 (final) :)

From @rtibbles 

> I have noticed that we are having a few issues with our versions when there is a mismatch between the committed version and the tag (new builds on release-v0.10.x are showing as 0.10.2 final even though they don't match the final tag). 