### PR TITLE
Fix images in production

### DIFF
--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -3,7 +3,13 @@
  * which has urls written into it at runtime by the Kolibri server.
  */
 
+import setWebpackPublicPath from '../utils/setWebpackPublicPath';
+
 const urls = {
+  __setStaticURL(staticUrl) {
+    this.__staticURL = staticUrl;
+    setWebpackPublicPath(this);
+  },
   static(url) {
     if (!this.__staticURL) {
       throw new ReferenceError('Static URL is not defined');

--- a/kolibri/core/assets/src/kolibri_module.js
+++ b/kolibri/core/assets/src/kolibri_module.js
@@ -5,6 +5,11 @@
  */
 
 import coreApp from 'kolibri';
+import urls from 'kolibri.urls';
+import setWebpackPublicPath from './utils/setWebpackPublicPath';
+
+// Do this to set a public path for this module
+setWebpackPublicPath(urls);
 
 export default class KolibriModule {
   /**

--- a/kolibri/core/assets/src/utils/setWebpackPublicPath.js
+++ b/kolibri/core/assets/src/utils/setWebpackPublicPath.js
@@ -1,0 +1,7 @@
+export default function setWebpackPublicPath(urls) {
+  if (process.env.NODE_ENV === 'production') {
+    /* eslint-disable no-undef */
+    __webpack_public_path__ = urls.static(`${__kolibriModuleName}/`);
+    /* eslint-enable */
+  }
+}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -157,10 +157,9 @@ def kolibri_navigation_actions():
 def kolibri_set_urls(context):
     js_global_object_name = getattr(settings, 'JS_REVERSE_JS_GLOBAL_OBJECT_NAME', JS_GLOBAL_OBJECT_NAME)
     js_var_name = getattr(settings, 'JS_REVERSE_JS_VAR_NAME', JS_VAR_NAME)
-    js = (js_reverse_inline(context) +
-          """
+    js = (js_reverse_inline(context) + """
           Object.assign({kolibri}.urls, {global_object}.{js_var});
-          {kolibri}.urls.__staticURL = '{static_url}';
+          {kolibri}.urls.__setStaticURL('{static_url}');
           """.format(
         kolibri=conf.KOLIBRI_CORE_JS_NAME,
         global_object=js_global_object_name,

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -8,7 +8,7 @@
     />
 
     <div class="wrapper-table">
-      <div class="table-row main-row" :style="{ backgroundColor: $coreActionNormal }">
+      <div class="table-row main-row" :style="backgroundImageStyle">
         <div class="table-cell main-cell">
           <div class="box" :style="{ backgroundColor: $coreBgLight }">
             <CoreLogo :style="{'height': `${logoHeight}px`}" />
@@ -291,6 +291,12 @@
       guestURL() {
         return urls['kolibri:core:guest']();
       },
+      backgroundImageStyle() {
+        return {
+          backgroundColor: this.$coreActionNormal,
+          backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(${require('./background.jpg')})`,
+        };
+      },
     },
     watch: {
       username: 'setSuggestionTerm',
@@ -447,11 +453,7 @@
   }
 
   .main-row {
-    // Workaround for print-width css issue https://github.com/prettier/prettier/issues/4460
-    $bk-img: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('./background.jpg');
-
     text-align: center;
-    background-image: $bk-img;
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;

--- a/packages/kolibri-tools/jest.conf/fileMock.js
+++ b/packages/kolibri-tools/jest.conf/fileMock.js
@@ -1,0 +1,3 @@
+// As recommended by https://jestjs.io/docs/en/webpack#handling-static-assets
+
+module.exports = 'test-file-stub';

--- a/packages/kolibri-tools/jest.conf/index.js
+++ b/packages/kolibri-tools/jest.conf/index.js
@@ -4,6 +4,10 @@ const babelConfig = require('../.babelrc.js');
 
 const moduleNameMapper = {
   '^testUtils$': path.resolve(__dirname, './testUtils'),
+  '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': path.resolve(
+    __dirname,
+    './fileMock.js'
+  ),
 };
 
 Object.keys(apiSpecAliases).forEach(key => {


### PR DESCRIPTION
### Summary
Makes public paths on the frontend dynamic in production. Removes a reference in CSS to a URL.

![image](https://user-images.githubusercontent.com/1680573/50669614-0de4c000-0f7b-11e9-8d0b-58f69a1f8ccf.png)


### Reviewer guidance
Do images display on the sign in page?

### References
Fixes #4577

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
