### PR TITLE
emphasize quality over quantity in code test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+comment:
+  layout: "files"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,8 +48,8 @@ Testing:
 
 - [ ] Contributor has fully tested the PR manually
 - [ ] If there are any front-end changes, before/after screenshots are included
-- [ ] Gherkin stories have been updated
-- [ ] Unit tests have been updated
+- [ ] Critical user journeys are covered by Gherkin stories
+- [ ] Critical and brittle code paths are covered by unit tests
 
 ### Reviewer Checklist
 

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,6 @@ Kolibri
   :target: https://pypi.python.org/pypi/kolibri/
 .. image:: https://travis-ci.org/learningequality/kolibri.svg?branch=develop
   :target: https://travis-ci.org/learningequality/kolibri
-.. image:: http://codecov.io/github/learningequality/kolibri/coverage.svg?branch=develop
-  :target: http://codecov.io/github/learningequality/kolibri?branch=develop
 .. image:: https://img.shields.io/badge/docs-user-ff69b4.svg
   :target: http://kolibri.readthedocs.org/en/latest/
 .. image:: https://img.shields.io/badge/docs-developer-69ffb4.svg

--- a/docs/development_workflow.rst
+++ b/docs/development_workflow.rst
@@ -19,7 +19,9 @@ Be sure to follow the `instructions <https://github.com/learningequality/kolibri
 
 Developers maintain their own clones of the Learning Equality `Kolibri repo <https://github.com/learningequality/kolibri/>`__ in their personal Github accounts, and `submit pull requests <https://help.github.com/articles/creating-a-pull-request/>`__ back to the LE repo.
 
-Every pull request (with a couple minor exceptions) requires testing, code review, automated tests, and potentially UI design review. Developers must fully test their own code before requesting a review, and then closely follow the template and checklist that appears in the PR description. All automated tests must pass.
+Every pull request will require some combination of manual testing, code review, automated tests, gherkin stories, and UI design review. Developers must fully test their own code before requesting a review, and then closely follow the template and checklist that appears in the PR description. All automated tests must pass.
+
+Unit tests and gherkin stories should be written to ensure coverage of critical, brittle, complicated, or otherwise risky paths through the code and user experience. Intentional, thoughtful coverage of these critical paths is more important than global percentage of code covered.
 
 Try to keep PRs as self-contained as possible. The bigger the PR, the more challenging it is to review, and the more likely that merging will be blocked by various issues. If your PR is not being reviewed in a timely manner, reach out to stakeholders and politely remind them that you're waiting for a review.
 


### PR DESCRIPTION
### Summary

Issues with our current use of unit test code coverage:

1. it optimizes for quantity over quality
2. it is not accurately measured
3. it slaps a ![image](https://user-images.githubusercontent.com/2367265/52371203-be763180-2a09-11e9-8086-e5b2d8c7db01.png) on most of our PRs that should be a ![image](https://user-images.githubusercontent.com/2367265/52371225-cd5ce400-2a09-11e9-8eda-c11e16c12d05.png)
4. it's [confusing](https://github.com/learningequality/kolibri/pull/4833#issuecomment-458732123) for new contributors

### Reviewer guidance

this PR:

* attempts to make codecov's reporting quieter, and also focus on which files have coverage changes rather than opaque diffs and convoluted tree map charts
* updates the documentation and PR template to clarify testing requirements in our PRs
* removes codecov badge from readme 

I appreciate [this perspective](https://www.artima.com/forums/flat.jsp?forum=106&thread=204677) (found via [stack overflow](https://stackoverflow.com/a/90021))

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
