### PR TITLE
prototyping notification links and stubs - round 4

### DIFF
--- a/kolibri/core/assets/src/views/InteractionList/index.vue
+++ b/kolibri/core/assets/src/views/InteractionList/index.vue
@@ -13,7 +13,7 @@
     </div>
 
     <p v-if="interactions.length">
-      {{ $tr('currAnswer', {ordinal: selectedInteractionIndex + 1 }) }}
+      {{ $tr('currAnswer', {value: selectedInteractionIndex + 1 }) }}
     </p>
     <p v-else>
       {{ $tr('noInteractions') }}
@@ -34,7 +34,7 @@
     components: { InteractionItem },
     mixins: [responsiveElement],
     $trs: {
-      currAnswer: '{ordinal, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} attempt',
+      currAnswer: 'Attempt {value, number, integer}',
       noInteractions: 'No attempts made on this question',
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/new/HomeActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/HomeActivityPage.vue
@@ -10,32 +10,26 @@
     <h2>{{ $tr('classActivity') }}</h2>
     <NotificationsFilter />
     <br>
-    <KGrid class="table-head">
-      <KGridItem :size="75" percentage>
-        {{ coachStrings.$tr('activityLabel') }}
-      </KGridItem>
-      <KGridItem :size="25" percentage>
-        {{ coachStrings.$tr('timeLabel') }}
-      </KGridItem>
-    </KGrid>
 
     <div>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
         time="1 minute ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Adam", itemName: "A video"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="2 minutes ago"
       >
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsty", itemName: "An exercise"}) }}
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsy", itemName: "An exercise"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="3 minutes ago"
         contentContext="Some lesson"
       >
@@ -43,15 +37,17 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="4 minutes ago"
         contentContext="Some lesson"
       >
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsy", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="5 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -60,7 +56,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="6 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -69,7 +66,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="10 minutes ago"
         contentContext="Some lesson"
       >
@@ -77,7 +75,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="15 minutes ago"
         contentContext="Some quiz"
       >
@@ -90,22 +89,25 @@
 
       <!-- Individual needs help -->
       <NotificationCard
-        targetPage="SomePage"
+        icon="help"
+        targetPage=""
         time="20 minutes ago"
       >
-        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsty", itemName: "An exercise"}) }}
+        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsy", itemName: "An exercise"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="help"
+        targetPage=""
         time="25 minutes ago"
         contentContext="Some lesson"
       >
-        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
+        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsy", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="help"
+        targetPage=""
         time="30 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -119,21 +121,24 @@
 
       <!-- Individual started -->
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="40 minutes ago"
       >
         {{ nStrings.$tr('individualStarted', {learnerName: "Adam", itemName: "A video"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="50 minutes ago"
       >
-        {{ nStrings.$tr('individualStarted', {learnerName: "Betsty", itemName: "An exercise"}) }}
+        {{ nStrings.$tr('individualStarted', {learnerName: "Betsy", itemName: "An exercise"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="1 hour ago"
         contentContext="Some lesson"
       >
@@ -141,15 +146,17 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="1 hour ago"
         contentContext="Some lesson"
       >
-        {{ nStrings.$tr('individualStarted', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
+        {{ nStrings.$tr('individualStarted', {learnerName: "Betsy", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="1 hour ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -158,7 +165,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="2 hours ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -167,7 +175,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="5 hours ago"
         contentContext="Some lesson"
       >
@@ -175,7 +184,8 @@
       </NotificationCard>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="3 days ago"
         contentContext="Some quiz"
       >

--- a/kolibri/plugins/coach/assets/src/views/new/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/HomePage/ActivityBlock.vue
@@ -10,206 +10,326 @@
       />
     </p>
 
-
     <div>
-      <div class="table-head">
-        {{ coachStrings.$tr('activityLabel') }}
-      </div>
 
-      <!-- Individual finished -->
-      <NotificationCard targetPage="SomePage">
+      <!-- Individual completed -->
+      <NotificationCard
+        icon="star"
+      >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Adam", itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsty", itemName: "An exercise"}) }}
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsLessonExerciseLearnerListPage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('multipleCompleted', {learnerName: "Betsy", numOthers: 4, itemName: "Counting with big numbers"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Adam", itemName: "A video assigned to the class"}) }}
+      <NotificationCard
+        icon="help"
+        targetPage="ReportsLessonLearnerExercisePage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Julie", itemName: "Counting with big numbers"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Carol", itemName: "A video assigned to a group"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Darren", itemName: "An exercise assigned to a group"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Edward", itemName: "Some lesson"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
-        {{ nStrings.$tr('individualCompleted', {learnerName: "Frank", itemName: "Some quiz"}) }}
-      </NotificationCard>
-
-
-      <!-- Individual finished -->
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="clock"
+      >
         {{ nStrings.$tr('individualStarted', {learnerName: "Adam", itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Betsty", itemName: "An exercise"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Adam", itemName: "A video assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Carol", itemName: "A video assigned to a group"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Darren", itemName: "An exercise assigned to a group"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Edward", itemName: "Some lesson"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
-        {{ nStrings.$tr('individualStarted', {learnerName: "Frank", itemName: "Some quiz"}) }}
+      <NotificationCard
+        icon="clock"
+        targetPage="ReportsLessonLearnerListPage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('multipleStarted', {learnerName: "Edward", numOthers: 6, itemName: "Some lesson"}) }}
       </NotificationCard>
 
 
-      <!-- Multiple finished -->
-      <NotificationCard targetPage="SomePage">
+
+
+
+
+
+
+
+
+      <!-- One of every kind of notification type below --
+
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsLessonResourceLearnerListPage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Adam", itemName: "A video assigned to the class"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsLessonExerciseLearnerPage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Betsy", itemName: "An exercise assigned to the class"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsGroupReportLessonResourceLearnerListPage"
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Carol", itemName: "A video assigned to a group"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsGroupReportLessonExerciseLearnerPage"
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Darren", itemName: "An exercise assigned to a group"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsLessonLearnerPage"
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Edward", itemName: "Some lesson"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage="ReportsQuizLearnerPage"
+        contentContext="Some quiz"
+      >
+        {{ nStrings.$tr('individualCompleted', {learnerName: "Frank", itemName: "Some quiz"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="clock"
+        targetPage="ReportsLearnerActivityExercisePage"
+      >
+        {{ nStrings.$tr('individualStarted', {learnerName: "Betsy", itemName: "An exercise"}) }}
+      </NotificationCard>
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Adam", numOthers: 1, itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('multipleCompleted', {learnerName: "Betsty", numOthers: 2, itemName: "An exercise"}) }}
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
+        {{ nStrings.$tr('multipleCompleted', {learnerName: "Betsy", numOthers: 2, itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Adam", numOthers: 3, itemName: "A video assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('multipleCompleted', {learnerName: "Betsty", numOthers: 4, itemName: "An exercise assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Carol", numOthers: 5, itemName: "A video assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Darren", numOthers: 6, itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Edward", numOthers: 7, itemName: "Some lesson"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some quiz"
+      >
         {{ nStrings.$tr('multipleCompleted', {learnerName: "Frank", numOthers: 8, itemName: "Some quiz"}) }}
       </NotificationCard>
-
-
-      <!-- Multiple finished -->
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+      >
         {{ nStrings.$tr('multipleStarted', {learnerName: "Adam", numOthers: 1, itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('multipleStarted', {learnerName: "Betsty", numOthers: 2, itemName: "An exercise"}) }}
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+      >
+        {{ nStrings.$tr('multipleStarted', {learnerName: "Betsy", numOthers: 2, itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleStarted', {learnerName: "Adam", numOthers: 3, itemName: "A video assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('multipleStarted', {learnerName: "Betsty", numOthers: 4, itemName: "An exercise assigned to the class"}) }}
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('multipleStarted', {learnerName: "Betsy", numOthers: 4, itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleStarted', {learnerName: "Carol", numOthers: 5, itemName: "A video assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleStarted', {learnerName: "Darren", numOthers: 6, itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('multipleStarted', {learnerName: "Edward", numOthers: 7, itemName: "Some lesson"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
+      <NotificationCard
+        icon="clock"
+        targetPage=""
+        contentContext="Some quiz"
+      >
         {{ nStrings.$tr('multipleStarted', {learnerName: "Frank", numOthers: 8, itemName: "Some quiz"}) }}
       </NotificationCard>
-
-
-      <!-- Whole group finished -->
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "A video assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "Some lesson"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some quiz"
+      >
         {{ nStrings.$tr('wholeGroupCompleted', {groupName: "Group A", itemName: "Some quiz"}) }}
       </NotificationCard>
-
-
-      <!-- Whole class finished -->
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "A video"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "An exercise"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "A video assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "An exercise assigned to the class"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "Some lesson"}) }}
-      </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
-        {{ nStrings.$tr('wholeClassCompleted', {className: "5th Grade", itemName: "Some quiz"}) }}
-      </NotificationCard>
-
-
-      <!-- Whole class finished - alternative -->
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "A video"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "A video assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "Some lesson"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some quiz">
+      <NotificationCard
+        icon="star"
+        targetPage=""
+        contentContext="Some quiz"
+      >
         {{ nStrings.$tr('everyoneCompleted', {itemName: "Some quiz"}) }}
       </NotificationCard>
-
-
-      <!-- Individual needs help -->
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsty", itemName: "An exercise"}) }}
+      <NotificationCard
+        icon="help"
+        targetPage=""
+      >
+        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsy", itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsty", itemName: "An exercise assigned to the class"}) }}
+      <NotificationCard
+        icon="help"
+        targetPage=""
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Betsy", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="help"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('individualNeedsHelp', {learnerName: "Darren", itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
-
-
-      <!-- Multiple need help -->
-      <NotificationCard targetPage="SomePage">
-        {{ nStrings.$tr('multipleNeedHelp', {learnerName: "Betsty", numOthers: 1, itemName: "An exercise"}) }}
+      <NotificationCard
+        icon="help"
+        targetPage=""
+      >
+        {{ nStrings.$tr('multipleNeedHelp', {learnerName: "Betsy", numOthers: 1, itemName: "An exercise"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" contentContext="Some lesson">
-        {{ nStrings.$tr('multipleNeedHelp', {learnerName: "Betsty", numOthers: 2, itemName: "An exercise assigned to the class"}) }}
+      <NotificationCard
+        icon="help"
+        targetPage=""
+        contentContext="Some lesson"
+      >
+        {{ nStrings.$tr('multipleNeedHelp', {learnerName: "Betsy", numOthers: 2, itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
-      <NotificationCard targetPage="SomePage" learnerContext="Group A" contentContext="Some lesson">
+      <NotificationCard
+        icon="help"
+        targetPage=""
+        learnerContext="Group A"
+        contentContext="Some lesson"
+      >
         {{ nStrings.$tr('multipleNeedHelp', {learnerName: "Darren", numOthers: 3, itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
-
+ -->
     </div>
   </div>
 

--- a/kolibri/plugins/coach/assets/src/views/new/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/HomePage/ItemProgressDisplay.vue
@@ -13,6 +13,7 @@
     />
 
     <LearnerProgressCount
+      v-if="needHelp"
       :count="needHelp"
       :verbosity="0"
       icon="help"
@@ -62,6 +63,7 @@
 <style lang="scss" scoped>
 
   .item {
+    margin-bottom: 8px;
     border-top: 1px solid gray;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/new/HomePage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/HomePage/index.vue
@@ -4,8 +4,7 @@
     <KGridItem size="100" percentage>
       <OverviewBlock class="new-coach-block" />
     </KGridItem>
-    <KGridItem sizes="100, 50, 50" percentage>
-
+    <KGridItem sizes="100, 100, 50" percentage>
       <KGrid :gutter="8">
         <KGridItem size="100" percentage>
           <QuizzesBlock class="new-coach-block" />
@@ -14,9 +13,8 @@
           <LessonsBlock class="new-coach-block" />
         </KGridItem>
       </KGrid>
-
     </KGridItem>
-    <KGridItem sizes="100, 50, 50" percentage>
+    <KGridItem sizes="100, 100, 50" percentage>
       <ActivityBlock class="new-coach-block" />
     </KGridItem>
   </KGrid>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsGroupActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsGroupActivityPage.vue
@@ -6,50 +6,48 @@
     <NotificationsFilter />
     <br>
 
-    <KGrid class="table-head">
-      <KGridItem :size="75" percentage>
-        {{ coachStrings.$tr('activityLabel') }}
-      </KGridItem>
-      <KGridItem :size="25" percentage>
-        {{ coachStrings.$tr('timeLabel') }}
-      </KGridItem>
-    </KGrid>
     <div>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="1 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="2 minutes ago"
       >
         {{ nStrings.$tr('individualStarted', {learnerName: "John", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="3 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Steve", itemName: "An exercise"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="4 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Mary", itemName: "A video assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="6 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "John", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="8 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -57,7 +55,8 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Mary", itemName: "A video assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="10 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -65,21 +64,24 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Steve", itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="15 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Frank", itemName: "Some lesson"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="20 minutes ago"
         contentContext="Some quiz"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "Some quiz"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="50 minutes ago"
         contentContext="Some lesson"
       >

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsGroupLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsGroupLearnerActivityPage.vue
@@ -6,50 +6,48 @@
     <NotificationsFilter />
     <br>
 
-    <KGrid class="table-head">
-      <KGridItem :size="75" percentage>
-        {{ coachStrings.$tr('activityLabel') }}
-      </KGridItem>
-      <KGridItem :size="25" percentage>
-        {{ coachStrings.$tr('timeLabel') }}
-      </KGridItem>
-    </KGrid>
     <div>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="1 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="2 minutes ago"
       >
         {{ nStrings.$tr('individualStarted', {learnerName: "Julie", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="3 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="4 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="6 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="8 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -57,7 +55,8 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="10 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -65,21 +64,24 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="15 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "Some lesson"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="20 minutes ago"
         contentContext="Some quiz"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "Some quiz"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="50 minutes ago"
         contentContext="Some lesson"
       >

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsGroupReportQuizLearnerListPage.vue
@@ -10,7 +10,7 @@
     <table class="new-coach-table">
       <thead>
         <tr>
-          <td>{{ coachStrings.$tr('titleLabel') }}</td>
+          <td>{{ coachStrings.$tr('nameLabel') }}</td>
           <td>{{ coachStrings.$tr('scoreLabel') }}</td>
           <td>{{ coachStrings.$tr('progressLabel') }}</td>
         </tr>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLearnerActivityExercisePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLearnerActivityExercisePage.vue
@@ -1,0 +1,31 @@
+<template>
+
+  <div>
+    <BackLink
+      :text="coachStrings.$tr('activityLabel')"
+      :to="newCoachRoute('ReportsLearnerActivityPage')"
+    />
+    <LearnerExerciseReport />
+  </div>
+
+</template>
+
+
+<script>
+
+  import imports from './imports';
+  import LearnerExerciseReport from './shared/LearnerExerciseReport';
+
+  export default {
+    name: 'ReportsLearnerActivityExercisePage',
+    components: {
+      LearnerExerciseReport,
+    },
+    mixins: [imports],
+    $trs: {},
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLearnerActivityPage.vue
@@ -6,50 +6,48 @@
     <NotificationsFilter />
     <br>
 
-    <KGrid class="table-head">
-      <KGridItem :size="75" percentage>
-        {{ coachStrings.$tr('activityLabel') }}
-      </KGridItem>
-      <KGridItem :size="25" percentage>
-        {{ coachStrings.$tr('timeLabel') }}
-      </KGridItem>
-    </KGrid>
     <div>
 
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="1 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="2 minutes ago"
       >
         {{ nStrings.$tr('individualStarted', {learnerName: "Julie", itemName: "A video"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="3 minutes ago"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="4 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="6 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise assigned to the class"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="8 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -57,7 +55,8 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="10 minutes ago"
         learnerContext="Group A"
         contentContext="Some lesson"
@@ -65,21 +64,24 @@
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise assigned to a group"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="15 minutes ago"
         contentContext="Some lesson"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "Some lesson"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="star"
+        targetPage=""
         time="20 minutes ago"
         contentContext="Some quiz"
       >
         {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "Some quiz"}) }}
       </NotificationCard>
       <NotificationCard
-        targetPage="SomePage"
+        icon="clock"
+        targetPage=""
         time="50 minutes ago"
         contentContext="Some lesson"
       >

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonExerciseHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonExerciseHeader.vue
@@ -4,7 +4,7 @@
 
     <p>
       <BackLink
-        :to="newCoachRoute('ReportsLessonPage')"
+        :to="newCoachRoute('ReportsLessonReportPage')"
         :text="$tr('back', { lesson: lessonName })"
       />
     </p>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonExerciseLearnerListPage.vue
@@ -9,25 +9,25 @@
     <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
     <p>
       <LearnerProgressCount
-        :count="3"
+        :count="4"
         verbosity="0"
         verb="completed"
         icon="star"
       />
       <LearnerProgressCount
-        :count="5"
+        :count="2"
         verbosity="0"
         verb="started"
         icon="clock"
       />
       <LearnerProgressCount
-        :count="5"
+        :count="1"
         verbosity="0"
         verb="needHelp"
         icon="help"
       />
       <LearnerProgressCount
-        :count="2"
+        :count="0"
         verbosity="0"
         verb="notStarted"
         icon="nothing"
@@ -45,9 +45,8 @@
       </thead>
       <tbody>
         <tr>
-          <td><KRouterLink text="April" :to="learnerLink" /></td>
+          <td><KRouterLink text="Adam" :to="learnerLink" /></td>
           <td>
-
             <LearnerProgressLabel
               :count="1"
               verbosity="1"
@@ -56,13 +55,12 @@
             />
           </td>
           <td><TimeDuration :seconds="60*15" /></td>
-          <td>Gnomes | Explorers</td>
+          <td>a, b</td>
           <td>some time ago</td>
         </tr>
         <tr>
-          <td><KRouterLink text="John" :to="learnerLink" /></td>
+          <td><KRouterLink text="April" :to="learnerLink" /></td>
           <td>
-
             <LearnerProgressLabel
               :count="1"
               verbosity="1"
@@ -71,13 +69,26 @@
             />
           </td>
           <td><TimeDuration :seconds="60*15" /></td>
-          <td>Gnomes | Explorers</td>
+          <td>a, b</td>
           <td>some time ago</td>
         </tr>
         <tr>
-          <td><KRouterLink text="Steve" :to="learnerLink" /></td>
+          <td><KRouterLink text="Betsy" :to="learnerLink" /></td>
           <td>
-
+            <LearnerProgressLabel
+              :count="1"
+              verbosity="1"
+              verb="completed"
+              icon="star"
+            />
+          </td>
+          <td><TimeDuration :seconds="60*15" /></td>
+          <td>a, b</td>
+          <td>some time ago</td>
+        </tr>
+        <tr>
+          <td><KRouterLink text="Edward" :to="learnerLink" /></td>
+          <td>
             <LearnerProgressLabel
               :count="1"
               verbosity="1"
@@ -86,7 +97,49 @@
             />
           </td>
           <td><TimeDuration :seconds="60*15" /></td>
-          <td>Gnomes | Explorers</td>
+          <td>a, b</td>
+          <td>some time ago</td>
+        </tr>
+        <tr>
+          <td><KRouterLink text="John" :to="learnerLink" /></td>
+          <td>
+            <LearnerProgressLabel
+              :count="1"
+              verbosity="1"
+              verb="completed"
+              icon="star"
+            />
+          </td>
+          <td><TimeDuration :seconds="60*15" /></td>
+          <td>a, b</td>
+          <td>some time ago</td>
+        </tr>
+        <tr>
+          <td><KRouterLink text="Julie" :to="learnerLink" /></td>
+          <td>
+            <LearnerProgressLabel
+              :count="1"
+              verbosity="1"
+              verb="needHelp"
+              icon="help"
+            />
+          </td>
+          <td><TimeDuration :seconds="60*15" /></td>
+          <td></td>
+          <td>some time ago</td>
+        </tr>
+        <tr>
+          <td><KRouterLink text="Steve" :to="learnerLink" /></td>
+          <td>
+            <LearnerProgressLabel
+              :count="1"
+              verbosity="1"
+              verb="completed"
+              icon="star"
+            />
+          </td>
+          <td><TimeDuration :seconds="60*15" /></td>
+          <td></td>
           <td>some time ago</td>
         </tr>
       </tbody>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonHeader.vue
@@ -1,0 +1,79 @@
+<template>
+
+  <div>
+    <p>
+      <BackLink
+        :to="newCoachRoute('ReportsLessonListPage')"
+        :text="$tr('back')"
+      />
+    </p>
+    <h1>Some Lesson</h1>
+    <KDropdownMenu
+      slot="optionsDropdown"
+      :text="coachStrings.$tr('optionsLabel')"
+      :options="actionOptions"
+      appearance="raised-button"
+      @select="goTo($event.value)"
+    />
+    <dl>
+      <dt>{{ coachStrings.$tr('statusLabel') }}</dt>
+      <dd><LessonActive :active="true" /></dd>
+      <dt>{{ coachStrings.$tr('recipientsLabel') }}</dt>
+      <dd>Group 1, Group 2</dd>
+      <dt>{{ coachStrings.$tr('descriptionLabel') }}</dt>
+      <dd>Ipsum lorem</dd>
+    </dl>
+
+    <div>
+      <KRouterLink
+        :text="coachStrings.$tr('reportLabel')"
+        appearance="flat-button"
+        class="new-coach-tab"
+        :to="newCoachRoute('ReportsLessonReportPage')"
+      />
+      <KRouterLink
+        :text="coachStrings.$tr('learnersLabel')"
+        appearance="flat-button"
+        class="new-coach-tab"
+        :to="newCoachRoute('ReportsLessonLearnerListPage')"
+      />
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import imports from './imports';
+
+  export default {
+    name: 'ReportsLessonHeader',
+    components: {},
+    mixins: [imports],
+    computed: {
+      actionOptions() {
+        return [
+          { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsLessonEditorPage' },
+          {
+            label: this.coachStrings.$tr('manageResourcesAction'),
+            value: 'ReportsLessonManagerPage',
+          },
+        ];
+      },
+    },
+    methods: {
+      goTo(page) {
+        this.$router.push({ name: 'NEW_COACH_PAGES', params: { page } });
+      },
+    },
+    $trs: {
+      back: 'All lessons',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerExercisePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerExercisePage.vue
@@ -1,0 +1,31 @@
+<template>
+
+  <div>
+    <BackLink
+      :text="coachStrings.$tr('combinedLabel', {firstItem: 'Julie', secondItem: 'Some lesson'})"
+      :to="newCoachRoute('ReportsLessonLearnerPage')"
+    />
+    <LearnerExerciseReport />
+  </div>
+
+</template>
+
+
+<script>
+
+  import imports from './imports';
+  import LearnerExerciseReport from './shared/LearnerExerciseReport';
+
+  export default {
+    name: 'ReportsLessonLearnerExercisePage',
+    components: {
+      LearnerExerciseReport,
+    },
+    mixins: [imports],
+    $trs: {},
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerListPage.vue
@@ -1,0 +1,205 @@
+<template>
+
+  <div class="new-coach-block">
+
+    <ReportsLessonHeader />
+
+    <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
+
+    <table class="new-coach-table">
+      <thead>
+        <tr>
+          <td>{{ coachStrings.$tr('titleLabel') }}</td>
+          <td>{{ coachStrings.$tr('progressLabel') }}</td>
+          <td>{{ coachStrings.$tr('groupsLabel') }}</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Adam"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="0"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="clock"
+            />
+          </td>
+          <td><TruncatedItemList :items="[]" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="April"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="1"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="clock"
+            />
+          </td>
+          <td><TruncatedItemList :items="[]" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Betsy"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="1"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="clock"
+            />
+          </td>
+          <td><TruncatedItemList :items="[]" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Edward"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="0"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="clock"
+            />
+          </td>
+          <td><TruncatedItemList :items="[]" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="John"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="10"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="star"
+            />
+          </td>
+          <td><TruncatedItemList :items="['a', 'b', 'c', 'd']" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Julie"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusCount
+              :count="1"
+              verbosity="1"
+              obj="question"
+              adjective="difficult"
+              icon="help"
+            />
+          </td>
+          <td><TruncatedItemList :items="['a', 'b', 'c', 'd']" /></td>
+        </tr>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Steve"
+              :to="newCoachRoute('ReportsLessonLearnerPage')"
+            />
+          </td>
+          <td>
+            <ItemStatusRatio
+              :count="8"
+              :total="10"
+              verbosity="1"
+              obj="question"
+              adjective="completed"
+              icon="clock"
+            />
+          </td>
+          <td><TruncatedItemList :items="['a', 'b']" /></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</template>
+
+
+<script>
+
+  import imports from './imports';
+  import ReportsLessonHeader from './ReportsLessonHeader';
+
+  export default {
+    name: 'ReportsLessonLearnerListPage',
+    components: {
+      ReportsLessonHeader,
+    },
+    mixins: [imports],
+    data() {
+      return {
+        filter: 'allQuizzes',
+      };
+    },
+    computed: {
+      filterOptions() {
+        return [
+          {
+            label: this.$tr('allQuizzes'),
+            value: 'allQuizzes',
+          },
+          {
+            label: this.$tr('activeQuizzes'),
+            value: 'activeQuizzes',
+          },
+          {
+            label: this.$tr('inactiveQuizzes'),
+            value: 'inactiveQuizzes',
+          },
+        ];
+      },
+    },
+    beforeMount() {
+      this.filter = this.filterOptions[0];
+    },
+    $trs: {
+      averageScore: 'Average score: {score, number, percent}',
+      allQuizzes: 'All quizzes',
+      activeQuizzes: 'Active quizzes',
+      inactiveQuizzes: 'Inactive quizzes',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonLearnerPage.vue
@@ -1,0 +1,86 @@
+<template>
+
+  <div class="new-coach-block">
+    <p>
+      <BackLink
+        :to="newCoachRoute('ReportsLessonLearnerListPage')"
+        text="Some lesson"
+      />
+    </p>
+    <h1>
+      {{ coachStrings.$tr('combinedLabel', {firstItem: 'Julie', secondItem: 'Some lesson'}) }}
+    </h1>
+    <dl>
+      <dt>{{ coachStrings.$tr('statusLabel') }}</dt>
+      <dd><LessonActive :active="true" /></dd>
+      <dt>{{ coachStrings.$tr('recipientsLabel') }}</dt>
+      <dd>Group 1, Group 2</dd>
+      <dt>{{ coachStrings.$tr('descriptionLabel') }}</dt>
+      <dd>Ipsum lorem</dd>
+    </dl>
+
+    <h2>{{ coachStrings.$tr('numberOfResources', {value: 4}) }}</h2>
+    <table class="new-coach-table">
+      <thead>
+        <tr>
+          <td>{{ coachStrings.$tr('titleLabel') }}</td>
+          <td>{{ coachStrings.$tr('progressLabel') }}</td>
+          <td>{{ coachStrings.$tr('timeSpentLabel') }}</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <KRouterLink
+              text="Some exercise"
+              :to="newCoachRoute('ReportsLessonLearnerExercisePage')"
+            />
+          </td>
+          <td>
+            <LearnerProgressLabel
+              :verbosity="1"
+              :count="1"
+              verb="needHelp"
+              icon="help"
+            />
+          </td>
+          <td><TimeDuration :seconds="360" /></td>
+        </tr>
+        <tr>
+          <td>
+            Some video
+          </td>
+          <td>
+            <LearnerProgressLabel
+              :verbosity="1"
+              :count="1"
+              verb="completed"
+              icon="star"
+            />
+          </td>
+          <td><TimeDuration :seconds="120" /></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</template>
+
+
+<script>
+
+  import imports from './imports';
+
+  export default {
+    name: 'ReportsLessonLearnerPage',
+    components: {},
+    mixins: [imports],
+    $trs: {
+      lessonProgressLabel: "'{lesson}' progress",
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonListPage.vue
@@ -22,7 +22,7 @@
           <td>
             <KRouterLink
               text="Lesson A"
-              :to="newCoachRoute('ReportsLessonPage')"
+              :to="newCoachRoute('ReportsLessonReportPage')"
             />
           </td>
           <td>
@@ -41,7 +41,7 @@
           <td>
             <KRouterLink
               text="Lesson B"
-              :to="newCoachRoute('ReportsLessonPage')"
+              :to="newCoachRoute('ReportsLessonReportPage')"
             />
           </td>
           <td>

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonReportPage.vue
@@ -1,28 +1,8 @@
 <template>
 
   <div class="new-coach-block">
-    <p>
-      <BackLink
-        :to="newCoachRoute('ReportsLessonListPage')"
-        :text="$tr('back')"
-      />
-    </p>
-    <h1>Some Lesson</h1>
-    <KDropdownMenu
-      slot="optionsDropdown"
-      :text="coachStrings.$tr('optionsLabel')"
-      :options="actionOptions"
-      appearance="raised-button"
-      @select="goTo($event.value)"
-    />
-    <dl>
-      <dt>{{ coachStrings.$tr('statusLabel') }}</dt>
-      <dd><LessonActive :active="true" /></dd>
-      <dt>{{ coachStrings.$tr('recipientsLabel') }}</dt>
-      <dd>Group 1, Group 2</dd>
-      <dt>{{ coachStrings.$tr('descriptionLabel') }}</dt>
-      <dd>Ipsum lorem</dd>
-    </dl>
+
+    <ReportsLessonHeader />
 
     <table class="new-coach-table">
       <thead>
@@ -87,10 +67,13 @@
 <script>
 
   import imports from './imports';
+  import ReportsLessonHeader from './ReportsLessonHeader';
 
   export default {
-    name: 'ReportsLessonPage',
-    components: {},
+    name: 'ReportsLessonReportPage',
+    components: {
+      ReportsLessonHeader,
+    },
     mixins: [imports],
     computed: {
       actionOptions() {

--- a/kolibri/plugins/coach/assets/src/views/new/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/ReportsLessonResourceLearnerListPage.vue
@@ -3,7 +3,7 @@
   <div class="new-coach-block">
     <p>
       <BackLink
-        :to="newCoachRoute('ReportsLessonPage')"
+        :to="newCoachRoute('ReportsLessonReportPage')"
         :text="$tr('back', { lesson: lessonName })"
       />
     </p>

--- a/kolibri/plugins/coach/assets/src/views/new/imports.js
+++ b/kolibri/plugins/coach/assets/src/views/new/imports.js
@@ -1,3 +1,4 @@
+import KModal from 'kolibri.coreVue.components.KModal';
 import KButton from 'kolibri.coreVue.components.KButton';
 import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
 import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
@@ -26,6 +27,7 @@ import ItemStatusLabel from './shared/status/ItemStatusLabel';
 export default {
   name: 'ReportsQuizHeader',
   components: {
+    KModal,
     KButton,
     KCheckbox,
     KDropdownMenu,

--- a/kolibri/plugins/coach/assets/src/views/new/newPages.js
+++ b/kolibri/plugins/coach/assets/src/views/new/newPages.js
@@ -25,6 +25,7 @@ import ReportsGroupReportQuizLearnerPage from './ReportsGroupReportQuizLearnerPa
 import ReportsGroupReportQuizQuestionListPage from './ReportsGroupReportQuizQuestionListPage';
 import ReportsGroupReportQuizQuestionPage from './ReportsGroupReportQuizQuestionPage';
 import ReportsLearnerActivityPage from './ReportsLearnerActivityPage';
+import ReportsLearnerActivityExercisePage from './ReportsLearnerActivityExercisePage';
 import ReportsLearnerListPage from './ReportsLearnerListPage';
 import ReportsLearnerReportPage from './ReportsLearnerReportPage';
 import ReportsLearnerReportLessonPage from './ReportsLearnerReportLessonPage';
@@ -38,7 +39,10 @@ import ReportsQuizPreviewPage from './ReportsQuizPreviewPage';
 import ReportsQuizQuestionListPage from './ReportsQuizQuestionListPage';
 import ReportsQuizQuestionPage from './ReportsQuizQuestionPage';
 import ReportsLessonListPage from './ReportsLessonListPage';
-import ReportsLessonPage from './ReportsLessonPage';
+import ReportsLessonReportPage from './ReportsLessonReportPage';
+import ReportsLessonLearnerListPage from './ReportsLessonLearnerListPage';
+import ReportsLessonLearnerPage from './ReportsLessonLearnerPage';
+import ReportsLessonLearnerExercisePage from './ReportsLessonLearnerExercisePage';
 import ReportsLessonEditorPage from './ReportsLessonEditorPage';
 import ReportsLessonManagerPage from './ReportsLessonManagerPage';
 import ReportsLessonResourceLearnerListPage from './ReportsLessonResourceLearnerListPage';
@@ -76,6 +80,7 @@ export const newPageMap = {
   ReportsGroupReportQuizQuestionListPage,
   ReportsGroupReportQuizQuestionPage,
   ReportsLearnerActivityPage,
+  ReportsLearnerActivityExercisePage,
   ReportsLearnerListPage,
   ReportsLearnerReportPage,
   ReportsLearnerReportLessonPage,
@@ -88,7 +93,10 @@ export const newPageMap = {
   ReportsQuizPreviewPage,
   ReportsQuizQuestionListPage,
   ReportsQuizQuestionPage,
-  ReportsLessonPage,
+  ReportsLessonLearnerListPage,
+  ReportsLessonLearnerPage,
+  ReportsLessonLearnerExercisePage,
+  ReportsLessonReportPage,
   ReportsLessonResourceLearnerListPage,
   ReportsLessonExerciseLearnerListPage,
   ReportsLessonExerciseQuestionListPage,
@@ -101,9 +109,20 @@ export const newPageMap = {
 
 export const newImmersivePages = [
   'ReportsQuizEditorPage',
-  'ReportsLearnerReportLessonExercisePage',
   'ReportsLessonEditorPage',
   'ReportsLessonManagerPage',
-  'ReportsLessonResourceLearnerListPage',
+  'ReportsGroupLearnerReportQuizPage',
+  'ReportsGroupReportQuizLearnerPage',
+  'ReportsQuizLearnerPage',
+  'ReportsLearnerReportQuizPage',
   'ReportsLessonExerciseLearnerPage',
+  'ReportsGroupLearnerReportLessonExercisePage',
+  'ReportsGroupReportLessonExerciseLearnerPage',
+  'ReportsLearnerReportLessonExercisePage',
+  'ReportsLearnerActivityExercisePage',
+  'ReportsGroupReportLessonExerciseQuestionPage',
+  'ReportsLessonExerciseQuestionPage',
+  'ReportsQuizQuestionPage',
+  'ReportsGroupReportQuizQuestionPage',
+  'ReportsLessonLearnerExercisePage',
 ];

--- a/kolibri/plugins/coach/assets/src/views/new/shared/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/new/shared/commonCoachStrings.js
@@ -16,6 +16,7 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   previewAction: 'Preview',
   saveAction: 'Save',
   renameAction: 'Rename',
+  showAction: 'Show',
   showMoreAction: 'Show more',
   sortedAscendingAction: 'Sort in ascending order',
   sortedDescendingAction: 'Sort in descending order',

--- a/kolibri/plugins/coach/assets/src/views/new/shared/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/shared/notifications/NotificationCard.vue
@@ -1,19 +1,32 @@
 <template>
-
-  <router-link
-    class="notification"
-    :to="route"
-  >
+  <div class="notification">
+    <p class="context icon-spacer">{{ context }}</p>
     <KGrid>
-      <KGridItem :size="time ? 75 : 100" percentage>
-        <p class="context">{{ context }}</p>
-        <p class="text"><slot></slot></p>
+      <KGridItem :size="time ? 50 : 75" percentage>
+        <StatusIcon
+          :icon="icon"
+          class="icon"
+        />
+        <div class="icon-spacer">
+          <slot></slot>
+        </div>
       </KGridItem>
-      <KGridItem v-if="time" :size="25" percentage>
+      <KGridItem v-if="time" :size="25" percentage alignment="center">
         {{ time }}
       </KGridItem>
+      <KGridItem :size="25" percentage>
+        <div class="button-wrapper">
+          <KRouterLink
+            v-if="targetPage"
+            appearance="flat-button"
+            class="show-btn"
+            :text="coachStrings.$tr('showAction')"
+            :to="newCoachRoute(targetPage)"
+          />
+        </div>
+      </KGridItem>
     </KGrid>
-  </router-link>
+  </div>
 
 </template>
 
@@ -21,12 +34,20 @@
 <script>
 
   import imports from '../../imports';
+  import StatusIcon from '../status/StatusIcon';
 
   export default {
     name: 'NotificationCard',
+    components: {
+      StatusIcon,
+    },
     mixins: [imports],
     props: {
       targetPage: {
+        type: String,
+        required: false,
+      },
+      icon: {
         type: String,
         required: true,
       },
@@ -47,9 +68,6 @@
       },
     },
     computed: {
-      route() {
-        return { name: 'NEW_COACH_PAGES', params: { page: this.targetPage } };
-      },
       context() {
         if (this.learnerContext && this.contentContext) {
           return `${this.learnerContext} • ${this.contentContext}`;
@@ -68,28 +86,38 @@
 
 <style lang="scss" scoped>
 
+  .icon {
+    position: absolute;
+  }
+
+  .icon-spacer {
+    margin-left: 40px;
+  }
+
   .notification {
-    display: block;
-    padding: 8px;
-    color: black;
+    position: relative;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-bottom: 16px;
     text-decoration: none;
     border-top: 1px solid rgb(223, 223, 223);
   }
 
-  .notification:hover {
-    background-color: #eeeeee;
-  }
-
   .context {
-    margin-top: 0;
+    margin-top: 4;
     margin-bottom: 4px;
     font-size: small;
     color: gray;
   }
 
-  .text {
-    margin-top: 0;
-    margin-bottom: 0;
+  .button-wrapper {
+    position: relative;
+  }
+
+  .show-btn {
+    position: absolute;
+    top: -15px;
+    right: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/new/shared/status/ItemStatusCount.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/shared/status/ItemStatusCount.vue
@@ -22,7 +22,7 @@
     },
     mixins: [statusStringsMixin],
     props: {
-      object: {
+      obj: {
         type: String,
         required: true,
         validator: isValidObject,

--- a/kolibri/plugins/coach/assets/src/views/new/shared/status/StatusIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/new/shared/status/StatusIcon.vue
@@ -1,15 +1,41 @@
 <template>
 
-  <mat-svg v-if="icon === 'clock'" category="device" name="access_time" />
-  <mat-svg v-else-if="icon === 'star'" category="action" name="stars" />
-  <mat-svg v-else-if="icon === 'help'" category="alert" name="error" />
-  <mat-svg v-else-if="icon === 'learners'" category="social" name="people" />
-  <mat-svg v-else-if="icon === 'nothing'" category="content" name="remove_circle" />
+  <mat-svg
+    v-if="icon === 'clock'"
+    category="device"
+    name="access_time"
+    :style="{ fill: $coreStatusProgress }"
+  />
+  <mat-svg
+    v-else-if="icon === 'star'"
+    category="action"
+    name="stars"
+    :style="{ fill: $coreStatusMastered }"
+  />
+  <mat-svg
+    v-else-if="icon === 'help'"
+    category="alert"
+    name="error"
+    :style="{ fill: $coreStatusWrong }"
+  />
+  <mat-svg
+    v-else-if="icon === 'learners'"
+    category="social"
+    name="people"
+  />
+  <mat-svg
+    v-else-if="icon === 'nothing'"
+    category="content"
+    name="remove_circle"
+    :style="{ fill: $coreGrey200 }"
+  />
 
 </template>
 
 
 <script>
+
+  import { mapGetters } from 'vuex';
 
   export default {
     name: 'StatusIcon',
@@ -21,6 +47,14 @@
           return ['clock', 'star', 'help', 'learners', 'nothing'].includes(value);
         },
       },
+    },
+    computed: {
+      ...mapGetters([
+        '$coreStatusMastered',
+        '$coreStatusProgress',
+        '$coreStatusWrong',
+        '$coreGrey200',
+      ]),
     },
   };
 


### PR DESCRIPTION
### 0.12.x string stubs

* Round 1: #4632
* Round 2: #4642
* Round 3: #4651
* Round 4 final: #4662 (this one)

### Summary

Next step after #4651

Prototyping link behaviors for the activity notifications. Some factors:

* We've gotten feedback that the link destinations can be confusing - particularly for the "Someone and N other" type events. Users wanted to see the full list of users implied by that phrase, but instead lost context in an unexpected list of content items.
* We've removed the 'Channels' tab, which means that some links no longer have a destination.
* We've gotten feedback that people don't understand the distinction between Check icons and Star icons, both of which are used to mean "Completed"
* We don't currently have specs for hover state, click areas, tab focus, etc on the notification cards.



### Reviewer guidance

| screenshot | notes |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/50505599-80a8e500-0a29-11e9-9e3c-dc89cc738f88.png) | Added a 'show' button because (a) the styling is already defined and (b) certain items don't have any link to go to |
| ![image](https://user-images.githubusercontent.com/2367265/50505637-c06fcc80-0a29-11e9-87b0-7e98e511d95d.png) | Added a new 'Learners' tab to the 'Lesson' report page, as a more natural link destination from these notifications than the list of lesson items |
| ![image](https://user-images.githubusercontent.com/2367265/50505724-26f4ea80-0a2a-11e9-999a-c8ec90c18362.png) | standardized on yellow stars to mean 'completed' |
 
feedback is welcome

### References

* [Actionable coach notification specs](https://docs.google.com/document/d/1f-Z1lbDGYXybI4R7k-MKZ3NUX8w4L_gkoEv-BiYXwhg/edit)
* [Figma mockup](https://www.figma.com/file/D5wXhmWNGyt60SpGBgFucwZU/Coach-reports-0.12?node-id=0%3A1)

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst


----

cc @jonboiser @jtamiace @khangmach 


