### PR TITLE
Move all URL setting on kolibriGlobal object to initialization.

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -1,3 +1,12 @@
+// Shim Array includes for ES7 spec compliance
+require('array-includes').shim();
+// polyfill for older browsers
+// TODO: rtibbles whittle down these polyfills to only what is needed for the application
+require('core-js');
+
+// Do this before any async imports to ensure that public paths
+// are set correctly
+require('kolibri.urls').default.setUp();
 // include global styles
 require('purecss/build/base-min.css');
 require('../styles/main.scss');
@@ -10,13 +19,6 @@ require('keen-ui/src/bootstrap');
 const KeenUiConfig = require('keen-ui/src/config').default;
 KeenUiConfig.set(require('../keen-config/options.json'));
 require('../keen-config/font-stack.scss');
-
-// polyfill for older browsers
-// TODO: rtibbles whittle down these polyfills to only what is needed for the application
-require('core-js');
-
-// Shim Array includes for ES7 spec compliance
-require('array-includes').shim();
 
 // set up logging
 const logging = require('kolibri.lib.logging').default;

--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -6,8 +6,9 @@
 import setWebpackPublicPath from '../utils/setWebpackPublicPath';
 
 const urls = {
-  __setStaticURL(staticUrl) {
-    this.__staticURL = staticUrl;
+  setUp() {
+    Object.assign(this, global.kolibriUrls);
+    this.__staticURL = global.staticUrl;
     setWebpackPublicPath(this);
   },
   static(url) {

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -33,14 +33,10 @@
 {% kolibri_sentry_error_reporting %}
 {% kolibri_language_globals %}
 {% kolibri_content_cache_key %}
+{% kolibri_set_urls %}
 {% webpack_asset 'default_frontend' %}
 {% kolibri_set_server_time %}
 {% kolibri_navigation_actions %}
-<script type="text/javascript">
-  {% cache 5000 js_urls %}
-    {% kolibri_set_urls %}
-  {% endcache %}
-</script>
 <!-- Bootstrapping the currently logged in user's session object into the page. -->
 {% kolibri_bootstrap_model 'session' 'SessionResource' kwargs_pk='current'%}
 {% webpack_base_assets %}

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -382,8 +382,6 @@ SILENCED_SYSTEM_CHECKS = ["auth.W004"]
 # Configuration for Django JS Reverse
 # https://github.com/ierror/django-js-reverse#options
 
-JS_REVERSE_JS_VAR_NAME = 'kolibriUrls'
-
 JS_REVERSE_EXCLUDE_NAMESPACES = ['admin', ]
 
 ENABLE_DATA_BOOTSTRAPPING = True


### PR DESCRIPTION
### Summary
We now use a dynamic webpack public path, but this only got set after urls had been loaded from the backend.
This PR puts all URL reversal into the template prior to default frontend initialization, and moves all URL setting into the entry point of the default frontend bundle.
This means that no asynchronous webpack chunk loading can happen prior to the webpack public url being properly set.

### Reviewer guidance
Does our Sentry integration load its chunk properly in production mode?
Do static images still load properly?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
