### PR TITLE
Make bottom margin exactly the height of the exercise progress bar

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -80,7 +80,9 @@
   import LessonResourceViewer from './classes/LessonResourceViewer';
   import ActionBarSearchBox from './ActionBarSearchBox';
 
-  const BOTTOM_SPACED_RESERVED = 117;
+  // Bottom toolbar is 111px high on mobile, 113px normally.
+  // We reserve the smaller number so there is no gap on either screen size.
+  const BOTTOM_SPACED_RESERVED = 111;
 
   const pageNameToComponentMap = {
     [PageNames.TOPICS_ROOT]: ChannelsPage,


### PR DESCRIPTION
### Summary

#3812 Was caused by making the bottom margin of the Learn Index (when viewing exercises) too high by about 6 pixels; the shadow was actually fine.

This shrinks down the bottom margin so this gap is not present. Note in the comments, that we pick the smaller margin of 111px (vs. 113px) because this is a constant, and we don't want the gap to be there when not on a mobile display.

Fixes #3812

**before**
<img width="410" alt="screen shot 2018-09-27 at 2 35 40 pm" src="https://user-images.githubusercontent.com/10248067/46176035-e1762500-c262-11e8-970c-59047d165cd5.png">


**after**
<img width="579" alt="screen shot 2018-09-27 at 2 30 40 pm" src="https://user-images.githubusercontent.com/10248067/46176042-e4711580-c262-11e8-8773-40500c686102.png">


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
