### PR TITLE
use lock objects on the threads run methods

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -13,6 +13,7 @@ from requests.exceptions import Timeout
 
 import kolibri
 from kolibri.core.device.models import DeviceSettings
+from kolibri.utils.server import vacuum_db_lock
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,8 @@ class Command(BaseCommand):
         while True:
             try:
                 logger.info("Attempting a ping.")
-                data = self.perform_ping(server)
+                with vacuum_db_lock:
+                    data = self.perform_ping(server)
                 logger.info("Ping succeeded! (response: {}) Sleeping for {} minutes.".format(data, interval))
                 time.sleep(interval * 60)
                 continue

--- a/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
@@ -5,6 +5,8 @@ from django.core.management.base import BaseCommand
 from django.db import connections
 from django.db import DEFAULT_DB_ALIAS
 
+from kolibri.utils.server import vacuum_db_lock
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,7 +29,8 @@ class Command(BaseCommand):
         interval = options['interval']
         if connection.vendor == "sqlite":
             while True:
-                self.perform_vacuum(connection)
+                with vacuum_db_lock:
+                    self.perform_vacuum(connection)
                 if not interval:
                     break
                 logger.info("Next Vacuum in {interval} minutes.".format(interval=interval))

--- a/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
@@ -20,19 +20,19 @@ class Command(BaseCommand):
             help='Specifies the database to vacuum. Defaults to the "default" database.',
         )
         parser.add_argument(
-            '--interval', action='store', dest='interval', default=False, type=bool,
+            '--scheduled', action='store', dest='scheduled', default=False, type=bool,
             help='Flag to specify whether to run the process continuosly (currently set every day at 3AM). If False, no repetition will happen',
         )
 
     def handle(self, *args, **options):
         database = options['database']
         connection = connections[database]
-        interval = options['interval']
+        scheduled = options['scheduled']
         if connection.vendor == "sqlite":
             while True:
                 with vacuum_db_lock:
                     self.perform_vacuum(connection)
-                if not interval:
+                if not scheduled:
                     break
                 current_dt = datetime.datetime.now()
                 _3AM = datetime.time(hour=3)

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -47,7 +47,7 @@ DAEMON_LOG = os.path.join(conf.KOLIBRI_HOME, "server.log")
 LISTEN_ADDRESS = "0.0.0.0"
 
 # use locks so vacuum doesn't conflict with ping
-lock = threading.Lock()
+vacuum_db_lock = threading.Lock()
 
 
 class NotRunning(Exception):
@@ -106,8 +106,7 @@ class PingbackThread(threading.Thread):
         thread.start()
 
     def run(self):
-        with lock:
-            call_command("ping")
+        call_command("ping")
 
 
 class VacuumThread(threading.Thread):
@@ -119,9 +118,8 @@ class VacuumThread(threading.Thread):
         thread.start()
 
     def run(self):
-        with lock:
-            # Try to do the vacuum every 3 hours
-            call_command("vacuumsqlite", interval=10)
+        # Try to do the vacuum every 3 hours
+        call_command("vacuumsqlite", interval=10)
 
 
 def stop(pid=None, force=False):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -118,8 +118,8 @@ class VacuumThread(threading.Thread):
         thread.start()
 
     def run(self):
-        # Try to do the vacuum every 3 hours
-        call_command("vacuumsqlite", interval=True)
+        # Do the vacuum every day at 3am local server time
+        call_command("vacuumsqlite", scheduled=True)
 
 
 def stop(pid=None, force=False):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -46,6 +46,9 @@ DAEMON_LOG = os.path.join(conf.KOLIBRI_HOME, "server.log")
 # Currently non-configurable until we know how to properly handle this
 LISTEN_ADDRESS = "0.0.0.0"
 
+# use locks so vacuum doesn't conflict with ping
+lock = threading.Lock()
+
 
 class NotRunning(Exception):
     """
@@ -103,7 +106,8 @@ class PingbackThread(threading.Thread):
         thread.start()
 
     def run(self):
-        call_command("ping")
+        with lock:
+            call_command("ping")
 
 
 class VacuumThread(threading.Thread):
@@ -115,8 +119,9 @@ class VacuumThread(threading.Thread):
         thread.start()
 
     def run(self):
-        # Try to do the vacuum every 3 hours
-        call_command("vacuumsqlite", interval=10)
+        with lock:
+            # Try to do the vacuum every 3 hours
+            call_command("vacuumsqlite", interval=10)
 
 
 def stop(pid=None, force=False):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -119,7 +119,7 @@ class VacuumThread(threading.Thread):
 
     def run(self):
         # Try to do the vacuum every 3 hours
-        call_command("vacuumsqlite", interval=10)
+        call_command("vacuumsqlite", interval=True)
 
 
 def stop(pid=None, force=False):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

It seems that the vacuum and ping command are trying to access the database at the same time during startup. This causes some important models to not be generated by the ping command, as well as database is locked errors. Although, kolibri starts per usual even given this error. This PR adds a blocking lock to the threads so one process can not execute until the other has finished.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

`make assets`
`kolibri start`
is there any database is locked errors?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4334

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
