### PR TITLE
Add 'view more' and pre-fetched filters in Lesson's search

### DIFF
--- a/kolibri/core/assets/src/views/KCheckbox.vue
+++ b/kolibri/core/assets/src/views/KCheckbox.vue
@@ -45,6 +45,7 @@
 
       <label
         v-if="label"
+        dir="auto"
         class="k-checkbox-label"
         :for="id"
         :class="{ 'visuallyhidden': !showLabel }"

--- a/kolibri/core/assets/src/views/buttons-and-links/KRouterLink.vue
+++ b/kolibri/core/assets/src/views/buttons-and-links/KRouterLink.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!-- no extra whitespace inside link -->
-  <router-link :class="buttonClasses" :to="to">{{ text }}</router-link>
+  <router-link :class="buttonClasses" :to="to" dir="auto">{{ text }}</router-link>
 
 </template>
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/actions.js
@@ -1,0 +1,16 @@
+import pickBy from 'lodash/pickBy';
+import uniq from 'lodash/uniq';
+import { ContentNodeSearchResource } from 'kolibri.resources';
+
+export function fetchAdditionalSearchResults(store, params) {
+  return ContentNodeSearchResource.fetchCollection({
+    getParams: pickBy({
+      search: params.searchTerm,
+      kind: params.kind,
+      channel_id: params.channelId,
+      exclude_content_ids: uniq(params.currentResults.map(({ content_id }) => content_id)),
+    }),
+  }).then(results => {
+    store.commit('SET_ADDITIONAL_SEARCH_RESULTS', results);
+  });
+}

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -1,3 +1,4 @@
+import pickBy from 'lodash/pickBy';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import {
   ContentNodeResource,
@@ -72,6 +73,9 @@ function showResourceSelectionPage(store, params) {
             store.commit('lessonSummary/resources/SET_ANCESTOR_COUNTS', ancestorCounts);
             // carry pendingSelections over from other interactions in this modal
             store.commit('lessonSummary/resources/SET_CONTENT_LIST', contentList);
+            if (params.searchResults) {
+              store.commit('lessonSummary/resources/SET_SEARCH_RESULTS', params.searchResults);
+            }
             store.commit('SET_PAGE_NAME', pageName);
             store.commit('SET_TOOLBAR_ROUTE', {
               name: LessonsPageNames.SUMMARY,
@@ -201,17 +205,22 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
   );
 }
 
-export function showLessonResourceSearchPage(store, params) {
+export function showLessonResourceSearchPage(store, params, query = {}) {
   return store.dispatch('loading').then(() => {
     return ContentNodeSearchResource.fetchCollection({
       getParams: {
         search: params.searchTerm,
+        ...pickBy({
+          kind: query.kind,
+          channel_id: query.channel,
+        }),
       },
     }).then(results => {
       return showResourceSelectionPage(store, {
         classId: params.classId,
         lessonId: params.lessonId,
         contentList: results.results,
+        searchResults: results,
         pageName: LessonsPageNames.SELECTION_SEARCH,
       });
     });

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
@@ -3,6 +3,7 @@ function defaultState() {
     ancestorCounts: {},
     ancestors: [],
     contentList: [],
+    searchResults: {},
     currentContentNode: {},
     preview: {
       completionData: null,
@@ -29,6 +30,9 @@ export default {
     },
     SET_CONTENT_LIST(state, contentList) {
       state.contentList = contentList;
+    },
+    SET_SEARCH_RESULTS(state, searchResults) {
+      state.searchResults = searchResults;
     },
     SET_PREVIEW_STATE(state, previewState) {
       state.preview = previewState;

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
@@ -1,9 +1,18 @@
+import union from 'lodash/union';
+import unionBy from 'lodash/unionBy';
+import * as actions from './actions';
+
 function defaultState() {
   return {
     ancestorCounts: {},
     ancestors: [],
     contentList: [],
-    searchResults: {},
+    searchResults: {
+      channel_ids: [],
+      content_kinds: [],
+      results: [],
+      total_results: 0,
+    },
     currentContentNode: {},
     preview: {
       completionData: null,
@@ -15,6 +24,12 @@ function defaultState() {
 export default {
   namespaced: true,
   state: defaultState(),
+  actions,
+  getters: {
+    numRemainingSearchResults(state) {
+      return state.searchResults.total_results - state.searchResults.results.length;
+    },
+  },
   mutations: {
     SET_STATE(state, payload) {
       Object.assign(state, payload);
@@ -36,6 +51,24 @@ export default {
     },
     SET_PREVIEW_STATE(state, previewState) {
       state.preview = previewState;
+    },
+    SET_ADDITIONAL_SEARCH_RESULTS(state, searchResults) {
+      // Append the new results
+      state.searchResults.results = unionBy(
+        [...state.searchResults.results, ...searchResults.results],
+        'id'
+      );
+      // Append the filters
+      state.searchResults.channel_ids = union(
+        state.searchResults.channel_ids,
+        searchResults.channel_ids
+      );
+      state.searchResults.content_kinds = union(
+        state.searchResults.content_kinds,
+        searchResults.content_kinds
+      );
+      // NOTE: Don't update total_results. Must keep the value set initially
+      // for remainingSearchResults to work properly
     },
   },
 };

--- a/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
@@ -69,7 +69,7 @@ export default [
     path: '/:classId/lessons/:lessonId/selection/search/:searchTerm',
     component: LessonResourceSelectionPage,
     handler: toRoute => {
-      showLessonResourceSearchPage(store, toRoute.params);
+      showLessonResourceSearchPage(store, toRoute.params, toRoute.query);
     },
   },
   {

--- a/kolibri/plugins/coach/assets/src/views/GroupsPage/GroupSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/GroupsPage/GroupSection.vue
@@ -4,7 +4,7 @@
 
     <KGrid>
       <KGridItem sizes="100, 100, 50" percentage>
-        <h2 class="group-name right-margin">{{ group.name }}</h2>
+        <h2 dir="auto" class="group-name right-margin">{{ group.name }}</h2>
         <span class="small-text">
           {{ $tr('numLearners', {count: group.users.length }) }}
         </span>
@@ -66,7 +66,7 @@
               @click.native.stop
             />
           </td>
-          <td class="core-table-main-col">{{ user.full_name }}</td>
+          <td dir="auto" class="core-table-main-col">{{ user.full_name }}</td>
           <td>{{ user.username }}</td>
         </tr>
       </tbody>

--- a/kolibri/plugins/coach/assets/src/views/NavTitle.vue
+++ b/kolibri/plugins/coach/assets/src/views/NavTitle.vue
@@ -3,7 +3,7 @@
   <div>
     <h2>
       <template v-if="className">
-        {{ className }}
+        <span dir="auto">{{ className }}</span>
       </template>
       <template v-else>
         {{ $tr('coachPageHeader') }}
@@ -20,7 +20,7 @@
           v-for="(coach, idx) in classCoaches"
           :key="idx"
         >
-          <span>{{ coach.full_name }}</span>
+          <span dir="auto">{{ coach.full_name }}</span>
         </li>
       </ul>
     </div>

--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -7,7 +7,7 @@
           :kind="kind"
           class="title-lesson-icon"
         />
-        <h1 class="lesson-summary-header-title">
+        <h1 class="lesson-summary-header-title" dir="auto">
           {{ title }}
         </h1>
       </div>
@@ -37,7 +37,7 @@
         <dt>
           {{ $tr('description') }}
         </dt>
-        <dd>
+        <dd dir="auto">
           {{ description || $tr('noDescription') }}
         </dd>
       </template>
@@ -61,7 +61,7 @@
             v-for="recipientGroup in recipientGroups"
             :key="recipientGroup.id"
           >
-            <span>{{ recipientGroup.name }}</span>
+            <span dir="auto">{{ recipientGroup.name }}</span>
           </li>
         </ul>
       </dd>

--- a/kolibri/plugins/coach/assets/src/views/exams/CreateExamPage/TopicRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CreateExamPage/TopicRow.vue
@@ -14,7 +14,11 @@
     <td class="core-table-main-col">
       <div class="topic-title">
         <ContentIcon :kind="topic" />
-        <button class="title" @click="$emit('goToTopic', topicId)">
+        <button
+          dir="auto"
+          class="title"
+          @click="$emit('goToTopic', topicId)"
+        >
           {{ topicTitle }}
         </button>
       </div>

--- a/kolibri/plugins/coach/assets/src/views/exams/ExamReportPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/ExamReportPage/index.vue
@@ -59,9 +59,9 @@
                   :text="examTaker.name"
                   :to="examDetailPageLink(examTaker.id)"
                 />
-                <template v-else>
+                <span dir="auto" v-else>
                   {{ examTaker.name }}
-                </template>
+                </span>
               </td>
 
               <td>
@@ -77,7 +77,6 @@
               </td>
 
               <td>
-
                 {{
                   examTaker.score === undefined ?
                     '–' :
@@ -85,7 +84,9 @@
                 }}
               </td>
 
-              <td v-if="!viewByGroups">{{ examTaker.group.name || '–' }}</td>
+              <td v-if="!viewByGroups" dir="auto">
+                {{ examTaker.group.name || '–' }}
+              </td>
             </tr>
           </tbody>
         </CoreTable>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
@@ -1,56 +1,87 @@
 <template>
 
-  <ul class="content-list">
-    <KCheckbox
-      :label="$tr('selectAllCheckboxLabel')"
-      v-if="showSelectAll"
-      :checked="selectAllChecked"
-      @change="$emit('changeselectall', $event)"
-    />
-    <li
-      v-for="content in contentList"
-      class="content-list-item"
-      :key="content.id"
-    >
+  <div>
+    <ul class="content-list">
       <KCheckbox
-        v-if="!contentHasCheckbox(content)"
-        class="content-checkbox"
-        :label="content.title"
-        :showLabel="false"
-        :checked="contentIsChecked(content)"
-        @change="handleCheckboxChange(content.id, $event)"
+        :label="$tr('selectAllCheckboxLabel')"
+        v-if="showSelectAll"
+        :checked="selectAllChecked"
+        @change="$emit('changeselectall', $event)"
       />
-      <LessonContentCard
-        class="content-card"
-        :title="content.title"
-        :thumbnail="content.thumbnail"
-        :description="content.description"
-        :kind="content.kind"
-        :message="contentCardMessage(content)"
-        :link="contentCardLink(content)"
-        :numCoachContents="content.num_coach_contents"
+      <li
+        v-for="content in contentList"
+        class="content-list-item"
+        :key="content.id"
+      >
+        <KCheckbox
+          v-if="!contentHasCheckbox(content)"
+          class="content-checkbox"
+          :label="content.title"
+          :showLabel="false"
+          :checked="contentIsChecked(content)"
+          @change="handleCheckboxChange(content.id, $event)"
+        />
+        <LessonContentCard
+          class="content-card"
+          :title="content.title"
+          :thumbnail="content.thumbnail"
+          :description="content.description"
+          :kind="content.kind"
+          :message="contentCardMessage(content)"
+          :link="contentCardLink(content)"
+          :numCoachContents="content.num_coach_contents"
+        />
+      </li>
+    </ul>
+
+    <template>
+      <KButton
+        v-if="showButton"
+        :text="$tr('viewMoreButtonLabel')"
+        @click="$emit('moreresults')"
+        :primary="false"
       />
-    </li>
-  </ul>
+      <KCircularLoader
+        v-if="viewMoreButtonState === 'waiting'"
+        :delay="false"
+      />
+      <!-- TODO introduce messages in next version -->
+      <p v-else-if="viewMoreButtonState === 'error'">
+        <mat-svg category="alert" name="error" />
+        <!-- {{ $tr('moreResultsError') }} -->
+      </p>
+      <!-- <p v-else-if="viewMoreButtonState === 'no_more_results'">
+        {{ $tr('noMoreResults') }}
+      </p> -->
+    </template>
+  </div>
 
 </template>
 
 
 <script>
 
+  import KButton from 'kolibri.coreVue.components.KButton';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
+  import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
   import LessonContentCard from './LessonContentCard';
 
   export default {
     name: 'ContentCardList',
     components: {
+      KButton,
       KCheckbox,
+      KCircularLoader,
       LessonContentCard,
     },
     props: {
       showSelectAll: {
         type: Boolean,
         default: false,
+      },
+      viewMoreButtonState: {
+        type: String,
+        required: true,
       },
       selectAllChecked: {
         type: Boolean,
@@ -81,6 +112,13 @@
         required: true,
       },
     },
+    computed: {
+      showButton() {
+        return (
+          this.viewMoreButtonState !== 'waiting' && this.viewMoreButtonState !== 'no_more_results'
+        );
+      },
+    },
     methods: {
       handleCheckboxChange(contentId, checked) {
         this.$emit('change_content_card', { contentId, checked });
@@ -88,8 +126,9 @@
     },
     $trs: {
       selectAllCheckboxLabel: 'Select all',
-      // Used for future 'View more' button
       viewMoreButtonLabel: 'View more',
+      noMoreResults: 'No more results',
+      moreResultsError: 'Failed to get more results',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -17,6 +17,7 @@
         v-model.trim="searchTerm"
         type="search"
         class="input"
+        dir="auto"
         :placeholder="$tr('searchBoxLabel')"
         ref="searchinput"
       >

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
@@ -5,7 +5,7 @@
       {{ searchResultsSubheader }}
     </h2>
 
-    <div v-if="searchResults.results.length > 0">
+    <div>
       <div class="ib">
         <mat-svg
           category="content"
@@ -40,7 +40,10 @@
         />
       </div>
 
-      <div class="ib">
+      <div
+        v-show="roleFilterOptions.length > 0"
+        class="ib"
+      >
         <mat-svg
           category="social"
           name="person"
@@ -89,7 +92,11 @@
       searchResults: {
         type: Object,
         default() {
-          return {};
+          return {
+            results: [],
+            content_kinds: [],
+            channel_ids: [],
+          };
         },
       },
       value: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
@@ -5,7 +5,7 @@
       {{ searchResultsSubheader }}
     </h2>
 
-    <div v-if="searchResults.length > 0">
+    <div v-if="searchResults.results.length > 0">
       <div class="ib">
         <mat-svg
           category="content"
@@ -66,7 +66,6 @@
 
   import { mapGetters } from 'vuex';
   import find from 'lodash/find';
-  import map from 'lodash/map';
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -88,9 +87,9 @@
     },
     props: {
       searchResults: {
-        type: Array,
+        type: Object,
         default() {
-          return [];
+          return {};
         },
       },
       value: {
@@ -109,7 +108,9 @@
       }),
       searchResultsSubheader() {
         const msg =
-          this.searchResults.length === 0 ? 'noSearchResultsMessage' : 'searchResultsMessage';
+          this.searchResults.results.length === 0
+            ? 'noSearchResultsMessage'
+            : 'searchResultsMessage';
         return this.$tr(msg, { searchTerm: this.searchTerm });
       },
       allFilter() {
@@ -119,42 +120,35 @@
         return find(this.contentKindFilterOptions, { value: this.value.kind }) || {};
       },
       contentKindFilterOptions() {
-        const contentKinds = map(this.searchResults, 'kind');
-        if (contentKinds.length === 0) {
-          return [];
-        }
-        const options = Object.keys(kindFilterToLabelMap)
-          .filter(kind => contentKinds.includes(kind))
-          .map(kind => ({
-            label: this.$tr(kindFilterToLabelMap[kind]),
-            value: kind,
-          }));
+        const contentKinds = this.searchResults.content_kinds;
+        const options = contentKinds.map(kind => ({
+          label: this.$tr(kindFilterToLabelMap[kind]),
+          value: kind,
+        }));
         return [this.allFilter, ...options];
       },
       channelValue() {
         return find(this.channelFilterOptions, { value: this.value.channel }) || {};
       },
       channelFilterOptions() {
-        const channelIds = map(this.searchResults, 'channel_id');
-        if (channelIds.length === 0) {
-          return [];
-        }
-        const options = this.channels
-          .filter(channel => channelIds.includes(channel.id))
-          .map(channel => ({
-            label: channel.title,
-            value: channel.id,
-          }));
+        const channelIds = this.searchResults.channel_ids;
+        const options = channelIds.map(id => find(this.channels, { id })).map(channel => ({
+          label: channel.title,
+          value: channel.id,
+        }));
         return [this.allFilter, ...options];
       },
       roleValue() {
         return find(this.roleFilterOptions, { value: this.value.role }) || {};
       },
       roleFilterOptions() {
-        if (this.searchResults.length === 0) {
+        if (this.searchResults.results.length === 0) {
           return [];
         }
-        const hasCoachContents = find(this.searchResults, result => result.num_coach_contents > 0);
+        const hasCoachContents = find(
+          this.searchResults.results,
+          result => result.num_coach_contents > 0
+        );
         const options = [this.allFilter];
         if (hasCoachContents) {
           options.push({ label: this.$tr('coach'), value: 'coach' });

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/__tests__/LessonsSearchFilters.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/SearchTools/__tests__/LessonsSearchFilters.spec.js
@@ -11,7 +11,11 @@ function makeWrapper() {
         channel: '123',
         role: null,
       },
-      searchResults: [{}],
+      searchResults: {
+        results: [],
+        content_kinds: [],
+        channel_ids: [],
+      },
     },
   });
   const kSelects = wrapper.findAll({ name: 'KSelect' });
@@ -23,26 +27,20 @@ function makeWrapper() {
   return { wrapper, els };
 }
 
-//
 describe('LessonsSearchFilters', () => {
-  it('does not show filters if there are no results', () => {
-    const { wrapper } = makeWrapper();
-    wrapper.setProps({
-      searchResults: [],
-    });
-    const filters = wrapper.findAll({ name: 'KSelect' });
-    expect(filters).toHaveLength(0);
-  });
-
   it('has the correct content kind filter options based on search results', () => {
     const { wrapper, els } = makeWrapper();
     wrapper.setProps({
-      searchResults: [{ kind: 'html5' }, { kind: 'exercise' }],
+      searchResults: {
+        results: [],
+        channel_ids: [],
+        content_kinds: ['html5', 'exercise'],
+      },
     });
     expect(els.kindSelect().props().options).toEqual([
       { label: 'All', value: null },
-      { label: 'Exercises', value: 'exercise' },
       { label: 'Apps', value: 'html5' },
+      { label: 'Exercises', value: 'exercise' },
     ]);
   });
 
@@ -50,10 +48,11 @@ describe('LessonsSearchFilters', () => {
     const { wrapper, els } = makeWrapper();
     wrapper.vm.$store.state.core.channels.list = [{ id: '123', title: 'Channel 123' }];
     wrapper.setProps({
-      searchResults: [
-        { kind: 'html5', channel_id: '123' },
-        { kind: 'exercise', channel_id: '123' },
-      ],
+      searchResults: {
+        channel_ids: ['123'],
+        content_kinds: [],
+        results: [{ kind: 'html5', channel_id: '123' }, { kind: 'exercise', channel_id: '123' }],
+      },
     });
     expect(els.channelSelect().props().options).toEqual([
       { label: 'All', value: null },
@@ -64,10 +63,14 @@ describe('LessonsSearchFilters', () => {
   it('has the correct role filter options when there are no coach contents', () => {
     const { wrapper, els } = makeWrapper();
     wrapper.setProps({
-      searchResults: [
-        { kind: 'topic', channel_id: '123', num_coach_contents: 0 },
-        { kind: 'exercise', channel_id: '123', num_coach_contents: 0 },
-      ],
+      searchResults: {
+        channel_ids: [],
+        content_kinds: [],
+        results: [
+          { kind: 'topic', channel_id: '123', num_coach_contents: 0 },
+          { kind: 'exercise', channel_id: '123', num_coach_contents: 0 },
+        ],
+      },
     });
     expect(els.roleSelect().props().options).toEqual([
       { label: 'All', value: null },
@@ -78,10 +81,14 @@ describe('LessonsSearchFilters', () => {
   it('has the correct role filter options when there are coach contents', () => {
     const { wrapper, els } = makeWrapper();
     wrapper.setProps({
-      searchResults: [
-        { kind: 'topic', channel_id: '123', num_coach_contents: 1 },
-        { kind: 'exercise', channel_id: '123', num_coach_contents: 0 },
-      ],
+      searchResults: {
+        channel_ids: [],
+        content_kinds: [],
+        results: [
+          { kind: 'topic', channel_id: '123', num_coach_contents: 1 },
+          { kind: 'exercise', channel_id: '123', num_coach_contents: 0 },
+        ],
+      },
     });
     expect(els.roleSelect().props().options).toEqual([
       { label: 'All', value: null },

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -45,6 +45,7 @@
       v-if="!isExiting"
       :contentList="filteredContentList"
       :showSelectAll="selectAllIsVisible"
+      :viewMoreButtonState="viewMoreButtonState"
       :selectAllChecked="addableContent.length === 0"
       :contentIsChecked="contentIsInLesson"
       :contentHasCheckbox="contentIsDirectoryKind"
@@ -52,6 +53,7 @@
       :contentCardLink="contentLink"
       @changeselectall="toggleTopicInWorkingResources"
       @change_content_card="toggleSelected"
+      @moreresults="handleMoreResults"
     />
 
   </div>
@@ -106,26 +108,22 @@
         },
         isExiting: false,
         workingResourcesCopy: [...this.$store.state.lessonSummary.workingResources],
+        moreResultsState: null,
       };
     },
     computed: {
       ...mapState(['classId', 'pageName']),
       ...mapState('lessonSummary', ['currentLesson', 'workingResources', 'resourceCache']),
       ...mapState('lessonSummary/resources', ['ancestorCounts', 'contentList', 'searchResults']),
+      ...mapGetters('lessonSummary/resources', ['numRemainingSearchResults']),
       ...mapGetters(['contentNodeIsTopic']),
       filteredContentList() {
-        const { channel, kind, role } = this.filters;
+        const { role } = this.filters;
         if (!this.inSearchMode) {
           return this.contentList;
         }
-        return this.contentList.filter(contentNode => {
+        return this.searchResults.results.filter(contentNode => {
           let passesFilters = true;
-          if (channel) {
-            passesFilters = passesFilters && contentNode.channel_id === channel;
-          }
-          if (kind) {
-            passesFilters = passesFilters && contentNode.kind === kind;
-          }
           if (role === 'nonCoach') {
             passesFilters = passesFilters && contentNode.num_coach_contents === 0;
           }
@@ -158,6 +156,15 @@
           this.pageName !== LessonsPageNames.SELECTION_ROOT &&
           !every(this.contentList, this.contentIsDirectoryKind)
         );
+      },
+      viewMoreButtonState() {
+        if (this.moreResultsState === 'waiting' || this.moreResultsState === 'error') {
+          return this.moreResultsState;
+        }
+        if (this.numRemainingSearchResults === 0) {
+          return 'no_more_results';
+        }
+        return 'visible';
       },
       contentIsInLesson() {
         return ({ id }) => this.workingResources.includes(id);
@@ -216,6 +223,7 @@
     methods: {
       ...mapActions(['createSnackbar', 'clearSnackbar']),
       ...mapActions('lessonSummary', ['saveLessonResources', 'addToResourceCache']),
+      ...mapActions('lessonSummary/resources', ['fetchAdditionalSearchResults']),
       ...mapMutations('lessonSummary', {
         addToWorkingResources: 'ADD_TO_WORKING_RESOURCES',
         removeFromSelectedResources: 'REMOVE_FROM_WORKING_RESOURCES',
@@ -310,6 +318,21 @@
             last_id: lastId,
           },
         });
+      },
+      handleMoreResults() {
+        this.moreResultsState = 'waiting';
+        this.fetchAdditionalSearchResults({
+          searchTerm: this.searchTerm,
+          kind: this.filters.kind,
+          channelId: this.filters.channel,
+          currentResults: this.searchResults.results,
+        })
+          .then(() => {
+            this.moreResultsState = null;
+          })
+          .catch(() => {
+            this.moreResultsState = 'error';
+          });
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -35,7 +35,7 @@
       v-if="inSearchMode"
       class="search-filters"
       :searchTerm="searchTerm"
-      :searchResults="contentList"
+      :searchResults="searchResults"
       v-model="filters"
     />
 
@@ -65,6 +65,7 @@
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import debounce from 'lodash/debounce';
   import every from 'lodash/every';
+  import pickBy from 'lodash/pickBy';
   import xor from 'lodash/xor';
   import UiToolbar from 'keen-ui/src/UiToolbar';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -99,9 +100,9 @@
       return {
         // null corresponds to 'All' filter value
         filters: {
-          channel: null,
-          kind: null,
-          role: null,
+          channel: this.$route.query.channel || null,
+          kind: this.$route.query.kind || null,
+          role: this.$route.query.role || null,
         },
         isExiting: false,
         workingResourcesCopy: [...this.$store.state.lessonSummary.workingResources],
@@ -110,7 +111,7 @@
     computed: {
       ...mapState(['classId', 'pageName']),
       ...mapState('lessonSummary', ['currentLesson', 'workingResources', 'resourceCache']),
-      ...mapState('lessonSummary/resources', ['ancestorCounts', 'contentList']),
+      ...mapState('lessonSummary/resources', ['ancestorCounts', 'contentList', 'searchResults']),
       ...mapGetters(['contentNodeIsTopic']),
       filteredContentList() {
         const { channel, kind, role } = this.filters;
@@ -172,6 +173,11 @@
       workingResources(newVal, oldVal) {
         this.showResourcesDifferenceMessage(newVal.length - oldVal.length);
         this.debouncedSaveResources();
+      },
+      filters(newVal) {
+        this.$router.push({
+          query: pickBy(newVal),
+        });
       },
     },
     beforeRouteLeave(to, from, next) {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/ResourceListTable.vue
@@ -65,7 +65,7 @@
               :to="resourceUserSummaryLink(resourceId)"
               :text="resourceTitle(resourceId)"
             />
-            <p class="channel-title">
+            <p dir="auto" class="channel-title">
               <dfn class="visuallyhidden"> {{ $tr('parentChannelLabel') }} </dfn>
               {{ resourceChannelTitle(resourceId) }}
             </p>

--- a/kolibri/plugins/coach/assets/src/views/reports/LearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/LearnerListPage.vue
@@ -9,7 +9,7 @@
           :kind="contentScopeSummary.kind"
           colorstyle="text-default"
         />
-        {{ contentScopeSummary.title }}
+        <span dir="auto">{{ contentScopeSummary.title }}</span>
       </h1>
       <CoachContentLabel
         :isTopic="isTopic(contentScopeSummary)"
@@ -64,7 +64,7 @@
             :num="isExercisePage ? row.exerciseProgress : row.contentProgress"
             :isExercise="isExercisePage"
           />
-          <td>{{ row.groupName || '–' }}</td>
+          <td dir="auto">{{ row.groupName || '–' }}</td>
           <ActivityCell v-if="!isRootLearnerPage" :date="row.lastActive" />
         </tr>
       </tbody>

--- a/kolibri/plugins/coach/assets/src/views/reports/table-cells/NameCell.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/table-cells/NameCell.vue
@@ -4,7 +4,7 @@
     <div class="title">
       <div>
         <KRouterLink v-if="link" :text="title" :to="link" class="link" />
-        <span v-else>{{ title }}</span>
+        <span dir="auto" v-else>{{ title }}</span>
       </div>
       <div>
         <slot name="details"></slot>

--- a/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
@@ -10,6 +10,7 @@
           </th>
           <td>
             <a
+              dir="auto"
               v-for="(url, index) in deviceInfo.urls"
               :key="index"
               :href="url"
@@ -40,6 +41,7 @@
         />
       </div>
       <TechnicalTextBlock
+        dir="auto"
         v-if="advancedShown"
         :text="infoText"
         class="bottom-section"

--- a/kolibri/plugins/device_management/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -20,7 +20,7 @@
               :permissionType="getPermissionType(user.id)"
             />
           </td>
-          <td class="core-table-main-col">
+          <td class="core-table-main-col" dir="auto">
             {{ user.full_name }}
             <span v-if="isCurrentUser(user.username)"> ({{ $tr('you') }})</span>
           </td>

--- a/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
@@ -8,7 +8,7 @@
 
     <template v-else>
       <div class="section user-info">
-        <h1>
+        <h1 dir="auto">
           {{ user.full_name }}
           <span v-if="isCurrentUser">
             ({{ $tr('you') }})
@@ -30,7 +30,7 @@
 
           <tr>
             <th scope="row">{{ $tr('facilityLabel') }}</th>
-            <td>{{ facilityName }}</td>
+            <td dir="auto">{{ facilityName }}</td>
           </tr>
         </table>
 

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/index.vue
@@ -3,7 +3,7 @@
   <div>
 
     <div>
-      <h1 class="title-header">
+      <h1 class="title-header" dir="auto">
         {{ currentClass.name }}
       </h1>
       <KButton

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -49,7 +49,9 @@
             </UiIcon>
           </td>
           <td>
-            {{ user.full_name }}
+            <span dir="auto">
+              {{ user.full_name }}
+            </span>
             <UserTypeDisplay
               aria-hidden="true"
               :userType="user.kind"

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -14,6 +14,7 @@
       </h3>
       <p
         v-if="subtitle"
+        dir="auto"
         class="subtitle"
         :class="{ 'no-footer': !hasFooter }"
       >

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -13,6 +13,7 @@
         type="search"
         class="search-input"
         ref="searchInput"
+        dir="auto"
         :placeholder="$tr('searchBoxLabel')"
       >
       <div class="search-buttons-wrapper">

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h1 class="classroom-name">
+    <h1 dir="auto" class="classroom-name">
       {{ classroomName }}
     </h1>
 

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -7,14 +7,14 @@
           kind="lesson"
           class="lesson-icon"
         />
-        <h1 class="title">
+        <h1 dir="auto" class="title">
           {{ currentLesson.title }}
           <ProgressIcon v-if="lessonHasResources" :progress="lessonProgress" />
         </h1>
       </div>
       <div v-if="currentLesson.description!==''">
         <h3>{{ $tr('teacherNote') }}</h3>
-        <p> {{ currentLesson.description }}</p>
+        <p dir="auto">{{ currentLesson.description }}</p>
       </div>
     </section>
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Make individual requests for filtered search results, per learn page
1. Use pre-fetched filter values instead of inferring them post-fetch from results
1. Add "view" more functionality
1. Add auto="dir" attributes to text containers that might hold user-entered text (see #3899), but does not fix the issue for text inside of Keen-UI elements, or internationalized strings that inject user-entered text

**View More**

![view more](https://user-images.githubusercontent.com/10248067/45971048-f2b5fc00-bfec-11e8-8258-8892241d6f06.gif)

**Filters**

![filtering](https://user-images.githubusercontent.com/10248067/45971063-f9dd0a00-bfec-11e8-84c9-3d8982d50297.gif)

### Reviewer guidance

1. Check that managing resources outside of search workflow still works
1. Check that managing resources inside of search workflow works
1. Check filters
1. Check "view more" button, when there are (not) more results

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #4297 for Lessons
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
