### PR TITLE
Bump to 0.9.5.dev

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -6,7 +6,7 @@ from .utils.version import get_version
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 9, 4, 'final', 0)
+VERSION = (0, 9, 5, 'alpha', 0)
 
 __author__ = 'Learning Equality'
 __email__ = 'info@learningequality.org'


### PR DESCRIPTION
Maintainer PR

From: @rtibbles 

> Also, Nalanda reported that the 0.9.4-beta5 they are running was displaying to the user as 0.9.4 final.