### PR TITLE
Properly filter attemptlogs in exercise detail view

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/exerciseDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/exerciseDetail/actions.js
@@ -2,10 +2,10 @@ import { AttemptLogResource } from 'kolibri.resources';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 
 export function setAttemptLogs(store, params) {
-  const { userId, exercise } = params;
+  const { learnerId, exercise } = params;
   return AttemptLogResource.fetchCollection({
     getParams: {
-      user: userId,
+      user: learnerId,
       content: exercise.content_id,
     },
     force: true,


### PR DESCRIPTION
### Summary
Fixes a bug whereby attemptlogs would not be filtered by user for the exercise detail view.

### Reviewer guidance
View an exercise where one learner in a lesson has made some attempts, and one learner has made none.
Click into the learner who has made none. It should now give an error, saying that no attemptLogs were returned from the fetch and that `attemptLogs[0]` is undefined. Previously, it would fetch lots of attemptLogs for other people!

Before
![noattemptsbroken](https://user-images.githubusercontent.com/1680573/52312770-a7c7d000-2960-11e9-8dbc-ddddb4c683bb.gif)

After
![noattemptsproper](https://user-images.githubusercontent.com/1680573/52312773-ab5b5700-2960-11e9-9a99-9237990f920e.gif)


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
