### PR TITLE
Allow daemonization on OSX.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -659,8 +659,6 @@ def main(args=None):  # noqa: max-complexity=13
         call_command("clearsessions")
 
         daemon = not arguments['--foreground']
-        if sys.platform == 'darwin':
-            daemon = False
         start(port, daemon=daemon)
         return
 

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -97,15 +97,16 @@ def _posix_become_daemon(our_home_dir='.', out_log='/dev/null',
     except OSError as e:
         sys.stderr.write("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror))
         os._exit(1)
-
-    si = open('/dev/null', 'r')
-    so = open(out_log, 'a+', buffering)
-    se = open(err_log, 'a+', buffering)
-    os.dup2(si.fileno(), sys.stdin.fileno())
-    os.dup2(so.fileno(), sys.stdout.fileno())
-    os.dup2(se.fileno(), sys.stderr.fileno())
-    # Set custom file descriptors so that they get proper buffering.
-    sys.stdout, sys.stderr = so, se
+    if sys.platform != 'darwin':  # This block breaks on OS X
+        # Fix courtesy of https://github.com/serverdensity/python-daemon/blob/master/daemon.py#L94
+        si = open('/dev/null', 'r')
+        so = open(out_log, 'a+', buffering)
+        se = open(err_log, 'a+', buffering)
+        os.dup2(si.fileno(), sys.stdin.fileno())
+        os.dup2(so.fileno(), sys.stdout.fileno())
+        os.dup2(se.fileno(), sys.stderr.fileno())
+        # Set custom file descriptors so that they get proper buffering.
+        sys.stdout, sys.stderr = so, se
 
 
 def _windows_become_daemon(our_home_dir='.', out_log=None, err_log=None, umask=0o022):


### PR DESCRIPTION
### Summary
I _think_ this should fix our issue with daemonization on OSX, courtesy of this https://github.com/serverdensity/python-daemon/blob/master/daemon.py#L94

Have added the relevant if statement to our daemonization logic.

### Reviewer guidance
Can you run as a background task on OSX now?

### References
I thought there was an open issue for this, but I cannot find it.

----

### Contributor Checklist

- [ ] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
