### PR TITLE
Add safety checking around content cache key fetching.

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -61,12 +61,16 @@ class ContentCacheKey(models.Model):
         cache_key.key = time.time()
         cache_key.save()
         cache.delete(CONTENT_CACHE_KEY_CACHE_KEY)
+        return cache_key
 
     @classmethod
     def get_cache_key(cls):
         key = cache.get(CONTENT_CACHE_KEY_CACHE_KEY)
         if key is None:
-            cache_key = cls.objects.get()
+            try:
+                cache_key = cls.objects.get()
+            except cls.DoesNotExist:
+                cache_key = cls.update_cache_key()
             key = cache_key.key
             cache.set(CONTENT_CACHE_KEY_CACHE_KEY, key, 5000)
         return key


### PR DESCRIPTION
### Summary
Fixes what is probably not an issue for production, but that occurred when trying to merge the content cache key changes into develop.

### Reviewer guidance
Have a quick look-see?

The basic idea is to never allow the `get_cache_key` method to throw an error during normal operation, and just generate a cache key if none exists.

### References
See https://github.com/learningequality/kolibri/pull/4233

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
