### PR TITLE
Fix fullscreen for Chrome 71

### DIFF
--- a/kolibri/core/assets/src/views/CoreFullscreen.vue
+++ b/kolibri/core/assets/src/views/CoreFullscreen.vue
@@ -24,6 +24,7 @@
     data() {
       return {
         isInFullscreen: false,
+        toggling: false,
       };
     },
     computed: {
@@ -50,20 +51,20 @@
       }
     },
     methods: {
-      enterFullScreen() {
-        if (fullscreenApiIsSupported) {
-          ScreenFull.toggle(this.$refs.fullscreen);
-        }
-        this.isInFullscreen = true;
-      },
-      exitFullscreen() {
-        if (fullscreenApiIsSupported) {
-          ScreenFull.toggle(this.$refs.fullscreen);
-        }
-        this.isInFullscreen = false;
-      },
       toggleFullscreen() {
-        this.isInFullscreen ? this.exitFullscreen() : this.enterFullScreen();
+        if (!this.toggling) {
+          let fullScreenPromise;
+          this.toggling = true;
+          if (fullscreenApiIsSupported) {
+            fullScreenPromise = ScreenFull.toggle(this.$refs.fullscreen);
+          } else {
+            fullScreenPromise = Promise.resolve();
+          }
+          fullScreenPromise.then(() => {
+            this.isInFullscreen = ScreenFull.isFullscreen;
+            this.toggling = false;
+          });
+        }
       },
     },
   };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "material-design-icons": "^3.0.1",
     "purecss": "^0.6.2",
     "rest": "^1.3.2",
-    "screenfull": "^3.3.2",
+    "screenfull": "^4.0.0",
     "seededshuffle": "^0.1.1",
     "shave": "^2.1.3",
     "vue": "^2.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8295,9 +8295,10 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
-screenfull@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-3.3.2.tgz#a6adf3b3f5556da812725385880600f5b39fbf25"
+screenfull@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.0.0.tgz#86f3c26a2e516c8143884d8af16d07f0cb653394"
+  integrity sha512-b5e07aVR219hkfKqKsBpUqGrR4JCB8UeHT3RiocIf/fXE9TMSkadO5H83r7XYSV05w2uRF9gWvZYiLgOHS6O5g==
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
### Summary
Chrome 71 became picky about accepting `undefined` as the options parameter to `requestFullscreen`, the older version of screenfull we were using was doing that. The new version does not.
This remedies the error by upgrading screenfull.

Unfortunately, the version change changes the API of Screenfull to a Promise based one, so the toggling method had to be refactored to deal with the promises.

### Reviewer guidance
Does full screen toggling work on:
* PDFs
* Videos
* EPubs
By:
* Clicking a fullscreen icon
* Clicking a 'no full screen icon'
* Pressing escape
On:
* Chrome 71
* Firefox

### References
Fixes #4680

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
