### PR TITLE
Clear LearnerClassroomResource cache when lessons and quizzes log progress

### DIFF
--- a/kolibri/core/assets/src/api-resources/index.js
+++ b/kolibri/core/assets/src/api-resources/index.js
@@ -19,7 +19,6 @@ export { default as MasteryLogResource } from './masteryLog';
 export { default as SignUpResource } from './signUp';
 export { default as ExamResource } from './exam';
 export { default as ExamAssignmentResource } from './examassignment';
-export { default as UserExamResource } from './userexam';
 export { default as ExamLogResource } from './examLog';
 export { default as ExamAttemptLogResource } from './examAttemptLog';
 export { default as FacilityDatasetResource } from './facilityDataset';

--- a/kolibri/core/assets/src/api-resources/userexam.js
+++ b/kolibri/core/assets/src/api-resources/userexam.js
@@ -1,6 +1,0 @@
-import { Resource } from 'kolibri.lib.apiResource';
-
-export default new Resource({
-  name: 'userexam',
-  idKey: 'id',
-});

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -183,12 +183,4 @@ function getExamReport(store, examId, userId, questionNumber = 0, interactionInd
   });
 }
 
-function canViewExam(exam, examLog) {
-  return exam.active && !examLog.closed;
-}
-
-function canViewExamReport(exam, examLog) {
-  return !canViewExam(exam, examLog);
-}
-
-export { convertExamQuestionSourcesV0V1, getExamReport, canViewExam, canViewExamReport };
+export { convertExamQuestionSourcesV0V1, getExamReport };

--- a/kolibri/core/exams/api_urls.py
+++ b/kolibri/core/exams/api_urls.py
@@ -4,12 +4,10 @@ from rest_framework import routers
 
 from .api import ExamAssignmentViewset
 from .api import ExamViewset
-from .api import UserExamViewset
 
 router = routers.SimpleRouter()
 router.register(r'exam', ExamViewset, base_name='exam')
 router.register(r'examassignment', ExamAssignmentViewset, base_name='examassignment')
-router.register(r'userexam', UserExamViewset, base_name='userexam')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -14,52 +14,6 @@ from kolibri.core.auth.test.helpers import provision_device
 DUMMY_PASSWORD = "password"
 
 
-class UserExamAPITestCase(APITestCase):
-
-    def setUp(self):
-        provision_device()
-        self.facility = Facility.objects.create(name="MyFac")
-        user = FacilityUser.objects.create(username="admin", facility=self.facility)
-        self.exam = models.Exam.objects.create(
-            title="title",
-            question_count=1,
-            active=True,
-            collection=self.facility,
-            creator=user
-        )
-        self.assignment = models.ExamAssignment.objects.create(
-            exam=self.exam,
-            collection=self.facility,
-            assigned_by=user,
-        )
-
-    def test_logged_in_userexam_list(self):
-
-        user = FacilityUser.objects.create(username="learner", facility=self.facility)
-        user.set_password("pass")
-        user.save()
-
-        self.client.login(username=user.username, password="pass")
-
-        response = self.client.get(reverse("kolibri:core:userexam-list"))
-        self.assertEqual(len(response.data), 1)
-
-    def test_logged_in_user_userexam_no_delete(self):
-
-        user = FacilityUser.objects.create(username="learner", facility=self.facility)
-        user.set_password("pass")
-        user.save()
-
-        self.client.login(username=user.username, password="pass")
-
-        response = self.client.delete(reverse("kolibri:core:userexam-detail", kwargs={'pk': self.assignment.id}))
-        self.assertEqual(response.status_code, 403)
-
-    def test_anonymous_userexam_list(self):
-        response = self.client.get(reverse("kolibri:core:userexam-list"))
-        self.assertEqual(len(response.data), 0)
-
-
 class ExamAPITestCase(APITestCase):
 
     def setUp(self):

--- a/kolibri/plugins/learn/assets/src/modules/examReportViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examReportViewer/handlers.js
@@ -1,6 +1,7 @@
-import { getExamReport, canViewExamReport } from 'kolibri.utils.exams';
+import { getExamReport } from 'kolibri.utils.exams';
 import router from 'kolibri.coreVue.router';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
+import { canViewExamReport } from '../../utils/exams';
 import { ClassesPageNames } from '../../constants';
 
 export function showExamReport(store, params) {

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/actions.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/actions.js
@@ -21,6 +21,9 @@ export function setAndSaveCurrentExamAttemptLog(
   store,
   { contentId, itemId, currentAttemptLog, examId }
 ) {
+  // Clear the learner classroom cache here as its progress data is now
+  // stale
+  LearnerClassroomResource.clearCache();
   setExamAttemptLog(store, { contentId, itemId, attemptLog: currentAttemptLog });
 
   // If a save has already been fired for this particular attempt log,

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/actions.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/actions.js
@@ -1,4 +1,4 @@
-import { ExamAttemptLogResource, ExamLogResource, UserExamResource } from 'kolibri.resources';
+import { ExamAttemptLogResource, ExamLogResource } from 'kolibri.resources';
 import router from 'kolibri.coreVue.router';
 import { now } from 'kolibri.utils.serverClock';
 import { ClassesPageNames } from '../../constants';
@@ -21,12 +21,6 @@ export function setAndSaveCurrentExamAttemptLog(
   store,
   { contentId, itemId, currentAttemptLog, examId }
 ) {
-  // As soon as this has happened, we should clear any previous cache for the
-  // UserExamResource - as that data has now changed.
-  UserExamResource.clearCache();
-  // Not sure why, but need to clear cache for PATCHing to not fail
-  ExamAttemptLogResource.clearCache();
-
   setExamAttemptLog(store, { contentId, itemId, attemptLog: currentAttemptLog });
 
   // If a save has already been fired for this particular attempt log,
@@ -79,7 +73,6 @@ export function closeExam(store) {
     },
   })
     .then(() => {
-      UserExamResource.clearCache();
       LearnerClassroomResource.clearCache();
     })
     .catch(error => {

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -1,16 +1,17 @@
 import {
   ContentNodeResource,
-  UserExamResource,
+  ExamResource,
   ExamLogResource,
   ExamAttemptLogResource,
 } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
-import { canViewExam, convertExamQuestionSourcesV0V1 } from 'kolibri.utils.exams';
+import { convertExamQuestionSourcesV0V1 } from 'kolibri.utils.exams';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { now } from 'kolibri.utils.serverClock';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import router from 'kolibri.coreVue.router';
 import shuffled from 'kolibri.utils.shuffled';
+import { canViewExam } from '../../utils/exams';
 import { PageNames, ClassesPageNames } from '../../constants';
 import { contentState } from '../coreLearn/utils';
 import { calcQuestionsAnswered } from './utils';
@@ -32,7 +33,7 @@ export function showExam(store, params) {
     questionNumber = Number(questionNumber); // eslint-disable-line no-param-reassign
 
     const promises = [
-      UserExamResource.fetchModel({ id: examId }),
+      ExamResource.fetchModel({ id: examId }),
       ExamLogResource.fetchCollection({ getParams: examParams }),
       ExamAttemptLogResource.fetchCollection({ getParams: examParams }),
       store.dispatch('setAndCheckChannels'),

--- a/kolibri/plugins/learn/assets/src/utils/exams.js
+++ b/kolibri/plugins/learn/assets/src/utils/exams.js
@@ -1,0 +1,7 @@
+export function canViewExam(exam, examLog) {
+  return exam.active && !examLog.closed;
+}
+
+export function canViewExamReport(exam, examLog) {
+  return !canViewExam(exam, examLog);
+}

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -476,6 +476,7 @@ oriented data synchronization.
       updateExerciseProgressMethod() {
         this.updateExerciseProgress({ progressPercent: this.exerciseProgress });
         updateContentNodeProgress(this.channelId, this.id, this.exerciseProgress);
+        this.$emit('updateProgress', this.exerciseProgress);
       },
       sessionInitialized() {
         if (this.isUserLoggedIn) {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -46,7 +46,7 @@
       @sessionInitialized="setWasIncomplete"
       @startTracking="startTracking"
       @stopTracking="stopTracking"
-      @updateProgress="updateProgress"
+      @updateProgress="updateExerciseProgress"
       @updateContentState="updateContentState"
     />
 
@@ -268,6 +268,10 @@
         this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
           updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
         );
+        this.$emit('updateProgress', progressPercent);
+      },
+      updateExerciseProgress(progressPercent) {
+        this.$emit('updateProgress', progressPercent);
       },
       updateContentState(contentState, forceSave = true) {
         this.updateContentNodeState({ contentState, forceSave });

--- a/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
@@ -29,7 +29,7 @@
 <script>
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { canViewExam } from 'kolibri.utils.exams';
+  import { canViewExam } from '../../utils/exams';
   import ContentCard from '../ContentCard';
   import { examViewerLink, examReportViewerLink } from './classPageLinks';
 

--- a/kolibri/plugins/learn/assets/src/views/classes/AssignedLessonsCards.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AssignedLessonsCards.vue
@@ -51,9 +51,9 @@
     },
     methods: {
       getLessonProgress(lesson) {
-        const { resources_completed, total_resources } = lesson.progress;
+        const { resource_progress, total_resources } = lesson.progress;
         if (total_resources === 0) return undefined;
-        return resources_completed / total_resources;
+        return resource_progress / total_resources;
       },
       lessonPlaylistLink,
     },

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -1,7 +1,9 @@
 <template>
 
   <div>
-    <ContentPage>
+    <ContentPage
+      @updateProgress="updateProgress"
+    >
       <div slot="below_content" class="below-content-area">
         <template v-if="nextLessonResource">
           <h1>{{ $tr('nextInLesson') }}</h1>
@@ -28,6 +30,7 @@
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import ContentCard from '../ContentCard';
   import ContentPage from '../ContentPage';
+  import { LearnerClassroomResource } from '../../apiResources';
   import { lessonResourceViewerLink } from './classPageLinks';
 
   // HACK replace computed properties since they use different module in Lessons
@@ -75,6 +78,11 @@
     },
     methods: {
       getContentNodeThumbnail,
+      updateProgress() {
+        // Clear the learner classroom cache here as its progress data is now
+        // stale
+        LearnerClassroomResource.clearCache();
+      },
     },
     $trs: {
       nextInLesson: 'Next in lesson',

--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -67,15 +67,14 @@ class LessonProgressSerializer(ModelSerializer):
 
     def get_progress(self, instance):
         content_ids = [resource['content_id'] for resource in instance.resources]
-        num_completed_logs = ContentSummaryLog.objects \
-            .exclude(completion_timestamp__isnull=True) \
+        resource_progress = ContentSummaryLog.objects \
             .filter(
                 user=self.context['user'],
                 content_id__in=content_ids
             ) \
-            .count()
+            .aggregate(Sum('progress')).get('progress__sum')
         return {
-            'resources_completed': num_completed_logs,
+            'resource_progress': resource_progress,
             'total_resources': len(instance.resources),
         }
 


### PR DESCRIPTION
### Summary
Progress on the 'class resource' page of Learn is displayed from the LearnerClassroom endpoint.
When progress happens in quizzes or exams, this does not get updated automatically.
In order to log that happening, we clear the cache on the frontend Resource.

### Reviewer guidance
Difficult to properly review this until #4733 has been merged, as taking quizzes is currently broken. I added some local fixes to allow me to test.

Can review the lesson behaviour, where the progress on a lesson should now update as soon as any progress has happened on a constituent resource.

### References
Fixes #4613 

Also cleans up some code that is no longer necessary en route.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
