### PR TITLE
Bump Django to 1.11.17 and add Python 3.7 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,10 @@ matrix:
         - TOX_ENV=pythonbuild3.7
     - python: "2.7"
       env:
-        - TOX_ENV=pythonlint
+        - TOX_ENV=pythonlint2
+    - python: "3.6"
+      env:
+        - TOX_ENV=pythonlint3
     - python: "2.7"
       env:
         - TOX_ENV=licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ matrix:
     - python: "3.6"
       env:
         - TOX_ENV=pythonbuild3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - TOX_ENV=pythonbuild3.7
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint
@@ -53,6 +58,11 @@ matrix:
     - python: "3.6"
       env:
         - TOX_ENV=py3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - TOX_ENV=py3.7
     - python: "2.7"
       env:
         - TOX_ENV=node6.x

--- a/kolibri/core/analytics/pskolibri/__init__.py
+++ b/kolibri/core/analytics/pskolibri/__init__.py
@@ -228,7 +228,7 @@ class Process(object):
         if pid is None:
             pid = os.getpid()
         else:
-            if not PY3 and not isinstance(pid, (int, long)):
+            if not PY3 and not isinstance(pid, (int, long)):  # noqa F821
                 raise TypeError('pid must be an integer (got %r)' % pid)
             if pid < 0:
                 raise ValueError('pid must be a positive integer (got %s)' % pid)

--- a/kolibri/core/content/templatetags/content_tags.py
+++ b/kolibri/core/content/templatetags/content_tags.py
@@ -34,4 +34,4 @@ def content_renderer_assets():
 
     :return: HTML of script tags to insert into template
     """
-    return webpack_asset_render(hooks.ContentRendererHook, async=True)
+    return webpack_asset_render(hooks.ContentRendererHook, is_async=True)

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -36,7 +36,7 @@ TUPLE_TYPES = tuple, set, frozenset, list
 if (sys.version_info > (3, 0)):
     VALID_TYPES = int, float, str, bool
 else:
-    VALID_TYPES = int, float, str, unicode, bool
+    VALID_TYPES = int, float, str, unicode, bool  # noqa F821
 
 
 class ParamValidator(object):

--- a/kolibri/core/webpack/templatetags/webpack_tags.py
+++ b/kolibri/core/webpack/templatetags/webpack_tags.py
@@ -70,7 +70,7 @@ def webpack_base_assets():
 
     :return: HTML of script tags to insert into base.html
     """
-    return webpack_asset_render(hooks.FrontEndBaseSyncHook, async=False)
+    return webpack_asset_render(hooks.FrontEndBaseSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -82,4 +82,4 @@ def webpack_base_async_assets():
 
     :return: HTML of script tags to insert into base.html
     """
-    return webpack_asset_render(hooks.FrontEndBaseASyncHook, async=True)
+    return webpack_asset_render(hooks.FrontEndBaseASyncHook, is_async=True)

--- a/kolibri/core/webpack/utils.py
+++ b/kolibri/core/webpack/utils.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import warnings
+
 from django.utils.safestring import mark_safe
 
 
@@ -16,7 +18,14 @@ def webpack_asset_render(HookClass, is_async=False, **kwargs):
 
     # Backwards compatibility: The reserved keyword 'async' was used before.
     # May be removed in 0.12+.
-    is_async = kwargs.pop('async', is_async)
+    async_deprecated = kwargs.pop('async', None)
+    if async_deprecated is not None:
+        is_async = async_deprecated
+        warnings.warn(
+            "Using 'async' keyword in webpack_asset_render() is removed in "
+            "kolibri 0.12",
+            DeprecationWarning
+        )
 
     tags = []
     for hook in HookClass().registered_hooks:

--- a/kolibri/core/webpack/utils.py
+++ b/kolibri/core/webpack/utils.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.utils.safestring import mark_safe
 
 
-def webpack_asset_render(HookClass, async=False):
+def webpack_asset_render(HookClass, is_async=False, **kwargs):
     """
     This is produces content for a  script tag for a WebpackInclusionHook subclass that implement
     different render to html methods either sync or async.
@@ -13,13 +13,18 @@ def webpack_asset_render(HookClass, async=False):
     :param sync: Render sync or async.
     :return: HTML of script tags to insert
     """
+
+    # Backwards compatibility: The reserved keyword 'async' was used before.
+    # May be removed in 0.12+.
+    is_async = kwargs.pop('async', is_async)
+
     tags = []
     for hook in HookClass().registered_hooks:
-        if not async and hasattr(hook, 'render_to_page_load_sync_html'):
+        if not is_async and hasattr(hook, 'render_to_page_load_sync_html'):
             tags.append(
                 hook.render_to_page_load_sync_html()
             )
-        elif async and hasattr(hook, 'render_to_page_load_async_html'):
+        elif is_async and hasattr(hook, 'render_to_page_load_async_html'):
             tags.append(
                 hook.render_to_page_load_async_html()
             )

--- a/kolibri/plugins/coach/templatetags/coach_tags.py
+++ b/kolibri/plugins/coach/templatetags/coach_tags.py
@@ -4,11 +4,14 @@ coach template tags
 ========================
 Tags for including plugin javascript assets into a template.
 """
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from __future__ import absolute_import, print_function, unicode_literals
 from django import template
-from kolibri.core.webpack.utils import webpack_asset_render
+
 from .. import hooks
+from kolibri.core.webpack.utils import webpack_asset_render
 
 register = template.Library()
 
@@ -20,7 +23,7 @@ def coach_assets():
     by any concrete hook that subclasses CoachSyncHook.
     :return: HTML of script tags to insert into coach/coach.html
     """
-    return webpack_asset_render(hooks.CoachSyncHook, async=False)
+    return webpack_asset_render(hooks.CoachSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -30,4 +33,4 @@ def coach_async_assets():
     by any concrete hook that subclasses CoachSyncHook.
     :return: HTML of script tags to insert into coach/coach.html
     """
-    return webpack_asset_render(hooks.CoachAsyncHook, async=True)
+    return webpack_asset_render(hooks.CoachAsyncHook, is_async=True)

--- a/kolibri/plugins/device_management/templatetags/device_management_tags.py
+++ b/kolibri/plugins/device_management/templatetags/device_management_tags.py
@@ -33,4 +33,4 @@ def device_management_assets():
 
     :return: HTML of script tags to insert into device_management.html
     """
-    return webpack_asset_render(DeviceManagementSyncHook, async=False)
+    return webpack_asset_render(DeviceManagementSyncHook, is_async=False)

--- a/kolibri/plugins/facility_management/templatetags/facility_management_tags.py
+++ b/kolibri/plugins/facility_management/templatetags/facility_management_tags.py
@@ -33,4 +33,4 @@ def facility_management_assets():
 
     :return: HTML of script tags to insert into the template
     """
-    return webpack_asset_render(FacilityManagementSyncHook, async=False)
+    return webpack_asset_render(FacilityManagementSyncHook, is_async=False)

--- a/kolibri/plugins/learn/templatetags/learn_tags.py
+++ b/kolibri/plugins/learn/templatetags/learn_tags.py
@@ -32,7 +32,7 @@ def learn_assets():
 
     :return: HTML of script tags to insert into management/management.html
     """
-    return webpack_asset_render(hooks.LearnSyncHook, async=False)
+    return webpack_asset_render(hooks.LearnSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -43,4 +43,4 @@ def learn_async_assets():
 
     :return: HTML of script tags to insert into management/management.html
     """
-    return webpack_asset_render(hooks.LearnAsyncHook, async=True)
+    return webpack_asset_render(hooks.LearnAsyncHook, is_async=True)

--- a/kolibri/plugins/setup_wizard/templatetags/setup_wizard_tags.py
+++ b/kolibri/plugins/setup_wizard/templatetags/setup_wizard_tags.py
@@ -32,7 +32,7 @@ def setup_wizard_assets():
 
     :return: HTML of script tags to insert into setup_wizard/setup_wizard.html
     """
-    return webpack_asset_render(hooks.SetupWizardSyncHook, async=False)
+    return webpack_asset_render(hooks.SetupWizardSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -43,4 +43,4 @@ def setup_wizard_async_assets():
 
     :return: HTML of script tags to insert into setup_wizard/setup_wizard.html
     """
-    return webpack_asset_render(hooks.SetupWizardAsyncHook, async=True)
+    return webpack_asset_render(hooks.SetupWizardAsyncHook, is_async=True)

--- a/kolibri/plugins/style_guide/templatetags/style_guide_tags.py
+++ b/kolibri/plugins/style_guide/templatetags/style_guide_tags.py
@@ -23,7 +23,7 @@ def style_guide_assets():
     by any concrete hook that subclasses UserSyncHook.
     :return: HTML of script tags to insert into style_guide/style_guide.html
     """
-    return webpack_asset_render(hooks.StyleGuideSyncHook, async=False)
+    return webpack_asset_render(hooks.StyleGuideSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -33,4 +33,4 @@ def style_guide_async_assets():
     by any concrete hook that subclasses StyleGuideSyncHook.
     :return: HTML of script tags to insert into style_guide/style_guide.html
     """
-    return webpack_asset_render(hooks.StyleGuideAsyncHook, async=True)
+    return webpack_asset_render(hooks.StyleGuideAsyncHook, is_async=True)

--- a/kolibri/plugins/user/templatetags/user_tags.py
+++ b/kolibri/plugins/user/templatetags/user_tags.py
@@ -23,7 +23,7 @@ def user_assets():
     by any concrete hook that subclasses UserSyncHook.
     :return: HTML of script tags to insert into user/user.html
     """
-    return webpack_asset_render(hooks.UserSyncHook, async=False)
+    return webpack_asset_render(hooks.UserSyncHook, is_async=False)
 
 
 @register.simple_tag()
@@ -33,4 +33,4 @@ def user_async_assets():
     by any concrete hook that subclasses UserSyncHook.
     :return: HTML of script tags to insert into user/user.html
     """
-    return webpack_asset_render(hooks.UserAsyncHook, async=True)
+    return webpack_asset_render(hooks.UserAsyncHook, is_async=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ requests==2.20.0
 cherrypy==13.0.1  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <13.1.0
 tempora<1.13  # derived no-upper-bounds dependency of cherrypy causing issues  # pyup: <1.13
 cheroot<6.2.0  # 6.2.0 introduced a namespaced pkg # pyup: <6.2.0
-iceqube==0.0.5
+iceqube==0.1b1
 futures==3.1.1  # Temporarily pinning this until we can do a Python 2/3 compatible solution of newer versions # pyup: <=3.1.1
 porter2stemmer==1.0
 unicodecsv==0.14.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 django-filter==1.1.0
 django-js-reverse==0.8.2
 djangorestframework==3.8.2
-django==1.11.15  # pyup: >=1.11,<2
+django==1.11.17  # pyup: >=1.11,<2
 six==1.11.0
 colorlog==3.1.4
 configobj==5.0.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7, 3.4, 3.5, 3.6}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -17,11 +17,13 @@ basepython =
     pythonbuild3.4: python3.4
     pythonbuild3.5: python3.5
     pythonbuild3.6: python3.6
+    pythonbuild3.7: python3.7
     licenses: python2.7
     py2.7: python2.7
     py3.4: python3.4
     py3.5: python3.5
     py3.6: python3.6
+    py3.7: python3.7
     pypy: pypy
     docs: python3.5
     pythonlint: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, npmbuild, node6.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -26,7 +26,8 @@ basepython =
     py3.7: python3.7
     pypy: pypy
     docs: python3.5
-    pythonlint: python2.7
+    pythonlint2: python2.7
+    pythonlint3: python3.6
     node6.x: python2.7
     npmbuild: python2.7
     nocext: python2.7
@@ -113,7 +114,13 @@ commands =
     py.test {posargs:--cov=kolibri --color=no}
     # rm -rf {env:KOLIBRI_HOME}
 
-[testenv:pythonlint]
+[testenv:pythonlint2]
+deps =
+    -r{toxinidir}/requirements/dev.txt
+commands =
+    flake8 kolibri
+
+[testenv:pythonlint3]
 deps =
     -r{toxinidir}/requirements/dev.txt
 commands =


### PR DESCRIPTION
### Summary

This adds Python 3.7 compatibility, assuming that it's confirmed with by CI...

### Reviewer guidance

Any discussion points about targeting this for 0.11.1?

### References

#4548

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
