### PR TITLE
Inline nav items

### DIFF
--- a/kolibri/core/assets/src/views/LogoutSideNavEntry.vue
+++ b/kolibri/core/assets/src/views/LogoutSideNavEntry.vue
@@ -39,6 +39,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -30,6 +30,10 @@ class NavigationHook(KolibriHook):
     # : A string or lazy proxy for the url
     url = "/"
 
+    # Set this to True so that any time this is mixed in with a
+    # frontend asset hook, the resulting frontend code will be rendered inline.
+    inline = True
+
     def get_menu(self):
         menu = {}
         for hook in self.registered_hooks:

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -270,17 +270,29 @@ class WebpackBundleHook(hooks.KolibriHook):
             src = None
             if chunk['name'].endswith('.js'):
                 if self.inline:
+                    # During development, we do not write built files to disk
+                    # Because of this, this call might return None
                     src = self.get_filecontent(chunk['url'])
                 if src is not None:
+                    # If it is not None, then we can inline it
                     yield inline_js_tag.format(src=src)
                 else:
+                    # If src is None, either this is not something we should be inlining
+                    # or we are in development mode and need to fetch the file from the
+                    # development server, not the disk
                     yield js_tag.format(url=chunk['url'])
             elif chunk['name'].endswith('.css'):
                 if self.inline:
+                    # During development, we do not write built files to disk
+                    # Because of this, this call might return None
                     src = self.get_filecontent(chunk['url'])
                 if src is not None:
+                    # If it is not None, then we can inline it
                     yield inline_css_tag.format(src=src)
                 else:
+                    # If src is None, either this is not something we should be inlining
+                    # or we are in development mode and need to fetch the file from the
+                    # development server, not the disk
                     yield css_tag.format(url=chunk['url'])
 
     def frontend_message_tag(self):

--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -1,13 +1,24 @@
 from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls import url
+from django.http.response import HttpResponseRedirect
 from rest_framework.documentation import include_docs_urls
+from rest_framework_swagger.views import get_swagger_view
 
 from kolibri.deployment.default.urls import urlpatterns
 from kolibri.utils.api import Generator
 
+
+def webpack_redirect_view(request):
+    return HttpResponseRedirect('http://127.0.0.1:3000/__open-in-editor?{query}'.format(query=request.GET.urlencode()))
+
+
+schema_view = get_swagger_view(title='Kolibri API')
+
 urlpatterns = urlpatterns + [
-    url(r'^docs/', include_docs_urls(title='Kolibri API', generator_class=Generator))
+    url(r'^docs/', include_docs_urls(title='Kolibri API', generator_class=Generator)),
+    url(r'^__open-in-editor/', webpack_redirect_view),
+    url(r'^api_explorer/', schema_view)
 ]
 
 if getattr(settings, 'DEBUG_PANEL_ACTIVE', False):
@@ -16,22 +27,3 @@ if getattr(settings, 'DEBUG_PANEL_ACTIVE', False):
     urlpatterns = [
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
-
-if getattr(settings, 'REST_SWAGGER', False):
-    from rest_framework_swagger.views import get_swagger_view
-
-    schema_view = get_swagger_view(title='Kolibri API')
-
-    urlpatterns += [
-        url(r'^api_explorer/', schema_view)
-    ]
-
-if getattr(settings, 'REDIRECT_WEBPACK', False):
-    from django.http.response import HttpResponseRedirect
-
-    def webpack_redirect_view(request):
-        return HttpResponseRedirect('http://127.0.0.1:3000/__open-in-editor?{query}'.format(query=request.GET.urlencode()))
-
-    urlpatterns += [
-        url(r'^__open-in-editor/', webpack_redirect_view)
-    ]

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -106,6 +106,17 @@ QUEUE_JOB_STORAGE_PATH = os.path.join(conf.KOLIBRI_HOME, "job_storage.sqlite3")
 # By default don't cache anything unless it explicitly requests it to!
 CACHE_MIDDLEWARE_SECONDS = 0
 
+CACHES = {
+    # Default cache
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    # Cache for builtfiles - frontend assets that only change on upgrade.
+    'built_files': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+}
+
 ROOT_URLCONF = 'kolibri.deployment.default.urls'
 
 TEMPLATES = [

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -6,10 +6,6 @@ from .base import *  # noqa isort:skip @UnusedWildImport
 
 INSTALLED_APPS += ['rest_framework_swagger']  # noqa
 
-REST_SWAGGER = True
-
-REDIRECT_WEBPACK = True
-
 INTERNAL_IPS = ['127.0.0.1']
 
 ROOT_URLCONF = 'kolibri.deployment.default.dev_urls'

--- a/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.vue
@@ -43,6 +43,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/plugins/device_management/assets/src/views/DeviceManagementSideNavEntry.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceManagementSideNavEntry.vue
@@ -43,6 +43,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/plugins/facility_management/assets/src/views/FacilityManagementSideNavEntry.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityManagementSideNavEntry.vue
@@ -43,6 +43,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
@@ -41,6 +41,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/plugins/user/assets/src/views/LoginSideNavEntry.vue
+++ b/kolibri/plugins/user/assets/src/views/LoginSideNavEntry.vue
@@ -45,6 +45,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/plugins/user/assets/src/views/UserProfileSideNavEntry.vue
+++ b/kolibri/plugins/user/assets/src/views/UserProfileSideNavEntry.vue
@@ -44,6 +44,3 @@
   export default component;
 
 </script>
-
-
-<style lang="scss" scoped></style>

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -252,6 +252,10 @@ def update():
     from kolibri.core.content.utils.annotation import update_channel_metadata
     update_channel_metadata()
 
+    from django.core.cache import caches
+    cache = caches['built_files']
+    cache.clear()
+
 
 update.called = False
 


### PR DESCRIPTION
### Summary
#3559 created glorious, wonderful, pluggable side nav items.

However, the approach that was eventually taken resulted in many little webpack bundles being included into the template to support this.

Also, in spite of having no styling inside them, these curious little bundles also produced empty css files that were useless, but added an extra request to page load.

### Reviewer guidance
This PR attempts to resolve the above problems thusly:
* Firstly, it adds an `inline` property that allows JS and CSS for `WebpackFrontendHook`s to be inlined into the Django template.
* It applies this `inline` property to the `NavigationHook` class, so that any time this is mixed in with the `WebpackFrontEndHook`, then the nav items are inlined in the template.
* After some frustrating investigation, it became apparent that the empty css blocks were due to vue-loader insisting that there was some css, so this was resolved by removing the empty `<style>` blocks from the side nav components.

Caveats:
* This only affects production, development stays the same, as I didn't want to implement fetching the files from the webpack dev server.
* Applying the `inline` property to the `NavigationHook` class appears a slightly risky approach at first glance, as it depends which order the mixins are added to the child hooks - so this might need some cleanup.
* The inlining could break relative path references for files, so it might not be possible to use an image in a nav item or other inlined code.
* The inlining could be potentially detrimental to performance (I have attempted to mitigate this by caching the reading of static files from disk), as it increases the size of the template which is never cached by Django according to our current caching setup. In addition, these static files are normally served by CherryPy, and hence never normally have to traverse the Django server in production. This could be further mitigated once 0.10 is merged into develop, and we add additional caching logic to allow generated HTML to be better cached.

### References
Some of the code for accessing static files is modified from [django-compressor](https://django-compressor.readthedocs.io/en/latest/), a project we had previously used in KA Lite, but eventually removed.

As far as I can tell, it does not allow the intermixing of JS and CSS when compressing frontend assets, so would be harder to quickly drop in for our purposes, but given that there is no CSS currently for side nav items, it could potentially be used. However, when I tried an initial naive implementation, it gave errors.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
