### PR TITLE
change logging to be logger in retry logic

### DIFF
--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -125,17 +125,17 @@ class Command(AsyncCommand):
                     try:
                         os.remove(dest)
                     except IOError as e:
-                        logging.error("Tried to remove {}, but exception {} occurred.".format(
+                        logger.error("Tried to remove {}, but exception {} occurred.".format(
                             dest, e))
                         pass
                     self.cancel()
                 return True
 
         except Exception as e:
-            logging.error("An error occurred during channel import: {}".format(e))
+            logger.error("An error occurred during channel import: {}".format(e))
             retry_import(e, skip_404=False)
 
-            logging.info('Waiting for 30 seconds before retrying import: {}\n'.format(
+            logger.info('Waiting for 30 seconds before retrying import: {}\n'.format(
                 filetransfer.source))
             sleep(30)
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -227,7 +227,7 @@ class Command(AsyncCommand):
                 self.progresstrackers[0].progress = original_value
                 self.progresstrackers[0].update_callback(original_progress.progress_fraction, original_progress)
 
-                logging.info('Waiting for 30 seconds before retrying import: {}\n'.format(
+                logger.info('Waiting for 30 seconds before retrying import: {}\n'.format(
                     filetransfer.source))
                 sleep(30)
                 return False, 0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I think my PR for retry logic was merged after #4064 , so I didn't notice that `logging` was changed to `logger`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check if the logging messages are displayed.
To get the logging messages for retry logic, please follow the reviewer guidance in https://github.com/learningequality/kolibri/pull/3741. Thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
