### PR TITLE
Add import-from-peer server workflow

### DIFF
--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -7,13 +7,12 @@ export default new Resource({
   /**
    * Initiates a Task that imports a Channel Metadata DB from a remote source
    *
-   * @param {string} channel_id -
+   * @param {string} params.channel_id -
+   * @param {string} [params.baseurl]
    *
    */
-  startRemoteChannelImport({ channel_id }) {
-    return this.postListEndpoint('startremotechannelimport', {
-      channel_id,
-    });
+  startRemoteChannelImport(params) {
+    return this.postListEndpoint('startremotechannelimport', pickBy(params));
   },
 
   /**

--- a/kolibri/core/assets/src/state/modules/snackbar.js
+++ b/kolibri/core/assets/src/state/modules/snackbar.js
@@ -1,7 +1,10 @@
 export default {
   state: {
     isVisible: false,
-    options: {},
+    options: {
+      text: '',
+      autoDismiss: true,
+    },
   },
   getters: {
     snackbarIsVisible(state) {

--- a/kolibri/core/assets/src/views/KTextbox.vue
+++ b/kolibri/core/assets/src/views/KTextbox.vue
@@ -37,6 +37,7 @@
   export default {
     name: 'KTextbox',
     components: { UiTextbox },
+    inheritAttrs: true,
     props: {
       /**
        * v-model

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -149,7 +149,12 @@ class FileDownload(Transfer):
         self.response = self.session.get(
             self.source, stream=True, timeout=self.timeout)
         self.response.raise_for_status()
-        self.total_size = int(self.response.headers['content-length'])
+        try:
+            self.total_size = int(self.response.headers['content-length'])
+        except Exception:
+            # HACK: set the total_size very large so downloads are not considered "corrupted"
+            # in importcontent._start_file_transfer
+            self.total_size = 1e100
 
         self.started = True
 

--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -27,7 +27,7 @@ class NetworkLocation(models.Model):
             info = NetworkClient(base_url=self.base_url).info
             self.application = info.get("application", self.application) or ""
             self.kolibri_version = info.get("kolibri_version", self.kolibri_version) or ""
-            self.device_name = info.get("device_name", self.device_name) or ""
+            self.device_name = self.device_name or info.get("device_name") or ""
             self.instance_id = info.get("instance_id", self.instance_id) or ""
             self.operating_system = info.get("operating_system", self.operating_system) or ""
             self.save()

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -96,7 +96,7 @@ class TasksViewSet(viewsets.ViewSet):
             raise serializers.ValidationError("The channel_id field is required.")
 
         # optional arguments
-        baseurl = request.data.get("base_url", conf.OPTIONS['Urls']['CENTRAL_CONTENT_BASE_URL'])
+        baseurl = request.data.get("baseurl", conf.OPTIONS['Urls']['CENTRAL_CONTENT_BASE_URL'])
         node_ids = request.data.get("node_ids", None)
         exclude_node_ids = request.data.get("exclude_node_ids", None)
 
@@ -116,7 +116,7 @@ class TasksViewSet(viewsets.ViewSet):
             "importcontent",
             "network",
             channel_id,
-            base_url=baseurl,
+            baseurl=baseurl,
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             extra_metadata=job_metadata,

--- a/kolibri/integration_testing/features/admin/admin-manage-import-network-addresses.feature
+++ b/kolibri/integration_testing/features/admin/admin-manage-import-network-addresses.feature
@@ -1,0 +1,73 @@
+Feature: Admin manage import network locations
+  Admin needs to be able to add and remove a network location from which they can import content
+
+  Background:
+    Given I am signed in to Kolibri as an admin userId
+      And I am on the *Device > Content* page
+
+  Scenario: Access the Select Network Address modal
+    When I click on *Import*
+      And I select the *Local network or internet* radio button
+      And I click the *Continue* button
+    Then I see the *Select network address* modal
+
+  Scenario: No addresses have been saved
+    Given I have not saved any addresses
+      And I am on the *Select network address* modal
+    Then I see an alert saying 'You have not entered any addresses'
+      And The *Continue* button is disabled
+
+  Scenario: Adding an address
+    Given I am on the *Select network address* modal
+    When I click the *New address* button
+    Then I see the *New address* modal
+    When I enter <network_address> in the *Full network address* field
+      And I enter <network_name> in the *Network name* field
+      And I press the *Add* button
+    Then The *New address* modal disappears
+      And I see the *Select network address
+      And I see a snackbar alert saying 'Successfully added address'
+      And I see a radio button with <network_name> as the label
+      And That radio button has <network_address> as the description
+
+  Scenario: Removing an address
+    Given I am on the *Select network address* modal
+      And I have saved a network location for <network_name>
+    When I click the *Forget* button next to the radio button for <network_name>
+    Then The radio button for <network_name> disappears from the list
+      And I see a snackbar alert saying 'Successfully removed address'
+
+  Scenario: A saved address is available to import from
+    Given I am on the *Select network address* modal
+      And I have saved a network location for <network_name>
+      And <network_name> is available
+    Then the radio button for <network_name> is enabled
+
+  Scenario: A saved address is not available to import from
+    Given I am on the *Select network address* modal
+      And I have saved a network location for <network_name>
+      And <network_name> is not available
+    Then the radio button for <network_name> is disabled
+
+  Scenario: Attempting to add an address with an invalid URL
+    Given I am on the *New address* modal
+      And <network_name> does not have a valid URL
+    When I enter <network_address> in the *Full network address* field
+      And I enter <network_name> in the *Network name* field
+      And I press the *Add* button
+    Then I see an error saying 'Please enter a valid IP address, URL, or hostname' error under the *Full network address* field
+
+  Scenario: Attempting to add an address without a running Kolibri instance
+    Given I am on the *New address* modal
+      And <network_name> does not have a running Kolibri instance
+    When I enter <network_address> in the *Full network address* field
+      And I enter <network_name> in the *Network name* field
+      And I press the *Add* button
+    Then I see an error saying 'Could not connect to this network address' error under the *Full network address* field
+
+Examples:
+| network_address  | network_name       | is_available | url_valid | has_kolibri |
+| 126.1.1.5:8000   | Main Server        | true         | true      | true        |
+| 126.1.1.6:8000   | Unavailable Server | false        | true      | true        |
+| !!!.&&&.???      | Invalid Server     | false        | false     | false       |
+| doesnotexist.tor | Unreachable server | false        | true      | false       |

--- a/kolibri/integration_testing/features/admin/admin-manage-import-network-addresses.feature
+++ b/kolibri/integration_testing/features/admin/admin-manage-import-network-addresses.feature
@@ -2,7 +2,7 @@ Feature: Admin manage import network locations
   Admin needs to be able to add and remove a network location from which they can import content
 
   Background:
-    Given I am signed in to Kolibri as an admin userId
+    Given I am signed in to Kolibri as an admin user
       And I am on the *Device > Content* page
 
   Scenario: Access the Select Network Address modal

--- a/kolibri/plugins/device_management/assets/src/apiResources.js
+++ b/kolibri/plugins/device_management/assets/src/apiResources.js
@@ -1,0 +1,5 @@
+import { Resource } from 'kolibri.lib.apiResource';
+
+export const NetworkLocationResource = new Resource({
+  name: 'networklocation',
+});

--- a/kolibri/plugins/device_management/assets/src/constants.js
+++ b/kolibri/plugins/device_management/assets/src/constants.js
@@ -12,6 +12,7 @@ export const ContentWizardPages = {
   SELECT_CONTENT_TOPIC: 'SELECT_CONTENT_TOPIC',
   SELECT_DRIVE: 'SELECT_DRIVE',
   SELECT_IMPORT_SOURCE: 'SELECT_IMPORT_SOURCE',
+  SELECT_NETWORK_ADDRESS: 'SELECT_NETWORK_ADDRESS',
 };
 
 export const TaskTypes = {
@@ -34,9 +35,10 @@ export const TaskStatuses = {
 };
 
 export const TransferTypes = {
-  LOCALIMPORT: 'localimport',
-  REMOTEIMPORT: 'remoteimport',
   LOCALEXPORT: 'localexport',
+  LOCALIMPORT: 'localimport',
+  PEERIMPORT: 'peerimport',
+  REMOTEIMPORT: 'remoteimport',
 };
 
 export const ContentWizardErrors = {
@@ -50,6 +52,9 @@ export const ContentWizardErrors = {
   DRIVE_ERROR: 'DRIVE_ERROR',
   TRANSFER_IN_PROGRESS: 'TRANSFER_IN_PROGRESS',
   TREEVIEW_LOADING_ERROR: 'TREEVIEW_LOADING_ERROR',
+  NETWORK_LOCATION_DOES_NOT_EXIST: 'NETWORK_LOCATION_DOES_NOT_EXIST',
+  NETWORK_LOCATION_UNAVAILABLE: 'NETWORK_LOCATION_UNAVAILABLE',
+  NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL: 'NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL',
 };
 
 export const ErrorTypes = {
@@ -61,6 +66,7 @@ export const ErrorTypes = {
 export const ContentSources = {
   LOCAL_DRIVE: 'local',
   KOLIBRI_STUDIO: 'network',
+  PEER_KOLIBRI_SERVER: 'PEER_KOLIBRI_SERVER',
 };
 
 export const pageNameToModuleMap = {

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentWizardActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentWizardActions.js
@@ -10,8 +10,6 @@ const translator = createTranslator('ContentWizardTexts', {
   loadingChannelsToolbar: 'Loading channels…',
 });
 
-const { LOCAL_DRIVE, KOLIBRI_STUDIO } = ContentSources;
-
 // Provide a intermediate state before Available Channels is fully-loaded
 function prepareForAvailableChannelsPage(store) {
   store.commit('manageContent/SET_TOOLBAR_TITLE', translator.$tr('loadingChannelsToolbar'), {
@@ -25,12 +23,12 @@ export function goForwardFromSelectImportSourceModal(store, source) {
   const { transferredChannel } = store.state;
   const { isImportingMore } = store.getters;
 
-  if (source === LOCAL_DRIVE) {
+  if (source === ContentSources.LOCAL_DRIVE) {
     store.commit('SET_TRANSFER_TYPE', TransferTypes.LOCALIMPORT);
     store.commit('SET_WIZARD_PAGENAME', ContentWizardPages.SELECT_DRIVE);
   }
 
-  if (source === KOLIBRI_STUDIO) {
+  if (source === ContentSources.KOLIBRI_STUDIO) {
     store.commit('SET_TRANSFER_TYPE', TransferTypes.REMOTEIMPORT);
     if (isImportingMore) {
       // From import-more-from-channel workflow
@@ -39,6 +37,11 @@ export function goForwardFromSelectImportSourceModal(store, source) {
     // From top-level import workflow
     prepareForAvailableChannelsPage(store);
     return router.push(availableChannelsPageLink());
+  }
+
+  if (source === ContentSources.PEER_KOLIBRI_SERVER) {
+    store.commit('SET_TRANSFER_TYPE', TransferTypes.PEERIMPORT);
+    store.commit('SET_WIZARD_PAGENAME', ContentWizardPages.SELECT_NETWORK_ADDRESS);
   }
 }
 

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/apiPeerImport.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/apiPeerImport.js
@@ -1,0 +1,63 @@
+import { RemoteChannelResource } from 'kolibri.resources';
+import { NetworkLocationResource } from '../../apiResources';
+import { ContentWizardErrors } from '../../constants';
+
+export function getAvailableChannelsOnPeerServer(store, addressId) {
+  return new Promise((resolve, reject) => {
+    NetworkLocationResource.fetchModel({ id: addressId })
+      .then(networkLocation => {
+        if (networkLocation.available) {
+          store.commit('manageContent/wizard/SET_SELECTED_PEER', networkLocation);
+          RemoteChannelResource.fetchCollection({
+            getParams: {
+              baseurl: networkLocation.base_url,
+            },
+            force: true,
+          })
+            .then(remoteChannels => {
+              resolve(remoteChannels.filter(channel => channel.total_resources > 0));
+            })
+            .catch(() => {
+              reject({ error: ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL });
+            });
+        } else {
+          // Fail if the Network Location is not running at the moment
+          reject({ error: ContentWizardErrors.NETWORK_LOCATION_UNAVAILABLE });
+        }
+      })
+      .catch(() => {
+        reject({ error: ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_EXIST });
+      });
+  });
+}
+
+export function getTransferredChannelOnPeerServer(store, { addressId, channelId }) {
+  return new Promise((resolve, reject) => {
+    NetworkLocationResource.fetchModel({ id: addressId })
+      .then(networkLocation => {
+        if (networkLocation.available) {
+          store.commit('manageContent/wizard/SET_SELECTED_PEER', networkLocation);
+          RemoteChannelResource.fetchModel({
+            id: channelId,
+            getParams: {
+              baseurl: networkLocation.base_url,
+            },
+            force: true,
+          })
+            .then(channels => {
+              resolve({ ...channels[0] });
+            })
+            .catch(() => {
+              // Only appears of channel is not on the device. Will still load
+              // gracefully if channel has zero resources
+              reject({ error: ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL });
+            });
+        } else {
+          reject({ error: ContentWizardErrors.NETWORK_LOCATION_UNAVAILABLE });
+        }
+      })
+      .catch(() => {
+        reject({ error: ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_EXIST });
+      });
+  });
+}

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/apiPeerImport.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/apiPeerImport.js
@@ -48,7 +48,7 @@ export function getTransferredChannelOnPeerServer(store, { addressId, channelId 
               resolve({ ...channels[0] });
             })
             .catch(() => {
-              // Only appears of channel is not on the device. Will still load
+              // Only appears if channel with channelId is not on the device. Will still load
               // gracefully if channel has zero resources
               reject({ error: ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL });
             });

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/getters.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/getters.js
@@ -19,24 +19,18 @@ export function nodeTransferCounts(state) {
   return function(transferType) {
     const { included, omitted } = state.nodesForTransfer;
     const getDifference = key => (sumBy(included, key) || 0) - (sumBy(omitted, key) || 0);
-    // This will overestimate transfer size, since it counts items under topic that may not
-    // be on the USB drive
-    if (transferType === TransferTypes.LOCALIMPORT) {
-      return {
-        resources: getDifference('total_resources') - getDifference('on_device_resources'),
-        fileSize: getDifference('total_file_size') - getDifference('on_device_file_size'),
-      };
-    }
-    if (transferType === TransferTypes.REMOTEIMPORT) {
-      return {
-        resources: getDifference('total_resources') - getDifference('on_device_resources'),
-        fileSize: getDifference('total_file_size') - getDifference('on_device_file_size'),
-      };
-    }
     if (transferType === TransferTypes.LOCALEXPORT) {
       return {
         resources: getDifference('on_device_resources'),
         fileSize: getDifference('on_device_file_size'),
+      };
+    } else {
+      // For REMOTE/LOCAL/PEERIMPORT
+      // This will overestimate transfer size, since it counts items under topic that may not
+      // be on the USB drive
+      return {
+        resources: getDifference('total_resources') - getDifference('on_device_resources'),
+        fileSize: getDifference('total_file_size') - getDifference('on_device_file_size'),
       };
     }
   };
@@ -52,6 +46,10 @@ export function inLocalImportMode(state) {
 
 export function inRemoteImportMode(state) {
   return state.transferType === TransferTypes.REMOTEIMPORT;
+}
+
+export function inPeerImportMode(state) {
+  return state.transferType === TransferTypes.PEERIMPORT;
 }
 
 export function driveCanBeUsedForTransfer(state, getters, rootState, rootGetters) {

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -11,6 +11,10 @@ import {
 import { ContentWizardPages, ContentWizardErrors, TransferTypes } from '../../constants';
 import { manageContentPageLink } from '../../views/ManageContentPage/manageContentLinks';
 import { getAvailableSpaceOnDrive, loadChannelMetaData } from './actions/selectContentActions';
+import {
+  getAvailableChannelsOnPeerServer,
+  getTransferredChannelOnPeerServer,
+} from './apiPeerImport';
 
 const translator = createTranslator('WizardHandlerTexts', {
   loadingChannelToolbar: 'Loading channel…',
@@ -53,16 +57,22 @@ function getInstalledChannelsPromise(store) {
 }
 
 function getTransferType(params) {
-  const { for_export, drive_id } = params;
-  // invalid combination
-  if (for_export && !drive_id) {
-    return null;
+  const { for_export, drive_id, address_id } = params;
+  // invalid combinations
+  if (for_export) {
+    if (!drive_id || address_id) {
+      return null;
+    }
   }
   if (drive_id) {
     return for_export ? TransferTypes.LOCALEXPORT : TransferTypes.LOCALIMPORT;
-  } else {
-    return TransferTypes.REMOTEIMPORT;
   }
+
+  if (address_id) {
+    return TransferTypes.PEERIMPORT;
+  }
+  // If no parameters, assume REMOTEIMPORT
+  return TransferTypes.REMOTEIMPORT;
 }
 
 function handleError(store, error) {
@@ -110,13 +120,20 @@ export function showAvailableChannelsPage(store, params) {
     availableChannelsPromise = new Promise((resolve, reject) => {
       getInstalledChannelsPromise(store).then(() => {
         return RemoteChannelResource.fetchCollection()
-          .then(publicChannels => {
+          .then(remoteChannels => {
             return store
-              .dispatch('manageContent/wizard/getAllRemoteChannels', publicChannels)
+              .dispatch('manageContent/wizard/getAllRemoteChannels', remoteChannels)
               .then(allChannels => resolve(allChannels));
           })
           .catch(() => reject({ error: ContentWizardErrors.KOLIBRI_STUDIO_UNAVAILABLE }));
       });
+    });
+  }
+
+  if (transferType === TransferTypes.PEERIMPORT) {
+    selectedDrivePromise = Promise.resolve({});
+    availableChannelsPromise = getInstalledChannelsPromise(store).then(() => {
+      return getAvailableChannelsOnPeerServer(store, params.address_id);
     });
   }
 
@@ -160,7 +177,6 @@ export function showSelectContentPage(store, params) {
   // HACK if going directly to URL, we make sure channelList has this channel at the minimum.
   // We only get the one channel, since GETing /api/channel with file sizes is slow.
   // We let it fail silently, since it is only used to show "on device" files/resources.
-  // eslint-disable-next-line
   const installedChannelPromise = ChannelResource.fetchModel({
     id: params.channel_id,
     getParams: {
@@ -222,6 +238,14 @@ export function showSelectContentPage(store, params) {
           },
           () => reject({ error: ContentWizardErrors.CHANNEL_NOT_FOUND_ON_STUDIO })
         );
+    });
+  }
+
+  if (transferType === TransferTypes.PEERIMPORT) {
+    availableSpacePromise = getAvailableSpaceOnDrive();
+    transferredChannelPromise = getTransferredChannelOnPeerServer(store, {
+      addressId: params.address_id,
+      channelId: params.channel_id,
     });
   }
 

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/index.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/index.js
@@ -16,6 +16,7 @@ function defaultState() {
     transferType: '',
     availableChannels: [],
     selectedDrive: {},
+    selectedPeer: {},
     availableSpace: null,
     transferredChannel: {},
     currentTopicNode: {},
@@ -60,6 +61,9 @@ export default {
   mutations: {
     RESET_STATE(state) {
       Object.assign(state, defaultState());
+    },
+    SET_SELECTED_PEER(state, selectedPeer) {
+      state.selectedPeer = selectedPeer;
     },
     ADD_NODE_TO_INCLUDE_LIST(state, node) {
       state.nodesForTransfer.included.push(node);

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
@@ -20,7 +20,7 @@ export function getRemoteChannelByToken(token) {
  *
  */
 export function downloadChannelMetadata(store) {
-  const { transferredChannel, selectedDrive } = store.state.manageContent.wizard;
+  const { transferredChannel, selectedDrive, selectedPeer } = store.state.manageContent.wizard;
   let promise;
   if (store.getters['manageContent/wizard/inLocalImportMode']) {
     promise = TaskResource.startDiskChannelImport({
@@ -30,6 +30,11 @@ export function downloadChannelMetadata(store) {
   } else if (store.getters['manageContent/wizard/inRemoteImportMode']) {
     promise = TaskResource.startRemoteChannelImport({
       channel_id: transferredChannel.id,
+    });
+  } else if (store.getters['manageContent/wizard/inPeerImportMode']) {
+    promise = TaskResource.startRemoteChannelImport({
+      channel_id: transferredChannel.id,
+      baseurl: selectedPeer.base_url,
     });
   } else {
     return Error('Channel Metadata is only downloaded when importing');

--- a/kolibri/plugins/device_management/assets/src/routes/wizardTransitionRoutes.js
+++ b/kolibri/plugins/device_management/assets/src/routes/wizardTransitionRoutes.js
@@ -9,8 +9,8 @@ import { ContentWizardPages } from '../constants';
 import { selectContentTopicLink } from '../views/ManageContentPage/manageContentLinks';
 
 // To update the treeview topic programatically
-export function navigateToTopicUrl(node) {
-  router.push(selectContentTopicLink(node));
+export function navigateToTopicUrl(node, query) {
+  router.push(selectContentTopicLink(node, query));
 }
 
 export default [
@@ -20,6 +20,7 @@ export default [
     handler: ({ query }) => {
       return showAvailableChannelsPage(store, {
         for_export: String(query.for_export) === 'true',
+        address_id: query.address_id,
         drive_id: query.drive_id,
       });
     },
@@ -36,6 +37,7 @@ export default [
 
       return showSelectContentPage(store, {
         channel_id: params.channel_id,
+        address_id: query.address_id,
         drive_id: query.drive_id,
         for_export: String(query.for_export) === 'true',
       });

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -6,7 +6,7 @@
       :errorType="status"
     />
 
-    <h1 v-if="status===''" class="spec-ref-title">
+    <h1 v-if="status === ''" class="spec-ref-title">
       <span v-if="inExportMode">{{ $tr('yourChannels') }}</span>
       <span v-else-if="inLocalImportMode">{{ selectedDrive.name }}</span>
       <span v-else>{{ $tr('channels') }}</span>

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -81,7 +81,9 @@
       </div>
     </div>
     <p v-else>
-      {{ $tr('noChannelsAvailable') }}
+      <span v-if="!status">
+        {{ $tr('noChannelsAvailable') }}
+      </span>
     </p>
   </div>
 

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -6,7 +6,7 @@
       :errorType="status"
     />
 
-    <h1 class="spec-ref-title">
+    <h1 v-if="status===''" class="spec-ref-title">
       <span v-if="inExportMode">{{ $tr('yourChannels') }}</span>
       <span v-else-if="inLocalImportMode">{{ selectedDrive.name }}</span>
       <span v-else>{{ $tr('channels') }}</span>
@@ -80,6 +80,9 @@
         />
       </div>
     </div>
+    <p v-else>
+      {{ $tr('noChannelsAvailable') }}
+    </p>
   </div>
 
 </template>
@@ -142,6 +145,7 @@
       ...mapState('manageContent/wizard', [
         'availableChannels',
         'selectedDrive',
+        'selectedPeer',
         'status',
         'transferType',
       ]),
@@ -155,6 +159,10 @@
             });
           case TransferTypes.REMOTEIMPORT:
             return this.$tr('documentTitleForRemoteImport');
+          case TransferTypes.PEERIMPORT:
+            return this.$tr('documentTitleForLocalImport', {
+              driveName: this.selectedPeer.device_name,
+            });
           default:
             return '';
         }
@@ -208,6 +216,11 @@
             return this.$tr('exportToDisk', { driveName: this.selectedDrive.name });
           case TransferTypes.LOCALIMPORT:
             return this.$tr('importFromDisk', { driveName: this.selectedDrive.name });
+          case TransferTypes.PEERIMPORT:
+            return this.$tr('importFromPeer', {
+              deviceName: this.selectedPeer.device_name,
+              address: this.selectedPeer.base_url,
+            });
           default:
             return this.$tr('kolibriCentralServer');
         }
@@ -219,6 +232,7 @@
       goToSelectContentPageForChannel(channel) {
         this.$router.push(
           selectContentPageLink({
+            addressId: this.$route.query.address_id,
             channelId: channel.id,
             driveId: this.$route.query.drive_id,
             forExport: this.$route.query.for_export,
@@ -251,6 +265,7 @@
       channels: 'Channels',
       exportToDisk: 'Export to {driveName}',
       importFromDisk: 'Import from {driveName}',
+      importFromPeer: 'Import from {deviceName} ({address})',
       kolibriCentralServer: 'Kolibri Studio',
       languageFilterLabel: 'Language',
       titleFilterPlaceholder: 'Search for a channel…',
@@ -261,6 +276,7 @@
       documentTitleForLocalImport: "Available Channels on '{driveName}'",
       documentTitleForRemoteImport: 'Available Channels on Kolibri Studio',
       documentTitleForExport: 'Available Channels on this device',
+      noChannelsAvailable: 'No channels are available on this device',
     },
   };
 

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -172,6 +172,7 @@
       },
       selectContentLink() {
         return selectContentPageLink({
+          addressId: this.$route.query.address_id,
           channelId: this.channel.id,
           driveId: this.$route.query.drive_id,
           forExport: this.$route.query.for_export,

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
@@ -6,6 +6,7 @@
     :cancelText="$tr('cancelButtonLabel')"
     size="medium"
     @submit="handleSubmit"
+    :submitDisabled="attemptingToConnect"
     @cancel="$emit('cancel')"
   >
     <KTextbox
@@ -48,7 +49,6 @@
   import { createAddress } from './api';
 
   const Statuses = {
-    ATTEMPTING_TO_CONNECT: 'ATTEMPTING_TO_CONNECT',
     COULD_NOT_CONNECT: 'COULD_NOT_CONNECT',
     INVALID_ADDRESS: 'INVALID_ADDRESS',
   };
@@ -65,10 +65,10 @@
       return {
         address: '',
         addressBlurred: false,
+        attemptingToConnect: false,
         name: '',
         nameBlurred: false,
         status: '',
-        attemptingToConnect: false,
       };
     },
     computed: {
@@ -92,9 +92,6 @@
       },
       formIsInvalid() {
         return this.addressIsInvalid || this.nameIsInvalid;
-      },
-      isTryingToConnect() {
-        return this.status === Statuses.ATTEMPTING_TO_CONNECT;
       },
     },
     methods: {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
@@ -1,0 +1,147 @@
+<template>
+
+  <KModal
+    :title="$tr('header')"
+    :submitText="$tr('submitButtonLabel')"
+    :cancelText="$tr('cancelButtonLabel')"
+    size="medium"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    <KTextbox
+      v-model="address"
+      :label="$tr('addressLabel')"
+      :placeholder="$tr('addressPlaceholder')"
+      :autofocus="true"
+      :invalid="addressIsInvalid"
+      :invalidText="addressInvalidText"
+      :disabled="attemptingToConnect"
+      @blur="addressBlurred = true"
+    />
+    <KTextbox
+      v-model="name"
+      :label="$tr('nameLabel')"
+      :placeholder="$tr('namePlaceholder')"
+      :invalid="nameIsInvalid"
+      :invalidText="$tr('fieldIsRequired')"
+      :maxlength="40"
+      :disabled="attemptingToConnect"
+      @blur="nameBlurred = true"
+    />
+
+    <UiAlert
+      v-if="attemptingToConnect"
+      :dismissible="false"
+    >
+      {{ $tr('tryingToConnect') }}
+    </UiAlert>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import KModal from 'kolibri.coreVue.components.KModal';
+  import KTextbox from 'kolibri.coreVue.components.KTextbox';
+  import UiAlert from 'keen-ui/src/UiAlert';
+  import { createAddress } from './api';
+
+  const Statuses = {
+    ATTEMPTING_TO_CONNECT: 'ATTEMPTING_TO_CONNECT',
+    COULD_NOT_CONNECT: 'COULD_NOT_CONNECT',
+    INVALID_ADDRESS: 'INVALID_ADDRESS',
+  };
+
+  export default {
+    name: 'AddAddressForm',
+    components: {
+      KModal,
+      KTextbox,
+      UiAlert,
+    },
+    props: {},
+    data() {
+      return {
+        address: '',
+        addressBlurred: false,
+        name: '',
+        nameBlurred: false,
+        status: '',
+        attemptingToConnect: false,
+      };
+    },
+    computed: {
+      addressInvalidText() {
+        if (this.status === Statuses.INVALID_ADDRESS) {
+          return this.$tr('errorInvalidAddress');
+        }
+        if (this.status === Statuses.COULD_NOT_CONNECT) {
+          return this.$tr('errorCouldNotConnect');
+        }
+        if (this.address === '') {
+          return this.$tr('fieldIsRequired');
+        }
+        return '';
+      },
+      addressIsInvalid() {
+        return this.addressBlurred && this.addressInvalidText !== '';
+      },
+      nameIsInvalid() {
+        return this.nameBlurred && this.name === '';
+      },
+      formIsInvalid() {
+        return this.addressIsInvalid || this.nameIsInvalid;
+      },
+      isTryingToConnect() {
+        return this.status === Statuses.ATTEMPTING_TO_CONNECT;
+      },
+    },
+    methods: {
+      handleSubmit() {
+        this.addressBlurred = true;
+        this.nameBlurred = true;
+        this.status = '';
+        if (this.formIsInvalid) {
+          return Promise.resolve();
+        }
+        this.attemptingToConnect = true;
+        return createAddress({
+          base_url: this.address,
+          device_name: this.name,
+        })
+          .then(() => {
+            this.$emit('added_address');
+          })
+          .catch(err => {
+            const { id } = err.entity[0];
+            if (id === 'NETWORK_LOCATION_NOT_FOUND') {
+              this.status = Statuses.COULD_NOT_CONNECT;
+            } else {
+              this.status = Statuses.INVALID_ADDRESS;
+            }
+          })
+          .then(() => {
+            this.attemptingToConnect = false;
+          });
+      },
+    },
+    $trs: {
+      addressLabel: 'Full network address',
+      addressPlaceholder: 'e.g. http://123.456.7.89:8080',
+      cancelButtonLabel: 'Cancel',
+      errorCouldNotConnect: 'Could not connect to this network address',
+      errorInvalidAddress: 'Please enter a valid IP address, URL, or hostname',
+      header: 'New address',
+      fieldIsRequired: 'This field is required',
+      nameLabel: 'Network name',
+      namePlaceholder: 'e.g. House network',
+      submitButtonLabel: 'Add',
+      tryingToConnect: 'Trying to connect to server…',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -1,0 +1,224 @@
+<template>
+
+  <KModal
+    :title="$tr('header')"
+    :submitText="$tr('submitButtonLabel')"
+    :cancelText="$tr('cancelButtonLabel')"
+    size="medium"
+    @submit="handleSubmit"
+    :submitDisabled="submitDisabled"
+    @cancel="$emit('cancel')"
+  >
+    <KButton
+      class="new-address-button"
+      :text="$tr('newAddressButtonLabel')"
+      @click="$emit('click_add_address')"
+      appearance="basic-link"
+      v-show="!newAddressButtonDisabled"
+    />
+
+    <UiAlert
+      v-if="uiAlertProps"
+      v-show="showUiAlerts"
+      :type="uiAlertProps.type"
+      :dismissible="false"
+    >
+      {{ uiAlertProps.text }}
+      <KButton
+        v-if="requestsFailed"
+        appearance="basic-link"
+        :text="$tr('refreshAddressesButtonLabel')"
+        @click="refreshAddressList"
+      />
+    </UiAlert>
+
+    <template v-for="(a, idx) in addresses">
+      <div :key="`div-${idx}`">
+        <KRadioButton
+          class="radio-button"
+          v-model="selectedAddressId"
+          :key="idx"
+          :value="a.id"
+          :label="a.device_name"
+          :description="a.base_url"
+          :disabled="!a.available || !a.hasContent"
+        />
+        <KButton
+          @click="removeAddress(a.id)"
+          :key="`forget-${idx}`"
+          :text="$tr('forgetAddressButtonLabel')"
+          appearance="basic-link"
+        />
+      </div>
+    </template>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { mapGetters, mapState } from 'vuex';
+  import find from 'lodash/find';
+  import KButton from 'kolibri.coreVue.components.KButton';
+  import KModal from 'kolibri.coreVue.components.KModal';
+  import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
+  import UiAlert from 'keen-ui/src/UiAlert';
+  import { deleteAddress, fetchAddresses } from './api';
+
+  const Stages = {
+    FETCHING_ADDRESSES: 'FETCHING_ADDRESSES',
+    FETCHING_SUCCESSFUL: 'FETCHING_SUCCESSFUL',
+    FETCHING_FAILED: 'FETCHING_FAILED',
+    DELETING_ADDRESS: 'DELETING_ADDRESS',
+    DELETING_SUCCESSFUL: 'DELETING_SUCCESSFUL',
+    DELETING_FAILED: 'DELETING_FAILED',
+  };
+
+  export default {
+    name: 'SelectAddressForm',
+    components: {
+      KButton,
+      KModal,
+      KRadioButton,
+      UiAlert,
+    },
+    props: {},
+    data() {
+      return {
+        addresses: [],
+        selectedAddressId: '',
+        showUiAlerts: false,
+        stage: '',
+        Stages,
+      };
+    },
+    computed: {
+      ...mapGetters('manageContent/wizard', ['isImportingMore']),
+      ...mapState('manageContent/wizard', ['transferredChannel']),
+      submitDisabled() {
+        return (
+          this.selectedAddressId === '' ||
+          this.stage === Stages.FETCHING_ADDRESSES ||
+          this.stage === Stages.DELETING_ADDRESS
+        );
+      },
+      newAddressButtonDisabled() {
+        return this.stage === Stages.FETCHING_ADDRESSES;
+      },
+      requestsSucessful() {
+        return (
+          this.stage === Stages.FETCHING_SUCCESSFUL || this.stage === Stages.DELETING_SUCCESSFUL
+        );
+      },
+      requestsFailed() {
+        return this.stage === Stages.FETCHING_FAILED || this.stage === Stages.DELETING_FAILED;
+      },
+      uiAlertProps() {
+        if (this.stage === Stages.FETCHING_ADDRESSES) {
+          return {
+            text: this.$tr('fetchingAddressesText'),
+            type: 'info',
+          };
+        }
+        if (this.requestsSucessful && this.addresses.length === 0) {
+          return {
+            text: this.$tr('noAddressText'),
+            type: 'info',
+          };
+        }
+        if (this.stage === Stages.FETCHING_FAILED) {
+          return {
+            text: this.$tr('fetchingFailedText'),
+            type: 'error',
+          };
+        }
+        if (this.stage === Stages.DELETING_FAILED) {
+          return {
+            text: this.$tr('deletingFailedText'),
+            type: 'error',
+          };
+        }
+        return null;
+      },
+    },
+    beforeMount() {
+      return this.refreshAddressList();
+    },
+    mounted() {
+      // Wait a little bit of time before showing UI alerts so there is no flash
+      // if data comes back quickly
+      setTimeout(() => {
+        this.showUiAlerts = true;
+      }, 100);
+    },
+    methods: {
+      refreshAddressList() {
+        this.stage = Stages.FETCHING_ADDRESSES;
+        this.addresses = [];
+        return fetchAddresses(this.isImportingMore ? this.transferredChannel.id : '')
+          .then(addresses => {
+            this.addresses = addresses;
+            this.resetSelectedAddress();
+            this.stage = Stages.FETCHING_SUCCESSFUL;
+          })
+          .catch(() => {
+            this.stage = Stages.FETCHING_FAILED;
+          });
+      },
+      resetSelectedAddress() {
+        const availableAddress = find(this.addresses, { available: true });
+        if (availableAddress) {
+          this.selectedAddressId = availableAddress.id;
+        } else {
+          this.selectedAddressId = '';
+        }
+      },
+      removeAddress(id) {
+        this.stage = Stages.DELETING_ADDRESS;
+        return deleteAddress(id)
+          .then(() => {
+            this.addresses = this.addresses.filter(a => a.id !== id);
+            this.resetSelectedAddress(this.addresses);
+            this.stage = Stages.DELETING_SUCCESSFUL;
+            this.$emit('removed_address');
+          })
+          .catch(() => {
+            this.stage = Stages.DELETING_FAILED;
+          });
+      },
+      handleSubmit() {
+        if (this.selectedAddressId) {
+          this.$emit('submit', find(this.addresses, { id: this.selectedAddressId }));
+        }
+      },
+    },
+    $trs: {
+      cancelButtonLabel: 'Cancel',
+      deletingFailedText: 'There was a problem removing this address',
+      fetchingAddressesText: 'Looking for available addresses…',
+      fetchingFailedText: 'There was a problem getting the available addresses',
+      forgetAddressButtonLabel: 'Forget',
+      header: 'Select network address',
+      newAddressButtonLabel: 'New address',
+      noAddressText: 'You have not entered any addresses',
+      refreshAddressesButtonLabel: 'Refresh addresses',
+      submitButtonLabel: 'Continue',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .new-address-button {
+    margin-bottom: 16px;
+  }
+
+  .radio-button {
+    display: inline-block;
+    width: 75%;
+  }
+
+</style>

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/AddAddressForm.spec.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/AddAddressForm.spec.js
@@ -1,0 +1,87 @@
+import { mount } from '@vue/test-utils';
+import AddAddressForm from '../AddAddressForm';
+import makeStore from '../../../../../test/utils/makeStore';
+import { createAddress } from '../api';
+
+jest.mock('../api', () => ({
+  createAddress: jest.fn(),
+}));
+
+function makeWrapper() {
+  const store = makeStore();
+  const wrapper = mount(AddAddressForm, {
+    store,
+  });
+  wrapper.setData({
+    name: 'Home Network',
+    nameBlurred: true,
+    address: 'home.network',
+    addressBlurred: true,
+  });
+  const els = {
+    addressTextbox: () => wrapper.findAll({ name: 'KTextbox' }).at(0),
+    nameTextbox: () => wrapper.findAll({ name: 'KTextbox' }).at(1),
+  };
+  return { store, wrapper, els };
+}
+
+describe('AddAddressForm', () => {
+  beforeEach(() => {
+    createAddress.mockReset();
+  });
+
+  it('shows a URL formatting error if API responds with one', async () => {
+    const { els, wrapper } = makeWrapper();
+    createAddress.mockRejectedValue({
+      entity: [
+        {
+          id: 'NETWORK_LOCATION_NOT_FOUND',
+        },
+      ],
+    });
+    expect(els.addressTextbox().props().invalid).toEqual(false);
+    try {
+      await wrapper.vm.handleSubmit();
+    } catch (err) {
+      expect(els.addressTextbox().props().invalid).toEqual(true);
+      expect(els.addressTextbox().props().invalidText).toEqual(
+        'Could not connect to this network address'
+      );
+    }
+  });
+
+  it('shows a server unavailable error if API responds with one', async () => {
+    const { els, wrapper } = makeWrapper();
+    createAddress.mockRejectedValue({
+      entity: [{ id: 'INVALID_NETWORK_LOCATION_FORMAT' }],
+    });
+    expect(els.addressTextbox().props().invalid).toEqual(false);
+    try {
+      await wrapper.vm.handleSubmit();
+    } catch (err) {
+      expect(els.addressTextbox().props().invalid).toEqual(true);
+      expect(els.addressTextbox().props().invalidText).toEqual(
+        'Please enter a valid IP address, URL, or hostname'
+      );
+    }
+  });
+
+  it('does not emit a "added_address" event if address and name are not provided', async () => {
+    const { els, wrapper } = makeWrapper();
+    wrapper.setData({
+      name: '',
+      address: '',
+    });
+    await wrapper.vm.handleSubmit();
+    expect(wrapper.emitted().added_address).toBeUndefined();
+    expect(els.addressTextbox().props().invalid).toEqual(true);
+    expect(els.nameTextbox().props().invalid).toEqual(true);
+  });
+
+  it('emits a "added_address" event if adding the address is successful', async () => {
+    const { wrapper } = makeWrapper();
+    createAddress.mockResolvedValue();
+    await wrapper.vm.handleSubmit();
+    expect(wrapper.emitted().added_address).toHaveLength(1);
+  });
+});

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
@@ -1,0 +1,114 @@
+import { mount } from '@vue/test-utils';
+import SelectAddressForm from '../SelectAddressForm';
+import makeStore from '../../../../../test/utils/makeStore';
+import { fetchAddresses } from '../api';
+
+const addresses = [
+  {
+    id: '1',
+    device_name: 'Available Server',
+    base_url: 'http://localhost:8000',
+    available: true,
+    hasContent: true,
+  },
+  {
+    id: '2',
+    device_name: 'Unavailable Server',
+    base_url: 'http://localhost:8001',
+    available: false,
+    hasContent: true,
+  },
+  {
+    id: '3',
+    device_name: 'Content-less Server',
+    base_url: 'http://localhost:8001',
+    available: true,
+    hasContent: false,
+  },
+];
+
+jest.mock('../api.js', () => ({
+  fetchAddresses: jest.fn(),
+  deleteAddress: jest.fn().mockResolvedValue(),
+}));
+
+function makeWrapper() {
+  const store = makeStore();
+  const wrapper = mount(SelectAddressForm, {
+    store,
+  });
+  // prettier-ignore
+  const els = {
+    KModal: () => wrapper.find({ name: 'KModal' }),
+    newAddressButton: () => wrapper.find('button.new-address-button'),
+    uiAlert: () => wrapper.find({ name: 'ui-alert' }),
+    radioButtons: () => wrapper.findAll({ name: 'KRadioButton' }),
+  };
+  return { store, wrapper, els };
+}
+
+describe('SelectAddressForm', () => {
+  beforeEach(() => {
+    fetchAddresses.mockReset();
+    fetchAddresses.mockResolvedValue(addresses);
+  });
+
+  it('shows a loading message when fetching addresses', () => {
+    // and continue button and new address buttons are disabled
+    const { els } = makeWrapper();
+    expect(els.KModal().props().submitDisabled).toEqual(true);
+    expect(els.newAddressButton().isVisible()).toEqual(false);
+    expect(els.uiAlert().exists()).toEqual(true);
+    expect(els.uiAlert().text()).toEqual('Looking for available addresses…');
+  });
+
+  it('shows one address for each one fetched', async () => {
+    const { els, wrapper } = makeWrapper();
+    await wrapper.vm.$nextTick();
+    expect(els.radioButtons()).toHaveLength(3);
+    const server1 = els.radioButtons().at(0);
+    expect(server1.props().label).toEqual('Available Server');
+    expect(server1.props().description).toEqual('http://localhost:8000');
+    // For some reason, KModal's props are not correct
+    expect(wrapper.vm.submitDisabled).toEqual(false);
+    // expect(els.KModal().props().submitDisabled).toEqual(false);
+  });
+
+  it('if there are no addresses, it shows an empty message', async () => {
+    fetchAddresses.mockResolvedValue([]);
+    const { els, wrapper } = makeWrapper();
+    await wrapper.vm.$nextTick();
+    expect(els.radioButtons()).toHaveLength(0);
+    expect(els.uiAlert().exists()).toEqual(true);
+    expect(els.uiAlert().text()).toEqual('You have not entered any addresses');
+    expect(els.KModal().props().submitDisabled).toEqual(true);
+  });
+
+  it('if an address is (un)available, it is (dis)enabled', async () => {
+    const { els, wrapper } = makeWrapper();
+    function radioButtonNIsDisabled(n) {
+      return els
+        .radioButtons()
+        .at(n)
+        .props().disabled;
+    }
+    await wrapper.vm.$nextTick();
+    expect(radioButtonNIsDisabled(0)).toEqual(false);
+    expect(radioButtonNIsDisabled(1)).toEqual(true);
+    expect(radioButtonNIsDisabled(2)).toEqual(true);
+  });
+
+  it('clicking "forget" next to an address triggers a forgetting action', async () => {
+    const { wrapper } = makeWrapper();
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.removeAddress();
+    expect(wrapper.emitted().removed_address).toHaveLength(1);
+  });
+
+  it('clicking "continue" emits a "submit" event with the selected location ID', async () => {
+    const { wrapper, els } = makeWrapper();
+    await wrapper.vm.$nextTick();
+    els.KModal().vm.$emit('submit');
+    expect(wrapper.emitted().submit[0][0].id).toEqual('1');
+  });
+});

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectNetworkAddressModal.spec.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectNetworkAddressModal.spec.js
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import makeStore from '../../../../../test/utils/makeStore';
+import SelectNetworkAddressModal from '../index.vue';
+
+jest.mock('../api.js', () => ({
+  fetchAddresses: jest.fn().mockResolvedValue([]),
+  deleteAddress: jest.fn().mockResolvedValue(),
+  createAddress: jest.fn().mockResolvedValue(),
+}));
+
+// prettier-ignore
+function makeWrapper() {
+  const store = makeStore();
+  const wrapper = mount(SelectNetworkAddressModal, {
+    store,
+  })
+  const els = {
+    SelectAddressForm: () => wrapper.find({ name: 'SelectAddressForm' }),
+    AddAddressForm: () => wrapper.find({ name: 'AddAddressForm' }),
+  };
+
+  const actions = {
+    clickNewAddress: () => els.SelectAddressForm().find({ name: 'KButton' }).vm.$emit('click'),
+    clickAddAddressCancel: () => els.AddAddressForm().vm.$emit('cancel'),
+    clickSelectAddressCancel: () => els.SelectAddressForm().vm.$emit('cancel'),
+  }
+
+  return { wrapper, store, els, actions };
+}
+
+describe('SelectNetworkAddressModal', () => {
+  it('starts on the Select Address Form', () => {
+    const { els } = makeWrapper();
+    expect(els.SelectAddressForm().isVueComponent).toBe(true);
+  });
+
+  it('clicking the "new address" button takes you to the New Address Form', () => {
+    const { els, actions } = makeWrapper();
+    actions.clickNewAddress();
+    expect(els.SelectAddressForm().exists()).toBe(false);
+    expect(els.AddAddressForm().isVueComponent).toBe(true);
+  });
+
+  it('clicking "cancel" on the New Address Form takes you back', () => {
+    const { actions, wrapper } = makeWrapper();
+    actions.clickNewAddress();
+    expect(wrapper.vm.stage).toBe('ADD_ADDRESS');
+    actions.clickAddAddressCancel();
+    // Can't test presence of component for some reason. Checking the wrapper.vm.stage
+    expect(wrapper.vm.stage).toBe('SELECT_ADDRESS');
+  });
+
+  it('click "cancel" on Select Address Form clears the wizard state', () => {
+    const { store, actions } = makeWrapper();
+    store.commit('manageContent/wizard/SET_WIZARD_PAGENAME', 'SELECT_NETWORK_ADDRESS');
+    actions.clickSelectAddressCancel();
+    expect(store.state.manageContent.wizard.pageName).toEqual('');
+  });
+
+  describe('responding to a new address', () => {
+    it('on a success, the address list is reset and a snackbar is shown', () => {
+      const { wrapper, actions, store } = makeWrapper();
+      wrapper.vm.saveAddress = jest.fn().mockResolvedValue();
+      actions.clickNewAddress();
+      wrapper.vm.handleAddedAddress({
+        name: 'New Network',
+        address: '0.0.0.1:8000',
+      });
+      // And we are sent back to the Select Address Modal
+      expect(wrapper.vm.stage).toEqual('SELECT_ADDRESS');
+      expect(store.state.core.snackbar).toEqual({
+        isVisible: true,
+        options: {
+          text: 'Successfully added address',
+          autoDismiss: true,
+        },
+      });
+    });
+  });
+  // TODO clicking submit
+});

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/api.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/api.js
@@ -26,8 +26,12 @@ export function fetchAddresses(withChannelId = '') {
     // locations that do not have the channel we are importing from.
     if (withChannelId !== '') {
       const locationsWithAvailbilityPromises = locations.map(location => {
-        return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
-          return { ...location, hasContent: isAvailable };
+        // Need to wrap in normal promise, otherwise Promise.all will cause some of these
+        // to resolve as undefined
+        return new Promise(resolve => {
+          return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
+            resolve({ ...location, hasContent: isAvailable });
+          });
         });
       });
       return Promise.all(locationsWithAvailbilityPromises);

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/api.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/api.js
@@ -1,0 +1,51 @@
+import { RemoteChannelResource } from 'kolibri.resources';
+import { NetworkLocationResource } from '../../../apiResources';
+
+function channelIsAvailableAtLocation(channelId, location) {
+  if (!location.available) {
+    return Promise.resolve(false);
+  }
+  return RemoteChannelResource.fetchModel({
+    id: channelId,
+    getParams: {
+      baseurl: location.base_url,
+    },
+    force: true,
+  })
+    .then(() => {
+      return true;
+    })
+    .catch(() => {
+      return false;
+    });
+}
+
+export function fetchAddresses(withChannelId = '') {
+  return NetworkLocationResource.fetchCollection({ force: true }).then(locations => {
+    // If channelId is provided, then we are in an 'import-more' workflow and disable
+    // locations that do not have the channel we are importing from.
+    if (withChannelId !== '') {
+      const locationsWithAvailbilityPromises = locations.map(location => {
+        return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
+          return { ...location, hasContent: isAvailable };
+        });
+      });
+      return Promise.all(locationsWithAvailbilityPromises);
+    }
+
+    // If channelId is not provided, then we are at top-level import workflow and do not
+    // disable any locations unless it is unavailable
+    return locations.map(location => ({ ...location, hasContent: location.available }));
+  });
+}
+
+export function createAddress(address) {
+  return NetworkLocationResource.createModel({
+    base_url: address.base_url,
+    device_name: address.device_name,
+  }).save();
+}
+
+export function deleteAddress(id) {
+  return NetworkLocationResource.deleteModel({ id });
+}

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
@@ -1,0 +1,92 @@
+<template>
+
+  <div>
+    <SelectAddressForm
+      v-if="stage === Stages.SELECT_ADDRESS"
+      @cancel="resetContentWizardState"
+      @click_add_address="goToAddAddress"
+      @removed_address="handleRemovedAddress"
+      @submit="handleSelectAddressSubmit"
+    />
+    <AddAddressForm
+      v-if="stage === Stages.ADD_ADDRESS"
+      @cancel="goToSelectAddress"
+      @added_address="handleAddedAddress"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
+  import { availableChannelsPageLink, selectContentPageLink } from '../manageContentLinks';
+  import AddAddressForm from './AddAddressForm';
+  import SelectAddressForm from './SelectAddressForm';
+
+  const Stages = {
+    ADD_ADDRESS: 'ADD_ADDRESS',
+    SELECT_ADDRESS: 'SELECT_ADDRESS',
+  };
+
+  export default {
+    name: 'SelectNetworkAddressModal',
+    components: {
+      AddAddressForm,
+      SelectAddressForm,
+    },
+    data() {
+      return {
+        stage: Stages.SELECT_ADDRESS,
+        Stages,
+      };
+    },
+    computed: {
+      ...mapGetters('manageContent/wizard', ['isImportingMore']),
+      ...mapState('manageContent/wizard', ['transferredChannel']),
+    },
+    methods: {
+      ...mapActions(['createSnackbar']),
+      ...mapMutations('manageContent/wizard', {
+        resetContentWizardState: 'RESET_STATE',
+      }),
+      goToAddAddress() {
+        this.stage = Stages.ADD_ADDRESS;
+      },
+      goToSelectAddress() {
+        this.stage = Stages.SELECT_ADDRESS;
+      },
+      handleAddedAddress() {
+        this.createSnackbar({
+          text: this.$tr('addAddressSnackbarText'),
+          autoDismiss: true,
+        });
+        this.goToSelectAddress();
+      },
+      handleRemovedAddress() {
+        this.createSnackbar({
+          text: this.$tr('removeAddressSnackbarText'),
+          autoDismiss: true,
+        });
+      },
+      handleSelectAddressSubmit(address) {
+        if (this.isImportingMore) {
+          this.$router.push(
+            selectContentPageLink({ addressId: address.id, channelId: this.transferredChannel.id })
+          );
+        } else {
+          this.$router.push(availableChannelsPageLink({ addressId: address.id }));
+        }
+      },
+    },
+    $trs: {
+      addAddressSnackbarText: 'Successfully added address',
+      removeAddressSnackbarText: 'Successfully removed address',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
@@ -2,7 +2,7 @@
 
   <KModal
     :title="title"
-    size="small"
+    size="medium"
     :submitText="$tr('continue')"
     :cancelText="$tr('cancel')"
     :submitDisabled="selectedDriveId===''"

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -2,7 +2,7 @@
 
   <KModal
     :title="$tr('selectLocalRemoteSourceTitle')"
-    size="small"
+    size="medium"
     :submitText="$tr('continue')"
     :cancelText="$tr('cancel')"
     :submitDisabled="formIsDisabled"
@@ -13,14 +13,20 @@
       <KRadioButton
         :label="$tr('network')"
         v-model="source"
-        value="network"
+        :value="ContentSources.KOLIBRI_STUDIO"
         :disabled="formIsDisabled || kolibriStudioIsOffline"
         :autofocus="!kolibriStudioIsOffline"
       />
       <KRadioButton
+        :label="$tr('localNetworkOrInternet')"
+        v-model="source"
+        :value="ContentSources.PEER_KOLIBRI_SERVER"
+        :disabled="formIsDisabled"
+      />
+      <KRadioButton
         :label="$tr('localDrives')"
         v-model="source"
-        value="local"
+        :value="ContentSources.LOCAL_DRIVE"
         :disabled="formIsDisabled"
       />
     </div>
@@ -31,13 +37,11 @@
 
 <script>
 
-  import { mapActions, mapMutations } from 'vuex';
+  import { mapActions, mapGetters, mapMutations } from 'vuex';
   import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
   import { RemoteChannelResource } from 'kolibri.resources';
   import KModal from 'kolibri.coreVue.components.KModal';
   import { ContentSources } from '../../../constants';
-
-  const { LOCAL_DRIVE, KOLIBRI_STUDIO } = ContentSources;
 
   export default {
     name: 'SelectImportSourceModal',
@@ -47,15 +51,19 @@
     },
     data() {
       return {
-        source: KOLIBRI_STUDIO,
+        source: ContentSources.KOLIBRI_STUDIO,
         formIsDisabled: true,
         kolibriStudioIsOffline: false,
+        ContentSources,
       };
+    },
+    computed: {
+      ...mapGetters('manageContent/wizard', ['isImportingMore']),
     },
     created() {
       RemoteChannelResource.getKolibriStudioStatus().then(({ entity }) => {
         if (entity.status === 'offline') {
-          this.source = LOCAL_DRIVE;
+          this.source = ContentSources.PEER_KOLIBRI_SERVER;
           this.kolibriStudioIsOffline = true;
         }
         this.formIsDisabled = false;
@@ -64,7 +72,8 @@
     $trs: {
       cancel: 'Cancel',
       continue: 'Continue',
-      network: 'Kolibri Studio',
+      network: 'Kolibri Studio (online)',
+      localNetworkOrInternet: 'Local network or internet',
       localDrives: 'Attached drive or memory card',
       selectLocalRemoteSourceTitle: 'Import from',
     },

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/index.vue
@@ -1,14 +1,9 @@
 <template>
 
   <div>
-    <SelectImportSourceModal
-      v-if="atSelectImportSource"
-      ref="selectImportSourceModal"
-    />
-    <SelectDriveModal
-      v-if="atSelectDrive"
-      ref="selectDriveModal"
-    />
+    <SelectImportSourceModal v-if="atSelectImportSource" />
+    <SelectDriveModal v-if="atSelectDrive" />
+    <SelectNetworkAddressModal v-if="atSelectNetworkAddress" />
   </div>
 
 </template>
@@ -17,14 +12,16 @@
 <script>
 
   import { ContentWizardPages } from '../../../constants';
+  import SelectNetworkAddressModal from '../SelectNetworkAddressModal';
   import SelectImportSourceModal from './SelectImportSourceModal';
   import SelectDriveModal from './SelectDriveModal';
 
   export default {
     name: 'SelectTransferSourceModal',
     components: {
-      SelectImportSourceModal,
       SelectDriveModal,
+      SelectImportSourceModal,
+      SelectNetworkAddressModal,
     },
     props: {
       pageName: {
@@ -37,6 +34,9 @@
       },
       atSelectDrive() {
         return this.pageName === ContentWizardPages.SELECT_DRIVE;
+      },
+      atSelectNetworkAddress() {
+        return this.pageName === ContentWizardPages.SELECT_NETWORK_ADDRESS;
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/manageContentLinks.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/manageContentLinks.js
@@ -1,28 +1,30 @@
 import { ContentWizardPages, PageNames } from '../../constants';
 
-export function selectContentTopicLink(topicNode) {
+export function selectContentTopicLink(topicNode, query) {
   return {
     name: ContentWizardPages.SELECT_CONTENT_TOPIC,
     params: {
       node_id: topicNode.id,
       node: topicNode,
     },
+    query,
   };
 }
 
 export function availableChannelsPageLink(params = {}) {
-  const { driveId, forExport } = params;
+  const { driveId, forExport, addressId } = params;
   return {
     name: ContentWizardPages.AVAILABLE_CHANNELS,
     query: {
       drive_id: driveId,
       for_export: forExport,
+      address_id: addressId,
     },
   };
 }
 
 export function selectContentPageLink(params = {}) {
-  const { channelId, driveId, forExport } = params;
+  const { channelId, driveId, forExport, addressId } = params;
   return {
     name: ContentWizardPages.SELECT_CONTENT,
     params: {
@@ -31,6 +33,7 @@ export function selectContentPageLink(params = {}) {
     query: {
       drive_id: driveId,
       for_export: forExport,
+      address_id: addressId,
     },
   };
 }

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -96,7 +96,7 @@
         'transferType',
       ]),
       breadcrumbs() {
-        return this.path.map(transformBreadrumb);
+        return this.path.map(x => transformBreadrumb(x, this.$route.query));
       },
       childNodes() {
         // Guard against when state is reset going back to manage content page
@@ -163,7 +163,7 @@
         return node.importable && node.total_resources;
       },
       updateCurrentTopicNode(node) {
-        return navigateToTopicUrl.call(this, node);
+        return navigateToTopicUrl.call(this, node, this.$route.query);
       },
       toggleSelectAll() {
         this.toggleSelection(this.annotatedTopicNode);

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentWizardUiAlert.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentWizardUiAlert.vue
@@ -25,6 +25,10 @@
     [ContentWizardErrors.TRANSFER_IN_PROGRESS]: 'transferInProgressError',
     // Recycling 'channel not found error'
     [ContentWizardErrors.TREEVIEW_LOADING_ERROR]: 'channelNotFoundError',
+    [ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_EXIST]: 'networkLocationDoesNotExist',
+    [ContentWizardErrors.NETWORK_LOCATION_UNAVAILABLE]: 'networkLocationUnavailable',
+    [ContentWizardErrors.NETWORK_LOCATION_DOES_NOT_HAVE_CHANNEL]:
+      'networkLocationDoesNotHaveChannel',
   };
 
   export default {
@@ -49,7 +53,12 @@
       driveUnavailableError: 'Drive not found or is disconnected',
       driveNotWritableError: 'Drive is not writable',
       driveError: 'There was a problem accessing the drives connected to the server',
+      networkLocationDoesNotExist: 'The device with this ID does not exist',
+      networkLocationUnavailable:
+        'The Kolibri server on the selected device is not available at the moment',
       transferInProgressError: 'A content transfer is currently in progress',
+      networkLocationDoesNotHaveChannel:
+        'The device with this ID does not have the desired channel',
     },
   };
 

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/treeViewUtils.js
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/treeViewUtils.js
@@ -195,9 +195,9 @@ export function annotateNode(node, selectedNodes, forImport = true) {
  * into a form that can be used in k-breadcrumbs props.items { text, link: LinkObject }.
  *
  */
-export function transformBreadrumb(node) {
+export function transformBreadrumb(node, query) {
   return {
     text: node.title || translator.$tr('noTitle'),
-    link: selectContentTopicLink(node),
+    link: selectContentTopicLink(node, query),
   };
 }

--- a/kolibri/plugins/device_management/assets/test/utils/makeStore.js
+++ b/kolibri/plugins/device_management/assets/test/utils/makeStore.js
@@ -63,6 +63,10 @@ const channelsOnDevice = [
   },
 ];
 
+export default function makeStore() {
+  return coreStoreFactory(pluginModule);
+}
+
 // Use for availableChannelsPage and all children:
 // channel-list-item
 export function makeAvailableChannelsPageStore() {


### PR DESCRIPTION
### Summary

Adds a workflow that allows a user to import content from a accessible and compatible Kolibri instance, complementing the other two workflows to import from Kolibri Studio or an attached USB drive with content.


### Reviewer guidance

#### General
1. Check to see that the two older workflows still work fine
1. Try to do the entire workflow with keyboard

#### Happy paths

1. Import content from a channel on a second server from top-level workflow (starting with "import" button on the top of the Manage Content Page)
1. Same, but with "import more" workflow (using button next to an already-installed channel)

#### Sad paths

1. Try to import from a server that is not "available"
1. Try to import from a server that does not have the channel you want to import
1. Try to directly access the URLs for the Available Channels Page and Select Content Page for the two scenarios above.
1. Try to delete a saved address that has already been deleted
1. Try to import from a server when offline (or Kolibri Studio is otherwise not accessible).

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
