### PR TITLE
Expand class names with '&-', fix typeerror in profile page

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/assignments/AssignmentSummary.vue
@@ -191,13 +191,14 @@
   .group-list {
     padding: 0;
     margin: 0;
-    &-item {
-      display: inline;
-      margin: 0;
-      list-style: none;
-      &:not(:last-child)::after {
-        content: ', ';
-      }
+  }
+
+  .group-list-item {
+    display: inline;
+    margin: 0;
+    list-style: none;
+    &:not(:last-child)::after {
+      content: ', ';
     }
   }
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -155,21 +155,21 @@
     // maintaining a simple right/left alignment in a single text-line without floats. Simple RTL
     display: table;
     width: 100%;
+  }
 
-    &-title {
-      display: inline-block;
-      font-size: 1em;
+  .resource-list-header-title {
+    display: inline-block;
+    font-size: 1em;
+  }
 
-      &-block {
-        display: table-cell;
-        text-align: left;
-      }
-    }
+  .resource-list-header-title-block {
+    display: table-cell;
+    text-align: left;
+  }
 
-    &-add-resource-button {
-      display: table-cell;
-      text-align: right;
-    }
+  .resource-list-header-add-resource-button {
+    display: table-cell;
+    text-align: right;
   }
 
   .no-resources-message {

--- a/kolibri/plugins/device_management/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/WelcomeModal.vue
@@ -48,14 +48,12 @@
 
 <style lang="scss" scoped>
 
-  .welcome-modal {
-    &-description {
-      margin-top: 16px;
-    }
-    &-dismiss-button {
-      margin-top: 24px;
-      margin-bottom: 16px;
-    }
+  .welcome-modal-description {
+    margin-top: 16px;
+  }
+  .welcome-modal-dismiss-button {
+    margin-top: 24px;
+    margin-bottom: 16px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -275,52 +275,53 @@
 
     position: relative;
     margin-top: 1em;
+  }
 
-    &-control-container {
-      position: relative;
-      overflow: visible;
-    }
+  .content-carousel-control-container {
+    position: relative;
+    overflow: visible;
+  }
 
-    &-card {
-      position: absolute;
-      left: 0;
-      transition: left 0.4s ease, box-shadow $core-time ease;
-    }
+  .content-carousel-card {
+    position: absolute;
+    left: 0;
+    transition: left 0.4s ease, box-shadow $core-time ease;
+  }
 
-    &-next-control,
-    &-previous-control {
-      position: absolute;
-      top: $card-height / 2;
-      z-index: 2; // material
-      width: $control-hit-width;
-      height: $control-hit-height;
-      text-align: center;
-      vertical-align: middle;
-      transform: translateY(-($control-hit-height / 2));
-      // styles that apply to both control buttons
-      &:active {
-        z-index: 8; // material
-      }
+  .content-carousel-next-control,
+  .content-carousel-previous-control {
+    position: absolute;
+    top: $card-height / 2;
+    z-index: 2; // material
+    width: $control-hit-width;
+    height: $control-hit-height;
+    text-align: center;
+    vertical-align: middle;
+    transform: translateY(-($control-hit-height / 2));
+    // styles that apply to both control buttons
+    &:active {
+      z-index: 8; // material
+    }
+  }
 
-      &-button {
-        // center align within hitbox
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
-        &:active {
-          box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23); // material
-        }
-      }
+  .content-carousel-next-control-button,
+  .content-carousel-previous-control-button {
+    // center align within hitbox
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+    &:active {
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23); // material
     }
+  }
 
-    // position-specific styles for each control button
-    &-next-control {
-      right: -($control-hit-width / 2) - 25;
-    }
-    &-previous-control {
-      left: -($control-hit-width / 2);
-    }
+  // position-specific styles for each control button
+  .content-carousel-next-control {
+    right: -($control-hit-width / 2) - 25;
+  }
+  .content-carousel-previous-control {
+    left: -($control-hit-width / 2);
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -28,8 +28,10 @@
         @enter="slide"
       >
 
+        <!-- eslint-disable vue/no-use-v-if-with-v-for -->
         <ContentCard
-          v-for="(content, index) in showableContents"
+          v-for="(content, index) in contents"
+          v-if="isInThisSet(index)"
           :key="content.id"
           class="content-carousel-card"
           :style="positionCalc(index)"
@@ -117,9 +119,6 @@
       };
     },
     computed: {
-      showableContents() {
-        return this.contents.filter((x, index) => this.isInThisSet(index));
-      },
       animationAttr() {
         return this.isRtl ? 'right' : 'left';
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupHeader.vue
@@ -50,25 +50,25 @@
     margin-top: $header-size;
     margin-bottom: $header-size / 2;
     vertical-align: bottom;
+  }
 
-    &-header,
-    &-view-more {
-      display: inline-block;
-      width: 50%;
-    }
+  .card-group-details-header,
+  .card-group-details-view-more {
+    display: inline-block;
+    width: 50%;
+  }
 
-    &-header {
-      margin: 0;
-      clear: none;
-      font-size: $header-size;
-      color: $core-text-default;
-      text-align: left;
-    }
+  .card-group-details-header {
+    margin: 0;
+    clear: none;
+    font-size: $header-size;
+    color: $core-text-default;
+    text-align: left;
+  }
 
-    &-view-more {
-      text-align: right;
-      text-decoration: underline;
-    }
+  .card-group-details-view-more {
+    text-align: right;
+    text-decoration: underline;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -158,24 +158,24 @@
 
   .permission-preset {
     cursor: pointer;
+  }
 
-    &-modal {
-      &-dismiss-button {
-        text-transform: uppercase;
-      }
-    }
+  .permission-preset-modal-dismiss-button {
+    text-transform: uppercase;
   }
 
   .permission-preset-human {
     margin-bottom: 8px;
-    &-title {
-      font-weight: bold;
-    }
-    &-detail {
-      display: list-item;
-      margin-left: 20px;
-      line-height: 1.4em;
-    }
+  }
+
+  .permission-preset-human-title {
+    font-weight: bold;
+  }
+
+  .permission-preset-human-detail {
+    display: list-item;
+    margin-left: 20px;
+    line-height: 1.4em;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -72,38 +72,36 @@
 
   $core-title-md: 21px; // filling in for future typography styles
 
-  .onboarding-form {
-    &-fields {
-      padding: 0;
-      margin: 0;
-      margin-bottom: 24px;
-      border: 0;
-    }
+  .onboarding-form-fields {
+    padding: 0;
+    margin: 0;
+    margin-bottom: 24px;
+    border: 0;
+  }
 
-    &-header {
-      margin-top: 0;
-      margin-bottom: 16px;
-      font-size: $core-title-md;
-    }
+  .onboarding-form-header {
+    margin-top: 0;
+    margin-bottom: 16px;
+    font-size: $core-title-md;
+  }
 
-    &-legend {
-      // Fixes issue in IE11 where the description span would not be broken up
-      width: 100%;
-      margin-bottom: 8px;
-    }
+  .onboarding-form-legend {
+    // Fixes issue in IE11 where the description span would not be broken up
+    width: 100%;
+    margin-bottom: 8px;
+  }
 
-    &-description {
-      margin-bottom: 8px;
-    }
+  .onboarding-form-description {
+    margin-bottom: 8px;
+  }
 
-    &-submit {
-      margin: 0;
-    }
+  .onboarding-form-submit {
+    margin: 0;
   }
 
   .form-footer {
-    margin-top: 24px;
     margin: 24px 0;
+    margin-top: 24px;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/ErrorPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/ErrorPage.vue
@@ -52,17 +52,17 @@
 
   @import '~kolibri.styles.definitions';
 
-  .error-page {
-    &-subheader {
-      margin-bottom: 24px;
-    }
-    &-retry-button {
-      margin-bottom: 16px;
-    }
-    &-subtext {
-      font-size: 12px;
-      color: $core-text-annotation;
-    }
+  .error-page-subheader {
+    margin-bottom: 24px;
+  }
+
+  .error-page-retry-button {
+    margin-bottom: 16px;
+  }
+
+  .error-page-subtext {
+    font-size: 12px;
+    color: $core-text-annotation;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/SubmissionStatePage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/SubmissionStatePage.vue
@@ -43,23 +43,23 @@
 
   .submission-state-page {
     text-align: center;
+  }
 
-    &-header {
-      margin-top: 0;
-      margin-bottom: 24px;
-      font-size: 21px;
-      color: $core-accent-color;
-    }
+  .submission-state-page-header {
+    margin-top: 0;
+    margin-bottom: 24px;
+    font-size: 21px;
+    color: $core-accent-color;
+  }
 
-    &-body {
-      font-size: 14px;
-    }
+  .submission-state-page-body {
+    font-size: 14px;
+  }
 
-    &-spinner {
-      display: inline-block;
-      height: 32px; // setting to the height of the spinner to make the wrapper hug it
-      margin-bottom: 40px;
-    }
+  .submission-state-page-spinner {
+    display: inline-block;
+    height: 32px; // setting to the height of the spinner to make the wrapper hug it
+    margin-bottom: 40px;
   }
 
 </style>

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -108,6 +108,7 @@
 <script>
 
   import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
+  import pickBy from 'lodash/pickBy';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { validateUsername } from 'kolibri.utils.validators';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -180,7 +181,7 @@
       }),
       ...mapState('profile', ['busy', 'errorCode', 'passwordState', 'success', 'profileErrors']),
       userPermissions() {
-        return this.getUserPermissions.filter(Boolean);
+        return pickBy(this.getUserPermissions);
       },
       passwordModalVisible() {
         return this.passwordState.modal;


### PR DESCRIPTION
### Summary

1. Expands class names using '&-' SCSS macro Fixes #3505 
1. Fix a type error, where `.filter` was used on an Object.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
