### PR TITLE
clarify disk availability

### DIFF
--- a/kolibri/core/assets/src/styles/main.scss
+++ b/kolibri/core/assets/src/styles/main.scss
@@ -99,6 +99,15 @@ button {
   }
 }
 
+hr {
+  display: block;
+  height: 1px;
+  padding: 0;
+  margin: 1em 0;
+  border: 0;
+  border-top: 1px solid $core-text-disabled;
+}
+
 .rtl-icon {
   transform: scaleX(-1);
 }

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
@@ -1,45 +1,40 @@
 <template>
 
-  <section>
-    <div class="counters">
-      <div class="choose-message">
-        <span v-if="isInImportMode">
-          {{ $tr('chooseContentToImport') }}
-        </span>
-        <span v-else>
-          {{ $tr('chooseContentToExport') }}
-        </span>
-      </div>
-
-      <div class="table-row">
-        <span class="remaining-space">
-          {{ $tr('remainingSpace', { space: bytesForHumans(remainingSpaceAfterTransfer) }) }}
-        </span>
-
-        <div class="resources-selected">
-          <span class="resources-selected-message">
-            {{ fileSizeText }}
-          </span>
-
-          <KButton
-            class="confirm-button"
-            :text="buttonText"
-            :primary="true"
-            :disabled="buttonIsDisabled"
-            @click="$emit('clickconfirm')"
-          />
-        </div>
-      </div>
-    </div>
-
-    <UiAlert
-      v-if="remainingSpaceAfterTransfer<=0"
-      type="error"
-      :dismissible="false"
-    >
-      {{ $tr('notEnoughSpace') }}
-    </UiAlert>
-  </section>
+  <KGrid>
+    <KGridItem sizes="100, 75, 75" percentage>
+      <h3 class="choose-message" v-if="isInImportMode">
+        {{ $tr('chooseContentToImport') }}
+      </h3>
+      <h3 class="choose-message" v-else>
+        {{ $tr('chooseContentToExport') }}
+      </h3>
+      <p class="available-space">
+        {{ $tr('availableSpace', { space: bytesForHumans(spaceOnDrive) }) }}
+      </p>
+      <p class="resources-selected-message">
+        {{ fileSizeText }}
+      </p>
+    </KGridItem>
+    <KGridItem sizes="100, 25, 25" percentage alignments="left, right, right">
+      <KButton
+        class="confirm-button"
+        :text="buttonText"
+        :primary="true"
+        :disabled="buttonIsDisabled"
+        @click="$emit('clickconfirm')"
+        :style="{ top: buttonOffset }"
+      />
+    </KGridItem>
+    <KGridItem size="100" percentage>
+      <UiAlert
+        v-if="remainingSpaceAfterTransfer <= 0"
+        type="error"
+        :dismissible="false"
+      >
+        {{ $tr('notEnoughSpace') }}
+      </UiAlert>
+    </KGridItem>
+  </KGrid>
 
 </template>
 
@@ -47,6 +42,9 @@
 <script>
 
   import KButton from 'kolibri.coreVue.components.KButton';
+  import KGrid from 'kolibri.coreVue.components.KGrid';
+  import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiAlert from 'keen-ui/src/UiAlert';
   import bytesForHumans from '../ManageContentPage/bytesForHumans';
 
@@ -56,8 +54,11 @@
     name: 'SelectedResourcesSize',
     components: {
       KButton,
+      KGrid,
+      KGridItem,
       UiAlert,
     },
+    mixins: [responsiveWindow],
     props: {
       mode: {
         type: String,
@@ -89,6 +90,12 @@
           resources: this.resourceCount,
         });
       },
+      buttonOffset() {
+        if (this.windowIsSmall) {
+          return '0';
+        }
+        return '72px';
+      },
     },
     methods: {
       bytesForHumans,
@@ -99,8 +106,9 @@
       export: 'export',
       import: 'import',
       notEnoughSpace: 'Not enough space on your device. Select less content to make more space.',
-      remainingSpace: 'Your remaining space: {space}',
-      resourcesSelected: 'Resources selected: {resources, number, integer} ({fileSize})',
+      availableSpace: 'Space available: {space}',
+      resourcesSelected:
+        'Content selected: {fileSize} ({resources, number, integer} {resources, plural, one {resource} other {resources}})',
     },
   };
 
@@ -109,36 +117,9 @@
 
 <style lang="scss" scoped>
 
-  .counters {
-    // using table to separate element by alignment while keeping them on the same line
-    // avoids magic numbers, keeps text lined up.
-    display: table;
-    width: 100%;
-    line-height: 1em;
-  }
-
-  .choose-message {
-    display: table-row;
-    padding: 8px 0;
-    font-weight: bold;
-  }
-
-  .remaining-space {
-    display: table-cell;
-    text-align: left;
-  }
-
-  .resources-selected {
-    display: table-cell;
-    text-align: right;
-  }
-
-  .table-row {
-    display: table-row;
-  }
-
   .confirm-button {
-    margin-right: 0;
+    position: relative;
+    margin: 0;
   }
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
@@ -106,7 +106,7 @@
       export: 'export',
       import: 'import',
       notEnoughSpace: 'Not enough space on your device. Select less content to make more space.',
-      availableSpace: 'Space available: {space}',
+      availableSpace: 'Drive space available: {space}',
       resourcesSelected:
         'Content selected: {fileSize} ({resources, number, integer} {resources, plural, one {resource} other {resources}})',
     },

--- a/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
@@ -87,7 +87,7 @@ describe('selectedResourcesSize component', () => {
   it('shows the "remaining space message"', () => {
     const wrapper = makeWrapper();
     const { availableSpaceMsg } = getElements(wrapper);
-    expect(availableSpaceMsg()).toEqual('Space available: 5 GB');
+    expect(availableSpaceMsg()).toEqual('Drive space available: 5 GB');
   });
 
   it('shows an error notification when remaining space goes to zero', () => {

--- a/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/selected-resources-size.spec.js
@@ -23,7 +23,7 @@ function getElements(wrapper) {
     buttonText: () => wrapper.find(KButton).text().trim(),
     chooseMsg: () => wrapper.find('.choose-message').text().trim(),
     notification: () => wrapper.find(UiAlert),
-    remainingSpaceMsg: () => wrapper.find('.remaining-space').text().trim(),
+    availableSpaceMsg: () => wrapper.find('.available-space').text().trim(),
     resourcesSelectedMsg: () => wrapper.find('.resources-selected-message').text().trim(),
   }
 }
@@ -46,7 +46,7 @@ describe('selectedResourcesSize component', () => {
   it('shows correct "resources selected" message given resourceCount & fileSize props', () => {
     const wrapper = makeWrapper();
     const { resourcesSelectedMsg } = getElements(wrapper);
-    expect(resourcesSelectedMsg()).toEqual('Resources selected: 10 (10 MB)');
+    expect(resourcesSelectedMsg()).toEqual('Content selected: 10 MB (10 resources)');
   });
 
   it('confirmation button is disabled when no resources are selected', () => {
@@ -86,8 +86,8 @@ describe('selectedResourcesSize component', () => {
 
   it('shows the "remaining space message"', () => {
     const wrapper = makeWrapper();
-    const { remainingSpaceMsg } = getElements(wrapper);
-    expect(remainingSpaceMsg()).toEqual('Your remaining space: 4 GB');
+    const { availableSpaceMsg } = getElements(wrapper);
+    expect(availableSpaceMsg()).toEqual('Space available: 5 GB');
   });
 
   it('shows an error notification when remaining space goes to zero', () => {


### PR DESCRIPTION

### Summary

* Clarifies disk availability, instead of doing a confusing subtraction.
* Moves the two important values (available disk space and selected content size) closer together so it's clear what needs to be compared
* Switches to a responsive, grid-based layout for the import button
* Adds consistent styling for `hr` tags, which were previously unstyled

|  |  |
|--|--|
| before | ![image](https://user-images.githubusercontent.com/2367265/45787974-c5ec9800-bc2c-11e8-9688-55f8451faf46.png) |
| after |  ![image](https://user-images.githubusercontent.com/2367265/45789446-90e44380-bc34-11e8-9eaf-585a2a8a0f12.png) |


### Reviewer guidance

Please see if this helps address some of the confusion we've seen

cc @khangmach @ivanistheone @benjaoming @jonboiser

### References

Addresses issues discussed in #3883 and #4007

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
