### PR TITLE
Backport #4118 to 0.10.x (Ensure plugins are updated before loading Django settings)

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -145,6 +145,9 @@ def initialize(debug=False):
         version = version.strip() if version else ""
         change_version = kolibri.__version__ != version
         if change_version:
+            # dbbackup will load settings.INSTALLED_APPS.
+            # we need to ensure plugins are correct in conf.config before
+            enable_default_plugins()
             # Version changed, make a backup no matter what.
             from kolibri.core.deviceadmin.utils import dbbackup
             try:
@@ -155,7 +158,6 @@ def initialize(debug=False):
                 logger.warning(
                     "Skipped automatic database backup, not compatible with "
                     "this DB engine.")
-            enable_default_plugins()
 
         django.setup()
 


### PR DESCRIPTION
### Summary
This PR backports an existing fix for several issues ( #3805,  #3806,  #4021) that has already been applied in release 0.11

### Reviewer guidance
Same as in #4118 

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
