### PR TITLE
Add ChunkedEncodingError to import content retry logic

### DIFF
--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -3,6 +3,7 @@ from le_utils.constants import content_kinds
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
+from requests.exceptions import ChunkedEncodingError
 
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
@@ -99,6 +100,7 @@ def retry_import(e, **kwargs):
     if (
             isinstance(e, ConnectionError) or
             isinstance(e, Timeout) or
+            isinstance(e, ChunkedEncodingError) or
             (isinstance(e, HTTPError) and e.response.status_code in RETRY_STATUS_CODE) or
             (isinstance(e, SSLERROR) and 'decryption failed or bad record mac' in str(e))):
         return True


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to add `ChunkedEncodingError` to the import content retry logic so that the server will retry downloading content when facing this specific exception.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if all the tests pass

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#4496 

----

### Contributor Checklist

- [X] Contributor has fully tested the PR manually
- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
