### PR TITLE
1) Validate quiz number of questions, 2) add notification links, 3) learner/group activity pages

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -51,11 +51,11 @@ class Router {
     this._vueRouter.addRoutes(routes);
 
     // attach a helper method that generates a route object and warns if it's not valid
-    this._vueRouter.getRoute = this.getRoute = (name, params = {}) => {
+    this._vueRouter.getRoute = this.getRoute = (name, params = {}, query = {}) => {
       if (!this._routes[name]) {
         logging.warn(`Route name '${name}' is not registered`);
       }
-      return { name, params };
+      return { name, params, query };
     };
 
     // attach a helper method that returns original route definition

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -154,7 +154,7 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
         """
         It provides the list of ClassroomNotificationsViewset from DRF.
         Then it fetches and saves the needed information to know how many coaches
-        are requesting notificatios in the last five minutes
+        are requesting notifications in the last five minutes
         """
         response = super(viewsets.ReadOnlyModelViewSet, self).list(request, *args, **kwargs)
 

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -275,6 +275,7 @@ export default {
         exams: state.examMap,
         classId: state.id,
         className: state.name,
+        contentNodes: state.contentNodeMap,
       };
     },
   },

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -1,4 +1,5 @@
 import groupBy from 'lodash/groupBy';
+import get from 'lodash/get';
 import find from 'lodash/find';
 import maxBy from 'lodash/maxBy';
 import { NotificationObjects } from '../../constants/notificationsConstants';
@@ -62,6 +63,7 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
     if (object === RESOURCE) {
       resource = {
         id: firstEvent.contentnode_id,
+        content_id: get(classSummary.contentNodes, [firstEvent.contentnode_id, 'content_id'], ''),
         type: firstEvent.contentnode_kind,
         name: firstEvent.resource,
       };

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/gettersUtils.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/gettersUtils.js
@@ -89,8 +89,11 @@ function makeParams(notification) {
     lessonId: notification.assignment.id,
     quizId: notification.assignment.id,
     resourceId: notification.resource.id,
-    exerciseId: notification.resource.id,
+    exerciseId: notification.resource.content_id,
     learnerId: notification.learnerSummary.firstUserId,
+    // For individual Quiz or Exercise notifications, default to first index for everything
+    questionId: 0,
+    interactionIndex: 0,
   };
 }
 
@@ -152,7 +155,7 @@ const pageNameToNotificationPropsMap = {
     isMultiple: false,
     isWholeClass: false,
   },
-  ReportsLessonLearnerExercisePage: {
+  REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT: {
     object: 'Exercise',
     isMultiple: false,
     isWholeClass: true,

--- a/kolibri/plugins/coach/assets/src/modules/exerciseDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/exerciseDetail/handlers.js
@@ -1,7 +1,7 @@
 import { ContentNodeResource } from 'kolibri.resources';
 import store from 'kolibri.coreVue.vuex.store';
 
-export function exerciseRootRedirectHandler(params, name, next) {
+export function exerciseRootRedirectHandler(params, name, next, query) {
   return showExerciseDetailView(params).then(attemptId => {
     next({
       name: name,
@@ -10,6 +10,7 @@ export function exerciseRootRedirectHandler(params, name, next) {
         attemptId,
         interactionIndex: 0,
       },
+      query,
     });
   });
 }

--- a/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
@@ -392,8 +392,13 @@ export default [
     path: path(CLASS, LESSON, EXERCISE, LEARNER),
     name: PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT,
     beforeEnter: (to, from, next) => {
-      const { params } = to;
-      return exerciseRootRedirectHandler(params, pages.ReportsLessonExerciseLearnerPage.name, next);
+      const { params, query } = to;
+      return exerciseRootRedirectHandler(
+        params,
+        pages.ReportsLessonExerciseLearnerPage.name,
+        next,
+        query
+      );
     },
     meta: {
       titleParts: ['LEARNER_NAME', 'EXERCISE_NAME', 'LESSON_NAME', 'CLASS_NAME'],

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -222,5 +222,26 @@ export default {
       }
       return router.getRoute(name, params);
     },
+    // In ActivityList, set the backLinkQuery to set the correct exit behavior
+    // for ReportsLessonExerciseLearnerPage and ReportsQuizLearnerPage.
+    backRouteForQuery(query) {
+      const lastPage = query.last;
+      switch (lastPage) {
+        case 'homepage':
+          return this.classRoute('HomePage', {});
+        case 'homeactivity':
+          return this.classRoute('HomeActivityPage', {});
+        case 'groupactivity':
+          return this.classRoute('ReportsGroupActivityPage', {
+            groupId: this.$route.query.last_id,
+          });
+        case 'learneractivity':
+          return this.classRoute('ReportsLearnerActivityPage', {
+            learnerId: this.$route.query.last_id,
+          });
+        default:
+          return null;
+      }
+    },
   },
 };

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -22,11 +22,11 @@
       <KGridItem :size="25" percentage>
         <div class="button-wrapper">
           <KRouterLink
-            v-if="targetPage"
+            v-if="targetPage.name"
             appearance="flat-button"
             class="show-btn"
             :text="coachStrings.$tr('showAction')"
-            :to="$router.getRoute(targetPage.name, targetPage.params)"
+            :to="$router.getRoute(targetPage.name, targetPage.params, targetPage.query)"
           />
         </div>
       </KGridItem>

--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -3,8 +3,8 @@
   <div class="bar-wrapper">
     <div class="bar" :style="barStyleStarted"></div>
     <div
-      v-if="showErrorBar" 
-      class="help-line" 
+      v-if="showErrorBar"
+      class="help-line"
       :style="helpLineStyle"
     ></div>
     <div class="bar" :style="barStyleCompleted"></div>
@@ -31,15 +31,15 @@
       ...mapGetters(['$coreStatusProgress', '$coreStatusMastered', '$coreStatusWrong']),
       barStyleCompleted() {
         return {
-          width: `${Math.floor((100 * this.completed) / this.total)}%`,
+          width: `${Math.ceil((100 * this.completed) / this.total)}%`,
           backgroundColor: this.$coreStatusMastered,
         };
       },
       barStyleStarted() {
         const widthRatio = this.started / this.total;
         return {
-          marginLeft: `${Math.floor((100 * this.completed) / this.total)}%`,
-          width: `${Math.floor(100 * widthRatio)}%`,
+          marginLeft: `${Math.ceil((100 * this.completed) / this.total)}%`,
+          width: `${Math.ceil(100 * widthRatio)}%`,
           backgroundColor: this.$coreStatusProgress,
         };
       },
@@ -47,8 +47,8 @@
         // add on 'completed' for offset
         const widthRatio = this.helpNeeded / this.total;
         return {
-          marginLeft: `${Math.floor((100 * this.completed) / this.total)}%`,
-          width: `${Math.floor(100 * widthRatio)}%`,
+          marginLeft: `${Math.ceil((100 * this.completed) / this.total)}%`,
+          width: `${Math.ceil(100 * widthRatio)}%`,
           backgroundColor: this.$coreStatusWrong,
         };
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
@@ -16,46 +16,12 @@
           :text="$tr('back')"
         />
       </p>
-      <h2>{{ $tr('classActivity') }}</h2>
-      <NotificationsFilter
-        :resourceFilter.sync="resourceFilter"
-        :progressFilter.sync="progressFilter"
+
+      <ActivityList
+        :notificationParams="notificationParams"
+        :noActivityString="$tr('noActivity')"
+        embeddedPageName="HomeActivityPage"
       />
-      <br>
-
-      <div>
-        <p v-if="!loading && nextPage === 1 && notifications.length === 0">
-          {{ $tr('noActivity') }}
-        </p>
-
-        <NotificationCard
-          v-for="notification in notifications"
-          v-show="showNotification(notification)"
-          :key="notification.id"
-          v-bind="cardPropsForNotification(notification)"
-        >
-          {{ cardTextForNotification(notification) }}
-        </NotificationCard>
-      </div>
-
-      <div
-        v-if="noFiltersApplied"
-        class="show-more"
-      >
-        <transition mode="out-in">
-          <KLinearLoader
-            v-if="loading"
-            :delay="false"
-          />
-          <template v-else>
-            <KButton
-              v-if="moreResults"
-              :text="coachStrings.$tr('showMoreAction')"
-              @click="fetchNotifications"
-            />
-          </template>
-        </transition>
-      </div>
 
     </KPageContainer>
   </CoreBase>
@@ -65,193 +31,20 @@
 
 <script>
 
-  import find from 'lodash/find';
-  import maxBy from 'lodash/maxBy';
-  import { mapState } from 'vuex';
-  import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoach from '../common';
-  import NotificationsFilter from '../common/notifications/NotificationsFilter';
-  import NotificationCard from '../common/notifications/NotificationCardNoLink';
   import { nStringsMixin } from '../common/notifications/notificationStrings';
-  import notificationsResource from '../../apiResources/notifications';
-  import { NotificationObjects } from '../../constants/notificationsConstants';
-  import { CollectionTypes } from '../../constants/lessonsConstants';
-
-  const { LESSON, RESOURCE, QUIZ } = NotificationObjects;
+  import ActivityList from '../common/notifications/ActivityList';
 
   export default {
     name: 'HomeActivityPage',
     components: {
-      KLinearLoader,
-      NotificationsFilter,
-      NotificationCard,
+      ActivityList,
     },
     mixins: [commonCoach, nStringsMixin],
-    data() {
-      return {
-        loading: true,
-        error: false,
-        moreResults: true,
-        nextPage: 1,
-        progressFilter: 'all',
-        resourceFilter: 'all',
-        notifications: [],
-        filters: {
-          ALL: 'all',
-          LESSON: 'lesson',
-          QUIZ: 'quiz',
-        },
-      };
-    },
     computed: {
-      ...mapState('coachNotifications', {
-        allNotifications: 'notifications',
-      }),
-      noFiltersApplied() {
-        return this.progressFilter === this.filters.ALL && this.resourceFilter === this.filters.ALL;
-      },
-      lastNotificationId() {
-        if (this.notifications.length > 0) {
-          return Number(maxBy(this.notifications, n => Number(n.id)).id);
-        }
-        return 0;
-      },
-    },
-    watch: {
-      allNotifications(newVal) {
-        const newNotifications = newVal.filter(n => Number(n.id) > this.lastNotificationId);
-        this.notifications = [
-          ...newNotifications.map(this.reshapeNotification),
-          ...this.notifications,
-        ];
-      },
-    },
-    beforeMount() {
-      this.fetchNotifications();
-    },
-    methods: {
-      fetchNotifications() {
-        this.loading = true;
-        return notificationsResource
-          .fetchCollection({
-            getParams: {
-              collection_id: this.$route.params.classId,
-              page_size: 10,
-              page: this.nextPage,
-            },
-            force: true,
-          })
-          .then(data => {
-            this.notifications = [
-              ...this.notifications,
-              ...data.results.map(this.reshapeNotification).filter(Boolean),
-            ];
-            this.moreResults = data.next !== null;
-            this.nextPage = this.nextPage + 1;
-            this.loading = false;
-          });
-      },
-      showNotification(notification) {
-        if (this.noFiltersApplied) {
-          return true;
-        }
-        let progressPasses = true;
-        let resourcePasses = true;
-        if (this.progressFilter !== this.filters.ALL) {
-          progressPasses = notification.event === this.progressFilter;
-        }
-        if (this.resourceFilter !== this.filters.ALL) {
-          if (this.resourceFilter === this.filters.LESSON) {
-            resourcePasses = notification.object === LESSON;
-          } else if (this.resourceFilter === this.filters.QUIZ) {
-            resourcePasses = notification.object === QUIZ;
-          } else {
-            resourcePasses = notification.resource.type === this.resourceFilter;
-          }
-        }
-        return progressPasses && resourcePasses;
-      },
-      // Takes the raw notification and reshapes it to match the objects
-      // created by the summarizedNotifications getter.
-      reshapeNotification(notification) {
-        const { object } = notification;
-        // Finds the first group the user_id is in and just uses that label.
-        // Does not make additional notifications if the user is in more than
-        // one group that has been assigned lesson or quiz.
-        let groups;
-        if (object === QUIZ) {
-          const examMatch = this.examMap[notification.quiz_id];
-          if (!examMatch) return null;
-          groups = [...examMatch.groups];
-        } else if (object === LESSON || object === RESOURCE) {
-          const lessonMatch = this.lessonMap[notification.lesson_id];
-          if (!lessonMatch) return null;
-          groups = [...lessonMatch.groups];
-        }
-        let collection = {};
-        // If assigned to whole class
-        if (groups.length === 0) {
-          collection = {
-            name: this.name,
-            type: CollectionTypes.CLASSROOM,
-          };
-        } else {
-          const groupMatch = find(groups, groupId => {
-            const found = this.groupMap[groupId];
-            if (found) {
-              return found.member_ids.includes(notification.user_id);
-            }
-            return false;
-          });
-          if (groupMatch) {
-            collection = {
-              name: this.groupMap[groupMatch].name,
-              type: CollectionTypes.LEARNERGROUP,
-            };
-          } else {
-            // If learner group was deleted, then just give it the header
-            // for the whole class
-            collection = {
-              name: this.name,
-              type: CollectionTypes.CLASSROOM,
-            };
-          }
-        }
-
+      notificationParams() {
         return {
-          event: notification.event,
-          object,
-          timestamp: notification.timestamp,
-          collection,
-          id: Number(notification.id),
-          assignment: {
-            name: object === QUIZ ? notification.quiz : notification.lesson,
-            type: object === QUIZ ? ContentNodeKinds.EXAM : ContentNodeKinds.LESSON,
-          },
-          resource: {
-            name: notification.resource || '',
-            type: notification.contentnode_kind,
-          },
-          learnerSummary: {
-            firstUserName: notification.user,
-            total: 1,
-          },
-        };
-      },
-      cardPropsForNotification(notification) {
-        const { collection } = notification;
-        const learnerContext =
-          collection.type === CollectionTypes.LEARNERGROUP ? collection.name : '';
-        // Only differences from ActivityBlock is that there is no targetPage,
-        // and the time is used
-        return {
-          eventType: notification.event,
-          objectType: notification.object,
-          resourceType: notification.resource.type,
-          contentContext: notification.assignment.name,
-          learnerContext,
-          time: notification.timestamp,
+          collection_id: this.$route.params.classId,
         };
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -10,9 +10,10 @@
       <BlockItem
         v-for="notification in notifications"
         :key="notification.groupCode + '_' + notification.lastId"
-        v-bind="cardPropsForNotification(notification)"
       >
-        <NotificationCard>
+        <NotificationCard
+          v-bind="cardPropsForNotification(notification)"
+        >
           {{ cardTextForNotification(notification) }}
         </NotificationCard>
       </BlockItem>
@@ -60,7 +61,12 @@
           eventType: notification.event,
           objectType: notification.object,
           resourceType: notification.resource.type,
-          targetPage: notificationLink(notification),
+          targetPage: {
+            ...notificationLink(notification),
+            query: {
+              last: 'homepage',
+            },
+          },
           contentContext: notification.assignment.name,
           learnerContext,
         };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -8,6 +8,7 @@
     :appBarTitle="coachStrings.$tr('coachLabel')"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
+    :marginBottom="72"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -9,6 +9,7 @@
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
     :pageTitle="$tr('documentTitle')"
+    :marginBottom="72"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
@@ -12,124 +12,10 @@
     <KPageContainer>
 
       <ReportsGroupHeader />
-      <NotificationsFilter />
-      <br>
 
-      <div>
-
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="1 minutes ago"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "A video"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="clock"
-          targetPage=""
-          time="2 minutes ago"
-        >
-          {{ nStrings.$tr('individualStarted', {
-            learnerName: "John",
-            itemName: "A video"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="3 minutes ago"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Steve",
-            itemName: "An exercise"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="4 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Mary",
-            itemName: "A video assigned to the class"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="6 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "John",
-            itemName: "An exercise assigned to the class"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="8 minutes ago"
-          learnerContext="Group A"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Mary",
-            itemName: "A video assigned to a group"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="10 minutes ago"
-          learnerContext="Group A"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Steve",
-            itemName: "An exercise assigned to a group"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="15 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Frank",
-            itemName: "Some lesson"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="20 minutes ago"
-          contentContext="Some quiz"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "Some quiz"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="clock"
-          targetPage=""
-          time="50 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualStarted', {
-            learnerName: "Sam",
-            itemName: "Some quiz"
-          }) }}
-        </NotificationCard>
-      </div>
-
-      <KButton
-        :text="coachStrings.$tr('showMoreAction')"
+      <ActivityList
+        :notificationParams="notificationParams"
+        embeddedPageName="ReportsGroupActivityPage"
       />
 
     </KPageContainer>
@@ -141,21 +27,22 @@
 <script>
 
   import commonCoach from '../common';
-  import NotificationCard from '../common/notifications/NotificationCard';
-  import { nStringsMixin } from '../common/notifications/notificationStrings';
-  import NotificationsFilter from '../common/notifications/NotificationsFilter';
+  import ActivityList from '../common/notifications/ActivityList';
   import ReportsGroupHeader from './ReportsGroupHeader';
 
   export default {
     name: 'ReportsGroupActivityPage',
     components: {
-      NotificationsFilter,
+      ActivityList,
       ReportsGroupHeader,
-      NotificationCard,
     },
-    mixins: [commonCoach, nStringsMixin],
-    $trs: {
-      resourceTitleLabel: 'Resource title',
+    mixins: [commonCoach],
+    computed: {
+      notificationParams() {
+        return {
+          collection_id: this.$route.params.groupId,
+        };
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
@@ -52,12 +52,10 @@
         :text="coachStrings.$tr('membersLabel')"
         :to="classRoute('ReportsGroupLearnerListPage', {})"
       />
-      <!-- TODO COACH
       <HeaderTab
         :text="coachStrings.$tr('activityLabel')"
         :to="classRoute('ReportsGroupActivityPage', {})"
       />
-       -->
     </HeaderTabs>
   </div>
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -12,115 +12,10 @@
     <KPageContainer>
 
       <ReportsLearnerHeader />
-      <NotificationsFilter />
-      <br>
 
-      <div>
-
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="1 minutes ago"
-        >
-          {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "A video"}) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="clock"
-          targetPage=""
-          time="2 minutes ago"
-        >
-          {{ nStrings.$tr('individualStarted', {learnerName: "Julie", itemName: "A video"}) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="3 minutes ago"
-        >
-          {{ nStrings.$tr('individualCompleted', {learnerName: "Julie", itemName: "An exercise"}) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="4 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "A video assigned to the class"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="6 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "An exercise assigned to the class"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="8 minutes ago"
-          learnerContext="Group A"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "A video assigned to a group"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="10 minutes ago"
-          learnerContext="Group A"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "An exercise assigned to a group"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="15 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "Some lesson"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="star"
-          targetPage=""
-          time="20 minutes ago"
-          contentContext="Some quiz"
-        >
-          {{ nStrings.$tr('individualCompleted', {
-            learnerName: "Julie",
-            itemName: "Some quiz"
-          }) }}
-        </NotificationCard>
-        <NotificationCard
-          icon="clock"
-          targetPage=""
-          time="50 minutes ago"
-          contentContext="Some lesson"
-        >
-          {{ nStrings.$tr('individualStarted', {
-            learnerName: "Julie",
-            itemName: "Some quiz"
-          }) }}
-        </NotificationCard>
-      </div>
-
-      <KButton
-        :text="coachStrings.$tr('showMoreAction')"
+      <ActivityList
+        :notificationParams="notificationParams"
+        embeddedPageName="ReportsLearnerActivityPage"
       />
 
     </KPageContainer>
@@ -132,21 +27,23 @@
 <script>
 
   import commonCoach from '../common';
-  import NotificationCard from '../common/notifications/NotificationCard';
-  import { nStringsMixin } from '../common/notifications/notificationStrings';
-  import NotificationsFilter from '../common/notifications/NotificationsFilter';
+  import ActivityList from '../common/notifications/ActivityList';
   import ReportsLearnerHeader from './ReportsLearnerHeader';
 
   export default {
     name: 'ReportsLearnerActivityPage',
     components: {
-      NotificationsFilter,
+      ActivityList,
       ReportsLearnerHeader,
-      NotificationCard,
     },
-    mixins: [commonCoach, nStringsMixin],
-    $trs: {
-      resourceTitleLabel: 'Resource title',
+    mixins: [commonCoach],
+    computed: {
+      notificationParams() {
+        return {
+          collection_id: this.$route.params.classId,
+          learner_id: this.$route.params.learnerId,
+        };
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerPage.vue
@@ -27,11 +27,11 @@
       LearnerExerciseReport,
     },
     mixins: [commonCoach],
-    $trs: {},
     computed: {
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsLessonExerciseLearnerListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLessonExerciseLearnerListPage', {});
       },
     },
     methods: {
@@ -43,6 +43,7 @@
             lessonId: this.$route.params.lessonId,
             ...params,
           },
+          query: this.$route.query,
         });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerPage.vue
@@ -30,10 +30,10 @@
     computed: {
       ...mapState('examReportDetail', ['exam']),
       toolbarRoute() {
-        return this.classRoute('ReportsQuizLearnerListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsQuizLearnerListPage', {});
       },
     },
-    $trs: {},
     methods: {
       handleNavigation(params) {
         this.$router.push({
@@ -42,6 +42,7 @@
             classId: this.$route.params.classId,
             ...params,
           },
+          query: this.$route.query,
         });
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. At quiz creation, validates the number input to make sure it is not empty, or outside of 1-50 question range.
1. At HomeActivityPage, adds links to all individual learner notifications. Makes adjustments to QuizLearnerPage and ExerciseLearnerPage to exit back to the correct page when clicking "X"
1. Adds the "Activity" tab for Learners and Learner Groups
1. Fix the gaps in the ProgressSummaryBars
1. Add extra bottom margin on ExamCreate pages to fix #4849

### Reviewer guidance

1. Check to see if #4932 is fixed. A user cannot continue the quiz creation workflow if the number of questions input is empty. _However_, there is still a problem with setting big numbers (e.g typing in 56 is not invalidated, but simply recognized as "5")
1. Visit the Home Activity Page and click different kinds of links, including for lessons, exams, and exercises. Generate new activity while on the page and see that it gets updated.
1. Visit the Activity Page for a learner page and do similar tests.
1. Visit the Activity page for a learner group. _However_, at the moment, the notifications API does not filter for learner group, but this page will get updated with new notifications.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
