### PR TITLE
Exam Descendants Query Speedup

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -262,52 +262,15 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         ids = ids.split(',')
         kind = self.request.query_params.get('descendant_kind', None)
         nodes = models.ContentNode.objects.filter(id__in=ids, available=True)
-        descendants = nodes.get_descendants(include_self=False).filter(available=True).distinct()
-        if kind and kind != content_kinds.TOPIC:
-            # Include topics in the query as we need to use these to find duplicated ancestors.
-            descendants = descendants.filter(kind__in=[kind, content_kinds.TOPIC])
-        elif kind == content_kinds.TOPIC:
-            descendants.filter(kind=kind)
-        query_data = list(descendants.annotate(ancestor_id=Subquery(nodes.filter(
-            tree_id=OuterRef('tree_id'),
-            lft__lt=OuterRef('lft'),
-            rght__gt=OuterRef('rght'),
-            # Order by reverse level, so nodes are annotated with their nearest ancestor
-        ).order_by('-level').values_list('id', flat=True)[:1])).values('id', 'title', 'kind', 'content_id', 'ancestor_id'))
         data = []
-        # Now that we have the data annotated with the nearest ancestor
-        # Look through each of the original ids that were passed in and find any topics that
-        # have these ids as ancestors
-        for node_id in ids:
-
-            def copy_node(node):
-                new_node = dict(node)
-                new_node['ancestor_id'] = node_id
+        for node in nodes:
+            def copy_node(new_node):
+                new_node['ancestor_id'] = node.id
                 return new_node
-
-            # Find any topics that are descendants of this node
-            descendant_topics = list(filter(lambda x: x['ancestor_id'] == node_id and x['kind'] == content_kinds.TOPIC, query_data))
-            # Loop through these topics while they exist
-            while descendant_topics:
-                # Create a new list of descendant topics of additional topics that we find
-                # during this search for descendant items from this node
-                new_descendant_topics = []
-                for topic in descendant_topics:
-                    # Find all descendant items that have this topic as an ancestor
-                    descendant_items = list(filter(lambda x: x['ancestor_id'] == topic['id'], query_data))
-                    # Filter these items to find any topics, as we will then need to check for any contents of these
-                    new_descendant_topics += list(filter(lambda x: x['kind'] == content_kinds.TOPIC, descendant_items))
-                    # Add a copy of all these descendant items to the data we will return, but change the ancestor_id
-                    # to the current node
-                    data += list(map(copy_node, descendant_items))
-                # Set descendant topics to the new descendant topics we discovered during this iteration
-                # If this is empty it will halt the iteration
-                descendant_topics = new_descendant_topics
-        # Combine the new data we found while iterating over the descendants with the original query data
-        data = query_data + data
-        if kind:
-            # If we are filtering by kind, filter out any data that does not match the kind
-            data = list(filter(lambda x: x['kind'] == kind, data))
+            node_data = node.get_descendants()
+            if kind:
+                node_data = node_data.filter(kind=kind)
+            data += map(copy_node, node_data.values('id', 'title', 'kind', 'content_id'))
         return Response(data)
 
     @list_route(methods=['get'])


### PR DESCRIPTION
### Summary
I had tried to be clever to optimize and simplify queries for the exams page.
One of these queries was very complex and slow, to the point where loading the KA Math topic on the demo server would cause a timeout.

This PR resolves this by:
* Using multiple queries instead of a single complex query.
* Getting a ~40 times speed up on queries for KA Math.

### Reviewer guidance
Mark all of KA Math as available.
Create an exam.
Navigate to the KA Math topic.
Be pleasantly surprised.

I tried a similar 'uncleverization' of the descendant_assessments endpoint also, and it made zero difference.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
