### PR TITLE
Fix styling and behaviour issue on username autocomplete.

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -42,19 +42,21 @@
                 />
               </transition>
               <transition name="list">
-                <ul
-                  v-if="simpleSignIn && suggestions.length"
-                  v-show="showDropdown"
-                  class="suggestions"
-                >
-                  <UiAutocompleteSuggestion
-                    v-for="(suggestion, i) in suggestions"
-                    :key="i"
-                    :suggestion="suggestion"
-                    :style="{ backgroundColor: highlightedIndex === i ? $coreGrey : ''}"
-                    @click.native="fillUsername(suggestion)"
-                  />
-                </ul>
+                <div class="suggestions-wrapper">
+                  <ul
+                    v-if="simpleSignIn && suggestions.length"
+                    v-show="showDropdown"
+                    class="suggestions"
+                  >
+                    <UiAutocompleteSuggestion
+                      v-for="(suggestion, i) in suggestions"
+                      :key="i"
+                      :suggestion="suggestion"
+                      :style="{ backgroundColor: highlightedIndex === i ? $coreGrey : ''}"
+                      @mousedown.native="fillUsername(suggestion)"
+                    />
+                  </ul>
+                </div>
               </transition>
               <transition name="textbox">
                 <KTextbox
@@ -511,6 +513,11 @@
 
   .footer-cell .small-text {
     margin-top: 8px;
+  }
+
+  .suggestions-wrapper {
+    position: relative;
+    width: 100%;
   }
 
   .suggestions {


### PR DESCRIPTION
### Summary
Somehow the autocomplete box became incredibly wide.
Fixing the wideness caused the autocomplete to stop functioning as intended.
This PR fixes both these issues.

### Reviewer guidance
Set facility to allow passwordless login.
Create multiple learner accounts starting with the same three letters in their username.
Type the first three letters that they share.
Check that:
* The autocomplete drop down subtends the same width as the text box.
* When you click on an option, the text box is autofilled with the option.

Before:
![autocompletebefore](https://user-images.githubusercontent.com/1680573/51778556-357d0300-20b7-11e9-862e-e53b59d5cf18.gif)

After:
![autcompleteafter](https://user-images.githubusercontent.com/1680573/51778557-3ada4d80-20b7-11e9-9baa-4c72767a1f00.gif)


### References
Fixes #4780

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
