### PR TITLE
Split language list into multiple columns

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/modal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/modal.vue
@@ -7,13 +7,16 @@
     @submit="setLang"
     @cancel="closeModal"
   >
-    <k-radio-button
-      v-for="language in languageOptions"
-      :key="language.id"
-      :value="language.id"
-      :label="language.lang_name"
-      v-model="selectedLanguage"
-    />
+    <div class = "language-list">
+      <k-radio-button
+        v-for="language in languageOptions"
+        :key="language.id"
+        :value="language.id"
+        :label="language.lang_name"
+        v-model="selectedLanguage"
+      />
+    </div>
+
   </k-modal>
 
 </template>
@@ -53,4 +56,29 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .language-list {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  @media only screen and (min-width: 375px) {
+    .language-list {
+      .k-radio-button {
+        flex: 1 0 calc(50% - 10px);
+        margin-top: 10px;
+        margin-left: 10px;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 374px) {
+    .language-list {
+      .k-radio-button {
+        flex: 1 0 200px;
+      }
+    }
+  }
+
+</style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Changed the language list to split into multiple columns.

**Desktop:**
![language_list_desktop](https://user-images.githubusercontent.com/15672948/46868152-b4f80680-ce27-11e8-908d-4868a79e6233.png)
**Mobile:**
![language_list_mobile](https://user-images.githubusercontent.com/15672948/46868149-b32e4300-ce27-11e8-97bb-5adf9f4516f5.png)

…

### Reviewer guidance
Open the change language modal on various devices

…

### References
https://github.com/learningequality/kolibri/issues/4237

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
