### PR TITLE
Cache dataset_id lookups for logs and remove related lookups

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -189,15 +189,15 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         inconsistencies, make sure it matches the inferred dataset, otherwise raise a ``KolibriValidationError``.
         If we have no dataset and it can't be inferred, we raise a ``KolibriValidationError`` exception as well.
         """
-        inferred_dataset = self.infer_dataset(*args, **kwargs)
+        inferred_dataset_id = self.infer_dataset(*args, **kwargs)
         if self.dataset_id:
             # make sure currently stored dataset matches inferred dataset, if any
-            if inferred_dataset and inferred_dataset != self.dataset:
+            if inferred_dataset_id and inferred_dataset_id != self.dataset_id:
                 raise KolibriValidationError("This model is not associated with the correct FacilityDataset.")
         else:
             # use the inferred dataset, if there is one, otherwise throw an error
-            if inferred_dataset:
-                self.dataset = inferred_dataset
+            if inferred_dataset_id:
+                self.dataset_id = inferred_dataset_id
             else:
                 raise KolibriValidationError("FacilityDataset ('dataset') not provided, and could not be inferred.")
 
@@ -541,7 +541,7 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
         return "{dataset_id}:user-ro:{user_id}".format(dataset_id=self.dataset_id, user_id=self.ID_PLACEHOLDER)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.facility.dataset
+        return self.facility.dataset_id
 
     def get_permission(self, permission):
         try:
@@ -882,7 +882,7 @@ class Collection(MorangoMPTTModel, AbstractFacilityDataModel):
         if self.parent:
             # subcollections inherit dataset from root of their tree
             # (we can't call `get_root` directly on self, as it won't work if self hasn't yet been saved)
-            return self.parent.get_root().dataset
+            return self.parent.get_root().dataset_id
         else:
             return None  # the root node (i.e. Facility) must be explicitly tied to a dataset
 
@@ -929,11 +929,11 @@ class Membership(AbstractFacilityDataModel):
         return '{collection_id}'.format(collection_id=self.collection_id)
 
     def infer_dataset(self, *args, **kwargs):
-        user_dataset = self.user.dataset
-        collection_dataset = self.collection.dataset
-        if user_dataset != collection_dataset:
+        user_dataset_id = self.user.dataset_id
+        collection_dataset_id = self.collection.dataset_id
+        if user_dataset_id != collection_dataset_id:
             raise KolibriValidationError("Collection and user for a Membership object must be in same dataset.")
-        return user_dataset
+        return user_dataset_id
 
     def __str__(self):
         return "{user}'s membership in {collection}".format(user=self.user, collection=self.collection)
@@ -978,11 +978,11 @@ class Role(AbstractFacilityDataModel):
         return '{collection_id}:{kind}'.format(collection_id=self.collection_id, kind=self.kind)
 
     def infer_dataset(self, *args, **kwargs):
-        user_dataset = self.user.dataset
-        collection_dataset = self.collection.dataset
-        if user_dataset != collection_dataset:
+        user_dataset_id = self.user.dataset_id
+        collection_dataset_id = self.collection.dataset_id
+        if user_dataset_id != collection_dataset_id:
             raise KolibriValidationError("The collection and user for a Role object must be in the same dataset.")
-        return user_dataset
+        return user_dataset_id
 
     def __str__(self):
         return "{user}'s {kind} role for {collection}".format(user=self.user, kind=self.kind, collection=self.collection)
@@ -1042,7 +1042,7 @@ class Facility(Collection):
         # if we don't yet have a dataset, create a new one for this facility
         if not self.dataset_id:
             self.dataset = FacilityDataset.objects.create()
-        return self.dataset
+        return self.dataset_id
 
     def get_classrooms(self):
         """

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -50,7 +50,7 @@ class Exam(AbstractFacilityDataModel):
     archive = models.BooleanField(default=False)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.creator.dataset
+        return self.creator.dataset_id
 
     def calculate_partition(self):
         return self.dataset_id
@@ -81,7 +81,7 @@ class ExamAssignment(AbstractFacilityDataModel):
     assigned_by = models.ForeignKey(FacilityUser, related_name='assigned_exams', blank=False, null=False)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.assigned_by.dataset
+        return self.assigned_by.dataset_id
 
     def calculate_source_id(self):
         return "{exam_id}:{collection_id}".format(exam_id=self.exam_id, collection_id=self.collection_id)

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -66,7 +66,7 @@ class Lesson(AbstractFacilityDataModel):
     morango_model_name = 'lesson'
 
     def infer_dataset(self, *args, **kwargs):
-        return self.created_by.dataset
+        return self.created_by.dataset_id
 
     def calculate_partition(self):
         return self.dataset_id
@@ -101,7 +101,7 @@ class LessonAssignment(AbstractFacilityDataModel):
     morango_model_name = 'lessonassignment'
 
     def infer_dataset(self, *args, **kwargs):
-        return self.assigned_by.dataset
+        return self.assigned_by.dataset_id
 
     def calculate_source_id(self):
         return "{lesson_id}:{collection_id}".format(lesson_id=self.lesson_id, collection_id=self.collection_id)

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 
 from datetime import timedelta
 
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
@@ -74,13 +73,7 @@ class BaseLogModel(AbstractFacilityDataModel):
 
     def infer_dataset(self, *args, **kwargs):
         if self.user_id:
-            cache_key = 'log_infer_dataset_{user_id}'.format(user_id=self.user_id)
-            if cache.get(cache_key) is not None:
-                return cache.get(cache_key)
-            else:
-                dataset_id = self.user.dataset_id
-                cache.set(cache_key, dataset_id, 60 * 10)
-                return dataset_id
+            return self.cache_related_dataset_lookup('user')
         elif self.dataset_id:
             # confirm that there exists a facility with that dataset_id
             try:
@@ -206,13 +199,7 @@ class MasteryLog(BaseLogModel):
     complete = models.BooleanField(default=False)
 
     def infer_dataset(self, *args, **kwargs):
-        cache_key = 'log_infer_dataset_{user_id}'.format(user_id=self.user_id)
-        if cache.get(cache_key) is not None:
-            return cache.get(cache_key)
-        else:
-            dataset_id = self.user.dataset_id
-            cache.set(cache_key, dataset_id, 60 * 10)
-            return dataset_id
+        return self.cache_related_dataset_lookup('user')
 
     def calculate_source_id(self):
         return "{summarylog_id}:{mastery_level}".format(summarylog_id=self.summarylog_id, mastery_level=self.mastery_level)

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -73,7 +73,7 @@ class BaseLogModel(AbstractFacilityDataModel):
 
     def infer_dataset(self, *args, **kwargs):
         if self.user_id:
-            return self.cache_related_dataset_lookup('user')
+            return self.cached_related_dataset_lookup('user')
         elif self.dataset_id:
             # confirm that there exists a facility with that dataset_id
             try:
@@ -199,7 +199,7 @@ class MasteryLog(BaseLogModel):
     complete = models.BooleanField(default=False)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.cache_related_dataset_lookup('user')
+        return self.cached_related_dataset_lookup('user')
 
     def calculate_source_id(self):
         return "{summarylog_id}:{mastery_level}".format(summarylog_id=self.summarylog_id, mastery_level=self.mastery_level)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The main motivation behind this PR is to optimize deserialization (serialized store models being loaded into the django app layer). When we deserialize, for each model we call `save`, which calls `ensure_dataset`, which does lots of db related lookups. This adds up and makes this operation slow.

Performance Improvement for same number of records:
**BEFORE:**
```
('func: ', 'deserialization')
('queries:', 2955)
('READS: ', 2363)
('WRITES: ', 582)
took: 9.25s
```

**AFTER:**
```
('func: ', 'deserialization')
('queries:', 1655)
('READS: ', 1063)
('WRITES: ', 582)
took: 5.29s
```

Proposed solution in this PR:
Change related lookup calls in `infer_dataset` calls from `self.user.dataset` -> `self.user.dataset_id` (reduces read queries by one).
Also caching dataset lookup calls for logs (saves one read query per log). 

Possible point of contention: One thing is that sqlite does not enforce foreign key constraints so it may be possible to save an object with a non existent `dataset_id`.
Possible solution: We can enable foreign key constraints (if the sqlite version supports it) which would avoid the above https://www.sqlite.org/foreignkeys.html#fk_enable

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do tests pass?
Does using the app as normal work or noticing any strange behavior?

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
