### PR TITLE
Revert "stub string" from community lang update

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -56,8 +56,6 @@
       changeLanguageModalHeader: 'Change language',
       cancelButtonText: 'Cancel',
       confirmButtonText: 'Confirm',
-      // TODO: https://github.com/learningequality/kolibri/issues/4512
-      communitySupported: 'Community-supported language in this release',
     },
     data() {
       return {


### PR DESCRIPTION


### Summary

This reverts commit 0b5cd9e074faeba72ec67979c8bb1bffafd0d98c because we decided not to implement #4512 

### Reviewer guidance

check it out


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
