### PR TITLE
remove tqdm dependency

### DIFF
--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -3,7 +3,10 @@ from collections import namedtuple
 
 from django.core.management.base import BaseCommand
 from iceqube.exceptions import UserCancelledError
-from tqdm import tqdm
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
 
 Progress = namedtuple(
     'Progress',
@@ -30,18 +33,12 @@ class ProgressTracker():
         self.level = level
         self.update_callback = update_callback
 
-        # initialize the tqdm progress bar
-        self.progressbar = tqdm(total=total)
-
     def update_progress(self, increment=1, message="", extra_data=None):
-
-        self.progressbar.update(increment)
-
         self.progress += increment
-
         self.message = message
-
         self.extra_data = extra_data
+
+        logging.info('Progress: {:.0%} | {} | {}'.format(1.0 * self.progress / self.total, self.message, self.extra_data))
 
         if callable(self.update_callback):
             p = self.get_progress()
@@ -60,8 +57,7 @@ class ProgressTracker():
         return self.update_progress
 
     def __exit__(self, *exc_details):
-        if self.progressbar is not None:
-            self.progressbar.close()
+        pass
 
 
 class AsyncCommand(BaseCommand):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,6 @@ configobj==5.0.6
 docopt==0.6.2
 django-mptt==0.9.1
 djangorestframework-csv==2.1.0
-tqdm==4.24.0                     # progress bars
 requests==2.20.1
 cherrypy==13.0.1  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <13.1.0
 tempora<1.13  # derived no-upper-bounds dependency of cherrypy causing issues  # pyup: <1.13


### PR DESCRIPTION

### Summary

TQDM puts out new releases [very often](https://github.com/tqdm/tqdm/releases), and has in the past caused us issues with thread safety, spurious errors, android issues, security issues, and excess logging.


### Reviewer guidance

I don't think there is any strong reason to include this dependency, and I believe it's simpler to remove it entirely.

### References

Some past TQDM-related stuff:

* https://github.com/learningequality/kolibri/pull/4158
* https://github.com/learningequality/kolibri/issues/2648
* https://github.com/learningequality/kolibri/issues/3963
* https://github.com/learningequality/kolibri/issues/4308
* https://github.com/learningequality/kolibri/pull/2654

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
