### PR TITLE
Add missing context when webpack file fails to load

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -139,8 +139,14 @@ class WebpackBundleHook(hooks.KolibriHook):
                 # Might need to change this if we move to a different cache backend.
                 cache.set(cache_key, stats_file_content, None)
             return stats_file_content
-        except IOError:
-            raise WebpackError('Webpack build file missing, front-end assets cannot be loaded')
+        except IOError as e:
+            if hasattr(e, "filename"):
+                problem = "Problems loading: {file}".format(file=e.filename)
+            else:
+                problem = "Not file-related."
+            raise WebpackError(
+                'Webpack build file missing, front-end assets cannot be loaded. {problem}'.format(problem=problem)
+            )
 
     @property
     @hooks.registered_method


### PR DESCRIPTION
### Summary

Helps troubleshoot errors that are due to plugins requested that don't really exist.. or in case we have some other terrible complex issue with Webpack assets.

Before:

![image](https://user-images.githubusercontent.com/374612/47029221-4db1bd80-d16b-11e8-9efa-37187ab8e3af.png)

After:

![image](https://user-images.githubusercontent.com/374612/47029229-55716200-d16b-11e8-8b27-5f6961071da9.png)


### Reviewer guidance

n/a

### References

Nope, just referencing myself and time wasted :)

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
