### PR TITLE
don't back up db for dev builds

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -123,6 +123,11 @@ def version_file():
     return os.path.join(KOLIBRI_HOME, '.data_version')
 
 
+def should_back_up(kolibri_version, version_file_contents):
+    change_version = kolibri_version != version_file_contents
+    return change_version and 'dev' not in version_file_contents and 'dev' not in kolibri_version
+
+
 def initialize(debug=False):
     """
     Currently, always called before running commands. This may change in case
@@ -144,9 +149,8 @@ def initialize(debug=False):
 
         version = open(version_file(), "r").read()
         version = version.strip() if version else ""
-        change_version = kolibri.__version__ != version
 
-        if change_version and 'dev' not in version and 'dev' not in kolibri.__version__:
+        if should_back_up(kolibri.__version__, version):
             # dbbackup will load settings.INSTALLED_APPS.
             # we need to ensure plugins are correct in conf.config before
             enable_default_plugins()
@@ -165,7 +169,7 @@ def initialize(debug=False):
 
         setup_logging(debug=debug)
 
-        if change_version:
+        if kolibri.__version__ != version:
             logger.info(
                 "Version was {old}, new version: {new}".format(
                     old=version,

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -145,7 +145,8 @@ def initialize(debug=False):
         version = open(version_file(), "r").read()
         version = version.strip() if version else ""
         change_version = kolibri.__version__ != version
-        if change_version:
+
+        if change_version and 'dev' not in version:
             # dbbackup will load settings.INSTALLED_APPS.
             # we need to ensure plugins are correct in conf.config before
             enable_default_plugins()

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -146,7 +146,7 @@ def initialize(debug=False):
         version = version.strip() if version else ""
         change_version = kolibri.__version__ != version
 
-        if change_version and 'dev' not in version:
+        if change_version and 'dev' not in version and 'dev' not in kolibri.__version__:
             # dbbackup will load settings.INSTALLED_APPS.
             # we need to ensure plugins are correct in conf.config before
             enable_default_plugins()

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -14,7 +14,6 @@ import pytest
 from mock import patch
 
 import kolibri
-from kolibri.core.deviceadmin.tests.test_dbrestore import is_sqlite_settings
 from kolibri.utils import cli
 from kolibri.utils import options
 

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -231,16 +231,13 @@ def test_first_run(
 @patch('kolibri.utils.cli.update')
 def test_update(update, version_file=None, orig_version=None):
     """
-    Tests that update() function performs as expected, creating a database
-    backup automatically when version changes
+    Tests that update() function performs as expected
     """
     version_file = cli.version_file()
     open(version_file, "w").write(orig_version + "_test")
-
     if is_sqlite_settings():
         with patch('kolibri.core.deviceadmin.utils.dbbackup') as dbbackup:
             cli.initialize()
-            dbbackup.assert_called_once()
     else:
         cli.initialize()
     update.assert_called_once()

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -235,11 +235,7 @@ def test_update(update, version_file=None, orig_version=None):
     """
     version_file = cli.version_file()
     open(version_file, "w").write(orig_version + "_test")
-    if is_sqlite_settings():
-        with patch('kolibri.core.deviceadmin.utils.dbbackup') as dbbackup:
-            cli.initialize()
-    else:
-        cli.initialize()
+    cli.initialize()
     update.assert_called_once()
 
 

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -244,6 +244,18 @@ def test_update(update, version_file=None, orig_version=None):
 
 
 @pytest.mark.django_db
+def test_should_back_up():
+    """
+    Tests our db backup logic: skip for dev versions, and backup on change
+    """
+    assert cli.should_back_up('0.10.0', '0.10.1')
+    assert not cli.should_back_up('0.10.0', '0.10.0')
+    assert not cli.should_back_up('0.10.0-dev0', '0.10.0')
+    assert not cli.should_back_up('0.10.0', '0.10.0-dev0')
+    assert not cli.should_back_up('0.10.0-dev0', '0.10.0-dev0')
+
+
+@pytest.mark.django_db
 @patch('kolibri.utils.cli.update')
 @patch('kolibri.core.deviceadmin.utils.dbbackup')
 def test_update_no_version_change(dbbackup, update, orig_version=None):


### PR DESCRIPTION

### Summary

We've noticed that the DB is backed far too often for devs. This change skips backup which saves disk space and CPU consumption.

### Reviewer guidance

check it out

### References

refs #4578

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
