### PR TITLE
Auth migration fix

### DIFF
--- a/kolibri/auth/migrations/0004_auto_20170816_1607.py
+++ b/kolibri/auth/migrations/0004_auto_20170816_1607.py
@@ -3,7 +3,9 @@
 from __future__ import unicode_literals
 
 import django.core.validators
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
+
 from kolibri.auth.constants.role_kinds import ADMIN
 
 
@@ -41,7 +43,7 @@ def device_owner_to_super_user(apps, schema_editor):
                 _morango_partition=real_superuser._morango_partition,
             )
             real_role = RealRole(
-                user=real_superuser,
+                user_id=superuser.id,
                 collection=real_default_facility,
                 kind=ADMIN,
                 dataset_id=dataset_id,

--- a/kolibri/auth/migrations/0004_auto_20170816_1607.py
+++ b/kolibri/auth/migrations/0004_auto_20170816_1607.py
@@ -31,6 +31,9 @@ def device_owner_to_super_user(apps, schema_editor):
                 dataset_id=dataset_id
             )
             uuid = real_superuser.calculate_uuid()
+            # due to uniqueness constraints, can't have two users with same username for a facility
+            # so we end up only keeping the superuser
+            FacilityUser.objects.filter(username=device_owner.username).delete()
             superuser = FacilityUser.objects.create(
                 username=device_owner.username,
                 password=device_owner.password,

--- a/kolibri/auth/test/test_data_migrations.py
+++ b/kolibri/auth/test/test_data_migrations.py
@@ -1,8 +1,11 @@
-from django.test import TestCase
-from django.db.migrations.executor import MigrationExecutor
 from django.db import connection
-from kolibri.auth.models import Classroom, Facility, FacilityUser
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TestCase
+
 from kolibri.auth.constants.role_kinds import ADMIN
+from kolibri.auth.models import Classroom
+from kolibri.auth.models import Facility
+from kolibri.auth.models import FacilityUser
 
 # Modified from https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 
@@ -53,13 +56,17 @@ class MultipleCollectionTestCase(TestMigrations):
             username="test",
         )
         self.username = deviceowner.username
+        # does the migration run successfully with 2 device owners?
+        DeviceOwner.objects.create(
+            username="test2",
+        )
 
     def test_username_migrated(self):
-        self.assertEqual(self.username, FacilityUser.objects.get().username)
+        self.assertTrue(FacilityUser.objects.filter(username=self.username).exists())
 
     def test_in_default_facility_migrated(self):
-        self.assertEqual(self.facility, FacilityUser.objects.get().facility)
+        self.assertEqual(self.facility, FacilityUser.objects.get(username=self.username).facility)
 
     def test_admin(self):
-        self.assertEqual(FacilityUser.objects.get().roles.first().collection, self.facility)
-        self.assertEqual(FacilityUser.objects.get().roles.first().kind, ADMIN)
+        self.assertEqual(FacilityUser.objects.get(username=self.username).roles.first().collection, self.facility)
+        self.assertEqual(FacilityUser.objects.get(username=self.username).roles.first().kind, ADMIN)

--- a/kolibri/auth/test/test_data_migrations.py
+++ b/kolibri/auth/test/test_data_migrations.py
@@ -65,9 +65,7 @@ class MultipleCollectionTestCase(TestMigrations):
         DeviceOwner.objects.create(
             username="test2",
         )
-
-    def test_username_migrated(self):
-        self.assertTrue(FacilityUser.objects.filter(username=self.username).exists())
+        self.username2 = deviceowner.username
 
     def test_in_default_facility_migrated(self):
         self.assertEqual(self.facility, FacilityUser.objects.get(username=self.username).facility)
@@ -75,3 +73,10 @@ class MultipleCollectionTestCase(TestMigrations):
     def test_admin(self):
         self.assertEqual(FacilityUser.objects.get(username=self.username).roles.first().collection, self.facility)
         self.assertEqual(FacilityUser.objects.get(username=self.username).roles.first().kind, ADMIN)
+
+    def test_device_owners_created(self):
+        self.assertTrue(FacilityUser.objects.filter(username=self.username).exists())
+        self.assertTrue(FacilityUser.objects.filter(username=self.username2).exists())
+
+    def test_facilityuser_deleted(self):
+        self.assertTrue(FacilityUser.objects.get(username=self.username).is_superuser)

--- a/kolibri/auth/test/test_data_migrations.py
+++ b/kolibri/auth/test/test_data_migrations.py
@@ -1,3 +1,6 @@
+import os
+import unittest
+
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TestCase
@@ -40,6 +43,7 @@ class TestMigrations(TestCase):
         pass
 
 
+@unittest.skipIf(os.environ.get('TOX_ENV') == 'postgres', "Skipping postgres due to unsupported upgrade")
 class MultipleCollectionTestCase(TestMigrations):
 
     migrate_from = '0003_auto_20170621_0958'

--- a/kolibri/auth/test/test_data_migrations.py
+++ b/kolibri/auth/test/test_data_migrations.py
@@ -48,6 +48,11 @@ class MultipleCollectionTestCase(TestMigrations):
     def setUp(self):
         self.facility = Facility.objects.create(name='Test')
         self.classroom = Classroom.objects.create(name='TestClass', parent=self.facility)
+        # does the migration run successfully with 2 users having the same username?
+        FacilityUser.objects.create(
+            username="test",
+            facility_id=self.facility.id
+        )
         super(MultipleCollectionTestCase, self).setUp()
 
     def setUpBeforeMigration(self, apps):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We now correctly calculate the id of role objects for facility users. Before we were getting id collisions due to improper calculations.
We now delete a facility user during migration if they have the same username as a device owner. This is due to there being a uniqueness constraint on username/facility.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

I've seen both cases mentioned above happen upon upgrading kolibri in UNETE CAPs.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
