### PR TITLE
Let devserver run with built assets

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -156,7 +156,10 @@ class WebpackBundleHook(hooks.KolibriHook):
                     continue
             relpath = '{0}/{1}'.format(self.unique_slug, filename)
             if getattr(django_settings, 'DEVELOPER_MODE', False):
-                f['url'] = f['publicPath']
+                try:
+                    f['url'] = f['publicPath']
+                except KeyError:
+                    f['url'] = staticfiles_storage.url(relpath)
             else:
                 f['url'] = staticfiles_storage.url(relpath)
             yield f


### PR DESCRIPTION
### Summary
Recent build work removed the publicPath from built assets. This allows the devserver to just load from staticfiles if running with built assets.

### Reviewer guidance
Build assets. Run devserver, check it works!
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
