### PR TITLE
Drop esprima for message extraction and use espree.

### DIFF
--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-kolibri": "0.12.0-dev.1",
     "eslint-plugin-vue": "^5.0.0-beta.3",
     "espree": "^4.1.0",
-    "esprima": "https://github.com/jquery/esprima.git",
     "esquery": "^1.0.1",
     "express": "^4.16.4",
     "file-loader": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,11 +154,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@shopify/draggable@^1.0.0-beta.8":
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.8.tgz#2eb3c2f72298ce3e53fe16f34ab124cc495cd4fc"
-  integrity sha512-9IeBPQM93Ad4qFKUopwuTClzoST/1OId4MaSd/8FB5ScCL2tl25UaOGNR8E2hjiL7xK4LN5+I1Ews6amS7YAiA==
-
 "@sentry/browser@4.5.3":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.5.3.tgz#69744d13b01c490f366cbf2676790624b9f7c0a0"
@@ -210,6 +205,11 @@
   dependencies:
     "@sentry/types" "4.5.3"
     tslib "^1.9.3"
+
+"@shopify/draggable@^1.0.0-beta.8":
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.8.tgz#2eb3c2f72298ce3e53fe16f34ab124cc495cd4fc"
+  integrity sha512-9IeBPQM93Ad4qFKUopwuTClzoST/1OId4MaSd/8FB5ScCL2tl25UaOGNR8E2hjiL7xK4LN5+I1Ews6amS7YAiA==
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
@@ -4020,10 +4020,6 @@ esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-"esprima@https://github.com/jquery/esprima.git":
-  version "4.0.0-dev"
-  resolved "https://github.com/jquery/esprima.git#c0dfa42da4da9fa242dac623278a082cb38edc20"
 
 esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Summary
We currently use esprima for message extraction - unfortunately it is infrequently updated and has compatibility issues with ES2017 syntax. This resolves this issue by replacing esprima with espree.

### Reviewer guidance
Do messages still get built properly?

### References
Fixes #4768

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
