### PR TITLE
Fixes #4414: Properly handle ping JSON response in Python 3 (including tests)

### DIFF
--- a/kolibri/core/analytics/test/test_ping.py
+++ b/kolibri/core/analytics/test/test_ping.py
@@ -10,6 +10,8 @@ from django.core.management import call_command
 from django.test import TestCase
 from requests.models import Response
 
+from .test_utils import BaseDeviceSetupMixin
+
 
 def load_zipped_json(data):
     try:
@@ -40,7 +42,7 @@ def mocked_requests_post_wrapper(json_data, status_code):
     return mocked_requests_post
 
 
-class PingCommandTestCase(TestCase):
+class PingCommandTestCase(BaseDeviceSetupMixin, TestCase):
 
     @mock.patch('requests.post', side_effect=mocked_requests_post_wrapper({"id": 17}, 200))
     def test_ping_succeeds(self, post_mock):

--- a/kolibri/core/analytics/test/test_ping.py
+++ b/kolibri/core/analytics/test/test_ping.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import zlib
+
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+from requests.models import Response
+
+
+def load_zipped_json(data):
+    try:
+        data = zlib.decompress(data)
+    except Exception:
+        pass
+    return json.loads(data)
+
+
+def mocked_requests_post_wrapper(json_data, status_code):
+
+    def mocked_requests_post(*args, **kwargs):
+
+        class MockResponse(Response):
+
+            def __init__(self):
+                self.json_data = json_data
+                self.status_code = status_code
+                self._content = json.dumps(json_data).encode()
+                self.reason = ""
+                self.url = args[0]
+
+            def json(self):
+                return self.json_data
+
+        return MockResponse()
+
+    return mocked_requests_post
+
+
+class PingCommandTestCase(TestCase):
+
+    @mock.patch('requests.post', side_effect=mocked_requests_post_wrapper({"id": 17}, 200))
+    def test_ping_succeeds(self, post_mock):
+        call_command("ping", once=True)
+        assert len(post_mock.call_args_list) == 2
+        assert post_mock.call_args_list[0][0][0].endswith("/pingback")
+        assert post_mock.call_args_list[1][0][0].endswith("/statistics")
+        assert load_zipped_json(post_mock.call_args_list[1][1]["data"])["pi"] == 17
+
+    @mock.patch('requests.post', side_effect=mocked_requests_post_wrapper({}, 400))
+    def test_ping_fails(self, post_mock):
+        call_command("ping", once=True)
+        assert len(post_mock.call_args_list) == 1
+        assert post_mock.call_args_list[0][0][0].endswith("/pingback")

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -185,7 +185,7 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         actual = extract_facility_statistics(facility)
         facility_id_hash = actual.pop('fi')
         # just assert the beginning hex values of the facility id don't match
-        self.assertFalse(facility_id_hash.startswith(facility.id[:3].encode()))
+        self.assertFalse(facility_id_hash.startswith(facility.id[:3]))
         expected = {
             "s": {
                 "preset": facility_presets.default,

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -78,7 +78,7 @@ def extract_facility_statistics(facility):
 
     return {
         # facility_id
-        "fi": base64.encodestring(hashlib.md5(facility.id.encode()).digest())[:10],
+        "fi": base64.encodestring(hashlib.md5(facility.id.encode()).digest())[:10].decode(),
         # settings
         "s": settings,
         # learners_count


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Previously, hard to automate a test of the ping command because it ran indefinitely (looping/sleeping). Added a "run once" option, wrote tests, and fixed the Python 3 decoding issue from #4414.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #4414.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
