### PR TITLE
Handle case insensitive checks in validate method

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -40,7 +40,6 @@ from .serializers import FacilityDatasetSerializer
 from .serializers import FacilitySerializer
 from .serializers import FacilityUsernameSerializer
 from .serializers import FacilityUserSerializer
-from .serializers import FacilityUserSignupSerializer
 from .serializers import LearnerGroupSerializer
 from .serializers import MembershipSerializer
 from .serializers import PublicFacilitySerializer
@@ -286,7 +285,7 @@ class LearnerGroupViewSet(viewsets.ModelViewSet):
 @method_decorator(signin_redirect_exempt, name='dispatch')
 class SignUpViewSet(viewsets.ViewSet):
 
-    serializer_class = FacilityUserSignupSerializer
+    serializer_class = FacilityUserSerializer
 
     def extract_request_data(self, request):
         return {

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -37,28 +37,20 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         extra_kwargs = {'password': {'write_only': True}}
         fields = ('id', 'username', 'full_name', 'password', 'facility', 'roles', 'is_superuser')
 
-    def create(self, validated_data):
-        if FacilityUser.objects.filter(username__iexact=validated_data['username']).exists():
-            raise serializers.ValidationError(detail={'username': ['An account with that username already exists.']},
-                                              code=error_constants.USERNAME_ALREADY_EXISTS)
-        return super(FacilityUserSerializer, self).create(validated_data)
-
-    def update(self, instance, validated_data):
-        if validated_data.get('username') and FacilityUser.objects.exclude(id__exact=instance.id).filter(username__iexact=validated_data['username']).exists():
-            raise serializers.ValidationError(detail={'username': ['An account with that username already exists.']},
-                                              code=error_constants.USERNAME_ALREADY_EXISTS)
-        return super(FacilityUserSerializer, self).update(instance, validated_data)
-
-
-class FacilityUserSignupSerializer(FacilityUserSerializer):
-
-    def validate_username(self, value):
-        if FacilityUser.objects.filter(username__iexact=value).exists():
-            raise serializers.ValidationError(
-                detail='An account with that username already exists.',
-                code=error_constants.USERNAME_ALREADY_EXISTS
-            )
-        return value
+    def validate(self, attrs):
+        username = attrs.get('username')
+        # first condition is for creating object, second is for updating
+        facility = attrs.get('facility') or getattr(self.instance, 'facility')
+        # if obj doesn't exist, return data
+        try:
+            obj = FacilityUser.objects.get(username__iexact=username, facility=facility)
+        except FacilityUser.DoesNotExist:
+            return attrs
+        # if we are updating object, and this `instance` is the same object, return data
+        if self.instance and obj.id == self.instance.id:
+            return attrs
+        else:
+            raise serializers.ValidationError('An account with that username already exists.', code=error_constants.USERNAME_ALREADY_EXISTS)
 
 
 class FacilityUsernameSerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -411,7 +411,7 @@ class FacilityTestCase(TestCase):
 
 class FacilityUserTestCase(TestCase):
 
-    def test_able_to_create_user_with_same_username(self):
+    def test_able_to_create_user_with_same_username_at_orm_level(self):
         self.facility = Facility.objects.create()
         self.device_settings = DeviceSettings.objects.create()
         FacilityUser.objects.create(username='bob', facility=self.facility)

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -31,6 +31,9 @@ class NoFacilityFacilityUserSerializer(FacilityUserSerializer):
         model = FacilityUser
         fields = ('id', 'username', 'full_name', 'password', )
 
+    def validate(self, attrs):
+        return attrs
+
 
 class DeviceProvisionSerializer(serializers.Serializer):
     facility = FacilitySerializer()

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from django.db.models import Sum
 from rest_framework import serializers
 from rest_framework.serializers import SerializerMethodField
-from rest_framework.validators import UniqueTogetherValidator
 
+from kolibri.core import error_constants
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.exams.models import Exam
@@ -90,12 +90,20 @@ class ExamSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ('data_model_version',)
 
-        validators = [
-            UniqueTogetherValidator(
-                queryset=Exam.objects.all(),
-                fields=('collection', 'title')
-            )
-        ]
+    def validate(self, attrs):
+        title = attrs.get('title')
+        # first condition is for creating object, second is for updating
+        collection = attrs.get('collection') or getattr(self.instance, 'collection')
+        # if obj doesn't exist, return data
+        try:
+            obj = Exam.objects.get(title__iexact=title, collection=collection)
+        except Exam.DoesNotExist:
+            return attrs
+        # if we are updating object, and this `instance` is the same object, return data
+        if self.instance and obj.id == self.instance.id:
+            return attrs
+        else:
+            raise serializers.ValidationError('The fields title, collection must make a unique set.', code=error_constants.UNIQUE)
 
     def validate_question_sources(self, value):
         for question in value:

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 from .. import models
@@ -11,6 +12,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import provision_device
+
 
 DUMMY_PASSWORD = "password"
 
@@ -277,11 +279,11 @@ class ExamAPITestCase(APITestCase):
         })
         self.assertEqual(response.status_code, 403)
 
-    def test_cannot_create_exam_same_title(self):
+    def test_cannot_create_exam_same_title_case_insensitive(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(reverse("kolibri:core:exam-list"), {
-            "title": "title",
+            "title": "TiTlE",
             "question_count": 1,
             "active": True,
             "collection": self.facility.id,
@@ -292,7 +294,7 @@ class ExamAPITestCase(APITestCase):
             }],
         }, format="json")
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0]['id'], error_constants.UNIQUE)
 
 

--- a/kolibri/core/lessons/serializers.py
+++ b/kolibri/core/lessons/serializers.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-from rest_framework import serializers
 from rest_framework.serializers import JSONField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import PrimaryKeyRelatedField
@@ -71,7 +70,7 @@ class LessonSerializer(ModelSerializer):
         if self.instance and obj.id == self.instance.id:
             return attrs
         else:
-            raise serializers.ValidationError('The fields title, collection must make a unique set.', code=error_constants.UNIQUE)
+            raise ValidationError('The fields title, collection must make a unique set.', code=error_constants.UNIQUE)
 
     def validate_resources(self, resources):
         # Validates that every ContentNode passed into resources is actually installed

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 from .. import models
@@ -11,6 +12,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import provision_device
+
 
 DUMMY_PASSWORD = "password"
 
@@ -202,16 +204,16 @@ class LessonAPITestCase(APITestCase):
         })
         self.assertEqual(response.status_code, 403)
 
-    def test_cannot_create_lesson_same_title(self):
+    def test_cannot_create_lesson_same_title_case_insensitive(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(reverse("kolibri:core:lesson-list"), {
-            "title": "title",
+            "title": "TiTlE",
             "is_active": True,
             "collection": self.facility.id,
             "lesson_assignments": [{
                 "collection": self.facility.id,
             }],
         }, format="json")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0]['id'], error_constants.UNIQUE)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We now do case insensitive lookups when determining if a `title` is already being used for lessons and exams.
Same approach is used to clean up some of the serializer code for `FacilityUser` when doing lookups on `username`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try making lessons or exams with the same TitLeS.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
