### PR TITLE
new status summary widget, plus lots of fixes

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -21,7 +21,7 @@ class CoachToolsModule extends KolibriApp {
   ready() {
     router.beforeEach((to, from, next) => {
       this.store.commit('SET_PAGE_NAME', to.name);
-      if (to.name !== 'CoachClassListPage') {
+      if (!['CoachClassListPage', 'StatusTestPage'].includes(to.name)) {
         this.store
           .dispatch('initClassInfo', to.params.classId)
           .then(next, error => this.store.dispatch('handleApiError', error));

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
@@ -69,9 +69,9 @@ describe('coach summary data helpers', () => {
       expect(store.getters.getContentStatusForLearner('XXXX', 'XXXX')).toEqual('not_started');
     });
   });
-  describe('getContentStatusCounts', () => {
+  describe('getContentStatusTally', () => {
     it('returns total statuses given a content item and a list of learners', () => {
-      const output = store.getters.getContentStatusCounts('content_Q', [
+      const output = store.getters.getContentStatusTally('content_Q', [
         'learner_id_1',
         'learner_id_2',
         'learner_id_3',

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -46,7 +46,7 @@ export default {
       );
     };
   },
-  getContentStatusCounts(state, getters) {
+  getContentStatusTally(state, getters) {
     return function(contentId, learnerIds) {
       const tallies = {
         started: 0,
@@ -66,7 +66,7 @@ export default {
       return get(state.examLearnerStatusMap, [examId, learnerId, 'status'], STATUSES.notStarted);
     };
   },
-  getExamStatusCounts(state, getters) {
+  getExamStatusTally(state, getters) {
     return function(examId, learnerIds) {
       const tallies = {
         started: 0,
@@ -86,7 +86,7 @@ export default {
       return get(getters.lessonLearnerStatusMap, [lessonId, learnerId], STATUSES.notStarted);
     };
   },
-  getLessonStatusCounts(state, getters) {
+  getLessonStatusTally(state, getters) {
     return function(lessonId, learnerIds) {
       const tallies = {
         started: 0,

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -4,6 +4,7 @@ import { ClassroomResource } from 'kolibri.resources';
 import CoachClassListPage from '../views/CoachClassListPage';
 import HomePage from '../views/home/HomePage';
 import HomeActivityPage from '../views/home/HomeActivityPage';
+import StatusTestPage from '../views/StatusTestPage';
 import reportRoutes from './reportRoutes';
 import planRoutes from './planRoutes';
 
@@ -46,6 +47,13 @@ export default [
   {
     path: '/:classId/home/activity',
     component: HomeActivityPage,
+    handler() {
+      store.dispatch('notLoading');
+    },
+  },
+  {
+    path: '/statusTestPage',
+    component: StatusTestPage,
     handler() {
       store.dispatch('notLoading');
     },

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -4,7 +4,7 @@ import { ClassroomResource } from 'kolibri.resources';
 import CoachClassListPage from '../views/CoachClassListPage';
 import HomePage from '../views/home/HomePage';
 import HomeActivityPage from '../views/home/HomeActivityPage';
-import StatusTestPage from '../views/StatusTestPage';
+import StatusTestPage from '../views/common/status/StatusTestPage';
 import reportRoutes from './reportRoutes';
 import planRoutes from './planRoutes';
 
@@ -52,7 +52,7 @@ export default [
     },
   },
   {
-    path: '/statusTestPage',
+    path: '/about/statuses',
     component: StatusTestPage,
     handler() {
       store.dispatch('notLoading');

--- a/kolibri/plugins/coach/assets/src/views/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/StatusTestPage.vue
@@ -1,0 +1,203 @@
+<template>
+
+  <div class="overview">
+    <table>
+      <tr style="color: gray">
+        <th>scenario</th>
+        <th>example tally</th>
+        <th>status bar</th>
+        <th>verbosity</th>
+        <th>ratio variant</th>
+        <th>count variant</th>
+      </tr>
+      <tbody v-for="(tally, index) in testSummaries" :key="index" style="border: 2px solid gray">
+        <tr>
+          <th rowspan="2" style="max-width: 100px; text-align: left;">
+            {{ tally.name }}
+          </th>
+          <td rowspan="2">
+            <table>
+              <tr><td>not started</td><td> {{ tally.notStarted }}</td></tr>
+              <tr><td>started</td><td> {{ tally.started }}</td></tr>
+              <tr><td>completed</td><td> {{ tally.completed }}</td></tr>
+              <tr><td>help needed</td><td> {{ tally.helpNeeded }}</td></tr>
+            </table>
+          </td>
+          <td rowspan="2" style="width: 200px; text-align: center; position: relative;">
+            <div class="bar">
+              <ProgressSummaryBar
+                :started="tally.started + tally.helpNeeded"
+                :completed="tally.completed"
+                :total="tally.completed + tally.started + tally.notStarted + tally.helpNeeded"
+              />
+            </div>
+          </td>
+          <td style="text-align: center">long</td>
+          <td>
+            <StatusSummary :tallyObject="tally" :verbose="true" :ratio="true" />
+          </td>
+          <td>
+            <StatusSummary :tallyObject="tally" :verbose="true" :ratio="false" />
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center">short</td>
+          <td>
+            <StatusSummary :tallyObject="tally" :verbose="false" :ratio="true" />
+          </td>
+          <td>
+            <StatusSummary :tallyObject="tally" :verbose="false" :ratio="false" />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoach from './common';
+  import ProgressSummaryBar from './common/status/ProgressSummaryBar';
+  import StatusSummary from './common/status/StatusSummary';
+
+  export default {
+    name: 'StatusTestPage',
+    components: {
+      StatusSummary,
+      ProgressSummaryBar,
+    },
+    mixins: [commonCoach],
+    data() {
+      return {
+        testSummaries: [
+          {
+            name: 'all started',
+            started: 12,
+            notStarted: 0,
+            completed: 0,
+            helpNeeded: 0,
+          },
+          {
+            name: 'none started',
+            started: 0,
+            notStarted: 12,
+            completed: 0,
+            helpNeeded: 0,
+          },
+          {
+            name: 'all completed',
+            started: 0,
+            notStarted: 0,
+            completed: 12,
+            helpNeeded: 0,
+          },
+          {
+            name: 'all need help',
+            started: 0,
+            notStarted: 0,
+            completed: 0,
+            helpNeeded: 12,
+          },
+          {
+            name: 'some started',
+            started: 6,
+            notStarted: 6,
+            completed: 0,
+            helpNeeded: 0,
+          },
+          {
+            name: 'some completed',
+            started: 0,
+            notStarted: 6,
+            completed: 6,
+            helpNeeded: 0,
+          },
+          {
+            name: 'some completed, others need help',
+            started: 0,
+            notStarted: 0,
+            completed: 6,
+            helpNeeded: 6,
+          },
+          {
+            name: 'all started, some need help',
+            started: 6,
+            notStarted: 0,
+            completed: 0,
+            helpNeeded: 6,
+          },
+          {
+            name: 'some completed, some started',
+            started: 4,
+            notStarted: 4,
+            completed: 4,
+            helpNeeded: 0,
+          },
+          {
+            name: 'some completed, some need help',
+            started: 0,
+            notStarted: 4,
+            completed: 4,
+            helpNeeded: 4,
+          },
+          {
+            name: 'some started, some need help',
+            started: 4,
+            notStarted: 4,
+            completed: 0,
+            helpNeeded: 4,
+          },
+          {
+            name: 'some completed, some started, others need help',
+            started: 4,
+            notStarted: 0,
+            completed: 4,
+            helpNeeded: 4,
+          },
+          {
+            name: 'some completed, some started, some need help',
+            started: 3,
+            notStarted: 3,
+            completed: 3,
+            helpNeeded: 3,
+          },
+        ],
+      };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .overview {
+    padding: 30px;
+    margin: 30px;
+    background-color: white;
+  }
+
+  .bar {
+    display: inline-block;
+    width: 150px;
+    height: 16px;
+    margin: auto;
+  }
+
+  td,
+  tbody th {
+    padding: 4px;
+    padding-right: 8px;
+    padding-left: 8px;
+    font-weight: normal;
+    border: 1px solid #c8c8c8;
+  }
+
+  table table td,
+  table table tr {
+    border: none;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -35,10 +35,8 @@ import HeaderTable from './common/HeaderTable';
 import HeaderTableRow from './common/HeaderTable/HeaderTableRow';
 import HeaderTabs from './common/HeaderTabs';
 import HeaderTab from './common/HeaderTabs/HeaderTab';
-import LearnerProgressRatio from './common/status/LearnerProgressRatio';
-import LearnerProgressCount from './common/status/LearnerProgressCount';
-import LearnerProgressLabel from './common/status/LearnerProgressLabel';
 import StatusSummary from './common/status/StatusSummary';
+import HelpNeeded from './common/status/HelpNeeded';
 import ItemStatusRatio from './common/status/ItemStatusRatio';
 import ItemStatusCount from './common/status/ItemStatusCount';
 import ItemStatusLabel from './common/status/ItemStatusLabel';
@@ -74,10 +72,8 @@ export default {
     HeaderTableRow,
     HeaderTabs,
     HeaderTab,
-    LearnerProgressRatio,
-    LearnerProgressCount,
     StatusSummary,
-    LearnerProgressLabel,
+    HelpNeeded,
     ItemStatusRatio,
     ItemStatusCount,
     ItemStatusLabel,

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -36,6 +36,7 @@ import HeaderTableRow from './common/HeaderTable/HeaderTableRow';
 import HeaderTabs from './common/HeaderTabs';
 import HeaderTab from './common/HeaderTabs/HeaderTab';
 import StatusSummary from './common/status/StatusSummary';
+import StatusSimple from './common/status/StatusSimple';
 import HelpNeeded from './common/status/HelpNeeded';
 import ItemStatusRatio from './common/status/ItemStatusRatio';
 import ItemStatusCount from './common/status/ItemStatusCount';
@@ -73,6 +74,7 @@ export default {
     HeaderTabs,
     HeaderTab,
     StatusSummary,
+    StatusSimple,
     HelpNeeded,
     ItemStatusRatio,
     ItemStatusCount,

--- a/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
@@ -28,7 +28,7 @@
 
   .wrapper {
     position: relative;
-    margin-right: 16px;
+    white-space: nowrap;
   }
 
   .label {

--- a/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
@@ -2,7 +2,10 @@
 
   <span class="wrapper">
     <slot></slot>
-    <span class="label">{{ label }}</span>
+
+    <transition name="fade">
+      <span :key="label" class="label">{{ label }}</span>
+    </transition>
   </span>
 
 </template>
@@ -26,6 +29,8 @@
 
 <style lang="scss" scoped>
 
+   @import '~kolibri.styles.definitions';
+
   .wrapper {
     position: relative;
     white-space: nowrap;
@@ -40,6 +45,18 @@
     top: -1px;
     width: 16px;
     vertical-align: middle;
+  }
+
+  .fade-leave-active {
+    position: absolute;
+  }
+
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity $core-time ease;
+  }
+  .fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
+    opacity: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
@@ -29,7 +29,7 @@
 
 <style lang="scss" scoped>
 
-   @import '~kolibri.styles.definitions';
+  @import '~kolibri.styles.definitions';
 
   .wrapper {
     position: relative;

--- a/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LabeledIcon.vue
@@ -32,11 +32,12 @@
   }
 
   .label {
-    margin-left: 8px;
+    margin-left: 6px;
   }
 
   .wrapper svg {
     position: relative;
+    top: -1px;
     width: 16px;
     vertical-align: middle;
   }

--- a/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
@@ -1,16 +1,21 @@
 <template>
 
   <span>
-    <LabeledIcon :label="label">
+    <LabeledIcon
+      :label="label"
+      :style="active ? {} : { color: $coreGrey300 }"
+    >
       <mat-svg
         v-if="active"
-        category="action"
-        name="check_circle"
+        category="image"
+        name="brightness_1"
+        :style="{ fill: $coreStatusCorrect }"
       />
       <mat-svg
         v-else
-        category="content"
-        name="remove_circle"
+        category="image"
+        name="brightness_1"
+        :style="{ fill: $coreGrey300 }"
       />
     </LabeledIcon>
   </span>
@@ -20,6 +25,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import LabeledIcon from './LabeledIcon';
 
   export default {
@@ -38,6 +44,7 @@
       inactive: 'Inactive',
     },
     computed: {
+      ...mapGetters(['$coreStatusCorrect', '$coreGrey300']),
       label() {
         return this.active ? this.$tr('active') : this.$tr('inactive');
       },

--- a/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
@@ -1,16 +1,21 @@
 <template>
 
   <span>
-    <LabeledIcon :label="label">
+    <LabeledIcon
+      :label="label"
+      :style="active ? {} : { color: $coreGrey300 }"
+    >
       <mat-svg
         v-if="active"
-        category="action"
-        name="check_circle"
+        category="image"
+        name="brightness_1"
+        :style="{ fill: $coreStatusCorrect }"
       />
       <mat-svg
         v-else
-        category="content"
-        name="remove_circle"
+        category="image"
+        name="brightness_1"
+        :style="{ fill: $coreGrey300 }"
       />
     </LabeledIcon>
   </span>
@@ -20,6 +25,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import LabeledIcon from './LabeledIcon';
 
   export default {
@@ -38,6 +44,7 @@
       inactive: 'Inactive',
     },
     computed: {
+      ...mapGetters(['$coreStatusCorrect', '$coreGrey300']),
       label() {
         return this.active ? this.$tr('active') : this.$tr('inactive');
       },

--- a/kolibri/plugins/coach/assets/src/views/common/status/CoachStatusIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/CoachStatusIcon.vue
@@ -25,9 +25,9 @@
   />
   <mat-svg
     v-else-if="icon === ICONS.nothing"
-    category="content"
-    name="remove_circle"
-    :style="{ fill: $coreGrey200 }"
+    category="image"
+    name="brightness_1"
+    :style="{ fill: $coreGrey300 }"
   />
 
 </template>
@@ -54,7 +54,7 @@
         '$coreStatusMastered',
         '$coreStatusProgress',
         '$coreStatusWrong',
-        '$coreGrey200',
+        '$coreGrey300',
       ]),
       ICONS() {
         return ICONS;

--- a/kolibri/plugins/coach/assets/src/views/common/status/HelpNeeded.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/HelpNeeded.vue
@@ -23,8 +23,10 @@
   export default {
     name: 'HelpNeeded',
     components: {
-      LearnerProgressCount,
-      LearnerProgressRatio,
+      // eslint-disable-next-line vue/no-unused-components
+      LearnerProgressCount, // it is used, it's just referenced dynamically
+      // eslint-disable-next-line vue/no-unused-components
+      LearnerProgressRatio, // it is used, it's just referenced dynamically
     },
     props: {
       count: {

--- a/kolibri/plugins/coach/assets/src/views/common/status/HelpNeeded.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/HelpNeeded.vue
@@ -1,0 +1,69 @@
+<template>
+
+  <div>
+    <component
+      :is="ratio ? LearnerProgressRatio : LearnerProgressCount"
+      :verb="VERBS.needHelp"
+      :icon="ICONS.help"
+      :total="total"
+      :count="count"
+      :verbosity="verbosity"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { VERBS, ICONS } from './constants';
+  import LearnerProgressCount from './LearnerProgressCount';
+  import LearnerProgressRatio from './LearnerProgressRatio';
+
+  export default {
+    name: 'HelpNeeded',
+    components: {
+      LearnerProgressCount,
+      LearnerProgressRatio,
+    },
+    props: {
+      count: {
+        type: Number,
+        required: true,
+      },
+      total: {
+        type: Number,
+        default: 0,
+      },
+      verbose: {
+        type: Boolean,
+        default: true,
+      },
+      ratio: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    computed: {
+      verbosity() {
+        return this.verbose ? 1 : 0;
+      },
+      ICONS() {
+        return ICONS;
+      },
+      VERBS() {
+        return VERBS;
+      },
+      LearnerProgressCount() {
+        return LearnerProgressCount;
+      },
+      LearnerProgressRatio() {
+        return LearnerProgressRatio;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressCount.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressCount.vue
@@ -1,14 +1,25 @@
 <template>
 
-  <LabeledIcon :label="text">
-    <CoachStatusIcon :icon="icon" />
-  </LabeledIcon>
+  <div>
+    <LabeledIcon :label="text">
+      <CoachStatusIcon ref="status" :icon="icon" />
+    </LabeledIcon>
+    <KTooltip
+      v-if="false"
+      reference="status"
+      placement="top"
+      :refs="$refs"
+    >
+      {{ tooltip }}
+    </KTooltip>
+  </div>
 
 </template>
 
 
 <script>
 
+  import KTooltip from 'kolibri.coreVue.components.KTooltip';
   import LabeledIcon from '../LabeledIcon';
   import { coachStrings } from '../commonCoachStrings';
   import CoachStatusIcon from './CoachStatusIcon';
@@ -17,6 +28,7 @@
   export default {
     name: 'LearnerProgressCount',
     components: {
+      KTooltip,
       CoachStatusIcon,
       LabeledIcon,
     },
@@ -31,16 +43,29 @@
         type: String,
         required: true,
       },
+      showRatioInTooltip: {
+        type: Boolean,
+        default: false,
+      },
     },
     computed: {
+      strings() {
+        return this.translations.learnerProgress[this.verb];
+      },
       text() {
         if (!this.verbosityNumber) {
           return coachStrings.$tr('integer', { value: this.count });
         }
-        return this.translations.learnerProgress[this.verb].$tr(
-          this.shorten('count', this.verbosityNumber),
-          { count: this.count }
-        );
+        return this.strings.$tr(this.shorten('count', this.verbosityNumber), { count: this.count });
+      },
+      tooltip() {
+        if (this.showRatioInTooltip) {
+          return this.strings.$tr(this.shorten('ratio', 2), {
+            count: this.count,
+            total: this.total,
+          });
+        }
+        return this.strings.$tr(this.shorten('count', 2), { count: this.count });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressLabel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressLabel.vue
@@ -1,14 +1,25 @@
 <template>
 
-  <LabeledIcon :label="text">
-    <CoachStatusIcon :icon="icon" />
-  </LabeledIcon>
+  <div>
+    <LabeledIcon :label="text">
+      <CoachStatusIcon ref="status" :icon="icon" />
+    </LabeledIcon>
+    <KTooltip
+      v-if="false"
+      reference="status"
+      placement="top"
+      :refs="$refs"
+    >
+      {{ tooltip }}
+    </KTooltip>
+  </div>
 
 </template>
 
 
 <script>
 
+  import KTooltip from 'kolibri.coreVue.components.KTooltip';
   import LabeledIcon from '../LabeledIcon';
   import { coachStrings } from '../commonCoachStrings'; // eslint-disable-line no-unused-vars
   import CoachStatusIcon from './CoachStatusIcon';
@@ -19,6 +30,7 @@
     components: {
       CoachStatusIcon,
       LabeledIcon,
+      KTooltip,
     },
     mixins: [statusStringsMixin],
     props: {
@@ -33,14 +45,19 @@
       },
     },
     computed: {
+      strings() {
+        return this.translations.learnerProgress[this.verb];
+      },
       text() {
         if (!this.verbosityNumber) {
           return '';
         }
-        return this.translations.learnerProgress[this.verb].$tr(
-          this.shorten('label', this.verbosityNumber),
-          { count: this.count }
-        );
+        return this.strings.$tr(this.shorten('label', this.verbosityNumber), { count: this.count });
+      },
+      tooltip() {
+        return this.strings.$tr(this.shorten('label', 2), {
+          count: this.count,
+        });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressRatio.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressRatio.vue
@@ -1,14 +1,25 @@
 <template>
 
-  <LabeledIcon :label="text">
-    <CoachStatusIcon :icon="icon" />
-  </LabeledIcon>
+  <div>
+    <LabeledIcon :label="text">
+      <CoachStatusIcon ref="status" :icon="icon" />
+    </LabeledIcon>
+    <KTooltip
+      v-if="false"
+      reference="status"
+      placement="top"
+      :refs="$refs"
+    >
+      {{ tooltip }}
+    </KTooltip>
+  </div>
 
 </template>
 
 
 <script>
 
+  import KTooltip from 'kolibri.coreVue.components.KTooltip';
   import LabeledIcon from '../LabeledIcon';
   import { coachStrings } from '../commonCoachStrings';
   import CoachStatusIcon from './CoachStatusIcon';
@@ -19,13 +30,10 @@
     components: {
       CoachStatusIcon,
       LabeledIcon,
+      KTooltip,
     },
     mixins: [statusStringsMixin],
     props: {
-      total: {
-        type: Number,
-        required: true,
-      },
       verb: {
         type: String,
         required: true,
@@ -37,25 +45,28 @@
       },
     },
     computed: {
+      strings() {
+        return this.translations.learnerProgress[this.verb];
+      },
       text() {
         if (!this.verbosityNumber) {
           return coachStrings.$tr('ratioShort', { value: this.count, total: this.total });
         }
         if (this.count === this.total && this.total > 2 && this.verb != 'notStarted') {
-          return this.translations.learnerProgress[this.verb].$tr(
-            this.shorten('allOfMoreThanTwo', this.verbosityNumber),
-            {
-              total: this.total,
-            }
-          );
-        }
-        return this.translations.learnerProgress[this.verb].$tr(
-          this.shorten('ratio', this.verbosityNumber),
-          {
-            count: this.count,
+          return this.strings.$tr(this.shorten('allOfMoreThanTwo', this.verbosityNumber), {
             total: this.total,
-          }
-        );
+          });
+        }
+        return this.strings.$tr(this.shorten('ratio', this.verbosityNumber), {
+          count: this.count,
+          total: this.total,
+        });
+      },
+      tooltip() {
+        return this.strings.$tr(this.shorten('ratio', 2), {
+          count: this.count,
+          total: this.total,
+        });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -11,23 +11,11 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import tallyMixin from './tallyMixin';
 
   export default {
     name: 'ProgressSummaryBar',
-    props: {
-      completed: {
-        type: Number,
-        required: true,
-      },
-      started: {
-        type: Number,
-        required: true,
-      },
-      total: {
-        type: Number,
-        required: true,
-      },
-    },
+    mixins: [tallyMixin],
     computed: {
       ...mapGetters(['$coreStatusProgress', '$coreStatusMastered']),
       percentageCompleted() {
@@ -40,6 +28,7 @@
         };
       },
       percentageStarted() {
+        // add on 'started' for offset
         return (this.started + this.completed) / this.total;
       },
       barStyleStarted() {
@@ -65,7 +54,7 @@
     overflow: hidden;
     background-color: #dedede;
     border-radius: $radius;
-    opacity: 0.6;
+    opacity: 0.5;
   }
 
   .bar {

--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -13,7 +13,7 @@
   import { mapGetters } from 'vuex';
 
   export default {
-    name: 'DashboardBar',
+    name: 'ProgressSummaryBar',
     props: {
       completed: {
         type: Number,

--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -2,6 +2,11 @@
 
   <div class="bar-wrapper">
     <div class="bar" :style="barStyleStarted"></div>
+    <div
+      v-if="showErrorBar" 
+      class="help-line" 
+      :style="helpLineStyle"
+    ></div>
     <div class="bar" :style="barStyleCompleted"></div>
   </div>
 
@@ -16,25 +21,35 @@
   export default {
     name: 'ProgressSummaryBar',
     mixins: [tallyMixin],
-    computed: {
-      ...mapGetters(['$coreStatusProgress', '$coreStatusMastered']),
-      percentageCompleted() {
-        return this.completed / this.total;
+    props: {
+      showErrorBar: {
+        type: Boolean,
+        default: false,
       },
+    },
+    computed: {
+      ...mapGetters(['$coreStatusProgress', '$coreStatusMastered', '$coreStatusWrong']),
       barStyleCompleted() {
         return {
-          width: `${Math.floor(100 * this.percentageCompleted)}%`,
+          width: `${Math.floor((100 * this.completed) / this.total)}%`,
           backgroundColor: this.$coreStatusMastered,
         };
       },
-      percentageStarted() {
-        // add on 'started' for offset
-        return (this.started + this.completed) / this.total;
-      },
       barStyleStarted() {
+        const widthRatio = this.started / this.total;
         return {
-          width: `${Math.floor(100 * this.percentageStarted)}%`,
+          marginLeft: `${Math.floor((100 * this.completed) / this.total)}%`,
+          width: `${Math.floor(100 * widthRatio)}%`,
           backgroundColor: this.$coreStatusProgress,
+        };
+      },
+      helpLineStyle() {
+        // add on 'completed' for offset
+        const widthRatio = this.helpNeeded / this.total;
+        return {
+          marginLeft: `${Math.floor((100 * this.completed) / this.total)}%`,
+          width: `${Math.floor(100 * widthRatio)}%`,
+          backgroundColor: this.$coreStatusWrong,
         };
       },
     },
@@ -54,13 +69,23 @@
     overflow: hidden;
     background-color: #dedede;
     border-radius: $radius;
-    opacity: 0.5;
   }
 
   .bar {
     position: absolute;
     height: 100%;
     margin-right: auto;
+    opacity: 0.55;
+    transition: all $core-time ease;
+  }
+
+  .help-line {
+    position: absolute;
+    bottom: 0;
+    width: 45%;
+    height: 2px;
+    margin-right: auto;
+    background-color: red;
     transition: all $core-time ease;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSimple.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSimple.vue
@@ -1,0 +1,94 @@
+<template>
+
+  <LearnerProgressLabel
+    :verb="verb"
+    :icon="icon"
+    :verbosity="verbosity"
+    :style="style"
+    :count="1"
+  />
+
+</template>
+
+
+<script>
+
+  import { mapGetters } from 'vuex';
+  import { STATUSES } from '../../../modules/classSummary/constants';
+  import { VERBS, ICONS } from './constants';
+  import LearnerProgressLabel from './LearnerProgressLabel';
+
+  const VERB_MAP = {
+    [STATUSES.notStarted]: VERBS.notStarted,
+    [STATUSES.started]: VERBS.started,
+    [STATUSES.helpNeeded]: VERBS.needHelp,
+    [STATUSES.completed]: VERBS.completed,
+  };
+
+  const ICON_MAP = {
+    [STATUSES.notStarted]: ICONS.nothing,
+    [STATUSES.started]: ICONS.clock,
+    [STATUSES.helpNeeded]: ICONS.help,
+    [STATUSES.completed]: ICONS.star,
+  };
+
+  export default {
+    name: 'StatusSimple',
+    components: {
+      LearnerProgressLabel,
+    },
+    props: {
+      verbose: {
+        type: Boolean,
+        default: true,
+      },
+      status: {
+        type: String,
+        required: true,
+      },
+    },
+    computed: {
+      ...mapGetters(['$coreGrey300']),
+      verb() {
+        return VERB_MAP[this.status];
+      },
+      icon() {
+        return ICON_MAP[this.status];
+      },
+      verbosity() {
+        return this.verbose ? 1 : 0;
+      },
+      style() {
+        if (this.status === STATUSES.notStarted) {
+          return { color: this.$coreGrey300 };
+        }
+        return '';
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .multi-line .item {
+    display: block;
+  }
+
+  .single-line {
+    white-space: nowrap;
+  }
+
+  .single-line .item {
+    display: inline-block;
+    &:not(:last-child) {
+      margin-right: 16px;
+    }
+  }
+
+  .lighten {
+    color: #b3b3b3;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -26,8 +26,7 @@
     </template>
     <template v-else-if="total === notStarted && !showAll">
       <!-- special cases when no one has started -->
-      <component
-        :is="ratio ? LearnerProgressRatio : LearnerProgressCount"
+      <LearnerProgressCount
         class="item"
         :style="{ color: $coreGrey300 }"
         :verb="VERBS.notStarted"

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -50,7 +50,7 @@
       />
       <component
         :is="!verbose || completed ? LearnerProgressCount : LearnerProgressRatio"
-        v-if="started"
+        v-if="showItem(started)"
         class="item"
         :verb="VERBS.started"
         :icon="ICONS.clock"
@@ -60,7 +60,7 @@
       />
       <component
         :is="!verbose || started || completed ? LearnerProgressCount : LearnerProgressRatio"
-        v-if="helpNeeded && showNeedsHelp"
+        v-if="showItem(helpNeeded) && showNeedsHelp"
         class="item"
         :verb="VERBS.needHelp"
         :icon="ICONS.help"
@@ -69,7 +69,7 @@
         :verbosity="verbosity"
       />
       <LearnerProgressCount
-        v-if="!verbose"
+        v-if="showItem(!verbose)"
         class="item lighten"
         :verb="VERBS.notStarted"
         :icon="ICONS.nothing"
@@ -81,7 +81,7 @@
     <template v-else>
       <!-- for counts -->
       <LearnerProgressCount
-        v-if="completed"
+        v-if="showItem(completed)"
         class="item"
         :verb="VERBS.completed"
         :icon="ICONS.star"
@@ -90,7 +90,7 @@
         :verbosity="verbosity"
       />
       <LearnerProgressCount
-        v-if="started"
+        v-if="showItem(started)"
         class="item"
         :verb="VERBS.started"
         :icon="ICONS.clock"
@@ -99,7 +99,7 @@
         :verbosity="verbosity"
       />
       <LearnerProgressCount
-        v-if="helpNeeded && showNeedsHelp"
+        v-if="showItem(helpNeeded) && showNeedsHelp"
         class="item"
         :verb="VERBS.needHelp"
         :icon="ICONS.help"
@@ -137,6 +137,10 @@
         type: Boolean,
         default: true,
       },
+      singleLineShowZeros: {
+        type: Boolean,
+        default: true,
+      },
       showNeedsHelp: {
         type: Boolean,
         default: true,
@@ -157,6 +161,11 @@
       },
       LearnerProgressRatio() {
         return LearnerProgressRatio;
+      },
+    },
+    methods: {
+      showItem(suggested) {
+        return suggested || (this.singleLineShowZeros && !this.verbose);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -47,6 +47,7 @@
         :total="total"
         :count="completed"
         :verbosity="verbosity"
+        showRatioInTooltip
       />
       <component
         :is="!verbose || completed ? LearnerProgressCount : LearnerProgressRatio"
@@ -57,6 +58,7 @@
         :total="total"
         :count="started"
         :verbosity="verbosity"
+        showRatioInTooltip
       />
       <component
         :is="!verbose || started || completed ? LearnerProgressCount : LearnerProgressRatio"
@@ -67,6 +69,7 @@
         :total="total"
         :count="helpNeeded"
         :verbosity="verbosity"
+        showRatioInTooltip
       />
       <LearnerProgressCount
         v-if="showItem(!verbose)"
@@ -76,6 +79,7 @@
         :total="total"
         :count="notStarted"
         :verbosity="verbosity"
+        showRatioInTooltip
       />
     </template>
     <template v-else>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -11,7 +11,7 @@
     See locahost:8000/coach/#/about/learnerStatusTypes for a parametric overview
     of the possible behaviors.
    -->
-  <div :class="{ verbose }">
+  <div :class="verbose ? 'multi-line' : 'single-line'">
     <template v-if="total === completed">
       <!-- special cases when everyone has finished -->
       <component
@@ -166,8 +166,19 @@
 
 <style lang="scss" scoped>
 
-  .verbose .item {
+  .multi-line .item {
     display: block;
+  }
+
+  .single-linec {
+    white-space: nowrap;
+  }
+
+  .single-line .item {
+    display: inline-block;
+    &:not(:last-child) {
+      margin-right: 16px;
+    }
   }
 
   .lighten {

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -12,7 +12,7 @@
     of the possible behaviors.
    -->
   <div :class="verbose ? 'multi-line' : 'single-line'">
-    <template v-if="total === completed">
+    <template v-if="total === completed && !showAll">
       <!-- special cases when everyone has finished -->
       <component
         :is="ratio || verbose ? LearnerProgressRatio : LearnerProgressCount"
@@ -24,7 +24,7 @@
         :verbosity="verbosity"
       />
     </template>
-    <template v-else-if="total === notStarted">
+    <template v-else-if="total === notStarted && !showAll">
       <!-- special cases when no one has started -->
       <component
         :is="ratio ? LearnerProgressRatio : LearnerProgressCount"
@@ -40,7 +40,7 @@
       <!-- for ratios we only want to display the ratio on the first displayed item -->
       <component
         :is="!verbose ? LearnerProgressCount : LearnerProgressRatio"
-        v-if="completed"
+        v-if="showItem(completed)"
         class="item"
         :verb="VERBS.completed"
         :icon="ICONS.star"
@@ -162,10 +162,13 @@
       LearnerProgressRatio() {
         return LearnerProgressRatio;
       },
+      showAll() {
+        return this.singleLineShowZeros && !this.verbose;
+      },
     },
     methods: {
       showItem(suggested) {
-        return suggested || (this.singleLineShowZeros && !this.verbose);
+        return suggested || this.showAll;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -28,7 +28,8 @@
       <!-- special cases when no one has started -->
       <component
         :is="ratio ? LearnerProgressRatio : LearnerProgressCount"
-        class="item lighten"
+        class="item"
+        :style="{ color: $coreGrey300 }"
         :verb="VERBS.notStarted"
         :icon="ICONS.nothing"
         :total="total"
@@ -73,7 +74,8 @@
       />
       <LearnerProgressCount
         v-if="showItem(!verbose)"
-        class="item lighten"
+        class="item"
+        :style="{ color: $coreGrey300 }"
         :verb="VERBS.notStarted"
         :icon="ICONS.nothing"
         :total="total"
@@ -119,6 +121,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import { VERBS, ICONS } from './constants';
   import LearnerProgressCount from './LearnerProgressCount';
   import LearnerProgressRatio from './LearnerProgressRatio';
@@ -151,6 +154,7 @@
       },
     },
     computed: {
+      ...mapGetters(['$coreGrey300']),
       verbosity() {
         return this.verbose ? 1 : 0;
       },
@@ -186,7 +190,7 @@
     display: block;
   }
 
-  .single-linec {
+  .single-line {
     white-space: nowrap;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -1,35 +1,189 @@
 <template>
 
-  <div>
-    {{ completed }} / {{ started }} / {{ total }}
+  <div :class="{ verbose }">
+    <template v-if="total === completed">
+      <!-- special cases when everyone has finished -->
+      <component
+        :is="ratio || verbose ? LearnerProgressRatio : LearnerProgressCount"
+        class="item"
+        :verb="VERBS.completed"
+        :icon="ICONS.star"
+        :total="total"
+        :count="completed"
+        :verbosity="verbosity"
+      />
+    </template>
+    <template v-else-if="total === notStarted">
+      <!-- special cases when no one has started -->
+      <component
+        :is="ratio ? LearnerProgressRatio : LearnerProgressCount"
+        class="item lighten"
+        :verb="VERBS.notStarted"
+        :icon="ICONS.nothing"
+        :total="total"
+        :count="notStarted"
+        :verbosity="verbosity"
+      />
+    </template>
+    <template v-else-if="ratio">
+      <!-- for ratios we only want to display the ratio on the first displayed item -->
+      <component
+        :is="!verbose ? LearnerProgressCount : LearnerProgressRatio"
+        v-if="completed"
+        class="item"
+        :verb="VERBS.completed"
+        :icon="ICONS.star"
+        :total="total"
+        :count="completed"
+        :verbosity="verbosity"
+      />
+      <component
+        :is="!verbose || completed ? LearnerProgressCount : LearnerProgressRatio"
+        v-if="started"
+        class="item"
+        :verb="VERBS.started"
+        :icon="ICONS.clock"
+        :total="total"
+        :count="started"
+        :verbosity="verbosity"
+      />
+      <component
+        :is="!verbose || started || completed ? LearnerProgressCount : LearnerProgressRatio"
+        v-if="helpNeeded"
+        class="item"
+        :verb="VERBS.needHelp"
+        :icon="ICONS.help"
+        :total="total"
+        :count="helpNeeded"
+        :verbosity="verbosity"
+      />
+      <LearnerProgressCount
+        v-if="!verbose"
+        class="item lighten"
+        :verb="VERBS.notStarted"
+        :icon="ICONS.nothing"
+        :total="total"
+        :count="notStarted"
+        :verbosity="verbosity"
+      />
+    </template>
+    <template v-else>
+      <!-- for counts -->
+      <LearnerProgressCount
+        v-if="completed"
+        class="item"
+        :verb="VERBS.completed"
+        :icon="ICONS.star"
+        :total="total"
+        :count="completed"
+        :verbosity="verbosity"
+      />
+      <LearnerProgressCount
+        v-if="started"
+        class="item"
+        :verb="VERBS.started"
+        :icon="ICONS.clock"
+        :total="total"
+        :count="started"
+        :verbosity="verbosity"
+      />
+      <LearnerProgressCount
+        v-if="helpNeeded"
+        class="item"
+        :verb="VERBS.needHelp"
+        :icon="ICONS.help"
+        :total="total"
+        :count="helpNeeded"
+        :verbosity="verbosity"
+      />
+    </template>
   </div>
+
 
 </template>
 
 
 <script>
 
+  import { VERBS, ICONS } from './constants';
+  import LearnerProgressCount from './LearnerProgressCount';
+  import LearnerProgressRatio from './LearnerProgressRatio';
+
   export default {
     name: 'StatusSummary',
-    components: {},
+    components: {
+      LearnerProgressCount,
+      LearnerProgressRatio,
+    },
     props: {
-      total: {
-        type: Number,
+      // Every learner should be tallied into _one and only_ one status
+      tallyObject: {
+        type: Object,
         required: true,
+        validator(value) {
+          return (
+            Number.isInteger(value.started) &&
+            Number.isInteger(value.notStarted) &&
+            Number.isInteger(value.completed) &&
+            Number.isInteger(value.helpNeeded)
+          );
+        },
       },
-      completed: {
-        type: Number,
-        required: true,
+      verbose: {
+        type: Boolean,
+        default: true,
       },
-      started: {
-        type: Number,
-        required: true,
+      ratio: {
+        type: Boolean,
+        default: true,
       },
     },
-    computed: {},
+    computed: {
+      started() {
+        // To the user, all these are considered having 'started'
+        return this.tallyObject.started + this.tallyObject.helpNeeded;
+      },
+      completed() {
+        return this.tallyObject.completed;
+      },
+      helpNeeded() {
+        return this.tallyObject.helpNeeded;
+      },
+      notStarted() {
+        return this.tallyObject.notStarted;
+      },
+      total() {
+        return this.started + this.tallyObject.completed + this.notStarted;
+      },
+      verbosity() {
+        return this.verbose ? 1 : 0;
+      },
+      ICONS() {
+        return ICONS;
+      },
+      VERBS() {
+        return VERBS;
+      },
+      LearnerProgressCount() {
+        return LearnerProgressCount;
+      },
+      LearnerProgressRatio() {
+        return LearnerProgressRatio;
+      },
+    },
   };
 
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .verbose .item {
+    display: block;
+  }
+
+  .lighten {
+    color: #b3b3b3;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -5,10 +5,10 @@
     <div class="moving">
       <ProgressSummaryBar
         :showErrorBar="true"
-        :tallyObject="movingTally"
+        :tally="movingTally"
       />
       <StatusSummary
-        :tallyObject="movingTally"
+        :tally="movingTally"
         :verbose="false"
         :ratio="true"
         :showNeedsHelp="true"
@@ -40,24 +40,24 @@
           </td>
           <td rowspan="2" style="width: 200px; text-align: center; position: relative;">
             <div class="bar">
-              <ProgressSummaryBar :showErrorBar="true" :tallyObject="tally" />
+              <ProgressSummaryBar :showErrorBar="true" :tally="tally" />
             </div>
           </td>
           <td style="text-align: center">long</td>
           <td>
-            <StatusSummary :tallyObject="tally" :verbose="true" :ratio="true" />
+            <StatusSummary :tally="tally" :verbose="true" :ratio="true" />
           </td>
           <td>
-            <StatusSummary :tallyObject="tally" :verbose="true" :ratio="false" />
+            <StatusSummary :tally="tally" :verbose="true" :ratio="false" />
           </td>
         </tr>
         <tr>
           <td style="text-align: center">short</td>
           <td>
-            <StatusSummary :tallyObject="tally" :verbose="false" :ratio="true" />
+            <StatusSummary :tally="tally" :verbose="false" :ratio="true" />
           </td>
           <td>
-            <StatusSummary :tallyObject="tally" :verbose="false" :ratio="false" />
+            <StatusSummary :tally="tally" :verbose="false" :ratio="false" />
           </td>
         </tr>
       </tbody>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -3,7 +3,8 @@
   <div class="overview">
 
     <div class="moving">
-      <ProgressSummaryBar
+      <ProgressSummaryBar 
+        :showErrorBar="true"
         :tallyObject="movingTally"
       />
       <StatusSummary
@@ -39,7 +40,7 @@
           </td>
           <td rowspan="2" style="width: 200px; text-align: center; position: relative;">
             <div class="bar">
-              <ProgressSummaryBar :tallyObject="tally" />
+              <ProgressSummaryBar :showErrorBar="true" :tallyObject="tally" />
             </div>
           </td>
           <td style="text-align: center">long</td>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -1,6 +1,20 @@
 <template>
 
   <div class="overview">
+
+    <div class="moving">
+      <ProgressSummaryBar
+        :tallyObject="movingTally"
+      />
+      <StatusSummary
+        :tallyObject="movingTally"
+        :verbose="false"
+        :ratio="false"
+        :showNeedsHelp="true"
+        :singleLineShowZeros="true"
+      />
+    </div>
+
     <table>
       <tr style="color: gray">
         <th>scenario</th>
@@ -160,7 +174,40 @@
             helpNeeded: 3,
           },
         ],
+        started: 3,
+        completed: 0,
+        notStarted: 10,
+        helpNeeded: 1,
       };
+    },
+    computed: {
+      movingTally() {
+        return {
+          completed: this.completed,
+          notStarted: this.notStarted,
+          started: this.started,
+          helpNeeded: this.helpNeeded,
+        };
+      },
+    },
+    mounted() {
+      this.update();
+    },
+    methods: {
+      update() {
+        if (this.notStarted === 0) {
+          this.notStarted = 12;
+          this.completed = 0;
+          this.started = 3;
+          this.helpNeeded = 0;
+        } else {
+          this.notStarted -= 2;
+          this.completed += 1;
+          this.started += 1;
+          this.helpNeeded = this.helpNeeded ? 0 : this.started;
+        }
+        setTimeout(this.update, 5000);
+      },
     },
   };
 
@@ -168,6 +215,14 @@
 
 
 <style lang="scss" scoped>
+
+  .moving {
+    margin: 64px;
+  }
+  .moving > :last-child {
+    margin-top: 8px;
+    margin-bottom: 64px;
+  }
 
   .overview {
     padding: 30px;

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -25,11 +25,7 @@
           </td>
           <td rowspan="2" style="width: 200px; text-align: center; position: relative;">
             <div class="bar">
-              <ProgressSummaryBar
-                :started="tally.started + tally.helpNeeded"
-                :completed="tally.completed"
-                :total="tally.completed + tally.started + tally.notStarted + tally.helpNeeded"
-              />
+              <ProgressSummaryBar :tallyObject="tally" />
             </div>
           </td>
           <td style="text-align: center">long</td>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -3,14 +3,14 @@
   <div class="overview">
 
     <div class="moving">
-      <ProgressSummaryBar 
+      <ProgressSummaryBar
         :showErrorBar="true"
         :tallyObject="movingTally"
       />
       <StatusSummary
         :tallyObject="movingTally"
         :verbose="false"
-        :ratio="false"
+        :ratio="true"
         :showNeedsHelp="true"
         :singleLineShowZeros="true"
       />

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -58,9 +58,9 @@
 
 <script>
 
-  import commonCoach from './common';
-  import ProgressSummaryBar from './common/status/ProgressSummaryBar';
-  import StatusSummary from './common/status/StatusSummary';
+  import commonCoach from '../../common';
+  import ProgressSummaryBar from '../../common/status/ProgressSummaryBar';
+  import StatusSummary from '../../common/status/StatusSummary';
 
   export default {
     name: 'StatusTestPage',
@@ -197,7 +197,7 @@
 
   table table td,
   table table tr {
-    border: none;
+    border: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/status/statusStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/status/statusStrings.js
@@ -403,6 +403,17 @@ export const statusStringsMixin = {
         return output;
       },
     },
+    total: {
+      type: Number,
+      required: false,
+      validator(value) {
+        const output = value >= 0;
+        if (!output) {
+          logging.error(`'${value}' must be greater than 0`);
+        }
+        return output;
+      },
+    },
   },
   methods: {
     shorten(id, verbosity) {

--- a/kolibri/plugins/coach/assets/src/views/common/status/tallyMixin.js
+++ b/kolibri/plugins/coach/assets/src/views/common/status/tallyMixin.js
@@ -1,7 +1,7 @@
 export default {
   props: {
     // Every learner should be tallied into _one and only_ one status
-    tallyObject: {
+    tally: {
       type: Object,
       required: true,
       validator(value) {
@@ -17,19 +17,19 @@ export default {
   computed: {
     started() {
       // To the user, all these are considered having 'started'
-      return this.tallyObject.started + this.tallyObject.helpNeeded;
+      return this.tally.started + this.tally.helpNeeded;
     },
     completed() {
-      return this.tallyObject.completed;
+      return this.tally.completed;
     },
     helpNeeded() {
-      return this.tallyObject.helpNeeded;
+      return this.tally.helpNeeded;
     },
     notStarted() {
-      return this.tallyObject.notStarted;
+      return this.tally.notStarted;
     },
     total() {
-      return this.started + this.tallyObject.completed + this.notStarted;
+      return this.started + this.tally.completed + this.notStarted;
     },
   },
 };

--- a/kolibri/plugins/coach/assets/src/views/common/status/tallyMixin.js
+++ b/kolibri/plugins/coach/assets/src/views/common/status/tallyMixin.js
@@ -1,0 +1,35 @@
+export default {
+  props: {
+    // Every learner should be tallied into _one and only_ one status
+    tallyObject: {
+      type: Object,
+      required: true,
+      validator(value) {
+        return (
+          Number.isInteger(value.started) &&
+          Number.isInteger(value.notStarted) &&
+          Number.isInteger(value.completed) &&
+          Number.isInteger(value.helpNeeded)
+        );
+      },
+    },
+  },
+  computed: {
+    started() {
+      // To the user, all these are considered having 'started'
+      return this.tallyObject.started + this.tallyObject.helpNeeded;
+    },
+    completed() {
+      return this.tallyObject.completed;
+    },
+    helpNeeded() {
+      return this.tallyObject.helpNeeded;
+    },
+    notStarted() {
+      return this.tallyObject.notStarted;
+    },
+    total() {
+      return this.started + this.tallyObject.completed + this.notStarted;
+    },
+  },
+};

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -1,35 +1,39 @@
 <template>
 
-  <div class="item-wrapper">
-    <h3 class="title">{{ name }}</h3>
-    <div class="context"><Recipients :groups="groups" /></div>
+  <KGrid>
 
-    <ProgressSummaryBar
-      :completed="completed"
-      :started="started"
-      :total="completed + started + notStarted + needHelp"
-      class="dashboard-bar"
-    />
+    <KGridItem size="75" percentage>
+      <h3 class="title">{{ name }}</h3>
+    </KGridItem>
 
-    <LearnerProgressRatio
-      :count="completed"
-      :total="completed + started + notStarted + needHelp"
-      :verbosity="2"
-      :icon="progressIcon"
-      verb="completed"
-      class="progress completed"
-    />
+    <KGridItem size="25" percentage alignment="right">
+      <div class="context">
+        <Recipients :groups="groups" />
+      </div>
+    </KGridItem>
 
-    <LearnerProgressCount
-      v-if="needHelp"
-      :count="needHelp"
-      :verbosity="0"
-      icon="help"
-      verb="needHelp"
-      class="progress help"
-    />
+    <KGridItem size="100" percentage>
+      <ProgressSummaryBar
+        :tallyObject="tallyObject"
+        class="dashboard-bar"
+      />
+    </KGridItem>
 
-  </div>
+    <KGridItem size="75" percentage>
+      <StatusSummary
+        :tallyObject="tallyObject"
+      />
+    </KGridItem>
+
+    <KGridItem size="25" percentage alignment="right">
+      <HelpNeeded
+        :count="tallyObject.helpNeeded"
+        :verbose="false"
+        :ratio="false"
+      />
+    </KGridItem>
+
+  </KGrid>
 
 </template>
 
@@ -54,36 +58,13 @@
         type: Array,
         required: true,
       },
-      completed: {
-        type: Number,
-        default: 0,
-      },
-      started: {
-        type: Number,
-        default: 0,
-      },
-      notStarted: {
-        type: Number,
-        default: 0,
-      },
-      needHelp: {
-        type: Number,
-        default: 0,
+      tallyObject: {
+        type: Object,
+        required: true,
       },
       isLast: {
         type: Boolean,
         default: false,
-      },
-    },
-    computed: {
-      progressIcon() {
-        if (this.completed === 0) {
-          return 'nothing';
-        }
-        if (this.completed === this.total) {
-          return 'star';
-        }
-        return 'clock';
       },
     },
   };
@@ -94,40 +75,34 @@
 <style lang="scss" scoped>
 
   .title {
-    position: relative;
-    top: -4px;
-  }
-
-  .item-wrapper {
-    position: relative;
-    height: 80px;
+    margin-bottom: 0;
   }
 
   .context {
-    position: absolute;
-    top: 4px;
-    right: 0;
+    position: relative;
+    top: 16px;
     font-size: small;
-    line-height: 1.5em;
   }
 
   .dashboard-bar {
-    position: absolute;
-    top: 32px;
     width: 100%;
     height: 16px;
+    margin-top: 8px;
+    margin-bottom: 8px;
   }
 
   .progress {
     position: absolute;
     bottom: 0;
     font-size: 14px;
-    .completed {
-      left: 0;
-    }
-    .help {
-      right: 0;
-    }
+  }
+
+  .progress.completed {
+    left: 0;
+  }
+
+  .progress.help {
+    right: -12px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -27,6 +27,7 @@
 
     <KGridItem size="25" percentage alignment="right">
       <HelpNeeded
+        v-if="tally.helpNeeded"
         :count="tally.helpNeeded"
         :verbose="false"
         :ratio="false"

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -81,6 +81,7 @@
   .context {
     position: relative;
     top: 16px;
+    margin-bottom: 16px;
     font-size: small;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -4,17 +4,11 @@
     <h3 class="title">{{ name }}</h3>
     <div class="context"><Recipients :groups="groups" /></div>
 
-    <DashboardBar
+    <ProgressSummaryBar
       :completed="completed"
       :started="started"
       :total="completed + started + notStarted + needHelp"
       class="dashboard-bar"
-    />
-
-    <StatusSummary
-      :completed="completed"
-      :started="started"
-      :total="completed + started + notStarted + needHelp"
     />
 
     <LearnerProgressRatio
@@ -43,12 +37,12 @@
 <script>
 
   import commonCoach from '../../common';
-  import DashboardBar from './DashboardBar';
+  import ProgressSummaryBar from '../../common/status/ProgressSummaryBar';
 
   export default {
     name: 'ItemProgressDisplay',
     components: {
-      DashboardBar,
+      ProgressSummaryBar,
     },
     mixins: [commonCoach],
     props: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -14,20 +14,20 @@
 
     <KGridItem size="100" percentage>
       <ProgressSummaryBar
-        :tallyObject="tallyObject"
+        :tally="tally"
         class="dashboard-bar"
       />
     </KGridItem>
 
     <KGridItem size="75" percentage>
       <StatusSummary
-        :tallyObject="tallyObject"
+        :tally="tally"
       />
     </KGridItem>
 
     <KGridItem size="25" percentage alignment="right">
       <HelpNeeded
-        :count="tallyObject.helpNeeded"
+        :count="tally.helpNeeded"
         :verbose="false"
         :ratio="false"
       />
@@ -58,7 +58,7 @@
         type: Array,
         required: true,
       },
-      tallyObject: {
+      tally: {
         type: Object,
         required: true,
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -53,11 +53,12 @@
         'lessons',
         'lessonLearnerStatusMap',
         'getLessonStatusTally',
+        'getLearnersForGroups',
       ]),
       table() {
         const recent = orderBy(this.lessons, this.lastActivity, ['desc']).slice(0, MAX_LESSONS);
         return recent.map(lesson => {
-          const assigned = this.assignedLearnerIds(lesson);
+          const assigned = this.getLearnersForGroups(lesson.groups);
           return {
             key: lesson.id,
             name: lesson.title,
@@ -71,18 +72,6 @@
       },
     },
     methods: {
-      assignedLearnerIds(lesson) {
-        // assigned to the whole class
-        if (!lesson.groups.length) {
-          return this.learners.map(learner => learner.id);
-        }
-        // accumulate learner IDs of groups
-        const learnerIds = [];
-        lesson.groups.forEach(groupId => {
-          learnerIds.push(...this.groupMap[groupId].member_ids);
-        });
-        return learnerIds;
-      },
       // return the last activity among all users for a particular lesson
       lastActivity(lesson) {
         let last = null;

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -13,10 +13,7 @@
     >
       <ItemProgressDisplay
         :name="tableRow.name"
-        :completed="tableRow.statusCounts.completed"
-        :started="tableRow.statusCounts.started"
-        :notStarted="tableRow.statusCounts.notStarted"
-        :needHelp="tableRow.statusCounts.helpNeeded"
+        :tallyObject="tableRow.statusCounts"
         :groups="tableRow.groups"
       />
     </div>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -13,7 +13,7 @@
     >
       <ItemProgressDisplay
         :name="tableRow.name"
-        :tallyObject="tableRow.statusCounts"
+        :tally="tableRow.tally"
         :groups="tableRow.groups"
       />
     </div>
@@ -52,7 +52,7 @@
         'learners',
         'lessons',
         'lessonLearnerStatusMap',
-        'getLessonStatusCounts',
+        'getLessonStatusTally',
       ]),
       table() {
         const recent = orderBy(this.lessons, this.lastActivity, ['desc']).slice(0, MAX_LESSONS);
@@ -61,7 +61,7 @@
           return {
             key: lesson.id,
             name: lesson.title,
-            statusCounts: this.getLessonStatusCounts(lesson.id, assigned),
+            tally: this.getLessonStatusTally(lesson.id, assigned),
             groups: lesson.groups.map(groupId => this.groupMap[groupId].name),
           };
         });

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -13,7 +13,7 @@
     >
       <ItemProgressDisplay
         :name="tableRow.name"
-        :tallyObject="tableRow.statusCounts"
+        :tally="tableRow.tally"
         :groups="tableRow.groups"
       />
     </div>
@@ -47,7 +47,7 @@
     },
     computed: {
       ...mapState('classSummary', ['groupMap', 'examLearnerStatusMap']),
-      ...mapGetters('classSummary', ['learners', 'exams', 'getExamStatusCounts']),
+      ...mapGetters('classSummary', ['learners', 'exams', 'getExamStatusTally']),
       table() {
         const recent = orderBy(this.exams, this.lastActivity, ['desc']).slice(0, MAX_QUIZZES);
         return recent.map(exam => {
@@ -55,7 +55,7 @@
           return {
             key: exam.id,
             name: exam.title,
-            statusCounts: this.getExamStatusCounts(exam.id, assigned),
+            tally: this.getExamStatusTally(exam.id, assigned),
             groups: exam.groups.map(groupId => this.groupMap[groupId].name),
           };
         });

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -13,10 +13,7 @@
     >
       <ItemProgressDisplay
         :name="tableRow.name"
-        :completed="tableRow.statusCounts.completed"
-        :started="tableRow.statusCounts.started"
-        :notStarted="tableRow.statusCounts.notStarted"
-        :needHelp="tableRow.statusCounts.helpNeeded"
+        :tallyObject="tableRow.statusCounts"
         :groups="tableRow.groups"
       />
     </div>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -47,11 +47,16 @@
     },
     computed: {
       ...mapState('classSummary', ['groupMap', 'examLearnerStatusMap']),
-      ...mapGetters('classSummary', ['learners', 'exams', 'getExamStatusTally']),
+      ...mapGetters('classSummary', [
+        'learners',
+        'exams',
+        'getExamStatusTally',
+        'getLearnersForGroups',
+      ]),
       table() {
         const recent = orderBy(this.exams, this.lastActivity, ['desc']).slice(0, MAX_QUIZZES);
         return recent.map(exam => {
-          const assigned = this.assignedLearnerIds(exam);
+          const assigned = this.getLearnersForGroups(exam.groups);
           return {
             key: exam.id,
             name: exam.title,
@@ -65,18 +70,6 @@
       },
     },
     methods: {
-      assignedLearnerIds(exam) {
-        // assigned to the whole class
-        if (!exam.groups.length) {
-          return this.learners.map(learner => learner.id);
-        }
-        // accumulate learner IDs of groups
-        const learnerIds = [];
-        exam.groups.forEach(groupId => {
-          learnerIds.push(...this.groupMap[groupId].member_ids);
-        });
-        return learnerIds;
-      },
       // return the last activity among all users for a particular exam
       lastActivity(exam) {
         let last = null;

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
@@ -57,4 +57,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .new-coach-block {
+    min-width: 0;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/StatusIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/StatusIcon.vue
@@ -64,9 +64,14 @@
 
 <style lang="scss" scoped>
 
-  .status-icon,
   .status-icon-wrapper {
-    vertical-align: middle;
+    position: relative;
+  }
+
+  .status-icon {
+    position: relative;
+    top: -2px;
+    // vertical-align: middle;
   }
 
   .active-text {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -33,7 +33,7 @@
               />
             </td>
             <td>
-              TODO - lesson status for learner
+              <StatusSimple :status="tableRow.status" />
             </td>
             <td>
               <TruncatedItemList :items="tableRow.groups" />
@@ -72,6 +72,7 @@
         'getLearnersForGroups',
         'getContentStatusForLearner',
         'getGroupNamesForLearner',
+        'getLessonStatusForLearner',
       ]),
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
@@ -85,26 +86,12 @@
         const mapped = sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
-            numCompleted: this.numCompleted(learner.id),
+            status: this.getLessonStatusForLearner(this.lesson.id, learner.id),
           };
           Object.assign(tableRow, learner);
           return tableRow;
         });
         return mapped;
-      },
-    },
-    methods: {
-      numCompleted(learnerId) {
-        const contentIds = this.lesson.node_ids.map(
-          node_id => this.contentNodeMap[node_id].content_id
-        );
-        return contentIds.reduce((acc, contentId) => {
-          const status = this.getContentStatusForLearner(contentId, learnerId);
-          if (status === this.STATUSES.completed) {
-            return acc + 1;
-          }
-          return acc;
-        }, 0);
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -35,19 +35,9 @@
               />
             </td>
             <td>
-              <LearnerProgressRatio
-                :count="tableRow.numCompleted"
-                :total="tableRow.totalLearners"
-                verbosity="0"
-                :verb="VERBS.completed"
-                :icon="ICONS.learners"
-              />
-              <LearnerProgressCount
-                v-if="tableRow.numNeedingHelp"
-                :count="tableRow.numNeedingHelp"
-                verbosity="0"
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
+              <StatusSummary
+                :tallyObject="tableRow.tallyObject"
+                :verbose="true"
               />
             </td>
             <td>
@@ -85,9 +75,9 @@
     computed: {
       ...mapGetters('classSummary', [
         'lessons',
-        'lessonLearnerStatusMap',
         'getGroupNames',
         'getLearnersForGroups',
+        'getLessonStatusCounts',
       ]),
       filterOptions() {
         return [
@@ -117,10 +107,10 @@
         });
         const sorted = this._.sortBy(filtered, ['title', 'active']);
         const mapped = sorted.map(lesson => {
+          const learners = this.getLearnersForGroups(lesson.groups);
           const tableRow = {
-            totalLearners: this.getLearnersForGroups(lesson.groups).length,
-            numCompleted: this.numCompleted(lesson),
-            numNeedingHelp: this.numNeedingHelp(lesson),
+            totalLearners: learners.length,
+            tallyObject: this.getLessonStatusCounts(lesson.id, learners),
             groupNames: this.getGroupNames(lesson.groups),
           };
           Object.assign(tableRow, lesson);
@@ -137,22 +127,6 @@
       allLessons: 'All lessons',
       activeLessons: 'Active lessons',
       inactiveLessons: 'Inactive lessons',
-    },
-    methods: {
-      numCompleted(lesson) {
-        const learners = this.getLearnersForGroups(lesson.groups);
-        const statuses = learners.map(
-          learnerId => this.lessonLearnerStatusMap[lesson.id][learnerId]
-        );
-        return statuses.filter(status => status === this.STATUSES.completed).length;
-      },
-      numNeedingHelp(lesson) {
-        const learners = this.getLearnersForGroups(lesson.groups);
-        const statuses = learners.map(
-          learnerId => this.lessonLearnerStatusMap[lesson.id][learnerId]
-        );
-        return statuses.filter(status => status === this.STATUSES.helpNeeded).length;
-      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -36,7 +36,7 @@
             </td>
             <td>
               <StatusSummary
-                :tallyObject="tableRow.tallyObject"
+                :tally="tableRow.tally"
                 :verbose="true"
               />
             </td>
@@ -77,7 +77,7 @@
         'lessons',
         'getGroupNames',
         'getLearnersForGroups',
-        'getLessonStatusCounts',
+        'getLessonStatusTally',
       ]),
       filterOptions() {
         return [
@@ -110,7 +110,7 @@
           const learners = this.getLearnersForGroups(lesson.groups);
           const tableRow = {
             totalLearners: learners.length,
-            tallyObject: this.getLessonStatusCounts(lesson.id, learners),
+            tally: this.getLessonStatusTally(lesson.id, learners),
             groupNames: this.getGroupNames(lesson.groups),
           };
           Object.assign(tableRow, lesson);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -43,19 +43,9 @@
               />
             </td>
             <td>
-              <LearnerProgressRatio
-                :count="tableRow.numCompleted"
-                :total="recipients.length"
-                verbosity="1"
-                verb="completed"
-                icon="learners"
-              />
-              <LearnerProgressCount
-                v-if="tableRow.numNeedingHelp"
-                verb="needHelp"
-                icon="help"
-                :count="tableRow.numNeedingHelp"
-                :verbosity="0"
+              <StatusSummary
+                :tally="tableRow.tally"
+                :verbose="true"
               />
             </td>
             <td>
@@ -85,9 +75,10 @@
     computed: {
       ...mapState('classSummary', ['lessonMap', 'contentNodeMap', 'contentLearnerStatusMap']),
       ...mapGetters('classSummary', [
-        'getContentStatusForLearner',
         'getLearnersForGroups',
         'getContentAvgTimeSpent',
+        'getLessonStatusTally',
+        'getLearnersForGroups',
       ]),
       actionOptions() {
         return [
@@ -109,32 +100,16 @@
         const sorted = this._.sortBy(content, ['title']);
         const mapped = sorted.map(content => {
           const tableRow = {
-            numCompleted: this.numCompleted(content.content_id),
-            numNeedingHelp: this.numLearnersNeedingHelp(content),
             avgTimeSpent: this.getContentAvgTimeSpent(content.content_id, this.recipients),
+            tally: this.getLessonStatusTally(
+              this.lesson.id,
+              this.getLearnersForGroups(this.lesson.groups)
+            ),
           };
           Object.assign(tableRow, content);
           return tableRow;
         });
         return mapped;
-      },
-    },
-    methods: {
-      numCompleted(contentId) {
-        return this.recipients.reduce((acc, learnerId) => {
-          const status = this.getContentStatusForLearner(contentId, learnerId);
-          if (status === this.STATUSES.completed) {
-            return acc + 1;
-          }
-          return acc;
-        }, 0);
-      },
-      numLearnersNeedingHelp(content) {
-        // TODO COACH
-        if (content.kind === 'exercise') {
-          return 0;
-        }
-        return 0;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -33,19 +33,19 @@
       <p>
         <LearnerProgressCount
           :verbosity="0"
-          :count="statusCounts.completed"
+          :count="tally.completed"
           :verb="VERBS.completed"
           :icon="ICONS.star"
         />
         <LearnerProgressCount
           :verbosity="0"
-          :count="statusCounts.started"
+          :count="tally.started"
           :verb="VERBS.started"
           :icon="ICONS.clock"
         />
         <LearnerProgressCount
           :verbosity="0"
-          :count="statusCounts.notStarted"
+          :count="tally.notStarted"
           :verb="VERBS.notStarted"
           :icon="ICONS.nothing"
         />
@@ -108,7 +108,7 @@
         'getLearnersForGroups',
         'getContentAvgTimeSpent',
         'getGroupNames',
-        'getContentStatusCounts',
+        'getContentStatusTally',
         'getGroupNamesForLearner',
       ]),
       lesson() {
@@ -123,8 +123,8 @@
       avgTime() {
         return this.getContentAvgTimeSpent(this.$route.params.resourceId, this.recipients);
       },
-      statusCounts() {
-        return this.getContentStatusCounts(this.$route.params.resourceId, this.recipients);
+      tally() {
+        return this.getContentStatusTally(this.$route.params.resourceId, this.recipients);
       },
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -41,7 +41,7 @@
             </td>
             <td>
               <StatusSummary
-                :tallyObject="tableRow.tallyObject"
+                :tally="tableRow.tally"
                 :verbose="true"
               />
             </td>
@@ -81,7 +81,7 @@
         'examStatuses',
         'getGroupNames',
         'getLearnersForGroups',
-        'getExamStatusCounts',
+        'getExamStatusTally',
       ]),
       filterOptions() {
         return [
@@ -114,7 +114,7 @@
           const learnersForQuiz = this.getLearnersForGroups(exam.groups);
           const tableRow = {
             totalLearners: learnersForQuiz.length,
-            tallyObject: this.getExamStatusCounts(exam.id, learnersForQuiz),
+            tally: this.getExamStatusTally(exam.id, learnersForQuiz),
             groupNames: this.getGroupNames(exam.groups),
             avgScore: this.avgScore(exam, learnersForQuiz),
           };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -40,12 +40,9 @@
               <Score :value="tableRow.avgScore" />
             </td>
             <td>
-              <LearnerProgressRatio
-                :count="tableRow.numStarted + tableRow.numCompleted"
-                :verbosity="1"
-                :icon="ICONS.clock"
-                :total="tableRow.totalLearners"
-                :verb="VERBS.started"
+              <StatusSummary
+                :tallyObject="tableRow.tallyObject"
+                :verbose="true"
               />
             </td>
             <td><Recipients :groups="tableRow.groupNames" /></td>
@@ -84,7 +81,7 @@
         'examStatuses',
         'getGroupNames',
         'getLearnersForGroups',
-        'getExamStatusForLearner',
+        'getExamStatusCounts',
       ]),
       filterOptions() {
         return [
@@ -114,13 +111,10 @@
         });
         const sorted = this._.sortBy(filtered, ['title', 'active']);
         const mapped = sorted.map(exam => {
-          const { started, notStarted, completed } = this.counts(exam);
           const learnersForQuiz = this.getLearnersForGroups(exam.groups);
           const tableRow = {
             totalLearners: learnersForQuiz.length,
-            numCompleted: completed,
-            numStarted: started,
-            numNotStarted: notStarted,
+            tallyObject: this.getExamStatusCounts(exam.id, learnersForQuiz),
             groupNames: this.getGroupNames(exam.groups),
             avgScore: this.avgScore(exam, learnersForQuiz),
           };
@@ -134,16 +128,6 @@
       this.filter = this.filterOptions[0];
     },
     methods: {
-      counts(exam) {
-        const learners = this.getLearnersForGroups(exam.groups);
-        const statuses = learners.map(learnerId =>
-          this.getExamStatusForLearner(exam.id, learnerId)
-        );
-        const completed = statuses.filter(status => status === this.STATUSES.completed).length;
-        const started = statuses.filter(status => status === this.STATUSES.started).length;
-        const notStarted = statuses.filter(status => status === this.STATUSES.notStarted).length;
-        return { completed, started, notStarted };
-      },
       avgScore(exam, learnerIds) {
         const relevantStatuses = this.examStatuses.filter(
           status =>


### PR DESCRIPTION
### Summary

* new wrapper components for displaying consistent status summary views
* state transitions
* many small styling improvements
* upgraded a few instances to new component
* added a test page for viewing the new widget states at [http://localhost:8000/coach/#/about/statuses](http://localhost:8000/coach/#/about/statuses)
* adds a new prototype 'help needed' indicator in progress bars, also disabled by default

### Reviewer guidance

~NOTE - this PR depends on #4844, which should be reviewed and merged first~




### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
