### PR TITLE
Make it possible to persist ContentNode view state and other data.

### DIFF
--- a/kolibri/core/assets/src/mixins/contentRenderer.js
+++ b/kolibri/core/assets/src/mixins/contentRenderer.js
@@ -99,6 +99,10 @@ export default {
       default: () => defaultLanguage,
       validator: languageValidator,
     },
+    extraFields: {
+      type: Object,
+      default: () => {},
+    },
     showCorrectAnswer: {
       type: Boolean,
       default: false,

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -41,6 +41,12 @@ const timeThreshold = 120; // Update logs if 120 seconds have passed since last 
  */
 
 function _contentSummaryLoggingState(data) {
+  let extraFields = data.extraFields;
+  if (!extraFields) {
+    extraFields = {};
+  } else if (typeof extraFields === 'string') {
+    extraFields = JSON.parse(extraFields);
+  }
   return {
     id: data.id,
     start_timestamp: data.start_timestamp,
@@ -48,7 +54,7 @@ function _contentSummaryLoggingState(data) {
     end_timestamp: data.end_timestamp,
     progress: data.progress,
     time_spent: data.time_spent,
-    extra_fields: data.extra_fields,
+    extra_fields: extraFields,
     time_spent_before_current_session: data.time_spent,
     progress_before_current_session: data.progress,
   };
@@ -320,7 +326,7 @@ export function initContentSession(store, { channelId, contentId, contentKind })
               end_timestamp: now(),
               progress: 0,
               time_spent: 0,
-              extra_fields: '{}',
+              extra_fields: {},
               time_spent_before_current_session: 0,
               progress_before_current_session: 0,
             })
@@ -355,7 +361,7 @@ export function initContentSession(store, { channelId, contentId, contentKind })
       end_timestamp: now(),
       time_spent: 0,
       progress: 0,
-      extra_fields: '{}',
+      extra_fields: {},
     })
   );
 
@@ -553,6 +559,22 @@ export function updateTimeSpent(store, forceSave = false) {
   if (forceSave || timeThresholdMet) {
     saveLogs(store);
   }
+}
+
+/**
+ * Update the content state in the summary log
+ * To be called periodically by interval timer
+ * Must be called after initContentSession
+ * @param {boolean} forceSave
+ */
+export function updateContentState(store, contentState, forceSave = false) {
+  /* Update the logging state with new content state information */
+  store.commit('SET_LOGGING_CONTENT_STATE', contentState);
+
+  // update the time spent value to check time since last save
+  // and save if necessary, or save then reset the timer if forceSave
+  // is true
+  updateTimeSpent(store, forceSave);
 }
 
 /**

--- a/kolibri/core/assets/src/state/modules/logging.js
+++ b/kolibri/core/assets/src/state/modules/logging.js
@@ -38,6 +38,10 @@ export default {
     SET_LOGGING_COMPLETION_TIME(state, time) {
       state.summary.completion_timestamp = time;
     },
+    SET_LOGGING_CONTENT_STATE(state, contentState) {
+      // TODO: Consider whether we want to save these to the session log as well.
+      state.summary.extra_fields.contentState = contentState;
+    },
     SET_LOGGING_TIME(state, { sessionTime, summaryTime, currentTime }) {
       state.session.end_timestamp = currentTime;
       state.summary.end_timestamp = currentTime;

--- a/kolibri/core/assets/src/views/ContentRenderer/index.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/index.vue
@@ -17,6 +17,7 @@
           @startTracking="startTracking"
           @stopTracking="stopTracking"
           @updateProgress="updateProgress"
+          @updateContentState="updateContentState"
           @answerGiven="answerGiven"
           @hintTaken="hintTaken"
           @itemError="itemError"
@@ -24,6 +25,7 @@
           :files="availableFiles"
           :defaultFile="defaultFile"
           :itemId="itemId"
+          :extraFields="extraFields"
           :answerState="answerState"
           :allowHints="allowHints"
           :supplementaryFiles="supplementaryFiles"
@@ -104,6 +106,10 @@
       allowHints: {
         type: Boolean,
         default: true,
+      },
+      extraFields: {
+        type: Object,
+        default: () => {},
       },
       initSession: {
         type: Function,
@@ -203,6 +209,9 @@
       updateProgress(...args) {
         this.$emit('updateProgress', ...args);
         heartbeat.setActive();
+      },
+      updateContentState(...args) {
+        this.$emit('updateContentState', ...args);
       },
       startTracking(...args) {
         this.$emit('startTracking', ...args);

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -27,7 +27,7 @@ oriented data synchronization.
         :contentId="content.content_id"
         :channelId="channelId"
         :available="content.available"
-        :extraFields="content.extra_fields"
+        :extraFields="extraFields"
         :assessment="true"
         :itemId="itemId"
         :initSession="initSession"
@@ -38,6 +38,7 @@ oriented data synchronization.
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
+        @updateContentState="updateContentState"
       />
     </div>
 
@@ -168,8 +169,8 @@ oriented data synchronization.
         default: false,
       },
       extraFields: {
-        type: String,
-        default: '{}',
+        type: Object,
+        default: () => {},
       },
       initSession: {
         type: Function,
@@ -507,6 +508,9 @@ oriented data synchronization.
       },
       updateProgress(...args) {
         this.$emit('updateProgress', ...args);
+      },
+      updateContentState(...args) {
+        this.$emit('updateContentState', ...args);
       },
       startTracking(...args) {
         this.$emit('startTracking', ...args);

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -16,13 +16,14 @@
       @startTracking="startTracking"
       @stopTracking="stopTracking"
       @updateProgress="updateProgress"
+      @updateContentState="updateContentState"
       :id="content.id"
       :kind="content.kind"
       :files="content.files"
       :contentId="contentId"
       :channelId="channelId"
       :available="content.available"
-      :extraFields="content.extra_fields"
+      :extraFields="extraFields"
       :initSession="initSession"
     />
 
@@ -33,13 +34,14 @@
       @startTracking="startTracking"
       @stopTracking="stopTracking"
       @updateProgress="updateProgress"
+      @updateContentState="updateContentState"
       :id="content.id"
       :kind="content.kind"
       :files="content.files"
       :contentId="contentId"
       :channelId="channelId"
       :available="content.available"
-      :extraFields="content.extra_fields"
+      :extraFields="extraFields"
       :initSession="initSession"
     />
 
@@ -182,6 +184,7 @@
       ...mapState({
         summaryProgress: state => state.core.logging.summary.progress,
         sessionProgress: state => state.core.logging.session.progress,
+        extraFields: state => state.core.logging.summary.extra_fields,
       }),
       isTopic() {
         return this.content.kind === ContentNodeKinds.TOPIC;
@@ -243,6 +246,7 @@
         updateProgressAction: 'updateProgress',
         startTracking: 'startTrackingProgress',
         stopTracking: 'stopTrackingProgress',
+        updateContentNodeState: 'updateContentState',
       }),
       setWasIncomplete() {
         this.wasIncomplete = this.progress < 1;
@@ -257,6 +261,9 @@
       updateProgress(progressPercent, forceSave = false) {
         const summaryProgress = this.updateProgressAction({ progressPercent, forceSave });
         updateContentNodeProgress(this.channelId, this.contentNodeId, summaryProgress);
+      },
+      updateContentState(contentState, forceSave = true) {
+        this.updateContentNodeState(contentState, forceSave);
       },
       markAsComplete() {
         this.wasIncomplete = false;


### PR DESCRIPTION
### Summary

This enables ContentNode to persist its view state or other relevant data. 

### Reviewer guidance

This patch removes the HTML5 app portions of the change, so to test it, state persistence will be added to a view. See the changes to the HTML5 app renderer vue in #4036 for an example.

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
