### PR TITLE
make sure link text can wrap

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -56,6 +56,7 @@
               <p>
                 <KButton
                   :text="$tr('privacyLink')"
+                  class="privacy-link"
                   appearance="basic-link"
                   @click="privacyModalVisible = true"
                 />
@@ -380,6 +381,10 @@
       margin-top: 0;
       margin-bottom: 0;
     }
+  }
+
+  .privacy-link {
+    text-align: left;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
@@ -142,6 +142,7 @@ a.button {
   padding: 0;
   color: $core-action-normal;
   text-decoration: underline;
+  white-space: normal;
   cursor: pointer;
   transition: $transition;
 

--- a/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
@@ -104,7 +104,7 @@ exports[`side nav component should show nothing if no components are added and u
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
           <p>
-            <button dir="auto" type="button" class="link">
+            <button dir="auto" type="button" class="privacy-link link">
               Usage and privacy
               <!---->
             </button>

--- a/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
@@ -41,7 +41,7 @@ exports[`side nav component should be hidden if navShown is false 1`] = `
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
           <p>
-            <button dir="auto" type="button" class="link">
+            <button dir="auto" type="button" class="privacy-link link">
               Usage and privacy
               <!---->
             </button>


### PR DESCRIPTION

### Summary

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/47980927-b4e1d400-e07e-11e8-98aa-62816b59ede9.png) | ![image](https://user-images.githubusercontent.com/2367265/47980896-88c65300-e07e-11e8-8c6c-84fe8e437604.png) |
| ![image](https://user-images.githubusercontent.com/2367265/47980920-ac899900-e07e-11e8-8f53-ffac850ce419.png) | ![image](https://user-images.githubusercontent.com/2367265/47980910-9e3b7d00-e07e-11e8-8c20-200d8a682236.png) |


### Reviewer guidance

look good?

### References

N/A

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
