### PR TITLE
Use ImmersiveToolbar in  UserPermissionsPage

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/CoachIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachIndex.vue
@@ -46,7 +46,6 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
-  import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { PageNames } from '../constants';
   import { LessonsPageNames } from '../constants/lessonsConstants';
@@ -175,7 +174,6 @@
         examPreviewCompletionData: state => state.preview.completionData,
       }),
 
-      topLevelPageName: () => TopLevelPageNames.COACH,
       currentPage() {
         return pageNameToComponentMap[this.pageName] || null;
       },

--- a/kolibri/plugins/device_management/assets/src/modules/coreBase.js
+++ b/kolibri/plugins/device_management/assets/src/modules/coreBase.js
@@ -1,0 +1,55 @@
+import { ContentWizardPages, PageNames } from '../constants';
+
+export default {
+  namespaced: true,
+  state: {
+    appBarTitle: '',
+  },
+  getters: {
+    immersivePageIcon(state, getters, rootState) {
+      if (rootState.pageName === PageNames.USER_PERMISSIONS_PAGE) {
+        return 'arrow_back';
+      }
+      return 'close';
+    },
+    currentPageIsImmersive(state, getters, rootState) {
+      return [
+        ContentWizardPages.AVAILABLE_CHANNELS,
+        ContentWizardPages.SELECT_CONTENT,
+        PageNames.USER_PERMISSIONS_PAGE,
+      ].includes(rootState.pageName);
+    },
+    inContentManagementPage(state, getters, rootState) {
+      return [
+        ContentWizardPages.AVAILABLE_CHANNELS,
+        ContentWizardPages.SELECT_CONTENT,
+        PageNames.MANAGE_CONTENT_PAGE,
+      ].includes(rootState.pageName);
+    },
+    // NOTE: appBarTitle needs to be set imperatively in handlers and some components,
+    // but the back-button location should be a function of pageName.
+    immersivePageRoute(state, getters, rootState, rootGetters) {
+      // In all Import/Export pages, go back to ManageContentPage
+      if (getters.inContentManagementPage) {
+        return {
+          name: PageNames.MANAGE_CONTENT_PAGE,
+        };
+      } else if (rootState.pageName === PageNames.USER_PERMISSIONS_PAGE) {
+        // If Admin, goes back to ManagePermissionsPage
+        if (rootGetters.isSuperuser) {
+          return { name: PageNames.MANAGE_PERMISSIONS_PAGE };
+        } else {
+          // If Non-Admin, go to ManageContentPAge
+          return { name: PageNames.MANAGE_CONTENT_PAGE };
+        }
+      } else {
+        return {};
+      }
+    },
+  },
+  mutations: {
+    SET_APP_BAR_TITLE(state, appBarTitle) {
+      state.appBarTitle = appBarTitle;
+    },
+  },
+};

--- a/kolibri/plugins/device_management/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device_management/assets/src/modules/manageContent/index.js
@@ -7,7 +7,6 @@ function defaultState() {
     channelList: [],
     channelListLoading: false,
     taskList: [],
-    toolbarTitle: '',
   };
 }
 
@@ -29,9 +28,6 @@ export default {
     },
     SET_TASK_LIST(state, taskList) {
       state.taskList = [...taskList];
-    },
-    SET_TOOLBAR_TITLE(state, toolbarTitle) {
-      state.toolbarTitle = toolbarTitle;
     },
   },
   getters: {

--- a/kolibri/plugins/device_management/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/device_management/assets/src/modules/pluginModule.js
@@ -3,6 +3,7 @@ import deviceInfo from './deviceInfo';
 import manageContent from './manageContent';
 import managePermissions from './managePermissions';
 import userPermissions from './userPermissions';
+import coreBase from './coreBase';
 
 export default {
   state: {
@@ -46,5 +47,7 @@ export default {
     userPermissions,
     // MANAGE_CONTENT_PAGE + wizards
     manageContent,
+    // CoreBase properties
+    coreBase,
   },
 };

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentWizardActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentWizardActions.js
@@ -12,7 +12,7 @@ const translator = createTranslator('ContentWizardTexts', {
 
 // Provide a intermediate state before Available Channels is fully-loaded
 function prepareForAvailableChannelsPage(store) {
-  store.commit('manageContent/SET_TOOLBAR_TITLE', translator.$tr('loadingChannelsToolbar'), {
+  store.commit('coreBase/SET_APP_BAR_TITLE', translator.$tr('loadingChannelsToolbar'), {
     root: true,
   });
   store.commit('SET_PAGE_NAME', ContentWizardPages.AVAILABLE_CHANNELS, { root: true });

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -165,7 +165,7 @@ export function showSelectContentPage(store, params) {
   store.commit('manageContent/wizard/RESET_STATE');
   store.commit('SET_PAGE_NAME', ContentWizardPages.SELECT_CONTENT);
   store.commit('CORE_SET_PAGE_LOADING', true);
-  store.commit('manageContent/SET_TOOLBAR_TITLE', translator.$tr('loadingChannelToolbar'));
+  store.commit('coreBase/SET_APP_BAR_TITLE', translator.$tr('loadingChannelToolbar'));
 
   if (transferType === null) {
     return router.replace(manageContentPageLink());

--- a/kolibri/plugins/device_management/assets/src/routes/index.js
+++ b/kolibri/plugins/device_management/assets/src/routes/index.js
@@ -43,7 +43,7 @@ const routes = [
     path: '/permissions/:userid',
     handler: ({ params, name }) => {
       store.dispatch('preparePage', { name });
-      showUserPermissionsPage(store, params.userid).then(hideLoadingScreen);
+      showUserPermissionsPage(store, params.userid);
     },
   },
   {

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -195,20 +195,20 @@
     watch: {
       // HACK doing it here to avoid moving $trs out of the component
       transferType(val) {
-        this.setToolbarTitle(this.toolbarTitle(val));
+        this.setAppBarTitle(this.toolbarTitle(val));
       },
     },
     beforeMount() {
       this.languageFilter = { ...this.allLanguagesOption };
       if (this.status) {
-        this.setToolbarTitle(this.$tr('pageLoadError'));
+        this.setAppBarTitle(this.$tr('pageLoadError'));
       } else {
-        this.setToolbarTitle(this.toolbarTitle(this.transferType));
+        this.setAppBarTitle(this.toolbarTitle(this.transferType));
       }
     },
     methods: {
-      ...mapMutations('manageContent', {
-        setToolbarTitle: 'SET_TOOLBAR_TITLE',
+      ...mapMutations('coreBase', {
+        setAppBarTitle: 'SET_APP_BAR_TITLE',
       }),
       toolbarTitle(transferType) {
         switch (transferType) {

--- a/kolibri/plugins/device_management/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceIndex.vue
@@ -4,8 +4,9 @@
     :appBarTitle="currentPageAppBarTitle"
     :immersivePage="currentPageIsImmersive"
     :immersivePagePrimary="true"
-    :immersivePageRoute="exitWizardLink"
-    :toolbarTitle="toolbarTitle"
+    :immersivePageRoute="immersivePageRoute"
+    :immersivePageIcon="immersivePageIcon"
+    :toolbarTitle="currentPageAppBarTitle"
     :showSubNav="canManageContent && !currentPageIsImmersive"
   >
     <DeviceTopNav slot="sub-nav" />
@@ -28,7 +29,6 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
-  import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { ContentWizardPages, PageNames } from '../constants';
   import DeviceTopNav from './DeviceTopNav';
@@ -59,37 +59,29 @@
     computed: {
       ...mapGetters(['canManageContent']),
       ...mapState(['pageName', 'welcomeModalVisible']),
-      ...mapState('manageContent', ['toolbarTitle']),
-      inContentManagementPage() {
-        return [
-          ContentWizardPages.AVAILABLE_CHANNELS,
-          ContentWizardPages.SELECT_CONTENT,
-          PageNames.MANAGE_CONTENT_PAGE,
-        ].includes(this.pageName);
-      },
-      DEVICE: () => TopLevelPageNames.DEVICE,
+      ...mapState('coreBase', ['appBarTitle']),
+      ...mapGetters('coreBase', [
+        'currentPageIsImmersive',
+        'immersivePageIcon',
+        'immersivePageRoute',
+        'inContentManagementPage',
+      ]),
       currentPage() {
         return pageNameComponentMap[this.pageName];
       },
-      currentPageIsImmersive() {
-        // TODO make user-permissions-page immersive too
-        return (
-          this.pageName === ContentWizardPages.AVAILABLE_CHANNELS ||
-          this.pageName === ContentWizardPages.SELECT_CONTENT
-        );
-      },
       currentPageAppBarTitle() {
-        return this.toolbarTitle || this.$tr('deviceManagementTitle');
-      },
-      exitWizardLink() {
-        return {
-          name: PageNames.MANAGE_CONTENT_PAGE,
-        };
+        return this.appBarTitle || this.$tr('deviceManagementTitle');
       },
     },
     watch: {
       inContentManagementPage(val) {
         return val ? this.startTaskPolling() : this.stopTaskPolling();
+      },
+      currentPageIsImmersive(val) {
+        // If going to a non-immersive page, reset the state to show normal Toolbar
+        if (!val) {
+          this.$store.commit('coreBase/SET_APP_BAR_TITLE', '');
+        }
       },
     },
     mounted() {

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -202,15 +202,15 @@
       },
       transferredChannel(val) {
         if (val.name) {
-          this.setToolbarTitle(this.$tr('selectContent', { channelName: val.name }));
+          this.setAppBarTitle(this.$tr('selectContent', { channelName: val.name }));
         }
       },
     },
     mounted() {
       if (this.wholePageError) {
-        this.setToolbarTitle(this.$tr('pageLoadError'));
+        this.setAppBarTitle(this.$tr('pageLoadError'));
       } else {
-        this.setToolbarTitle(
+        this.setAppBarTitle(
           this.$tr('selectContent', { channelName: this.transferredChannel.name })
         );
       }
@@ -219,8 +219,8 @@
       this.cancelMetadataDownloadTask();
     },
     methods: {
-      ...mapMutations('manageContent', {
-        setToolbarTitle: 'SET_TOOLBAR_TITLE',
+      ...mapMutations('coreBase', {
+        setAppBarTitle: 'SET_APP_BAR_TITLE',
       }),
       ...mapActions('manageContent/wizard', ['transferChannelContent']),
       downloadChannelMetadata,

--- a/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <ImmersiveFullScreen v-bind="{ backPageLink, backPageText }">
+  <div>
     <!-- TODO should I try and use the baked in auth page? Does this have a URL-->
     <AuthMessage v-if="!isSuperuser" authorizedRole="superuser" />
 
@@ -87,7 +87,7 @@
       </div>
     </template>
 
-  </ImmersiveFullScreen>
+  </div>
 
 </template>
 
@@ -96,13 +96,11 @@
 
   import { mapState, mapGetters, mapActions } from 'vuex';
   import UserType from 'kolibri.utils.UserType';
-  import ImmersiveFullScreen from 'kolibri.coreVue.components.ImmersiveFullScreen';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
-  import { PageNames } from '../../constants';
 
   const SUCCESS = 'SUCCESS';
   const IN_PROGRESS = 'IN_PROGRESS';
@@ -117,7 +115,6 @@
     },
     components: {
       AuthMessage,
-      ImmersiveFullScreen,
       KButton,
       KCheckbox,
       PermissionsIcon,
@@ -162,16 +159,6 @@
           default:
             return '';
         }
-      },
-      backPageLink() {
-        if (this.isSuperuser) {
-          return { name: PageNames.MANAGE_PERMISSIONS_PAGE };
-        }
-        return { name: PageNames.MANAGE_CONTENT_PAGE };
-      },
-      backPageText() {
-        if (!this.isSuperuser) return this.$tr('goBack');
-        return this.user ? this.user.full_name : this.$tr('invalidUser');
       },
       // "dirty check" of permissions
       permissionsAreUnchanged() {
@@ -230,8 +217,6 @@
       devicePermissions: 'Device permissions',
       devicePermissionsDetails: 'Can import and export content channels',
       documentTitle: "{ name }'s Device Permissions",
-      goBack: 'Go Back',
-      invalidUser: 'Invalid user ID',
       makeSuperAdmin: 'Make super admin',
       permissionChangeConfirmation: 'Changes saved',
       saveButton: 'Save Changes',

--- a/kolibri/plugins/facility_management/assets/src/views/FacilityIndex.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityIndex.vue
@@ -25,7 +25,6 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
-  import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { PageNames } from '../constants';
   import ClassEditPage from './ClassEditPage';
@@ -67,7 +66,6 @@
       isEnrollmentPage() {
         return classEnrollmentPages.includes(this.pageName);
       },
-      topLevelPageName: () => TopLevelPageNames.MANAGE,
       currentPage() {
         return pageNameComponentMap[this.pageName] || null;
       },

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -30,7 +30,6 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
-  import { TopLevelPageNames } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
@@ -101,9 +100,6 @@
       }),
       ...mapState('examReportViewer', ['exam']),
       ...mapState(['pageName']),
-      topLevelPageName() {
-        return TopLevelPageNames.LEARN;
-      },
       currentPage() {
         if (RecommendedPages.includes(this.pageName)) {
           return RecommendedSubpage;


### PR DESCRIPTION
### Summary

Removes usage of ImmersiveFullScreen in UserPermissionsPage and replaces it with the ImmersiveToolBar.

![screen shot 2018-10-31 at 10 52 03 am](https://user-images.githubusercontent.com/10248067/47808376-7d300080-dcfb-11e8-982f-f7514c13ef4f.png)

### Reviewer guidance

1. Workflow should be visually similar to the older version
1. Check accessing the UserPermissionsPage when logged in under different permissions (guest, learner, admin, manage-content only, etc.). The toolbar title should be different.
1. Check exiting the page under different permissions (exiting should go to different places).

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
