### PR TITLE
Hide profile link when on profile page

### DIFF
--- a/kolibri/plugins/user/assets/src/views/UserProfileSideNavEntry.vue
+++ b/kolibri/plugins/user/assets/src/views/UserProfileSideNavEntry.vue
@@ -3,6 +3,7 @@
   <CoreMenuOption
     :label="$tr('profile')"
     :link="url"
+    v-if="show"
   >
     <mat-svg
       slot="icon"
@@ -16,10 +17,12 @@
 
 <script>
 
+  import { mapState } from 'vuex';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
+  import { PageNames } from '../constants';
 
   const component = {
     name: 'UserProfileSideNavEntry',
@@ -30,8 +33,12 @@
       profile: 'Profile',
     },
     computed: {
+      ...mapState(['pageName']),
       url() {
         return urls['kolibri:user:user']();
+      },
+      show() {
+        return this.pageName !== PageNames.PROFILE;
       },
     },
     role: UserKinds.LEARNER,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Profile link in side nav is now hidden when on profile page. 

![screen shot 2018-10-01 at 10 25 57 am](https://user-images.githubusercontent.com/6361732/46304956-df62dd80-c564-11e8-85bd-d989aeed58dc.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Click profile tab and any other tab to see differences.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3876

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
