### PR TITLE
Patch to check for username accounts before creating superuser account

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -76,6 +76,7 @@ def create_superuser(username=None, password=None, interactive=False):
         else:
             logger.warn("An account with username {username} already exists, not creating user account.".format(username=username))
 
+
 def create_device_settings(language_id=None, facility=None, interactive=False):
     if language_id is None and interactive:
         language_id = get_user_response(

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -70,9 +70,11 @@ def create_superuser(username=None, password=None, interactive=False):
             confirm = get_user_response("Confirm password for the super user: ")
 
     if username and password:
-        FacilityUser.objects.create_superuser(username, password)
-        logger.info("Superuser created with username {username}.".format(username=username))
-
+        if not FacilityUser.objects.filter(username__icontains=username).exists():
+            FacilityUser.objects.create_superuser(username, password)
+            logger.info("Superuser created with username {username}.".format(username=username))
+        else:
+            logger.warn("An account with username {username} already exists, not creating user account.".format(username=username))
 
 def create_device_settings(language_id=None, facility=None, interactive=False):
     if language_id is None and interactive:


### PR DESCRIPTION
SImple patch to first check for existing accounts before creating superuser account.  

Testcase: 
1. Create a Facility with the following command: 
$ kolibri manage provisiondevice --facility "Kolibri" --superusername admin --superuserpassword "changeme"  --language_id "en"
2. Re-run the same command again. 
3. You will get a django Auth validation error `django.core.exceptions.ValidationError: [u'An account with that username already exists']"],`

### Summary
This patch adds few lines of code to first check if any account with similar usernames exists before running the create super user command in provisiondevice.py  If an existing account is found, it prints out a warning. 

### Reviewer guidance

This patch effects only the management commands that are run on command line. 


### References
Downstream bug reports: https://github.com/iiab/iiab/issues/1094  https://github.com/iiab/iiab/issues/1387 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
