### PR TITLE
Update the content cache key when a channel is deleted.

### DIFF
--- a/kolibri/content/models.py
+++ b/kolibri/content/models.py
@@ -23,6 +23,7 @@ from mptt.models import MPTTModel
 from mptt.models import TreeForeignKey
 
 from .utils import paths
+from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.fields import DateTimeTzField
 
 PRESET_LOOKUP = dict(format_presets.choices)
@@ -304,3 +305,4 @@ class ChannelMetadata(models.Model):
     def delete_content_tree_and_files(self):
         # Use Django ORM to ensure cascading delete:
         self.root.delete()
+        ContentCacheKey.update_cache_key()


### PR DESCRIPTION
### Summary
Remember that thing I said wouldn't be a problem? It became a problem when we started caching channels.

### Reviewer guidance
When you delete a channel, does it disappear from Learn?

### References
Fixes #4234

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
