### PR TITLE
Kill the "download" button on error page

### DIFF
--- a/kolibri/core/assets/src/views/AppError/ReportErrorModal.vue
+++ b/kolibri/core/assets/src/views/AppError/ReportErrorModal.vue
@@ -37,7 +37,6 @@
     </h3>
     <TechnicalTextBlock
       :text="error"
-      :downloadFileName="downloadFileName"
       :maxHeight="240"
     />
 
@@ -96,10 +95,6 @@
       },
       emailAddressLink() {
         return `mailto:${this.emailAddress}`;
-      },
-      downloadFileName() {
-        const downloadTime = new Date();
-        return `kolibri-${this.$tr('errorFileDenotation')}-${downloadTime.toISOString()}.txt`;
       },
     },
   };

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -22,13 +22,6 @@
         ref="copyButton"
       />
     </div>
-    <div>
-      <KExternalLink
-        :text="$tr('downloadAsTextPrompt')"
-        :download="downloadFileName"
-        :href="textFileLink"
-      />
-    </div>
   </div>
 
 </template>
@@ -65,10 +58,6 @@
         type: Number,
         default: 72,
       },
-      downloadFileName: {
-        type: String,
-        required: true,
-      },
     },
     computed: {
       ...mapState({
@@ -76,14 +65,6 @@
       }),
       clipboardCapable() {
         return ClipboardJS.isSupported();
-      },
-      textFileLink() {
-        const windowsFormattedText = this.text.replace('\n', '\r\n');
-        const errorBlob = new Blob([windowsFormattedText], { type: 'text/plain', endings: 'native' });
-        if (navigator.msSaveBlob) {
-          return navigator.msSaveBlob(errorBlob, this.downloadFileName);
-        }
-        return URL.createObjectURL(errorBlob);
       },
       dynamicHeightStyle() {
         return {
@@ -140,14 +121,6 @@
 
   .copy-to-clipboard-button {
     margin-left: 0;
-  }
-
-  .download-as-text-link {
-    word-wrap: break-word;
-  }
-
-  .hide {
-    display: none;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -78,7 +78,8 @@
         return ClipboardJS.isSupported();
       },
       textFileLink() {
-        const errorBlob = new Blob([this.text], { type: 'text/plain' });
+        const windowsFormattedText = this.text.replace('\n', '\r\n');
+        const errorBlob = new Blob([windowsFormattedText], { type: 'text/plain', endings: 'native' });
         if (navigator.msSaveBlob) {
           return navigator.msSaveBlob(errorBlob, this.downloadFileName);
         }

--- a/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
@@ -43,7 +43,6 @@
         v-if="advancedShown"
         :text="infoText"
         class="bottom-section"
-        downloadFileName="device-info.txt"
       />
     </template>
 


### PR DESCRIPTION
Resolves #4315

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Trying to use Blob constructor features to make sure the text file uses the proper line endings. 

If this doesn't work, it's going to have to be regex.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Be on windows
1. Cause error
1. Open error report modal
2. download file
3. Open in notepad

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- #4315
----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
