### PR TITLE
Adding explicit bg definition to iframe in HTML5Renderer.

### DIFF
--- a/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
@@ -80,6 +80,8 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
+
   .btn {
     position: absolute;
     top: 8px;
@@ -98,6 +100,7 @@
   .iframe {
     width: 100%;
     height: 100%;
+    background-color: $core-bg-canvas;
   }
 
 </style>


### PR DESCRIPTION
Default behavior doesn't work reliably across browsers (transparent).
Resolves #4122