### PR TITLE
Fix problem when provisioning device with 'personal' preset

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -107,7 +107,7 @@
       }),
       continueOnboarding() {
         if (this.isLastStep) {
-          if (this.onboardingData.preset === 'personal') {
+          if (this.onboardingData.preset === 'informal') {
             this.provisionDevice({
               ...this.onboardingData,
               facility: {

--- a/kolibri/plugins/setup_wizard/assets/test/views/CreateLearnerAccountForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/CreateLearnerAccountForm.spec.js
@@ -29,8 +29,8 @@ describe('CreateLearnerAccountForm', () => {
     expect(wrapper.vm.settingIsEnabled).toEqual(false);
   });
 
-  it('has the correct default with "personal" preset', () => {
-    const { wrapper } = makeWrapper({ preset: 'personal' });
+  it('has the correct default with "informal" preset', () => {
+    const { wrapper } = makeWrapper({ preset: 'informal' });
     expect(wrapper.vm.settingIsEnabled).toEqual(true);
   });
 

--- a/kolibri/plugins/setup_wizard/assets/test/views/GuestAccessForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/GuestAccessForm.spec.js
@@ -29,8 +29,8 @@ describe('GuestAccessForm', () => {
     expect(wrapper.vm.settingIsEnabled).toEqual(false);
   });
 
-  it('has the correct default with "personal" preset', () => {
-    const { wrapper } = makeWrapper({ preset: 'personal' });
+  it('has the correct default with "informal" preset', () => {
+    const { wrapper } = makeWrapper({ preset: 'informal' });
     expect(wrapper.vm.settingIsEnabled).toEqual(true);
   });
 

--- a/kolibri/plugins/setup_wizard/assets/test/views/RequirePasswordForLearnersForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/RequirePasswordForLearnersForm.spec.js
@@ -29,8 +29,8 @@ describe('RequirePasswordForLearnersForm', () => {
     expect(wrapper.vm.settingIsEnabled).toEqual(false);
   });
 
-  it('has the correct default with "personal" preset', () => {
-    const { wrapper } = makeWrapper({ preset: 'personal' });
+  it('has the correct default with "informal" preset', () => {
+    const { wrapper } = makeWrapper({ preset: 'informal' });
     expect(wrapper.vm.settingIsEnabled).toEqual(true);
   });
 

--- a/kolibri/plugins/setup_wizard/assets/test/views/SetupWizardIndex.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/SetupWizardIndex.spec.js
@@ -55,10 +55,10 @@ describe('SetupWizardIndex', () => {
     expect(wrapper.vm.provisionDevice).toHaveBeenCalledTimes(1);
   });
 
-  it('submits a default facility name if "personal" preset is used', () => {
+  it('submits a default facility name if "informal" preset is used', () => {
     const { els, wrapper, store } = makeWrapper();
     // set superuser, since that's how name is derived
-    store.commit('SET_FACILITY_PRESET', 'personal');
+    store.commit('SET_FACILITY_PRESET', 'informal');
     store.commit('SET_SU', {
       name: 'Fred Rogers',
       username: 'mr_rogers',


### PR DESCRIPTION
### Summary

Fixes failure during device provisioning when using "Personal" (aka "informal") preset by using the correct key (e.g. "informal") in if-check.

### Reviewer guidance

1. Go through Setup Wizard through all 3 presets, especially personal/informal
1. Make sure device provisions properly

### References

Fixes #4202

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
