### PR TITLE
Cache key conversion

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -618,7 +618,9 @@ export class Resource {
         {},
         ...Object.keys(allParams)
           .sort()
-          .map(paramKey => ({ [paramKey]: allParams[paramKey] }))
+          .map(paramKey => ({
+            [paramKey]: paramKey === this.idKey ? String(allParams[paramKey]) : allParams[paramKey],
+          }))
       )
     );
   }

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -729,21 +729,22 @@ export class Resource {
     }
     // Add to the model cache using the default key if id is defined.
     const cache = this.__modelCache(endpointName);
+    let cacheKey;
     if (model.id) {
-      const cacheKey = this.__cacheKey({ [this.idKey]: model.id }, model.getParams);
+      cacheKey = this.__cacheKey({ [this.idKey]: model.id }, model.getParams);
       if (!cache[cacheKey]) {
         cache[cacheKey] = model;
       } else {
         cache[cacheKey].set(model.attributes);
       }
-      return cache[cacheKey];
+    } else {
+      // Otherwise use a hash of the models attributes to create a temporary cache key
+      cacheKey = this.__cacheKey(model.attributes);
+      cache[cacheKey] = model;
+      // invalidate collection cache because this new model may be included in a collection
+      this.collections = {};
     }
-    // Otherwise use a hash of the models attributes to create a temporary cache key
-    const cacheKey = this.__cacheKey(model.attributes);
-    cache[cacheKey] = model;
-    // invalidate collection cache because this new model may be included in a collection
-    this.collections = {};
-    return model;
+    return cache[cacheKey];
   }
 
   /**

--- a/kolibri/core/assets/test/api-resource.spec.js
+++ b/kolibri/core/assets/test/api-resource.spec.js
@@ -1,4 +1,5 @@
 import * as Resources from '../src/api-resource';
+
 jest.mock('kolibri.urls');
 
 describe('Resource', function() {
@@ -143,6 +144,12 @@ describe('Resource', function() {
     it('should add the collection to the cache', function() {
       resource.createCollection({});
       expect(Object.keys(resource.collections)).toHaveLength(1);
+    });
+  });
+  describe('__cacheKey method', function() {
+    it('should return integer to string instance', function() {
+      const expected_string = '{"id":"1"}';
+      expect(resource.__cacheKey({ ['id']: 1 })).toEqual(expected_string);
     });
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When passing an integer as the id to the cache key mechanism, it does not coerce the id to a string creating mismatching cache keys. 
Also `const cacheKey`  used to be locally scoped to within the if statement, so we make its scope local to the function. This solves an issue of creating another `cacheKey` variable but scoped as `cacheKey$1`, which does not resolve correctly.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do api calls still work? Does caching still work?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
