### PR TITLE
Wrapping strings definitions in quotes.

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
@@ -9,7 +9,7 @@
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
-    <p>{{ $tr(`addressDesc`) }}</p>
+    <p>{{ $tr('addressDesc') }}</p>
     <div>
       <KTextbox
         v-model="address"
@@ -22,7 +22,7 @@
         @blur="addressBlurred = true"
       />
     </div>
-    <p>{{ $tr(`nameDesc`) }}</p>
+    <p>{{ $tr('nameDesc') }}</p>
     <div>
       <KTextbox
         v-model="name"

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/AddAddressForm.vue
@@ -9,7 +9,7 @@
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
-    <p>{{ $tr(addressDesc) }}</p>
+    <p>{{ $tr(`addressDesc`) }}</p>
     <div>
       <KTextbox
         v-model="address"
@@ -22,7 +22,7 @@
         @blur="addressBlurred = true"
       />
     </div>
-    <p>{{ $tr(nameDesc) }}</p>
+    <p>{{ $tr(`nameDesc`) }}</p>
     <div>
       <KTextbox
         v-model="name"


### PR DESCRIPTION
Fixes bugs introduced in #4582.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Before:
![image](https://user-images.githubusercontent.com/9877852/50317333-e5839e80-046f-11e9-90a5-c87605a7eccb.png)

After:
![image](https://user-images.githubusercontent.com/9877852/50317265-8faef680-046f-11e9-9ab3-30aec36ecd61.png)


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
