### PR TITLE
Fix 'stars' for completed exercises

### DIFF
--- a/kolibri/plugins/learn/assets/src/state/mutations/classesMutations.js
+++ b/kolibri/plugins/learn/assets/src/state/mutations/classesMutations.js
@@ -1,7 +1,17 @@
+import Vue from 'kolibri.lib.vue';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 
 export function SET_LESSON_CONTENTNODES(state, contentNodes) {
   state.pageState.contentNodes = [...contentNodes];
+}
+
+export function SET_LESSON_CONTENTNODES_PROGRESS(state, progressArray) {
+  progressArray.forEach(progress => {
+    const contentNode = state.pageState.contentNodes.find(node => node.pk === progress.pk);
+    if (contentNode) {
+      Vue.set(contentNode, 'progress_fraction', progress.progress_fraction);
+    }
+  });
 }
 
 export function SET_CURRENT_LESSON(state, lesson) {


### PR DESCRIPTION
### Summary
This is a partial port of the changes to the lessons state management that is currently in develop.
By using ContentNodeSlim resource, makes loading more efficient, and then using ContentNodeProgress, allows dynamic updating of the progress on the lesson playlist page without requiring API calls.

### Reviewer guidance
Do lessons still render properly? Does lesson content still render properly? Does completing an exercise and then clicking back to the list page show that exercise as completed?

### References
Fixes #4236

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
