### PR TITLE
Add bottom margin to setup wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -154,11 +154,13 @@
     max-width: 550px;
     margin-top: 64px;
     margin-right: auto;
+    margin-bottom: 32px;
     margin-left: auto;
   }
 
   .mobile {
     margin-top: 40px;
+    margin-bottom: 20px;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -160,7 +160,7 @@
 
   .mobile {
     margin-top: 40px;
-    margin-bottom: 20px;
+    margin-bottom: 24px;
   }
 
 </style>


### PR DESCRIPTION
Add bottom margin to setup wizard

### Summary
The setup wizard doesn't have a bottom margin on small screens. This results in the continue button touching the bottom of the page.
![setupwizard_before](https://user-images.githubusercontent.com/7353802/52223315-03855100-28ae-11e9-8902-54a1b515dec8.png)

After applying some css, there is now some space between the button and the bottom of the page.
![setupwizard_after](https://user-images.githubusercontent.com/7353802/52223371-26b00080-28ae-11e9-9896-a83c57e669ca.png)

…

### Reviewer guidance

…

### References
Issue #4172

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
