### PR TITLE
Add propagate False to kolibri loggers to prevent double logging.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -322,6 +322,7 @@ LOGGING = {
         'kolibri': {
             'handlers': ['console', 'mail_admins', 'file', 'file_debug'],
             'level': 'INFO',
+            'propagate': False,
         },
         'iceqube': {
             'handlers': ['file', 'console'],

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -130,6 +130,7 @@ def get_logger(KOLIBRI_HOME):
             'kolibri': {
                 'handlers': ['console', 'file'],
                 'level': 'INFO',
+                'propagate': False,
             },
         }
     }


### PR DESCRIPTION
### Summary
We sometimes see logs from within the kolibri module appearing twice in the console. This adds propagate False in logging for the kolibri module, to prevent double logging showing up.

### Reviewer guidance
I don't have a clear path to replication here as it is not consistent when it happens, but I implemented a parallel fix in another project I was working on that removed this duplicate logging.

### References
Fixes #2940 

----

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [x] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependencies files were updated (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Link to diff of internal dependency change is included
- [x] CHANGELOG.rst is updated for high-level changes
- [x] Contributor is in AUTHORS.rst
