### PR TITLE
enable source maps in production

### DIFF
--- a/packages/kolibri-tools/lib/production.js
+++ b/packages/kolibri-tools/lib/production.js
@@ -7,7 +7,10 @@ const webpackBaseConfig = require('./webpack.config.base');
 const logger = require('./logging');
 
 function webpackConfig(pluginData) {
-  const pluginBundle = webpackBaseConfig(pluginData, { mode: 'production' });
+  const pluginBundle = webpackBaseConfig(pluginData, {
+    mode: 'production',
+    devtool: 'cheap-module-source-map',
+  });
 
   pluginBundle.stats = 'normal';
   pluginBundle.plugins = pluginBundle.plugins.concat([

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -32,7 +32,7 @@ const CONFIG = {
 
 function webpackConfig(pluginData, hot) {
   const pluginBundle = webpackBaseConfig(pluginData, { hot });
-  pluginBundle.devtool = '#cheap-module-source-map';
+  pluginBundle.devtool = 'cheap-module-source-map';
   pluginBundle.plugins = pluginBundle.plugins.concat([
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION

### Summary

* enables [source maps in production](https://webpack.js.org/guides/production/#source-mapping)
* rename `#cheap-module-source-map` to `cheap-module-source-map`

### Reviewer guidance

This will help us and our users debug. For example, [errors reported in Sentry](https://sentry.io/learningequality/kolibri-frontend/issues/873444819/) should be easier to understand.


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
