### PR TITLE
Fix types error in analytics middleware

### DIFF
--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -141,8 +141,8 @@ class MetricsMiddleware(MiddlewareMixin):
             path = request.get_full_path()
             duration, memory_before, memory, load_before, load = self.metrics.get_stats()
             max_time = False
-            if duration > MetricsMiddleware.slowest_request_time:
-                MetricsMiddleware.slowest_request_time = duration
+            if int(duration) > MetricsMiddleware.slowest_request_time:
+                MetricsMiddleware.slowest_request_time = int(duration)
                 max_time = True
             timestamp = time.strftime('%Y/%m/%d %H:%M:%S.%f')
             collected_information = (timestamp, path, duration, memory_before, memory, load_before, load, str(max_time))


### PR DESCRIPTION
### Summary
This commit fixes an error in 0.11 visible when activating the analytics middleware and the profile command is run. In such case the server becomes unusable:
```
ERROR    Internal Server Error: /api/auth/session/current/
Traceback (most recent call last):
  File "/datos/le/mio/kolibri/kolibri/dist/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/datos/le/mio/kolibri/kolibri/dist/django/utils/deprecation.py", line 142, in __call__
    response = self.process_response(request, response)
  File "/datos/le/mio/kolibri/kolibri/core/analytics/middleware.py", line 144, in process_response
    if duration > MetricsMiddleware.slowest_request_time:
TypeError: '>' not supported between instances of 'str' and 'int'
ERROR    "GET /api/auth/session/current/?active=false HTTP/1.1" 500 15893
```

### Reviewer guidance
1. Enable analytics middleware adding 
```
[Server]
PROFILE = true
```
2. restart Kolibri
3. run the command `kolibri manage profile`
4. browse to any page.
In 0.11 the above mentioned server error happens, if this patch is not applied.

### References
* references #4276 

### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [ ] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
