### PR TITLE
Prevent 404s on Content Reports

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -102,7 +102,7 @@ class ContentSummaryViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         channel_id = self.kwargs['channel_id']
-        return ContentNode.objects.filter(Q(channel_id=channel_id) & Q(available=True)).order_by('lft')
+        return ContentNode.objects.filter(Q(channel_id=channel_id)).order_by('lft')
 
 
 class RecentReportViewSet(ReportBaseViewSet):


### PR DESCRIPTION
### Summary
Trying to view a content report for unavailable content would throw a 404. This removes the availability filtering to prevent this so that reports can be viewed.

### Reviewer guidance
Look at progress on an unavailable content item, check that it displays.

### References
Fixes #4623

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
