### PR TITLE
No more 1000%

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleServerResponse.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleServerResponse.js
@@ -77,6 +77,8 @@ export default {
         { exercise_id: '2a722a9e57575148bc55deed7550ed62', question_id: '3' },
       ],
       groups: ['c4625c3fef6b7d918e9417d92e482e6f'],
+      data_version_model: 1,
+      question_count: 3,
     },
     {
       id: 'd7033a1cb888493763dc9b5f3ab2505b',
@@ -87,6 +89,8 @@ export default {
         { exercise_id: 'eadec7f803994b6eb8f401237ec0f777', question_id: 'B' },
       ],
       groups: ['8d2e8c66c05004657d676155dd0b305d'],
+      data_version_model: 1,
+      question_count: 2,
     },
     {
       id: '4018bcea43cee3d05811b641fca0b152',
@@ -98,6 +102,8 @@ export default {
         { exercise_id: '3a655a4b8adb5114a571dfd0c75cbc19', question_id: '12' },
       ],
       groups: ['7c20f664b6a5c43d64b0cdd3161be513'],
+      data_version_model: 1,
+      question_count: 3,
     },
     {
       id: '97316f077d470b45e912096edb534076',
@@ -109,6 +115,8 @@ export default {
         { exercise_id: '9baf781e43b0514085cc205176b0ee71', question_id: 'z' },
       ],
       groups: [],
+      data_version_model: 1,
+      question_count: 3,
     },
   ],
   exam_learner_status: [

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleState.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleState.js
@@ -153,6 +153,8 @@ export default {
         { exercise_id: '2a722a9e57575148bc55deed7550ed62', question_id: '3' },
       ],
       groups: ['c4625c3fef6b7d918e9417d92e482e6f'],
+      data_version_model: 1,
+      question_count: 3,
     },
     d7033a1cb888493763dc9b5f3ab2505b: {
       id: 'd7033a1cb888493763dc9b5f3ab2505b',
@@ -163,6 +165,8 @@ export default {
         { exercise_id: 'eadec7f803994b6eb8f401237ec0f777', question_id: 'B' },
       ],
       groups: ['8d2e8c66c05004657d676155dd0b305d'],
+      data_version_model: 1,
+      question_count: 2,
     },
     '4018bcea43cee3d05811b641fca0b152': {
       id: '4018bcea43cee3d05811b641fca0b152',
@@ -174,6 +178,8 @@ export default {
         { exercise_id: '3a655a4b8adb5114a571dfd0c75cbc19', question_id: '12' },
       ],
       groups: ['7c20f664b6a5c43d64b0cdd3161be513'],
+      data_version_model: 1,
+      question_count: 3,
     },
     '97316f077d470b45e912096edb534076': {
       id: '97316f077d470b45e912096edb534076',
@@ -185,6 +191,8 @@ export default {
         { exercise_id: '9baf781e43b0514085cc205176b0ee71', question_id: 'z' },
       ],
       groups: [],
+      data_version_model: 1,
+      question_count: 3,
     },
   },
   examLearnerStatusMap: {

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -39,6 +39,7 @@ function defaultState() {
      *     question_sources: [{exercise_id, question_id}, ...],
      *     groups: [id, ...],
      *     data_model_version,
+     *     question_count,
      *   }
      * }
      */
@@ -264,8 +265,7 @@ export default {
         if (status.num_correct === null) {
           status.score = null;
         } else {
-          status.score =
-            (1.0 * status.num_correct) / examMap[status.exam_id].question_sources.length;
+          status.score = (1.0 * status.num_correct) / examMap[status.exam_id].question_count;
         }
       });
       summary.content_learner_status.forEach(status => {

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -188,7 +188,7 @@ class ExamSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Exam
-        fields = ("id", "title", "active", "question_sources", "groups", "data_model_version")
+        fields = ("id", "title", "active", "question_sources", "groups", "data_model_version", "question_count")
 
 
 class ContentSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### Summary
Creates average score based on `question_count` rather than the length of `question_sources` on the exam model, to give consistent scoring between v0 and v1 exams.

### Reviewer guidance
Use sample data referenced in the issue.

### References
Fixes #4857

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
