### PR TITLE
Added tests for the server installer detection in Python

### DIFF
--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -1,0 +1,49 @@
+"""
+Tests for `kolibri.utils.server` module.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from mock import patch
+
+from kolibri.utils import server
+
+
+class TestServerInstallation(TestCase):
+    @patch('sys.argv', ['kolibri-0.9.3.pex', 'start'])
+    def test_pex(self):
+        install_type = server.installation_type()
+        assert install_type == 'pex'
+
+    def test_dev(self):
+        sys_args = ['kolibri', '--debug', 'manage', 'runserver',
+                    '--settings=kolibri.deployment.default.settings.dev', '\"0.0.0.0:8000\"']
+        with patch('sys.argv', sys_args):
+            install_type = server.installation_type()
+            assert install_type == 'devserver'
+
+    @patch('sys.argv', ['/usr/bin/kolibri', 'start'])
+    def test_dpkg(self):
+        with patch('kolibri.utils.server.check_output', return_value=''):
+            install_type = server.installation_type()
+            assert install_type == 'dpkg'
+
+    @patch('sys.argv', ['/usr/bin/kolibri', 'start'])
+    def test_apt(apt):
+        with patch('kolibri.utils.server.check_output', return_value='any repo'):
+            install_type = server.installation_type()
+            assert install_type == 'apt'
+
+    @patch('sys.argv', ['C:\\Python34\\Scripts\\kolibri', 'start'])
+    @patch('sys.path', ['', 'C:\\Program Files\\Kolibri\\kolibri.exe'])
+    def test_windows(self):
+        install_type = server.installation_type()
+        assert install_type == 'Windows'
+
+    @patch('sys.argv', ['/usr/local/bin/kolibri', 'start'])
+    def test_whl(self):
+        install_type = server.installation_type()
+        assert install_type == 'whl'


### PR DESCRIPTION
### Summary
This PR adds tests for the Python backend code added in #4232

### Reviewer guidance
* Check coverage
* run tests

### References
Resolves #4319

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
