### PR TITLE
remove references to 'lesson' in assignment modal

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentDetailsModal.vue
@@ -18,7 +18,7 @@
     <KTextbox
       @blur="titleIsVisited = true"
       ref="titleField"
-      :label="$tr('lessonTitlePlaceholder')"
+      :label="$tr('titlePlaceholder')"
       :maxlength="50"
       :autofocus="true"
       :invalid="titleIsInvalid"
@@ -141,7 +141,7 @@
         const unsharedIds = xor(this.selectedCollectionIds, this.initialSelectedCollectionIds);
         return unsharedIds.length > 0;
       },
-      lessonDetailsHaveChanged() {
+      detailsHaveChanged() {
         return (
           this.initialTitle !== this.title ||
           this.initialDescription !== this.description ||
@@ -160,7 +160,7 @@
 
         if (this.formIsValid) {
           this.formIsSubmitted = true;
-          if (!this.lessonDetailsHaveChanged) {
+          if (!this.detailsHaveChanged) {
             this.closeModal();
             return;
           }
@@ -190,7 +190,7 @@
       description: 'Description',
       fieldRequiredErro: 'This field is required',
       save: 'Save',
-      lessonTitlePlaceholder: 'Lesson title',
+      titlePlaceholder: 'Title',
       assignedGroupsLabel: 'Visible to',
     },
   };


### PR DESCRIPTION
### Summary

the assignment modal is serving dual-purpose for exams and lessons, but currently references lessons. this updates that.

we should be OK to change this string because there are other instances of the word "Title" in translation memory

### Reviewer guidance

look good? work good?

### References

fixes #4468

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
