### PR TITLE
Don't give misleading message to learners on exam submission.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -218,7 +218,8 @@
         return Promise.resolve();
       },
       goToQuestion(questionNumber) {
-        this.saveAnswer(true).then(() => {
+        const promise = this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve();
+        promise.then(() => {
           this.$router.push({
             name: ClassesPageNames.EXAM_VIEWER,
             params: {
@@ -230,6 +231,15 @@
         });
       },
       toggleModal() {
+        // Flush any existing save event to ensure
+        // that the subit modal contains the latest state
+        if (!this.submitModalOpen) {
+          const promise =
+            this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve();
+          return promise.then(() => {
+            this.submitModalOpen = !this.submitModalOpen;
+          });
+        }
         this.submitModalOpen = !this.submitModalOpen;
       },
       finishExam() {


### PR DESCRIPTION
### Summary
Flush saves when attempting to submit exam.

### Reviewer guidance
Can you change questions in an exam? Does it show the correct number of answered questions when you try to submit an exam?

### References
Fixes #4643

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
