### PR TITLE
Links fix

### DIFF
--- a/kolibri/core/assets/src/views/buttons-and-links/KExternalLink.vue
+++ b/kolibri/core/assets/src/views/buttons-and-links/KExternalLink.vue
@@ -5,7 +5,6 @@
     :class="buttonClasses"
     :href="href"
     :download="download"
-    :target="download ? '_self' : '_blank'"
     dir="auto"
   >
     {{ text }}

--- a/kolibri/plugins/demo_server/assets/src/views/DemoServerIndex.vue
+++ b/kolibri/plugins/demo_server/assets/src/views/DemoServerIndex.vue
@@ -21,12 +21,14 @@
             <KExternalLink
               href="https://learningequality.org/documentation/"
               :text="$tr('demoServerA1')"
+              target="_blank"
             />
           </li>
           <li>
             <KExternalLink
               href="https://learningequality.org/download/"
               :text="$tr('demoServerA2')"
+              target="_blank"
             />
           </li>
         </ul>


### PR DESCRIPTION
### Summary
Reverts https://github.com/learningequality/kolibri/commit/4f41ffe1d16bec010e33d80af5585d4a4a9ccdce

Sets explicit targets on Demo server banner links.

### Reviewer guidance
Do links open in the right way now?

### References
Fixes #4562

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
