### PR TITLE
More efficient descendants query

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -248,6 +248,13 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
 
     @list_route(methods=['get'])
     def descendants(self, request):
+        """
+        Returns a slim view all the descendants of a set of content nodes (as designated by the passed in ids).
+        In addition to id, title, kind, and content_id, each node is also annotated with the ancestor_id of one
+        of the ids that are passed into the request.
+        In the case where a node has more than one ancestor in the set of content nodes requested, duplicates of
+        that content node are returned, each annotated with one of the ancestor_ids for a node.
+        """
         ids = self.request.query_params.get('ids', None)
         if not ids:
             return Response([])

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -253,17 +253,53 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
             return Response([])
         ids = ids.split(',')
         kind = self.request.query_params.get('descendant_kind', None)
-        data = []
         nodes = models.ContentNode.objects.filter(id__in=ids, available=True)
-        for node in nodes:
-            descendants = node.get_descendants(include_self=False).filter(available=True)
-            if kind:
-                descendants = descendants.filter(kind=kind)
+        descendants = nodes.get_descendants(include_self=False).filter(available=True).distinct()
+        if kind and kind != content_kinds.TOPIC:
+            # Include topics in the query as we need to use these to find duplicated ancestors.
+            descendants = descendants.filter(kind__in=[kind, content_kinds.TOPIC])
+        elif kind == content_kinds.TOPIC:
+            descendants.filter(kind=kind)
+        query_data = list(descendants.annotate(ancestor_id=Subquery(nodes.filter(
+            tree_id=OuterRef('tree_id'),
+            lft__lt=OuterRef('lft'),
+            rght__gt=OuterRef('rght'),
+            # Order by reverse level, so nodes are annotated with their nearest ancestor
+        ).order_by('-level').values_list('id', flat=True)[:1])).values('id', 'title', 'kind', 'content_id', 'ancestor_id'))
+        data = []
+        # Now that we have the data annotated with the nearest ancestor
+        # Look through each of the original ids that were passed in and find any topics that
+        # have these ids as ancestors
+        for node_id in ids:
 
-            def set_ancestor_id(x):
-                x['ancestor_id'] = node.id
-                return x
-            data += map(set_ancestor_id, list(descendants.values('id', 'title', 'content_id')))
+            def copy_node(node):
+                new_node = dict(node)
+                new_node['ancestor_id'] = node_id
+                return new_node
+
+            # Find any topics that are descendants of this node
+            descendant_topics = filter(lambda x: x['ancestor_id'] == node_id and x['kind'] == content_kinds.TOPIC, query_data)
+            # Loop through these topics while they exist
+            while descendant_topics:
+                # Create a new list of descendant topics of additional topics that we find
+                # during this search for descendant items from this node
+                new_descendant_topics = []
+                for topic in descendant_topics:
+                    # Find all descendant items that have this topic as an ancestor
+                    descendant_items = filter(lambda x: x['ancestor_id'] == topic['id'], query_data)
+                    # Filter these items to find any topics, as we will then need to check for any contents of these
+                    new_descendant_topics += filter(lambda x: x['kind'] == content_kinds.TOPIC, descendant_items)
+                    # Add a copy of all these descendant items to the data we will return, but change the ancestor_id
+                    # to the current node
+                    data += map(copy_node, descendant_items)
+                # Set descendant topics to the new descendant topics we discovered during this iteration
+                # If this is empty it will halt the iteration
+                descendant_topics = new_descendant_topics
+        # Combine the new data we found while iterating over the descendants with the original query data
+        data = query_data + data
+        if kind:
+            # If we are filtering by kind, filter out any data that does not match the kind
+            data = filter(lambda x: x['kind'] == kind, data)
         return Response(data)
 
     @list_route(methods=['get'])

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -278,7 +278,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
                 return new_node
 
             # Find any topics that are descendants of this node
-            descendant_topics = filter(lambda x: x['ancestor_id'] == node_id and x['kind'] == content_kinds.TOPIC, query_data)
+            descendant_topics = list(filter(lambda x: x['ancestor_id'] == node_id and x['kind'] == content_kinds.TOPIC, query_data))
             # Loop through these topics while they exist
             while descendant_topics:
                 # Create a new list of descendant topics of additional topics that we find
@@ -286,12 +286,12 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
                 new_descendant_topics = []
                 for topic in descendant_topics:
                     # Find all descendant items that have this topic as an ancestor
-                    descendant_items = filter(lambda x: x['ancestor_id'] == topic['id'], query_data)
+                    descendant_items = list(filter(lambda x: x['ancestor_id'] == topic['id'], query_data))
                     # Filter these items to find any topics, as we will then need to check for any contents of these
-                    new_descendant_topics += filter(lambda x: x['kind'] == content_kinds.TOPIC, descendant_items)
+                    new_descendant_topics += list(filter(lambda x: x['kind'] == content_kinds.TOPIC, descendant_items))
                     # Add a copy of all these descendant items to the data we will return, but change the ancestor_id
                     # to the current node
-                    data += map(copy_node, descendant_items)
+                    data += list(map(copy_node, descendant_items))
                 # Set descendant topics to the new descendant topics we discovered during this iteration
                 # If this is empty it will halt the iteration
                 descendant_topics = new_descendant_topics
@@ -299,7 +299,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         data = query_data + data
         if kind:
             # If we are filtering by kind, filter out any data that does not match the kind
-            data = filter(lambda x: x['kind'] == kind, data)
+            data = list(filter(lambda x: x['kind'] == kind, data))
         return Response(data)
 
     @list_route(methods=['get'])


### PR DESCRIPTION
### Summary
Resolve hierarchical nesting of nodes in descendants query in memory to avoid multiple requests.

### Reviewer guidance
Does the exam search page still annotate selection as expected?
Does the code make sense?
Does the in memory looping look inefficient? (I think it is still better than the multiple queries)

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
