### PR TITLE
Load plugins from build_plugins.txt when env var BUILD_TIME_PLUGINS is empty

### DIFF
--- a/build_tools/webpack_json.py
+++ b/build_tools/webpack_json.py
@@ -12,9 +12,6 @@ from kolibri.plugins.registry import initialize
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 logging.StreamHandler(sys.stdout)
 
-os.environ.setdefault(
-    "BUILD_TIME_PLUGINS", os.path.realpath(os.path.join(os.path.dirname(__file__), "build_plugins.txt"))
-)
 
 def validate_modules(build_list):
     valid_module_names = [hook.__module__.replace('.kolibri_plugin', '') for hook in WebpackBundleHook().registered_hooks]
@@ -39,6 +36,8 @@ def main():
         build_list = args.plugins
     elif "BUILD_TIME_PLUGINS" in os.environ and os.environ["BUILD_TIME_PLUGINS"]:
         build_list = load_plugins_from_file(os.environ["BUILD_TIME_PLUGINS"])
+    else:
+        build_list = load_plugins_from_file(os.path.realpath(os.path.join(os.path.dirname(__file__), "build_plugins.txt")))
 
     logging.info("Gathering relevant modules from {}".format(build_list))
     initialize(build_list)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that the webpack build files for the plugin `demo_server` are missing in the latest 0.11 release. 
This is because in [env.list](https://github.com/learningequality/kolibri/blob/v0.11.0/docker/env.list#L1), the environment variable `BUILD_TIME_PLUGINS` is set to be empty string, so the code
```
os.environ.setdefault(
    "BUILD_TIME_PLUGINS", os.path.realpath(os.path.join(os.path.dirname(__file__), "build_plugins.txt"))
)
```
does not change the value to `build_tools/build_plugins.txt`.
This leads to the value of variable `build_list` to be `[]`

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

to test the change, we can either extract the whl file and check if the build files exist in `kolibri/plugins/demo_server` or enable the plugin first and then run kolibri to see if kolibri server starts successfully.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
