### PR TITLE
Initial Hashi implementation with localStorage sync support.

### DIFF
--- a/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
@@ -16,6 +16,7 @@
       <mat-svg v-else name="fullscreen" category="navigation" />
     </UiIconButton>
     <iframe
+      ref="iframe"
       class="iframe"
       sandbox="allow-scripts"
       frameBorder="0"
@@ -57,6 +58,8 @@
       },
     },
     mounted() {
+      this.iframeMessageReceived = this.iframeMessageReceived.bind(this);
+      window.addEventListener('message', this.iframeMessageReceived, true);
       this.$emit('startTracking');
       const self = this;
       this.timeout = setTimeout(() => {
@@ -64,10 +67,36 @@
       }, 15000);
     },
     beforeDestroy() {
+      window.removeEventListener('message', this.iframeMessageReceived);
       if (this.timeout) {
         clearTimeout(this.timeout);
       }
       this.$emit('stopTracking');
+    },
+    methods: {
+      iframeMessageReceived(event) {
+        if (!event) {
+          return;
+        }
+        const message = JSON.parse(event.data);
+        if (message.action === 'stateUpdated') {
+          this.$emit('updateContentState', message.params);
+        } else if (message.action === 'hashiInitialized') {
+          const iframe = this.$refs.iframe.contentWindow;
+
+          // On guest access, the user will be signed out, so just return
+          // an empty key value store in that case.
+          let contentState = {};
+          if (this.extraFields && this.extraFields.contentState) {
+            contentState = this.extraFields.contentState;
+          }
+          const data = {
+            action: 'kolibriDataLoaded',
+            params: { data: contentState },
+          };
+          iframe.postMessage(JSON.stringify(data), '*');
+        }
+      },
     },
     $trs: {
       exitFullscreen: 'Exit fullscreen',

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,8 @@
+{
+  "lerna": "2.11.0",
+  "packages": [
+    "packages/*"
+  ],
+  "version": "independent",
+  "npmClient": "yarn"
+}

--- a/packages/hashi/README.md
+++ b/packages/hashi/README.md
@@ -1,0 +1,36 @@
+Kolibri Hashi: HTML5 App Bridge Library
+========================================
+
+Getting Started
+----------------
+
+Step 1: Install Hashi package deps (run from Kolibri root)
+
+`lerna bootstrap`
+
+Step 2: Switch to the Hashi package root dir
+
+`cd packages/hashi`
+
+Step 3: Build Hashi and test HTML5 zip
+
+`yarn run build`
+
+Running the Code
+-----------------
+
+*Running the test HTML5 app in Kolibri*
+  1. Create a new channel in Studio or edit an existing one
+  2. Upload the `dist/localstorage_test.zip` file and publish
+  3. Import the published channel into Kolibri
+  4. Click on the HTML5 app node you created.
+      It should say `TIMES LOADED: 1`.
+  5. Click to visit another node, then re-enter the app node.
+      It should say `TIMES LOADED: 2`.
+  6. You're done! This confirms that Kolibri is saving localStorage data!
+
+*Creating a Hashi client*
+  1. Include `hashi.js` in the index.html of the HTML5 app zip
+  2. Modify the app to call `hashi.getLocalStorage()` and replace all
+     `localStorage` calls to use the storage object returned by
+     `hashi.getLocalStorage()`.

--- a/packages/hashi/package.json
+++ b/packages/hashi/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hashi",
+  "version": "0.1.0",
+  "description": "A library for integrating HTML5 apps and games with Kolibri.",
+  "main": "hashi.js",
+  "scripts": {
+    "build": "webpack --config ./webpack.config.js && python scripts/make_test_zip.py"
+  },
+  "author": "Learning Equality",
+  "license": "MIT",
+  "devDependencies": {
+    "http-server": "^0.11.1",
+    "jsdoc": "^3.5.5",
+    "npm-run-all": "^4.1.3",
+    "webpack": "4.6.0",
+    "webpack-cli": "2.0.15"
+  },
+  "dependencies": {
+  }
+}

--- a/packages/hashi/scripts/make_test_zip.py
+++ b/packages/hashi/scripts/make_test_zip.py
@@ -1,0 +1,19 @@
+import os
+import zipfile
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.abspath(os.path.join(script_dir, '..'))
+dist_dir = os.path.join(root_dir, 'dist')
+
+def make_test_zip():
+    zip_file = os.path.join(dist_dir, "localstorage_test.zip")
+    with zipfile.ZipFile(zip_file, "w") as zip:
+        index_file = os.path.join(root_dir, 'test', 'kzip', 'index.html')
+        zip.write(index_file, arcname='index.html')
+        zip.write(os.path.join('dist', 'hashi.js'), arcname='hashi.js')
+
+    print("dist/localstorage_test.zip created!")
+    print("To test, create a studio channel with this zip, then load it into Kolibri, then view the node multiple times.")
+
+if __name__ == "__main__":
+    make_test_zip()

--- a/packages/hashi/src/hashi.js
+++ b/packages/hashi/src/hashi.js
@@ -1,0 +1,3 @@
+import getLocalStorage from './storage.js';
+
+module.exports = getLocalStorage;

--- a/packages/hashi/src/storage.js
+++ b/packages/hashi/src/storage.js
@@ -1,0 +1,127 @@
+/**
+* This class offers an API-compatible replacement for localStorage and sessionStorage
+* to be used when apps are run in sandbox mode.
+*
+* For more information, see: https://developer.mozilla.org/en-US/docs/Web/API/Storage
+*/
+class Storage {
+    constructor() {
+        // This copy of the data does not persist, and is simply used to speed up
+        // and allow for synchronous access to data. We need to ensure that this
+        // data is populated from Kolibri before handing this off to apps if possible.
+        this.sessionData = {};
+
+        // keys have list ordering, so we use a list to ensure order is not changed.
+        // Per the spec, key ordering is defined by user agent, so we don't have to
+        // model any specific sorting behavior, just be consistent.
+        this.sessionKeys = [];
+        this.initMessageSent = false;
+        this.dataReceived = false;
+    }
+
+    _sendMessage(name, data) {
+        var message = {
+            'action': name,
+            'params': data
+        };
+        console.log("Sending message to parent: " + JSON.stringify(message));
+        window.parent.postMessage(JSON.stringify(message), '*');
+    }
+
+    initData() {
+      const timeout = 5000;
+      let initDataPromise = null;
+      if (!this.initMessageSent) {
+        initDataPromise = new Promise((resolve, reject) => {
+            function parentMessageReceived(event) {
+              if (this.timer) {
+                clearTimeout(this.timer);
+              }
+              const message = JSON.parse(event.data);
+              if (message.action === 'kolibriDataLoaded') {
+                this.sessionData = message.params['data'];
+                this.sessionKeys = Object.keys(this.sessionData);
+                this.dataReceived = true;
+                resolve(this);
+              }
+            }
+            parentMessageReceived = parentMessageReceived.bind(this);
+
+            function timedOut() {
+                reject("Load timed out.");
+            }
+
+            window.addEventListener('message', parentMessageReceived);
+            this._sendMessage('hashiInitialized', {});
+            this.timer = setTimeout(timedOut, timeout);
+        });
+
+        this.initMessageSent = true;
+      }
+      return initDataPromise;
+    }
+
+    get length() {
+        return this.sessionKeys.length;
+    }
+
+    key(index) {
+        return this.sessionKeys[index];
+    }
+
+    getItem(keyName) {
+        // TODO: Evaluate the performance implications of using postMessage and waiting for value
+        return this.sessionData[keyName];
+    }
+
+    setItem(keyName, value) {
+        console.log("setItem called");
+        if (this.sessionKeys.indexOf(keyName) === -1) {
+            this.sessionKeys.push(keyName);
+        }
+        this.sessionData[keyName] = value
+        this._sendMessage('stateUpdated', this.sessionData);
+    }
+
+    removeItem(keyName) {
+        delete this.sessionData[keyName];
+
+        var keyIndex = this.sessionKeys.indexOf(keyName);
+        if (keyIndex != -1) {
+            this.sessionKeys.splice(keyIndex, 1);
+        }
+        this._sendMessage('stateUpdated', this.sessionData);
+    }
+
+    clear() {
+        this.sessionKeys = [];
+        this.sessionData = {};
+
+        this._sendMessage('stateUpdated', this.sessionData);
+    }
+}
+
+export const getLocalStorage = () => {
+    // even referencing localStorage can throw a SecurityError, so don't assign to localStorage by default here.
+    let storage = null;
+    try {
+        // while some browsers throw immediately when trying to access localStorage, others only throw when
+        // you try to write to it, so we use a write test as the canonical way of testing if it works
+        const key = "testing_that_local_storage_is_allowed_using_a_key_that_would_never_actually_be_used";
+        localStorage.setItem(key, "It works!");
+        localStorage.removeItem(key);
+        storage = localStorage;
+        // we need to make this a promise as well for API consistency since we need a promise for Hashi storage.
+        const storagePromise = new Promise((resolve, reject) => {resolve(storage)});
+        return storagePromise;
+    } catch (e) {
+        if (e.name === 'SecurityError') {
+            console.log("Running in sandboxed iFrame, setting localStorage to Hashi.Storage instance.");
+            storage = new Storage();
+            return storage.initData();
+        } else {
+            throw e;
+        }
+    }
+    return storage;
+}

--- a/packages/hashi/test/README.md
+++ b/packages/hashi/test/README.md
@@ -1,0 +1,17 @@
+Hashi Tests
+============
+
+It is difficult to test Hashi through unit tests because a proper
+test environment needs to have a working iframe sandbox. Until we
+can determine a good way to perform automated testing, this
+directory will contain any files used for manual tests.
+
+test/kzip (Kolibri Zip Test)
+----------
+This directory contains the source files for a test HTML5 app
+that has been integrated with Kolibri via Hashi. This zip file
+gets built automatically when `yarn run build` is called to build
+Hashi. Tbe created zip is placed in the `dist` subfolder.
+
+This code can also be used as sample code for seeing a Hello World
+example of what HTML5 app Kolibri integration looks like.

--- a/packages/hashi/test/kzip/index.html
+++ b/packages/hashi/test/kzip/index.html
@@ -1,0 +1,27 @@
+<html>
+    <head>
+        <script src="hashi.js"></script>
+    </head>
+    <body>
+        <div id="timesLoaded-results">
+            TIMES LOADED: DETERMINING....
+        </div>
+        <div id="clear-results">
+
+        </div>
+        <script>
+            var storage = hashi.getLocalStorage().then(function(storage) {
+                console.log("It's loaded!");
+                var timesLoaded = storage.getItem("timesLoaded");
+                if (!timesLoaded) {
+                  timesLoaded = 0;
+                }
+                timesLoaded++;
+                storage.setItem("timesLoaded", timesLoaded);
+                var results = document.getElementById("timesLoaded-results");
+                results.innerText = "TIMES LOADED: " + timesLoaded;
+            });
+
+        </script>
+    </body>
+</html>

--- a/packages/hashi/webpack.config.js
+++ b/packages/hashi/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path')
+
+module.exports = {
+  entry: './src/storage.js',
+  output: {
+    filename: 'hashi.js',
+    path: path.resolve(__dirname, 'dist'),
+    library: 'hashi'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'buble-loader',
+        include: path.join(__dirname, 'src'),
+        options: {
+          objectAssign: 'Object.assign'
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

This PR adds the Hashi library as a subpackage of Kolibri using Lerna. By injecting hashi.js into an HTML5 app zip file and calling its getLocalStorage method, HTML5 apps can get a version of the localStorage object that syncs its data with Kolibri, making the data persistent as well as user and contentnode-specific.

### Reviewer guidance

This patch unfortunately does not have automated tests, as tests require a working iframe sandbox. I will be investigating the use of Sauce Labs and Cypress as ways of adding such testing. Instructions on performing manual tests are in the packages/hashi/README.md file.

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
