### PR TITLE
move dedupe by content_id to custom manager/queryset

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -456,16 +456,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
                     .order_by('-content_id__count')
 
                 most_popular = queryset.filter(content_id__in=list(content_counts_sorted[:20]))
-
-                # remove duplicate content items
-                deduped_list = []
-                content_ids = set()
-                for node in most_popular:
-                    if node.content_id not in content_ids:
-                        deduped_list.append(node)
-                        content_ids.add(node.content_id)
-
-                queryset = most_popular.filter(id__in=[node.id for node in deduped_list])
+                queryset = most_popular.dedupe_by_content_id()
 
             serializer = self.get_serializer(queryset, many=True)
 
@@ -503,16 +494,7 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
                 queryset = queryset.none()
             else:
                 resume = queryset.filter(content_id__in=list(content_ids[:10]))
-
-                # remove duplicate content items
-                deduped_list = []
-                content_ids = set()
-                for node in resume:
-                    if node.content_id not in content_ids:
-                        deduped_list.append(node)
-                        content_ids.add(node.content_id)
-
-                queryset = resume.filter(id__in=[node.id for node in deduped_list])
+                queryset = resume.dedupe_by_content_id()
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -56,8 +56,10 @@ from le_utils.constants import content_kinds
 from le_utils.constants import file_formats
 from le_utils.constants import format_presets
 from le_utils.constants.languages import LANGUAGE_DIRECTIONS
+from mptt.managers import TreeManager
 from mptt.models import MPTTModel
 from mptt.models import TreeForeignKey
+from mptt.querysets import TreeQuerySet
 
 from .utils import paths
 from kolibri.core.device.models import ContentCacheKey
@@ -140,6 +142,38 @@ class ContentTag(models.Model):
         return self.tag_name
 
 
+class ContentNodeQueryset(TreeQuerySet):
+
+    def dedupe_by_content_id(self):
+        # remove duplicate content nodes based on content_id
+        if OPTIONS['Database']["DATABASE_ENGINE"] == "sqlite":
+            # filter by ids for the deduplicated content nodes
+            deduped_list = []
+            content_ids = set()
+            for node in self:
+                if node.content_id not in content_ids:
+                    deduped_list.append(node)
+                    content_ids.add(node.content_id)
+            return self.filter(id__in=[node.id for node in deduped_list])
+
+        # when using postgres, we can call distinct on a specific column
+        elif OPTIONS['Database']["DATABASE_ENGINE"] == "postgres":
+            return self.order_by('content_id').distinct('content_id')
+
+
+class ContentNodeManager(models.Manager.from_queryset(ContentNodeQueryset), TreeManager):
+
+    def get_queryset(self, *args, **kwargs):
+        """
+        Ensures that this manager always returns nodes in tree order.
+        """
+        return super(TreeManager, self).get_queryset(
+            *args, **kwargs
+        ).order_by(
+            self.tree_id_attr, self.left_attr
+        )
+
+
 @python_2_unicode_compatible
 class ContentNode(MPTTModel):
     """
@@ -172,6 +206,8 @@ class ContentNode(MPTTModel):
     available = models.BooleanField(default=False)
     stemmed_metaphone = models.CharField(max_length=1800, blank=True)  # for fuzzy search in title and description
     lang = models.ForeignKey('Language', blank=True, null=True)
+
+    objects = ContentNodeManager()
 
     class Meta:
         ordering = ('lft',)

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -48,6 +48,7 @@ import uuid
 from gettext import gettext as _
 
 from django.core.urlresolvers import reverse
+from django.db import connection
 from django.db import models
 from django.db.models import Min
 from django.utils.encoding import python_2_unicode_compatible
@@ -146,14 +147,15 @@ class ContentTag(models.Model):
 class ContentNodeQueryset(TreeQuerySet):
 
     def dedupe_by_content_id(self):
+        # import ipdb; ipdb.set_trace()
         # remove duplicate content nodes based on content_id
-        if OPTIONS['Database']["DATABASE_ENGINE"] == "sqlite":
+        if connection.vendor == "sqlite":
             # adapted from https://code.djangoproject.com/ticket/22696
             deduped_ids = self.values('content_id').annotate(node_id=Min('id')).values_list('node_id', flat=True)
             return self.filter(id__in=deduped_ids)
 
         # when using postgres, we can call distinct on a specific column
-        elif OPTIONS['Database']["DATABASE_ENGINE"] == "postgres":
+        elif connection.vendor == "postgresql":
             return self.order_by('content_id').distinct('content_id')
 
 

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -325,7 +325,7 @@ def calculate_published_size(channel):
 
 def calculate_total_resource_count(channel):
     content_nodes = ContentNode.objects.filter(channel_id=channel.id)
-    channel.total_resource_count = content_nodes.filter(available=True).exclude(kind=content_kinds.TOPIC).count()
+    channel.total_resource_count = content_nodes.filter(available=True).exclude(kind=content_kinds.TOPIC).dedupe_by_content_id().count()
     channel.save()
 
 

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -49,7 +49,10 @@ class LocalFileFactory(factory.DjangoModelFactory):
 def create_mini_channel(channel_name='channel', channel_id=uuid.uuid4(), root_lang='en'):
     root = ContentNodeFactory.create(kind=content_kinds.TOPIC, channel_id=channel_id, lang_id=root_lang)
     child1 = ContentNodeFactory.create(parent=root, kind=content_kinds.VIDEO, channel_id=channel_id)
-    child2 = ContentNodeFactory.create(parent=root, kind=content_kinds.VIDEO, channel_id=channel_id)
+    dupe_content_id = uuid.uuid4().hex
+    child2 = ContentNodeFactory.create(parent=root, kind=content_kinds.VIDEO, channel_id=channel_id, content_id=dupe_content_id)
+    # create child3 node with duplicate content_id
+    ContentNodeFactory.create(parent=child1, kind=content_kinds.VIDEO, channel_id=channel_id, content_id=dupe_content_id)
     l1 = LocalFileFactory.create(id=uuid.uuid4().hex)
     l2 = LocalFileFactory.create(id=uuid.uuid4().hex)
     FileFactory.create(contentnode=child1, local_file=l1)
@@ -127,7 +130,7 @@ class PublicAPITestCase(APITestCase):
             'name': 'science',
             'language': 'es',  # root node language
             'description': '',
-            'total_resource_count': 2,
+            'total_resource_count': 2,  # should account for nodes with duplicate content_ids
             'version': 0,
             'published_size': 20,
             'last_published': None,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Moved deduplication of content nodes by `content_id` to a manager/queryset method.
Used in `most_popular` and `resume` endpoints and `total_resource_count` calculation.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does kolibri content related pages still work? do any errors come up about methods being undefined?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
