### PR TITLE
Explicitly add iOS Safari 9.3+ to the list of supported browsers.

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -6,4 +6,5 @@
 > 0.1%
 last 2 versions
 ie >= 9
+ios >= 9.3
 Firefox ESR


### PR DESCRIPTION
### Summary

As we have users who are stuck on iOS 9.3 due to device limitations, make sure we explicitly add iOS Safari 9.3+ to the list of supported browsers. 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
