### PR TITLE
add Sentry clients

### DIFF
--- a/docs/manual_testing.rst
+++ b/docs/manual_testing.rst
@@ -107,15 +107,17 @@ Collecting client and server errors using Sentry
 
 `Sentry <https://docs.sentry.io/>`__ clients are available for both backend and frontend error reporting. This can be particularly useful to have running on beta and demo servers in order to catch errors "in the wild".
 
-To set up error reporting, you'll need an `public key and a project ID <https://docs.sentry.io/error-reporting/quickstart>`__. You can set these either in options.ini or as environment variables.
+To set up error reporting, you'll need a `Sentry DSN <https://docs.sentry.io/error-reporting/quickstart>`__. These are available from your project settings at ``https://sentry.io/settings/[org_name]/[project_name]/keys/``
+
+You can set these either in options.ini or as environment variables.
 
 If using options.ini, under a ``Debug`` header you can use these options:
 
- * ``SENTRY_BACKEND_ENABLED``
- * ``SENTRY_BACKEND_PUBLIC_KEY``
- * ``SENTRY_BACKEND_PROJECT_ID``
- * ``SENTRY_FRONTEND_ENABLED``
- * ``SENTRY_FRONTEND_PUBLIC_KEY``
- * ``SENTRY_FRONTEND_PROJECT_ID``
+ * ``SENTRY_BACKEND_DSN``
+ * ``SENTRY_FRONTEND_DSN``
 
-If using environment variables, the names are the same but with ``KOLIBRI_DEBUG_`` prepended - for example ``KOLIBRI_DEBUG_SENTRY_BACKEND_ENABLED = 1``.
+Or if using environment variables:
+
+ * ``KOLIBRI_DEBUG_SENTRY_BACKEND_DSN``
+ * ``KOLIBRI_DEBUG_SENTRY_FRONTEND_DSN``
+

--- a/docs/manual_testing.rst
+++ b/docs/manual_testing.rst
@@ -100,3 +100,22 @@ In order to do this, a management command is available::
   kolibri manage generateuserdata
 
 This will generate user data for the each currently existing channel on the system. Use the `--help` flag for options.
+
+
+Collecting client and server errors using Sentry
+------------------------------------------------
+
+`Sentry <https://docs.sentry.io/>`__ clients are available for both backend and frontend error reporting. This can be particularly useful to have running on beta and demo servers in order to catch errors "in the wild".
+
+To set up error reporting, you'll need an `public key and a project ID <https://docs.sentry.io/error-reporting/quickstart>`__. You can set these either in options.ini or as environment variables.
+
+If using options.ini, under a ``Debug`` header you can use these options:
+
+ * ``SENTRY_BACKEND_ENABLED``
+ * ``SENTRY_BACKEND_PUBLIC_KEY``
+ * ``SENTRY_BACKEND_PROJECT_ID``
+ * ``SENTRY_FRONTEND_ENABLED``
+ * ``SENTRY_FRONTEND_PUBLIC_KEY``
+ * ``SENTRY_FRONTEND_PROJECT_ID``
+
+If using environment variables, the names are the same but with ``KOLIBRI_DEBUG_`` prepended - for example ``KOLIBRI_DEBUG_SENTRY_BACKEND_ENABLED = 1``.

--- a/docs/stack.rst
+++ b/docs/stack.rst
@@ -71,3 +71,4 @@ We use a number of mechanisms to help encourage code quality and consistency. Mo
 - In addition to building client assets, `webpack <https://webpack.github.io/>`__ runs linters on client-side code: `ESLint <http://eslint.org/>`__ for ES6 JavaScript, `Stylelint <https://stylelint.io/>`__ for SCSS, and `HTMLHint <http://htmlhint.com/>`__ for HTML and Vue.js components.
 - Client-side code is tested using `Jest <https://facebook.github.io/jest/>`__
 - `codecov <https://codecov.io/>`__ reports on the test coverage
+- We have `Sentry <https://docs.sentry.io/>`__ clients integrated (off by default) for automated error reporting

--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -23,6 +23,24 @@ const logging = require('kolibri.lib.logging').default;
 
 logging.setDefaultLevel(process.env.NODE_ENV === 'production' ? 2 : 0);
 
+// optionally set up client-side Sentry error reporting
+if (global.sentryDSN) {
+  require.ensure(['@sentry/browser'], function(require) {
+    const Sentry = require('@sentry/browser');
+    const Vue = require('vue');
+
+    Sentry.init({
+      dsn: global.sentryDSN,
+      release: __version,
+      integrations: [new Sentry.Integrations.Vue({ Vue })],
+    });
+    logging.warn('Sentry error logging is enabled - this disables some local error reporting!');
+    logging.warn(
+      '(see https://github.com/vuejs/vue/issues/8433 and https://docs.sentry.io/platforms/javascript/vue/)'
+    );
+  });
+}
+
 // Create an instance of the global app object.
 // This is exported by webpack as the kolibriGlobal object, due to the 'output.library' flag
 // which exports the coreApp at the bottom of this file as a named global variable:

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -3,23 +3,7 @@ import router from 'kolibri.coreVue.router';
 import Vue from 'kolibri.lib.vue';
 import store from 'kolibri.coreVue.vuex.store';
 import heartbeat from 'kolibri.heartbeat';
-import * as Sentry from '@sentry/browser';
-import logger from 'kolibri.lib.logging';
 import KolibriModule from 'kolibri_module';
-
-export const logging = logger.getLogger(__filename);
-
-if (global.sentryEnabled) {
-  logging.warn('Sentry error logging is enabled - this disables all local error reporting!');
-  logging.warn(
-    '(see https://github.com/vuejs/vue/issues/8433 and https://docs.sentry.io/platforms/javascript/vue/)'
-  );
-  Sentry.init({
-    dsn: `https://${global.sentryConfig.publicKey}@sentry.io/${global.sentryConfig.projectId}`,
-    release: __version,
-    integrations: [new Sentry.Integrations.Vue({ Vue })],
-  });
-}
 
 /*
  * A class for single page apps that control routing and vuex state.

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -3,7 +3,23 @@ import router from 'kolibri.coreVue.router';
 import Vue from 'kolibri.lib.vue';
 import store from 'kolibri.coreVue.vuex.store';
 import heartbeat from 'kolibri.heartbeat';
+import * as Sentry from '@sentry/browser';
+import logger from 'kolibri.lib.logging';
 import KolibriModule from 'kolibri_module';
+
+export const logging = logger.getLogger(__filename);
+
+if (global.sentryEnabled) {
+  logging.warn('Sentry error logging is enabled - this disables all local error reporting!');
+  logging.warn(
+    '(see https://github.com/vuejs/vue/issues/8433 and https://docs.sentry.io/platforms/javascript/vue/)'
+  );
+  Sentry.init({
+    dsn: `https://${global.sentryConfig.publicKey}@sentry.io/${global.sentryConfig.projectId}`,
+    release: __version,
+    integrations: [new Sentry.Integrations.Vue({ Vue })],
+  });
+}
 
 /*
  * A class for single page apps that control routing and vuex state.

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
+    "@sentry/browser": "4.5.3",
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "array-includes": "^3.0.3",
     "clipboard": "^2.0.1",

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -30,6 +30,7 @@
   {% include "kolibri/loading_snippet.html" %}
 </rootvue>
 {% block frontend_assets %}
+{% kolibri_sentry_error_reporting %}
 {% kolibri_language_globals %}
 {% kolibri_content_cache_key %}
 {% webpack_asset 'default_frontend' %}
@@ -45,7 +46,6 @@
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}
 {% content_renderer_assets %}
-{% kolibri_sentry_error_reporting %}
 {% endblock %}
 
 {% block content %}

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -45,6 +45,7 @@
 {% webpack_base_assets %}
 {% webpack_base_async_assets %}
 {% content_renderer_assets %}
+{% kolibri_sentry_error_reporting %}
 {% endblock %}
 
 {% block content %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -237,31 +237,16 @@ def _kolibri_bootstrap_helper(context, base_name, api_resource, route, **kwargs)
 @register.simple_tag()
 def kolibri_sentry_error_reporting():
 
-    if not conf.OPTIONS['Debug']['SENTRY_FRONTEND_ENABLED']:
+    if not conf.OPTIONS['Debug']['SENTRY_FRONTEND_DSN']:
         return ''
-
-    warning = """
-      <script>console.warn("Sentry error reporting is enabled but {} is not defined.");</script>
-    """
-    if not conf.OPTIONS['Debug']['SENTRY_FRONTEND_PUBLIC_KEY']:
-        logger.warn('SENTRY_FRONTEND_PUBLIC_KEY is not defined')
-        return mark_safe(warning.format('SENTRY_FRONTEND_PUBLIC_KEY'))
-    if not conf.OPTIONS['Debug']['SENTRY_FRONTEND_PROJECT_ID']:
-        logger.warn('SENTRY_FRONTEND_PROJECT_ID is not defined')
-        return mark_safe(warning.format('SENTRY_FRONTEND_PROJECT_ID'))
 
     template = """
       <script>
-        var sentryEnabled = true;
-        var sentryConfig = {{
-          publicKey: '{}',
-          projectId: '{}',
-        }};
+        var sentryDSN = '{}';
       </script>
     """
     return mark_safe(
         template.format(
-            conf.OPTIONS['Debug']['SENTRY_FRONTEND_PUBLIC_KEY'],
-            conf.OPTIONS['Debug']['SENTRY_FRONTEND_PROJECT_ID'],
+            conf.OPTIONS['Debug']['SENTRY_FRONTEND_DSN'],
         )
     )

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -396,23 +396,14 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 600
 
 
-if conf.OPTIONS['Debug']['SENTRY_BACKEND_ENABLED']:
+if conf.OPTIONS['Debug']['SENTRY_BACKEND_DSN']:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 
-    print("Sentry error logging is enabled")
-
-    if not conf.OPTIONS['Debug']['SENTRY_BACKEND_PUBLIC_KEY']:
-        print('SENTRY_BACKEND_PUBLIC_KEY is not defined')
-
-    if not conf.OPTIONS['Debug']['SENTRY_BACKEND_PROJECT_ID']:
-        print('SENTRY_BACKEND_PROJECT_ID is not defined')
-
     sentry_sdk.init(
-        dsn="https://{}@sentry.io/{}".format(
-            conf.OPTIONS['Debug']['SENTRY_BACKEND_PUBLIC_KEY'],
-            conf.OPTIONS['Debug']['SENTRY_BACKEND_PROJECT_ID'],
-        ),
+        dsn=conf.OPTIONS['Debug']['SENTRY_BACKEND_DSN'],
         integrations=[DjangoIntegration()],
         release=kolibri.__version__,
     )
+
+    print("Sentry backend error logging is enabled")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -394,3 +394,25 @@ SESSION_COOKIE_NAME = "kolibri"
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 SESSION_COOKIE_AGE = 600
+
+
+if conf.OPTIONS['Debug']['SENTRY_BACKEND_ENABLED']:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    print("Sentry error logging is enabled")
+
+    if not conf.OPTIONS['Debug']['SENTRY_BACKEND_PUBLIC_KEY']:
+        print('SENTRY_BACKEND_PUBLIC_KEY is not defined')
+
+    if not conf.OPTIONS['Debug']['SENTRY_BACKEND_PROJECT_ID']:
+        print('SENTRY_BACKEND_PROJECT_ID is not defined')
+
+    sentry_sdk.init(
+        dsn="https://{}@sentry.io/{}".format(
+            conf.OPTIONS['Debug']['SENTRY_BACKEND_PUBLIC_KEY'],
+            conf.OPTIONS['Debug']['SENTRY_BACKEND_PROJECT_ID'],
+        ),
+        integrations=[DjangoIntegration()],
+        release=kolibri.__version__,
+    )

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -94,6 +94,34 @@ option_spec = {
             "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
     },
+    "Debug": {
+        "SENTRY_BACKEND_ENABLED": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_ENABLED", ),
+        },
+        "SENTRY_BACKEND_PUBLIC_KEY": {
+            "type": "string",
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_PUBLIC_KEY", ),
+        },
+        "SENTRY_BACKEND_PROJECT_ID": {
+            "type": "string",
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_PROJECT_ID", ),
+        },
+        "SENTRY_FRONTEND_ENABLED": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_ENABLED", ),
+        },
+        "SENTRY_FRONTEND_PUBLIC_KEY": {
+            "type": "string",
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_PUBLIC_KEY", ),
+        },
+        "SENTRY_FRONTEND_PROJECT_ID": {
+            "type": "string",
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_PROJECT_ID", ),
+        },
+    },
 }
 
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -95,31 +95,13 @@ option_spec = {
         },
     },
     "Debug": {
-        "SENTRY_BACKEND_ENABLED": {
-            "type": "boolean",
-            "default": False,
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_ENABLED", ),
-        },
-        "SENTRY_BACKEND_PUBLIC_KEY": {
+        "SENTRY_BACKEND_DSN": {
             "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_PUBLIC_KEY", ),
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_DSN", ),
         },
-        "SENTRY_BACKEND_PROJECT_ID": {
+        "SENTRY_FRONTEND_DSN": {
             "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_PROJECT_ID", ),
-        },
-        "SENTRY_FRONTEND_ENABLED": {
-            "type": "boolean",
-            "default": False,
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_ENABLED", ),
-        },
-        "SENTRY_FRONTEND_PUBLIC_KEY": {
-            "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_PUBLIC_KEY", ),
-        },
-        "SENTRY_FRONTEND_PROJECT_ID": {
-            "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_PROJECT_ID", ),
+            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_DSN", ),
         },
     },
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,3 +30,4 @@ python-dateutil==2.7.5
 ifcfg==0.17
 sqlalchemy==1.2.10
 user-agents==1.1.0
+sentry-sdk==0.6.9

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,58 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.5.3.tgz#69744d13b01c490f366cbf2676790624b9f7c0a0"
+  integrity sha512-ePbsyXtZS9jWM0lD8rxA46omJjJcQPaRZak08TyxFBGm1YOUFvvNAA6rNjUtK4fFEznLhPA5YcllcOCBE2bPPg==
+  dependencies:
+    "@sentry/core" "4.5.3"
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/core@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.5.3.tgz#e55a42c694deec903aec2479e4a282d5a7a43878"
+  integrity sha512-off7XkyyiPXJTQ1XYPzxsY3zLHztMdK1kuIeHzyoIzu4kvs8H75eqou+fADo04JmfaMNy+OZSoW+5Aq2SZR2Ng==
+  dependencies:
+    "@sentry/hub" "4.5.3"
+    "@sentry/minimal" "4.5.3"
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/hub@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.5.3.tgz#54ce5988ac6dedbe9bba99e2c00f8f26eb677dfe"
+  integrity sha512-4b8oPVAGw/hf11CQN9J7hAk2wzD2HIZsQBl/PcB/p5r1UyHw8cibpVobJulkHJMBJMiZ/twIBGZ1G1qK3LJdhw==
+  dependencies:
+    "@sentry/types" "4.5.3"
+    "@sentry/utils" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/minimal@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.5.3.tgz#7b69481df2d61e4b935d067be62a52824190f616"
+  integrity sha512-W9+eEZosoDKTAJkab/bxsSRim7I4lqeWHLhmCchDimKcdmpBzC+gOCT0PywwOWRLW08LhTHfmnNSAJv6PaZiCA==
+  dependencies:
+    "@sentry/hub" "4.5.3"
+    "@sentry/types" "4.5.3"
+    tslib "^1.9.3"
+
+"@sentry/types@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.5.3.tgz#3350dce2b7f9b936a8c327891c12e3aef7bd8852"
+  integrity sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag==
+
+"@sentry/utils@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.5.3.tgz#6893fca9fde230b230360779362752e9b5570852"
+  integrity sha512-yIYqnuq9cd9nAUJ2MPmq++Mgy81qB2fglsDB8TiBfk2eaba79qFcKp8xg3w3EMDHZMlfmlx4fkTmZJ/+V02oWQ==
+  dependencies:
+    "@sentry/types" "4.5.3"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -11573,7 +11625,7 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
### Summary

Adds Sentry clients to both the front- and backend, off by default, and configurable using options.ini or environment variables.

### Reviewer guidance

Is this structure acceptable? @rtibbles suggested maybe using an external settings file - is that actually necessary?

### References

* Instructions on using Sentry: https://github.com/learningequality/kolibri/pull/4774/files#diff-1eed66c9b6a7aa504cc4be09853b801fR103
* Follow-up issue on migrating this functionality to an external plugin: #4775

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
