### PR TITLE
Annotate content when a channel is imported/updated

### DIFF
--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -308,10 +308,9 @@ class BaseChannelImportClassOtherMethodsTestCase(TestCase):
 
 class MaliciousDatabaseTestCase(TestCase):
 
-    @patch('kolibri.core.content.utils.channel_import.set_leaf_node_availability_from_local_file_availability')
-    @patch('kolibri.core.content.utils.channel_import.recurse_availability_up_tree')
+    @patch('kolibri.core.content.utils.channel_import.update_content_metadata')
     @patch('kolibri.core.content.utils.channel_import.initialize_import_manager')
-    def test_non_existent_root_node(self, initialize_manager_mock, recurse_mock, leaf_mock):
+    def test_non_existent_root_node(self, initialize_manager_mock, update_content_metadata_mock):
         import_mock = MagicMock()
         initialize_manager_mock.return_value = import_mock
         channel_id = '6199dde695db4ee4ab392222d5af1e5c'

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -286,17 +286,21 @@ def topic_coach_content_annotation(channel_id):
     bridge.end()
 
 
+def update_content_metadata(channel_id):
+    set_leaf_node_availability_from_local_file_availability(channel_id)
+    recurse_availability_up_tree(channel_id)
+    topic_coach_content_annotation(channel_id)
+    calculate_channel_fields(channel_id)
+    ContentCacheKey.update_cache_key()
+
+
 def annotate_content(channel_id, checksums=None):
     if checksums is None:
         set_local_file_availability_from_disk()
     else:
         mark_local_files_as_available(checksums)
 
-    set_leaf_node_availability_from_local_file_availability(channel_id)
-    recurse_availability_up_tree(channel_id)
-    topic_coach_content_annotation(channel_id)
-    calculate_channel_fields(channel_id)
-    ContentCacheKey.update_cache_key()
+    update_content_metadata(channel_id)
 
 
 def calculate_channel_fields(channel_id):

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -6,8 +6,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import text
 
-from .annotation import recurse_availability_up_tree
-from .annotation import set_leaf_node_availability_from_local_file_availability
+from .annotation import update_content_metadata
 from .channels import read_channel_metadata_from_db_file
 from .paths import get_content_database_file_path
 from .sqlalchemybridge import Bridge
@@ -677,8 +676,7 @@ def import_channel_from_local_db(channel_id, cancel_check=None):
 
     import_manager.end()
 
-    set_leaf_node_availability_from_local_file_availability(channel_id)
-    recurse_availability_up_tree(channel_id)
+    update_content_metadata(channel_id)
 
     channel = ChannelMetadata.objects.get(id=channel_id)
     channel.last_updated = local_now()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue https://github.com/learningequality/kolibri/issues/4005 that when a channel is updated, on device resources/file size are shown as 0. This is because the content metadata is not updated in the channel import logic.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Import a channel and import some content from the channel
Update the channel in Studio and click the update button in the channel import page of kolibri
Check whether the numbers for on device resources/file size are correct.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4005

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
