### PR TITLE
Fixes #4606: Handle missing logs for stats pingback, and add "timestamp" and "installer" fields

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -8,6 +8,7 @@ import requests
 from django.core.management.base import BaseCommand
 from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.timezone import get_current_timezone
+from django.utils.timezone import localtime
 from morango.models import InstanceIDModel
 from requests.exceptions import ConnectionError
 from requests.exceptions import RequestException
@@ -20,6 +21,7 @@ from ...utils import extract_facility_statistics
 from kolibri.core.auth.models import Facility
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.device.models import DeviceSettings
+from kolibri.utils.server import installation_type
 from kolibri.utils.server import vacuum_db_lock
 
 logger = logging.getLogger(__name__)
@@ -100,6 +102,8 @@ class Command(BaseCommand):
             "language": language,
             "timezone": timezone,
             "uptime": int((datetime.now() - self.started).total_seconds() / 60),
+            "timestamp": localtime(),
+            "installer": installation_type(),
         }
 
         logger.debug("Pingback data: {}".format(data))

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -219,6 +219,22 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         }
         assert actual == expected
 
+    def test_regression_4606_no_usersessions(self):
+        UserSessionLog.objects.all().delete()
+        facility = self.facilities[0]
+        # will raise an exception if we haven't addressed https://github.com/learningequality/kolibri/issues/4606
+        actual = extract_facility_statistics(facility)
+        assert actual["f"] == "2018-10-11"
+        assert actual["l"] == "2019-10-11"
+
+    def test_regression_4606_no_contentsessions(self):
+        ContentSessionLog.objects.all().delete()
+        facility = self.facilities[0]
+        # will raise an exception if we haven't addressed https://github.com/learningequality/kolibri/issues/4606
+        actual = extract_facility_statistics(facility)
+        assert actual["f"] == "2018-10-11"
+        assert actual["l"] == "2019-10-11"
+
 
 class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
 

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -235,6 +235,15 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         assert actual["f"] == "2018-10-11"
         assert actual["l"] == "2019-10-11"
 
+    def test_regression_4606_no_contentsessions_or_usersessions(self):
+        ContentSessionLog.objects.all().delete()
+        UserSessionLog.objects.all().delete()
+        facility = self.facilities[0]
+        # will raise an exception if we haven't addressed https://github.com/learningequality/kolibri/issues/4606
+        actual = extract_facility_statistics(facility)
+        assert actual["f"] is None
+        assert actual["l"] is None
+
 
 class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
 

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Count
 from django.db.models import Max
 from django.db.models import Min
@@ -34,7 +35,7 @@ facility_settings = [
 
 
 def dump_zipped_json(data):
-    jsondata = json.dumps(data)
+    jsondata = json.dumps(data, sort_keys=True, cls=DjangoJSONEncoder)
     try:
         # perform the import in here as zlib isn't available on some platforms
         import zlib

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -64,9 +64,12 @@ def extract_facility_statistics(facility):
                     .filter(start_timestamp__gt=datetime.datetime(2016, 1, 1))
                     .aggregate(first=Min("start_timestamp"), last=Max("end_timestamp")))
 
+    first_times = [d["first"] for d in [usersess_agg, contsess_agg] if d["first"]]
+    last_times = [d["last"] for d in [usersess_agg, contsess_agg] if d["last"]]
+
     # since newly provisioned devices won't have logs, we don't know whether we have an available datetime object
-    first_interaction_timestamp = getattr(min(usersess_agg["first"], contsess_agg["first"]), 'strftime', None)
-    last_interaction_timestamp = getattr(max(usersess_agg["last"], contsess_agg["last"]), 'strftime', None)
+    first_interaction_timestamp = getattr(min(first_times), 'strftime', None)
+    last_interaction_timestamp = getattr(max(last_times), 'strftime', None)
 
     sesslogs_by_kind = contsessions.order_by("kind").values("kind").annotate(count=Count("kind"))
     sesslogs_by_kind = {log["kind"]: log["count"] for log in sesslogs_by_kind}

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -65,12 +65,13 @@ def extract_facility_statistics(facility):
                     .filter(start_timestamp__gt=datetime.datetime(2016, 1, 1))
                     .aggregate(first=Min("start_timestamp"), last=Max("end_timestamp")))
 
+    # extract the first and last times we've seen logs, ignoring any that are None
     first_times = [d["first"] for d in [usersess_agg, contsess_agg] if d["first"]]
     last_times = [d["last"] for d in [usersess_agg, contsess_agg] if d["last"]]
 
     # since newly provisioned devices won't have logs, we don't know whether we have an available datetime object
-    first_interaction_timestamp = getattr(min(first_times), 'strftime', None)
-    last_interaction_timestamp = getattr(max(last_times), 'strftime', None)
+    first_interaction_timestamp = getattr(min(first_times), 'strftime', None) if first_times else None
+    last_interaction_timestamp = getattr(max(last_times), 'strftime', None) if last_times else None
 
     sesslogs_by_kind = contsessions.order_by("kind").values("kind").annotate(count=Count("kind"))
     sesslogs_by_kind = {log["kind"]: log["count"] for log in sesslogs_by_kind}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some tweaks to the `ping` management command and associated utilities to:
- Fix #4606, by handling missing logs gracefully when computing first and last usage timestamps
- Add fields `timestamp` and `installer`, which have been supported on nutritionfacts for a while but were not being sent

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Run `kolibri manage ping` on a fresh database that's been onboarded but hasn't had any content interactions.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #4606 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
