### PR TITLE
Force autosave after leaving preview page

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonContentPreviewPage/index.vue
@@ -114,7 +114,7 @@
       };
     },
     computed: {
-      ...mapGetters(['getChannelForNode']),
+      ...mapGetters('lessonSummary', ['getChannelForNode']),
       ...mapState('lessonSummary', ['workingResources', 'currentContentNode']),
       ...mapState('lessonSummary/resources', {
         questions: state => state.preview.questions,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -174,6 +174,19 @@
         this.debouncedSaveResources();
       },
     },
+    beforeRouteEnter(to, from, next) {
+      // HACK if last page was LessonContentPreviewPage, then we need to make sure
+      // to immediately autosave just in case a change was made there. This gets
+      // called whether or not a change is made, because we don't track changes
+      // enough steps back.
+      if (from.name === LessonsPageNames.SELECTION_CONTENT_PREVIEW) {
+        next(vm => {
+          return vm.saveResources();
+        });
+      } else {
+        next();
+      }
+    },
     beforeRouteLeave(to, from, next) {
       // Only autosave if changes have been made
       if (xor(this.workingResources, this.workingResourcesCopy).length > 0) {


### PR DESCRIPTION

### Summary

Adds a hook in LessonResourceSelection page that forces a lesson auto-save if the last page was a Lesson Resource Preview page. This fixes #4298 in a limited way. If the user modifies the lesson inside the preview page and then quits their session, the changes will not be saved; they need to exit the preview page for the changes to be saved.

To handle that scenario, we would need to copy the logic in beforeRouteLeave in the Selection page to the Preview page.

![preview save](https://user-images.githubusercontent.com/10248067/45849605-6f905f80-bce7-11e8-8e65-2f986e5515f6.gif)

### Reviewer guidance


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
