### PR TITLE
Make cross plugin reference fail safe

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/EditUserModal.vue
@@ -43,6 +43,7 @@
       />
 
       <KExternalLink
+        v-if="devicePermissionsPageLink"
         class="super-admin-description"
         :text="editingSelf ? $tr('viewInDeviceTabPrompt') : $tr('changeInDeviceTabPrompt')"
         :href="devicePermissionsPageLink"
@@ -226,9 +227,10 @@
         return this.kind === UserKinds.SUPERUSER;
       },
       devicePermissionsPageLink() {
-        const devicePageUrl = urls['kolibri:devicemanagementplugin:device_management']();
-        // HACK needs longer term method
-        return `${devicePageUrl}#/permissions/${this.id}`;
+        const devicePageUrl = urls['kolibri:devicemanagementplugin:device_management'];
+        if (devicePageUrl) {
+          return `${devicePageUrl()}#/permissions/${this.id}`;
+        }
       },
       newType() {
         // never got the chance to even change it


### PR DESCRIPTION
### Summary
We should not make naive references to other plugins from plugins, as if the plugin is disabled, it will break the frontend code.

### Reviewer guidance
Does the link still display and link to the right place?
Does the link not display if the device management plugin is disabled?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
