### PR TITLE
Channel list speedup

### DIFF
--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -75,7 +75,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
                 if 'total_resources' in include_fields:
                     # count the total number of renderable non-topic resources in the channel
                     # (note: it's faster to count them all and then subtract the unrenderables, of which there are fewer)
-                    value['total_resources'] = channel_nodes.count() - unrenderable_nodes.count()
+                    value['total_resources'] = channel_nodes.dedupe_by_content_id().count() - unrenderable_nodes.dedupe_by_content_id().count()
 
                 if 'total_file_size' in include_fields:
                     # count the total file size of files associated with renderable content nodes
@@ -83,12 +83,12 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
                     value['total_file_size'] = _total_file_size(channel_nodes) - _total_file_size(unrenderable_nodes)
 
                 if 'on_device_resources' in include_fields:
-                    # count the total number of resources from the channel already available
-                    value['on_device_resources'] = channel_nodes.filter(available=True).exclude(kind=content_kinds.TOPIC).count()
+                    # read the precalculated total number of resources from the channel already available
+                    value['on_device_resources'] = instance.total_resource_count
 
                 if 'on_device_file_size' in include_fields:
-                    # count the total size of available files associated with the channel
-                    value['on_device_file_size'] = _total_file_size(_files_for_nodes(channel_nodes).filter(available=True))
+                    # read the precalculated total size of available files associated with the channel
+                    value['on_device_file_size'] = instance.published_size
 
         return value
 


### PR DESCRIPTION
### Summary
* We are already precalculating some data about channels on a device
* This PR uses that data to give a small speed up of Channel List loading on the Device page
* Use precalculated values where possible for channel metadata optional fields
* Also brings some resource counts into line with others by deduping resource counts by content_id.

### Reviewer guidance
With lots of channels installed, see if the channel list loads appreciably quicker.

### References
Partially addresses #3866

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
