### PR TITLE
Get available disk space from CONTENT_DIR instead of KOLIBRI_HOME

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -51,6 +51,8 @@ class FreeSpaceView(mixins.ListModelMixin, viewsets.GenericViewSet):
         path = request.query_params.get('path')
         if path is None:
             free = get_free_space()
+        elif path == "Content":
+            free = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
         else:
             free = get_free_space(path)
 

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
@@ -59,7 +59,7 @@ export function getAvailableSpaceOnDrive(selectedDrive) {
   }
   return client({
     path: `${urls['kolibri:core:freespace']()}`,
-    params: {},
+    params: { path: 'Content' },
   })
     .then(({ entity }) => entity.freespace)
     .catch(() => -1);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that available disk space report still shows the disk space of KOLIBRI_HOME when the content directory is changed to something else through `kolibri manage content movedirectory`

Before:
<img width="487" alt="screen shot 2018-09-26 at 12 19 01 pm" src="https://user-images.githubusercontent.com/19424916/46105524-1151f980-c18b-11e8-8227-b5d344f05c17.png">

After:
<img width="484" alt="screen shot 2018-09-26 at 12 19 31 pm" src="https://user-images.githubusercontent.com/19424916/46105533-1747da80-c18b-11e8-98d6-54c156995c52.png">


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Plug in a USB
2. Run the command `kolibri manage content movedirectory <external_drive_directory>`
3. Run `kolibri start`
4. Import a channel. In the channel import page, check that if the available disk space is from KOLIBRI_HOME or USB

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4227

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
