### PR TITLE
Show notification on SelectImportSourceModal while checking STudio

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -9,25 +9,31 @@
     @submit="goForward"
     @cancel="resetContentWizardState"
   >
-    <div>
+    <UiAlert
+      v-if="formIsDisabled"
+      type="info"
+      :dismissible="false"
+    >
+      {{ $tr('loadingMessage') }}
+    </UiAlert>
+
+    <div v-else>
       <KRadioButton
         :label="$tr('network')"
         v-model="source"
         :value="ContentSources.KOLIBRI_STUDIO"
-        :disabled="formIsDisabled || kolibriStudioIsOffline"
+        :disabled="kolibriStudioIsOffline"
         :autofocus="!kolibriStudioIsOffline"
       />
       <KRadioButton
         :label="$tr('localNetworkOrInternet')"
         v-model="source"
         :value="ContentSources.PEER_KOLIBRI_SERVER"
-        :disabled="formIsDisabled"
       />
       <KRadioButton
         :label="$tr('localDrives')"
         v-model="source"
         :value="ContentSources.LOCAL_DRIVE"
-        :disabled="formIsDisabled"
       />
     </div>
   </KModal>
@@ -41,6 +47,7 @@
   import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
   import { RemoteChannelResource } from 'kolibri.resources';
   import KModal from 'kolibri.coreVue.components.KModal';
+  import UiAlert from 'keen-ui/src/UiAlert';
   import { ContentSources } from '../../../constants';
 
   export default {
@@ -48,6 +55,7 @@
     components: {
       KRadioButton,
       KModal,
+      UiAlert,
     },
     data() {
       return {
@@ -76,6 +84,7 @@
       localNetworkOrInternet: 'Local network or internet',
       localDrives: 'Attached drive or memory card',
       selectLocalRemoteSourceTitle: 'Import from',
+      loadingMessage: 'Loading connections…',
     },
     methods: {
       ...mapActions('manageContent/wizard', ['goForwardFromSelectImportSourceModal']),


### PR DESCRIPTION

### Summary

Shows a on the Select Import Source Modal if it takes more than 100 msec to determine whether or not Kolibri Studio is available.

![loading](https://user-images.githubusercontent.com/10248067/45706402-07981880-bb31-11e8-9978-1b851e19c062.gif)

Fixes #4070

### Reviewer guidance

1. Check modal behavior on a fast connection
1. Check modal behavior on a slow connection
1. Check modal behavior when offline

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
