### PR TITLE
Fetch root topic by `root` not channel id.

### DIFF
--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -254,7 +254,7 @@ export function showSelectContentPage(store, params) {
       return loadChannelMetadata(store).then(() => {
         if (isSamePage()) {
           return updateTreeViewTopic(store, {
-            id: store.state.manageContent.wizard.transferredChannel.id,
+            id: store.state.manageContent.wizard.transferredChannel.root,
             title: transferredChannel.name,
           }).then(() => {});
         }


### PR DESCRIPTION
### Summary
For a long time we have been enforcing that the channel id and the id of the root topic node are identical, however, this has not always been the case (and perhaps will not always be). This fixes a place where this assumption is made in the channel import frontend code.

### Reviewer guidance
Can you still import channels?
Can you import a channel from Studio that has a root node id different to the channel id (I don't know of one I can currently test with, so have only tested the first scenario).

Any ideas on writing a test for this? I looked at `showSelectContentPage.spec.js` but it didn't actually directly test the handler.

### References
Fixes #4550 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
