### PR TITLE
calculate list of available node ids for lesson in class summary endpoint

### DIFF
--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+
+from django.core.urlresolvers import reverse
+from le_utils.constants import content_kinds
+from rest_framework.test import APITestCase
+
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.lessons import models
+
+DUMMY_PASSWORD = "password"
+
+
+class ClassSummaryTestCase(APITestCase):
+
+    fixtures = ['content_test.json']
+    the_channel_id = '6199dde695db4ee4ab392222d5af1e5c'
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name="MyFac")
+        self.classroom = Classroom.objects.create(name='classrom', parent=self.facility)
+        self.admin = FacilityUser.objects.create(username="admin", facility=self.facility)
+        self.admin.set_password(DUMMY_PASSWORD)
+        self.admin.save()
+        self.facility.add_admin(self.admin)
+        self.lesson = models.Lesson.objects.create(
+            title="title",
+            is_active=True,
+            collection=self.classroom,
+            created_by=self.admin
+        )
+
+    def test_non_existent_nodes_dont_show_up_in_lessons(self):
+        node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).first()
+        last_node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).last()
+        real_data = {'contentnode_id': node.id, 'content_id': node.content_id, 'channel_id': node.channel_id}
+        switched_data = {'contentnode_id': uuid.uuid4().hex, 'content_id': last_node.content_id, 'channel_id': node.channel_id}
+        fake_data = {'contentnode_id': uuid.uuid4().hex, 'content_id': uuid.uuid4().hex, 'channel_id': node.channel_id}
+        self.lesson.resources = [real_data, switched_data, fake_data]
+        self.lesson.save()
+
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse("kolibri:coach:classsummary-detail", kwargs={'pk': self.classroom.id}))
+        node_ids = response.data['lessons'][0]['node_ids']
+        self.assertIn(real_data['contentnode_id'], node_ids)
+        # swapped data
+        self.assertIn(last_node.id, node_ids)
+        self.assertNotIn(fake_data['contentnode_id'], node_ids)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Content nodes that do not exist in lessons, will not be returned in the api response.
Those nodes will removed from the `nodes_id` list, or the `contentnode_id` will be swapped out if there is a matching `content_id` for another node elsewhere.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create lesson and add some content
2. Delete content
3. Check if content is still returned in the lesson

Does UI behave correctly?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

First step towards addressing https://github.com/learningequality/kolibri/issues/4839

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
