### PR TITLE
Don't aggressively cache recommendation endpoints.

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -57,7 +57,7 @@ def cache_forever(some_func):
             request = args[0]
             request = kwargs.get('request', request)
         except IndexError:
-            request = None
+            request = kwargs.get('request', None)
         if isinstance(request, HttpRequest):
             if any(map(lambda x: x in request.GET, ['popular', 'next_steps', 'resume'])):
                 timeout = 600

--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.db.models import Sum
 from django.db.models.aggregates import Count
 from django.http import Http404
+from django.http.request import HttpRequest
 from django.utils.cache import patch_response_headers
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -47,7 +48,20 @@ def cache_forever(some_func):
 
     def wrapper_func(*args, **kwargs):
         response = some_func(*args, **kwargs)
-        patch_response_headers(response, cache_timeout=cache_timeout)
+        # This caching has the unfortunate effect of also caching the dynamically
+        # generated filters for recommendation, this quick hack checks if
+        # the request is any of those filters, and then applies less long running
+        # caching on it.
+        timeout = cache_timeout
+        try:
+            request = args[0]
+            request = kwargs.get('request', request)
+        except IndexError:
+            request = None
+        if isinstance(request, HttpRequest):
+            if any(map(lambda x: x in request.GET, ['popular', 'next_steps', 'resume'])):
+                timeout = 600
+        patch_response_headers(response, cache_timeout=timeout)
         return response
 
     return wrapper_func


### PR DESCRIPTION
### Summary
Reduces the cache time on content recommendations from 20 years to 10 minutes.

### Reviewer guidance
Check the headers on the responses, they should be set to cache for 10 minutes from now.
----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
