### PR TITLE
Ensure the snackbar does not reappear after the resource page is left

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -50,8 +50,11 @@
         return false;
       },
     },
+    beforeDestroy() {
+      this.clearSnackbar();
+    },
     methods: {
-      ...mapActions(['createSnackbar']),
+      ...mapActions(['createSnackbar', 'clearSnackbar']),
       ...mapActions('lessonSummary', ['addToResourceCache']),
       handleAddResource(content) {
         this.$store.commit('lessonSummary/ADD_TO_WORKING_RESOURCES', content.id);

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -46,9 +46,11 @@
         return Boolean(this.selectedExercises[this.currentContentNode.id]);
       },
     },
+    beforeDestroy() {
+      this.clearSnackbar();
+    },
     methods: {
-      ...mapActions(['createSnackbar']),
-      ...mapActions(['createSnackbar']),
+      ...mapActions(['createSnackbar', 'clearSnackbar']),
       ...mapActions('examCreation', ['addToSelectedExercises', 'removeFromSelectedExercises']),
       handleAddResource(content) {
         this.addToSelectedExercises([content]);


### PR DESCRIPTION
### Summary
Ensures the snackbar does not appear after the page is left in Lessons and Quiz plans.


### Reviewer guidance
Instruccions to reproduce the issue are at #4848 
Using this PR code the snackbar will disappear after leaving the resource that has been added.


### References
Closes #4848 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
