### PR TITLE
Dynamic style mixin

### DIFF
--- a/docs/frontend_architecture/core.rst
+++ b/docs/frontend_architecture/core.rst
@@ -64,11 +64,11 @@ In order to apply a style using a computed class, define a style object as a com
 
 .. code-block:: javascript
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
+    mixins: [themeMixin],
     computed: {
-      ...mapGetters(['$coreBgCanvas'])
       pseudoStyle() {
         return {
           ':hover': {

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -105,6 +105,7 @@ import KTooltip from '../views/KTooltip';
 import UiIconButton from '../views/KeenUiIconButton.vue';
 import * as colour from '../utils/colour';
 import shuffled from '../utils/shuffled';
+import themeMixin from '../mixins/theme';
 import vue from './kolibriVue';
 import * as client from './client';
 import urls from './urls';
@@ -195,6 +196,7 @@ export default {
       responsiveWindow,
       responsiveElement,
       contentRendererMixin,
+      themeMixin,
     },
   },
   resources,

--- a/kolibri/core/assets/src/core-app/vuexModality.js
+++ b/kolibri/core/assets/src/core-app/vuexModality.js
@@ -1,4 +1,9 @@
-/* global kolibriGlobal */
+import store from 'kolibri.coreVue.vuex.store';
+import logger from 'kolibri.lib.logging';
+import { nameSpace } from '../state/modules/theme';
+
+const logging = logger.getLogger(__filename);
+
 /**
  * Adapted from https://github.com/alice/modality
  * Version: 1.0.2
@@ -42,8 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return el.msMatchesSelector;
     }
 
-    /* eslint-disable-next-line */
-    console.error("Couldn't find any matchesSelector method on document.body.");
+    logging.error("Couldn't find any matchesSelector method on document.body.");
   })();
 
   const disableFocusRingByDefault = function() {
@@ -96,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'focus',
     e => {
       if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
-        kolibriGlobal.coreVue.vuex.store.commit('SET_MODALITY', 'keyboard');
+        store.commit(`${nameSpace}/SET_MODALITY`, 'keyboard');
       }
     },
     true
@@ -105,7 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.body.addEventListener(
     'blur',
     () => {
-      kolibriGlobal.coreVue.vuex.store.commit('SET_MODALITY', null);
+      store.commit(`${nameSpace}/SET_MODALITY`, null);
     },
     true
   );

--- a/kolibri/core/assets/src/core-app/vuexModality.js
+++ b/kolibri/core/assets/src/core-app/vuexModality.js
@@ -1,6 +1,6 @@
 import store from 'kolibri.coreVue.vuex.store';
 import logger from 'kolibri.lib.logging';
-import { nameSpace } from '../state/modules/theme';
+import { THEME_MODULE_NAMESPACE } from '../state/modules/theme';
 
 const logging = logger.getLogger(__filename);
 
@@ -100,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'focus',
     e => {
       if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
-        store.commit(`${nameSpace}/SET_MODALITY`, 'keyboard');
+        store.commit(`${THEME_MODULE_NAMESPACE}/SET_MODALITY`, 'keyboard');
       }
     },
     true
@@ -109,7 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.body.addEventListener(
     'blur',
     () => {
-      store.commit(`${nameSpace}/SET_MODALITY`, null);
+      store.commit(`${THEME_MODULE_NAMESPACE}/SET_MODALITY`, null);
     },
     true
   );

--- a/kolibri/core/assets/src/mixins/theme.js
+++ b/kolibri/core/assets/src/mixins/theme.js
@@ -1,8 +1,8 @@
 import { mapGetters } from 'vuex';
-import themeModule, { nameSpace } from '../state/modules/theme';
+import themeModule, { THEME_MODULE_NAMESPACE } from '../state/modules/theme';
 
 export default {
   computed: {
-    ...mapGetters(nameSpace, Object.keys(themeModule.getters)),
+    ...mapGetters(THEME_MODULE_NAMESPACE, Object.keys(themeModule.getters)),
   },
 };

--- a/kolibri/core/assets/src/mixins/theme.js
+++ b/kolibri/core/assets/src/mixins/theme.js
@@ -1,0 +1,8 @@
+import { mapGetters } from 'vuex';
+import themeModule, { nameSpace } from '../state/modules/theme';
+
+export default {
+  computed: {
+    ...mapGetters(nameSpace, Object.keys(themeModule.getters)),
+  },
+};

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -2,7 +2,7 @@ import connectionModule from '../connection';
 import loggingModule from '../logging';
 import sessionModule from '../session';
 import snackbarModule from '../snackbar';
-import themeModule, { nameSpace } from '../theme';
+import themeModule, { THEME_MODULE_NAMESPACE } from '../theme';
 import * as getters from './getters';
 import * as actions from './actions';
 import mutations from './mutations';
@@ -33,6 +33,6 @@ export default {
     logging: loggingModule,
     session: sessionModule,
     snackbar: snackbarModule,
-    [nameSpace]: themeModule,
+    [THEME_MODULE_NAMESPACE]: themeModule,
   },
 };

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -2,7 +2,7 @@ import connectionModule from '../connection';
 import loggingModule from '../logging';
 import sessionModule from '../session';
 import snackbarModule from '../snackbar';
-import themeModule from '../theme';
+import themeModule, { nameSpace } from '../theme';
 import * as getters from './getters';
 import * as actions from './actions';
 import mutations from './mutations';
@@ -33,6 +33,6 @@ export default {
     logging: loggingModule,
     session: sessionModule,
     snackbar: snackbarModule,
-    theme: themeModule,
+    [nameSpace]: themeModule,
   },
 };

--- a/kolibri/core/assets/src/state/modules/theme.js
+++ b/kolibri/core/assets/src/state/modules/theme.js
@@ -1,5 +1,7 @@
 import { lighten, darken } from 'kolibri.utils.colour';
 
+export const nameSpace = 'kolibriCoreTheme';
+
 const initialState = {
   '$core-action-light': '#e2d1e0',
   '$core-action-dark': '#72486f',
@@ -28,6 +30,7 @@ const initialState = {
 };
 
 export default {
+  namespaced: true,
   state: { ...initialState },
   getters: {
     $coreActionNormal(state) {

--- a/kolibri/core/assets/src/state/modules/theme.js
+++ b/kolibri/core/assets/src/state/modules/theme.js
@@ -1,6 +1,6 @@
 import { lighten, darken } from 'kolibri.utils.colour';
 
-export const nameSpace = 'kolibriCoreTheme';
+export const THEME_MODULE_NAMESPACE = 'kolibriCoreTheme';
 
 const initialState = {
   '$core-action-light': '#e2d1e0',

--- a/kolibri/core/assets/src/styles/globalDynamicStyles.js
+++ b/kolibri/core/assets/src/styles/globalDynamicStyles.js
@@ -1,5 +1,6 @@
 import { StyleSheet as baseStyleSheet } from 'aphrodite/no-important';
 import store from 'kolibri.coreVue.vuex.store';
+import { nameSpace } from '../state/modules/theme';
 
 const globalSelectorHandler = (selector, _, generateSubtreeStyles) => {
   if (selector[0] !== '*') {
@@ -13,19 +14,23 @@ const globalExtension = { selectorHandler: globalSelectorHandler };
 
 const { StyleSheet, css } = baseStyleSheet.extend([globalExtension]);
 
+function getter(value) {
+  return store.getters[`${nameSpace}/${value}`];
+}
+
 function generateGlobalStyles() {
   const htmlBodyStyles = {
-    color: store.getters.$coreTextDefault,
-    backgroundColor: store.getters.$coreBgCanvas,
+    color: getter('$coreTextDefault'),
+    backgroundColor: getter('$coreBgCanvas'),
   };
 
   const globalStyles = StyleSheet.create({
     globals: {
       '*html': htmlBodyStyles,
       '*body': htmlBodyStyles,
-      '*:focus': store.getters.$coreOutline,
+      '*:focus': getter('$coreOutline'),
       '*hr': {
-        borderTop: `1px solid ${store.getters.$coreTextDisabled}`,
+        borderTop: `1px solid ${getter('$coreTextDisabled')}`,
       },
     },
   });

--- a/kolibri/core/assets/src/styles/globalDynamicStyles.js
+++ b/kolibri/core/assets/src/styles/globalDynamicStyles.js
@@ -1,6 +1,6 @@
 import { StyleSheet as baseStyleSheet } from 'aphrodite/no-important';
 import store from 'kolibri.coreVue.vuex.store';
-import { nameSpace } from '../state/modules/theme';
+import { THEME_MODULE_NAMESPACE } from '../state/modules/theme';
 
 const globalSelectorHandler = (selector, _, generateSubtreeStyles) => {
   if (selector[0] !== '*') {
@@ -15,7 +15,7 @@ const globalExtension = { selectorHandler: globalSelectorHandler };
 const { StyleSheet, css } = baseStyleSheet.extend([globalExtension]);
 
 function getter(value) {
-  return store.getters[`${nameSpace}/${value}`];
+  return store.getters[`${THEME_MODULE_NAMESPACE}/${value}`];
 }
 
 function generateGlobalStyles() {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -103,6 +103,7 @@
 <script>
 
   import { mapGetters, mapState, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiToolbar from 'keen-ui/src/UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -128,7 +129,7 @@
       LogoutSideNavEntry,
       UserTypeDisplay,
     },
-    mixins: [responsiveWindow, navComponentsMixin],
+    mixins: [responsiveWindow, navComponentsMixin, themeMixin],
     $trs: {
       userTypeLabel: 'User type',
       languageSwitchMenuOption: 'Change language',
@@ -151,7 +152,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'getUserKind', '$coreActionNormal', '$coreTextDefault']),
+      ...mapGetters(['isUserLoggedIn', 'getUserKind']),
       ...mapState({
         username: state => state.core.session.username,
       }),

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -32,7 +32,8 @@
 
 <script>
 
-  import { mapGetters, mapState, mapActions } from 'vuex';
+  import { mapState, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
   import ClipboardJS from 'clipboard';
 
@@ -46,6 +47,7 @@
     components: {
       KButton,
     },
+    mixins: [themeMixin],
     props: {
       text: {
         type: String,
@@ -61,7 +63,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgError', '$coreGrey300']),
       ...mapState({
         error: state => state.core.error,
       }),

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -69,7 +69,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
 
   export default {
@@ -77,6 +77,7 @@
     components: {
       CoachContentLabel,
     },
+    mixins: [themeMixin],
     $trs: {
       header: 'Answer history',
       today: 'Today',
@@ -93,15 +94,6 @@
         type: Number,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters([
-        '$coreBgLight',
-        '$coreTextAnnotation',
-        '$coreStatusWrong',
-        '$coreStatusCorrect',
-        '$coreTextDisabled',
-      ]),
     },
     mounted() {
       this.$nextTick(() => {

--- a/kolibri/core/assets/src/views/CoachContentLabel.vue
+++ b/kolibri/core/assets/src/views/CoachContentLabel.vue
@@ -34,7 +34,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
 
@@ -44,6 +44,7 @@
       UiIcon,
       KTooltip,
     },
+    mixins: [themeMixin],
     props: {
       value: {
         type: Number,
@@ -56,7 +57,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreStatusProgress']),
       titleText() {
         if (this.isTopic) {
           return this.$tr('topicTitle', { count: this.value });

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -99,6 +99,7 @@
 
   import { mapState, mapGetters } from 'vuex';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import AppBar from 'kolibri.coreVue.components.AppBar';
   import SideNav from 'kolibri.coreVue.components.SideNav';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
@@ -131,7 +132,7 @@
       ScrollingHeader,
       UpdateNotification,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     props: {
       appBarTitle: {
         type: String,
@@ -244,7 +245,6 @@
         busy: state => state.core.signInBusy,
         notifications: state => state.core.notifications,
       }),
-      ...mapGetters(['$coreBgCanvas']),
       headerHeight() {
         return this.windowIsSmall ? 56 : 64;
       },

--- a/kolibri/core/assets/src/views/CoreInfoIcon/index.vue
+++ b/kolibri/core/assets/src/views/CoreInfoIcon/index.vue
@@ -23,7 +23,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
 
@@ -33,6 +33,7 @@
       UiIcon,
       KTooltip,
     },
+    mixins: [themeMixin],
     props: {
       iconAriaLabel: {
         type: String,
@@ -46,9 +47,6 @@
         type: String,
         required: false,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreAccentColor']),
     },
   };
 

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -45,7 +45,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
 
   export default {
@@ -53,6 +53,7 @@
     components: {
       UiIcon,
     },
+    mixins: [themeMixin],
     props: {
       type: String,
       label: String,
@@ -64,12 +65,6 @@
       },
     },
     computed: {
-      ...mapGetters([
-        '$coreGrey200',
-        '$coreAccentColor',
-        '$coreTextAnnotation',
-        '$coreTextDefault',
-      ]),
       classes() {
         return {
           'is-divider': this.isDivider,

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -34,10 +34,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'CoreMenu',
+    mixins: [themeMixin],
     props: {
       hasIcons: {
         type: Boolean,
@@ -58,7 +59,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreTextDefault']),
       classes() {
         return {
           'is-raised': this.raised,

--- a/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
@@ -31,11 +31,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'KeenUiSnackbar',
-
+    mixins: [themeMixin],
     props: {
       message: String,
       action: String,
@@ -46,7 +46,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreBgLight']),
       transitionName() {
         return 'ui-snackbar--transition-' + this.transition;
       },

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -1,9 +1,10 @@
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'CoreTable',
+    mixins: [themeMixin],
     props: {
       selectable: {
         type: Boolean,
@@ -12,7 +13,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey', '$coreTextAnnotation']),
       tHeadStyle() {
         return {
           borderBottom: `solid 1px ${this.$coreGrey}`,

--- a/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
+++ b/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
@@ -36,7 +36,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
@@ -63,6 +63,7 @@
       KIcon,
       KLabeledIcon,
     },
+    mixins: [themeMixin],
     props: {
       userName: {
         type: String,
@@ -83,7 +84,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgLight']),
       questionsCorrect() {
         return this.questions.reduce((a, q) => a + (q.correct === 1 ? 1 : 0), 0);
       },

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -53,7 +53,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import AttemptLogList from 'kolibri.coreVue.components.AttemptLogList';
   import InteractionList from 'kolibri.coreVue.components.InteractionList';
@@ -80,6 +80,7 @@
       KCheckbox,
       MultiPaneLayout,
     },
+    mixins: [themeMixin],
     props: {
       examAttempts: {
         type: Array,
@@ -150,7 +151,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreBgLight']),
       attemptLogs() {
         return this.examAttempts.map(attempt => {
           const exerciseId = this.questions[attempt.questionNumber - 1].exercise_id;

--- a/kolibri/core/assets/src/views/ImmersiveFullScreen.vue
+++ b/kolibri/core/assets/src/views/ImmersiveFullScreen.vue
@@ -37,13 +37,13 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
 
   export default {
     name: 'ImmersiveFullScreen',
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     props: {
       backPageLink: {
         type: Object,
@@ -53,9 +53,6 @@
       backPageText: {
         type: String,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreBgCanvas', '$coreActionDark', '$coreBgLight']),
     },
   };
 

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -133,7 +133,7 @@
             : darken(this.$coreTextDefault, '25%'),
         };
         return {
-          backgroundColor: this.primary ? this.coreActionNormal : this.$coreTextDefault,
+          backgroundColor: this.primary ? this.$coreActionNormal : this.$coreTextDefault,
           ':hover': hoverAndFocus,
         };
       },

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -70,7 +70,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiToolbar from 'keen-ui/src/UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import { darken } from 'kolibri.utils.colour';
@@ -82,6 +82,7 @@
       UiToolbar,
       UiIconButton,
     },
+    mixins: [themeMixin],
     props: {
       appBarTitle: {
         type: String,
@@ -116,13 +117,6 @@
       },
     },
     computed: {
-      ...mapGetters([
-        '$coreGrey200',
-        '$coreGrey300',
-        '$coreActionDark',
-        '$coreActionNormal',
-        '$coreTextDefault',
-      ]),
       hasRoute() {
         return Boolean(this.route);
       },

--- a/kolibri/core/assets/src/views/InteractionList/InteractionItem.vue
+++ b/kolibri/core/assets/src/views/InteractionList/InteractionItem.vue
@@ -41,10 +41,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'InteractionItem',
+    mixins: [themeMixin],
     props: {
       interaction: {
         type: Object,
@@ -56,13 +57,6 @@
       },
     },
     computed: {
-      ...mapGetters([
-        '$coreTextAnnotation',
-        '$coreStatusWrong',
-        '$coreStatusCorrect',
-        '$coreTextDisabled',
-        '$coreTextDefault',
-      ]),
       isAnswer() {
         return this.interaction.type === 'answer';
       },

--- a/kolibri/core/assets/src/views/KCheckbox.vue
+++ b/kolibri/core/assets/src/views/KCheckbox.vue
@@ -62,13 +62,14 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   /**
    * Used for toggling boolean user input
    */
   export default {
     name: 'KCheckbox',
+    mixins: [themeMixin],
     props: {
       /**
        * Label
@@ -112,13 +113,6 @@
       isActive: false,
     }),
     computed: {
-      ...mapGetters([
-        '$coreActionNormal',
-        '$coreTextAnnotation',
-        '$coreOutline',
-        '$coreGrey300',
-        '$coreTextDisabled',
-      ]),
       id() {
         return `k-checkbox-${this._uid}`;
       },

--- a/kolibri/core/assets/src/views/KCircularLoader.vue
+++ b/kolibri/core/assets/src/views/KCircularLoader.vue
@@ -80,14 +80,14 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   /**
    * Used to show indeterminate loading
    */
   export default {
     name: 'KCircularLoader',
-
+    mixins: [themeMixin],
     props: {
       /**
        * Whether there should be a delay before the loader displays
@@ -120,7 +120,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreLoading', '$coreActionNormal']),
       classes() {
         return [`ui-progress-circular--type-${this.type}`];
       },

--- a/kolibri/core/assets/src/views/KEmptyPlaceholder.vue
+++ b/kolibri/core/assets/src/views/KEmptyPlaceholder.vue
@@ -7,13 +7,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'KEmptyPlaceholder',
-    computed: {
-      ...mapGetters(['$coreGrey300']),
-    },
+    mixins: [themeMixin],
   };
 
 </script>

--- a/kolibri/core/assets/src/views/KFilterTextbox.vue
+++ b/kolibri/core/assets/src/views/KFilterTextbox.vue
@@ -40,7 +40,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   /**
@@ -56,6 +56,7 @@
       UiIcon,
       UiIconButton,
     },
+    mixins: [themeMixin],
     props: {
       /**
        * v-model
@@ -79,7 +80,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation', '$coreTextDefault', '$coreGrey300']),
       model: {
         get() {
           return this.value;

--- a/kolibri/core/assets/src/views/KLinearLoader.vue
+++ b/kolibri/core/assets/src/views/KLinearLoader.vue
@@ -46,14 +46,14 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   /**
    * Used to show determinate or indeterminate loading
    */
   export default {
     name: 'KLinearLoader',
-
+    mixins: [themeMixin],
     props: {
       /**
        * Whether there should be a delay before the loader displays
@@ -79,7 +79,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreLoading']),
       classes() {
         return [`ui-progress-linear--type-${this.type}`, this.delay ? 'delay' : ''];
       },

--- a/kolibri/core/assets/src/views/KModal.vue
+++ b/kolibri/core/assets/src/views/KModal.vue
@@ -92,7 +92,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import debounce from 'lodash/debounce';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -105,7 +105,7 @@
     components: {
       KButton,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     $trs: {
       // error alerts
       errorAlert: 'Error in { title }',
@@ -177,7 +177,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreBgLight', '$coreGrey']),
       modalSizeStyles() {
         return {
           'max-width': `${this.maxModalWidth - 32}px`,

--- a/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
+++ b/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
@@ -27,7 +27,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import UiIcon from 'keen-ui/src/UiIcon';
 
@@ -37,6 +37,7 @@
   export default {
     name: 'KNavbarLink',
     components: { UiIcon },
+    mixins: [themeMixin],
     props: {
       /**
        * The text
@@ -55,7 +56,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgCanvas', '$coreActionDark', '$coreOutline']),
       tabStyles() {
         return {
           color: this.$coreBgCanvas,

--- a/kolibri/core/assets/src/views/KNavbar/index.vue
+++ b/kolibri/core/assets/src/views/KNavbar/index.vue
@@ -49,7 +49,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import throttle from 'lodash/throttle';
 
@@ -58,14 +58,13 @@
    */
   export default {
     name: 'KNavbar',
-    mixins: [responsiveElement],
+    mixins: [responsiveElement, themeMixin],
     data() {
       return {
         enoughSpace: true,
       };
     },
     computed: {
-      ...mapGetters(['$coreActionNormal', '$coreOutlineAnyModality']),
       maxWidth() {
         return this.enoughSpace ? this.elementWidth : this.elementWidth - 38 * 2;
       },

--- a/kolibri/core/assets/src/views/KRadioButton.vue
+++ b/kolibri/core/assets/src/views/KRadioButton.vue
@@ -56,13 +56,14 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   /**
    * Used to display all options
    */
   export default {
     name: 'KRadioButton',
+    mixins: [themeMixin],
     model: {
       prop: 'currentValue',
     },
@@ -114,13 +115,6 @@
       active: false,
     }),
     computed: {
-      ...mapGetters([
-        '$coreActionNormal',
-        '$coreTextAnnotation',
-        '$coreOutline',
-        '$coreGrey300',
-        '$coreTextDisabled',
-      ]),
       isChecked() {
         return this.value.toString() === this.currentValue.toString();
       },

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -170,7 +170,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import fuzzysearch from 'fuzzysearch';
   import startswith from 'lodash/startsWith';
   import sortby from 'lodash/sortBy';
@@ -190,7 +190,7 @@
       KCircularLoader,
       KeenUiSelectOption,
     },
-
+    mixins: [themeMixin],
     props: {
       name: String,
       value: {
@@ -279,7 +279,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreActionNormal']),
       classes() {
         return [
           `ui-select-type-${this.type}`,

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelectOption.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelectOption.vue
@@ -43,15 +43,15 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
 
   export default {
     name: 'KeenUiSelectOption',
-
     components: {
       UiIcon,
     },
+    mixins: [themeMixin],
 
     props: {
       option: {
@@ -86,7 +86,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreActionNormal']),
       classes() {
         return [
           `ui-select-option--type-${this.type}`,

--- a/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
+++ b/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
@@ -106,7 +106,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon.vue';
 
   import autosize from 'autosize';
@@ -114,7 +114,6 @@
 
   export default {
     name: 'KeenUiTextbox',
-
     components: {
       UiIcon,
     },
@@ -122,6 +121,7 @@
     directives: {
       autofocus,
     },
+    mixins: [themeMixin],
 
     props: {
       name: String,
@@ -206,7 +206,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreActionNormal']),
       classes() {
         return [
           `ui-textbox--icon-position-${this.iconPosition}`,

--- a/kolibri/core/assets/src/views/KTooltip/index.vue
+++ b/kolibri/core/assets/src/views/KTooltip/index.vue
@@ -23,7 +23,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import isArray from 'lodash/isArray';
   import Popper from './Popper';
 
@@ -35,6 +35,7 @@
     components: {
       Popper,
     },
+    mixins: [themeMixin],
     props: {
       /**
        * String of ref which tooltip will be positioned relative to.
@@ -71,7 +72,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreTextDefault']),
       readyToInit() {
         return this.mounted && this.htmlElement;
       },

--- a/kolibri/core/assets/src/views/KeenUiIconButton.vue
+++ b/kolibri/core/assets/src/views/KeenUiIconButton.vue
@@ -70,7 +70,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
   import UiPopover from 'keen-ui/src/UiPopover';
   import UiTooltip from 'keen-ui/src/UiTooltip';
@@ -86,6 +86,7 @@
       KCircularLoader,
       UiTooltip,
     },
+    mixins: [themeMixin],
 
     props: {
       type: {
@@ -138,7 +139,6 @@
     },
 
     computed: {
-      ...mapGetters(['$coreActionNormal', '$coreOutline']),
       classes() {
         return [
           `keen-ui-icon-button--type-${this.type}`,

--- a/kolibri/core/assets/src/views/PermissionsIcon.vue
+++ b/kolibri/core/assets/src/views/PermissionsIcon.vue
@@ -37,7 +37,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { PermissionTypes, UserKinds } from 'kolibri.coreVue.vuex.constants';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
@@ -48,6 +48,7 @@
       UserTypeDisplay,
       KTooltip,
     },
+    mixins: [themeMixin],
     props: {
       permissionType: {
         type: String,
@@ -58,7 +59,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreStatusMastered', '$coreTextDefault']),
       UserKinds() {
         return UserKinds;
       },

--- a/kolibri/core/assets/src/views/ProgressBar.vue
+++ b/kolibri/core/assets/src/views/ProgressBar.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'ProgressBar',
@@ -36,6 +36,7 @@
       label: 'Progress',
       pct: '{0, number, percent}',
     },
+    mixins: [themeMixin],
     props: {
       progress: {
         type: Number,
@@ -52,7 +53,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey', '$coreActionNormal']),
       percent() {
         return Math.max(Math.min(this.progress * 100, 100), 0);
       },

--- a/kolibri/core/assets/src/views/ProgressIcon.vue
+++ b/kolibri/core/assets/src/views/ProgressIcon.vue
@@ -32,7 +32,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIcon from 'keen-ui/src/UiIcon';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
 
@@ -46,6 +46,7 @@
       UiIcon,
       KTooltip,
     },
+    mixins: [themeMixin],
     props: {
       progress: {
         type: Number,
@@ -56,7 +57,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreStatusProgress', '$coreStatusMastered']),
       isInProgress() {
         return this.progress !== null && this.progress >= 0 && this.progress < 1;
       },

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -96,6 +96,7 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
@@ -129,7 +130,7 @@
       KButton,
       PrivacyInfoModal,
     },
-    mixins: [responsiveWindow, responsiveElement, navComponentsMixin],
+    mixins: [responsiveWindow, responsiveElement, navComponentsMixin, themeMixin],
     $trs: {
       kolibri: 'Kolibri',
       navigationLabel: 'Main user navigation',
@@ -160,16 +161,7 @@
       };
     },
     computed: {
-      ...mapGetters([
-        'isUserLoggedIn',
-        'isSuperuser',
-        'isAdmin',
-        'isCoach',
-        'canManageContent',
-        '$coreBgLight',
-        '$coreTextAnnotation',
-        '$coreTextDefault',
-      ]),
+      ...mapGetters(['isUserLoggedIn', 'isSuperuser', 'isAdmin', 'isCoach', 'canManageContent']),
       ...mapState({
         session: state => state.core.session,
       }),

--- a/kolibri/core/assets/src/views/buttons-and-links/buttonMixin.js
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttonMixin.js
@@ -1,4 +1,4 @@
-import { mapGetters } from 'vuex';
+import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 import { FLAT_BUTTON, RAISED_BUTTON, BASIC_LINK, validator } from './appearances.js';
 
 const $primaryRaisedColor = 'white';
@@ -11,6 +11,7 @@ const disabledStyle = {
 };
 
 export default {
+  mixins: [themeMixin],
   props: {
     /**
      * Button label text
@@ -36,14 +37,6 @@ export default {
     },
   },
   computed: {
-    ...mapGetters([
-      '$coreGrey200',
-      '$coreGrey300',
-      '$coreOutline',
-      '$coreActionDark',
-      '$coreActionNormal',
-      '$coreTextDefault',
-    ]),
     buttonClasses() {
       const buttonClass = 'button';
       const linkClass = 'link';

--- a/kolibri/core/assets/src/views/icons/KIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KIcon.vue
@@ -51,7 +51,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   const boolean = {
     type: Boolean,
@@ -60,6 +60,7 @@
 
   export default {
     name: 'KIcon',
+    mixins: [themeMixin],
     props: {
       /**
        * color to apply to the icon
@@ -109,7 +110,6 @@
       search: boolean,
     },
     computed: {
-      ...mapGetters(['$coreTextDefault']),
       style() {
         if (this.color) {
           return { fill: this.color };

--- a/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
@@ -29,7 +29,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
 
@@ -39,6 +39,7 @@
       KRouterLink,
       UiIconButton,
     },
+    mixins: [themeMixin],
     props: {
       text: {
         type: String,
@@ -48,9 +49,6 @@
         type: Object,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreActionNormal']),
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
@@ -18,10 +18,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'HeaderTab',
+    mixins: [themeMixin],
     props: {
       text: {
         type: String,
@@ -38,7 +39,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreActionNormal', '$coreTextAnnotation', '$coreGrey300', '$coreOutline']),
       activeClasses() {
         // return both fixed and dynamic classes
         return `router-link-active ${this.$computedClass({ color: this.$coreActionNormal })}`;

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
@@ -73,6 +73,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import AttemptLogList from 'kolibri.coreVue.components.AttemptLogList';
   import InteractionList from 'kolibri.coreVue.components.InteractionList';
@@ -91,7 +92,7 @@
       MultiPaneLayout,
       CoachContentLabel,
     },
-    mixins: [commonCoach],
+    mixins: [commonCoach, themeMixin],
     $trs: {},
     data() {
       return {
@@ -99,7 +100,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreBgLight']),
       ...mapGetters('exerciseDetail', [
         'currentAttemptLog',
         'currentInteraction',

--- a/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
@@ -12,9 +12,9 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'LessonActive',
@@ -22,6 +22,7 @@
       KLabeledIcon,
       KIcon,
     },
+    mixins: [themeMixin],
     props: {
       active: {
         type: Boolean,
@@ -33,7 +34,6 @@
       inactive: 'Inactive',
     },
     computed: {
-      ...mapGetters(['$coreStatusCorrect', '$coreGrey300']),
       label() {
         return this.active ? this.$tr('active') : this.$tr('inactive');
       },

--- a/kolibri/plugins/coach/assets/src/views/common/Placeholder.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/Placeholder.vue
@@ -10,10 +10,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'Placeholder',
+    mixins: [themeMixin],
     props: {
       ready: {
         type: Boolean,
@@ -29,7 +30,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreTextDisabled']),
       placeholderStyle() {
         return {
           backgroundColor: this.$coreTextDisabled,

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
@@ -50,13 +50,13 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { coachStringsMixin } from './commonCoachStrings';
 
   export default {
     name: 'QuestionDetailLearnerList',
     $trs: {},
-    mixins: [coachStringsMixin],
+    mixins: [coachStringsMixin, themeMixin],
     props: {
       learners: {
         type: Array,
@@ -66,15 +66,6 @@
         type: Number,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters([
-        '$coreBgLight',
-        '$coreTextAnnotation',
-        '$coreStatusWrong',
-        '$coreStatusCorrect',
-        '$coreTextDisabled',
-      ]),
     },
     mounted() {
       this.$nextTick(() => {

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
@@ -60,6 +60,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import InteractionList from 'kolibri.coreVue.components.InteractionList';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
@@ -82,7 +83,7 @@
       MultiPaneLayout,
       CoachContentLabel,
     },
-    mixins: [commonCoach],
+    mixins: [commonCoach, themeMixin],
     $trs: {},
     data() {
       return {
@@ -98,7 +99,6 @@
         'questionId',
         'title',
       ]),
-      ...mapGetters(['$coreBgLight']),
       ...mapGetters('questionDetail', [
         'currentLearner',
         'currentInteraction',

--- a/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
@@ -12,9 +12,9 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'QuizActive',
@@ -22,6 +22,7 @@
       KLabeledIcon,
       KIcon,
     },
+    mixins: [themeMixin],
     props: {
       active: {
         type: Boolean,
@@ -33,7 +34,6 @@
       inactive: 'Inactive',
     },
     computed: {
-      ...mapGetters(['$coreStatusCorrect', '$coreGrey300']),
       label() {
         return this.active ? this.$tr('active') : this.$tr('inactive');
       },

--- a/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
@@ -21,11 +21,12 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'TruncatedItemList',
     components: {},
+    mixins: [themeMixin],
     props: {
       items: {
         type: Array,
@@ -37,9 +38,6 @@
       twoItems: '{item1}, {item2}',
       threeItems: '{item1}, {item2}, {item3}',
       manyItems: '{item1}, {item2}, and {count, number, integer} others',
-    },
-    computed: {
-      ...mapGetters(['$coreGrey300']),
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/common/status/CoachStatusIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/CoachStatusIcon.vue
@@ -13,8 +13,8 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import KIcon from 'kolibri.coreVue.components.KIcon';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { ICONS } from './constants';
 
   export default {
@@ -22,6 +22,7 @@
     components: {
       KIcon,
     },
+    mixins: [themeMixin],
     props: {
       icon: {
         type: String,
@@ -32,12 +33,6 @@
       },
     },
     computed: {
-      ...mapGetters([
-        '$coreStatusMastered',
-        '$coreStatusProgress',
-        '$coreStatusWrong',
-        '$coreGrey300',
-      ]),
       ICONS() {
         return ICONS;
       },

--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -15,12 +15,12 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import tallyMixin from './tallyMixin';
 
   export default {
     name: 'ProgressSummaryBar',
-    mixins: [tallyMixin],
+    mixins: [tallyMixin, themeMixin],
     props: {
       showErrorBar: {
         type: Boolean,
@@ -28,7 +28,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreStatusProgress', '$coreStatusMastered', '$coreStatusWrong']),
       barStyleCompleted() {
         return {
           width: `${Math.ceil((100 * this.completed) / this.total)}%`,

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSimple.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSimple.vue
@@ -13,7 +13,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { STATUSES } from '../../../modules/classSummary/constants';
   import { VERBS, ICONS } from './constants';
   import LearnerProgressLabel from './LearnerProgressLabel';
@@ -37,6 +37,7 @@
     components: {
       LearnerProgressLabel,
     },
+    mixins: [themeMixin],
     props: {
       verbose: {
         type: Boolean,
@@ -48,7 +49,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey300']),
       verb() {
         return VERB_MAP[this.status];
       },

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -139,7 +139,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { VERBS, ICONS } from './constants';
   import LearnerProgressCount from './LearnerProgressCount';
   import LearnerProgressRatio from './LearnerProgressRatio';
@@ -152,7 +152,7 @@
       // eslint-disable-next-line vue/no-unused-components
       LearnerProgressRatio, // it is used, it's just referenced dynamically
     },
-    mixins: [tallyMixin],
+    mixins: [tallyMixin, themeMixin],
     props: {
       verbose: {
         type: Boolean,
@@ -172,7 +172,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey300']),
       verbosity() {
         return this.verbose ? 1 : 0;
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -42,7 +42,7 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import commonCoach from '../../common';
   import ProgressSummaryBar from '../../common/status/ProgressSummaryBar';
 
@@ -51,7 +51,7 @@
     components: {
       ProgressSummaryBar,
     },
-    mixins: [commonCoach],
+    mixins: [commonCoach, themeMixin],
     props: {
       name: {
         type: String,
@@ -74,9 +74,6 @@
         required: false,
         validators: validateLinkObject,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreTextDefault']),
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/AssessmentQuestionListItem.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/AssessmentQuestionListItem.vue
@@ -35,7 +35,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import KDragSortWidget from 'kolibri.coreVue.components.KDragSortWidget';
 
@@ -54,6 +54,7 @@
       CoachContentLabel,
       KDragSortWidget,
     },
+    mixins: [themeMixin],
     props: {
       draggable: {
         type: Boolean,
@@ -85,7 +86,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreOutline']),
       text() {
         if (this.questionNumberOfExercise === undefined) {
           return this.exerciseName;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/Bottom.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/Bottom.vue
@@ -11,13 +11,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'Bottom',
-    computed: {
-      ...mapGetters(['$coreBgLight']),
-    },
+    mixins: [themeMixin],
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -25,7 +25,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
 
   export default {
@@ -33,6 +33,7 @@
     components: {
       ContentRenderer,
     },
+    mixins: [themeMixin],
     props: {
       content: {
         type: Object,
@@ -55,7 +56,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgLight']),
       hasHeader() {
         return Boolean(this.header);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/QuestionList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/QuestionList.vue
@@ -31,7 +31,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
 
   export default {
@@ -39,6 +39,7 @@
     components: {
       KButton,
     },
+    mixins: [themeMixin],
     $trs: {
       questionListHeader: '{numOfQuestions, number} Questions',
       questionLabel: 'Question { questionNumber, number }',
@@ -60,7 +61,6 @@
       },
     },
     computed: {
-      ...mapGetters(['coreTextDisabled', '$coreGrey300']),
       buttonAndHeaderBorder() {
         return {
           borderBottom: `2px solid ${this.$coreTextDisabled}`,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/CardThumbnail.vue
@@ -21,7 +21,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import { validateContentNodeKind } from 'kolibri.utils.validators';
   import CornerIcon from './CornerIcon';
@@ -32,6 +32,7 @@
       ContentIcon,
       CornerIcon,
     },
+    mixins: [themeMixin],
     props: {
       thumbnail: {
         type: String,
@@ -44,7 +45,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation', '$coreBgLight']),
       thumbnailBackground() {
         return {
           backgroundColor: this.$coreBgLight,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -53,7 +53,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -69,6 +69,7 @@
       CoachContentLabel,
       KRouterLink,
     },
+    mixins: [themeMixin],
     props: {
       title: {
         type: String,
@@ -105,7 +106,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgLight', '$coreTextDefault']),
       isTopic() {
         return this.kind === ContentNodeKinds.CHANNEL || this.kind === ContentNodeKinds.TOPIC;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -64,7 +64,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
 
   export default {
@@ -77,13 +77,13 @@
     components: {
       UiIconButton,
     },
+    mixins: [themeMixin],
     data() {
       return {
         searchTerm: this.$route.params.searchTerm || '',
       };
     },
     computed: {
-      ...mapGetters(['$coreActionDark', '$coreTextAnnotation', '$coreTextDefault']),
       searchTermHasChanged() {
         return this.searchTerm !== this.$route.params.searchTerm;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -60,7 +60,8 @@
 
 <script>
 
-  import { mapActions, mapState, mapMutations, mapGetters } from 'vuex';
+  import { mapActions, mapState, mapMutations } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KDragSortWidget from 'kolibri.coreVue.components.KDragSortWidget';
   import KDragContainer from 'kolibri.coreVue.components.KDragContainer';
   import KDragHandle from 'kolibri.coreVue.components.KDragHandle';
@@ -86,6 +87,7 @@
       KGridItem,
       ContentIcon,
     },
+    mixins: [themeMixin],
     data() {
       return {
         workingResourcesBackup: this.$store.state.lessonSummary.workingResources,
@@ -93,7 +95,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation', '$coreBgLight']),
       ...mapState('lessonSummary', {
         lessonId: state => state.currentLesson.id,
         workingResources: state => state.workingResources,

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
@@ -74,7 +74,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import KButton from 'kolibri.coreVue.components.KButton';
   import { CollectionKinds, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -93,6 +93,7 @@
       HeaderTable,
       HeaderTableRow,
     },
+    mixins: [themeMixin],
     props: {
       kind: {
         type: String,
@@ -133,7 +134,6 @@
       entireClass: 'Entire class',
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation']),
       showDescription() {
         return this.description !== null;
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/AttemptSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/AttemptSummary.vue
@@ -68,7 +68,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
@@ -91,6 +91,7 @@
       KGrid,
       KGridItem,
     },
+    mixins: [themeMixin],
     props: {
       userName: {
         type: String,
@@ -110,7 +111,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey', '$coreBgLight']),
       isCompleted() {
         try {
           return this.summaryLog.currentmasterylog.complete;

--- a/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
@@ -54,6 +54,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import AttemptLogList from 'kolibri.coreVue.components.AttemptLogList';
@@ -82,6 +83,7 @@
       KCheckbox,
       MultiPaneLayout,
     },
+    mixins: [themeMixin],
     data() {
       return {
         showCorrectAnswer: false,
@@ -90,7 +92,6 @@
     computed: {
       ...mapState(['pageName', 'reportRefreshInterval']),
       ...mapState('classSummary', { classId: 'id' }),
-      ...mapGetters(['$coreBgLight']),
       ...mapGetters('exerciseDetail', [
         'currentAttemptLog',
         'currentInteraction',

--- a/kolibri/plugins/demo_server/assets/src/views/DemoServerIndex.vue
+++ b/kolibri/plugins/demo_server/assets/src/views/DemoServerIndex.vue
@@ -62,7 +62,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
 
@@ -72,6 +72,7 @@
       KButton,
       KExternalLink,
     },
+    mixins: [themeMixin],
     $trs: {
       demoServerHeader: 'Welcome to the Kolibri demo site!',
       demoServerP1: 'You are welcome to explore with any of the three primary user types:',
@@ -89,9 +90,6 @@
       return {
         bannerClosed: false,
       };
-    },
-    computed: {
-      ...mapGetters(['$coreBgLight']),
     },
     methods: {
       toggleBannerState(event) {

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -93,6 +93,7 @@
 <script>
 
   import { mapState, mapMutations, mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import KFilterTextbox from 'kolibri.coreVue.components.KFilterTextbox';
@@ -127,7 +128,7 @@
       KLinearLoader,
       KSelect,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     data() {
       return {
         languageFilter: {},
@@ -136,7 +137,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation']),
       ...mapGetters('manageContent', ['installedChannelsWithResources']),
       ...mapGetters('manageContent/wizard', [
         'inLocalImportMode',

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -76,6 +76,7 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
@@ -105,7 +106,7 @@
       KRouterLink,
       UiIcon,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     props: {
       channel: {
         type: Object,
@@ -124,7 +125,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey', '$coreStatusCorrect', '$coreTextAnnotation']),
       ...mapGetters('manageContent', ['channelIsInstalled']),
       ...mapState('manageContent', ['taskList']),
       manageChannelActions() {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelsGrid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelsGrid.vue
@@ -48,6 +48,7 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import DeleteChannelModal from './DeleteChannelModal';
   import ChannelListItem from './ChannelListItem';
@@ -59,13 +60,13 @@
       KLinearLoader,
       DeleteChannelModal,
     },
+    mixins: [themeMixin],
     data() {
       return {
         selectedChannelId: null,
       };
     },
     computed: {
-      ...mapGetters(['$coreTextError', '$coreTextAnnotation']),
       ...mapState('manageContent', ['channelListLoading']),
       ...mapGetters('manageContent', ['installedChannelsWithResources']),
       channelIsSelected() {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -55,7 +55,8 @@
 
 <script>
 
-  import { mapActions, mapGetters } from 'vuex';
+  import { mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -73,6 +74,7 @@
       KCircularLoader,
       KButton,
     },
+    mixins: [themeMixin],
     props: {
       type: RequiredString,
       status: RequiredString,
@@ -96,7 +98,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreStatusCorrect', '$coreTextError']),
       TaskStatuses: () => TaskStatuses,
       stageText() {
         // Special case for Channel DB downloading, since they never go into RUNNING

--- a/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
@@ -100,6 +100,7 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UserType from 'kolibri.utils.UserType';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
@@ -125,6 +126,7 @@
       PermissionsIcon,
       UserTypeDisplay,
     },
+    mixins: [themeMixin],
     data() {
       return {
         devicePermissionsChecked: undefined,
@@ -134,7 +136,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isSuperuser', 'facilities', '$coreTextAnnotation', '$coreTextDisabled']),
+      ...mapGetters(['isSuperuser', 'facilities']),
       ...mapState('userPermissions', ['user', 'permissions']),
       ...mapState({
         currentUsername: state => state.core.session.username,

--- a/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
@@ -47,7 +47,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
 
   export default {
@@ -60,6 +60,7 @@
     components: {
       KLinearLoader,
     },
+    mixins: [themeMixin],
     props: {
       heading: {
         type: String,
@@ -77,9 +78,6 @@
         type: Boolean,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreGrey200']),
     },
     methods: {
       handleChange(newValue) {

--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -159,6 +159,7 @@
   import FocusLock from 'vue-focus-lock';
 
   import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -216,7 +217,7 @@
       SearchButton,
       LoadingError,
     },
-    mixins: [responsiveWindow, responsiveElement, contentRendererMixin],
+    mixins: [responsiveWindow, responsiveElement, contentRendererMixin, themeMixin],
     data: () => ({
       book: null,
       rendition: null,
@@ -237,7 +238,7 @@
       updateContentStateInterval: null,
     }),
     computed: {
-      ...mapGetters(['sessionTimeSpent', '$coreBgLight']),
+      ...mapGetters(['sessionTimeSpent']),
       savedLocation() {
         if (this.extraFields && this.extraFields.contentState) {
           return this.extraFields.contentState.savedLocation;

--- a/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
@@ -89,7 +89,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -144,6 +144,7 @@
       SideBar,
       UiIconButton,
     },
+    mixins: [themeMixin],
     props: {
       book: {
         type: Object,
@@ -159,7 +160,6 @@
       markInstance: null,
     }),
     computed: {
-      ...mapGetters(['$coreTextAnnotation', '$coreGrey']),
       numberOfSearchResults() {
         if (this.maxSearchResultsExceeded) {
           return this.$tr('overCertainNumberOfSearchResults', { num: MAX_SEARCH_RESULTS });

--- a/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
@@ -80,7 +80,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
@@ -107,6 +107,7 @@
       KGridItem,
       KButton,
     },
+    mixins: [themeMixin],
     props: {
       theme: {
         type: Object,
@@ -127,7 +128,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreOutline']),
       themes() {
         return THEMES;
       },

--- a/kolibri/plugins/document_epub_render/assets/src/views/SideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SideBar.vue
@@ -9,13 +9,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'SideBar',
-    computed: {
-      ...mapGetters(['$coreBgCanvas']),
-    },
+    mixins: [themeMixin],
   };
 
 </script>

--- a/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
@@ -66,7 +66,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -87,6 +87,7 @@
       SettingsButton,
       SearchButton,
     },
+    mixins: [themeMixin],
     props: {
       title: {
         type: String,
@@ -96,9 +97,6 @@
         type: Boolean,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreGrey200']),
     },
     methods: {
       focusOnTocButton() {

--- a/kolibri/plugins/document_pdf_render/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/PdfRendererIndex.vue
@@ -79,6 +79,7 @@
   import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
   // polyfill necessary for recycle list
   import 'intersection-observer';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import responsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -108,7 +109,7 @@
       RecycleList,
       CoreFullscreen,
     },
-    mixins: [responsiveWindow, responsiveElement, contentRendererMixin],
+    mixins: [responsiveWindow, responsiveElement, contentRendererMixin, themeMixin],
     data: () => ({
       progress: null,
       scale: null,
@@ -123,7 +124,7 @@
       updateContentStateInterval: null,
     }),
     computed: {
-      ...mapGetters(['sessionTimeSpent', '$coreTextDefault']),
+      ...mapGetters(['sessionTimeSpent']),
       pdfURL() {
         return this.defaultFile.storage_url;
       },

--- a/kolibri/plugins/facility_management/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/DataPage/index.vue
@@ -72,6 +72,7 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
@@ -90,6 +91,7 @@
       KGridItem,
       DataPageTaskProgress,
     },
+    mixins: [themeMixin],
     data() {
       return {
         lista: urls,
@@ -121,7 +123,6 @@
       documentTitle: 'Manage Data',
     },
     computed: {
-      ...mapGetters(['$coreBgWarning', '$coreTextAnnotation']),
       ...mapGetters('manageCSV', [
         'inSessionCSVCreation',
         'inSummaryCSVCreation',

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -92,7 +92,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
@@ -109,6 +109,7 @@
       KLabeledIcon,
       KIcon,
     },
+    mixins: [themeMixin],
     props: {
       users: {
         type: Array,
@@ -143,7 +144,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgLight', '$coreTextAnnotation']),
       allAreSelected() {
         return Boolean(this.users.length) && this.users.every(user => this.value.includes(user.id));
       },

--- a/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_app_renderer/assets/src/views/Html5AppRendererIndex.vue
@@ -31,7 +31,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import contentRendererMixin from 'kolibri.coreVue.mixins.contentRendererMixin';
   import { now } from 'kolibri.utils.serverClock';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -44,7 +44,7 @@
       UiIconButton,
       CoreFullscreen,
     },
-    mixins: [contentRendererMixin],
+    mixins: [contentRendererMixin, themeMixin],
     props: {
       defaultFile: {
         type: Object,
@@ -57,7 +57,6 @@
       };
     },
     computed: {
-      ...mapGetters(['$coreBgCanvas']),
       rooturl() {
         return this.defaultFile.storage_url;
       },

--- a/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
@@ -34,7 +34,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import SearchBox from './SearchBox';
@@ -45,14 +45,13 @@
       UiIconButton,
       SearchBox,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     data() {
       return {
         searchBoxIsOpen: false,
       };
     },
     computed: {
-      ...mapGetters(['$coreActionNormal']),
       searchBoxIsDropdown() {
         return this.windowIsSmall;
       },

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/ExerciseAttempts/AnswerIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/ExerciseAttempts/AnswerIcon.vue
@@ -43,7 +43,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
 
   export default {
@@ -51,6 +51,7 @@
     components: {
       KTooltip,
     },
+    mixins: [themeMixin],
     props: {
       answer: {
         type: String,
@@ -61,7 +62,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreStatusCorrect', '$coreTextAnnotation']),
       tooltipText() {
         switch (this.answer) {
           case 'right':

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/ExerciseAttempts/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/ExerciseAttempts/index.vue
@@ -25,12 +25,13 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import AnswerIcon from './AnswerIcon';
 
   export default {
     name: 'ExerciseAttempts',
     components: { AnswerIcon },
+    mixins: [themeMixin],
     props: {
       // Creates an empty space awaiting a new attempt
       waitingForAttempt: {
@@ -52,7 +53,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreTextAnnotation']),
       numItemsToRender() {
         if (this.waitingForAttempt) {
           return this.numSpaces;

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -112,6 +112,7 @@ oriented data synchronization.
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { InteractionTypes, MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import shuffled from 'kolibri.utils.shuffled';
   import { now } from 'kolibri.utils.serverClock';
@@ -130,7 +131,7 @@ oriented data synchronization.
       KButton,
       UiAlert,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     $trs: {
       goal: 'Get {count, number, integer} {count, plural, other {correct}}',
       tryAgain: 'Try again',
@@ -210,15 +211,7 @@ oriented data synchronization.
       };
     },
     computed: {
-      ...mapGetters([
-        'isUserLoggedIn',
-        '$coreBgLight',
-        '$coreBgLight',
-        '$coreGrey',
-        '$coreStatusMastered',
-        '$coreTextAnnotation',
-        '$coreTextDefault',
-      ]),
+      ...mapGetters(['isUserLoggedIn']),
       ...mapState('topicsTree', {
         topicsTreeContent: 'content',
       }),

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -65,7 +65,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import { validateContentNodeKind } from 'kolibri.utils.validators';
@@ -76,6 +76,7 @@
       ContentIcon,
       ProgressIcon,
     },
+    mixins: [themeMixin],
     props: {
       thumbnail: {
         type: String,
@@ -105,13 +106,6 @@
       },
     },
     computed: {
-      ...mapGetters([
-        '$coreGrey',
-        '$coreBgLight',
-        '$coreStatusMastered',
-        '$coreStatusProgress',
-        '$coreTextAnnotation',
-      ]),
       isMastered() {
         return this.progress === 1;
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -47,7 +47,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
@@ -66,6 +66,7 @@
       TextTruncator,
       KButton,
     },
+    mixins: [themeMixin],
     props: {
       title: {
         type: String,
@@ -122,7 +123,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreBgLight', '$coreTextDefault']),
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupHeader.vue
@@ -21,7 +21,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
 
   export default {
@@ -30,13 +30,11 @@
     $trs: {
       viewMoreFromSectionButton: 'View more',
     },
+    mixins: [themeMixin],
     props: {
       header: { type: String },
       viewMorePageLink: { type: Object },
       showViewMore: { type: Boolean },
-    },
-    computed: {
-      ...mapGetters(['$coreTextDefault']),
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -30,13 +30,15 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
 
   export default {
     name: 'AnswerHistory',
     $trs: {
       question: 'Question { num }',
     },
+    mixins: [themeMixin],
     props: {
       questionNumber: {
         type: Number,
@@ -44,7 +46,6 @@
       },
     },
     computed: {
-      ...mapGetters(['$coreGrey', '$coreBgLight']),
       ...mapState('examViewer', ['questions']),
       ...mapState({ attemptLogs: 'examAttemptLogs' }),
     },

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -94,7 +94,8 @@
 
 <script>
 
-  import { mapGetters, mapState, mapActions } from 'vuex';
+  import { mapState, mapActions } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { InteractionTypes } from 'kolibri.coreVue.vuex.constants';
   import isEqual from 'lodash/isEqual';
   import { now } from 'kolibri.utils.serverClock';
@@ -137,13 +138,13 @@
       UiAlert,
       MultiPaneLayout,
     },
+    mixins: [themeMixin],
     data() {
       return {
         submitModalOpen: false,
       };
     },
     computed: {
-      ...mapGetters(['$coreBgLight', '$coreTextDefault']),
       ...mapState(['examAttemptLogs']),
       ...mapState('examViewer', [
         'channelId',

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/Snackbar.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/Snackbar.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
 
   export default {
@@ -39,9 +39,7 @@
     components: {
       UiIconButton,
     },
-    computed: {
-      ...mapGetters(['$coreBgCanvas']),
-    },
+    mixins: [themeMixin],
   };
 
 </script>

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
@@ -81,6 +81,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { MaxPointsPerContent, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import PointsIcon from 'kolibri.coreVue.components.PointsIcon';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
@@ -101,6 +102,7 @@
       Snackbar,
       UiAlert,
     },
+    mixins: [themeMixin],
     props: {
       nextContent: {
         type: Object,
@@ -118,12 +120,7 @@
     }),
 
     computed: {
-      ...mapGetters([
-        'isUserLoggedIn',
-        '$coreStatusCorrect',
-        '$coreTextAnnotation',
-        '$coreTextDefault',
-      ]),
+      ...mapGetters(['isUserLoggedIn']),
       SNACKBARS() {
         return SNACKBARS;
       },

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -108,6 +108,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import KSelect from 'kolibri.coreVue.components.KSelect';
@@ -144,6 +145,7 @@
       UiIconButton,
       KSelect,
     },
+    mixins: [themeMixin],
     props: {
       icon: {
         type: String,
@@ -169,7 +171,6 @@
       ...mapGetters({
         channels: 'getChannels',
       }),
-      ...mapGetters(['$coreActionDark', '$coreTextDefault', '$coreTextAnnotation']),
       ...mapState('search', [
         'searchTerm',
         'channel_ids',

--- a/kolibri/plugins/learn/assets/src/views/TotalPoints.vue
+++ b/kolibri/plugins/learn/assets/src/views/TotalPoints.vue
@@ -23,6 +23,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import PointsIcon from 'kolibri.coreVue.components.PointsIcon';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
 
@@ -33,8 +34,9 @@
       PointsIcon,
       KTooltip,
     },
+    mixins: [themeMixin],
     computed: {
-      ...mapGetters(['totalPoints', 'currentUserId', 'isUserLoggedIn', '$coreTextAnnotation']),
+      ...mapGetters(['totalPoints', 'currentUserId', 'isUserLoggedIn']),
     },
     watch: { currentUserId: 'fetchPoints' },
     created() {

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -57,6 +57,7 @@
   import videojs from 'video.js';
   import throttle from 'lodash/throttle';
   import Lockr from 'lockr';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
   import ResponsiveElement from 'kolibri.coreVue.mixins.responsiveElement';
   import contentRendererMixin from 'kolibri.coreVue.mixins.contentRendererMixin';
@@ -100,7 +101,7 @@
     },
     components: { KCircularLoader, CoreFullscreen },
 
-    mixins: [ResponsiveElement, contentRendererMixin],
+    mixins: [ResponsiveElement, contentRendererMixin, themeMixin],
 
     data: () => ({
       dummyTime: 0,

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -38,7 +38,8 @@
 
 <script>
 
-  import { mapActions, mapState, mapMutations, mapGetters } from 'vuex';
+  import { mapActions, mapState, mapMutations } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import LoadingPage from './submission-states/LoadingPage';
   import ErrorPage from './submission-states/ErrorPage';
@@ -69,7 +70,7 @@
       LoadingPage,
       ErrorPage,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     $trs: {
       onboardingNextStepButton: 'Continue',
       onboardingFinishButton: 'Finish',
@@ -88,7 +89,6 @@
     },
     computed: {
       ...mapState(['onboardingStep', 'onboardingData', 'loading', 'error']),
-      ...mapGetters(['$coreActionNormal']),
       currentOnboardingForm() {
         return stepToOnboardingFormMap[this.onboardingStep] || null;
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/ErrorPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/ErrorPage.vue
@@ -25,7 +25,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
   import SubmissionStatePage from './SubmissionStatePage';
 
@@ -39,9 +39,7 @@
         "If retrying doesn't work, restart the server and refresh the page.",
       errorPageRetryButtonLabel: 'Retry',
     },
-    computed: {
-      ...mapGetters(['$coreTextAnnotation']),
-    },
+    mixins: [themeMixin],
     methods: {
       refreshPage() {
         global.location.reload(true);

--- a/kolibri/plugins/setup_wizard/assets/src/views/submission-states/SubmissionStatePage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/submission-states/SubmissionStatePage.vue
@@ -21,20 +21,18 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
 
   export default {
     name: 'SubmissionStatePage',
     components: { KCircularLoader },
+    mixins: [themeMixin],
     props: {
       header: {
         type: String,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters(['$coreAccentColor']),
     },
   };
 

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -114,6 +114,7 @@
   import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import pickBy from 'lodash/pickBy';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { validateUsername } from 'kolibri.utils.validators';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -161,7 +162,7 @@
       ChangeUserPasswordModal,
       UserTypeDisplay,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     data() {
       return {
         username: this.$store.state.core.session.username,
@@ -181,7 +182,6 @@
         'isSuperuser',
         'totalPoints',
         'userHasPermissions',
-        '$coreStatusCorrect',
       ]),
       ...mapState({
         session: state => state.core.session,

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -139,6 +139,7 @@
 
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { FacilityUsernameResource } from 'kolibri.resources';
+  import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { LoginErrors } from 'kolibri.coreVue.vuex.constants';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
@@ -190,7 +191,7 @@
       LanguageSwitcherFooter,
       PrivacyInfoModal,
     },
-    mixins: [responsiveWindow],
+    mixins: [responsiveWindow, themeMixin],
     data() {
       return {
         username: '',
@@ -208,7 +209,7 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig', '$coreGrey', '$coreActionNormal', '$coreBgLight']),
+      ...mapGetters(['facilityConfig']),
       // backend's default facility on load
       ...mapState(['facilityId']),
       ...mapState('signIn', ['hasMultipleFacilities']),


### PR DESCRIPTION
### Summary
More clean up for dynamic styles.
Creates a dynamic style `themeMixin` that imports all the dynamic style getters into computed properties.
Removes all dynamic style only map getters and imports the mixin instead.
Imports the theme module as a namespaced module to keep it encapsulated.
Updates all references to the theme module.

### Reviewer guidance
Give a quick whirl, make sure there are no obvious missing getters.
I confirmed that I had the put the mixin in all appropriate files by doing a search with this regex: `\$core(?!-)` on all .vue files, and verifying that the same number of files appeared as when searching for the import: `import themeMixin from 'kolibri.coreVue.mixins.themeMixin';`.

In addition, the import is used in one js file: `buttonMixin.js`.

### References
Also does a flyby partial fix of #4859, as I had to edit the file anyway to update the mutation.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
