### PR TITLE
Add mgmt cmd for dumping user data to several files

### DIFF
--- a/kolibri/core/auth/management/commands/user_info.py
+++ b/kolibri/core/auth/management/commands/user_info.py
@@ -1,0 +1,67 @@
+import json
+import logging
+import os
+
+from django.core import serializers
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db.models import Model
+
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.serializers import FacilityUserSerializer
+from kolibri.core.device.models import DevicePermissions
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "To allow administrators to comply with GDPR requests, this command dumps all associated data for a user to several files."
+
+    def add_arguments(self, parser):
+        parser.add_argument('username', action='store', type=str, help='Username of user for data dump')
+
+    def handle(self, *args, **options):
+        try:
+            user = FacilityUser.objects.get(username=options['username'])
+        except FacilityUser.DoesNotExist:
+            raise CommandError('User with username `{username}` does not exist.'.format(username=options['username']))
+
+        # create username directory to hold associated files
+        cwd = os.getcwd()
+        directory_location = os.path.join(cwd, user.username)
+        if not os.path.isdir(directory_location):
+            os.makedirs(directory_location)
+
+        # write basic user data to file
+        file_name = '{user}.txt'.format(user=user.username)
+        file_location = os.path.join(directory_location, file_name)
+        data = FacilityUserSerializer(user).data
+        logger.info('Writing user data to {file}...'.format(file=file_location))
+        with open(file_location, 'w') as outfile:
+            json.dump(data, outfile, sort_keys=True, indent=4)
+
+        # get related managers for user model
+        managers = []
+        for related_object in user._meta.related_objects:
+            try:
+                managers.append(getattr(user, related_object.get_accessor_name()))
+            # regular users do not have device permissions
+            except (DevicePermissions.DoesNotExist,):
+                pass
+
+        # write data for each model to a file
+        for manager in managers:
+            # currently accounts for one-to-one field on DevicePermissions
+            if isinstance(manager, Model):
+                file_name = '{model}.txt'.format(model=manager.__class__.__name__.lower())
+                models = [manager]
+            else:
+                file_name = '{model}.txt'.format(model=manager.model.__name__.lower())
+                models = manager.all()
+            file_location = os.path.join(directory_location, file_name)
+            # only create file if models exist
+            if models:
+                data = serializers.serialize("json", models, indent=4)
+                logger.info('Writing data to {file}...'.format(file=file_location))
+                with open(file_location, 'w') as outfile:
+                    outfile.write(data)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This adds a management command which will dump all data for a user to a directory, containing various files where each file holds specific data related to the user.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

`kolibri manage user_info {username}`

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4304

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
