### PR TITLE
Prevent lint fixing from exiting before file writes are complete

### DIFF
--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -260,15 +260,15 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
           }
           // Only write if the formatted file is different to the source file.
           if (write && formatted !== source) {
-            fs.writeFile(file, formatted, { encoding }, error => {
-              if (error) {
-                reject({ error: error.message, code: errorOrChange });
-                return;
-              }
+            try {
+              fs.writeFileSync(file, formatted, { encoding });
               if (!silent) {
                 logging.info(`Rewriting a prettier version of ${file}`);
               }
-            });
+            } catch (error) {
+              reject({ error: error.message, code: errorOrChange });
+              return;
+            }
           }
           resolve({ code });
         })


### PR DESCRIPTION
### Summary
#4722 moved the point where the promise in the linting was resolved, to ensure that linting errors were caught on Travis.

However for single file linting, this allowed a race condition where the process might exit before writing had complete.

This PR uses a synchronous write file to prevent race condition during auto-fix file rewrites.

### Reviewer guidance
Make an auto-fixable linting error in a JS file. Run:
`yarn run lint:fix <filepath>`
Make sure that the file does not get set to 0 bytes!

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
