### PR TITLE
Handle keyboard-dependent focus outlines in Vuex

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -11,6 +11,7 @@ require('kolibri.urls').default.setUp();
 require('purecss/build/base-min.css');
 require('../styles/main.scss');
 require('../styles/globalDynamicStyles');
+require('./vuexModality');
 
 // Required to setup Keen UI, should be imported only once in your project
 require('keen-ui/src/bootstrap');

--- a/kolibri/core/assets/src/core-app/vuexModality.js
+++ b/kolibri/core/assets/src/core-app/vuexModality.js
@@ -1,0 +1,112 @@
+/* global kolibriGlobal */
+/**
+ * Adapted from https://github.com/alice/modality
+ * Version: 1.0.2
+ *
+ * For Kolibri, this mirrors in Vuex the DOM updates done by modality.js in Keen-UI,
+ * which gives the code in theme.js easier access to the current modality.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  let hadKeyboardEvent = false;
+  const keyboardModalityWhitelist = [
+    'input:not([type])',
+    'input[type=text]',
+    'input[type=number]',
+    'input[type=date]',
+    'input[type=time]',
+    'input[type=datetime]',
+    'textarea',
+    '[role=textbox]',
+    '[supports-modality=keyboard]',
+  ].join(',');
+
+  let isHandlingKeyboardThrottle;
+
+  const matcher = (() => {
+    const el = document.body;
+
+    if (el.matchesSelector) {
+      return el.matchesSelector;
+    }
+
+    if (el.webkitMatchesSelector) {
+      return el.webkitMatchesSelector;
+    }
+
+    if (el.mozMatchesSelector) {
+      return el.mozMatchesSelector;
+    }
+
+    if (el.msMatchesSelector) {
+      return el.msMatchesSelector;
+    }
+
+    /* eslint-disable-next-line */
+    console.error("Couldn't find any matchesSelector method on document.body.");
+  })();
+
+  const disableFocusRingByDefault = function() {
+    const css = 'body:not([modality=keyboard]) :focus { outline: none; }';
+    const head = document.head || document.getElementsByTagName('head')[0];
+    const style = document.createElement('style');
+
+    style.type = 'text/css';
+    style.id = 'disable-focus-ring';
+
+    if (style.styleSheet) {
+      style.styleSheet.cssText = css;
+    } else {
+      style.appendChild(document.createTextNode(css));
+    }
+
+    head.insertBefore(style, head.firstChild);
+  };
+
+  const focusTriggersKeyboardModality = function(el) {
+    let triggers = false;
+
+    if (matcher) {
+      triggers =
+        matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly])');
+    }
+
+    return triggers;
+  };
+
+  disableFocusRingByDefault();
+
+  document.body.addEventListener(
+    'keydown',
+    () => {
+      hadKeyboardEvent = true;
+
+      if (isHandlingKeyboardThrottle) {
+        clearTimeout(isHandlingKeyboardThrottle);
+      }
+
+      isHandlingKeyboardThrottle = setTimeout(() => {
+        hadKeyboardEvent = false;
+      }, 100);
+    },
+    true
+  );
+
+  document.body.addEventListener(
+    'focus',
+    e => {
+      if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
+        kolibriGlobal.coreVue.vuex.store.commit('SET_MODALITY', 'keyboard');
+      }
+    },
+    true
+  );
+
+  document.body.addEventListener(
+    'blur',
+    () => {
+      kolibriGlobal.coreVue.vuex.store.commit('SET_MODALITY', null);
+    },
+    true
+  );
+});

--- a/kolibri/core/assets/src/state/modules/theme.js
+++ b/kolibri/core/assets/src/state/modules/theme.js
@@ -24,6 +24,7 @@ const initialState = {
   '$core-grey': '#e0e0e0',
 
   '$core-loading': '#03a9f4',
+  modality: null,
 };
 
 export default {
@@ -90,7 +91,15 @@ export default {
     $coreLoading(state) {
       return state['$core-loading'];
     },
+    // Should only use these styles to outline stuff that will be focused
+    // on keyboard-tab-focus
     $coreOutline(state) {
+      if (state.modality !== 'keyboard') {
+        return {
+          outline: 'none',
+        };
+      }
+
       return {
         outlineColor: darken(state['$core-action-light'], 0.1),
         outlineStyle: 'solid',
@@ -105,6 +114,9 @@ export default {
     },
     RESET_THEME_VALUE(state, varName) {
       state[varName] = initialState[varName];
+    },
+    SET_MODALITY(state, modality) {
+      state.modality = modality;
     },
   },
 };

--- a/kolibri/core/assets/src/state/modules/theme.js
+++ b/kolibri/core/assets/src/state/modules/theme.js
@@ -107,6 +107,16 @@ export default {
         outlineOffset: '4px',
       };
     },
+    // Should use this when the outline needs to be applied regardless
+    // of modality
+    $coreOutlineAnyModality(state) {
+      return {
+        outlineColor: darken(state['$core-action-light'], 0.1),
+        outlineStyle: 'solid',
+        outlineWidth: '3px',
+        outlineOffset: '4px',
+      };
+    },
   },
   mutations: {
     SET_CORE_THEME(state, theme) {

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -119,7 +119,6 @@
       ...mapGetters([
         '$coreGrey200',
         '$coreGrey300',
-        '$coreOutline',
         '$coreActionDark',
         '$coreActionNormal',
         '$coreTextDefault',

--- a/kolibri/core/assets/src/views/KNavbar/index.vue
+++ b/kolibri/core/assets/src/views/KNavbar/index.vue
@@ -65,7 +65,7 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreActionNormal', '$coreOutline']),
+      ...mapGetters(['$coreActionNormal', '$coreOutlineAnyModality']),
       maxWidth() {
         return this.enoughSpace ? this.elementWidth : this.elementWidth - 38 * 2;
       },
@@ -76,7 +76,7 @@
       },
       scrollButton() {
         return {
-          ':hover': this.$coreOutline,
+          ':hover': this.$coreOutlineAnyModality,
         };
       },
     },

--- a/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
@@ -4,7 +4,7 @@ exports[`app bar component drop down user menu should show the language modal li
 <div style="background-color: rgb(153, 97, 137);" navshown="true">
   <div class="ui-toolbar app-bar ui-toolbar--type-clear ui-toolbar--text-color-white ui-toolbar--progress-position-bottom" style="height: 20px;">
     <div class="ui-toolbar__left">
-      <div class="ui-toolbar__nav-icon"><button type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-default keen-ui-icon-button--size-normal KeenUiIconButton-noKey-0_8x3dw5">
+      <div class="ui-toolbar__nav-icon"><button type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-default keen-ui-icon-button--size-normal KeenUiIconButton-noKey-0_1e7m9ar">
           <div class="keen-ui-icon-button-icon" style="color: rgb(153, 97, 137);">
             <mat-svg name="menu" category="navigation" class="icon"></mat-svg>
           </div>

--- a/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`side nav component should be hidden if navShown is false 1`] = `
 <div class="side-nav-wrapper" style="position: relative;">
   <div class="side-nav" style="width: 100px; color: rgb(58, 58, 58); background-color: rgb(255, 255, 255); display: none;" name="side-nav">
-    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_8x3dw5">
+    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
         <div class="keen-ui-icon-button-icon" style="color: rgb(153, 97, 137);">
           <mat-svg name="close" category="navigation" class="side-nav-header-close"></mat-svg>
         </div>
@@ -28,7 +28,7 @@ exports[`side nav component should be hidden if navShown is false 1`] = `
         <div class="side-nav-scrollable-area-footer-info">
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
-          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_1pw22jz link">Usage and privacy
+          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_khtjim link">Usage and privacy
               <!----></a></p>
         </div>
       </div>
@@ -50,7 +50,7 @@ exports[`side nav component should be hidden if navShown is false 1`] = `
 exports[`side nav component should show nothing if no components are added and user is not logged in 1`] = `
 <div class="side-nav-wrapper" style="position: relative;">
   <div class="side-nav" style="width: 100px; color: rgb(58, 58, 58); background-color: rgb(255, 255, 255);" name="side-nav">
-    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_8x3dw5">
+    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
         <div class="keen-ui-icon-button-icon" style="color: rgb(153, 97, 137);">
           <mat-svg name="close" category="navigation" class="side-nav-header-close"></mat-svg>
         </div>
@@ -75,7 +75,7 @@ exports[`side nav component should show nothing if no components are added and u
         <div class="side-nav-scrollable-area-footer-info">
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
-          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_1pw22jz link">Usage and privacy
+          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_khtjim link">Usage and privacy
               <!----></a></p>
         </div>
       </div>

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -5,7 +5,7 @@
 
       <thead slot="thead">
         <tr>
-          <th v-if="selectable" class="core-table-icon-col">
+          <th v-if="selectable" class="core-table-checkbox-col">
             <KCheckbox
               :label="selectAllLabel"
               :showLabel="false"
@@ -34,7 +34,7 @@
           v-for="user in users"
           :key="user.id"
         >
-          <td v-if="selectable" class="core-table-icon-col">
+          <td v-if="selectable" class="core-table-checkbox-col">
             <KCheckbox
               :label="userCheckboxLabel"
               :showLabel="false"


### PR DESCRIPTION
### Summary

1. vendors and modifies modality.js helper to manipulate vuex theme module. manages a `core.modality` property in vuex
1. rewrites $coreOutline getter to conditionally apply outline styles depending on value of `core.modality`


### Reviewer guidance

1. Interact with links, buttons, and all kinds of inputs (inside and outside of exercises) to see if keyboard focus works okay

### References

Fixes #4822 
----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
