### PR TITLE
Add full URLs in exercises to ensure they always load

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -87,8 +87,8 @@ class ZipContentTestCase(TestCase):
         self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
 
     def test_content_security_policy_header_http_referer(self):
-        response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_REFERER="http://testserver")
-        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+        response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_REFERER="http://testserver:1234/iam/a/real/path/#thatsomeonemightuse")
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver:1234")
 
     def test_access_control_allow_origin_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
@@ -112,11 +112,11 @@ class ZipContentTestCase(TestCase):
         response = self.client.get(self.zip_file_base_url + self.test_name_3, HTTP_REFERER=server_name)
         self.assertEqual(
             response.content.decode('utf-8'),
-            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
+            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name.replace('http:', '') + self.zip_file_base_url)).strip("/"))
 
     def test_json_image_replacement_no_http_referer_header(self):
         server_name = "http://testserver"
         response = self.client.get(self.zip_file_base_url + self.test_name_3)
         self.assertEqual(
             response.content.decode('utf-8'),
-            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
+            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name.replace('http:', '') + self.zip_file_base_url)).strip("/"))

--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -110,9 +110,13 @@ class ZipContentTestCase(TestCase):
     def test_json_image_replacement_http_referer_header(self):
         server_name = "http://testserver"
         response = self.client.get(self.zip_file_base_url + self.test_name_3, HTTP_REFERER=server_name)
-        self.assertEqual(response.content, self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
 
     def test_json_image_replacement_no_http_referer_header(self):
         server_name = "http://testserver"
         response = self.client.get(self.zip_file_base_url + self.test_name_3)
-        self.assertEqual(response.content, self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))

--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -5,6 +5,7 @@ import zipfile
 
 from django.test import Client
 from django.test import TestCase
+from le_utils.constants import exercises
 
 from ..models import LocalFile
 from ..utils.paths import get_content_storage_file_path
@@ -22,6 +23,8 @@ class ZipContentTestCase(TestCase):
     test_str_1 = "This is a test!"
     test_name_2 = "testfile2.txt"
     test_str_2 = "And another test..."
+    test_name_3 = "testfile3.json"
+    test_str_3 = "A test of image placeholder replacement ${placeholder}".format(placeholder=exercises.IMG_PLACEHOLDER)
 
     def setUp(self):
 
@@ -41,6 +44,7 @@ class ZipContentTestCase(TestCase):
         with zipfile.ZipFile(self.zip_path, "w") as zf:
             zf.writestr(self.test_name_1, self.test_str_1)
             zf.writestr(self.test_name_2, self.test_str_2)
+            zf.writestr(self.test_name_3, self.test_str_3)
 
         self.zip_file_obj = LocalFile(id=self.hash, extension=self.extension, available=True)
         self.zip_file_base_url = self.zip_file_obj.get_storage_url()
@@ -82,6 +86,10 @@ class ZipContentTestCase(TestCase):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
 
+    def test_content_security_policy_header_http_referer(self):
+        response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_REFERER="http://testserver")
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+
     def test_access_control_allow_origin_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
         self.assertEqual(response.get("Access-Control-Allow-Origin"), "*")
@@ -98,3 +106,13 @@ class ZipContentTestCase(TestCase):
         self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)
         response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval)
         self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)
+
+    def test_json_image_replacement_http_referer_header(self):
+        server_name = "http://testserver"
+        response = self.client.get(self.zip_file_base_url + self.test_name_3, HTTP_REFERER=server_name)
+        self.assertEqual(response.content, self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))
+
+    def test_json_image_replacement_no_http_referer_header(self):
+        server_name = "http://testserver"
+        response = self.client.get(self.zip_file_base_url + self.test_name_3)
+        self.assertEqual(response.content, self.test_str_3.replace("$" + exercises.IMG_PLACEHOLDER, (server_name + self.zip_file_base_url).strip("/")))

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -32,7 +32,7 @@ def _add_access_control_headers(request, response):
 
 def get_referrer_url(request):
     if request.META.get('HTTP_REFERER'):
-        # If available user HTTP_REFERER to infer the host as that will give us more
+        # If available use HTTP_REFERER to infer the host as that will give us more
         # information if Kolibri is behind a proxy.
         return urlparse(request.META.get('HTTP_REFERER'))
 

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -47,8 +47,8 @@ def generate_image_prefix_url(request, zipped_filename):
             "embedded_filepath": ''
         })[:-1]
     if parsed_referrer_url:
-        # Reconstruct the parsed URL using only the scheme(0) and host + port(1)
-        zipcontent = urlunparse((parsed_referrer_url[0], parsed_referrer_url[1], zipcontent, '', '', ''))
+        # Reconstruct the parsed URL using a blank scheme and host + port(1)
+        zipcontent = urlunparse(('', parsed_referrer_url[1], zipcontent, '', '', ''))
     return zipcontent.encode()
 
 


### PR DESCRIPTION
### Summary
Previously we were just replacing a relative path to origin for image URLs inside perseus json blobs. On some browsers these were not then properly resolved, resulting in images being missing.

This fixes that by always creating a full URL for replacing in the json blob. It attempts to construct this with a URL derived from the `HTTP_REFERER` header, which appears to be widely supported, as this will give the host that the frontend request this from, not the host that Kolibri is running on (in case Kolibri is behind a proxy).

It also uses this to more accurately set our Content Security Policy header, so that it still works even behind a poorly configured proxy.

### Reviewer guidance
Check that Perseus images still work.
Check that they now work on older iOS.
See my tests, do they cover everything?

### References
Fixes #1049

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
