### PR TITLE
Remove python building from travis test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,23 +22,6 @@ matrix:
   include:
     - python: "2.7"
       env:
-        - TOX_ENV=pythonbuild2.7
-    - python: "3.4"
-      env:
-        - TOX_ENV=pythonbuild3.4
-    - python: "3.5"
-      env:
-        - TOX_ENV=pythonbuild3.5
-    - python: "3.6"
-      env:
-        - TOX_ENV=pythonbuild3.6
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env:
-        - TOX_ENV=pythonbuild3.7
-    - python: "2.7"
-      env:
         - TOX_ENV=pythonlint2
     - python: "3.6"
       env:


### PR DESCRIPTION
### Summary
We currently test building on every supported Python version - let's let Buildkite tell us this instead!

Doing this on develop as it's not vital.

### Reviewer guidance
Does Travis run a bit faster?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
