### PR TITLE
Change layout of Cards and Card Lists (fixes many issues)

### DIFF
--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -25,6 +25,7 @@
 <script>
 
   import shave from 'shave';
+  import debounce from 'lodash/debounce';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import KButton from 'kolibri.coreVue.components.KButton';
 
@@ -70,23 +71,27 @@
         }
         return this.text;
       },
+      currentDimensions() {
+        return {
+          text: this.text,
+          maxHeight: this.maxHeight,
+          elementWidth: this.elementWidth,
+          elementHeight: this.elementHeight,
+        };
+      },
+      debouncedHandleUpdate() {
+        return debounce(this.handleUpdate, 50);
+      },
     },
     watch: {
-      text() {
-        this.handleUpdate();
-      },
-      maxHeight() {
-        this.handleUpdate();
-      },
-      elementWidth() {
-        this.handleUpdate();
-      },
-      elementHeight() {
-        this.handleUpdate();
+      currentDimensions() {
+        this.debouncedHandleUpdate();
       },
     },
     methods: {
       handleUpdate() {
+        // TODO make "View Less" disappear when user expands window
+        // and text isn't truncated any more.
         shave(this.$refs.shaveEl, this.maxHeight);
         this.$nextTick(() => {
           this.textIsTruncated = Boolean(this.$el.querySelector('.js-shave'));

--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -110,6 +110,7 @@
 <style lang="scss" scoped>
 
   .ar {
+    margin-top: 8px;
     text-align: right;
   }
 

--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -9,7 +9,7 @@
     >
       {{ text }}
     </div>
-    <div class="ar">
+    <div class="show-more">
       <KButton
         v-if="showViewMore && (textIsTruncated || viewAllText)"
         appearance="basic-link"
@@ -109,7 +109,7 @@
 
 <style lang="scss" scoped>
 
-  .ar {
+  .show-more {
     margin-top: 8px;
     text-align: right;
   }

--- a/kolibri/plugins/coach/assets/src/views/exams/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CreateExamPage/index.vue
@@ -441,7 +441,7 @@
         };
       },
       contentHasCheckbox() {
-        return this.pageName === PageNames.EXAM_CREATION_ROOT;
+        return this.pageName !== PageNames.EXAM_CREATION_ROOT;
       },
       contentIsSelected(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
@@ -24,7 +24,7 @@
           @change="handleCheckboxChange(content.id, $event)"
         />
         <LessonContentCard
-          class="content-card"
+          :class="{'with-checkbox': needCheckboxes}"
           :title="content.title"
           :thumbnail="content.thumbnail"
           :description="content.description"
@@ -130,6 +130,9 @@
           this.viewMoreButtonState !== 'waiting' && this.viewMoreButtonState !== 'no_more_results'
         );
       },
+      needCheckboxes() {
+        return this.contentList.some(c => this.contentHasCheckbox(c));
+      },
     },
     methods: {
       handleCheckboxChange(contentId, checked) {
@@ -149,6 +152,8 @@
 
 <style lang="scss" scoped>
 
+  @import './LessonContentCard/card';
+
   .content-list {
     display: block;
     padding: 0;
@@ -164,12 +169,12 @@
   .content-checkbox {
     position: absolute;
     top: 34%; // offset accouting for shadow on card
-    left: -32px;
+    left: 0;
     display: inline-block;
   }
 
-  .content-card {
-    width: 100%;
+  .with-checkbox {
+    margin-left: $checkbox-offset;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/ContentCardList.vue
@@ -15,7 +15,7 @@
         :key="content.id"
       >
         <KCheckbox
-          v-if="!contentHasCheckbox(content)"
+          v-if="contentHasCheckbox(content)"
           class="content-checkbox"
           :label="content.title"
           :showLabel="false"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/card.scss
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/card.scss
@@ -1,2 +1,3 @@
 $thumb-width: 158px;
 $thumb-height: $thumb-width;
+$checkbox-offset: 42px;

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -170,7 +170,7 @@
   }
 
   .description {
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .message {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -121,7 +121,7 @@
   .content-card {
     display: block;
     height: $thumb-height;
-    margin-bottom: 16px;
+    margin-bottom: 24px;
     text-align: left;
     text-decoration: none;
     background-color: $core-bg-light;

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -137,12 +137,14 @@
   }
 
   .text {
+    $left-offset: $thumb-width + $checkbox-offset;
+
     position: absolute;
     top: 0;
     bottom: 0;
-    left: $thumb-width;
-    width: calc(100% - #{$thumb-width});
-    padding: 24px;
+    left: $left-offset;
+    width: calc(100% - #{$left-offset});
+    padding: 16px;
     overflow-y: auto;
     color: $core-text-default;
   }
@@ -175,8 +177,8 @@
 
   .message {
     position: absolute;
-    top: 24px;
-    right: 24px;
+    top: 16px;
+    right: 16px;
     color: $core-text-default;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -23,7 +23,7 @@
 
       <TextTruncator
         :text="description"
-        :maxHeight="40"
+        :maxHeight="80"
         :showViewMore="true"
         class="description"
       />

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="resource-selection-page">
+  <div>
     <h1>
       {{ $tr('documentTitle', { lessonName: currentLesson.title }) }}
     </h1>
@@ -53,7 +53,7 @@
       :viewMoreButtonState="viewMoreButtonState"
       :selectAllChecked="addableContent.length === 0"
       :contentIsChecked="contentIsInLesson"
-      :contentHasCheckbox="contentIsDirectoryKind"
+      :contentHasCheckbox="c => !contentIsDirectoryKind(c)"
       :contentCardMessage="selectionMetadata"
       :contentCardLink="contentLink"
       @changeselectall="toggleTopicInWorkingResources"
@@ -396,11 +396,6 @@
 
 
 <style lang="scss" scoped>
-
-  .resource-selection-page {
-    // offset to maintain straight lines in form w/ dynamic checkbox
-    margin-left: 64px;
-  }
 
   .exit-search-button {
     margin-left: 0;

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
@@ -32,6 +32,8 @@ export function loadChannelMetaData(store) {
       // Replacing them here with canonical type from ChannelResource.
       store.commit('manageContent/wizard/SET_TRANSFERRED_CHANNEL', {
         ...channel,
+        total_resources: transferredChannel.total_resources,
+        total_file_size: transferredChannel.total_file_size,
         version: transferredChannel.version,
         public: transferredChannel.public,
       });

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -298,6 +298,7 @@ export function updateTreeViewTopic(store, topic) {
   return ContentNodeGranularResource.fetchModel({
     id: topic.id,
     getParams: fetchArgs,
+    force: true,
   })
     .then(contents => {
       store.commit('manageContent/wizard/SET_CURRENT_TOPIC_NODE', contents);

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -305,7 +305,10 @@ export function updateTreeViewTopic(store, topic) {
       store.dispatch('manageContent/wizard/updatePathBreadcrumbs', topic);
     })
     .catch(() => {
-      store.commit('manageContent/wizard/SET_WIZARD_STATUS', 'TREEVIEW_LOADING_ERROR');
+      store.commit(
+        'manageContent/wizard/SET_WIZARD_STATUS',
+        ContentWizardErrors.TREEVIEW_LOADING_ERROR
+      );
     })
     .then(() => {
       store.commit('CORE_SET_PAGE_LOADING', false);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -7,7 +7,7 @@
     <TextTruncator
       v-if="topic.description"
       :text="topic.description"
-      :maxHeight="50"
+      :maxHeight="90"
       :showTooltip="false"
       :showViewMore="true"
       dir="auto"


### PR DESCRIPTION
### Summary

1. Increase max-height for descriptions. Fixes #4394.
1. Force fetch all ContentNodeGranular requests in import/export. Fixes #4435
1. Increase font size in Lesson cards (per #4403). Also reduces inner-card padding to 16px. Fixes #4396.
1. Move cards with checkboxes to center. Lists with no check-able cards are also aligned to the left. Fixes #4397 and #4391
1. Increase bottom margin on cards to 24px. Fixes #4395.
1. Makes sure to append total resources + file size when normalizing ChannelMetadata objects during import/export. Fixes #4409 and Fixes #4331

*Card Layouts*

All with checkboxes, none with checkboxes, some with checkboxes. Screenshot taken before increase inter-card spacing to 24px.

![screen shot 2018-10-15 at 3 30 30 pm](https://user-images.githubusercontent.com/10248067/46982369-d90a5080-d090-11e8-9cc7-658aab419de7.png)
![screen shot 2018-10-15 at 3 30 16 pm](https://user-images.githubusercontent.com/10248067/46982370-d90a5080-d090-11e8-9b35-3a0557d89103.png)
![screen shot 2018-10-15 at 3 30 10 pm](https://user-images.githubusercontent.com/10248067/46982372-d90a5080-d090-11e8-8991-6b74eabd719d.png)

### Reviewer guidance

1. Check cards' appearance in Lesson + Exam workflows with various channels
1. Check to see that granular import/export workflow accurately reflects the state of the server.
1. Check to see that #4409 and #4331 are addressed when importing from kolibri studio or peer server.
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
