### PR TITLE
Content Node fetching cleanup

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -54,12 +54,17 @@ function getExamReport(store, examId, userId, questionNumber = 0, interactionInd
         const questionSources = exam.question_sources;
 
         const questionList = createQuestionList(questionSources);
+        let contentPromise;
 
-        const contentPromise = ContentNodeResource.fetchCollection({
-          getParams: {
-            ids: questionSources.map(item => item.exercise_id),
-          },
-        });
+        if (questionSources.length) {
+          contentPromise = ContentNodeResource.fetchCollection({
+            getParams: {
+              ids: questionSources.map(item => item.exercise_id),
+            },
+          });
+        } else {
+          contentPromise = ConditionalPromise.resolve([]);
+        }
 
         contentPromise.only(
           samePageCheckGenerator(store),

--- a/kolibri/plugins/coach/assets/src/modules/examReport/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examReport/handlers.js
@@ -15,13 +15,15 @@ export function showExamReportPage(store, params) {
       const promises = [
         LearnerGroupResource.fetchCollection({ getParams: { parent: classId } }),
         ExamResource.fetchCollection({ getParams: { collection: classId }, force: true }),
-        ContentNodeSlimResource.fetchCollection({
-          getParams: {
-            ids: exam.question_sources.map(item => item.exercise_id),
-            fields: ['id'],
-            include_fields: ['num_coach_contents'],
-          },
-        }),
+        exam.question_sources.length
+          ? ContentNodeSlimResource.fetchCollection({
+              getParams: {
+                ids: exam.question_sources.map(item => item.exercise_id),
+                fields: ['id'],
+                include_fields: ['num_coach_contents'],
+              },
+            })
+          : ConditionalPromise.resolve([]),
         store.dispatch('setClassState', classId),
       ];
       ConditionalPromise.all(promises).only(

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -1,5 +1,5 @@
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
-import { LessonResource, ContentNodeResource } from 'kolibri.resources';
+import { LessonResource, ContentNodeSlimResource } from 'kolibri.resources';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { error as logError } from 'kolibri.lib.logging';
 import router from 'kolibri.coreVue.router';
@@ -58,9 +58,10 @@ export function getResourceCache(store, resourceIds) {
   }
 
   if (nonCachedResourceIds.length) {
-    return ContentNodeResource.fetchCollection({
+    return ContentNodeSlimResource.fetchCollection({
       getParams: {
         ids: nonCachedResourceIds,
+        include_fields: ['num_coach_contents'],
       },
     }).then(contentNodes => {
       contentNodes.forEach(contentNode =>

--- a/kolibri/plugins/coach/assets/src/modules/reports/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/reports/handlers.js
@@ -1,10 +1,5 @@
 import { now } from 'kolibri.utils.serverClock';
-import {
-  ChannelResource,
-  ContentNodeResource,
-  FacilityUserResource,
-  LearnerGroupResource,
-} from 'kolibri.resources';
+import { ChannelResource, FacilityUserResource, LearnerGroupResource } from 'kolibri.resources';
 import { PageNames } from '../../constants';
 import {
   ContentScopes,
@@ -32,10 +27,6 @@ function _showChannelList(store, classId, userId = null, showRecentOnly = false)
       collectionKind: userScope,
       collectionId: userScopeId,
     }),
-    // Get the ContentNode for the ChannelRoot for getting num_coach_contents
-    ContentNodeResource.fetchCollection({
-      getParams: { ids: channels.map(({ root_id }) => root_id) },
-    }),
     store.dispatch('setClassState', classId),
   ];
 
@@ -44,7 +35,7 @@ function _showChannelList(store, classId, userId = null, showRecentOnly = false)
   }
 
   return Promise.all(promises).then(
-    ([, , , user]) => {
+    ([, , user]) => {
       const defaultSortCol = showRecentOnly ? TableColumns.DATE : TableColumns.NAME;
       setReportSorting(store, { sortColumn: defaultSortCol, sortOrder: SortOrders.DESCENDING });
       store.commit('reports/SET_REPORT_PROPERTIES', {

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -106,11 +106,16 @@ export function showExam(store, params) {
             `Question number ${questionNumber} is not valid for this exam`
           );
         } else {
-          const contentPromise = ContentNodeResource.fetchCollection({
-            getParams: {
-              ids: exam.question_sources.map(item => item.exercise_id),
-            },
-          });
+          let contentPromise;
+          if (exam.question_sources.length) {
+            contentPromise = ContentNodeResource.fetchCollection({
+              getParams: {
+                ids: exam.question_sources.map(item => item.exercise_id),
+              },
+            });
+          } else {
+            contentPromise = ConditionalPromise.resolve([]);
+          }
           contentPromise.only(
             samePageCheckGenerator(store),
             contentNodes => {

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
@@ -17,12 +17,15 @@ export function showLessonPlaylist(store, { lessonId }) {
         }
         store.commit('SET_PAGE_NAME', ClassesPageNames.LESSON_PLAYLIST);
         store.commit('lessonPlaylist/SET_CURRENT_LESSON', lesson);
-        return ContentNodeSlimResource.fetchCollection({
-          getParams: {
-            ids: lesson.resources.map(resource => resource.contentnode_id),
-            include_fields,
-          },
-        });
+        if (lesson.resources.length) {
+          return ContentNodeSlimResource.fetchCollection({
+            getParams: {
+              ids: lesson.resources.map(resource => resource.contentnode_id),
+              include_fields,
+            },
+          });
+        }
+        return Promise.resolve([]);
       })
       .then(contentNodes => {
         const sortedContentNodes = contentNodes.sort((a, b) => {


### PR DESCRIPTION
### Summary
* Adds conditional logic to prevent fetches of empty `ids` arrays.
* Uses ContentNodeSlim when only summary information about ContentNodes is being displayed.
* Removes unnecessary call to ContentNode endpoint when coach report API returns `num_coach_contents` data already.

### Reviewer guidance
Do exams and lessons display properly when they have no resources in them?
Does the channels coach report still display properly, (especially if a channel has coach contents)?
Does the Lesson Summary coach report display properly (especially if a lesson has coach contents)?

### References
Fixes #4415

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
