### PR TITLE
Fixes sign-up validation

### DIFF
--- a/integration_testing/features/guest/guest-sign-up-account.feature
+++ b/integration_testing/features/guest/guest-sign-up-account.feature
@@ -15,6 +15,11 @@ Feature: Guest sign up for account
      And I click the *Finish* button 
     Then I am signed in and I can see the *Learn > Channels* page
 
+  Scenario: Username is already taken
+    Given A user already exists with some username
+    When I try to sign up for a new account with that username
+    Then I get a validation message shown next to the username field that the name is already taken
+
   Examples:
   | full_name | password | username | password | facility |
   | juan .p   | learner  | juan     | pass     | school   |

--- a/kolibri/core/assets/src/views/AppBody.vue
+++ b/kolibri/core/assets/src/views/AppBody.vue
@@ -81,6 +81,7 @@
           };
         }
         return {
+          maxWidth: '1000px',
           padding: `${this.isMobile ? 16 : 32}px`,
         };
       },
@@ -100,7 +101,6 @@
   }
 
   .body-wrapper {
-    max-width: 1000px;
     margin: auto;
   }
 

--- a/kolibri/core/assets/src/views/AppBody.vue
+++ b/kolibri/core/assets/src/views/AppBody.vue
@@ -13,7 +13,7 @@
 
     <div
       v-else
-      :style="bodyPadding"
+      :style="bodyStyle"
       class="body-wrapper"
     >
       <slot></slot>
@@ -48,6 +48,11 @@
         required: false,
         default: 0,
       },
+      // when true, don't add any margins or padding (regardless of gaps)
+      fullScreen: {
+        type: Boolean,
+        default: false,
+      },
     },
     computed: {
       ...mapState({
@@ -59,16 +64,22 @@
       },
       contentStyle() {
         return {
-          top: `${this.topGap}px`,
-          bottom: `${this.bottomGap}px`,
+          top: `${this.fullScreen ? 0 : this.topGap}px`,
+          bottom: `${this.fullScreen ? 0 : this.bottomGap}px`,
         };
       },
       loaderPositionStyles() {
         return {
-          top: `${this.topGap}px`,
+          top: `${this.fullScreen ? 0 : this.topGap}px`,
         };
       },
-      bodyPadding() {
+      bodyStyle() {
+        if (this.fullScreen) {
+          return {
+            padding: '0px',
+            height: '100%',
+          };
+        }
         return {
           padding: `${this.isMobile ? 16 : 32}px`,
         };

--- a/kolibri/core/assets/src/views/CoreBase.vue
+++ b/kolibri/core/assets/src/views/CoreBase.vue
@@ -1,9 +1,7 @@
 <template>
 
   <div>
-    <!-- temporary hack, resolves flicker when using other templates -->
-    <template v-if="navBarNeeded">
-
+    <template v-if="!fullScreen">
       <ImmersiveToolbar
         v-if="immersivePage"
         :appBarTitle="toolbarTitle || appBarTitle"
@@ -13,7 +11,6 @@
         :height="headerHeight"
         @nav-icon-click="$emit('navIconClick')"
       />
-
       <template v-else>
         <AppBar
           ref="appBar"
@@ -41,12 +38,12 @@
           @toggleSideNav="navShown=!navShown"
         />
       </template>
-
     </template>
 
     <AppBody
       :topGap="appBodyTopGap"
       :bottomGap="bottomMargin"
+      :fullScreen="fullScreen"
     >
       <AuthMessage
         v-if="notAuthorized"
@@ -100,10 +97,10 @@
         required: false,
         default: '',
       },
-      // Prop that determines whether to show nav components
-      navBarNeeded: {
+      // Prop that determines whether to show nav components and provide margins
+      fullScreen: {
         type: Boolean,
-        default: true,
+        default: false,
       },
       // reserve space at the bottom for floating widgets
       bottomMargin: {
@@ -134,11 +131,13 @@
         required: false,
         default: false,
       },
+      // generally a 'back' or 'close' icon
       immersivePageIcon: {
         type: String,
         required: false,
         default: 'close',
       },
+      // link to where the 'back' button should go
       immersivePageRoute: {
         type: Object,
         required: false,

--- a/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
@@ -141,6 +141,7 @@ a.button {
   display: inline;
   padding: 0;
   color: $core-action-normal;
+  text-align: left;
   text-decoration: underline;
   white-space: normal;
   cursor: pointer;

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -55,8 +55,10 @@ class FacilityUserSignupSerializer(FacilityUserSerializer):
 
     def validate_username(self, value):
         if FacilityUser.objects.filter(username__iexact=value).exists():
-            raise serializers.ValidationError(detail={'username': ['An account with that username already exists.']},
-                                              code=error_constants.USERNAME_ALREADY_EXISTS)
+            raise serializers.ValidationError(
+                detail='An account with that username already exists.',
+                code=error_constants.USERNAME_ALREADY_EXISTS
+            )
         return value
 
 

--- a/kolibri/plugins/user/assets/src/modules/signUp/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/signUp/actions.js
@@ -20,7 +20,7 @@ export function signUpNewUser(store, signUpCreds) {
         store.commit('SET_SIGN_UP_ERRORS', errors);
       } else {
         // No errors we recognize, flag there are unrecognized errors
-        store.commit('SET_UNRECOGNIZED_ERROR');
+        store.dispatch('handleApiError', error, { root: true });
       }
       store.commit('SET_SIGN_UP_BUSY', false);
     });

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -24,14 +24,6 @@
       class="signup-form"
       @submit.prevent="signUp"
     >
-      <UiAlert
-        v-if="unknownError"
-        type="error"
-        @dismiss="resetSignUpState"
-      >
-        {{ errorMessage }}
-      </UiAlert>
-
       <h1 class="signup-title">{{ $tr('createAccount') }}</h1>
 
       <KTextbox
@@ -287,15 +279,6 @@
           !this.confirmedPasswordIsInvalid &&
           !this.facilityIsInvalid
         );
-      },
-      unknownError() {
-        if (this.errorCode) {
-          return this.errorCode !== 400;
-        }
-        return false;
-      },
-      errorMessage() {
-        return this.$tr('genericError');
       },
     },
     beforeMount() {

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -2,29 +2,12 @@
 
   <div class="signup-page">
 
-    <UiToolbar type="colored" textColor="white">
-      <template slot="icon">
-        <CoreLogo class="app-bar-icon" />
-      </template>
-      <template slot="brand">
-        {{ $tr('kolibri') }}
-      </template>
-      <div slot="actions">
-        <router-link
-          class="signin"
-          :to="signInPage"
-        >
-          <span>{{ $tr('logIn') }}</span>
-        </router-link>
-      </div>
-    </UiToolbar>
-
     <form
       ref="form"
       class="signup-form"
       @submit.prevent="signUp"
     >
-      <h1 class="signup-title">{{ $tr('createAccount') }}</h1>
+      <h1>{{ $tr('createAccount') }}</h1>
 
       <KTextbox
         id="name"
@@ -127,10 +110,7 @@
   import { mapState, mapActions, mapGetters, mapMutations } from 'vuex';
   import { validateUsername } from 'kolibri.utils.validators';
   import KButton from 'kolibri.coreVue.components.KButton';
-  import UiAlert from 'kolibri.coreVue.components.UiAlert';
   import KTextbox from 'kolibri.coreVue.components.KTextbox';
-  import UiToolbar from 'keen-ui/src/UiToolbar';
-  import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import PrivacyInfoModal from 'kolibri.coreVue.components.PrivacyInfoModal';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
@@ -164,10 +144,7 @@
     },
     components: {
       KButton,
-      UiAlert,
       KTextbox,
-      UiToolbar,
-      CoreLogo,
       KSelect,
       LanguageSwitcherFooter,
       PrivacyInfoModal,
@@ -327,54 +304,17 @@
   @import '~kolibri.styles.definitions';
   $iphone-5-width: 320px;
   $vertical-page-margin: 100px;
-  $logo-size: 1.64 * 1.125;
-  $logo-margin: 0.38 * $logo-size;
-
-  // component, highest level
-  .signup-page {
-    width: 100%;
-    height: 100%;
-    overflow-y: auto;
-  }
-
-  .signin {
-    margin-right: 1em;
-    color: white;
-    text-decoration: none;
-  }
 
   // Form
-  .signup-title {
-    text-align: center;
-  }
-
   .signup-form {
-    width: $iphone-5-width - 20;
-    margin-top: $vertical-page-margin;
+    max-width: $iphone-5-width - 20;
     margin-right: auto;
     margin-left: auto;
   }
 
-  .terms {
-    height: 6em;
-    padding: 0.5em;
-    margin-bottom: 1em;
-    overflow-y: scroll;
-    color: $core-text-annotation;
-    background-color: $core-bg-light;
-    p {
-      margin-top: 0;
-    }
-  }
-
-  .app-bar-icon {
-    height: 40px;
-    margin-left: 0.25em;
-  }
-
   .footer {
     margin: 36px;
-    margin-top: 96px;
+    margin-top: 48px;
   }
 
   .privacy-link {

--- a/kolibri/plugins/user/assets/src/views/UserIndex.vue
+++ b/kolibri/plugins/user/assets/src/views/UserIndex.vue
@@ -1,17 +1,14 @@
 <template>
 
-  <div>
-    <!-- v-if applied to component and not core-base because it sets doc title -->
-    <CoreBase
-      :navBarNeeded="navBarNeeded"
-      :appBarTitle="appBarTitle"
-    >
-      <component :is="currentPage" v-if="navBarNeeded" />
-    </CoreBase>
-    <div v-if="!navBarNeeded" class="full-page">
-      <component :is="currentPage" />
-    </div>
-  </div>
+  <CoreBase
+    :immersivePage="pageName === PageNames.SIGN_UP"
+    immersivePagePrimary
+    :immersivePageRoute="{ name: PageNames.SIGN_IN }"
+    :appBarTitle="appBarTitle"
+    :fullScreen="pageName === PageNames.SIGN_IN"
+  >
+    <component :is="currentPage" />
+  </CoreBase>
 
 </template>
 
@@ -41,8 +38,10 @@
       appBarTitle() {
         if (this.pageName === PageNames.PROFILE) {
           return this.$tr('userProfileTitle');
+        } else if (this.pageName === PageNames.SIGN_UP) {
+          return this.$tr('userSignUpTitle');
         }
-        return '';
+        return this.$tr('userSignInTitle');
       },
       currentPage() {
         return pageNameComponentMap[this.pageName] || null;
@@ -50,25 +49,18 @@
       navBarNeeded() {
         return this.pageName !== PageNames.SIGN_IN && this.pageName !== PageNames.SIGN_UP;
       },
+      PageNames() {
+        return PageNames;
+      },
     },
     $trs: {
       userProfileTitle: 'Profile',
+      userSignUpTitle: 'Sign up',
+      userSignInTitle: 'Sign in',
     },
   };
 
 </script>
 
 
-<style lang="scss" scoped>
-
-  @import '~kolibri.styles.definitions';
-
-  .full-page {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: $core-bg-canvas;
-  }
-
-</style>
+<style lang="scss" scoped></style>


### PR DESCRIPTION
### Summary

* fixes regression - display validation when username already exists (#4575)
* fixes issue where our 'unknown error' window was hidden
* implements this screen as a standard `core-base` immersive view rather than a custom special case, and delete a lot of unneeded styles and code

### Reviewer guidance

On the error handling side, I'm not at all clear what the intended API is. This change seems to fix the problem, but now we have three different styles of raising errors, with different schemas for `detail`:

A simple string:

```python
            raise serializers.ValidationError(
                detail='An account with that username already exists.',
                code=error_constants.USERNAME_ALREADY_EXISTS
            )
```

A dict of lists of strings:

```python
            raise serializers.ValidationError(detail={'username': ['An account with that username already exists.']},
                                              code=error_constants.USERNAME_ALREADY_EXISTS)
```

A dict of strings:

```python
            raise serializers.ValidationError(detail={'classroom': 'This user is already in a group in this class'},
                                              code=error_constants.USER_ALREADY_IN_GROUP_IN_CLASS)
```

This makes no sense to me and I can't find any documentation about how it's intended to be used.

### References

fixes #4575

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
