### PR TITLE
Make any cross-plugin url references safe to plugin removal.

### DIFF
--- a/kolibri/core/assets/src/core-app/__mocks__/urls.js
+++ b/kolibri/core/assets/src/core-app/__mocks__/urls.js
@@ -1,10 +1,18 @@
-const urls = new Proxy(
-  {},
-  {
-    get() {
-      return () => '';
-    },
-  }
-);
+let returnedUrl = 'test';
+
+const urlsObject = {
+  __setUrl(url) {
+    returnedUrl = url;
+  },
+};
+
+const urls = new Proxy(urlsObject, {
+  get(obj, prop) {
+    if (obj[prop]) {
+      return obj[prop];
+    }
+    return () => returnedUrl;
+  },
+});
 
 export default urls;

--- a/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassListPage.vue
@@ -9,9 +9,9 @@
     >
       <KExternalLink
         slot="details"
-        v-if="isAdmin"
+        v-if="isAdmin && createClassUrl"
         :text="$tr('noClassesDetailsForAdmin')"
-        href="/facility"
+        :href="createClassUrl"
       />
     </AuthMessage>
 
@@ -70,6 +70,7 @@
   import orderBy from 'lodash/orderBy';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
+  import urls from 'kolibri.urls';
   import { PageNames } from '../constants';
   import { filterAndSortUsers } from '../../../../facility_management/assets/src/userSearchUtils';
 
@@ -122,6 +123,12 @@
         }
         if (this.isFacilityCoach) {
           return this.$tr('noClassesDetailsForFacilityCoach');
+        }
+      },
+      createClassUrl() {
+        const facilityUrl = urls['kolibri:facilitymanagementplugin:facility_management'];
+        if (facilityUrl) {
+          return facilityUrl();
         }
       },
     },

--- a/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/ClassListPage.spec.js
@@ -1,6 +1,9 @@
 import { mount } from '@vue/test-utils';
+import urls from 'kolibri.urls';
 import makeStore from '../makeStore';
 import ClassListPage from '../../src/views/ClassListPage';
+
+jest.mock('kolibri.urls');
 
 function makeWrapper() {
   const store = makeStore();
@@ -45,7 +48,9 @@ describe('ClassListPage', () => {
       });
     });
 
-    it('when an admin and no classes in facility', () => {
+    it('when an admin and no classes in facility and a facility url is defined', () => {
+      const testUrl = '/facility';
+      urls.__setUrl(testUrl);
       const { els, store } = makeWrapper();
       store.state.core.session.kind = ['admin'];
       testAuthMessage(els, {
@@ -53,7 +58,19 @@ describe('ClassListPage', () => {
         bodyText: 'Create a class and enroll learners',
       });
       // prettier-ignore
-      expect(els.AuthMessage().find('a').attributes().href).toEqual('/facility');
+      expect(els.AuthMessage().find('a').attributes().href).toEqual(testUrl);
+    });
+
+    it('when an admin and no classes in facility and no facility url is defined', () => {
+      urls.__setUrl(undefined);
+      const { els, store } = makeWrapper();
+      store.state.core.session.kind = ['admin'];
+      testAuthMessage(els, {
+        headerText: 'There are no classes yet',
+        bodyText: 'Create a class and enroll learners',
+      });
+      // prettier-ignore
+      expect(els.AuthMessage().find('a').exists()).toBeFalsy();
     });
 
     it('when a facility coach and no classes in facility', () => {

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -3,7 +3,7 @@
   <div>
     <h1>{{ $tr('header') }}</h1>
     <p>
-      <KExternalLink :text="$tr('adminLink')" href="/device/#/content" />
+      <KExternalLink v-if="deviceContentUrl" :text="$tr('adminLink')" :href="deviceContentUrl" />
     </p>
   </div>
 
@@ -13,6 +13,7 @@
 <script>
 
   import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
+  import urls from 'kolibri.urls';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -23,6 +24,14 @@
     },
     components: {
       KExternalLink,
+    },
+    computed: {
+      deviceContentUrl() {
+        const deviceContentUrl = urls['kolibri:devicemanagementplugin:device_management'];
+        if (deviceContentUrl) {
+          return `${deviceContentUrl()}#/content`;
+        }
+      },
     },
     $trs: {
       header: 'No content channels available',

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -41,7 +41,7 @@
     </div>
 
     <div v-if="pointsAreVisible" class="points-wrapper">
-      <a class="points-link" href="/user"><TotalPoints /></a>
+      <a class="points-link" :href="userProfileLink"><TotalPoints /></a>
     </div>
 
     <div>
@@ -62,6 +62,7 @@
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import KNavbar from 'kolibri.coreVue.components.KNavbar';
   import KNavbarLink from 'kolibri.coreVue.components.KNavbarLink';
+  import urls from 'kolibri.urls';
   import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
   import ChannelsPage from './ChannelsPage';
   import TopicsPage from './TopicsPage';
@@ -231,6 +232,12 @@
         const isAssessment = content && content.assessment;
         // height of .attempts-container in AssessmentWrapper
         return isAssessment ? BOTTOM_SPACED_RESERVED : 0;
+      },
+      userProfileLink() {
+        const profileLink = urls['kolibri:user:user'];
+        if (profileLink) {
+          return profileLink();
+        }
       },
     },
   };


### PR DESCRIPTION
### Summary
Continuing cleanup of cross-plugin references.

Previous to this PR we had some bare references to URLs, this was unsafe for plugin purposes, and also due to the new `URL_PATH_PREFIX` option which means these links would have broken.

This PR resolves these two issues by referencing URLs from the kolibri `urls` object, and then only attempting to invoke the URL function if it exists.

### Reviewer guidance
Do these links still function?

Question:
1) The pattern in here could be made more general by making the URLs object return a function that returns `undefined` when the URL is not defined, which would avoid having to reimplement undefined checking on the URL function itself - would this be useful? My sense is it might be overkill.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
