### PR TITLE
remove start_progress mock in the content import test cases

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -192,10 +192,9 @@ class Command(AsyncCommand):
             * False, 0 - the transfer fails and needs to retry.
         """
         try:
-            if self.progresstrackers:
-                # Save the current progress value
-                original_value = self.progresstrackers[0].progress
-                original_progress = self.progresstrackers[0].get_progress()
+            # Save the current progress value
+            original_value = self.progresstrackers[0].progress
+            original_progress = self.progresstrackers[0].get_progress()
 
             with filetransfer, self.start_progress(total=filetransfer.total_size) as file_dl_progress_update:
                 # If size of the source file is smaller than the the size


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The original issue is that variable `original_value` is referenced before assignment, meaning that the [if statement](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/content/management/commands/importcontent.py#L195) to check the `self.progresstrackers` failed. I put the if statement there because there was a test case failing, and putting it there fixed the issue at that time.

The reason behind this error is that `start_progress` mock in the unit tests caused `self.progresstrackers` to be empty.

However, in reality, `self.progresstrackers` should always have at least one tracker inside when called in function [`_start_file_transfer`](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/content/management/commands/importcontent.py#L185). That is to say, the if statement is not necessary. Instead of using the if statement to check `self.progresstrackers` to let the unit tests pass, I remove the `start_progress` mocks in the import content test cases to let them be closer to the circumstances in reality. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the tests pass.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4455

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
