### PR TITLE
Handle adding large topics to exams

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -267,7 +267,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
             def copy_node(new_node):
                 new_node['ancestor_id'] = node.id
                 return new_node
-            node_data = node.get_descendants()
+            node_data = node.get_descendants().filter(available=True)
             if kind:
                 node_data = node_data.filter(kind=kind)
             data += map(copy_node, node_data.values('id', 'title', 'kind', 'content_id'))
@@ -294,7 +294,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         ids = self.request.query_params.get('ids', '').split(',')
         data = 0
         if ids and ids[0]:
-            nodes = models.ContentNode.objects.filter(id__in=ids).prefetch_related('assessmentmetadata')
+            nodes = models.ContentNode.objects.filter(id__in=ids, available=True).prefetch_related('assessmentmetadata')
             data = nodes.aggregate(Sum('assessmentmetadata__number_of_assessments'))['assessmentmetadata__number_of_assessments__sum'] or 0
         return Response(data)
 

--- a/kolibri/plugins/coach/assets/src/constants/examConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/examConstants.js
@@ -1,3 +1,5 @@
 export const Modals = {
   PREVIEW_EXAM: 'PREVIEW_EXAM',
 };
+
+export const MAX_QUESTIONS = 50;

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
@@ -187,7 +187,7 @@ export function filterAndAnnotateContentList(childNodes) {
 }
 
 export function updateSelectedQuestions(store) {
-  if (!store.state.selectedExercises.length) {
+  if (!Object.keys(store.state.selectedExercises).length) {
     store.commit('SET_SELECTED_QUESTIONS', []);
     return Promise.resolve();
   }
@@ -196,7 +196,7 @@ export function updateSelectedQuestions(store) {
     // If there are more exercises than questions, no need to fetch them all so
     // choose N at random where N is the the number of questions.
     const exerciseIds = shuffled(
-      uniq(store.state.selectedExercises.map(exercise => exercise.id)),
+      Object.keys(store.state.selectedExercises),
       store.state.seed
     ).slice(0, store.state.numberOfQuestions);
 

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
@@ -1,5 +1,3 @@
-import unionBy from 'lodash/unionBy';
-import find from 'lodash/find';
 import * as actions from './actions';
 
 function getRandomInt() {
@@ -12,7 +10,7 @@ function defaultState() {
     numberOfQuestions: 10,
     seed: getRandomInt(), // consistent seed is used for question selection
     contentList: [],
-    selectedExercises: [],
+    selectedExercises: {},
     availableQuestions: 0,
     searchResults: {
       channel_ids: [],
@@ -72,19 +70,19 @@ export default {
       state.contentList = contentList;
     },
     ADD_TO_SELECTED_EXERCISES(state, exercises) {
-      state.selectedExercises = unionBy([...state.selectedExercises, ...exercises], 'id');
-    },
-    REMOVE_FROM_SELECTED_EXERCISES(state, exercises) {
-      state.selectedExercises = state.selectedExercises.filter(
-        resource => exercises.findIndex(exercise => exercise.id === resource.id) === -1
+      Object.assign(
+        state.selectedExercises,
+        ...exercises.map(exercise => ({ [exercise.id]: exercise }))
       );
     },
-    SET_SELECTED_EXERCISES(state, exercises) {
-      state.selectedExercises = unionBy(exercises, 'id');
+    REMOVE_FROM_SELECTED_EXERCISES(state, exercises) {
+      exercises.forEach(exercise => {
+        delete state.selectedExercises[exercise.id];
+      });
     },
     UPDATE_SELECTED_EXERCISES(state, exercises) {
       exercises.forEach(newExercise => {
-        Object.assign(find(state.selectedExercises, { id: newExercise.id }), newExercise);
+        Object.assign(state.selectedExercises[newExercise.id], newExercise);
       });
     },
     SET_AVAILABLE_QUESTIONS(state, availableQuestions) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -193,6 +193,7 @@
   import commonCoach from '../../common';
   import QuizDetailEditor from '../../common/QuizDetailEditor';
   import ExamPreview from '../CoachExamsPage/ExamPreview';
+  import { MAX_QUESTIONS } from '../../../constants/examConstants';
   import AssessmentQuestionListItem from './AssessmentQuestionListItem';
   import Bottom from './Bottom';
   import CeateExamPage from './index';
@@ -200,8 +201,6 @@
   const createExamPageStrings = crossComponentTranslator(CeateExamPage);
   const quizDetailStrings = crossComponentTranslator(QuizDetailEditor);
   const previewQuizStrings = crossComponentTranslator(ExamPreview);
-
-  const MAX_QUESTIONS = 50;
 
   export default {
     name: 'CreateExamPreview',

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -243,7 +243,11 @@
     },
     computed: {
       ...mapState(['toolbarRoute']),
-      ...mapState('examCreation', ['loadingNewQuestions', 'selectedQuestions']),
+      ...mapState('examCreation', [
+        'loadingNewQuestions',
+        'selectedQuestions',
+        'selectedExercises',
+      ]),
       annotatedQuestions() {
         const counts = {};
         const totals = {};
@@ -283,15 +287,8 @@
       currentQuestion() {
         return this.selectedQuestions[this.currentQuestionIndex] || {};
       },
-      exercises() {
-        const exercises = {};
-        this.$store.state.examCreation.selectedExercises.forEach(exercise => {
-          exercises[exercise.id] = exercise;
-        });
-        return exercises;
-      },
       content() {
-        return this.exercises[this.currentQuestion.exercise_id];
+        return this.selectedExercises[this.currentQuestion.exercise_id];
       },
       questionId() {
         return this.currentQuestion.question_id;
@@ -366,7 +363,7 @@
         this.$store.dispatch('examCreation/updateSelectedQuestions');
       },
       numCoachContents(exerciseId) {
-        return this.exercises[exerciseId].num_coach_contents;
+        return this.selectedExercises[exerciseId].num_coach_contents;
       },
       isSelected(question) {
         return (

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -286,12 +286,7 @@
         return [...exercises, ...topicExercises];
       },
       addableExercises() {
-        return this.allExercises.filter(
-          exercise =>
-            this.selectedExercises.findIndex(
-              selectedExercise => selectedExercise.id === exercise.id
-            ) === -1
-        );
+        return this.allExercises.filter(exercise => !this.selectedExercises[exercise.id]);
       },
       selectAllChecked() {
         return this.addableExercises.length === 0;
@@ -324,7 +319,7 @@
         return 'visible';
       },
       selectionIsInvalidText() {
-        if (this.selectedExercises.length === 0) {
+        if (Object.keys(this.selectedExercises).length === 0) {
           return this.$tr('noneSelected');
         }
         return null;
@@ -395,48 +390,27 @@
       },
       contentIsSelected(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {
-          return content.exercises.every(
-            exercise =>
-              this.selectedExercises.findIndex(
-                selectedExercise => selectedExercise.id === exercise.id
-              ) !== -1
-          );
+          return content.exercises.every(exercise => Boolean(this.selectedExercises[exercise.id]));
         } else {
-          return (
-            this.selectedExercises.findIndex(
-              selectedExercise => selectedExercise.id === content.id
-            ) !== -1
-          );
+          return Boolean(this.selectedExercises[content.id]);
         }
       },
       contentIsIndeterminate(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {
-          const everyExerciseSelected = content.exercises.every(
-            exercise =>
-              this.selectedExercises.findIndex(
-                selectedExercise => selectedExercise.id === exercise.id
-              ) !== -1
+          const everyExerciseSelected = content.exercises.every(exercise =>
+            Boolean(this.selectedExercises[exercise.id])
           );
           if (everyExerciseSelected) {
             return false;
           }
-          const someExerciseSelected = content.exercises.some(
-            exercise =>
-              this.selectedExercises.findIndex(
-                selectedExercise => selectedExercise.id === exercise.id
-              ) !== -1
-          );
-          return someExerciseSelected;
+          return content.exercises.some(exercise => Boolean(this.selectedExercises[exercise.id]));
         }
         return false;
       },
       selectionMetadata(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {
-          const count = content.exercises.filter(
-            exercise =>
-              this.selectedExercises.findIndex(
-                selectedExercise => selectedExercise.id === exercise.id
-              ) !== -1
+          const count = content.exercises.filter(exercise =>
+            Boolean(this.selectedExercises[exercise.id])
           ).length;
           if (count === 0) {
             return '';

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -151,6 +151,7 @@
 
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import { PageNames } from '../../../constants/';
+  import { MAX_QUESTIONS } from '../../../constants/examConstants';
   import LessonsSearchBox from '../../plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox';
   import LessonsSearchFilters from '../../plan/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters';
   import ResourceSelectionBreadcrumbs from '../../plan/LessonResourceSelectionPage/SearchTools/ResourceSelectionBreadcrumbs';
@@ -160,8 +161,6 @@
   import Bottom from './Bottom';
 
   const quizDetailStrings = crossComponentTranslator(QuizDetailEditor);
-
-  const MAX_QUESTIONS = 50;
 
   export default {
     // TODO: Rename this to 'ExamCreationPage'

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -43,11 +43,7 @@
       ...mapState(['toolbarRoute']),
       ...mapState('examCreation', ['preview', 'selectedExercises', 'currentContentNode']),
       isSelected() {
-        return (
-          this.selectedExercises.findIndex(
-            exercise => exercise.id === this.currentContentNode.id
-          ) !== -1
-        );
+        return Boolean(this.selectedExercises[this.currentContentNode.id]);
       },
     },
     methods: {


### PR DESCRIPTION
### Summary
Currently, adding large topics to quizzes causes two issues:
1) It makes a request with too many exercise ids in it to the `node_assessments` endpoint, resulting in a 411 error.
2) It adds new exercises to the data store using a `unionBy` operation, and then various methods for verifying if a topic should be checked or indeterminately checked using searches over arrays for membership.
3) Lastly, there were some issues in the backend code that caused these issues to arise for large channels, even when they were only partially imported.

This PR deals with these issues thusly:
1) Only make a request to the `node_assessments` endpoint if the number of selected exercises is less than the maximum number of questions in a quiz. This prevents the 411.
2) The first issue is troublesome, but the second was the major contributor to the browser freezing. This is resolved by using an object rather than an array to store selected exercises - this allows uniquely updating to be done much more efficiently, and for any methods not to have to do array searches over potentially very long arrays. All references to `selectedExercises` should now be updated to reflect that it is now an `id: entity` object store.
3) Ensures `node_assessments` and `descendant_assessments` endpoints both filter by availability.

### Reviewer guidance
Ensure that the entire quiz creation work flow works as expected, including adding and removing large topics.

Did I catch every reference to `selectedExercises`?

### References
Fixes #4740

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
