### PR TITLE
Remove limitation on multiple group membership.

### DIFF
--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 
-from .constants.collection_kinds import LEARNERGROUP
 from .models import Classroom
 from .models import Facility
 from .models import FacilityDataset
@@ -74,17 +73,6 @@ class MembershipSerializer(serializers.ModelSerializer):
     class Meta:
         model = Membership
         fields = ('id', 'collection', 'user')
-
-    def create(self, validated_data):
-        user = validated_data["user"]
-        collection = validated_data["collection"]
-        if collection.kind == LEARNERGROUP and user.memberships.filter(collection__parent=collection.parent).exists():
-            # We are trying to create a membership for a user in a group, but they already belong to a group
-            # in the same class as this group. We may want to allow this, but the frontend does not currently
-            # support this. Error!
-            raise serializers.ValidationError(detail={'classroom': 'This user is already in a group in this class'},
-                                              code=error_constants.USER_ALREADY_IN_GROUP_IN_CLASS)
-        return super(MembershipSerializer, self).create(validated_data)
 
 
 class FacilityDatasetSerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -482,7 +482,7 @@ class GroupMembership(APITestCase):
         models.Membership.objects.create(user=self.user, collection=self.lg12)
         url = reverse('kolibri:core:membership-list')
         response = self.client.post(url, {'user': self.user.id, 'collection': self.lg11.id})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 201)
 
     def test_create_class_membership_group_membership_different_class(self):
         self.classroom2_membership.delete()


### PR DESCRIPTION
### Summary
In 0.12 we're making multiple group membership great again.
Remove a previous placed limitation on being in multiple groups in a class.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
