### PR TITLE
Epub Sandbox v1

### DIFF
--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -123,7 +123,6 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'buble-loader',
-        exclude: /node_modules\/(?!(keen-ui)\/).*/,
         options: {
           objectAssign: 'Object.assign',
         },

--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -146,7 +146,6 @@
 
   import Epub from 'epubjs/src/epub';
   import defaultManager from 'epubjs/src/managers/default';
-  import iFrameView from 'epubjs/src/managers/views/iframe';
   import { EVENTS } from 'epubjs/src/utils/constants';
 
   import Mark from 'mark.js';
@@ -162,6 +161,7 @@
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import contentRendererMixin from 'kolibri.coreVue.mixins.contentRendererMixin';
 
+  import iFrameView from './SandboxIFrameView';
   import LoadingScreen from './LoadingScreen';
   import LoadingError from './LoadingError';
   import TopBar from './TopBar';

--- a/kolibri/plugins/document_epub_render/assets/src/views/SandboxIFrameView.js
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SandboxIFrameView.js
@@ -1,0 +1,11 @@
+import iFrameView from 'epubjs/src/managers/views/iframe';
+
+class SandboxIFrameView extends iFrameView {
+  create() {
+    const iframe = super.create();
+    iframe.sandbox = 'allow-scripts allow-same-origin';
+    return iframe;
+  }
+}
+
+export default SandboxIFrameView;


### PR DESCRIPTION
### Summary
* Adds the `sandbox` attribute to the epub iframe
* For maximum compatibility with epubjs adds `allow-scripts` and `allow-same-origin` sandbox options, so that epubjs can continue to communicate synchronously with the iframe.

### Reviewer guidance
Anything look awry with epub rendering?

I had to remove the buble exclude of node modules - this works fine for vanilla Kolibri, but we will need to add in a specific exception for buble into the perseus renderer webpack config.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
