### PR TITLE
Styling updates

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -82,6 +82,7 @@ import KDraggable from '../views/kSortable/KDraggable';
 import KDragHandle from '../views/kSortable/KDragHandle';
 import KDragContainer from '../views/kSortable/KDragContainer';
 import KDragSortWidget from '../views/kSortable/KDragSortWidget';
+import KEmptyPlaceholder from '../views/KEmptyPlaceholder';
 
 // webpack optimization
 import buttonAndLinkStyles from '../views/buttons-and-links/buttons.scss';
@@ -180,6 +181,7 @@ export default {
       KDragHandle,
       KDragContainer,
       KDragSortWidget,
+      KEmptyPlaceholder,
     },
     router,
     mixins: {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -83,6 +83,7 @@ import KDragHandle from '../views/kSortable/KDragHandle';
 import KDragContainer from '../views/kSortable/KDragContainer';
 import KDragSortWidget from '../views/kSortable/KDragSortWidget';
 import KEmptyPlaceholder from '../views/KEmptyPlaceholder';
+import KPageContainer from '../views/KPageContainer';
 
 // webpack optimization
 import CoreInfoIcon from '../views/CoreInfoIcon';
@@ -181,6 +182,7 @@ export default {
       KDragContainer,
       KDragSortWidget,
       KEmptyPlaceholder,
+      KPageContainer,
     },
     router,
     mixins: {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -85,7 +85,6 @@ import KDragSortWidget from '../views/kSortable/KDragSortWidget';
 import KEmptyPlaceholder from '../views/KEmptyPlaceholder';
 
 // webpack optimization
-import buttonAndLinkStyles from '../views/buttons-and-links/buttons.scss';
 import CoreInfoIcon from '../views/CoreInfoIcon';
 import * as contentNode from '../utils/contentNodeUtils';
 import AttemptLogList from '../views/AttemptLogList';
@@ -194,7 +193,6 @@ export default {
   styles: {
     definitions,
     keenVars,
-    buttonAndLinkStyles,
   },
   urls,
   utils: {

--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -21,6 +21,7 @@
     props: {
       date: {
         type: Date,
+        required: false,
       },
     },
     data: () => ({

--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -3,7 +3,7 @@
   <span v-if="date">
     {{ $formatRelative(date, { now: now }) }}
   </span>
-  <span v-else :style="{ color: this.$coreGrey300 }">–</span>
+  <KEmptyPlaceholder v-else />
 
 </template>
 
@@ -11,10 +11,13 @@
 <script>
 
   import { now } from 'kolibri.utils.serverClock';
-  import { mapGetters } from 'vuex';
+  import KEmptyPlaceholder from 'kolibri.coreVue.components.KEmptyPlaceholder';
 
   export default {
     name: 'ElapsedTime',
+    components: {
+      KEmptyPlaceholder,
+    },
     props: {
       date: {
         type: Date,
@@ -24,9 +27,6 @@
       now: now(),
       timer: null,
     }),
-    computed: {
-      ...mapGetters(['$coreGrey300']),
-    },
     mounted() {
       this.timer = setInterval(() => {
         this.now = now();

--- a/kolibri/core/assets/src/views/KEmptyPlaceholder.vue
+++ b/kolibri/core/assets/src/views/KEmptyPlaceholder.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <span :style="{color: $coreGrey300}">—</span>
+
+</template>
+
+
+<script>
+
+  import { mapGetters } from 'vuex';
+
+  export default {
+    name: 'KEmptyPlaceholder',
+    computed: {
+      ...mapGetters(['$coreGrey300']),
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
+++ b/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
@@ -6,7 +6,7 @@
       :class="$computedClass(tabStyles)"
       :to="link"
     >
-      <div class="tab-icon">
+      <div class="tab-icon dimmable">
         <UiIcon
           class="icon"
           tabindex="-1"
@@ -16,7 +16,7 @@
         </UiIcon>
       </div>
 
-      <div class="tab-title" tabindex="-1">
+      <div class="tab-title dimmable" tabindex="-1">
         {{ title }}
       </div>
     </router-link>
@@ -97,6 +97,9 @@
     border-top-left-radius: $radius;
     border-top-right-radius: $radius;
     transition: background-color $core-time ease;
+    .dimmable {
+      opacity: 0.6;
+    }
   }
 
   .router-link-active,
@@ -106,6 +109,9 @@
     border-bottom-color: white;
     border-bottom-style: solid;
     border-bottom-width: 2px;
+    .dimmable {
+      opacity: 1;
+    }
   }
 
   .icon {

--- a/kolibri/core/assets/src/views/KPageContainer.vue
+++ b/kolibri/core/assets/src/views/KPageContainer.vue
@@ -1,0 +1,42 @@
+<template>
+
+  <div
+    class="page-container"
+    :class="{small : windowIsSmall }"
+  >
+    <slot></slot>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+
+  export default {
+    name: 'KPageContainer',
+    mixins: [responsiveWindow],
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri.styles.definitions';
+
+  .page-container {
+    @extend %dropshadow-1dp;
+
+    padding: 8px 24px 24px;
+    margin-top: 24px;
+    background-color: white;
+    border-radius: 4px;
+  }
+
+  .page-container.small {
+    padding: 8px 16px 16px;
+  }
+
+</style>

--- a/kolibri/core/assets/test/views/elapsed-time.spec.js
+++ b/kolibri/core/assets/test/views/elapsed-time.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import ElapsedTime from '../../src/views/ElapsedTime';
 
@@ -12,7 +12,7 @@ function makeWrapper(options) {
     $coreGrey300: () => 'gray',
   };
   const store = new Vuex.Store({ getters });
-  return shallowMount(ElapsedTime, {
+  return mount(ElapsedTime, {
     ...options,
     store,
     localVue,
@@ -28,7 +28,7 @@ describe('elapsed time component', () => {
   it('should show display a "–" if no date is passed in', () => {
     const wrapper = makeWrapper({ propsData: {} });
     const timeText = getTimeText(wrapper);
-    expect(timeText).toEqual('–');
+    expect(timeText).toEqual('—');
   });
   it('should use seconds if the date passed in 1 second ago', () => {
     const date1SecondAgo = new Date(DUMMY_CURRENT_DATE);

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <h1>{{ coachStrings.$tr('classesLabel') }}</h1>
       <p>{{ $tr('classPageSubheader') }}</p>
 
@@ -39,7 +39,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 

--- a/kolibri/plugins/coach/assets/src/views/CoachIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachIndex.vue
@@ -27,33 +27,9 @@
       reportLessonDetailEditorTitle: 'Edit lesson details',
       reportLessonResourceManagerTitle: 'Manage resources',
     },
-    computed: {
-      currentClassroomId() {
-        return this.$route.params.classId;
-      },
-    },
-    watch: {
-      currentClassroomId() {},
-    },
   };
 
 </script>
 
 
-<style lang="scss">
-
-  @import '~kolibri.styles.definitions';
-
-  // COACH - under construction ...
-  .new-coach-block {
-    @extend %dropshadow-1dp;
-
-    min-width: 600px;
-    padding: 8px 24px 24px;
-    margin-top: 24px;
-    background-color: white;
-    border-radius: 4px;
-  }
-  // ... COACH - under construction
-
-</style>
+<style lang="scss"></style>

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -16,6 +16,7 @@ import meanBy from 'lodash/meanBy';
 import maxBy from 'lodash/maxBy';
 import map from 'lodash/map';
 import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
+import KPageContainer from 'kolibri.coreVue.components.KPageContainer';
 import filter from 'lodash/filter';
 import sortBy from 'lodash/sortBy';
 import { PageNames } from '../constants';
@@ -70,6 +71,7 @@ export default {
     QuizActive,
     HeaderTable,
     ElapsedTime,
+    KPageContainer,
     HeaderTableRow,
     HeaderTabs,
     HeaderTab,

--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
@@ -3,12 +3,14 @@
   <router-link
     ref="btn"
     :to="to"
-    class="button"
-    :activeClass="activeStyles"
+    class="header-tab"
+    :activeClass="activeClasses"
     :style="{ color: $coreTextAnnotation }"
-    :class="[defaultStyles, $computedClass({ ':focus': $coreOutline })]"
+    :class="defaultStyles"
   >
-    {{ text }}
+    <div class="inner" :style="{ borderColor: this.$coreActionNormal }">
+      {{ text }}
+    </div>
   </router-link>
 
 </template>
@@ -37,15 +39,13 @@
     },
     computed: {
       ...mapGetters(['$coreActionNormal', '$coreTextAnnotation', '$coreGrey300', '$coreOutline']),
-      activeStyles() {
-        return this.$computedClass({
-          borderColor: this.$coreActionNormal,
-          color: this.$coreActionNormal,
-          borderBottomWidth: '2px',
-        });
+      activeClasses() {
+        // return both fixed and dynamic classes
+        return `router-link-active ${this.$computedClass({ color: this.$coreActionNormal })}`;
       },
       defaultStyles() {
         return this.$computedClass({
+          ':focus': this.$coreOutline,
           ':hover': {
             backgroundColor: this.$coreGrey300,
           },
@@ -62,14 +62,13 @@
   @import '~kolibri.styles.definitions';
 
   // a lot copied from KButton
-  .button {
+  .header-tab {
     position: relative;
     top: 9px;
     display: inline-table; // helps with vertical layout
     min-width: 64px;
     max-width: 100%;
     min-height: 36px;
-    padding: 0 16px;
     margin: 8px;
     overflow: hidden;
     font-size: 14px;
@@ -89,6 +88,18 @@
     border-top-right-radius: $radius;
     outline: none;
     transition: background-color $core-time ease;
+  }
+
+  .inner {
+    padding: 0 16px;
+    margin-bottom: 2px;
+    border-style: solid;
+    border-width: 0;
+  }
+
+  .router-link-active .inner {
+    margin-bottom: 0;
+    border-bottom-width: 2px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="tab-block">
+  <div class="tab-block" :class="{small : windowIsSmall }">
     <slot></slot>
   </div>
 
@@ -9,8 +9,11 @@
 
 <script>
 
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+
   export default {
     name: 'HeaderTabs',
+    mixins: [responsiveWindow],
   };
 
 </script>
@@ -25,6 +28,14 @@
     margin-bottom: 24px;
     margin-left: -24px;
     border-bottom: 1px solid #dedede;
+  }
+
+  .small {
+    padding-right: 16px;
+    padding-left: 16px;
+    margin-right: -16px;
+    margin-bottom: 16px;
+    margin-left: -16px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/Score.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/Score.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span>
-    <template v-if="value === undefined || value === null">-</template>
+    <KEmptyPlaceholder v-if="value === undefined || value === null" />
     <template v-else>{{ coachStrings.$tr('percentage', {value}) }}</template>
   </span>
 
@@ -10,11 +10,14 @@
 
 <script>
 
+  import KEmptyPlaceholder from 'kolibri.coreVue.components.KEmptyPlaceholder';
   import { coachStringsMixin } from './commonCoachStrings';
 
   export default {
     name: 'Score',
-    components: {},
+    components: {
+      KEmptyPlaceholder,
+    },
     mixins: [coachStringsMixin],
     props: {
       value: {

--- a/kolibri/plugins/coach/assets/src/views/common/TimeDuration.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TimeDuration.vue
@@ -1,14 +1,14 @@
 <template>
 
   <span v-if="seconds">{{ formattedTime }}</span>
-  <span v-else :style="{color: this.$coreGrey300}">–</span>
+  <KEmptyPlaceholder v-else />
 
 </template>
 
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import KEmptyPlaceholder from 'kolibri.coreVue.components.KEmptyPlaceholder';
 
   const MINUTE = 60;
   const HOUR = MINUTE * 60;
@@ -16,7 +16,9 @@
 
   export default {
     name: 'TimeDuration',
-    components: {},
+    components: {
+      KEmptyPlaceholder,
+    },
     props: {
       seconds: {
         type: Number,
@@ -24,7 +26,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey300']),
       formattedTime() {
         if (this.seconds < 2 * MINUTE) {
           return this.$tr('seconds', { value: Math.floor(this.seconds) });

--- a/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('HomePage', {})"
@@ -52,7 +52,7 @@
         </transition>
       </div>
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -7,14 +7,15 @@
   >
     <ContentIcon slot="icon" :kind="ContentNodeKinds.ACTIVITY" />
     <transition-group name="list">
-      <NotificationCard
+      <BlockItem
         v-for="notification in notifications"
         :key="notification.groupCode + '_' + notification.lastId"
         v-bind="cardPropsForNotification(notification)"
-        class="block-item"
       >
-        {{ cardTextForNotification(notification) }}
-      </NotificationCard>
+        <NotificationCard>
+          {{ cardTextForNotification(notification) }}
+        </NotificationCard>
+      </BlockItem>
     </transition-group>
     <div v-if="notifications.length === 0">
       {{ $tr('noActivity') }}
@@ -34,12 +35,14 @@
   import { CollectionTypes } from '../../../constants/lessonsConstants';
   import { notificationLink } from '../../../modules/coachNotifications/gettersUtils';
   import Block from './Block';
+  import BlockItem from './BlockItem';
 
   export default {
     name: 'ActivityBlock',
     components: {
       NotificationCard,
       Block,
+      BlockItem,
     },
     mixins: [nStringsMixin, commonCoach],
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
@@ -67,13 +67,4 @@
     right: -24px;
   }
 
-  /deep/ .block-item:not(:last-child) {
-    padding-right: 24px;
-    padding-bottom: 16px;
-    padding-left: 24px;
-    margin-right: -24px;
-    margin-left: -24px;
-    border-bottom: 1px solid #dedede;
-  }
-
 </style>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="new-coach-block">
+  <KPageContainer class="block">
     <KGrid>
       <KGridItem sizes="100, 50, 50" percentage>
         <h2>
@@ -18,7 +18,7 @@
       </KGridItem>
     </KGrid>
     <slot></slot>
-  </div>
+  </KPageContainer>
 
 </template>
 
@@ -51,8 +51,7 @@
 
 <style lang="scss" scoped>
 
-  .new-coach-block {
-    min-width: auto;
+  .block {
     margin-top: 16px;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
@@ -1,0 +1,46 @@
+<template>
+
+  <div
+    class="block-item"
+    :class="{small : windowIsSmall }"
+  >
+    <slot></slot>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+
+  export default {
+    name: 'BlockItem',
+    mixins: [responsiveWindow],
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .block-item {
+    padding-right: 24px;
+    padding-bottom: 16px;
+    padding-left: 24px;
+    margin-right: -24px;
+    margin-left: -24px;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid #dedede;
+    }
+  }
+
+  .small .block-item {
+    padding-right: 16px;
+    padding-left: 16px;
+    margin-right: -16px;
+    margin-left: -16px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -6,7 +6,7 @@
     :allLinkRoute="classRoute('ReportsLessonListPage', {})"
   >
     <ContentIcon slot="icon" :kind="ContentNodeKinds.LESSON" />
-    <div
+    <BlockItem
       v-for="tableRow in table"
       :key="tableRow.key"
       class="block-item"
@@ -16,7 +16,7 @@
         :tally="tableRow.tally"
         :groupNames="tableRow.groups"
       />
-    </div>
+    </BlockItem>
   </Block>
 
 </template>
@@ -28,6 +28,7 @@
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../../common';
   import Block from './Block';
+  import BlockItem from './BlockItem';
   import ItemProgressDisplay from './ItemProgressDisplay';
   import ActivityBlock from './ActivityBlock';
 
@@ -40,6 +41,7 @@
     components: {
       ItemProgressDisplay,
       Block,
+      BlockItem,
     },
     mixins: [commonCoach],
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <KPageContainer>
     <p>
       <BackLink
         :to="$router.getRoute('CoachClassListPage')"
@@ -20,7 +20,7 @@
         </template>
       </HeaderTableRow>
     </HeaderTable>
-  </div>
+  </KPageContainer>
 
 </template>
 

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -6,17 +6,16 @@
     :allLinkRoute="classRoute('ReportsQuizListPage', {})"
   >
     <ContentIcon slot="icon" :kind="ContentNodeKinds.EXAM" />
-    <div
+    <BlockItem
       v-for="tableRow in table"
       :key="tableRow.key"
-      class="block-item"
     >
       <ItemProgressDisplay
         :name="tableRow.name"
         :tally="tableRow.tally"
         :groupNames="tableRow.groups"
       />
-    </div>
+    </BlockItem>
   </Block>
 
 </template>
@@ -28,6 +27,7 @@
   import orderBy from 'lodash/orderBy';
   import commonCoach from '../../common';
   import Block from './Block';
+  import BlockItem from './BlockItem';
   import ItemProgressDisplay from './ItemProgressDisplay';
   import ActivityBlock from './ActivityBlock';
 
@@ -39,6 +39,7 @@
     components: {
       ItemProgressDisplay,
       Block,
+      BlockItem,
     },
     mixins: [commonCoach],
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
@@ -12,7 +12,7 @@
 
     <KGrid :gutter="16">
       <KGridItem size="100" percentage>
-        <OverviewBlock class="new-coach-block" />
+        <OverviewBlock />
       </KGridItem>
       <KGridItem sizes="100, 100, 50" percentage>
         <KGrid :gutter="16">

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/ExamReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/ExamReportPage.vue
@@ -67,9 +67,17 @@
                 {{ examTakerProgressText(examTaker) }}
               </td>
               <td>
-                {{ examTakerScoreText(examTaker) }}
+                <template v-if="examTaker.score !== undefined">
+                  {{ examTakerScoreText(examTaker) }}
+                </template>
+                <KEmptyPlaceholder v-else />
               </td>
-              <td v-if="!viewByGroups" dir="auto">{{ examTaker.group.name || '–' }}</td>
+              <td v-if="!viewByGroups" dir="auto">
+                <template v-if="examTaker.group.name">
+                  {{ examTaker.group.name }}
+                </template>
+                <KEmptyPlaceholder v-else />
+              </td>
             </tr>
           </transition-group>
         </CoreTable>
@@ -96,6 +104,7 @@
   import { USER, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
+  import KEmptyPlaceholder from 'kolibri.coreVue.components.KEmptyPlaceholder';
   import { PageNames } from '../../../constants';
   import { Modals as ExamModals } from '../../../constants/examConstants';
   import { AssignmentActions } from '../../../constants/assignmentsConstants';
@@ -117,6 +126,7 @@
       AssignmentSummary,
       ManageExamModals,
       KCheckbox,
+      KEmptyPlaceholder,
     },
     data() {
       return {
@@ -200,9 +210,6 @@
         }
       },
       examTakerScoreText({ score }) {
-        if (score === undefined) {
-          return '–';
-        }
         return this.$tr('scorePercentage', { num: score / this.exam.question_count });
       },
       averageScoreText(learners) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -9,7 +9,7 @@
   >
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <PlanHeader />
 
       <h1>{{ $tr('exams') }}</h1>
@@ -85,7 +85,7 @@
       <p v-else-if=" statusSelected.value === $tr('inactiveExams') && !inactiveExams.length">
         {{ $tr('noInactiveExams') }}
       </p>
-    </div>
+    </KPageContainer>
 
     <AssignmentDetailsModal
       v-if="showEditModal"

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -10,7 +10,7 @@
     authorizedRole="adminOrCoach"
   >
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <h1>{{ previewQuizStrings.$tr('preview') }}</h1>
       <h2>{{ detailsString }}</h2>
       <KGrid>
@@ -178,7 +178,7 @@
           @click="submit"
         />
       </Bottom>
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -10,7 +10,7 @@
     authorizedRole="adminOrCoach"
   >
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <h1>{{ $tr('createNewExam') }}</h1>
 
@@ -125,7 +125,7 @@
         />
       </Bottom>
 
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -9,79 +9,81 @@
     :appBarTitle="$tr('groupsHeader')"
     :immersivePageRoute="$router.getRoute('GroupsPage')"
   >
-    <div v-if="!currentGroup">
-      {{ $tr('groupDoesNotExist') }}
-    </div>
+    <KPageContainer>
+      <div v-if="!currentGroup">
+        {{ $tr('groupDoesNotExist') }}
+      </div>
 
-    <div v-else class="new-coach-block">
-      <h1>
-        {{ currentGroup.name }}
-      </h1>
+      <div v-else>
+        <h1>
+          {{ currentGroup.name }}
+        </h1>
 
-      <KGrid>
-        <KGridItem
-          class="number-learners"
-          :size="50"
-          percentage
-        >
-          {{ $tr('numberOfLearners', { count: currentGroup.users.length }) }}
-        </KGridItem>
-        <KGridItem :size="50" percentage alignment="right">
-          <KRouterLink
-            :primary="true"
-            appearance="raised-button"
-            :text="$tr('enrollButton')"
-            :to="$router.getRoute('GroupEnrollPage')"
-          />
-        </KGridItem>
-      </KGrid>
-
-      <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th class="core-table-main-col">
-              {{ $tr('fullName') }}
-            </th>
-            <th>
-              {{ $tr('username') }}
-            </th>
-            <th></th>
-          </tr>
-
-        </thead>
-
-        <tbody slot="tbody">
-          <p v-if="currentGroup.users.length === 0">
-            {{ $tr('noLearnersInGroup') }}
-          </p>
-          <tr
-            v-for="user in currentGroup.users"
-            :key="user.id"
+        <KGrid>
+          <KGridItem
+            class="number-learners"
+            :size="50"
+            percentage
           >
-            <td class="core-table-main-col">
-              {{ user.full_name }}
-            </td>
-            <td>
-              {{ user.username }}
-            </td>
-            <td class="button-col">
-              <KButton
-                :text="$tr('removeButton')"
-                appearance="flat-button"
-                @click="userForRemoval = user"
-              />
-            </td>
-          </tr>
-        </tbody>
-      </CoreTable>
-      <RemoveFromGroupModal
-        v-if="userForRemoval"
-        :groupName="currentGroup.name"
-        :username="userForRemoval.full_name"
-        @cancel="userForRemoval = null"
-        @confirm="removeSelectedUserFromGroup"
-      />
-    </div>
+            {{ $tr('numberOfLearners', { count: currentGroup.users.length }) }}
+          </KGridItem>
+          <KGridItem :size="50" percentage alignment="right">
+            <KRouterLink
+              :primary="true"
+              appearance="raised-button"
+              :text="$tr('enrollButton')"
+              :to="$router.getRoute('GroupEnrollPage')"
+            />
+          </KGridItem>
+        </KGrid>
+
+        <CoreTable>
+          <thead slot="thead">
+            <tr>
+              <th class="core-table-main-col">
+                {{ $tr('fullName') }}
+              </th>
+              <th>
+                {{ $tr('username') }}
+              </th>
+              <th></th>
+            </tr>
+
+          </thead>
+
+          <tbody slot="tbody">
+            <p v-if="currentGroup.users.length === 0">
+              {{ $tr('noLearnersInGroup') }}
+            </p>
+            <tr
+              v-for="user in currentGroup.users"
+              :key="user.id"
+            >
+              <td class="core-table-main-col">
+                {{ user.full_name }}
+              </td>
+              <td>
+                {{ user.username }}
+              </td>
+              <td class="button-col">
+                <KButton
+                  :text="$tr('removeButton')"
+                  appearance="flat-button"
+                  @click="userForRemoval = user"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </CoreTable>
+        <RemoveFromGroupModal
+          v-if="userForRemoval"
+          :groupName="currentGroup.name"
+          :username="userForRemoval.full_name"
+          @cancel="userForRemoval = null"
+          @confirm="removeSelectedUserFromGroup"
+        />
+      </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -9,7 +9,7 @@
   >
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <PlanHeader />
       <h1>{{ $tr('classGroups') }}</h1>
       <div class="ta-r">
@@ -66,7 +66,7 @@
         :groupId="selectedGroup.id"
       />
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
@@ -9,7 +9,7 @@
   >
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <PlanHeader />
 
       <div class="lesson-summary">
@@ -59,7 +59,7 @@
 
       </div>
 
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -9,7 +9,7 @@
   >
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <PlanHeader />
 
       <h1>{{ $tr('classLessons') }}</h1>
@@ -93,7 +93,7 @@
         @continue="handleDetailsModalContinue"
         @cancel="showModal=false"
       />
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLearnerListPage.vue
@@ -8,10 +8,10 @@
     :showSubNav="true"
   >
     <TopNavbar slot="sub-nav" />
-    <div class="new-coach-block">
+    <KPageContainer>
       <PlanHeader />
       Learner list
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupHeader />
       <NotificationsFilter />
@@ -133,7 +133,7 @@
         :text="coachStrings.$tr('showMoreAction')"
       />
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerActivityPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupLearnerHeader />
       <NotificationsFilter />
@@ -133,7 +133,7 @@
         :text="coachStrings.$tr('showMoreAction')"
       />
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <ReportsGroupHeader />
       <CoreTable>
         <thead slot="thead">
@@ -39,7 +39,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerReportLessonPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsGroupLearnerReportPage', {})"
@@ -81,7 +81,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerReportPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupLearnerHeader />
 
@@ -142,7 +142,7 @@
         </KGridItem>
       </KGrid>
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <ReportsHeader />
       <CoreTable>
         <thead slot="thead">
@@ -45,7 +45,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupReportLessonExerciseHeader />
 
@@ -92,7 +92,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupReportLessonExerciseHeader />
 
@@ -36,7 +36,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsGroupReportPage', {})"
@@ -77,7 +77,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsGroupReportLessonPage', {})"
@@ -107,7 +107,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupHeader />
 
@@ -150,7 +150,7 @@
         </KGridItem>
       </KGrid>
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupReportQuizHeader />
 
@@ -79,7 +79,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsGroupReportQuizHeader />
 
@@ -50,7 +50,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLearnerHeader />
       <NotificationsFilter />
@@ -124,7 +124,7 @@
         :text="coachStrings.$tr('showMoreAction')"
       />
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <ReportsHeader />
       <!-- TODO COACH
       <KCheckbox :label="coachStrings.$tr('viewByGroupsLabel')" />
@@ -43,7 +43,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsLearnerReportPage', {})"
@@ -78,7 +78,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLearnerHeader />
 
@@ -142,7 +142,7 @@
         </KGridItem>
       </KGrid>
 
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonEditorPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonEditorPage.vue
@@ -10,14 +10,14 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <LessonDetailEditor />
       <p><KButton :text="coachStrings.$tr('manageResourcesAction')" /></p>
       <h2>{{ coachStrings.$tr('numberOfResources', { value: 2 }) }}</h2>
       <pre>ResourceListTable</pre>
       <KButton :text="coachStrings.$tr('cancelAction')" :primary="false" />
       <KButton :text="coachStrings.$tr('saveAction')" :primary="true" />
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLessonExerciseHeader />
 
@@ -56,7 +56,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLessonExerciseHeader />
 
@@ -40,7 +40,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLessonHeader />
 
@@ -41,7 +41,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsLessonLearnerListPage')"
@@ -44,7 +44,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -9,7 +9,7 @@
   >
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <ReportsHeader />
       <KSelect
         v-model="filter"
@@ -49,7 +49,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonManagerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonManagerPage.vue
@@ -10,9 +10,9 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       Resource manager
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsLessonHeader />
 
@@ -54,7 +54,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <p>
         <BackLink
           :to="classRoute('ReportsLessonReportPage', {})"
@@ -62,7 +62,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizEditorPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizEditorPage.vue
@@ -10,11 +10,11 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <QuizDetailEditor />
       <KButton :text="coachStrings.$tr('cancelAction')" :primary="false" />
       <KButton :text="coachStrings.$tr('saveAction')" :primary="true" />
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsQuizHeader />
 
@@ -44,7 +44,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
       <ReportsHeader />
       <KSelect
         v-model="filter"
@@ -52,7 +52,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -10,7 +10,7 @@
 
     <TopNavbar slot="sub-nav" />
 
-    <div class="new-coach-block">
+    <KPageContainer>
 
       <ReportsQuizHeader />
 
@@ -50,7 +50,7 @@
           </tr>
         </transition-group>
       </CoreTable>
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/device_management/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceIndex.vue
@@ -18,9 +18,9 @@
       />
     </transition>
 
-    <div>
+    <KPageContainer>
       <component :is="currentPage" />
-    </div>
+    </KPageContainer>
   </CoreBase>
 
 </template>
@@ -30,6 +30,7 @@
 
   import { mapState, mapGetters, mapActions } from 'vuex';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
+  import KPageContainer from 'kolibri.coreVue.components.KPageContainer';
   import { ContentWizardPages, PageNames } from '../constants';
   import DeviceTopNav from './DeviceTopNav';
   import ManageContentPage from './ManageContentPage';
@@ -55,6 +56,7 @@
       CoreBase,
       WelcomeModal,
       DeviceTopNav,
+      KPageContainer,
     },
     computed: {
       ...mapGetters(['canManageContent']),

--- a/kolibri/plugins/facility_management/assets/src/views/FacilityIndex.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityIndex.vue
@@ -12,10 +12,10 @@
   >
     <FacilityTopNav slot="sub-nav" />
 
-    <div class="facility-management">
+    <KPageContainer>
       <!-- QUESTION should we explicitly define this in every page? -->
       <component :is="currentPage" />
-    </div>
+    </KPageContainer>
 
   </CoreBase>
 
@@ -26,6 +26,7 @@
 
   import { mapState, mapGetters } from 'vuex';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
+  import KPageContainer from 'kolibri.coreVue.components.KPageContainer';
   import { PageNames } from '../constants';
   import ClassEditPage from './ClassEditPage';
   import CoachClassAssignmentPage from './CoachClassAssignmentPage';
@@ -59,6 +60,7 @@
     components: {
       CoreBase,
       FacilityTopNav,
+      KPageContainer,
     },
     computed: {
       ...mapGetters(['isAdmin', 'isSuperuser']),

--- a/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/index.vue
@@ -45,7 +45,10 @@
           </td>
           <td>
             <span :ref="`coachNames${classroom.id}`">
-              {{ formattedCoachNames(classroom) }}
+              <template v-if="coachNames(classroom).length">
+                {{ formattedCoachNames(classroom) }}
+              </template>
+              <KEmptyPlaceholder v-else />
             </span>
             <KTooltip
               v-if="formattedCoachNamesTooltip(classroom)"
@@ -98,6 +101,7 @@
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
+  import KEmptyPlaceholder from 'kolibri.coreVue.components.KEmptyPlaceholder';
   import { Modals, PageNames } from '../../constants';
   import ClassCreateModal from './ClassCreateModal';
   import ClassDeleteModal from './ClassDeleteModal';
@@ -126,6 +130,7 @@
       KGridItem,
       UiIcon,
       KTooltip,
+      KEmptyPlaceholder,
     },
     data: () => ({ currentClassDelete: null }),
     computed: {
@@ -147,9 +152,6 @@
       },
       formattedCoachNames(classroom) {
         const coach_names = this.coachNames(classroom);
-        if (coach_names.length === 0) {
-          return '–';
-        }
         if (coach_names.length === 1) {
           return coach_names[0];
         }


### PR DESCRIPTION

### Summary

Consistent 'empty value' placeholder across all tables with gray text and an em-dash:



| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52193524-66221280-2804-11e9-9ea6-57f6fa128117.png)  |  ![image](https://user-images.githubusercontent.com/2367265/52193585-bbf6ba80-2804-11e9-864c-d63cce2872d2.png)|


New containers are now a core, responsive component and applied to Coach, Facilty, and Device:

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52193497-41c63600-2804-11e9-93a7-fa7bd9557b5d.png)  |  ![image](https://user-images.githubusercontent.com/2367265/52193337-9f0db780-2803-11e9-8321-d8bbdea57e13.png) |



top-nav tab styling updates:


| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52193479-307d2980-2804-11e9-926f-99225b6f75c4.png) | ![image](https://user-images.githubusercontent.com/2367265/52193363-b3ea4b00-2803-11e9-9722-4d53ce3831a9.png) |


Coach inner-tab styling updates:


| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52193463-25c29480-2804-11e9-91c0-9e52e75a1327.png) | ![image](https://user-images.githubusercontent.com/2367265/52193384-cbc1cf00-2803-11e9-80a3-2703110dfd2e.png) |






### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
