### PR TITLE
Fix clipped box shadows in ContentCardGroupCarousel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -81,7 +81,6 @@
 
   const contentCardWidth = 210;
   const gutterWidth = 20;
-  const horizontalShadowOffset = 12;
 
   export default {
     name: 'ContentCardGroupCarousel',
@@ -143,18 +142,14 @@
         return this.contentSetEnd >= this.contents.length - 1;
       },
       contentSetStyles() {
-        const cards = this.contentSetSize * contentCardWidth + horizontalShadowOffset;
+        const cards = this.contentSetSize * contentCardWidth;
         const gutters = (this.contentSetSize - 1) * gutterWidth;
         const maxCardShadowOffset = 14; // determined by css styles on cards
-        const topShadowOffset = 10;
         return {
           'min-width': `${contentCardWidth}px`,
-          'overflow-x': 'hidden',
           width: `${cards + gutters + maxCardShadowOffset}px`,
-          // Bottom shadow is a little bit bigger, so add a few pixels more
-          height: `${contentCardWidth + maxCardShadowOffset + topShadowOffset + 3}px`,
+          height: `${contentCardWidth + maxCardShadowOffset}px`,
           position: 'relative',
-          'padding-top': `${topShadowOffset}px`,
         };
       },
       contentControlsContainerStyles() {
@@ -214,7 +209,7 @@
         const indexInSet = index - this.contentSetStart;
         const gutterOffset = indexInSet * gutterWidth;
         const cardOffset = indexInSet * contentCardWidth;
-        return { [this.animationAttr]: `${cardOffset + gutterOffset + horizontalShadowOffset}px` };
+        return { [this.animationAttr]: `${cardOffset + gutterOffset}px` };
       },
       setStartPosition(el) {
         if (this.interacted) {
@@ -272,7 +267,9 @@
     @include clearfix();
 
     position: relative;
-    margin-top: 1em;
+    padding: ($control-hit-width / 2);
+    margin: -($control-hit-width / 2);
+    overflow: hidden;
 
     &-control-container {
       position: relative;

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -81,6 +81,7 @@
 
   const contentCardWidth = 210;
   const gutterWidth = 20;
+  const horizontalShadowOffset = 12;
 
   export default {
     name: 'ContentCardGroupCarousel',
@@ -142,15 +143,18 @@
         return this.contentSetEnd >= this.contents.length - 1;
       },
       contentSetStyles() {
-        const cards = this.contentSetSize * contentCardWidth;
+        const cards = this.contentSetSize * contentCardWidth + horizontalShadowOffset;
         const gutters = (this.contentSetSize - 1) * gutterWidth;
         const maxCardShadowOffset = 14; // determined by css styles on cards
+        const topShadowOffset = 10;
         return {
           'min-width': `${contentCardWidth}px`,
           'overflow-x': 'hidden',
           width: `${cards + gutters + maxCardShadowOffset}px`,
-          height: `${contentCardWidth + maxCardShadowOffset}px`,
+          // Bottom shadow is a little bit bigger, so add a few pixels more
+          height: `${contentCardWidth + maxCardShadowOffset + topShadowOffset + 3}px`,
           position: 'relative',
+          'padding-top': `${topShadowOffset}px`,
         };
       },
       contentControlsContainerStyles() {
@@ -210,7 +214,7 @@
         const indexInSet = index - this.contentSetStart;
         const gutterOffset = indexInSet * gutterWidth;
         const cardOffset = indexInSet * contentCardWidth;
-        return { [this.animationAttr]: `${cardOffset + gutterOffset}px` };
+        return { [this.animationAttr]: `${cardOffset + gutterOffset + horizontalShadowOffset}px` };
       },
       setStartPosition(el) {
         if (this.interacted) {


### PR DESCRIPTION
### Summary

This slightly changes some styles in ContentCardGroupCarousel so that the box shadows are not cut off at the top and left-most edges (right-most for RTL).

**Before**

<img width="651" alt="screen shot 2018-10-01 at 12 13 09 pm" src="https://user-images.githubusercontent.com/10248067/46310369-fbba4680-c573-11e8-96c1-c749f877bb6b.png">

**After (with more opacity)**
<img width="586" alt="screen shot 2018-10-03 at 10 47 43 am" src="https://user-images.githubusercontent.com/10248067/46428806-cb9cb000-c6f9-11e8-8fa1-00d67a198927.png">


### Reviewer guidance

1. Check it on RTL
1. Check it on different numbers of cards visible

### References

Fixes #3918 
…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
