### PR TITLE
Fix various issues obvious from navigation of coach reports

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -3,6 +3,8 @@ require('array-includes').shim();
 // polyfill for older browsers
 // TODO: rtibbles whittle down these polyfills to only what is needed for the application
 require('core-js');
+// polyfill for Promise finally
+require('promise.prototype.finally').shim();
 
 // Do this before any async imports to ensure that public paths
 // are set correctly

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
-    "@shopify/draggable": "^1.0.0-beta.8",
     "@sentry/browser": "4.5.3",
+    "@shopify/draggable": "^1.0.0-beta.8",
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "array-includes": "^3.0.3",
     "clipboard": "^2.0.1",
@@ -26,6 +26,7 @@
     "markdown-it": "^8.3.1",
     "material-design-icons": "^3.0.1",
     "popper.js": "^1.14.6",
+    "promise.prototype.finally": "^3.1.0",
     "purecss": "^0.6.2",
     "rest": "^1.3.2",
     "screenfull": "^4.0.0",

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -341,5 +341,8 @@ export default {
         store.commit('SET_STATE', summary);
       });
     },
+    refreshClassSummary(store) {
+      return store.dispatch('loadClassSummary', store.state.id);
+    },
   },
 };

--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -30,6 +30,9 @@ export function createGroup(store, { groupName, classId }) {
       store.commit('SET_GROUPS', groups);
       store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
       store.commit('SET_GROUP_MODAL', '');
+      // We have updated the groups, so update the classSummary
+      // to get that back up to date!
+      return store.dispatch('classSummary/refreshClassSummary', null, { root: true });
     },
     error => store.dispatch('handleError', error, { root: true })
   );

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -91,6 +91,11 @@ export function saveLessonResources(store, { lessonId, resourceIds }) {
     return LessonResource.saveModel({
       id: lessonId,
       data: { resources },
+    }).then(lesson => {
+      // Update the class summary now that there is a change to a lesson
+      return store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
+        return lesson;
+      });
     });
   });
 }
@@ -152,15 +157,18 @@ export function deleteLesson(store, { lessonId, classId }) {
 export function copyLesson(store, { payload, classroomName }) {
   LessonResource.saveModel({ data: payload })
     .then(() => {
-      store.dispatch('setLessonsModal', null);
-      store.dispatch(
-        'createSnackbar',
-        {
-          text: translator.$tr('copiedLessonTo', { classroomName }),
-          autoDismiss: true,
-        },
-        { root: true }
-      );
+      // Update the class summary now that there is a new lesson
+      store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
+        store.dispatch('setLessonsModal', null);
+        store.dispatch(
+          'createSnackbar',
+          {
+            text: translator.$tr('copiedLessonTo', { classroomName }),
+            autoDismiss: true,
+          },
+          { root: true }
+        );
+      });
     })
     .catch(error => {
       store.dispatch('handleApiError', error, { root: true });

--- a/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
@@ -41,7 +41,10 @@ export function createLesson(store, { classId, payload }) {
           },
           { root: true }
         );
-        resolve();
+        // Update the class summary now that we have a new lesson in town!
+        store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
+          resolve();
+        });
       })
       .catch(() => {
         reject();

--- a/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
@@ -32,7 +32,6 @@ export function createLesson(store, { classId, payload }) {
       },
     })
       .then(newLesson => {
-        router.push(lessonSummaryLink({ classId, lessonId: newLesson.id }));
         store.dispatch(
           'createSnackbar',
           {
@@ -43,6 +42,7 @@ export function createLesson(store, { classId, payload }) {
         );
         // Update the class summary now that we have a new lesson in town!
         store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
+          router.push(lessonSummaryLink({ classId, lessonId: newLesson.id }));
           resolve();
         });
       })

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -41,7 +41,7 @@ export default {
     },
   },
   getters: {
-    multipleClasses(state) {
+    classListPageEnabled(state) {
       return state.classList.length > 1;
     },
   },

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -40,6 +40,11 @@ export default {
       state.toolbarRoute = toolbarRoute;
     },
   },
+  getters: {
+    multipleClasses(state) {
+      return state.classList.length > 1;
+    },
+  },
   actions: {
     setClassList(store) {
       return ClassroomResource.fetchCollection({ getParams: { role: 'coach' } })
@@ -88,6 +93,9 @@ export default {
       if (store.state.classSummary.id !== classId) {
         store.dispatch('loading');
         return Promise.all([
+          // Make sure we load any class list data, so that we know
+          // whether this user has access to multiple classes or not.
+          store.dispatch('setClassList'),
           store.dispatch('classSummary/loadClassSummary', classId),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
         ]);

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -1,6 +1,5 @@
 import store from 'kolibri.coreVue.vuex.store';
 import router from 'kolibri.coreVue.router';
-import { ClassroomResource } from 'kolibri.resources';
 import CoachClassListPage from '../views/CoachClassListPage';
 import HomePage from '../views/home/HomePage';
 import HomeActivityPage from '../views/home/HomeActivityPage';
@@ -15,26 +14,22 @@ export default [
     path: '/',
     component: CoachClassListPage,
     handler() {
-      const classroomsPromise = ClassroomResource.fetchCollection({
-        getParams: { role: 'coach' },
-        force: true,
-      });
-      classroomsPromise.then(classrooms => {
-        if (classrooms.length === 1) {
-          router.replace({
-            name: HomePage.name,
-            params: { classId: classrooms[0].id },
-          });
-          return;
-        }
-        store.dispatch('loading');
-        store
-          .dispatch('setClassList')
-          .then(
-            () => store.dispatch('notLoading'),
-            error => store.dispatch('handleApiError', error)
-          );
-      });
+      store.dispatch('loading');
+      store.dispatch('setClassList').then(
+        () => {
+          if (!store.getters.classListPageEnabled) {
+            // If no class list page, redirect to
+            // the first (and only) class.
+            router.replace({
+              name: HomePage.name,
+              params: { classId: store.state.classList[0].id },
+            });
+            return;
+          }
+          store.dispatch('notLoading');
+        },
+        error => store.dispatch('handleApiError', error)
+      );
     },
   },
   {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -3,7 +3,7 @@
   <KPageContainer>
     <p>
       <BackLink
-        v-if="multipleClasses"
+        v-if="classListPageEnabled"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -42,7 +42,7 @@
       learner: '{count, plural, one {Learner} other {Learners}}',
     },
     computed: {
-      ...mapGetters(['multipleClasses']),
+      ...mapGetters(['classListPageEnabled']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -3,6 +3,7 @@
   <KPageContainer>
     <p>
       <BackLink
+        v-if="multipleClasses"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -27,6 +28,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import commonCoach from '../../common';
 
   export default {
@@ -40,6 +42,7 @@
       learner: '{count, plural, one {Learner} other {Learners}}',
     },
     computed: {
+      ...mapGetters(['multipleClasses']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -3,7 +3,7 @@
   <div>
     <p>
       <BackLink
-        v-if="multipleClasses"
+        v-if="classListPageEnabled"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -40,7 +40,7 @@
     components: {},
     mixins: [commonCoach],
     computed: {
-      ...mapGetters(['multipleClasses']),
+      ...mapGetters(['classListPageEnabled']),
       LessonsPageNames() {
         return LessonsPageNames;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -3,6 +3,7 @@
   <div>
     <p>
       <BackLink
+        v-if="multipleClasses"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -30,6 +31,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import commonCoach from '../common';
   import { LessonsPageNames } from '../../constants/lessonsConstants';
 
@@ -38,6 +40,7 @@
     components: {},
     mixins: [commonCoach],
     computed: {
+      ...mapGetters(['multipleClasses']),
       LessonsPageNames() {
         return LessonsPageNames;
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -30,7 +30,12 @@
         <transition-group slot="tbody" tag="tbody" name="list">
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
-              <KRouterLink :text="tableRow.name" :to="link(tableRow.id)" />
+              <KRouterLink
+                v-if="tableRow.status.status !== STATUSES.notStarted"
+                :text="tableRow.name"
+                :to="link(tableRow.id)"
+              />
+              <template v-else>{{ tableRow.name }}</template>
             </td>
             <td>
               <StatusSimple :status="tableRow.statusObj.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
@@ -17,7 +17,7 @@
       </HeaderTableRow>
       <HeaderTableRow>
         <template slot="key">{{ coachStrings.$tr('avgScoreLabel') }}</template>
-        <template slot="value">{{ coachStrings.$tr('percentage', { value: avgScore }) }}</template>
+        <Score slot="value" :value="avgScore" />
       </HeaderTableRow>
       <!-- TODO COACH
       <HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -25,9 +25,13 @@
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
               <KRouterLink
+                v-if="tableRow.statusObj.status !== STATUSES.notStarted"
                 :text="tableRow.name"
                 :to="detailLink(tableRow.id)"
               />
+              <template v-else>
+                {{ tableRow.name }}
+              </template>
             </td>
             <td>
               <StatusSimple :status="tableRow.statusObj.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -3,7 +3,7 @@
   <div>
     <p>
       <BackLink
-        v-if="multipleClasses"
+        v-if="classListPageEnabled"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -44,7 +44,7 @@
     components: {},
     mixins: [commonCoach],
     computed: {
-      ...mapGetters(['multipleClasses']),
+      ...mapGetters(['classListPageEnabled']),
     },
     $trs: {
       back: 'All classes',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -3,6 +3,7 @@
   <div>
     <p>
       <BackLink
+        v-if="multipleClasses"
         :to="$router.getRoute('CoachClassListPage')"
         :text="$tr('back')"
       />
@@ -35,12 +36,16 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import commonCoach from '../common';
 
   export default {
     name: 'ReportsHeader',
     components: {},
     mixins: [commonCoach],
+    computed: {
+      ...mapGetters(['multipleClasses']),
+    },
     $trs: {
       back: 'All classes',
       description: 'View reports for your learners and class materials',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -35,7 +35,12 @@
         <transition-group slot="tbody" tag="tbody" name="list">
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
-              <KRouterLink :text="tableRow.name" :to="link(tableRow.id)" />
+              <KRouterLink
+                v-if="tableRow.status.status !== STATUSES.notStarted"
+                :text="tableRow.name"
+                :to="link(tableRow.id)"
+              />
+              <template v-else>{{ tableRow.name }}</template>
             </td>
             <td>
               <StatusSimple :status="tableRow.status.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
@@ -31,7 +31,7 @@
       </HeaderTableRow>
       <HeaderTableRow>
         <template slot="key">{{ coachStrings.$tr('avgScoreLabel') }}</template>
-        <template slot="value">{{ coachStrings.$tr('percentage', { value: avgScore }) }}</template>
+        <Score slot="value" :value="avgScore" />
       </HeaderTableRow>
       <!-- TODO COACH
       <HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -26,6 +26,7 @@
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
               <KRouterLink
+                v-if="tableRow.statusObj.status !== STATUSES.notStarted"
                 :text="tableRow.name"
                 :to="classRoute('ReportsQuizLearnerPage', {
                   learnerId: tableRow.id,
@@ -33,6 +34,9 @@
                   interactionIndex: 0
                 })"
               />
+              <template v-else>
+                {{ tableRow.name }}
+              </template>
             </td>
             <td>
               <StatusSimple :status="tableRow.statusObj.status" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,7 +3716,19 @@ es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
-es-to-primitive@^1.1.1:
+es-abstract@^1.9.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
   integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
@@ -5166,7 +5178,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -9414,6 +9426,15 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise.prototype.finally@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz#66f161b1643636e50e7cf201dc1b84a857f3864e"
+  integrity sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.9.0"
+    function-bind "^1.1.1"
 
 prompts@^0.1.9:
   version "0.1.14"


### PR DESCRIPTION
### Summary
* Hides detail links for learners that haven't started.
* Use Score component so that we don't show NaN%
* Hides 'All classes' backlinks when there is only one class for the user
* Refresh class summary when creating new groups, lessons, and modifying lesson resources.

### Reviewer guidance
* For quizzes and exercises in lessons, make sure no links are shown if a learner has not started.
* For a quiz where there is no progress by any students, ensure that Average Score shows a grey dash.
* For a user with only one class that they can see, make sure that the backlinks at the top of each top level page (Home, Report, Plan) are hidden. For a user with more than one class, make sure they are shown.
* Create a new group, lesson, copy a lesson, and modify lesson resources and verify nothing breaks.

### References
Fixes #4930

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
