### PR TITLE
New strings covering a variety of issues

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/exams/CoachExamReport/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CoachExamReport/index.vue
@@ -92,7 +92,7 @@
     },
     $trs: {
       documentTitle: 'Quiz Report Detail',
-      missingContent: 'This quiz cannot be displayed because the content is missing',
+      missingContent: 'This quiz cannot be displayed because some content was deleted',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/exams/CoachExamReport/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CoachExamReport/index.vue
@@ -19,9 +19,9 @@
     :questions="questions"
     :exerciseContentNodes="exerciseContentNodes"
   />
-  <div v-else class="no-exercise-x">
-    <mat-svg category="navigation" name="close" />
-  </div>
+  <p v-else class="no-exercise">
+    {{ $tr('missingContent') }}
+  </p>
 
 </template>
 
@@ -92,6 +92,7 @@
     },
     $trs: {
       documentTitle: 'Quiz Report Detail',
+      missingContent: 'This quiz cannot be displayed because the content is missing',
     },
   };
 
@@ -102,10 +103,6 @@
 
   .no-exercise-x {
     text-align: center;
-    svg {
-      width: 200px;
-      height: 200px;
-    }
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/ExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/ExamPreview.vue
@@ -110,7 +110,7 @@
       question: 'Question { num }',
       numQuestions: '{num} {num, plural, one {question} other {questions}}',
       exercise: 'Exercise { num }',
-      missingContent: 'This quiz cannot be displayed because the content is missing',
+      missingContent: 'This quiz cannot be displayed because some content was deleted',
     },
     components: {
       CoachContentLabel,

--- a/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/ExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/exams/CoachExamsPage/ExamPreview.vue
@@ -15,8 +15,8 @@
         v-if="loading"
         :delay="false"
       />
-      <div v-else-if="exerciseContentNodes.length === 0" class="no-exercise-x">
-        <mat-svg category="navigation" name="close" />
+      <div v-else-if="exerciseContentNodes.length === 0" class="no-exercise">
+        {{ $tr('missingContent') }}
       </div>
       <div v-else @keyup.enter.stop>
         <div ref="header">
@@ -110,6 +110,7 @@
       question: 'Question { num }',
       numQuestions: '{num} {num, plural, one {question} other {questions}}',
       exercise: 'Exercise { num }',
+      missingContent: 'This quiz cannot be displayed because the content is missing',
     },
     components: {
       CoachContentLabel,
@@ -291,12 +292,8 @@
     margin-bottom: 0.25em;
   }
 
-  .no-exercise-x {
+  .no-exercise {
     text-align: center;
-    svg {
-      width: 200px;
-      height: 200px;
-    }
   }
 
   .o-y-auto {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -206,7 +206,7 @@
       onYourDevice: 'On your device',
       selectButton: 'Select',
       version: 'Version {version}',
-      channelNotAvailable: 'This channel is not available',
+      channelNotAvailable: 'This channel is no longer available',
     },
   };
 

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -206,6 +206,7 @@
       onYourDevice: 'On your device',
       selectButton: 'Select',
       version: 'Version {version}',
+      channelNotAvailable: 'This channel is not available',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -98,7 +98,7 @@
     },
     $trs: {
       documentTitle: '{ examTitle } report',
-      missingContent: 'This quiz cannot be displayed because the content is missing',
+      missingContent: 'This quiz cannot be displayed because some content was deleted',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -23,9 +23,9 @@
     />
   </div>
   <div v-else>
-    <div class="no-exercise-x">
-      <mat-svg category="navigation" name="close" />
-    </div>
+    <p class="no-exercise">
+      {{ $tr('missingContent') }}
+    </p>
   </div>
 
 </template>
@@ -98,6 +98,7 @@
     },
     $trs: {
       documentTitle: '{ examTitle } report',
+      missingContent: 'This quiz cannot be displayed because the content is missing',
     },
   };
 
@@ -106,12 +107,8 @@
 
 <style lang="scss" scoped>
 
-  .no-exercise-x {
+  .no-exercise {
     text-align: center;
-    svg {
-      width: 200px;
-      height: 200px;
-    }
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
@@ -176,6 +176,7 @@
       plusPoints: '+ { maxPoints, number } Points',
       next: 'Next:',
       signIn: 'Sign in or create an account to save points you earn',
+      askForHelp: 'Having trouble? Try asking someone for help',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -3,7 +3,7 @@
   <div>
     <div v-if="isUserLoggedIn ">
       <h2>{{ $tr('allClassesHeader') }}</h2>
-
+      <p v-if="!classrooms.length">{{ $tr('noClasses') }}</p>
       <div class="classrooms">
         <ContentCard
           v-for="c in classrooms"
@@ -57,6 +57,7 @@
     $trs: {
       allClassesHeader: 'Classes',
       documentTitle: 'All classes',
+      noClasses: 'You are not enrolled in any classes',
     },
   };
 


### PR DESCRIPTION

### Summary

New strings:

* "Having trouble? Try asking someone for help" (show to learner when struggling with exercise)
*  "This channel is not available" (shown when trying to update a channel that's been deleted on studio)
* "This quiz cannot be displayed because the content is missing" (shown when trying to view a quiz or quiz report but some content it references is not on the device)
* "You are not enrolled in any classes" (shown when a learner manually navigates to the classes URL)

### Reviewer guidance

all look good?

any issues

### References

* #4355
* #3947
* #3436
* #4647

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
