### PR TITLE
Divide language list into 2 columns

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -7,13 +7,23 @@
     @submit="setLang"
     @cancel="closeModal"
   >
-    <KRadioButton
-      v-for="language in languageOptions"
-      :key="language.id"
-      :value="language.id"
-      :label="language.lang_name"
-      v-model="selectedLanguage"
-    />
+
+    <KGrid>
+      <KGridItem
+        v-for="language in languageOptions"
+        :key="language.id"
+        sizes = "100, 100, 50"
+        percentage
+        alignment = "left"
+      >
+        <KRadioButton
+          :value="language.id"
+          :label="language.lang_name"
+          v-model="selectedLanguage"
+        />
+      </KGridItem>
+    </KGrid>
+
   </KModal>
 
 </template>
@@ -24,11 +34,18 @@
   import KModal from 'kolibri.coreVue.components.KModal';
   import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
   import { currentLanguage } from 'kolibri.utils.i18n';
+  import KGrid from 'kolibri.coreVue.components.KGrid';
+  import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import languageSwitcherMixin from './mixin';
 
   export default {
     name: 'LanguageSwitcherModal',
-    components: { KModal, KRadioButton },
+    components: {
+      KModal,
+      KGrid,
+      KGridItem,
+      KRadioButton,
+    },
     mixins: [languageSwitcherMixin],
     $trs: {
       changeLanguageModalHeader: 'Change language',
@@ -54,3 +71,4 @@
 
 
 <style lang="scss" scoped></style>
+

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -7,10 +7,14 @@
     @submit="setLang"
     @cancel="closeModal"
   >
-
-    <KGrid>
+    <KGrid
+      class="language-column"
+      v-for="(languageCol, index) in splitLanguageOptions"
+      :key="index"
+    >
       <KGridItem
-        v-for="language in languageOptions"
+        class="language-item"
+        v-for="language in languageCol"
         :key="language.id"
         sizes="100, 100, 50"
         percentage
@@ -57,6 +61,14 @@
         selectedLanguage: currentLanguage,
       };
     },
+    computed: {
+      splitLanguageOptions() {
+        let secondCol = this.languageOptions;
+        let firstCol = secondCol.splice(0, Math.ceil(secondCol.length / 2));
+
+        return [firstCol, secondCol];
+      },
+    },
     methods: {
       closeModal() {
         this.$emit('close');
@@ -70,5 +82,24 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  @media only screen and (min-width: 840px) {
+    .language-column {
+      display: inline-block;
+      width: 50%;
+      margin: 20px 0;
+      &:nth-child(2) {
+        padding-left: 20px;
+      }
+    }
+  }
+
+  .language-item {
+    .k-radio-button {
+      margin: 4px 0;
+    }
+  }
+
+</style>
 

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -12,9 +12,9 @@
       <KGridItem
         v-for="language in languageOptions"
         :key="language.id"
-        sizes = "100, 100, 50"
+        sizes="100, 100, 50"
         percentage
-        alignment = "left"
+        alignment="left"
       >
         <KRadioButton
           :value="language.id"

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -7,20 +7,18 @@
     @submit="setLang"
     @cancel="closeModal"
   >
-    <KGrid
-      class="language-column"
-      v-for="(languageCol, index) in splitLanguageOptions"
-      :key="index"
-    >
+    <KGrid>
       <KGridItem
-        class="language-item"
-        v-for="language in languageCol"
-        :key="language.id"
-        sizes="100, 100, 50"
+        v-for="(languageCol, index) in splitLanguageOptions"
+        :key="index"
+        :class="{ 'offset-col': windowIsSmall && index === 1 }"
+        sizes="100, 50, 50"
         percentage
         alignment="left"
       >
         <KRadioButton
+          v-for="language in languageCol"
+          :key="language.id"
           :value="language.id"
           :label="language.lang_name"
           v-model="selectedLanguage"
@@ -40,6 +38,7 @@
   import { currentLanguage } from 'kolibri.utils.i18n';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import languageSwitcherMixin from './mixin';
 
   export default {
@@ -50,7 +49,7 @@
       KGridItem,
       KRadioButton,
     },
-    mixins: [languageSwitcherMixin],
+    mixins: [languageSwitcherMixin, responsiveWindow],
     $trs: {
       changeLanguageModalHeader: 'Change language',
       cancelButtonText: 'Cancel',
@@ -84,22 +83,8 @@
 
 <style lang="scss" scoped>
 
-  @media only screen and (min-width: 840px) {
-    .language-column {
-      display: inline-block;
-      width: 50%;
-      margin: 20px 0;
-      &:nth-child(2) {
-        padding-left: 20px;
-      }
-    }
-  }
-
-  .language-item {
-    .k-radio-button {
-      margin: 4px 0;
-    }
+  .offset-col {
+    margin-top: -8px;
   }
 
 </style>
-


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Changed the language list to split into multiple columns.

**Desktop:**
![language_list_desktop](https://user-images.githubusercontent.com/15672948/46868152-b4f80680-ce27-11e8-908d-4868a79e6233.png)
**Mobile:**
![language_list_mobile](https://user-images.githubusercontent.com/15672948/46868149-b32e4300-ce27-11e8-97bb-5adf9f4516f5.png)

…

### Reviewer guidance
Open the change language modal on various devices

…

### References
https://github.com/learningequality/kolibri/issues/4237

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
