### PR TITLE
Pass in root node id of channel on create exam handler

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -33,6 +33,7 @@ export function showExamCreationRootPage(store, params) {
     }).then(channels => {
       const channelContentList = channels.map(channel => ({
         ...channel,
+        id: channel.root,
         title: channel.name,
         kind: ContentNodeKinds.CHANNEL,
       }));


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some channels don't have the root node id to be the same as the channel ID. We explicitly pass in the root ID to avoid any potential errors this might cause.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Use this channel before and after change.
`7c4e1cf2664435e384b8cbefcafafb53`

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Similar to https://github.com/learningequality/kolibri/pull/4591.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
