### PR TITLE
Revert in_exam and in_lesson filters for caching reasons

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -95,7 +95,11 @@ class IdFilter(FilterSet):
     ids = CharFilter(method="filter_ids")
 
     def filter_ids(self, queryset, name, value):
-        return queryset.filter(pk__in=value.split(','))
+        try:
+            return queryset.filter(pk__in=value.split(','))
+        except ValueError:
+            # Catch in case of a poorly formed UUID
+            return queryset.none()
 
     class Meta:
         fields = ['ids', ]

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -52,7 +52,7 @@ function getExamReport(store, examId, userId, questionNumber = 0, interactionInd
         const questionList = createQuestionList(questionSources);
 
         const contentPromise = ContentNodeResource.getCollection({
-          in_exam: exam.id,
+          ids: questionSources.map(item => item.exercise_id),
         }).fetch();
 
         contentPromise.only(

--- a/kolibri/plugins/coach/assets/src/state/actions/exam.js
+++ b/kolibri/plugins/coach/assets/src/state/actions/exam.js
@@ -445,7 +445,7 @@ export function showExamReportPage(store, classId, examId) {
         LearnerGroupResource.getCollection({ parent: classId }).fetch(),
         ExamResource.getCollection({ collection: classId }).fetch({}, true),
         ContentNodeResource.getCollection({
-          in_exam: exam.id,
+          ids: exam.question_sources.map(item => item.exercise_id),
           fields: ['id', 'num_coach_contents'],
         }).fetch(),
         setClassState(store, classId),

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -36,7 +36,7 @@
         </div>
       </div>
 
-      <resource-list-table v-if="lessonResources.length" />
+      <resource-list-table v-if="workingResources.length" />
 
       <p v-else class="no-resources-message">
         {{ $tr('noResourcesInLesson') }}
@@ -115,6 +115,7 @@
         lessonAssignments: state => state.pageState.currentLesson.lesson_assignments,
         lessonResources: state => state.pageState.currentLesson.resources,
         learnerGroups: state => state.pageState.learnerGroups,
+        workingResources: state => state.pageState.workingResources,
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/classesActions.js
@@ -95,7 +95,7 @@ export function showLessonPlaylist(store, { lessonId }) {
         include_fields.push('num_coach_contents');
       }
       return ContentNodeSlimResource.getCollection({
-        in_lesson: lesson.id,
+        ids: lesson.resources.map(resource => resource.contentnode_id),
         include_fields,
       }).fetch();
     })

--- a/kolibri/plugins/learn/assets/src/state/actions/main.js
+++ b/kolibri/plugins/learn/assets/src/state/actions/main.js
@@ -513,7 +513,7 @@ export function showExam(store, classId, examId, questionNumber) {
           handleError(store, `Question number ${questionNumber} is not valid for this exam`);
         } else {
           const contentPromise = ContentNodeResource.getCollection({
-            in_exam: exam.id,
+            ids: questionSources.map(item => item.exercise_id),
           }).fetch();
           contentPromise.only(
             samePageCheckGenerator(store),


### PR DESCRIPTION
### Summary
The aggressive caching introduced in 0.9.5-beta meant that the in_exam and in_lesson filters did not dynamically change when the underlying exams and lessons were edited.

This fixes this behaviour by reverting to using the `ids` filter, which will dynamically update the get params based on the ids in the exams and lessons.

It also adds a flyby fix to the LessonSummaryPage, and the selection and preview page to handle included resources from deleted channels.

### Reviewer guidance
Does updating the resources in a lesson also update the resources that a learner then sees?
Does the LessonSummaryPage and subsequent lesson selection pages now handle resources from a deleted channel?

### References
Fixes #4316

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
