### PR TITLE
0.11.0 changelog tweaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,12 +30,12 @@ Changed or fixed
  - Added more validation to help with log-in
  - Security: upgraded Python cryptography and pyopenssl libraries for CVE-2018-10903
 
-Translations
-~~~~~~~~~~~~
+Internationalization and localization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  - Languages: [ coming soon... ]
  - Improved consistency of language across the application, and renamed "Superuser" to "Super admin"
- - Many fixes to internationalization
+ - Many fixes to translation and localization
  - Consistent font rendering across all languages
 
 See a `full list <https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0>`__ of changes on Github

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-Changes are ordered reverse-chronologically.
+List of the most important changes for each release.
 
 0.11.0
 ------
@@ -9,27 +9,26 @@ Changes are ordered reverse-chronologically.
 Added
 ~~~~~
 
- - Added some basic commands to help with GDPR compliance
- - Added privacy information to help users and admins understand how their data is stored
- - Upgrades to exam and lesson creation, including search functionality and auto-save
  - Support for EPUB-format electronic books
+ - Upgrades to exam and lesson creation, including search functionality and auto-save
  - New error handling and reporting functionality
- - Import from custom network locations
- - Added a new setting for enabling or disabling guest access
+ - Channel import from custom network locations
+ - Setting for enabling or disabling guest access
+ - Basic commands to help with GDPR compliance
+ - Privacy information to help users and admins understand how their data is stored
 
 Changed or fixed
 ~~~~~~~~~~~~~~~~
 
- - Allow usernames in non-latin alphabets
- - Improvements in drive listing and space availability reporting
- - Improved rendering of some pages on smaller screens
- - Auto-refresh in coach reports
+ - Improvements to rendering of some pages on smaller screens
  - Improvements to search behavior in filtering and handling of large result sets
  - Improvements to the setup wizard based on user feedback and testing
  - Improvements to user management, particularly for admins and super admins
+ - Fix: Allow usernames in non-latin alphabets
+ - Fix: Drive listing and space availability reporting
+ - Auto-refresh in coach reports
  - Added more validation to help with log-in
  - Security: upgraded Python cryptography and pyopenssl libraries for CVE-2018-10903
- - Many additional bug fixes, under-the-hood updates, and performance improvements
 
 Translations
 ~~~~~~~~~~~~
@@ -39,7 +38,7 @@ Translations
  - Many fixes to internationalization
  - Consistent font rendering across all languages
 
-See a `more detailed list <https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0>`__ of changes on Github
+See a `full list <https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0>`__ of changes on Github
 
 
 0.10.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,27 +6,38 @@ Changes are ordered reverse-chronologically.
 0.11.0
 ------
 
+Added
+~~~~~
+
+ - Added some basic commands to help with GDPR compliance
+ - Added privacy information to help users and admins understand how their data is stored
  - Upgrades to exam and lesson creation, including search functionality and auto-save
  - Support for EPUB-format electronic books
  - New error handling and reporting functionality
- - Added a new setting for enabling or disabling guest access
- - Auto-refresh in coach reports
  - Import from custom network locations
- - Improvements to search behavior in filtering and handling of large result sets
- - Added some basic commands to help with GDPR compliance
- - Added privacy information to help users and admins understand how their data is stored
- - Improved consistency of language across the application, and renamed "Superuser" to "Super admin"
- - Many fixes to internationalization
- - Consistent font rendering across all languages
+ - Added a new setting for enabling or disabling guest access
+
+Changed or fixed
+~~~~~~~~~~~~~~~~
+
  - Allow usernames in non-latin alphabets
+ - Improvements in drive listing and space availability reporting
+ - Improved rendering of some pages on smaller screens
+ - Auto-refresh in coach reports
+ - Improvements to search behavior in filtering and handling of large result sets
  - Improvements to the setup wizard based on user feedback and testing
  - Improvements to user management, particularly for admins and super admins
  - Added more validation to help with log-in
- - Improvements in drive listing and space availability reporting
- - Improved rendering of some pages on smaller screens
  - Security: upgraded Python cryptography and pyopenssl libraries for CVE-2018-10903
  - Many additional bug fixes, under-the-hood updates, and performance improvements
+
+Translations
+~~~~~~~~~~~~
+
  - Languages: [ coming soon... ]
+ - Improved consistency of language across the application, and renamed "Superuser" to "Super admin"
+ - Many fixes to internationalization
+ - Consistent font rendering across all languages
 
 See a `more detailed list <https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0>`__ of changes on Github
 


### PR DESCRIPTION
### Summary

The changelog has grown in size and is becoming more and more unreadable. A bit of structure would help.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

?

### References

#4390 

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
