### PR TITLE
Make some paths with os.path more clear

### DIFF
--- a/build_tools/customize_build.py
+++ b/build_tools/customize_build.py
@@ -11,7 +11,7 @@ import tempfile
 
 import requests
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))
 
 os.environ.setdefault(
     "RUN_TIME_PLUGINS", os.path.realpath(os.path.join(os.path.dirname(__file__), "default_plugins.txt"))

--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -8,7 +8,8 @@ import sys
 import requests
 from bs4 import BeautifulSoup
 
-DIST_CEXT = 'kolibri/dist/cext'
+DIST_CEXT = os.path.join(
+    os.path.dirname(os.path.realpath(os.path.dirname(__file__))), 'kolibri', 'dist', 'cext')
 PYPI_DOWNLOAD = 'https://pypi.python.org/simple/'
 PIWHEEL_DOWNLOAD = 'https://www.piwheels.hostedpi.com/simple/'
 

--- a/build_tools/py2only.py
+++ b/build_tools/py2only.py
@@ -4,7 +4,8 @@ import sys
 
 dest = 'py2only'
 futures_dirname = 'concurrent'
-DIST_DIR = os.path.realpath('kolibri/dist')
+DIST_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(os.path.dirname(__file__))), 'kolibri', 'dist')
 
 
 def hide_py2_modules():
@@ -36,7 +37,7 @@ def _move_modules_to_py2only(module_name):
 
 if __name__ == '__main__':
     # Temporarily add `kolibri/dist` to PYTHONPATH to import future
-    sys.path = sys.path + [os.path.realpath(os.path.join(DIST_DIR))]
+    sys.path.append(DIST_DIR)
 
     try:
         os.makedirs(os.path.join(DIST_DIR, dest))


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

For https://github.com/learningequality/kolibri/issues/4462, I've searched through our codebase but haven't found any current issues about not resolving `os.path.realpath`.
However, I found some uses of `os.path` that can be improved by adding `os.path.realpath`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the assets can be built successfully

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4462

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
