### PR TITLE
Check port availability

### DIFF
--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -5,6 +5,7 @@ import sys
 
 from .conf import OPTIONS
 from .server import get_status
+from .server import LISTEN_ADDRESS
 from .server import NotRunning
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ def check_other_kolibri_running(port):
     except NotRunning:
         # In case that something other than Kolibri occupies the port,
         # check the port's availability.
-        check_port_availability('127.0.0.1', port)
+        check_port_availability(LISTEN_ADDRESS, port)
 
 
 def check_port_availability(host, port):

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -1,7 +1,8 @@
 import logging
 import os
-import socket
 import sys
+
+import portend
 
 from .conf import OPTIONS
 from .server import get_status
@@ -29,22 +30,15 @@ def check_other_kolibri_running(port):
 
 
 def check_port_availability(host, port):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    # This is to prevent the previous execution has left the socket
-    # in a TIME_WAIT start, and can't be immediately reused.
-    # From the bottom of https://docs.python.org/2/library/socket.html#example
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     try:
-        s.bind((host, port))
-        s.close()
-    except socket.error:
+        portend.free(host, port, timeout=2)
+    except portend.Timeout:
         # Port is occupied
         logger.error(
             "Port {} is occupied.\n"
             "Please check that you do not have other processes "
             "running on this port and try again.\n".format(port)
         )
-        s.close()
         sys.exit(1)
 
 

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -11,6 +11,8 @@ from .server import NotRunning
 
 logger = logging.getLogger(__name__)
 
+PORT_AVAILABILITY_CHECK_TIMEOUT = 2
+
 
 def check_other_kolibri_running(port):
     try:
@@ -31,7 +33,7 @@ def check_other_kolibri_running(port):
 
 def check_port_availability(host, port):
     try:
-        portend.free(host, port, timeout=2)
+        portend.free(host, port, timeout=PORT_AVAILABILITY_CHECK_TIMEOUT)
     except portend.Timeout:
         # Port is occupied
         logger.error(

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -1,5 +1,4 @@
-import socket
-
+import portend
 from django.test import TestCase
 from mock import patch
 
@@ -16,11 +15,11 @@ class SanityCheckTestCase(TestCase):
             logging_mock.assert_called()
 
     @patch('kolibri.utils.sanity_checks.logging.error')
-    @patch('kolibri.utils.sanity_checks.socket.socket')
+    @patch('kolibri.utils.sanity_checks.portend.free')
     @patch('kolibri.utils.sanity_checks.get_status')
-    def test_port_occupied(self, status_mock, socket_mock, logging_mock):
+    def test_port_occupied(self, status_mock, portend_mock, logging_mock):
         status_mock.side_effect = NotRunning('Kolibri not running')
-        socket_mock.return_value.bind.side_effect = socket.error
+        portend_mock.side_effect = portend.Timeout
         with self.assertRaises(SystemExit):
             cli.main({'start': True})
             logging_mock.assert_called()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that the function for port availability check does not really work. Previously, because of the wrong host, the unavailable port error is not caught by the function `check_port_availability` but by cherrypy. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Run ka-lite or some other program to occupy the port
2. Run kolibri with the same port and see the output on terminal

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4189

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
