### PR TITLE
creating a 'stop clean' command

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -38,6 +38,7 @@ www.learningequality.org
 Usage:
   kolibri start [--foreground] [--port=<port>] [options]
   kolibri stop [options]
+  kolibri stop-clean [options]
   kolibri restart [options]
   kolibri status [options]
   kolibri shell [options]
@@ -63,6 +64,7 @@ Options:
 Examples:
   kolibri start             Start Kolibri
   kolibri stop              Stop Kolibri
+  kolibri stop-clean        stop Kolibri - kill all sessions, sync DB with WAL files
   kolibri status            How is Kolibri doing?
   kolibri url               Tell me the address of Kolibri
   kolibri shell             Display a Django shell
@@ -665,6 +667,12 @@ def main(args=None):  # noqa: max-complexity=13
         return
 
     if arguments['stop']:
+        stop()
+        return
+
+    if arguments['stop-clean']:
+        call_command("clearsessions")
+        call_command("vacuumsqlite")  # empty WAL files into DB first
         stop()
         return
 


### PR DESCRIPTION

### Summary

Created a `stop-clean` command which shuts down sessions and vacuums the DB.

Chose not to add to `stop` in case the vacuum command takes a while; however I could also see it plausibly going there.

### Reviewer guidance

does this make sense?

### References

* recent issue with DB not being up-to-date with latest info: #4606 
* original PR: #4019

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
