### PR TITLE
User Edit Updates

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -56,7 +56,10 @@
         <template slot="header" v-if="isUserLoggedIn">
           <div class="role">{{ $tr('userTypeLabel') }}</div>
           <div>
-            <UserTypeDisplay :userType="getUserKind" />
+            <UserTypeDisplay
+              :distinguishCoachTypes="false"
+              :userType="getUserKind"
+            />
           </div>
         </template>
 

--- a/kolibri/plugins/facility_management/assets/src/modules/userManagement/actions.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/userManagement/actions.js
@@ -77,12 +77,10 @@ export function updateUser(store, { userId, updates }) {
         }
         return setUserRole(updatedUser, updates.role).then(userWithRole => {
           update(userWithRole);
-          store.dispatch('displayModal', false);
         });
       } else {
         update(updatedUser);
       }
-      store.dispatch('displayModal', false);
     },
     error => {
       store.commit('SET_BUSY', false);

--- a/kolibri/plugins/facility_management/assets/src/modules/userManagement/actions.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/userManagement/actions.js
@@ -65,8 +65,8 @@ export function updateUser(store, { userId, updates }) {
   const origUserState = store.state.facilityUsers.find(user => user.id === userId);
   const facilityRoleHasChanged = updates.role && origUserState.kind !== updates.role.kind;
 
-  return updateFacilityUser(store, { userId, updates }).then(
-    updatedUser => {
+  return updateFacilityUser(store, { userId, updates })
+    .then(updatedUser => {
       const update = userData => store.commit('UPDATE_USER', _userState(userData));
       if (facilityRoleHasChanged) {
         if (store.rootGetters.currentUserId === userId && store.rootGetters.isSuperuser) {
@@ -81,8 +81,8 @@ export function updateUser(store, { userId, updates }) {
       } else {
         update(updatedUser);
       }
-    },
-    error => {
+    })
+    .catch(error => {
       store.commit('SET_BUSY', false);
       const errorsCaught = CatchErrors(error, [ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS]);
       if (errorsCaught) {
@@ -90,8 +90,7 @@ export function updateUser(store, { userId, updates }) {
       } else {
         store.dispatch('handleApiError', error, { root: true });
       }
-    }
-  );
+    });
 }
 
 export function setError(store, error) {

--- a/kolibri/plugins/facility_management/assets/src/modules/userManagement/utils.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/userManagement/utils.js
@@ -55,6 +55,8 @@ export function updateFacilityLevelRoles(facilityUser, newRoleKind) {
   // Changing from one Facility-Level Role to another. Any Classroom-Level Roles
   // are left untouched
   if (FACILITY_ROLES.includes(newRoleKind)) {
-    return RoleResource.deleteModel({ id: currentFacilityRole.id }).then(createFacilityRole);
+    return createFacilityRole().then(() =>
+      RoleResource.deleteModel({ id: currentFacilityRole.id })
+    );
   }
 }

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
@@ -259,6 +259,7 @@
     },
     methods: {
       ...mapActions('userManagement', ['updateUser', 'displayModal', 'setError', 'displayModal']),
+      ...mapActions(['kolibriLogout']),
       submitForm() {
         if (this.formIsInvalid) {
           if (this.nameIsInvalid) {
@@ -285,7 +286,14 @@
         this.updateUser({
           userId: this.id,
           updates,
-        }).then(() => this.displayModal(false));
+        }).then(() => {
+          // newType is falsey if Super Admin, since that's not a facility role
+          if (this.editingSelf && this.newType && this.newType !== UserKinds.ADMIN) {
+            // user has demoted themselves
+            this.kolibriLogout();
+          }
+          this.displayModal(false);
+        });
       },
     },
   };

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
@@ -258,7 +258,7 @@
       }
     },
     methods: {
-      ...mapActions('userManagement', ['updateUser', 'displayModal', 'setError']),
+      ...mapActions('userManagement', ['updateUser', 'displayModal', 'setError', 'displayModal']),
       submitForm() {
         if (this.formIsInvalid) {
           if (this.nameIsInvalid) {
@@ -285,7 +285,7 @@
         this.updateUser({
           userId: this.id,
           updates,
-        });
+        }).then(() => this.displayModal(false));
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -10,7 +10,7 @@
 
     <section>
       <h2>{{ $tr('userType') }}</h2>
-      <UserTypeDisplay :userType="getUserKind" />
+      <UserTypeDisplay :distinguishCoachTypes="false" :userType="getUserKind" />
     </section>
 
     <section v-if="userHasPermissions">


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Mostly, covers case of Admin demotion of self. Rather than error or 400, users are logged out.

Resolves some role-manipulation-related bugs. Cleans up a previous bug fix.

I kind of want to add a test for some of these bugs, but feel like this should be merged first? @indirectlylit 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test out some use cases from userEditModal. The ones I was tried (where I found the bug) were:
- Admin demoting self
    - to facility coach, class coach, and learner
- Admin demoting/promoting others
- Super admin demoting/promoting others

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- #4323
- #4160
- #4324
- #4211 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
