### PR TITLE
Disable import/export buttons when downloading channel

### DIFF
--- a/kolibri/plugins/device_management/assets/src/modules/manageContent/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/manageContent/handlers.js
@@ -2,7 +2,10 @@ export function showManageContentPage(store) {
   store.commit('manageContent/RESET_STATE');
   store.commit('manageContent/wizard/RESET_STATE');
   if (store.getters.canManageContent) {
-    return store.dispatch('manageContent/refreshChannelList');
+    return Promise.all([
+      store.dispatch('manageContent/refreshTaskList'),
+      store.dispatch('manageContent/refreshChannelList'),
+    ]);
   }
   return Promise.resolve();
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds another call to the task list in order to have that vuex state filled before the page loads. To know whether or not to show the import/export buttons.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Switch quickly between tabs. Reload the page. Do the buttons show up while downloading a channel?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

![import_export_buttons](https://user-images.githubusercontent.com/6361732/51561425-10309080-1e3c-11e9-9514-580b6a052029.gif)

https://github.com/learningequality/kolibri/issues/4751

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
