### PR TITLE
Remove exception for corrupted files in transfer.py

### DIFF
--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -149,12 +149,7 @@ class FileDownload(Transfer):
         self.response = self.session.get(
             self.source, stream=True, timeout=self.timeout)
         self.response.raise_for_status()
-        try:
-            self.total_size = int(self.response.headers['content-length'])
-        except Exception:
-            # HACK: set the total_size very large so downloads are not considered "corrupted"
-            # in importcontent._start_file_transfer
-            self.total_size = 1e100
+        self.total_size = int(self.response.headers['content-length'])
 
         self.started = True
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to remove the exception for corrupted downloads in transfer.py, since it has been fixed through cloudflare. More information can be found in https://github.com/learningequality/kolibri/issues/4408

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test if downloading content works without the "corrupted download" errors.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4408

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
