### PR TITLE
Fix time overflow on 32bit architecture

### DIFF
--- a/kolibri/content/api.py
+++ b/kolibri/content/api.py
@@ -44,8 +44,9 @@ def cache_forever(some_func):
     """
     Decorator for patch_response_headers function
     """
-    # Approximately 20 years
-    cache_timeout = 620000000
+    # Approximately 1 year
+    # Source: https://stackoverflow.com/a/3001556/405682
+    cache_timeout = 31556926
 
     def wrapper_func(*args, **kwargs):
         response = some_func(*args, **kwargs)


### PR DESCRIPTION
### Summary

The "20 years" caching seems to have caused issues because it made the epoch overflow on 32 bit.

### Reviewer guidance

Should work fine

### References

https://github.com/learningequality/kolibri/issues/4385

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
