### PR TITLE
Gherking stories for profile and benchmark manage commands

### DIFF
--- a/integration_testing/features/super-admin/super-admin-benchmark-command.feature
+++ b/integration_testing/features/super-admin/super-admin-benchmark-command.feature
@@ -1,0 +1,35 @@
+Feature: Super Admin benchmark manage command
+    Super Admin needs to have a benchmark report of the server running Kolibri
+
+  Background:
+    Given that the Kolibri server is running
+      And super admin has open a terminal in the Operative System
+
+  Scenario: Kolibri running from source code
+    Given that I have the terminal open
+      And I have followed the needed steps to build Kolibri and have it running
+    When I enter <kolibri manage benchmark>
+      And I wait for the command prompt to appear again
+    Then I see a complete report with performance and benchmarking information, splited in sections.
+
+
+  Scenario: Kolibri running in Windows after using the Windows Installer
+    Given that I have the terminal open
+      And I use the File Browser to find the folder where Python is installed
+    When I type <cd> in the terminal
+      And drag the folder where Python is installed to drop it in the terminal
+    Then I see something similar to <cd c:\Python3.4> in the terminal
+    When I press Enter
+    Then I see the prompt indicates I am into that folder
+    When I enter <cd Scripts> to enter into the folder where Kolibri script exists
+    Then I see the prompt indicates I am into the Scripts folder
+    When I enter <kolibri manage benchmark>
+      And I wait for the command prompt to appear again
+    Then I see a complete report with performance and benchmarking information, splited in sections.
+
+    Scenario: Kolibri running in Linux or Mac after using pip, the deb package or the Mac installer
+      Given that I have the terminal open
+    When I enter <kolibri manage benchmark>
+      And I wait for the command prompt to appear again
+    Then I see a complete report with performance and benchmarking information, splited in sections.
+

--- a/integration_testing/features/super-admin/super-admin-benchmark-command.feature
+++ b/integration_testing/features/super-admin/super-admin-benchmark-command.feature
@@ -5,30 +5,8 @@ Feature: Super Admin benchmark manage command
     Given that the Kolibri server is running
       And super admin has open a terminal in the Operative System
 
-  Scenario: Kolibri running from source code
-    Given that I have the terminal open
-      And I have followed the needed steps to build Kolibri and have it running
-    When I enter <kolibri manage benchmark>
-      And I wait for the command prompt to appear again
-    Then I see a complete report with performance and benchmarking information, splited in sections.
-
-
-  Scenario: Kolibri running in Windows after using the Windows Installer
-    Given that I have the terminal open
-      And I use the File Browser to find the folder where Python is installed
-    When I type <cd> in the terminal
-      And drag the folder where Python is installed to drop it in the terminal
-    Then I see something similar to <cd c:\Python3.4> in the terminal
-    When I press Enter
-    Then I see the prompt indicates I am into that folder
-    When I enter <cd Scripts> to enter into the folder where Kolibri script exists
-    Then I see the prompt indicates I am into the Scripts folder
-    When I enter <kolibri manage benchmark>
-      And I wait for the command prompt to appear again
-    Then I see a complete report with performance and benchmarking information, splited in sections.
-
-    Scenario: Kolibri running in Linux or Mac after using pip, the deb package or the Mac installer
-      Given that I have the terminal open
+  Scenario: A terminal is open in the same machine where Kolibri is running
+    Given that I have access to the kolibri command line
     When I enter <kolibri manage benchmark>
       And I wait for the command prompt to appear again
     Then I see a complete report with performance and benchmarking information, splited in sections.

--- a/integration_testing/features/super-admin/super-admin-profile-command.feature
+++ b/integration_testing/features/super-admin/super-admin-profile-command.feature
@@ -5,44 +5,8 @@ Feature: Super Admin profile manage command
     Given that the Kolibri server is running
       And super admin has open a terminal in the Operative System
 
-  Scenario: Kolibri running from source code
-    Given that I have the terminal open
-      And I have followed the needed steps to build Kolibri and have it running
-    When I enter <kolibri manage profile --num_samples=6>
-    Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
-    When I use the browser to navigate through kolibri pages
-    Then I see new data appearing in requests_performance.log
-    When 1 minutes pass
-    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
-    When I open performance.log with a text editor
-    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
-    When I open requests_performance.log with a text editor
-    Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
-
-
-  Scenario: Kolibri running in Windows after using the Windows Installer
-    Given that I have the terminal open
-      And I use the File Browser to find the folder where Python is installed
-    When I type <cd> in the terminal
-      And drag the folder where Python is installed to drop it in the terminal
-    Then I see something similar to <cd c:\Python3.4> in the terminal
-    When I press Enter
-    Then I see the prompt indicates I am into that folder
-    When I enter <cd Scripts> to enter into the folder where Kolibri script exists
-    Then I see the prompt indicates I am into the Scripts folder
-    When I enter <kolibri manage profile --num_samples=6>
-    Then Two new log files appear in the KOLIBRI_HOME (Usually c:\Documents and Settings\$USER/.kolibri) performance.log and requests_performance.log
-    When I use the browser to navigate through kolibri pages
-    Then I see new data appearing in requests_performance.log
-    When 1 minutes pass
-    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
-    When I open performance.log with a text editor
-    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
-    When I open requests_performance.log with a text editor
-    Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
-
-    Scenario: Kolibri running in Linux or Mac after using pip, the deb package or the Mac installer
-      Given that I have the terminal open
+  Scenario: A terminal is open in the same machine where Kolibri is running
+    Given that I have access to the kolibri command line
     When I enter <kolibri manage profile --num_samples=6>
     Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
     When I use the browser to navigate through kolibri pages

--- a/integration_testing/features/super-admin/super-admin-profile-command.feature
+++ b/integration_testing/features/super-admin/super-admin-profile-command.feature
@@ -8,11 +8,11 @@ Feature: Super Admin profile manage command
   Scenario: Kolibri running from source code
     Given that I have the terminal open
       And I have followed the needed steps to build Kolibri and have it running
-    When I enter <kolibri manage profile>
+    When I enter <kolibri manage profile --num_samples=6>
     Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
     When I use the browser to navigate through kolibri pages
     Then I see new data appearing in requests_performance.log
-    When 10 minutes pass
+    When 1 minutes pass
     Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
     When I open performance.log with a text editor
     Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
@@ -30,11 +30,11 @@ Feature: Super Admin profile manage command
     Then I see the prompt indicates I am into that folder
     When I enter <cd Scripts> to enter into the folder where Kolibri script exists
     Then I see the prompt indicates I am into the Scripts folder
-    When I enter <kolibri manage profile>
+    When I enter <kolibri manage profile --num_samples=6>
     Then Two new log files appear in the KOLIBRI_HOME (Usually c:\Documents and Settings\$USER/.kolibri) performance.log and requests_performance.log
     When I use the browser to navigate through kolibri pages
     Then I see new data appearing in requests_performance.log
-    When 10 minutes pass
+    When 1 minutes pass
     Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
     When I open performance.log with a text editor
     Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
@@ -43,11 +43,11 @@ Feature: Super Admin profile manage command
 
     Scenario: Kolibri running in Linux or Mac after using pip, the deb package or the Mac installer
       Given that I have the terminal open
-    When I enter <kolibri manage profile>
+    When I enter <kolibri manage profile --num_samples=6>
     Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
     When I use the browser to navigate through kolibri pages
     Then I see new data appearing in requests_performance.log
-    When 10 minutes pass
+    When 1 minutes pass
     Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
     When I open performance.log with a text editor
     Then I check it has at least 60 lines beginning with a timestamp and several numbers per line

--- a/integration_testing/features/super-admin/super-admin-profile-command.feature
+++ b/integration_testing/features/super-admin/super-admin-profile-command.feature
@@ -1,0 +1,56 @@
+Feature: Super Admin profile manage command
+    Super Admin needs to have profile logs of the server running Kolibri
+
+  Background:
+    Given that the Kolibri server is running
+      And super admin has open a terminal in the Operative System
+
+  Scenario: Kolibri running from source code
+    Given that I have the terminal open
+      And I have followed the needed steps to build Kolibri and have it running
+    When I enter <kolibri manage profile>
+    Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
+    When I use the browser to navigate through kolibri pages
+    Then I see new data appearing in requests_performance.log
+    When 10 minutes pass
+    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
+    When I open performance.log with a text editor
+    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
+    When I open requests_performance.log with a text editor
+    Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
+
+
+  Scenario: Kolibri running in Windows after using the Windows Installer
+    Given that I have the terminal open
+      And I use the File Browser to find the folder where Python is installed
+    When I type <cd> in the terminal
+      And drag the folder where Python is installed to drop it in the terminal
+    Then I see something similar to <cd c:\Python3.4> in the terminal
+    When I press Enter
+    Then I see the prompt indicates I am into that folder
+    When I enter <cd Scripts> to enter into the folder where Kolibri script exists
+    Then I see the prompt indicates I am into the Scripts folder
+    When I enter <kolibri manage profile>
+    Then Two new log files appear in the KOLIBRI_HOME (Usually c:\Documents and Settings\$USER/.kolibri) performance.log and requests_performance.log
+    When I use the browser to navigate through kolibri pages
+    Then I see new data appearing in requests_performance.log
+    When 10 minutes pass
+    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
+    When I open performance.log with a text editor
+    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
+    When I open requests_performance.log with a text editor
+    Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
+
+    Scenario: Kolibri running in Linux or Mac after using pip, the deb package or the Mac installer
+      Given that I have the terminal open
+    When I enter <kolibri manage profile>
+    Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
+    When I use the browser to navigate through kolibri pages
+    Then I see new data appearing in requests_performance.log
+    When 10 minutes pass
+    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
+    When I open performance.log with a text editor
+    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
+    When I open requests_performance.log with a text editor
+    Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
+


### PR DESCRIPTION
### Summary
In #4276 two new Kolibri  management commands have been created.
These two commands will:
* benchmark: provide information in the console about the performance of the server where Kolibri runs
* profile: provide two logs files containing detailed measurements on how the server is behaving when Kolibri is in use
This PR is trying to create Gherking stories to test these two commands.


### Reviewer guidance
These stories are different to any precedent story because they require the use of a terminal in the OS. When using Windows that action is quite complex because Kolibri is not installed in the path of the System. I don't know exactly the level of depth for the needed steps to be able to execute any Kolibri management command.

IMPORTANT: This PR should not be merged until #4276 is merged

### References
* relates #4276 



### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
