### PR TITLE
Fix immersive toolbar styling.

### DIFF
--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -3,9 +3,12 @@
   <UiToolbar
     :title="appBarTitle"
     textColor="white"
-    type="colored"
+    type="clear"
     :showIcon="showIcon"
-    :style="{ height: height + 'px' }"
+    :style="{
+      height: height + 'px',
+      backgroundColor: primary ? $coreActionNormal : $coreTextDefault,
+    }"
     @nav-icon-click="$emit('navIconClick')"
   >
     <router-link
@@ -126,10 +129,12 @@
       },
       linkStyle() {
         const hoverAndFocus = {
-          backgroundColor: this.primary ? this.$coreActionDark : darken(this.$coreTextDefault, 0.1),
+          backgroundColor: this.primary
+            ? this.$coreActionDark
+            : darken(this.$coreTextDefault, '25%'),
         };
         return {
-          backgroundColor: this.primary ? '' : this.$coreTextDefault,
+          backgroundColor: this.primary ? this.coreActionNormal : this.$coreTextDefault,
           ':hover': hoverAndFocus,
         };
       },


### PR DESCRIPTION
### Summary
Fixes a styling issue for the immersive toolbar introduced by the dynamic styling refactor.

### Reviewer guidance
Take an exam as a learner.
Submit.
Look at the learner exam report view.
Does the toolbar display properly on the learner exam report view?

Before:
![image](https://user-images.githubusercontent.com/1680573/50807697-253fe800-12b0-11e9-9c0b-726b46718017.png)


After:
![image](https://user-images.githubusercontent.com/1680573/50807667-0e00fa80-12b0-11e9-873e-64b8caa34e59.png)


### References
Fixes what I could find of #4646 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
