### PR TITLE
Don’t count an exam as ‘completed’ until it’s ‘closed’

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams/ExamReportPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/ExamReportPage/index.vue
@@ -190,7 +190,7 @@
       },
       examTakerProgressText({ progress, closed }) {
         const { question_count } = this.exam;
-        if (progress === question_count || closed) {
+        if (closed) {
           return this.$tr('completed');
         } else if (progress !== undefined) {
           return this.$tr('remaining', { num: question_count - progress });


### PR DESCRIPTION
### Summary

On the Exam Reports Page, fixes the "progress" column so that it only says "complete" if the Exam Log's `complete` field is `true`. 

Fixes #3896

### Reviewer guidance

1. Follow steps in #3896 
1. To reproduce the original problem case, make sure you interact with _every_ problem in the exam, but don't submit it.
1. On Coach reports, it should say, e.g. "0 questions of 10 remaining" if you did not submit.
1. Once you submit, it should say "Completed"

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
