### PR TITLE
Android build mods

### DIFF
--- a/.buildkite/build_apk.sh
+++ b/.buildkite/build_apk.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # clone the repo if folder does not exist
 if [ ! -d $ANDROID_REPO_NAME ]; then
   echo '--- :robot_face: Cloning android repo'
-  git clone https://github.com/learningequality/${ANDROID_REPO_NAME}.git
+  git clone -b develop https://github.com/learningequality/${ANDROID_REPO_NAME}.git
 fi
 
 cd $ANDROID_REPO_NAME

--- a/.buildkite/build_apk.sh
+++ b/.buildkite/build_apk.sh
@@ -15,7 +15,15 @@ echo $PWD
 
 # Ensure that we're on the latest version of develop
 git fetch origin
-git checkout origin/develop
+
+# Defined in buildkite agent for release
+if [ -v ANDROID_VERSION_TAG ]; then
+  git checkout $ANDROID_VERSION_TAG
+  echo "Building with Android Installer Version $ANDROID_VERSION_TAG"
+else
+  git checkout origin/develop
+  echo "BUilding with Android Installer's Develop Branch"
+fi
 
 echo '--- :ferris_wheel: Copying in latest Kolibri whl'
 # copy in the latest whl to make it available to the Docker build script

--- a/.buildkite/build_apk.sh
+++ b/.buildkite/build_apk.sh
@@ -1,26 +1,36 @@
 #!/usr/bin/env bash
 
+ANDROID_REPO_NAME="kolibri-installer-android"
+
 set -euo pipefail
 
-# clone a fresh copy of the latest Kolibri Kivy repository
-yes y | rm -r kolibri-kivy/ || true 2> /dev/null
-git clone https://github.com/learningequality/kolibri-kivy.git
-cd kolibri-kivy
-git checkout develop
-cd ..
+# clone the repo if folder does not exist
+if [ ! -d $ANDROID_REPO_NAME ]; then
+  echo '--- :robot_face: Cloning android repo'
+  git clone https://github.com/learningequality/${ANDROID_REPO_NAME}.git
+fi
 
+cd $ANDROID_REPO_NAME
+echo $PWD
+
+# Ensure that we're on the latest version of develop
+git fetch origin
+git checkout origin/develop
+
+echo '--- :ferris_wheel: Copying in latest Kolibri whl'
 # copy in the latest whl to make it available to the Docker build script
-buildkite-agent artifact download 'dist/*.whl' dist/
-cp dist/*.whl kolibri-kivy/src
+buildkite-agent artifact download 'dist/*.whl' .
+# Should probably already be there
+mkdir -p whl
+mv dist/*.whl whl/
 
-# build the APK
-cd kolibri-kivy
-make rundocker
-cd ..
-
-# extract the APK into the installer directory, and rename it to match the whl
-mkdir -p installer
-cp kolibri-kivy/bin/*.apk installer/`basename -s .whl dist/*.whl`.apk
+echo '--- :construction_worker: Building the APK'
+# build apk using docker
+make run_docker
 
 # upload the APK to Buildkite
-buildkite-agent artifact upload 'installer/*.apk'
+# TODO add last argument to change name on upload
+cd dist/android/
+
+echo '--- :arrow_up: Uploading to Buildkite'
+buildkite-agent artifact upload '*-release.apk'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,13 @@ steps:
 
   - wait
 
+    # Android build only requires whl file
+  - label: Build Android APK
+    env:
+      KOLIBRI_ANDROID_BUILD_MODE: dev
+    command: &android_build
+      - .buildkite/build_apk.sh
+
   - label: Build Windows installer
     command: .buildkite/build_windows_installer.sh
 
@@ -34,11 +41,11 @@ steps:
   - label: Cleaning up
     command: make docker-clean
 
-  - block: "Create APK?"
-  - label: Build the Android APK file
-    command:
-     - mkdir -p dist
-     - .buildkite/build_apk.sh
+  - block: "Build release APK?"
+  - label: "Build Release APK"
+    env:
+      KOLIBRI_ANDROID_BUILD_MODE: release
+    command: *android_build
 
   - block: "Test .debs?"
   - label: Test on Trusty, Xenial, Bionic

--- a/kolibri/core/analytics/pskolibri/common.py
+++ b/kolibri/core/analytics/pskolibri/common.py
@@ -7,16 +7,13 @@ import os
 import sys
 from collections import namedtuple
 
-# Android is based on the Linux kernel, but due to security issues, we cannot
-# run the /proc command there, so we need a way to distinguish between the two.
-# Python for Android always sets some Android environment variables, so we check
-# for one of them to differentiate. This is how Kivy detects Android as well.
-ANDROID = "ANDROID_ARGUMENT" in os.environ
+from kolibri.utils.android import on_android
+
 
 PY3 = sys.version_info[0] == 3
 POSIX = os.name == "posix"
 WINDOWS = os.name == "nt"
-LINUX = sys.platform.startswith("linux") and not ANDROID
+LINUX = sys.platform.startswith("linux") and not on_android()
 MACOS = sys.platform.startswith("darwin")
 
 if PY3:

--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -6,21 +6,22 @@ import subprocess
 import sys
 
 from .constants import drivetypes
+from kolibri.utils.android import on_android
 
 logger = logging.getLogger(__name__)
 
 # Regex parser for the output of `mount` on OSX, which contains rows that looks like:
 #  /dev/disk1s1 on /Volumes/HP v125w (msdos, local, nodev, nosuid, noowners)
-OSX_MOUNT_PARSER = re.compile("^(?P<device>\S+) on (?P<path>.+) \((?P<filesystem>[^, ]+)", flags=re.MULTILINE)
+OSX_MOUNT_PARSER = re.compile(r"^(?P<device>\S+) on (?P<path>.+) \((?P<filesystem>[^, ]+)", flags=re.MULTILINE)
 
 # Regex parser for the output of `mount` on Linux, which contains rows that looks like:
 #  /dev/sdb2 on /media/user/KEEPOD type ext4 (rw,nosuid,nodev,uhelper=udisks2)
-LINUX_MOUNT_PARSER = re.compile("^(?P<device>\S+) on (?P<path>.+) type (?P<filesystem>\S+)", flags=re.MULTILINE)
+LINUX_MOUNT_PARSER = re.compile(r"^(?P<device>\S+) on (?P<path>.+) type (?P<filesystem>\S+)", flags=re.MULTILINE)
 
 # Regex parser for the output of 'mount' on Android, which contains rows that looks like:
 #  /dev/block/bootdevice/by-name/userdata /data ext4 rw,seclabel,nosuid,nodev,noatime,noauto_da_alloc,data=ordered 0 0
 # Note that access to /proc/ is restricted in later versions of Android. Will break the app.
-RAW_MOUNT_PARSER = re.compile("^(?P<device>\S+) (?P<path>\S+) (?P<filesystem>\S+)", flags=re.MULTILINE)
+RAW_MOUNT_PARSER = re.compile(r"^(?P<device>\S+) (?P<path>\S+) (?P<filesystem>\S+)", flags=re.MULTILINE)
 
 
 FILESYSTEM_BLACKLIST = set(["anon_inodefs", "bdev", "binfmt_misc", "cgroup", "cpuset", "debugfs", "devpts", "devtmpfs",
@@ -41,7 +42,7 @@ def get_drive_list():
 
     if sys.platform == "darwin":
         MOUNT_PARSER = OSX_MOUNT_PARSER
-    elif 'ANDROID_ARGUMENT' in os.environ:
+    elif on_android():
         MOUNT_PARSER = RAW_MOUNT_PARSER
     else:
         MOUNT_PARSER = LINUX_MOUNT_PARSER
@@ -101,7 +102,7 @@ def _get_drive_usage(path):
             "used": usage.used,
             "free": usage.free,
         }
-    elif 'ANDROID_ARGUMENT' in os.environ:
+    elif on_android():
         from jnius import autoclass
         StatFs = autoclass('android.os.StatFs')
         stats = StatFs(path)

--- a/kolibri/utils/android.py
+++ b/kolibri/utils/android.py
@@ -1,0 +1,9 @@
+from os import environ
+
+
+# Android is based on the Linux kernel, but due to security issues, we cannot
+# run the /proc command there, so we need a way to distinguish between the two.
+# Python for Android always sets some Android environment variables, so we check
+# for one of them to differentiate. This is how Kivy detects Android as well.
+def on_android():
+    return 'ANDROID_ARGUMENT' in environ

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -17,6 +17,7 @@ from .system import kill_pid
 from .system import pid_exists
 from kolibri.core.content.utils import paths
 from kolibri.utils import conf
+from kolibri.utils.android import on_android
 
 logger = logging.getLogger(__name__)
 
@@ -456,5 +457,11 @@ def installation_type(cmd_line=None):  # noqa:C901
                     break
         elif 'start' in cmd_line:
             install_type = 'whl'
+    if on_android():
+        from jnius import autoclass
+        context = autoclass('org.kivy.android.PythonActivity')
+        version_name = context.getPackageManager().getPackageInfo(
+            context.getPackageName(), 0).versionName
+        install_type = 'apk - {}'.format(version_name)
 
     return install_type

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -22,6 +22,7 @@ import sys
 import six
 
 from .conf import KOLIBRI_HOME
+from kolibri.utils.android import on_android
 
 
 def _posix_pid_exists(pid):
@@ -153,7 +154,7 @@ def get_free_space(path=KOLIBRI_HOME):
         if check == 0:
             raise ctypes.winError()
         result = free.value
-    elif 'ANDROID_ARGUMENT' in os.environ:
+    elif on_android():
         # This is meant for android, which needs to interact with android API to understand free
         # space. If we're somehow getting here on non-android, we've got a problem.
         try:
@@ -165,7 +166,7 @@ def get_free_space(path=KOLIBRI_HOME):
             try:
                 # for api version 18+
                 result = st.getFreeBlocksLong() * st.getBlockSizeLong()
-            except Exception as e:
+            except Exception:
                 # for api versions < 18
                 result = st.getFreeBlocks() * st.getBlockSize()
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Reintroduces android builds to Buldkite. 

Adds display mechanism for android version under the Device Info page.

Introduces an `on_android` function to consolidate the check mechanism in one place.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Let buildkite build the apk in the second step.

Install the APK, make sure it works. Check the device info page to ensure that the correct version number is being presented under "installer".

Run Kolibri and see if calls to `api.py` and `system.py` are working correctly.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
