### PR TITLE
Fix reactivity in vuex commit

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
@@ -70,7 +70,8 @@ export default {
       state.contentList = contentList;
     },
     ADD_TO_SELECTED_EXERCISES(state, exercises) {
-      Object.assign(
+      state.selectedExercises = Object.assign(
+        {},
         state.selectedExercises,
         ...exercises.map(exercise => ({ [exercise.id]: exercise }))
       );


### PR DESCRIPTION
### Summary
Fix regression 'select all' in quiz creation didn't work due to the way reactivity works in Vue
https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats


### Reviewer guidance

1. As a coach or an admin, go to Coach- Plan - New quiz
2. Select one channel
3. Click on 'Select all' button

All the resources in the channel must be selected

### References
Solves #4823 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
