### PR TITLE
Add validation warning to username input on login.

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -126,6 +126,7 @@
   import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
   import KTextbox from 'kolibri.coreVue.components.KTextbox';
   import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
+  import { validateUsername } from 'kolibri.utils.validators';
   import UiAutocompleteSuggestion from 'keen-ui/src/UiAutocompleteSuggestion';
   import UiAlert from 'keen-ui/src/UiAlert';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -148,6 +149,7 @@
       poweredBy: 'Kolibri {version}',
       required: 'This field is required',
       requiredForCoachesAdmins: 'Password is required for coaches and admins',
+      usernameNotAlphaNumUnderscore: 'Username can only contain letters, numbers, and underscores',
       documentTitle: 'User Sign In',
     },
     metaInfo() {
@@ -205,6 +207,8 @@
         if (this.usernameBlurred || this.formSubmitted) {
           if (this.username === '') {
             return this.$tr('required');
+          } else if (!validateUsername(this.username)) {
+            return this.$tr('usernameNotAlphaNumUnderscore');
           }
         }
         return '';

--- a/kolibri/plugins/user/assets/test/views/sign-in-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/sign-in-page.spec.js
@@ -15,4 +15,24 @@ describe('signInPage component', () => {
     const wrapper = makeWrapper();
     expect(wrapper.isVueInstance()).toEqual(true);
   });
+  it('will set the username as invalid if it contains punctuation and is blurred', () => {
+    const wrapper = makeWrapper();
+    wrapper.setData({ username: '?', usernameBlurred: true });
+    expect(wrapper.vm.usernameIsInvalid).toEqual(true);
+  });
+  it('will set the form as not valid if the username is invalid and is blurred', () => {
+    const wrapper = makeWrapper();
+    wrapper.setData({ username: '?', usernameBlurred: true });
+    expect(wrapper.vm.formIsValid).toEqual(false);
+  });
+  it('will set the validation text to required if the username is empty and blurred', () => {
+    const wrapper = makeWrapper();
+    wrapper.setData({ username: '', usernameBlurred: true });
+    expect(wrapper.vm.usernameIsInvalidText).toEqual(wrapper.vm.$options.$trs.required);
+  });
+  it('will set the validation text to empty if the username is empty and not blurred', () => {
+    const wrapper = makeWrapper();
+    wrapper.setData({ username: '', usernameBlurred: false });
+    expect(wrapper.vm.usernameIsInvalidText).toEqual('');
+  });
 });


### PR DESCRIPTION
### Summary
Previously we let people submit any username for login (aside from trimming the input).

This now validates the username based on our username validator and shows a validation error if they have input something invalid (spaces are not caught unless a character is entered subsequent to the space, due to the trim on the `v-model`).

It also disables the submit button until the form is valid.

### Reviewer guidance
Can you log in with a valid username?
Can you try to log in with an invalid username? (hopefully not!)

### References
Fixes #4068

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
