### PR TITLE
Use pytest fixtures: Isolate database restore tests

### DIFF
--- a/kolibri/core/deviceadmin/tests/conftest.py
+++ b/kolibri/core/deviceadmin/tests/conftest.py
@@ -1,0 +1,38 @@
+import logging
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from kolibri.utils import compat
+from kolibri.utils import conf
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def dbbackup_test_home(request):
+    """
+    This fixture creates a clean KOLIBRI_HOME, sets the environment and yields.
+    After returning, it unsets the environment
+    """
+
+    KOLIBRI_HOME_DBBACKUP = tempfile.mkdtemp()
+    PREVIOUS_HOME = conf.KOLIBRI_HOME
+    os.environ["KOLIBRI_HOME"] = KOLIBRI_HOME_DBBACKUP
+
+    # Reload the `conf` module, and we assume the whole application will have
+    # necessary changes. This assumes that no other modules read out internal
+    # values of the `conf` module, for instance
+    # `from kolibri.utils.conf import ...` would violate that assumption.
+    compat.reload_module(conf)
+
+    def fin():
+        logger.info("Removing {}".format(KOLIBRI_HOME_DBBACKUP))
+        shutil.rmtree(KOLIBRI_HOME_DBBACKUP)
+        os.environ["KOLIBRI_HOME"] = PREVIOUS_HOME
+        compat.reload_module(conf)
+
+    request.addfinalizer(fin)

--- a/kolibri/core/deviceadmin/tests/test_dbrestore.py
+++ b/kolibri/core/deviceadmin/tests/test_dbrestore.py
@@ -57,25 +57,25 @@ def mock_status_not_running():
     raise NotRunning(STATUS_UNKNOWN)
 
 
-def test_latest():
+def test_latest(dbbackup_test_home):
 
     with pytest.raises(RuntimeError):
         call_command("dbrestore", latest=True)
 
 
-def test_illegal_command():
+def test_illegal_command(dbbackup_test_home):
 
     with pytest.raises(CommandError):
         call_command("dbrestore", latest=True, dump_file="wup wup")
 
 
-def test_no_restore_from_no_file():
+def test_no_restore_from_no_file(dbbackup_test_home):
 
     with pytest.raises(CommandError):
         call_command("dbrestore", dump_file="does not exist")
 
 
-def test_active_kolibri():
+def test_active_kolibri(dbbackup_test_home):
     """
     Tests that we cannot restore while kolibri is active
     """
@@ -89,36 +89,35 @@ def test_active_kolibri():
             gs.assert_called_once()
 
 
-def test_inactive_kolibri():
+def test_inactive_kolibri(dbbackup_test_home):
     """
     Tests that we cannot restore while kolibri is active
     """
 
     with patch(
-        "kolibri.utils.server.get_status",
-        side_effect=mock_status_not_running
-    ) as gs:
-        # Since there's no backups available during a test, this should fail!
-        with pytest.raises(RuntimeError):
-            call_command("dbrestore", latest=True)
-            gs.assert_called_once()
+            "kolibri.utils.server.get_status",
+            side_effect=mock_status_not_running
+    ) as gs, pytest.raises(RuntimeError):
+
+        call_command("dbrestore", latest=True)
+        gs.assert_called_once()
 
 
-def test_not_sqlite():
+def test_not_sqlite(dbbackup_test_home):
     if is_sqlite_settings():
         return
     with pytest.raises(IncompatibleDatabase):
         dbrestore("/doesnt/matter.file")
 
 
-def test_fail_on_unknown_file():
+def test_fail_on_unknown_file(dbbackup_test_home):
     with pytest.raises(ValueError):
         get_dtm_from_backup_name("this-file-has-no-time")
 
 
 @pytest.mark.django_db
 @pytest.mark.filterwarnings('ignore:Overriding setting DATABASES')
-def test_restore_from_latest():
+def test_restore_from_latest(dbbackup_test_home):
     """
     Tests that we cannot restore while kolibri is active
     """
@@ -156,7 +155,7 @@ def test_restore_from_latest():
 
 @pytest.mark.django_db
 @pytest.mark.filterwarnings('ignore:Overriding setting DATABASES')
-def test_restore_from_file_to_memory():
+def test_restore_from_file_to_memory(dbbackup_test_home):
     """
     Restores from a file dump to a database stored in memory and reads contents
     from the new database.
@@ -187,7 +186,7 @@ def test_restore_from_file_to_memory():
 
 @pytest.mark.django_db
 @pytest.mark.filterwarnings('ignore:Overriding setting DATABASES')
-def test_restore_from_file_to_file():
+def test_restore_from_file_to_file(dbbackup_test_home):
     """
     Restores from a file dump to a database stored in a file and reads contents
     from the new database.
@@ -222,7 +221,7 @@ def test_restore_from_file_to_file():
             assert Facility.objects.filter(name="test file", kind=FACILITY).count() == 1
 
 
-def test_search_latest():
+def test_search_latest(dbbackup_test_home):
 
     search_root = tempfile.mkdtemp()
 

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -9,9 +9,7 @@ from django import db
 from django.conf import settings
 
 import kolibri
-from kolibri.utils.conf import KOLIBRI_HOME
-# Import db instead of db.connections because we want to use an instance of
-# connections that might be updated from outside.
+from kolibri.utils import conf
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +30,7 @@ class IncompatibleDatabase(Exception):
 
 
 def default_backup_folder():
-    return os.path.join(KOLIBRI_HOME, 'backups')
+    return os.path.join(conf.KOLIBRI_HOME, 'backups')
 
 
 def get_dtm_from_backup_name(fname):

--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -5,9 +5,18 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import importlib
 import sys
 
 from pkg_resources import parse_version as _parse_version
+
+
+def reload_module(mod):
+    """Reload a module, given differences in Python 2.7 and 3.4+"""
+    if hasattr(importlib, "reload"):
+        importlib.reload(mod)
+    else:
+        reload(mod)  # noqa: F821
 
 
 def module_exists(module_path):


### PR DESCRIPTION
### Summary

Tests for restoring the database need proper isolation. I think this fixture does a fair job. #4738 

### Reviewer guidance

We might be able to use this pattern for other interesting things :)

https://docs.pytest.org/en/latest/fixture.html

### References


#4738 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
