### PR TITLE
for learners, only show classrooms they are part of

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/classes/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/classes/handlers.js
@@ -1,10 +1,10 @@
-import { ClassroomResource } from 'kolibri.resources';
+import { LearnerClassroomResource } from '../../apiResources';
 import { ClassesPageNames } from '../../constants';
 
 // Shows a list of all the Classrooms a Learner is enrolled in
 export function showAllClassesPage(store) {
   return store.dispatch('loading').then(() => {
-    return ClassroomResource.fetchCollection()
+    return LearnerClassroomResource.fetchCollection()
       .then(classrooms => {
         store.commit('SET_PAGE_NAME', ClassesPageNames.ALL_CLASSES);
         store.commit('classes/SET_LEARNER_CLASSROOMS', classrooms);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We now use the `LearnerClassroomResource` on the learn page to give the correct filtering of classes a user is in from the backend.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Follow steps outlined in issue.
View classrooms under admin, coach, and learner.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4210

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
