### PR TITLE
update network address strings

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
@@ -9,26 +9,32 @@
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
-    <KTextbox
-      v-model="address"
-      :label="$tr('addressLabel')"
-      :placeholder="$tr('addressPlaceholder')"
-      :autofocus="true"
-      :invalid="addressIsInvalid"
-      :invalidText="addressInvalidText"
-      :disabled="attemptingToConnect"
-      @blur="addressBlurred = true"
-    />
-    <KTextbox
-      v-model="name"
-      :label="$tr('nameLabel')"
-      :placeholder="$tr('namePlaceholder')"
-      :invalid="nameIsInvalid"
-      :invalidText="$tr('fieldIsRequired')"
-      :maxlength="40"
-      :disabled="attemptingToConnect"
-      @blur="nameBlurred = true"
-    />
+    <p>{{ $tr(addressDesc) }}</p>
+    <div>
+      <KTextbox
+        v-model="address"
+        :label="$tr('addressLabel')"
+        :placeholder="$tr('addressPlaceholder')"
+        :autofocus="true"
+        :invalid="addressIsInvalid"
+        :invalidText="addressInvalidText"
+        :disabled="attemptingToConnect"
+        @blur="addressBlurred = true"
+      />
+    </div>
+    <p>{{ $tr(nameDesc) }}</p>
+    <div>
+      <KTextbox
+        v-model="name"
+        :label="$tr('nameLabel')"
+        :placeholder="$tr('namePlaceholder')"
+        :invalid="nameIsInvalid"
+        :invalidText="$tr('fieldIsRequired')"
+        :maxlength="40"
+        :disabled="attemptingToConnect"
+        @blur="nameBlurred = true"
+      />
+    </div>
 
     <UiAlert
       v-if="attemptingToConnect"
@@ -131,6 +137,7 @@
       },
     },
     $trs: {
+      addressDesc: "The network address can be an IP like '10.0.0.10' or a URL like 'example.com':",
       addressLabel: 'Full network address',
       addressPlaceholder: 'e.g. http://123.456.7.89:8080',
       cancelButtonLabel: 'Cancel',
@@ -138,6 +145,7 @@
       errorInvalidAddress: 'Please enter a valid IP address, URL, or hostname',
       header: 'New address',
       fieldIsRequired: 'This field is required',
+      nameDesc: 'You can choose a name for this address so you can remember it later:',
       nameLabel: 'Network name',
       namePlaceholder: 'e.g. House network',
       submitButtonLabel: 'Add',

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -9,14 +9,6 @@
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
-    <KButton
-      v-show="!newAddressButtonDisabled"
-      class="new-address-button"
-      :text="$tr('newAddressButtonLabel')"
-      appearance="basic-link"
-      @click="$emit('click_add_address')"
-    />
-
     <UiAlert
       v-if="uiAlertProps"
       v-show="showUiAlerts"
@@ -31,6 +23,14 @@
         @click="refreshAddressList"
       />
     </UiAlert>
+
+    <KButton
+      v-show="!newAddressButtonDisabled"
+      class="new-address-button"
+      :text="$tr('newAddressButtonLabel')"
+      appearance="basic-link"
+      @click="$emit('click_add_address')"
+    />
 
     <template v-for="(a, idx) in addresses">
       <div :key="`div-${idx}`">
@@ -200,8 +200,8 @@
       fetchingFailedText: 'There was a problem getting the available addresses',
       forgetAddressButtonLabel: 'Forget',
       header: 'Select network address',
-      newAddressButtonLabel: 'New address',
-      noAddressText: 'You have not entered any addresses',
+      newAddressButtonLabel: 'Add new address',
+      noAddressText: 'There are no addresses yet',
       refreshAddressesButtonLabel: 'Refresh addresses',
       submitButtonLabel: 'Continue',
     },

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
@@ -80,7 +80,7 @@ describe('SelectAddressForm', () => {
     await wrapper.vm.$nextTick();
     expect(els.radioButtons()).toHaveLength(0);
     expect(els.uiAlert().exists()).toEqual(true);
-    expect(els.uiAlert().text()).toEqual('You have not entered any addresses');
+    expect(els.uiAlert().text()).toEqual('There are no addresses yet');
     expect(els.KModal().props().submitDisabled).toEqual(true);
   });
 


### PR DESCRIPTION
### Summary

Cleans up the network address strings a little.

In the first page:

* renames 'New address' to 'Add new address' to make it a verb
* move it below the info message so the ordering flows a bit better
* reword info message to be consistent with other parts of the app and less judgmental

In the second page, added explanatory text for the fields

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/49772158-0cd4b180-fca1-11e8-8a98-f5f3ef1c0a44.png)  | ![image](https://user-images.githubusercontent.com/2367265/49772166-10683880-fca1-11e8-9815-3931928d9114.png) |
| ![image](https://user-images.githubusercontent.com/2367265/49772244-63da8680-fca1-11e8-9566-03e66563ec12.png) | ![image](https://user-images.githubusercontent.com/2367265/49772248-663ce080-fca1-11e8-8e37-9b1a34c9ad16.png) |


### Reviewer guidance

Do these changes look good?

### References

There's no issue filed, but it came up during the initial hack session that these fields were a bit confusing

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
