### PR TITLE
infer dataset on logs if defined

### DIFF
--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -74,10 +74,16 @@ class BaseLogModel(AbstractFacilityDataModel):
     def infer_dataset(self, *args, **kwargs):
         if self.user:
             return self.user.dataset
-        else:
-            facility = Facility.get_default_facility()
-            assert facility, "Before you can save logs, you must have a facility"
-            return facility.dataset
+        elif self.dataset_id:
+            # confirm that there exists a facility with that dataset_id
+            try:
+                return Facility.objects.get(dataset_id=self.dataset_id).dataset
+            except Facility.DoesNotExist:
+                pass
+        # if no user or matching facility, infer dataset from the default facility
+        facility = Facility.get_default_facility()
+        assert facility, "Before you can save logs, you must have a facility"
+        return facility.dataset
 
     objects = BaseLogQuerySet.as_manager()
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

If there is a dataset defined on a log, but the user is anonymous, then attempt to confirm dataset by checking if there is an existing facility for that dataset.
This fixes an issue during morango deserialization in which the inferred dataset does not match the actual dataset on logs that are anonymous. This is an issue for devices that have multiple facilities that are being synced because the default dataset is not always the actual dataset for the log in question.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
