### PR TITLE
Specify the csv path when listing disks in Windows

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -69,7 +69,13 @@ def _wmic_output():
     )
 
     # pipe output from the WMIC command to the temp file
-    cmd = "wmic logicaldisk list full /format:\"%WINDIR%\\System32\\wbem\\en-us\\csv\" > {}".format(OUTPUT_PATH)
+    csv_path = os.path.join(os.environ["WINDIR"], "System32", "wbem", "en-us", "csv.xsl")
+    # Use different WMIC commands, depending on whether the csv_path exists.
+    if os.path.exists(csv_path):
+        cmd = "wmic logicaldisk list full /format:\"{}\" > \"{}\"".format(csv_path, OUTPUT_PATH)
+    else:
+        # fallback when en-us directory does not exist
+        cmd = "wmic logicaldisk list full /format:csv > \"{}\"".format(OUTPUT_PATH)
     returnCode = os.system(cmd)
     if returnCode:
         raise Exception("Could not run command '{}'".format(cmd))

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -69,7 +69,7 @@ def _wmic_output():
     )
 
     # pipe output from the WMIC command to the temp file
-    cmd = "wmic logicaldisk list full /format:csv > {}".format(OUTPUT_PATH)
+    cmd = "wmic logicaldisk list full /format:\"%WINDIR%\\System32\\wbem\\en-us\\csv\" > {}".format(OUTPUT_PATH)
     returnCode = os.system(cmd)
     if returnCode:
         raise Exception("Could not run command '{}'".format(cmd))


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR fixes the issue that when the format in Windows 7 is set to be non US-English, users will not be able to see the external drive list, thus not able to do local import/export.
The issue is an [issue](https://social.msdn.microsoft.com/Forums/en-US/a9beeed3-99f0-4627-ba1e-aa0161fa58c9/wmic-invalid-xsl-format-or-file-name?forum=windowsgeneraldevelopmentissues#be9e599a-5cd8-4238-9918-df650a98c66b) in Windows 7 WMIC. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To reproduce the issue,
in Windows 7, run kolibri that is not from this PR. Set Format in `Control Panel-->Clock, Language, and Region --> Region and Language --> Formats --> Format` to be non US-English. Try to do local import or export in Kolibri. Users will not be able to see the drive list. And in `kolibri.log`, there will be an exception showing that wmic command didn't run successfully.

To test if this fix works,
in Windows 7, run the kolibri from this PR.Set Format in `Control Panel-->Clock, Language, and Region --> Region and Language --> Formats --> Format` to be non US-English. Try to do local import or export in Kolibri. Users should be able to see the external drive list.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4190

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
