### PR TITLE
Filter popular and next steps recommendations by coach content.

### DIFF
--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -833,6 +833,30 @@ class ContentNodeAPITestCase(APITestCase):
         response_content_ids = set(node['content_id'] for node in response.json())
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
+    def test_popular_no_coach_content(self):
+        expected_content_ids = self._create_session_logs()
+        node = content.ContentNode.objects.get(content_id=expected_content_ids[0])
+        node.coach_content = True
+        node.save()
+        expected_content_ids = expected_content_ids[1:]
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-popular'))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(expected_content_ids), response_content_ids)
+
+    def test_popular_coach_has_coach_content(self):
+        coach = FacilityUser.objects.create(username="coach", facility=self.facility)
+        coach.set_password(DUMMY_PASSWORD)
+        coach.save()
+        self.facility.add_coach(coach)
+        expected_content_ids = self._create_session_logs()
+        node = content.ContentNode.objects.get(content_id=expected_content_ids[0])
+        node.coach_content = True
+        node.save()
+        self.client.login(username="coach", password=DUMMY_PASSWORD)
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-popular'))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(expected_content_ids), response_content_ids)
+
     def test_popular_ten_minute_cache(self):
         self._create_session_logs()
         response = self.client.get(reverse('kolibri:core:contentnode_slim-popular'))
@@ -965,6 +989,48 @@ class ContentNodeAPITestCase(APITestCase):
         response_content_ids = set(node['content_id'] for node in response.json())
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
+    def test_next_steps_prereq_coach_content_not_coach(self):
+        facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="user", facility=facility)
+        root = content.ContentNode.objects.get(title='root')
+        ContentSummaryLog.objects.create(channel_id=root.channel_id,
+                                         content_id=root.content_id,
+                                         user_id=user.id,
+                                         progress=1,
+                                         start_timestamp=timezone.now(),
+                                         kind='audio')
+        user.set_password(DUMMY_PASSWORD)
+        user.save()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        post_req = root.prerequisite_for.first()
+        post_req.coach_content = True
+        post_req.save()
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-next-steps', kwargs={"pk": user.id}))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(), response_content_ids)
+
+    def test_next_steps_prereq_coach_content_coach(self):
+        facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="user", facility=facility)
+        facility.add_coach(user)
+        root = content.ContentNode.objects.get(title='root')
+        ContentSummaryLog.objects.create(channel_id=root.channel_id,
+                                         content_id=root.content_id,
+                                         user_id=user.id,
+                                         progress=1,
+                                         start_timestamp=timezone.now(),
+                                         kind='audio')
+        user.set_password(DUMMY_PASSWORD)
+        user.save()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        post_req = root.prerequisite_for.first()
+        post_req.coach_content = True
+        post_req.save()
+        expected_content_ids = (post_req.content_id,)
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-next-steps', kwargs={"pk": user.id}))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(expected_content_ids), response_content_ids)
+
     def test_next_steps_sibling(self):
         facility = Facility.objects.create(name="MyFac")
         user = FacilityUser.objects.create(username="user", facility=facility)
@@ -1005,6 +1071,48 @@ class ContentNodeAPITestCase(APITestCase):
                                          start_timestamp=timezone.now(),
                                          kind='audio')
         expected_content_ids = []
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-next-steps', kwargs={"pk": user.id}))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(expected_content_ids), response_content_ids)
+
+    def test_next_steps_sibling_coach_content_not_coach(self):
+        facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="user", facility=facility)
+        node = content.ContentNode.objects.get(content_id='ce603df7c46b424b934348995e1b05fb')
+        ContentSummaryLog.objects.create(channel_id=node.channel_id,
+                                         content_id=node.content_id,
+                                         user_id=user.id,
+                                         progress=1,
+                                         start_timestamp=timezone.now(),
+                                         kind='audio')
+        user.set_password(DUMMY_PASSWORD)
+        user.save()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        sibling = node.get_next_sibling()
+        sibling.coach_content = True
+        sibling.save()
+        response = self.client.get(reverse('kolibri:core:contentnode_slim-next-steps', kwargs={"pk": user.id}))
+        response_content_ids = set(node['content_id'] for node in response.json())
+        self.assertSetEqual(set(), response_content_ids)
+
+    def test_next_steps_sibling_coach_content_coach(self):
+        facility = Facility.objects.create(name="MyFac")
+        user = FacilityUser.objects.create(username="user", facility=facility)
+        facility.add_coach(user)
+        node = content.ContentNode.objects.get(content_id='ce603df7c46b424b934348995e1b05fb')
+        ContentSummaryLog.objects.create(channel_id=node.channel_id,
+                                         content_id=node.content_id,
+                                         user_id=user.id,
+                                         progress=1,
+                                         start_timestamp=timezone.now(),
+                                         kind='audio')
+        user.set_password(DUMMY_PASSWORD)
+        user.save()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        sibling = node.get_next_sibling()
+        sibling.coach_content = True
+        sibling.save()
+        expected_content_ids = (sibling.content_id,)
         response = self.client.get(reverse('kolibri:core:contentnode_slim-next-steps', kwargs={"pk": user.id}))
         response_content_ids = set(node['content_id'] for node in response.json())
         self.assertSetEqual(set(expected_content_ids), response_content_ids)


### PR DESCRIPTION
### Summary
Filter popular and next steps recommendations by coach content.
Leave resume alone, assume people are grandfathered in.

### Reviewer guidance
Does the code look right? Is coach content now hidden for non-coach users on recommendations?

### References
Fixes #4717

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
