### PR TITLE
Update gherking file to include latest changes in the performance command

### DIFF
--- a/integration_testing/features/super-admin/super-admin-profile-command.feature
+++ b/integration_testing/features/super-admin/super-admin-profile-command.feature
@@ -8,13 +8,15 @@ Feature: Super Admin profile manage command
   Scenario: A terminal is open in the same machine where Kolibri is running
     Given that I have access to the kolibri command line
     When I enter <kolibri manage profile --num_samples=6>
-    Then Two new log files appear in the KOLIBRI_HOME (Usually $HOME/.kolibri) performance.log and requests_performance.log
+      And I look at the KOLIBRI_HOME/performance directory (Usually $HOME/.kolibri/performance)
+    Then I see a xxxxxxxx_xxxxxx_performance.csv file, where xxxxxxxx_xxxxxx is current date and time, example 20181022_194415_performance.csv
     When I use the browser to navigate through kolibri pages
-    Then I see new data appearing in requests_performance.log
+      And I look at the KOLIBRI_HOME/performance directory (Usually $HOME/.kolibri/performance)
+    Then I see another file called xxxxxxxx_xxxxxx_requests_performance.csv, where xxxxxxxx_xxxxxx is the same date and time shown in the previous file
     When 1 minutes pass
-    Then I see again the prompt in the terminal and performance.log and requests_performance.log don't change anymore.
-    When I open performance.log with a text editor
-    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line
-    When I open requests_performance.log with a text editor
+    Then I see again the prompt in the terminal and performance.csv and requests_performance.csv files don't change anymore.
+    When I open performance.csv with a text editor or with a Spreadsheet application
+    Then I check it has at least 60 lines beginning with a timestamp and several numbers per line. First line is a header with the name of the fields
+    When I open requests_performance.csvwith a text editor
     Then I check it has at least one line per Kolibri page I have visited in the browser. Each lines begins with a timestamp and has several numbers.
 


### PR DESCRIPTION
### Summary
Gherking story for the new performance command was added in #4434 
Recently, there have been some changes in the behaviour of this command.
This PR includes these changes in the Gherking story


### Reviewer guidance
Open integration_testing/features/super-admin/super-admin-profile-command.feature
and read the story checking its syntax and logic.


### References
Relates #4434 

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
