### PR TITLE
Signup error

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -165,6 +165,7 @@ class FacilityUserViewSet(viewsets.ModelViewSet):
         self.set_password_if_needed(instance, serializer)
 
 
+@method_decorator(signin_redirect_exempt, name='dispatch')
 class FacilityUsernameViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter, )
     serializer_class = FacilityUsernameSerializer
@@ -231,6 +232,7 @@ class FacilityViewSet(viewsets.ModelViewSet):
         return queryset
 
 
+@method_decorator(signin_redirect_exempt, name='dispatch')
 class PublicFacilityViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
@@ -281,6 +283,7 @@ class LearnerGroupViewSet(viewsets.ModelViewSet):
     filter_fields = ('parent',)
 
 
+@method_decorator(signin_redirect_exempt, name='dispatch')
 class SignUpViewSet(viewsets.ViewSet):
 
     serializer_class = FacilityUserSignupSerializer

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -374,6 +374,13 @@ class AnonSignUpTestCase(APITestCase):
         self.client.post(reverse('kolibri:core:signup-list'), data={"username": "user", "password": DUMMY_PASSWORD})
         self.assertNotEqual(session_key, self.client.session.session_key)
 
+    def test_sign_up_able_no_guest_access(self):
+        self.facility.dataset.allow_guest_access = False
+        self.facility.dataset.save()
+        response = self.client.post(reverse('kolibri:core:signup-list'), data={"username": "user", "password": DUMMY_PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(models.FacilityUser.objects.all())
+
 
 class FacilityDatasetAPITestCase(APITestCase):
 

--- a/kolibri/plugins/user/assets/src/modules/signUp/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/signUp/actions.js
@@ -4,8 +4,8 @@ import CatchErrors from 'kolibri.utils.CatchErrors';
 import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
 
 export function signUpNewUser(store, signUpCreds) {
-  store.commit('SET_SIGN_UP_BUSY', true);
   store.commit('RESET_STATE');
+  store.commit('SET_SIGN_UP_BUSY', true);
   return SignUpResource.saveModel({ data: signUpCreds })
     .then(() => {
       redirectBrowser();


### PR DESCRIPTION
### Summary
0.11 introduced a new facility setting to allow facility admins to prevent guest access.
To accomplish this a redirect middleware was introduced to redirect all anonymous requests that were not whitelisted.
A few endpoints that are required for anonymous signup and other functionality were omitted from this whitelist.
This PR corrects that oversight, and adds a test for the signup behaviour case.

In addition, the frontend signUp action was reseting the state after setting its busy state, meaning that the busy state did not get set and a fat finger might submit two signup requests. This won't have any negative consequences, but seems unintentional.

### Reviewer guidance
1. Activate 'no guest access' in the facility settings.
2. Replicate the sign up error.
3. Test this PR and be able to sign up again!

### References
Fixes #4553 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
