### PR TITLE
Async log writing

### DIFF
--- a/kolibri/auth/api.py
+++ b/kolibri/auth/api.py
@@ -47,6 +47,8 @@ from .serializers import RoleSerializer
 from kolibri.core.mixins import BulkCreateMixin
 from kolibri.core.mixins import BulkDeleteMixin
 from kolibri.logger.models import UserSessionLog
+from kolibri.logger.tasks import add_to_save_queue
+from kolibri.utils.time import local_now
 
 
 class KolibriAuthPermissionsFilter(filters.BaseFilterBackend):
@@ -388,6 +390,10 @@ class SessionViewSet(viewsets.ViewSet):
             session['kind'].insert(0, 'superuser')
 
         if active:
-            UserSessionLog.update_log(user)
+            now = local_now()
+
+            def fn():
+                UserSessionLog.update_log(user, now=now)
+            add_to_save_queue(fn)
 
         return session

--- a/kolibri/logger/apps.py
+++ b/kolibri/logger/apps.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 from django.apps import AppConfig
 
+from .tasks import AsyncLogSavingThread
+
 
 class KolibriLoggerConfig(AppConfig):
     name = 'kolibri.logger'
@@ -11,4 +13,4 @@ class KolibriLoggerConfig(AppConfig):
     verbose_name = 'Kolibri Logger'
 
     def ready(self):
-        pass
+        AsyncLogSavingThread.start_command()

--- a/kolibri/logger/tasks.py
+++ b/kolibri/logger/tasks.py
@@ -1,0 +1,53 @@
+import threading
+import time
+
+from django.db import transaction
+
+LOG_SAVING_INTERVAL = 5
+
+QUEUE_1 = []
+
+QUEUE_2 = []
+
+ACTIVE_QUEUE = QUEUE_1
+
+
+def add_to_save_queue(fn):
+    global ACTIVE_QUEUE
+    ACTIVE_QUEUE.append(fn)
+
+
+def toggle_active_queue():
+    global ACTIVE_QUEUE
+    if ACTIVE_QUEUE == QUEUE_1:
+        ACTIVE_QUEUE = QUEUE_2
+    else:
+        ACTIVE_QUEUE = QUEUE_1
+
+
+def clear_queue(queue):
+    global QUEUE_1
+    global QUEUE_2
+    if queue == QUEUE_1:
+        QUEUE_1 = []
+    else:
+        QUEUE_2 = []
+
+
+class AsyncLogSavingThread(threading.Thread):
+
+    @classmethod
+    def start_command(cls):
+        thread = cls()
+        thread.daemon = True
+        thread.start()
+
+    def run(self):
+        while True:
+            queue = ACTIVE_QUEUE
+            toggle_active_queue()
+            with transaction.atomic():
+                for fn in queue:
+                    fn()
+            clear_queue(queue)
+            time.sleep(LOG_SAVING_INTERVAL)

--- a/kolibri/logger/test/test_api.py
+++ b/kolibri/logger/test/test_api.py
@@ -95,10 +95,14 @@ class ContentSessionLogAPITestCase(APITestCase):
         payload = {
             "end_timestamp": str(now)
         }
-        with patch('kolibri.logger.tasks.add_to_save_queue') as queue_mock:
+        delayed_fn_calls = []
+
+        def side_effect(fn):
+            delayed_fn_calls.append(fn)
+        with patch('kolibri.logger.tasks.add_to_save_queue', side_effect=side_effect):
             response = self.client.patch(reverse('contentsessionlog-detail', kwargs={"pk": log.id}), data=payload, format='json')
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            queue_mock.call_args[0][0]()
+            delayed_fn_calls[0]()
             log.refresh_from_db()
             self.assertEqual(log.end_timestamp, now)
 
@@ -203,10 +207,14 @@ class ContentSummaryLogAPITestCase(APITestCase):
         payload = {
             "end_timestamp": str(now)
         }
-        with patch('kolibri.logger.tasks.add_to_save_queue') as queue_mock:
+        delayed_fn_calls = []
+
+        def side_effect(fn):
+            delayed_fn_calls.append(fn)
+        with patch('kolibri.logger.tasks.add_to_save_queue', side_effect=side_effect):
             response = self.client.patch(reverse('contentsummarylog-detail', kwargs={"pk": log.id}), data=payload, format='json')
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            queue_mock.call_args[0][0]()
+            delayed_fn_calls[0]()
             log.refresh_from_db()
             self.assertEqual(log.end_timestamp, now)
 

--- a/kolibri/logger/test/test_task_queue.py
+++ b/kolibri/logger/test/test_task_queue.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from mock import MagicMock
+
+from ..tasks import AsyncLogQueue
+
+
+class TaskQueueTest(TestCase):
+
+    def test_run_queue_executes_inactive_queue(self):
+        log_queue = AsyncLogQueue()
+        fn = MagicMock()
+        log_queue.inactive_queue.append(fn)
+        log_queue.run_queue()
+        self.assertTrue(fn.called)
+
+    def test_run_queue_does_not_execute_active_queue(self):
+        log_queue = AsyncLogQueue()
+        fn = MagicMock()
+        log_queue.active_queue.append(fn)
+        log_queue.run_queue()
+        self.assertFalse(fn.called)
+
+    def test_toggle_queue_changes_queue(self):
+        log_queue = AsyncLogQueue()
+        active_queue = log_queue.active_queue
+        active_queue.append(1)
+        log_queue.toggle_active_queue()
+        self.assertNotEqual(active_queue, log_queue.active_queue)
+
+    def test_clear_queue_changes_queue_reference(self):
+        log_queue = AsyncLogQueue()
+        inactive_queue = log_queue.inactive_queue
+        inactive_queue.append(1)
+        log_queue.clear_queue()
+        self.assertNotEqual(inactive_queue, log_queue.inactive_queue)
+
+    def test_clear_queue_wont_clear_active_queue(self):
+        log_queue = AsyncLogQueue()
+        active_queue = log_queue.active_queue
+        active_queue.append(1)
+        log_queue.clear_queue()
+        self.assertEqual(log_queue.active_queue[0], 1)
+
+    def test_append_queue_adds_to_active_queue(self):
+        log_queue = AsyncLogQueue()
+        log_queue.append(1)
+        self.assertEqual(log_queue.active_queue[0], 1)

--- a/kolibri/logger/test/test_task_queue.py
+++ b/kolibri/logger/test/test_task_queue.py
@@ -6,42 +6,53 @@ from ..tasks import AsyncLogQueue
 
 class TaskQueueTest(TestCase):
 
-    def test_run_queue_executes_inactive_queue(self):
+    def test_run_queue_executes_running(self):
         log_queue = AsyncLogQueue()
         fn = MagicMock()
-        log_queue.inactive_queue.append(fn)
-        log_queue.run_queue()
+        log_queue.running.append(fn)
+        log_queue.run()
         self.assertTrue(fn.called)
 
-    def test_run_queue_does_not_execute_active_queue(self):
+    def test_run_does_not_execute_queue(self):
         log_queue = AsyncLogQueue()
         fn = MagicMock()
-        log_queue.active_queue.append(fn)
-        log_queue.run_queue()
+        log_queue.queue.append(fn)
+        log_queue.run()
         self.assertFalse(fn.called)
+
+    def test_run_executes_all_after_exceptions(self):
+        log_queue = AsyncLogQueue()
+
+        def exception_fn():
+            raise Exception('Just because!')
+        log_queue.running.append(exception_fn)
+        fn = MagicMock()
+        log_queue.running.append(fn)
+        log_queue.run()
+        self.assertTrue(fn.called)
 
     def test_toggle_queue_changes_queue(self):
         log_queue = AsyncLogQueue()
-        active_queue = log_queue.active_queue
-        active_queue.append(1)
-        log_queue.toggle_active_queue()
-        self.assertNotEqual(active_queue, log_queue.active_queue)
+        queue = log_queue.queue
+        queue.append(1)
+        log_queue.toggle_queue()
+        self.assertNotEqual(queue, log_queue.queue)
 
-    def test_clear_queue_changes_queue_reference(self):
+    def test_clear_running_changes_reference(self):
         log_queue = AsyncLogQueue()
-        inactive_queue = log_queue.inactive_queue
-        inactive_queue.append(1)
-        log_queue.clear_queue()
-        self.assertNotEqual(inactive_queue, log_queue.inactive_queue)
+        running = log_queue.running
+        running.append(1)
+        log_queue.clear_running()
+        self.assertNotEqual(running, log_queue.running)
 
-    def test_clear_queue_wont_clear_active_queue(self):
+    def test_clear_running_wont_clear_queue(self):
         log_queue = AsyncLogQueue()
-        active_queue = log_queue.active_queue
-        active_queue.append(1)
-        log_queue.clear_queue()
-        self.assertEqual(log_queue.active_queue[0], 1)
+        queue = log_queue.queue
+        queue.append(1)
+        log_queue.clear_running()
+        self.assertEqual(log_queue.queue[0], 1)
 
-    def test_append_queue_adds_to_active_queue(self):
+    def test_append_queue_adds_to_queue(self):
         log_queue = AsyncLogQueue()
         log_queue.append(1)
-        self.assertEqual(log_queue.active_queue[0], 1)
+        self.assertEqual(log_queue.queue[0], 1)


### PR DESCRIPTION
### Summary
Writing logs is time consuming.
Why wait for the disk to be free before we complete a request?
Stash requests to update logs on the disk in memory, and then just periodically write them to disk in a batch.
Adds tests for the PATCH behaviour.
Adds tests for the loq queue behaviour.

### Reviewer guidance
Do logs still get written?
Does data get lost?
What tests should I write for this?
What are the potential failure cases?
How can I do this better?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
