### PR TITLE
Coach group and lessons fixes

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -3,8 +3,6 @@ require('array-includes').shim();
 // polyfill for older browsers
 // TODO: rtibbles whittle down these polyfills to only what is needed for the application
 require('core-js');
-// polyfill for Promise finally
-require('promise.prototype.finally').shim();
 
 // Do this before any async imports to ensure that public paths
 // are set correctly

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -200,12 +200,13 @@ export class HeartBeat {
     if (this.timerId) {
       clearTimeout(this.timerId);
     }
-    return this.checkSession().finally(() => {
+    const final = () => {
       if (this.enabled) {
         this.setInactive();
         this.wait();
       }
-    });
+    };
+    return this.checkSession().then(final, final);
   }
   get events() {
     return [

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -26,7 +26,6 @@
     "markdown-it": "^8.3.1",
     "material-design-icons": "^3.0.1",
     "popper.js": "^1.14.6",
-    "promise.prototype.finally": "^3.1.0",
     "purecss": "^0.6.2",
     "rest": "^1.3.2",
     "screenfull": "^4.0.0",

--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -131,20 +131,22 @@ function _removeMultipleUsersFromGroup(store, groupId, userIds) {
 
 export function addUsersToGroup(store, { groupId, userIds }) {
   store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
+  const final = () => {
+    store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
+    store.commit('SET_GROUP_MODAL', '');
+  };
   return _addMultipleUsersToGroup(store, groupId, userIds)
     .catch(error => store.dispatch('handleError', error, { root: true }))
-    .finally(() => {
-      store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-      store.commit('SET_GROUP_MODAL', '');
-    });
+    .then(final, final);
 }
 
 export function removeUsersFromGroup(store, { groupId, userIds }) {
   store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
+  const final = () => {
+    store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
+    store.commit('SET_GROUP_MODAL', '');
+  };
   return _removeMultipleUsersFromGroup(store, groupId, userIds)
     .catch(error => store.dispatch('handleError', error, { root: true }))
-    .finally(() => {
-      store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-      store.commit('SET_GROUP_MODAL', '');
-    });
+    .then(final, final);
 }

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -214,8 +214,10 @@
         const lastId = this.$route.query.last_id;
         if (this.inSearchMode && lastId) {
           return topicListingLink({ ...this.routerParams, topicId: lastId });
-        } else {
+        } else if (this.inSearchMode) {
           return selectionRootLink({ ...this.routerParams });
+        } else {
+          return this.toolbarRoute;
         }
       },
     },

--- a/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
@@ -113,10 +113,11 @@
         if (numOfTotalSearchResultsSoFar > maxSearchResults) {
           resolve([]);
         } else {
+          const final = () => spineItem.unload.bind(spineItem);
           spineItem
             .load(book.load.bind(book))
-            .then(spineItem.find.bind(spineItem, searchQuery))
-            .finally(spineItem.unload.bind(spineItem))
+            .then(() => spineItem.find.bind(spineItem, searchQuery))
+            .then(final, final)
             .then(searchResults => resolve(searchResults));
         }
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,19 +3716,7 @@ es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
-es-abstract@^1.9.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
-  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
-  dependencies:
-    es-to-primitive "^1.2.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-keys "^1.0.12"
-
-es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
+es-to-primitive@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
   integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
@@ -5178,7 +5166,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -9426,15 +9414,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise.prototype.finally@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz#66f161b1643636e50e7cf201dc1b84a857f3864e"
-  integrity sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.9.0"
-    function-bind "^1.1.1"
 
 prompts@^0.1.9:
   version "0.1.14"


### PR DESCRIPTION
### Summary
The Promise finally polyfill did not fix an issue with enrolling users (either because it wasn't being applied, or because something strange is happening with our conditional promises in firefox).
Either way, it was simpler to just not use finally, as it is just syntactic sugar.

The recent fix to make search escaping in #4929 caused a regression which prevented the `Finish` button on lesson resource selection from exiting from the selection screen. This fixes that by adding an additional condition to the route handling.

### Reviewer guidance
Check that you can enroll users in groups in Firefox without errors showing.
Check that you can add resources to a lesson and then click 'Finish' to return to the lesson detail page.

### References
Fixes #4944.
Fixes #4945.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
