### PR TITLE
Correctly map lesson learner status data

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
@@ -108,6 +108,21 @@ describe('coach summary data helpers', () => {
       });
     });
   });
+  describe('getLessonStatusTally', () => {
+    it('returns total statuses given a lesson item and a list of learners', () => {
+      const output = store.getters.getLessonStatusTally('lesson_id_2', [
+        'learner_id_1',
+        'learner_id_3',
+        'learner_id_6',
+      ]);
+      expect(output).toEqual({
+        completed: 1,
+        started: 1,
+        notStarted: 1,
+        helpNeeded: 0,
+      });
+    });
+  });
   describe('getContentAvgTimeSpent', () => {
     it('returns average time a list of learners has worked on an item, omitting not started', () => {
       const output = store.getters.getContentAvgTimeSpent('content_Q', [

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleState2.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/sampleState2.js
@@ -810,6 +810,13 @@ export default {
         last_activity: new Date('2019-01-24T22:49:46.776Z'),
         time_spent: 123.34,
       },
+      learner_id_6: {
+        learner_id: 'learner_id_6',
+        content_id: 'content_V',
+        status: 'Completed',
+        last_activity: new Date('2019-01-24T22:47:10.710Z'),
+        time_spent: 123.34,
+      },
     },
     content_L: {
       learner_id_3: {

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -134,7 +134,11 @@ export default {
       if (!lessonId || !learnerId) {
         throw new Error('getLessonStatusStringForLearner: invalid parameter(s)');
       }
-      return get(getters.lessonLearnerStatusMap, [lessonId, learnerId], STATUSES.notStarted);
+      return get(
+        getters.lessonLearnerStatusMap,
+        [lessonId, learnerId, 'status'],
+        STATUSES.notStarted
+      );
     };
   },
   /*

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -107,9 +107,13 @@ function _lessonStatusForLearner(state, lessonId, learnerId) {
       return { status: STATUSES.notStarted };
     }
     const content_id = state.contentNodeMap[node_id].content_id;
-    return get(state.contentLearnerStatusMap, [content_id, learnerId], {
-      status: STATUSES.notStarted,
-    });
+    return {
+      status: get(
+        state.contentLearnerStatusMap,
+        [content_id, learnerId, 'status'],
+        STATUSES.notStarted
+      ),
+    };
   });
 
   const tally = {
@@ -235,7 +239,26 @@ export default {
       Object.values(state.lessonMap).forEach(lesson => {
         map[lesson.id] = {};
         Object.values(state.learnerMap).forEach(learner => {
-          map[lesson.id][learner.id] = _lessonStatusForLearner(state, lesson.id, learner.id);
+          let last = null;
+          // for all content items this learner has interacted with
+          // determine the latest interaction activity
+          Object.values(lesson.node_ids).forEach(node_id => {
+            const content_id = get(state.contentNodeMap, [node_id, 'content_id'], null);
+            const last_activity = get(
+              state.contentLearnerStatusMap,
+              [content_id, learner.id, 'last_activity'],
+              null
+            );
+            if (last_activity > last) {
+              last = last_activity;
+            }
+          });
+          map[lesson.id][learner.id] = {
+            lesson_id: lesson.id,
+            learner_id: learner.id,
+            status: _lessonStatusForLearner(state, lesson.id, learner.id),
+            last_activity: last,
+          };
         });
       });
       return map;

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -71,9 +71,9 @@
         if (!this.lessonLearnerStatusMap[lesson.id]) {
           return undefined;
         }
-        Object.values(this.lessonLearnerStatusMap[lesson.id]).forEach(status => {
-          if (status.last_activity > last) {
-            last = status.last_activity;
+        Object.values(this.lessonLearnerStatusMap[lesson.id]).forEach(learner => {
+          if (learner.last_activity > last) {
+            last = learner.last_activity;
           }
         });
         return last;
@@ -85,4 +85,3 @@
 
 
 <style lang="scss" scoped></style>
-

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -67,9 +67,10 @@
     methods: {
       // return the last activity among all users for a particular lesson
       lastActivity(lesson) {
-        let last = null;
+        // Default to UNIX 0 so activity-less lessons go to the end of the list
+        let last = new Date(0);
         if (!this.lessonLearnerStatusMap[lesson.id]) {
-          return undefined;
+          return last;
         }
         Object.values(this.lessonLearnerStatusMap[lesson.id]).forEach(learner => {
           if (learner.last_activity > last) {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -71,7 +71,7 @@
           return last;
         }
         Object.values(this.examLearnerStatusMap[exam.id]).forEach(status => {
-          if (status.last_activity >= last) {
+          if (status.last_activity > last) {
             last = status.last_activity;
           }
         });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

For `lessonLearnerStatusMap` we were only mapping the status object before. We now map it according to
```
    /*
     * lessonLearnerStatusMap := {
     *   [lesson_id]: {
     *     [learner_id]: { lesson_id, learner_id, status, last_activity }
     *   }
     * }
     */
```
We can now correctly sort lessons by latest activity timestamps.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create lessons & add content.
2. Interact with content.
3. See if lesson appears first, given the content item is in the lesson.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/4899.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [x] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
