### PR TITLE
Turn num_coach_contents into an explicitly included field

### DIFF
--- a/kolibri/plugins/coach/serializers.py
+++ b/kolibri/plugins/coach/serializers.py
@@ -15,7 +15,7 @@ from rest_framework import serializers
 from .utils.return_users import get_members_or_user
 from kolibri.auth.models import FacilityUser
 from kolibri.content.models import ContentNode
-from kolibri.content.serializers import ContentNodeSerializer
+from kolibri.content.utils.import_export_content import get_num_coach_contents
 from kolibri.core.lessons.models import Lesson
 from kolibri.logger.models import ContentSummaryLog
 
@@ -225,7 +225,7 @@ class ContentReportSerializer(serializers.ModelSerializer):
         value = super(ContentReportSerializer, self).to_representation(instance)
         value['progress'] = progress
         value['last_active'] = last_active
-        value['num_coach_contents'] = ContentNodeSerializer(instance, context=self.context).data['num_coach_contents']
+        value['num_coach_contents'] = get_num_coach_contents(instance)
         return value
 
 

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentTransferActions.js
@@ -1,5 +1,6 @@
-import { ChannelResource, TaskResource } from 'kolibri.resources';
+import { TaskResource } from 'kolibri.resources';
 import { taskList, wizardState, inLocalImportMode, inRemoteImportMode } from '../getters';
+import ChannelResource from '../../apiResources/deviceChannel';
 import { TaskStatuses } from '../../constants';
 
 export const ErrorTypes = {

--- a/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
+++ b/kolibri/plugins/device_management/assets/src/state/actions/contentWizardActions.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { handleApiError, samePageCheckGenerator } from 'kolibri.coreVue.vuex.actions';
-import { RemoteChannelResource, ChannelResource } from 'kolibri.resources';
+import { RemoteChannelResource } from 'kolibri.resources';
 import router from 'kolibri.coreVue.router';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { ContentWizardPages, ContentWizardErrors, TransferTypes } from '../../constants';
@@ -10,6 +10,7 @@ import {
   selectContentPageLink,
   manageContentPageLink,
 } from '../../views/manage-content-page/manageContentLinks';
+import ChannelResource from '../../apiResources/deviceChannel';
 import { isImportingMore } from '../getters';
 import {
   getAvailableSpaceOnDrive,

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -2,7 +2,8 @@
 import { expect } from 'chai';
 import Vue from 'vue-test'; // eslint-disable-line
 import sinon from 'sinon';
-import { ChannelResource, ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
+import { ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
+import ChannelResource from '../../src/apiResources/deviceChannel';
 import { loadChannelMetaData } from '../../src/state/actions/selectContentActions';
 import { wizardState } from '../../src/state/getters';
 import { mockResource } from 'testUtils'; // eslint-disable-line

--- a/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
@@ -5,7 +5,7 @@ import {
 } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { handleApiError } from 'kolibri.coreVue.vuex.actions';
-import { isUserLoggedIn } from 'kolibri.coreVue.vuex.getters';
+import { isUserLoggedIn, isCoach, isAdmin } from 'kolibri.coreVue.vuex.getters';
 import { LearnerClassroomResource, LearnerLessonResource } from '../../apiResources';
 import { ClassesPageNames } from '../../constants';
 
@@ -90,7 +90,14 @@ export function showLessonPlaylist(store, { lessonId }) {
         },
       });
       store.dispatch('SET_CURRENT_LESSON', lesson);
-      return ContentNodeSlimResource.getCollection({ in_lesson: lesson.id }).fetch();
+      const include_fields = [];
+      if (isCoach(store.state) || isAdmin(store.state)) {
+        include_fields.push('num_coach_contents');
+      }
+      return ContentNodeSlimResource.getCollection({
+        in_lesson: lesson.id,
+        include_fields,
+      }).fetch();
     })
     .then(contentNodes => {
       const sortedContentNodes = contentNodes.sort((a, b) => {


### PR DESCRIPTION
### Summary
* Coach contents would be dynamically returned depending on the role of the user
* Content node endpoints were being aggressively cached
* This meant that coach content numbers might not be correct
* This PR fixes that by requiring that requests for coach contents be explicitly added to the URL, avoiding the caching overlap.
* This PR fixes a few merge resolutions that failed to move the Device Management plugin to just use the device plugin specific channel resource.

### Reviewer guidance
Does importing content work?
Does displaying coach content icons work?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
