### PR TITLE
Revert CSS-based fix for carousel shadows, use inline-styles fixes #4399

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -81,6 +81,7 @@
 
   const contentCardWidth = 210;
   const gutterWidth = 20;
+  const horizontalShadowOffset = 12;
 
   export default {
     name: 'ContentCardGroupCarousel',
@@ -142,14 +143,18 @@
         return this.contentSetEnd >= this.contents.length - 1;
       },
       contentSetStyles() {
-        const cards = this.contentSetSize * contentCardWidth;
+        const cards = this.contentSetSize * contentCardWidth + horizontalShadowOffset;
         const gutters = (this.contentSetSize - 1) * gutterWidth;
         const maxCardShadowOffset = 14; // determined by css styles on cards
+        const topShadowOffset = 10;
         return {
           'min-width': `${contentCardWidth}px`,
+          'overflow-x': 'hidden',
           width: `${cards + gutters + maxCardShadowOffset}px`,
-          height: `${contentCardWidth + maxCardShadowOffset}px`,
+          // Bottom shadow is a little bit bigger, so add a few pixels more
+          height: `${contentCardWidth + maxCardShadowOffset + topShadowOffset + 3}px`,
           position: 'relative',
+          'padding-top': `${topShadowOffset}px`,
         };
       },
       contentControlsContainerStyles() {
@@ -209,7 +214,7 @@
         const indexInSet = index - this.contentSetStart;
         const gutterOffset = indexInSet * gutterWidth;
         const cardOffset = indexInSet * contentCardWidth;
-        return { [this.animationAttr]: `${cardOffset + gutterOffset}px` };
+        return { [this.animationAttr]: `${cardOffset + gutterOffset + horizontalShadowOffset}px` };
       },
       setStartPosition(el) {
         if (this.interacted) {
@@ -267,9 +272,7 @@
     @include clearfix();
 
     position: relative;
-    padding: ($control-hit-width / 2);
-    margin: -($control-hit-width / 2);
-    overflow: hidden;
+    margin-top: 1em;
 
     &-control-container {
       position: relative;

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -314,7 +314,7 @@
 
     // position-specific styles for each control button
     &-next-control {
-      right: -($control-hit-width / 2);
+      right: -($control-hit-width / 2) - 25;
     }
     &-previous-control {
       left: -($control-hit-width / 2);


### PR DESCRIPTION
This reverts commit 75f9e86239984611b67aa267850553105811a7cf.

Fixes #4399, since the CSS-based fix using negative margin blocks buttons near the carousel.

Also moves the 'next' / '->' control 25 pixels to the right to make it look more balanced

<img width="1053" alt="screen shot 2018-10-12 at 12 09 49 pm" src="https://user-images.githubusercontent.com/10248067/46889354-4790a980-ce18-11e8-91be-a783f7ef1c6a.png">

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
