### PR TITLE
Change windows installer signing script based on the current step name

### DIFF
--- a/.buildkite/sign_windows_installer.bat
+++ b/.buildkite/sign_windows_installer.bat
@@ -6,7 +6,7 @@ rem To sign the Windows installer set the `SIGN_WINDOWS_INSTALLER=true` environm
 IF NOT "%SIGN_WINDOWS_INSTALLER%" == "true" (GOTO DONT_SIGN)
 
 set current_path=%cd%
-buildkite-agent.exe artifact download "dist/*.exe" . --step "Build kolibri windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
+buildkite-agent.exe artifact download "dist/*.exe" . --step "Build Windows installer" --build %BUILDKITE_BUILD_ID% --agent-access-token %BUILDKITE_AGENT_ACCESS_TOKEN%
 %WINDOWS_SIGN_SCRIPT_PATH% "%current_path%\dist" && cd "%current_path%\installer\" && buildkite-agent.exe artifact upload "*.exe"
 GOTO END
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that the step name in `sign_windows_installer.bat` is not the same as the name in `pipeline.yml`, because we changed it in [this commit](https://github.com/learningequality/kolibri/commit/7fe51a9b8129351b81ca9d825a971f5ff8dc7b78#diff-8b496edab86012a437e80897eb7129c0L12).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the name in `sign_windows_installer.bat` is the same as the one in `pipeline.yml`.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Before the fix, signing windows installer on buildkite [failed](https://buildkite.com/learningequality/kolibri/builds/8606#95327bd5-6011-4761-9a71-5bd9388de3d1). 

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
