### PR TITLE
Clean up code, per advice in #3428

### DIFF
--- a/kolibri/core/logger/csv.py
+++ b/kolibri/core/logger/csv.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import math
 
 from rest_framework import serializers

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -451,8 +451,8 @@ class ExamAttemptLogAPITestCase(APITestCase):
         self.exam.active = False
         self.exam.save()
         response = self.client.patch(reverse('kolibri:core:examattemptlog-detail', kwargs={
-                'pk': examattemptlog.id
-            }), {"start_timestamp": timezone.now()}, format="json")
+            'pk': examattemptlog.id
+        }), {"start_timestamp": timezone.now()}, format="json")
         self.assertEqual(response.status_code, 403)
 
     def test_examlog_closed_patch_permissions(self):
@@ -472,8 +472,8 @@ class ExamAttemptLogAPITestCase(APITestCase):
         self.examlog.closed = True
         self.examlog.save()
         response = self.client.patch(reverse('kolibri:core:examattemptlog-detail', kwargs={
-                'pk': examattemptlog.id
-            }), {"start_timestamp": timezone.now()}, format="json")
+            'pk': examattemptlog.id
+        }), {"start_timestamp": timezone.now()}, format="json")
         self.assertEqual(response.status_code, 403)
 
     def tearDown(self):


### PR DESCRIPTION
### Summary

Adds a `unicode_literals` import in `logger.csv`, as strings exported in CSV may need to be encoded in unicode.

Ran autopep over every file in `logger`, only the one test file needed to be changed.

Fixes #3428
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
