### PR TITLE
Restore iOS support

### DIFF
--- a/kolibri/core/context_processors/custom_context_processor.py
+++ b/kolibri/core/context_processors/custom_context_processor.py
@@ -17,10 +17,6 @@ browser_requirements = [
         'major_version': 11,
     },
     {
-        'family': 'Mobile Safari',
-        'blacklist': True,
-    },
-    {
         'family': 'Android',
         'major_version': 4,
         'minor_version': 0,


### PR DESCRIPTION
...as iOS blockers are either resolved or no longer reproduce.

### Summary

This change restores Mobile Safari as a supported platform, as #1049 was addressed and the other two blockers don't reproduce (#1046 and #2158).  

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
