### PR TITLE
Unpin node in docker files

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
       gettext \
       git \
       git-lfs \
-      nodejs=10.14.1-1nodesource1 \
+      nodejs \
       psmisc \
       python2.7 \
       python-pip \

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
       gettext \
       git \
       git-lfs \
-      nodejs=10.14.1-1nodesource1 \
+      nodejs \
       python2.7 \
       python-pip \
       python-sphinx \


### PR DESCRIPTION
### Summary
The NodeJS PPA is deleting old minor versions, meaning our pinned versions in our docker files are failing to install.

This pragmatically resolves this by unpinning. Ugh.

### Reviewer guidance
Does buildkite build now?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
