### PR TITLE
workaround for Bengali on Edge browser

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -198,6 +198,15 @@ function _loadDefaultFonts() {
   const htmlEl = document.documentElement;
   const FULL_FONTS = 'full-fonts-loaded';
   const PARTIAL_FONTS = 'partial-fonts-loaded';
+
+  // Skip partial font usage and observer for Edge browser as a workaround for
+  //   https://github.com/learningequality/kolibri/issues/4515
+  // TODO: figure out exactly why this was happening and remove this logic.
+  if (/Edge/.test(global.navigator.userAgent)) {
+    htmlEl.classList.add(FULL_FONTS);
+    return;
+  }
+
   htmlEl.classList.add(PARTIAL_FONTS);
 
   const uiNormal = new FontFaceObserver('noto-full', { weight: 400 });


### PR DESCRIPTION
### Summary

As noted in #4515, Bengali is not displaying correctly in MS Edge.

Investigation appeared to show two issues:

1. the subset fonts are not rendering the text correctly, and appear to be missing critical ligatures
2. the 'normal' weight variant of the full `NotoSansBengali` was not being loaded by the `FontFaceObserver`

After an hour or so I couldn't fix either problem, so instead chose a work-around where we immediately reference the full font face, skipping both the subset and the observer loading delay.  This has the disadvantage of unnecessarily downloading the subset fonts, but other than that it seems to behave fairly well.

~Also in this PR: setting perseus renderer to 1.1.0~ [update: removed]

### Reviewer guidance

Does this address the issue? Any negative side-effects?

### References

partially addresses #4515

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
