### PR TITLE
Further low risk optimizations

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -73,6 +73,7 @@ class ChannelMetadataFilter(FilterSet):
         fields = ['available', 'has_exercise', ]
 
 
+@method_decorator(cache_forever, name='dispatch')
 class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ChannelMetadataSerializer
     filter_backends = (DjangoFilterBackend,)

--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -25,6 +25,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
     available = serializers.SerializerMethodField()
 
     def to_representation(self, instance):
+        # TODO: rtibbles - cleanup this for device specific serializer.
         value = super(ChannelMetadataSerializer, self).to_representation(instance)
 
         # if it has the file_size flag add extra file_size information

--- a/kolibri/core/assets/src/api-resources/channel.js
+++ b/kolibri/core/assets/src/api-resources/channel.js
@@ -11,4 +11,7 @@ export default class ChannelResource extends Resource {
   static resourceName() {
     return 'channel';
   }
+  static usesContentCacheKey() {
+    return true;
+  }
 }

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -404,7 +404,7 @@ function saveContentSessionLog(store, sessionModel, contentSession) {
   });
 }
 
-const debouncedSaveContentSessionLog = debounce(saveContentSessionLog, 1000, { maxWait: 10000 });
+const debouncedSaveContentSessionLog = debounce(saveContentSessionLog, 1000, { maxWait: 5000 });
 
 function saveContentSummaryLog(store, summaryModel, contentSummary) {
   summaryModel.save(contentSummary).catch(error => {
@@ -412,7 +412,7 @@ function saveContentSummaryLog(store, summaryModel, contentSummary) {
   });
 }
 
-const debouncedSaveContentSummaryLog = debounce(saveContentSummaryLog, 1000, { maxWait: 10000 });
+const debouncedSaveContentSummaryLog = debounce(saveContentSummaryLog, 1000, { maxWait: 5000 });
 
 /**
  * Do a PATCH to update existing logging models

--- a/kolibri/core/assets/src/state/actions.js
+++ b/kolibri/core/assets/src/state/actions.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce';
 import {
   isUserLoggedIn,
   currentUserId,
@@ -397,6 +398,22 @@ function setChannelInfo(store) {
     );
 }
 
+function saveContentSessionLog(store, sessionModel, contentSession) {
+  sessionModel.save(contentSession).catch(error => {
+    handleApiError(store, error);
+  });
+}
+
+const debouncedSaveContentSessionLog = debounce(saveContentSessionLog, 1000, { maxWait: 10000 });
+
+function saveContentSummaryLog(store, summaryModel, contentSummary) {
+  summaryModel.save(contentSummary).catch(error => {
+    handleApiError(store, error);
+  });
+}
+
+const debouncedSaveContentSummaryLog = debounce(saveContentSummaryLog, 1000, { maxWait: 10000 });
+
 /**
  * Do a PATCH to update existing logging models
  * Must be called after initContentSession
@@ -412,17 +429,19 @@ function saveLogs(store) {
   /* If a session model exists, save it with updated values */
   if (sessionLog.id) {
     const sessionModel = ContentSessionLogResource.getModel(sessionLog.id);
-    sessionModel.save(_contentSessionModel(store)).catch(error => {
-      handleApiError(store, error);
-    });
+    const contentSession = _contentSessionModel(store);
+    // Get all data from the vuex store synchronously, but then debounce the save to
+    // prevent repeated saves to the server.
+    debouncedSaveContentSessionLog(store, sessionModel, contentSession);
   }
 
   /* If a summary model exists, save it with updated values */
   if (summaryLog.id) {
     const summaryModel = ContentSummaryLogResource.getModel(summaryLog.id);
-    summaryModel.save(_contentSummaryModel(store)).catch(error => {
-      handleApiError(store, error);
-    });
+    const contentSummary = _contentSummaryModel(store);
+    // Get all data from the vuex store synchronously, but then debounce the save to
+    // prevent repeated saves to the server.
+    debouncedSaveContentSummaryLog(store, summaryModel, contentSummary);
   }
 }
 

--- a/kolibri/plugins/device_management/api.py
+++ b/kolibri/plugins/device_management/api.py
@@ -1,0 +1,17 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets
+
+from kolibri.content.api import ChannelMetadataFilter
+from kolibri.content.models import ChannelMetadata
+from kolibri.content.serializers import ChannelMetadataSerializer
+
+
+class DeviceChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = ChannelMetadataSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = ChannelMetadataFilter
+
+    def get_queryset(self):
+        return ChannelMetadata.objects.all() \
+            .order_by('-last_updated') \
+            .select_related('root__lang')

--- a/kolibri/plugins/device_management/api_urls.py
+++ b/kolibri/plugins/device_management/api_urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include
+from django.conf.urls import url
+from rest_framework import routers
+
+from .api import DeviceChannelMetadataViewSet
+
+router = routers.SimpleRouter()
+
+router.register('device_channel', DeviceChannelMetadataViewSet, base_name="device_channel")
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/kolibri/plugins/device_management/assets/src/apiResources/deviceChannel.js
+++ b/kolibri/plugins/device_management/assets/src/apiResources/deviceChannel.js
@@ -1,0 +1,11 @@
+import { Resource } from 'kolibri.lib.apiResource';
+
+class DeviceChannelResource extends Resource {
+  static resourceName() {
+    return 'kolibri:devicemanagementplugin:device_channel';
+  }
+}
+
+const deviceChannelResource = new DeviceChannelResource();
+
+export default deviceChannelResource;

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
@@ -1,5 +1,6 @@
 import { taskList, wizardState } from '../getters';
-import { ChannelResource, TaskResource } from 'kolibri.resources';
+import { TaskResource } from 'kolibri.resources';
+import ChannelResource from '../../apiResources/deviceChannel';
 import { TaskStatuses, TransferTypes } from '../../constants';
 
 export const ErrorTypes = {

--- a/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/manageContentActions.js
@@ -1,4 +1,4 @@
-import { ChannelResource } from 'kolibri.resources';
+import ChannelResource from '../../apiResources/deviceChannel';
 import { canManageContent } from 'kolibri.coreVue.vuex.getters';
 
 /**

--- a/kolibri/plugins/device_management/assets/test/actions/contentTreeViewerActions.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/contentTreeViewerActions.spec.js
@@ -6,7 +6,8 @@ import sinon from 'sinon';
 import omit from 'lodash/fp/omit';
 import { mockResource } from 'testUtils'; // eslint-disable-line
 import mutations from '../../src/state/mutations';
-import { ChannelResource, ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
+import ChannelResource from '../../src/apiResources/deviceChannel';
+import { ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
 import {
   addNodeForTransfer,
   removeNodeForTransfer,

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -7,7 +7,8 @@ import router from 'kolibri.coreVue.router';
 import { showSelectContentPage } from '../../src/state/actions/selectContentActions';
 import mutations from '../../src/state/mutations';
 import { wizardState } from '../../src/state/getters';
-import { ChannelResource, ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
+import ChannelResource from '../../src/apiResources/deviceChannel';
+import { ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
 import { mockResource } from 'testUtils'; // eslint-disable-line
 import { importExportWizardState } from '../../src/state/wizardState';
 import { defaultChannel } from '../utils/data';

--- a/kolibri/plugins/device_management/urls.py
+++ b/kolibri/plugins/device_management/urls.py
@@ -1,6 +1,10 @@
+import api_urls
+from django.conf.urls import include
 from django.conf.urls import url
+
 from .views import DeviceManagementView
 
 urlpatterns = [
     url('^$', DeviceManagementView.as_view(), name='device_management'),
+    url('^api/', include(api_urls.urlpatterns)),
 ]

--- a/kolibri/plugins/device_management/urls.py
+++ b/kolibri/plugins/device_management/urls.py
@@ -1,10 +1,10 @@
-import api_urls
 from django.conf.urls import include
 from django.conf.urls import url
 
+from .api_urls import urlpatterns
 from .views import DeviceManagementView
 
 urlpatterns = [
     url('^$', DeviceManagementView.as_view(), name='device_management'),
-    url('^api/', include(api_urls.urlpatterns)),
+    url('^api/', include(urlpatterns)),
 ]

--- a/kolibri/plugins/learn/templates/learn/learn.html
+++ b/kolibri/plugins/learn/templates/learn/learn.html
@@ -4,8 +4,6 @@
 {% load cache %}
 
 {% block content %}
-  <!-- Bootstrapping the initial information for all channels. -->
-  {% kolibri_bootstrap_collection 'channel' 'ChannelResource' available="true" %}
 
   {% if request.user.is_facility_user %}
     <!-- Bootstrapping the the user's memberships. -->


### PR DESCRIPTION
### Summary
* Debounces log saving to prevent a logalanche when a content item is completed (session and summary logs being saved 3 times each in close succession).
* Caches the channelmetadata endpoint to reduce load on learn page
* Creates separate uncached channel endpoint for device management

### Reviewer guidance
Can you still log progress?
Can you import content?
Can you load the channels tab on learn?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
