### PR TITLE
provide a width rule to onboarding form fieldset legend fixes #4353

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -87,6 +87,8 @@
     }
 
     &-legend {
+      // Fixes issue in IE11 where the description span would not be broken up
+      width: 100%;
       margin-bottom: 8px;
     }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Adds a rule to a `<legend>` tag, which seems to force it to right-size in IE11.

<img width="728" alt="screen shot 2018-10-02 at 2 34 24 pm" src="https://user-images.githubusercontent.com/10248067/46378700-4eb5fb80-c651-11e8-9c48-4c4ed590c026.png">

Fixes #4353
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
