### PR TITLE
Allow full screen fallback to function properly.

### DIFF
--- a/kolibri/core/assets/src/views/CoreFullscreen.vue
+++ b/kolibri/core/assets/src/views/CoreFullscreen.vue
@@ -61,7 +61,9 @@
             fullScreenPromise = Promise.resolve();
           }
           fullScreenPromise.then(() => {
-            this.isInFullscreen = ScreenFull.isFullscreen;
+            this.isInFullscreen = fullscreenApiIsSupported
+              ? ScreenFull.isFullscreen
+              : !this.isInFullscreen;
             this.toggling = false;
           });
         }


### PR DESCRIPTION
### Summary
A fix for fullscreen in Chrome 71 caused a regression that prevented our fallback fullscreen behaviour from functioning properly. This fixes that.

### Reviewer guidance
In browserstack, use an iPad Air 2 with iOS 9.3 (hidden under 'additional simulators') to replicate the bug. This patch fixes it.

### References
Fixes #4776

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
