### PR TITLE
Don't exit if database is locked while vacuuming

### DIFF
--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -6,6 +6,7 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
+import logging
 import os
 import time
 
@@ -13,9 +14,20 @@ from django.core.wsgi import get_wsgi_application
 from django.db.utils import OperationalError
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
+logger = logging.getLogger(__name__)
 
-try:
-    application = get_wsgi_application()
-except OperationalError:  # It happens when sqlite vacuum is being executed. The db is locked
-    time.sleep(60)  # vacuum should not take longer than 1 minute
-    application = get_wsgi_application()  # try again one last time
+application = None
+tries_remaining = 6
+interval = 10
+while not application and tries_remaining:
+    try:
+        logger.info("Starting Kolibri")
+        application = get_wsgi_application()
+    except OperationalError:
+        # an OperationalError happens when sqlite vacuum is being executed. the db is locked
+        logger.info("DB busy. Trying again in {}s".format(interval))
+        tries_remaining -= 1
+        time.sleep(interval)
+        application = get_wsgi_application()  # try again one last time
+if not application:
+    logger.error("Could not start Kolibri")

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -7,9 +7,15 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 import os
+import time
 
 from django.core.wsgi import get_wsgi_application
+from django.db.utils import OperationalError
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
 
-application = get_wsgi_application()
+try:
+    application = get_wsgi_application()
+except OperationalError:  # It happens when sqlite vacuum is being executed. The db is locked
+    time.sleep(60)  # vacuum should not take longer than 1 minute
+    application = get_wsgi_application()  # try again one last time

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -273,7 +273,6 @@ def start(port=None, daemon=True):
     :param: port: Port number (default: 8080)
     :param: daemon: Fork to background process (default: True)
     """
-
     run_cherrypy = conf.OPTIONS["Server"]["CHERRYPY_START"]
 
     # This is temporarily put in place because of
@@ -663,7 +662,11 @@ def main(args=None):  # noqa: max-complexity=13
         return
 
     if arguments['start']:
-
+        try:
+            with open(server.STARTUP_LOCK, 'w') as f:
+                f.write("%d\n%d" % (os.getpid(), port))
+        except (IOError, OSError):
+            logger.warn('Impossible to create file lock to communicate starting process')
         # Check if the content directory exists when Kolibri runs after the first time.
         check_content_directory_exists_and_writable()
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -663,8 +663,7 @@ def main(args=None):  # noqa: max-complexity=13
 
     if arguments['start']:
         try:
-            with open(server.STARTUP_LOCK, 'w') as f:
-                f.write("%d\n%d" % (os.getpid(), port))
+            server._write_pid_file(server.STARTUP_LOCK, port)
         except (IOError, OSError):
             logger.warn('Impossible to create file lock to communicate starting process')
         # Check if the content directory exists when Kolibri runs after the first time.

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -310,9 +310,9 @@ def get_status():  # noqa: max-complexity=16
         except (TypeError, ValueError):
             raise NotRunning(STATUS_STOPPED)
 
-        if not os.path.isfile(PID_FILE):
-            # There is no PID file (created by server daemon)
-            raise NotRunning(STATUS_STOPPED)  # Stopped
+    if not os.path.isfile(PID_FILE):
+        # There is no PID file (created by server daemon)
+        raise NotRunning(STATUS_STOPPED)  # Stopped
 
     # PID file exists and startup has finished, check if it is running
     try:

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -296,9 +296,8 @@ def get_status():  # noqa: max-complexity=16
     :raises: NotRunning
     """
 
-    # Is there a startup lock?
+    # Check if the system is still starting (clear sessions and vacuum not finished yet):
     if os.path.isfile(STARTUP_LOCK):
-
         try:
             pid, port = _read_pid_file(STARTUP_LOCK)
             # Does the PID in there still exist?
@@ -315,7 +314,7 @@ def get_status():  # noqa: max-complexity=16
             # There is no PID file (created by server daemon)
             raise NotRunning(STATUS_STOPPED)  # Stopped
 
-    # PID file exists, check if it is running
+    # PID file exists and startup has finished, check if it is running
     try:
         pid, port = _read_pid_file(PID_FILE)
     except (ValueError, OSError):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -107,11 +107,12 @@ def start(port=8080, run_cherrypy=True):
 def block():
     # Modified from:
     # https://github.com/cherrypy/cherrypy/blob/e5de08887ddb960b337e1f335c819c0b2873d850/cherrypy/process/wspbus.py#L326
+    unlock_after_vacuum()
     try:
         while True:
             time.sleep(100000)
     except Exception as e:
-        logger.error('Block interrupted!', e)
+        logger.error('Block interrupted! %s' % e)
     # Waiting for ALL child threads to finish is necessary on OS X.
     # See https://github.com/cherrypy/cherrypy/issues/581.
     # It's also good to let them all shut down before allowing
@@ -220,8 +221,19 @@ def run_server(port):
     server.subscribe()
 
     # Start the server engine (Option 1 *and* 2)
+    unlock_after_vacuum()  # don't start the server until vacuum finishes
     cherrypy.engine.start()
     cherrypy.engine.block()
+
+
+def unlock_after_vacuum():
+    while vacuum_db_lock.locked():
+        time.sleep(0.5)
+    if os.path.exists(STARTUP_LOCK):
+        try:
+            os.remove(STARTUP_LOCK)
+        except OSError:
+            pass  # lock file was deleted by other process
 
 
 def serve_static_dir(root, url):
@@ -284,22 +296,24 @@ def get_status():  # noqa: max-complexity=16
     :raises: NotRunning
     """
 
-    # There is no PID file (created by server daemon)
-    if not os.path.isfile(PID_FILE):
-        # Is there a startup lock?
-        if os.path.isfile(STARTUP_LOCK):
-            try:
-                pid, port = _read_pid_file(STARTUP_LOCK)
-                # Does the PID in there still exist?
-                if pid_exists(pid):
-                    raise NotRunning(STATUS_STARTING_UP)
-                # It's dead so assuming the startup went badly
-                else:
-                    raise NotRunning(STATUS_FAILED_TO_START)
-            # Couldn't parse to int or empty PID file
-            except (TypeError, ValueError):
-                raise NotRunning(STATUS_STOPPED)
-        raise NotRunning(STATUS_STOPPED)  # Stopped
+    # Is there a startup lock?
+    if os.path.isfile(STARTUP_LOCK):
+
+        try:
+            pid, port = _read_pid_file(STARTUP_LOCK)
+            # Does the PID in there still exist?
+            if pid_exists(pid):
+                raise NotRunning(STATUS_STARTING_UP)
+            # It's dead so assuming the startup went badly
+            else:
+                raise NotRunning(STATUS_FAILED_TO_START)
+        # Couldn't parse to int or empty PID file
+        except (TypeError, ValueError):
+            raise NotRunning(STATUS_STOPPED)
+
+        if not os.path.isfile(PID_FILE):
+            # There is no PID file (created by server daemon)
+            raise NotRunning(STATUS_STOPPED)  # Stopped
 
     # PID file exists, check if it is running
     try:


### PR DESCRIPTION
### Summary
When running kolibri  under uwsgi, we are keeping Kolibri process running too , to be able to execute the background tasks.
This can drive to a race condition if Kolibri is executing vacuum: the database is locked, uwsgi dies and the users can't access to the server.

This PR waits for one minute if the database connection fails and try it again one more time.


### Reviewer guidance
The only way to review it is to have the chance of doing a big vacuum executin when kolibri starts and run kolibri under uwsgi at the same time.

### References
No issues existing, just feedback from kolibri-server tests


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
