### PR TITLE
Add some other fixes to increment reactivity in vue store

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/index.js
@@ -1,3 +1,4 @@
+import Vue from 'kolibri.lib.vue';
 import * as actions from './actions';
 
 function getRandomInt() {
@@ -78,12 +79,12 @@ export default {
     },
     REMOVE_FROM_SELECTED_EXERCISES(state, exercises) {
       exercises.forEach(exercise => {
-        delete state.selectedExercises[exercise.id];
+        Vue.delete(state.selectedExercises, exercise.id);
       });
     },
     UPDATE_SELECTED_EXERCISES(state, exercises) {
       exercises.forEach(newExercise => {
-        Object.assign(state.selectedExercises[newExercise.id], newExercise);
+        Vue.set(state.selectedExercises, newExercise.id, newExercise);
       });
     },
     SET_AVAILABLE_QUESTIONS(state, availableQuestions) {


### PR DESCRIPTION
### Summary
This PR changes the way selectedExercises are updated and deleted in the vue store to make these changes reactive.

### Reviewer guidance
1. As a coach or an admin, go to Coach- Plan - New quiz
2. Select one channel
3. Click on 'Select all' checkbox
4. All the resources in the channel must be selected
5. Click again on 'Select all' checkbox
6. All the resources in the channel must be unselected

### References
* Closes #4823 
* Related to #4841 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
