### PR TITLE
Fix channel file size summaries in import/export workflows

### DIFF
--- a/integration_testing/features/admin/admin-manage-channel-sizes.feature
+++ b/integration_testing/features/admin/admin-manage-channel-sizes.feature
@@ -1,0 +1,26 @@
+Feature: Admin Device Management Channel Sizes
+  Admin should see the correct file sizes and resource counts regarding a channel
+
+  Background:
+    Given I am signed into Kolibri as an admin user
+      And I am on the *Device > Channels* page
+
+  Scenario: Correct file sizes when transferring content
+    When I am doing an <transfer_workflow>
+      And I go to the *Select Content Page* for <channel_name>
+    Then In the *Size: Total size* cell, it says <total_file_size>
+      And In the *Size: On your device* cell, it says <on_device_file_size>
+      And In the *Resources: Total size* cell, it says <total_resources>
+      And In the *Resources: On your device* cell, it says <on_device_resources>
+
+Examples:
+| channel_name        | on_device_file_size | total_file_size | on_device_resources | total_resources |
+| Khan Academy        | 1 GB                | 10 GB           | 10                  | 100             |
+
+Examples:
+| transfer_workflow               |
+| Import from Kolibri Studio      |
+| Import more from Kolibri Studio |
+| Export to a USB drive           |
+| Import from a USB drive         |
+| Import from a Peer              |

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/selectContentActions.js
@@ -1,28 +1,31 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import { downloadChannelMetadata } from '../utils';
+import { getChannelWithContentSizes } from '../apiChannelMetadata';
 
 /**
  * Transitions the import/export wizard to the 'load-channel-metadata' interstitial state
  *
  */
-export function loadChannelMetaData(store) {
+export function loadChannelMetadata(store) {
   let dbPromise;
   const { transferredChannel } = store.state.manageContent.wizard;
   const channelOnDevice = store.getters['manageContent/channelIsInstalled'](transferredChannel.id);
 
-  // Downloading the Content Metadata DB
-  if (!channelOnDevice) {
-    // Update metadata when no content db has been downloaded
-    dbPromise = downloadChannelMetadata(store);
-  } else if (!channelOnDevice.available && channelOnDevice.version < transferredChannel.version) {
-    // If channel _is_ on the device, but not "available" (i.e. no resources installed yet)
-    // _and_ has been updated, then download the metadata
+  // If channel _is_ on the device, but not "available" (i.e. no resources installed yet)
+  // _and_ has been updated, then download the metadata
+  const newChannelDbAvailable =
+    channelOnDevice &&
+    !channelOnDevice.available &&
+    channelOnDevice.version < transferredChannel.version;
+
+  // Update metadata when no content db has been downloaded or if it is stale
+  if (!channelOnDevice || newChannelDbAvailable) {
     dbPromise = downloadChannelMetadata(store);
   } else {
     // If already on device, then skip the DB download, and use on-device
     // Channel metadata, since it has root id.
-    dbPromise = Promise.resolve(channelOnDevice);
+    dbPromise = getChannelWithContentSizes(transferredChannel.id);
   }
 
   // Hydrating the store with the Channel Metadata
@@ -32,8 +35,6 @@ export function loadChannelMetaData(store) {
       // Replacing them here with canonical type from ChannelResource.
       store.commit('manageContent/wizard/SET_TRANSFERRED_CHANNEL', {
         ...channel,
-        total_resources: transferredChannel.total_resources,
-        total_file_size: transferredChannel.total_file_size,
         version: transferredChannel.version,
         public: transferredChannel.public,
       });

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/apiChannelMetadata.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/apiChannelMetadata.js
@@ -1,0 +1,20 @@
+import ChannelResource from '../../apiResources/deviceChannel';
+
+// Gets Metadata for Channels whose DBs have been downloaded onto the server.
+// Response includes all of the file/resource sizes.
+export function getChannelWithContentSizes(channelId) {
+  return new Promise((resolve, reject) => {
+    ChannelResource.fetchModel({
+      id: channelId,
+      getParams: {
+        include_fields: [
+          'total_resources',
+          'total_file_size',
+          'on_device_resources',
+          'on_device_file_size',
+        ],
+      },
+      force: true,
+    }).then(resolve, reject);
+  });
+}

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -4,7 +4,6 @@ import { createTranslator } from 'kolibri.utils.i18n';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { ContentNodeGranularResource, RemoteChannelResource } from 'kolibri.resources';
-import ChannelResource from '../../apiResources/deviceChannel';
 import { ContentWizardPages, ContentWizardErrors, TransferTypes } from '../../constants';
 import { manageContentPageLink } from '../../views/ManageContentPage/manageContentLinks';
 import { getAvailableSpaceOnDrive, loadChannelMetadata } from './actions/selectContentActions';

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -7,11 +7,12 @@ import { ContentNodeGranularResource, RemoteChannelResource } from 'kolibri.reso
 import ChannelResource from '../../apiResources/deviceChannel';
 import { ContentWizardPages, ContentWizardErrors, TransferTypes } from '../../constants';
 import { manageContentPageLink } from '../../views/ManageContentPage/manageContentLinks';
-import { getAvailableSpaceOnDrive, loadChannelMetaData } from './actions/selectContentActions';
+import { getAvailableSpaceOnDrive, loadChannelMetadata } from './actions/selectContentActions';
 import {
   getAvailableChannelsOnPeerServer,
   getTransferredChannelOnPeerServer,
 } from './apiPeerImport';
+import { getChannelWithContentSizes } from './apiChannelMetadata';
 
 const translator = createTranslator('WizardHandlerTexts', {
   loadingChannelToolbar: 'Loading channel…',
@@ -174,18 +175,7 @@ export function showSelectContentPage(store, params) {
   // HACK if going directly to URL, we make sure channelList has this channel at the minimum.
   // We only get the one channel, since GETing /api/channel with file sizes is slow.
   // We let it fail silently, since it is only used to show "on device" files/resources.
-  const installedChannelPromise = ChannelResource.fetchModel({
-    id: params.channel_id,
-    getParams: {
-      include_fields: [
-        'total_resources',
-        'total_file_size',
-        'on_device_resources',
-        'on_device_file_size',
-      ],
-    },
-    force: true,
-  })
+  const installedChannelPromise = getChannelWithContentSizes(params.channel_id)
     .then(channel => {
       if (store.state.manageContent.channelList.length === 0) {
         store.commit('manageContent/SET_CHANNEL_LIST', [channel]);
@@ -197,14 +187,13 @@ export function showSelectContentPage(store, params) {
     selectedDrivePromise = getSelectedDrive(store, drive_id);
     availableSpacePromise = selectedDrivePromise.then(drive => getAvailableSpaceOnDrive(drive));
     transferredChannelPromise = new Promise((resolve, reject) => {
-      getInstalledChannelsPromise(store).then(channels => {
-        const match = find(channels, { id: channel_id });
-        if (match) {
-          resolve({ ...match });
-        } else {
+      getChannelWithContentSizes(params.channel_id)
+        .then(channel => {
+          resolve({ ...channel });
+        })
+        .catch(() => {
           reject({ error: ContentWizardErrors.CHANNEL_NOT_FOUND_ON_SERVER });
-        }
-      });
+        });
     });
   }
 
@@ -263,7 +252,7 @@ export function showSelectContentPage(store, params) {
       store.commit('CORE_SET_PAGE_LOADING', false);
 
       const isSamePage = samePageCheckGenerator(store);
-      return loadChannelMetaData(store).then(() => {
+      return loadChannelMetadata(store).then(() => {
         if (isSamePage()) {
           return updateTreeViewTopic(store, {
             id: store.state.manageContent.wizard.transferredChannel.id,

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
@@ -1,7 +1,7 @@
 import { RemoteChannelResource, TaskResource } from 'kolibri.resources';
-import ChannelResource from '../../apiResources/deviceChannel';
 import { ErrorTypes } from '../../constants';
 import { waitForTaskToComplete } from '../manageContent/utils';
+import { getChannelWithContentSizes } from './apiChannelMetadata';
 
 /**
  * Makes request to RemoteChannel API with a token. Does not actually interact
@@ -51,17 +51,7 @@ export function downloadChannelMetadata(store) {
       const { taskId, cancelled } = completedTask;
       if (taskId && !cancelled) {
         return TaskResource.cancelTask(taskId).then(() => {
-          return ChannelResource.fetchModel({
-            id: transferredChannel.id,
-            getParams: {
-              include_fields: [
-                'total_resources',
-                'total_file_size',
-                'on_device_resources',
-                'on_device_file_size',
-              ],
-            },
-          });
+          return getChannelWithContentSizes(transferredChannel.id);
         });
       }
       return Promise.reject({ errorType: ErrorTypes.CHANNEL_TASK_ERROR });

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -41,8 +41,8 @@
 
       <tr class="on-device">
         <td>{{ $tr('onDeviceRow') }}</td>
-        <td>{{ $tr('resourceCount', { count: channelOnDevice.on_device_resources || 0 }) }}</td>
-        <td>{{ bytesForHumans(channelOnDevice.on_device_file_size || 0) }}</td>
+        <td>{{ $tr('resourceCount', { count: channel.on_device_resources || 0 }) }}</td>
+        <td>{{ bytesForHumans(channel.on_device_file_size || 0) }}</td>
       </tr>
     </table>
   </section>

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -19,7 +19,7 @@
               <KCheckbox
                 :label="$tr('selectAll')"
                 :checked="nodeIsChecked(annotatedTopicNode)"
-                :disabled="disableAll || annotatedTopicNode.disabled"
+                :disabled="disableSelectAll"
                 @change="toggleSelectAll"
               />
             </th>
@@ -61,6 +61,7 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import KBreadcrumbs from 'kolibri.coreVue.components.KBreadcrumbs';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import last from 'lodash/last';
   import every from 'lodash/every';
   import omit from 'lodash/omit';
@@ -101,6 +102,24 @@
       childNodes() {
         // Guard against when state is reset going back to manage content page
         return this.currentTopicNode.children || [];
+      },
+      noSelectableNodes() {
+        // If importing from an external drive, disable select-all if every child node is
+        // 1) a leaf node and 2) already on the server or not available on the drive
+        // TODO check to see if this logic is valid for PEER_IMPORT as well.
+        if (this.transferType === TransferTypes.LOCALIMPORT) {
+          return every(this.annotatedChildNodes, node => {
+            return (
+              node.kind !== ContentNodeKinds.TOPIC &&
+              (!node.available || node.on_device_resources > 0)
+            );
+          });
+        } else {
+          return false;
+        }
+      },
+      disableSelectAll() {
+        return this.disableAll || this.annotatedTopicNode.disabled || this.noSelectableNodes;
       },
       childNodesWithPath() {
         return this.childNodes.map(node => ({

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -63,7 +63,7 @@
         />
 
         <UiAlert
-          v-if="status!==''"
+          v-if="status !== ''"
           type="error"
           :dismissible="false"
         >
@@ -79,7 +79,7 @@
         </UiAlert>
         <!-- Contains size estimates + submit button -->
         <SelectedResourcesSize
-          v-if="availableSpace!==null"
+          v-if="availableSpace !== null"
           :mode="mode"
           :fileSize="nodeCounts.fileSize"
           :resourceCount="nodeCounts.resources"

--- a/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
+++ b/kolibri/plugins/device_management/assets/test/actions/showSelectContentPage.spec.js
@@ -1,6 +1,6 @@
 //
 import { ContentNodeGranularResource, TaskResource } from 'kolibri.resources';
-import { loadChannelMetaData } from '../../src/modules/wizard/actions/selectContentActions';
+import { loadChannelMetadata } from '../../src/modules/wizard/actions/selectContentActions';
 import { jestMockResource } from 'testUtils'; // eslint-disable-line
 import ChannelResource from '../../src/apiResources/deviceChannel';
 import { defaultChannel } from '../utils/data';
@@ -18,7 +18,7 @@ function hackStoreWatcher(store) {
   }, 1);
 }
 
-describe('loadChannelMetaData action', () => {
+describe('loadChannelMetadata action', () => {
   let store;
 
   beforeEach(() => {
@@ -76,7 +76,7 @@ describe('loadChannelMetaData action', () => {
 
   // Tests for common behavior
   function testNoChannelsAreImported(store, options) {
-    return loadChannelMetaData(store, options).then(() => {
+    return loadChannelMetadata(store, options).then(() => {
       expect(TaskResource.startDiskChannelImport).not.toHaveBeenCalled();
       expect(TaskResource.startRemoteChannelImport).not.toHaveBeenCalled();
     });
@@ -93,7 +93,7 @@ describe('loadChannelMetaData action', () => {
     });
 
     it('if channel is *not* on device, then "startdiskchannelimport" is called', () => {
-      return loadChannelMetaData(store).then(() => {
+      return loadChannelMetadata(store).then(() => {
         expect(TaskResource.startDiskChannelImport).toHaveBeenCalledWith({
           channel_id: 'localimport_brand_new_channel',
           drive_id: 'localimport_specs_drive',
@@ -104,7 +104,7 @@ describe('loadChannelMetaData action', () => {
 
     it('errors from startDiskChannelImport are handled', () => {
       TaskResource.startDiskChannelImport.mockRejectedValue();
-      return loadChannelMetaData(store).then(() => {
+      return loadChannelMetadata(store).then(() => {
         expect(store.state.manageContent.wizard.status).toEqual('CONTENT_DB_LOADING_ERROR');
       });
     });
@@ -121,7 +121,7 @@ describe('loadChannelMetaData action', () => {
     });
 
     it('if channel is *not* on device, then "startremotechannelimport" is called', () => {
-      return loadChannelMetaData(store).then(() => {
+      return loadChannelMetadata(store).then(() => {
         expect(TaskResource.startRemoteChannelImport).toHaveBeenCalledWith({
           channel_id: 'remoteimport_brand_new_channel',
         });
@@ -131,7 +131,7 @@ describe('loadChannelMetaData action', () => {
 
     it('errors from startRemoteChannelImport are handled', () => {
       TaskResource.startRemoteChannelImport.mockRejectedValue();
-      return loadChannelMetaData(store).then(() => {
+      return loadChannelMetadata(store).then(() => {
         expect(store.state.manageContent.wizard.status).toEqual('CONTENT_DB_LOADING_ERROR');
       });
     });

--- a/kolibri/plugins/device_management/assets/test/utils/makeStore.js
+++ b/kolibri/plugins/device_management/assets/test/utils/makeStore.js
@@ -100,7 +100,11 @@ export function makeSelectContentPageStore() {
   Object.assign(store.state.manageContent.wizard, {
     availableChannels: [...allChannels],
     transferType: 'localimport',
-    transferredChannel: { ...allChannels[0] },
+    transferredChannel: {
+      ...allChannels[0],
+      on_device_resources: 2000,
+      on_device_file_size: 95189556, // about 95 MB
+    },
     currentTopicNode: contentNodeGranularPayload(),
   });
   return store;

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -85,7 +85,11 @@ describe('selectContentPage', () => {
   });
 
   it('if channel is not on device, it shows size and resources as 0', () => {
-    updateMetaChannel(store, { id: 'not_awesome_channel' });
+    updateMetaChannel(store, {
+      id: 'not_awesome_channel',
+      on_device_resources: 0,
+      on_device_file_size: 0,
+    });
     const wrapper = makeWrapper({ store });
     const { onDeviceRows } = getElements(wrapper);
     const rows = onDeviceRows();


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. This fixes the incorrect displays of file/resources size for channels. How? By explicitly requesting these statistics and placing them in the `transferredChannel` part of `manageContent.wizard.state` (and having views rely on this data), rather than in `manageContent.channelList`, which does not have the full set of counts. Fixes #4452 
1. Disables the 'select all' checkbox in import/export at topics. mostly Fixes #3925 

### Reviewer guidance

1. See Gherkin stories for channel sizes. Test to see that the numbers are correct for all kinds of workflows. If testing against Khan Academy English version 13, there are 12473 resources, 39 GB file size.
1. To test 'select all', import a subset of a channel with some empty topics. Try to export the channel to a USB drive. When going to an empty topic, the select-all button should be disabled.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
