### PR TITLE
Fixes #4898: Return a status of STARTED as soon as user has opened exam

### DIFF
--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -108,9 +108,8 @@ class ExamStatusSerializer(serializers.ModelSerializer):
     def get_status(self, exam_log):
         if exam_log.closed:
             return COMPLETED
-        elif exam_log.attemptlogs.values_list("item").count() > 0:
+        else:
             return STARTED
-        return NOT_STARTED
 
     def get_num_correct(self, exam_log):
         return (


### PR DESCRIPTION
### Summary

Per https://github.com/learningequality/kolibri/issues/4898, we previously only marked an exam as started after the first answer had been submitted (`ExamAttemptLog` exists). With this PR, we mark an exam as started as soon as it's opened (based on whether an `ExamLog` exists).

After:
![image](https://user-images.githubusercontent.com/618416/52158061-4a264180-2649-11e9-97f7-45906b26fad3.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

In one browser, watch exam report. In another, log in as learner and open exam. In first browser, note that user now shows as having started.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #4898.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
