### PR TITLE
Enable epub renderer by default

### DIFF
--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -68,6 +68,7 @@ except ImportError:
         "kolibri.plugins.user",
         "kolibri_exercise_perseus_plugin",
         "kolibri.plugins.style_guide",
+        "kolibri.plugins.document_epub_render",
     ]
 
 #: Everything in this list is added to django.conf.settings.INSTALLED_APPS


### PR DESCRIPTION
### Summary

Enable epub renderer by default
Should fix #4341 

### Reviewer guidance

Test that is enabled by default.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
