### PR TITLE
Fix autosave issue when removing from a Lesson Resource Preview

### DIFF
--- a/kolibri/core/assets/src/views/KModal.vue
+++ b/kolibri/core/assets/src/views/KModal.vue
@@ -37,7 +37,7 @@
 
         <!-- Stop propagation of enter key to prevent the submit event from being emitted twice -->
         <form
-          @submit.prevent.once="emitSubmitEvent"
+          @submit.prevent="emitSubmitEvent"
           @keyup.enter.stop
         >
           <!-- Default slot for content -->

--- a/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/lessonsRoutes.js
@@ -60,8 +60,23 @@ export default [
     name: LessonsPageNames.SELECTION,
     path: '/:classId/lessons/:lessonId/selection/topic/:topicId',
     component: LessonResourceSelectionPage,
-    handler: toRoute => {
-      showLessonResourceSelectionTopicPage(store, toRoute.params);
+    handler: (toRoute, fromRoute) => {
+      // HACK if last page was LessonContentPreviewPage, then we need to make sure
+      // to immediately autosave just in case a change was made there. This gets
+      // called whether or not a change is made, because we don't track changes
+      // enough steps back.
+      let preHandlerPromise;
+      if (fromRoute.name === LessonsPageNames.SELECTION_CONTENT_PREVIEW) {
+        preHandlerPromise = store.dispatch('lessonSummary/saveLessonResources', {
+          lessonId: toRoute.params.lessonId,
+          resourceIds: store.state.lessonSummary.workingResources,
+        });
+      } else {
+        preHandlerPromise = Promise.resolve();
+      }
+      preHandlerPromise.then(() => {
+        showLessonResourceSelectionTopicPage(store, toRoute.params);
+      });
     },
   },
   {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -199,19 +199,6 @@
         });
       },
     },
-    beforeRouteEnter(to, from, next) {
-      // HACK if last page was LessonContentPreviewPage, then we need to make sure
-      // to immediately autosave just in case a change was made there. This gets
-      // called whether or not a change is made, because we don't track changes
-      // enough steps back.
-      if (from.name === LessonsPageNames.SELECTION_CONTENT_PREVIEW) {
-        next(vm => {
-          return vm.saveResources();
-        });
-      } else {
-        next();
-      }
-    },
     beforeRouteLeave(to, from, next) {
       // Only autosave if changes have been made
       if (xor(this.workingResources, this.workingResourcesCopy).length > 0) {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonResourceSelectionPage/index.vue
@@ -126,7 +126,6 @@
         'ancestors',
       ]),
       ...mapGetters('lessonSummary/resources', ['numRemainingSearchResults']),
-      ...mapGetters(['contentNodeIsTopic']),
       filteredContentList() {
         const { role } = this.filters;
         if (!this.inSearchMode) {


### PR DESCRIPTION
### Summary

1. Moves auto-save-when-coming-from-preview hack to the route handler for Lesson Resource Selection page. Why? Because when going from 1 to 0 resources in a lesson inside the preview page, the handler for Lesson Resource Selection will actually undo that change! Fixes #4445 
1. Removes a reference to a non-existent getter that was causing an error message
1. Changes a `submit.prevent.once` modifier to `submit.prevent` in KModal since, we need to prevent the default submit behavior always. Fixes #4451 



### Reviewer guidance

1. Check to see that #4445 is resolved. Especially check when going from 1 resource to zero.
1. Check to see that #4451 is resolved for both exams and lessons.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
