### PR TITLE
Use powers of 10 instead of 2 for KB, MB and GB

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/bytesForHumans.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/bytesForHumans.js
@@ -8,9 +8,9 @@ const translator = createTranslator('BytesForHumansStrings', {
 });
 
 const ONE_B = 1;
-const ONE_KB = 1024;
-const ONE_MB = 1048576;
-const ONE_GB = 1073741824;
+const ONE_KB = 10 ** 3;
+const ONE_MB = 10 ** 6;
+const ONE_GB = 10 ** 9;
 
 const stringMap = {
   [ONE_B]: 'fileSizeInBytes',

--- a/kolibri/plugins/device_management/assets/test/bytesForHumans.spec.js
+++ b/kolibri/plugins/device_management/assets/test/bytesForHumans.spec.js
@@ -1,8 +1,8 @@
 import bytesForHumans from '../src/views/ManageContentPage/bytesForHumans';
 
-const ONE_KB = 1024;
-const ONE_MB = 1048576;
-const ONE_GB = 1073741824;
+const ONE_KB = 10 ** 3;
+const ONE_MB = 10 ** 6;
+const ONE_GB = 10 ** 9;
 
 describe('bytesForHumans utility', () => {
   it('formats correctly for 0B', () => {

--- a/kolibri/plugins/device_management/assets/test/utils/makeStore.js
+++ b/kolibri/plugins/device_management/assets/test/utils/makeStore.js
@@ -46,7 +46,7 @@ const channelsOnDevice = [
   {
     ...allChannels[0],
     on_device_resources: 2000,
-    on_device_file_size: 95189556, // about 90 MB
+    on_device_file_size: 95189556, // about 95 MB
     available: true,
   },
   {

--- a/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
@@ -135,7 +135,7 @@ describe('channelListItem', () => {
     // ...and does not show the "On Device" indicator
     function test(wrapper) {
       const { resourcesSizeText, onDevice } = getElements(wrapper);
-      expect(resourcesSizeText()).toEqual('90 MB');
+      expect(resourcesSizeText()).toEqual('95 MB');
       expect(onDevice().exists()).toEqual(false);
     }
     test(manageWrapper);

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -73,7 +73,7 @@ describe('selectContentPage', () => {
     const { totalSizeRows } = getElements(wrapper);
     const rows = totalSizeRows();
     expect(rows.at(1).text()).toEqual('1,000');
-    expect(rows.at(2).text()).toEqual('4 GB');
+    expect(rows.at(2).text()).toEqual('5 GB');
   });
 
   it('if resources are on the device, it shows the total size of those', () => {
@@ -81,7 +81,7 @@ describe('selectContentPage', () => {
     const { onDeviceRows } = getElements(wrapper);
     const rows = onDeviceRows();
     expect(rows.at(1).text()).toEqual('2,000');
-    expect(rows.at(2).text()).toEqual('90 MB');
+    expect(rows.at(2).text()).toEqual('95 MB');
   });
 
   it('if channel is not on device, it shows size and resources as 0', () => {

--- a/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
@@ -46,7 +46,7 @@ describe('selectedResourcesSize component', () => {
   it('shows correct "resources selected" message given resourceCount & fileSize props', () => {
     const wrapper = makeWrapper();
     const { resourcesSelectedMsg } = getElements(wrapper);
-    expect(resourcesSelectedMsg()).toEqual('Resources selected: 10 (9 MB)');
+    expect(resourcesSelectedMsg()).toEqual('Resources selected: 10 (10 MB)');
   });
 
   it('confirmation button is disabled when no resources are selected', () => {


### PR DESCRIPTION
### Summary

This change simply updates the Kilo, Mega and Giga constants in the `bytesForHumans` Vue helper function to use powers of 10 rather than powers of 2.

### Reviewer guidance
Visit Device - Info page in Kolibri and compare the free disk space size to the one from your OS with and without the change introduced in this PR.

### References
Issue: https://github.com/learningequality/kolibri/issues/4272

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
