### PR TITLE
Don't cache recommendations 5ever.

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNodeSlim.js
+++ b/kolibri/core/assets/src/api-resources/contentNodeSlim.js
@@ -1,3 +1,4 @@
+import Store from 'kolibri.coreVue.vuex.store';
 import { Resource } from '../api-resource';
 
 /**
@@ -15,12 +16,12 @@ export default new Resource({
     return this.fetchDetailCollection('recommendations_for', id, getParams);
   },
   fetchResume(getParams) {
-    return this.fetchListCollection('resume', getParams);
+    return this.fetchDetailCollection('resume', Store.getters.currentUserId, getParams);
   },
   fetchPopular(getParams) {
     return this.fetchListCollection('popular', getParams);
   },
   fetchNextSteps(getParams) {
-    return this.fetchListCollection('next_steps', getParams);
+    return this.fetchDetailCollection('next_steps', Store.getters.currentUserId, getParams);
   },
 });


### PR DESCRIPTION
### Summary
In 0.11.x the recommendation filters were turned into separate list endpoints on the ContentNodeSlimViewset.

Meanwhile in an earlier version of Kolibri, aggressive caching was introduced to help with performance. This caching was made hackily less aggressive for the content recommendation endpoints.

Unfortunately, the hack did not work for the new endpoints.

### Reviewer guidance
Test that the recommendations part of Learn still works as expected.

### References
Fixes #4504 

---

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
