### PR TITLE
Handle multiple channels being returned from token

### DIFF
--- a/kolibri/core/assets/src/api-resources/remoteChannel.js
+++ b/kolibri/core/assets/src/api-resources/remoteChannel.js
@@ -5,4 +5,7 @@ export default new Resource({
   getKolibriStudioStatus() {
     return this.getListEndpoint('kolibri_studio_status');
   },
+  fetchChannelList(id) {
+    return this.fetchDetailCollection('retrieve_list', id);
+  },
 });

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -447,10 +447,9 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
                 completed_content_nodes = queryset.filter(content_id__in=completed_content_ids).order_by()
 
                 # Filter to only show content that the user has not engaged in, so as not to be redundant with resume
-                queryset = queryset.exclude(content_id__in=ContentSummaryLog.objects.filter(
-                    user=user).values_list('content_id', flat=True)).filter(
-                    Q(has_prerequisite__in=completed_content_nodes) |
-                    Q(lft__in=[rght + 1 for rght in completed_content_nodes.values_list('rght', flat=True)])
+                queryset = queryset.exclude(content_id__in=ContentSummaryLog.objects.filter(user=user).values_list('content_id', flat=True)).filter(
+                    Q(has_prerequisite__in=completed_content_nodes)
+                    | Q(lft__in=[rght + 1 for rght in completed_content_nodes.values_list('rght', flat=True)])
                 ).order_by()
 
         serializer = self.get_serializer(queryset, many=True)
@@ -770,6 +769,13 @@ class RemoteChannelViewSet(viewsets.ViewSet):
                 return Response({"status": "online"})
         except requests.ConnectionError:
             return Response({"status": "offline"})
+
+    @detail_route(methods=['get'])
+    def retrieve_list(self, request, pk=None):
+        baseurl = request.GET.get("baseurl", None)
+        keyword = request.GET.get("keyword", None)
+        language = request.GET.get("language", None)
+        return self._make_channel_endpoint_request(identifier=pk, baseurl=baseurl, keyword=keyword, language=language)
 
 
 class ContentNodeFileSizeViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/utils.js
@@ -14,6 +14,10 @@ export function getRemoteChannelByToken(token) {
   return RemoteChannelResource.fetchModel({ id: token, force: true });
 }
 
+export function getRemoteChannelBundleByToken(token) {
+  return RemoteChannelResource.fetchChannelList(token);
+}
+
 /**
  * Starts Task that downloads a Channel Metadata database.
  * NOTE: cannot be normally dispatched as an action, since it uses

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
@@ -35,6 +35,7 @@
 
 <script>
 
+  import { mapMutations } from 'vuex';
   import UiAlert from 'keen-ui/src/UiAlert';
   import KModal from 'kolibri.coreVue.components.KModal';
   import KTextbox from 'kolibri.coreVue.components.KTextbox';
@@ -66,14 +67,25 @@
       },
     },
     methods: {
+      ...mapMutations('manageContent/wizard', {
+        setAvailableChannels: 'SET_AVAILABLE_CHANNELS',
+      }),
       submitForm() {
         this.tokenLookupFailed = false;
         this.formIsSubmitted = true;
         if (this.tokenIsValid) {
           this.formIsDisabled = true;
           return this.lookupToken(this.token)
-            .then(([channel]) => {
-              this.$emit('channelfound', channel);
+            .then(channels => {
+              // unsure how many channels are returned from a single token so coerce to array
+              // resource layer appends id to object, so filter it out
+              const channelsList = Object.values(channels).filter(obj => obj !== this.token);
+              if (channelsList.length > 1) {
+                this.setAvailableChannels(channelsList);
+                this.$emit('closemodal');
+              } else {
+                this.$emit('channelfound', channelsList[0]);
+              }
             })
             .catch(error => {
               if (error.status.code === 404) {

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
@@ -39,7 +39,7 @@
   import UiAlert from 'keen-ui/src/UiAlert';
   import KModal from 'kolibri.coreVue.components.KModal';
   import KTextbox from 'kolibri.coreVue.components.KTextbox';
-  import { getRemoteChannelByToken } from '../../modules/wizard/utils';
+  import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
 
   export default {
     name: 'ChannelTokenModal',
@@ -77,14 +77,12 @@
           this.formIsDisabled = true;
           return this.lookupToken(this.token)
             .then(channels => {
-              // unsure how many channels are returned from a single token so coerce to array
-              // resource layer appends id to object, so filter it out
-              const channelsList = Object.values(channels).filter(obj => obj !== this.token);
-              if (channelsList.length > 1) {
-                this.setAvailableChannels(channelsList);
+              // tokens can return one or more channels
+              if (channels.length > 1) {
+                this.setAvailableChannels(channels);
                 this.$emit('closemodal');
               } else {
-                this.$emit('channelfound', channelsList[0]);
+                this.$emit('channelfound', channels[0]);
               }
             })
             .catch(error => {
@@ -101,7 +99,7 @@
         return Promise.resolve();
       },
       lookupToken(token) {
-        return getRemoteChannelByToken(token);
+        return getRemoteChannelBundleByToken(token);
       },
     },
     $trs: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When passing in a token that is a channel bundle, we update the available channels page to display those list of channels.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

in `options.py` change url to `https://develop.studio.learningequality.org`.
Pass in `havil-jinov` as the token.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4734
![channel bundles](https://user-images.githubusercontent.com/6361732/51420691-29d68d00-1b49-11e9-9f91-8f4350c0f869.gif)


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
