### PR TITLE
adding a 'kind' to the StatusIcon and add two new strings

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -24,7 +24,7 @@
         />
       </dt>
       <dd>
-        <StatusIcon :active="active" />
+        <StatusIcon :active="active" :type="kind" />
         <KButton
           appearance="basic-link"
           class="change-status-button"

--- a/kolibri/plugins/coach/assets/src/views/assignments/StatusIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/StatusIcon.vue
@@ -13,13 +13,15 @@
       name="lens"
       class="status-icon-inactive"
     />
-    <span class="active-text">{{ active ? $tr('active') : $tr('inactive') }}</span>
+    <span class="active-text">{{ text }}</span>
   </span>
 
 </template>
 
 
 <script>
+
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     name: 'StatusIcon',
@@ -28,10 +30,28 @@
         type: Boolean,
         default: false,
       },
+      type: {
+        type: String,
+        required: true,
+        validator(value) {
+          return [ContentNodeKinds.EXAM, ContentNodeKinds.LESSON].includes(value);
+        },
+      },
     },
     $trs: {
-      active: 'Active',
-      inactive: 'Inactive',
+      // both forms are necessary for languages where adjective and noun must agree
+      examActive: 'Active',
+      examInactive: 'Inactive',
+      lessonActive: 'Active',
+      lessonInactive: 'Inactive',
+    },
+    computed: {
+      text() {
+        if (this.type === ContentNodeKinds.EXAM) {
+          return this.active ? this.$tr('examActive') : this.$tr('examInactive');
+        }
+        return this.active ? this.$tr('lessonActive') : this.$tr('lessonInactive');
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/index.vue
@@ -38,7 +38,7 @@
           :key="exam.id"
         >
           <td class="core-table-icon-col">
-            <ContentIcon :kind="examIcon" />
+            <ContentIcon :kind="examKind" />
           </td>
 
           <td class="core-table-main-col">
@@ -51,7 +51,7 @@
           <td> {{ genRecipientsString(exam.assignments) }} </td>
 
           <td>
-            <StatusIcon :active="exam.active" />
+            <StatusIcon :active="exam.active" :type="examKind" />
           </td>
         </tr>
       </tbody>
@@ -125,7 +125,7 @@
     },
     computed: {
       ...mapState('examsRoot', ['exams']),
-      examIcon() {
+      examKind() {
         return ContentNodeKinds.EXAM;
       },
       sortedExams() {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -51,7 +51,7 @@
           <td>{{ $tr('numberOfResources', { count: lesson.resources.length }) }}</td>
           <td>{{ getLessonVisibility(lesson.lesson_assignments) }}</td>
           <td>
-            <StatusIcon :active="lesson.is_active" />
+            <StatusIcon :active="lesson.is_active" :type="lessonKind" />
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION

### Summary

addressing #4288

the strings on crowdin can be updated manually as described in the comments

### Reviewer guidance

does this all look right?

### References

see https://github.com/learningequality/kolibri/issues/4288#issuecomment-430428284

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
