### PR TITLE
Check the file size on disk after the file transfer

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -18,6 +18,10 @@ COPY_METHOD = "copy"
 
 logger = logging.getLogger(__name__)
 
+FILE_TRANSFERRED = 2
+FILE_SKIPPED = 1
+FILE_NOT_TRANSFERRED = 0
+
 
 class Command(AsyncCommand):
 
@@ -155,16 +159,16 @@ class Command(AsyncCommand):
                 finished = False
                 try:
                     while not finished:
-                        finished, increment = self._start_file_transfer(
+                        finished, status = self._start_file_transfer(
                             f, filetransfer, overall_progress_update)
 
                         if self.is_cancelled():
                             break
 
-                        if increment == 2:
+                        if status == FILE_TRANSFERRED:
                             file_checksums_to_annotate.append(f.id)
-                        else:
-                            number_of_skipped_files += increment
+                        elif status == FILE_SKIPPED:
+                            number_of_skipped_files += 1
                 except Exception as e:
                     exception = e
                     break
@@ -186,10 +190,10 @@ class Command(AsyncCommand):
         """
         Start to transfer the file from network/disk to the destination.
         Return value:
-            * True, 2 - successfully transfer the file.
-            * True, 1 - the file does not exist so it is skipped.
-            * True, 0 - the transfer is cancelled.
-            * False, 0 - the transfer fails and needs to retry.
+            * True, FILE_TRANSFERRED - successfully transfer the file.
+            * True, FILE_SKIPPED - the file does not exist so it is skipped.
+            * True, FILE_NOT_TRANSFERRED - the transfer is cancelled.
+            * False, FILE_NOT_TRANSFERRED - the transfer fails and needs to retry.
         """
         try:
             # Save the current progress value
@@ -200,10 +204,19 @@ class Command(AsyncCommand):
                 for chunk in filetransfer:
                     if self.is_cancelled():
                         filetransfer.cancel()
-                        return True, 0
+                        return True, FILE_NOT_TRANSFERRED
                     length = len(chunk)
                     overall_progress_update(length)
                     file_dl_progress_update(length)
+
+                # Ensure that if for some reason the total file size for the transfer
+                # is less than what we have marked in the database that we make up
+                # the difference so that the overall progress is never incorrect.
+                # This could happen, for example for a local transfer if a file
+                # has been replaced or corrupted (which we catch below) or for
+                # a remote transfer if the peer to peer transfer is is compressing
+                # files using gzip.
+                overall_progress_update(f.file_size - filetransfer.total_size)
 
                 # If size of the destination file is smaller than the size
                 # indicated in the database, it's very likely that the source
@@ -213,10 +226,9 @@ class Command(AsyncCommand):
                     e = "File {} is corrupted.".format(filetransfer.source)
                     logger.error("An error occurred during content import: {}".format(e))
                     os.remove(filetransfer.dest)
-                    overall_progress_update(f.file_size - dest_file_size_on_disk)
-                    return True, 1
+                    return True, FILE_SKIPPED
 
-            return True, 2
+            return True, FILE_TRANSFERRED
 
         except Exception as e:
             logger.error("An error occurred during content import: {}".format(e))
@@ -232,10 +244,10 @@ class Command(AsyncCommand):
                 logger.info('Waiting for 30 seconds before retrying import: {}\n'.format(
                     filetransfer.source))
                 sleep(30)
-                return False, 0
+                return False, FILE_NOT_TRANSFERRED
             else:
                 overall_progress_update(f.file_size)
-                return True, 1
+                return True, FILE_SKIPPED
 
     def handle_async(self, *args, **options):
         if options['command'] == 'network':


### PR DESCRIPTION
### Summary
Copied from #4793
> This PR is to fix the issue that the exercises are mistakenly considered as corrupted when transferring over local network. The issue behind that is we compare the size of the file over the network with the size in the database. Instead, we should compare the size of the file on the disk to the number in the database. Cherrypy compresses the files, so the size of the file over the network is smaller than the size in the database.

### Reviewer guidance
>1.  Check if we can successfully import exercises in CK-12 > Math > Elementary Math > Grade 1 > Addition and Subtraction facts to 10 from local network.
> 2. Check that if a file on the external drive is corrupted, whether the file would be skipped. I tested this by removing a file and then creating a random file with the same name.

### References
Supersedes #4793
Fixes #4790
https://community.learningequality.org/t/import-channel-content-from-network-location/985

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
