### PR TITLE
Increase font size of description, add spacing above read more link

### DIFF
--- a/kolibri/core/assets/src/views/text-truncator.vue
+++ b/kolibri/core/assets/src/views/text-truncator.vue
@@ -101,6 +101,7 @@
 <style lang="scss" scoped>
 
   .ar {
+    margin-top: 8px;
     text-align: right;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/content-card/index.vue
@@ -162,7 +162,7 @@
   }
 
   .description {
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .message {


### PR DESCRIPTION
### Summary

- Changed description font size from 12px to 14px

- Adding margin of 8px above 'View More' link

**Before:**
![description_before](https://user-images.githubusercontent.com/15672948/46873304-8170a880-ce36-11e8-83de-a36d4e7e816e.png)

**After:**
![description_after](https://user-images.githubusercontent.com/15672948/46873312-83d30280-ce36-11e8-86f7-df8d93bddf4a.png)



…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Coach view
2. Add new lesson/select existing lesson
3. Click on 'Add Resources'
4. View card descriptions
…

### References

https://github.com/learningequality/kolibri/issues/4396

----

### Contributor Checklist

- [ x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
