### PR TITLE
Get available disk space for symlinked directory

### DIFF
--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import sys
 from collections import namedtuple
@@ -199,7 +200,7 @@ class FreeSpaceTestCase(APITestCase):
 
                 response = self.client.get(reverse("kolibri:core:freespace"), {'path': 'test'})
 
-                os_statvfs_mock.assert_called_with('test')
+                os_statvfs_mock.assert_called_with(os.path.realpath('test'))
                 self.assertEqual(response.data, {'freespace': 2})
 
     def test_win_freespace_fail(self):

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -153,7 +153,7 @@ def get_free_space(path=KOLIBRI_HOME):
             raise ctypes.winError()
         result = free.value
     else:
-        st = os.statvfs(path)
+        st = os.statvfs(os.path.realpath(path))
         result = st.f_bavail * st.f_frsize
 
     return result


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix #4227 as the user requested, in the case that the content directory is symbolically linked to another location.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Plug in a USB
2. create a folder `content` inside the USB folder
3. Run kolibri 0.11-beta1 (or other versions, as long as it's not installers from this PR), and then stop the server (this is to get the kolibri home directory created. If ~/.kolibri has existed, please skip this step)
4. run `ln -s <usb_directory>/content ~/.kolibri`. After that, run `ls -l ~/.kolibri/content` to see if a symbolic link is created correctly. The result of the command should look something like this:
```
lingyiwang$ ls -l ~/.kolibri/content
lrwxr-xr-x  1 lingyiwang  staff  30 Oct 16 16:45 /Users/lingyiwang/.kolibri/content -> /Volumes/NO NAME/KOLIBRI_DATA/
```
5. Run kolibri 0.11-beta1 again. Go to channel import page to see the available disk space. 
It should look like this:
![image](https://user-images.githubusercontent.com/19424916/47054865-35d93a00-d169-11e8-9e7e-bf8e9b92da03.png)
After getting the value of the available disk space, stop the kolibri server.
6. Run kolibri installer from this PR. Go to channel import page to see the available disk space.
The available disk space should be changed. Instead of showing the available disk space of your device, it should show the available space of the USB.
For example:
![image](https://user-images.githubusercontent.com/19424916/47054904-75a02180-d169-11e8-9a54-ccb0c0cf16a2.png)


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#4227 

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
