### PR TITLE
Replace font rules in vendored Keen UI components to use noto

### DIFF
--- a/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
@@ -76,12 +76,15 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
   @import '~keen-ui/src/styles/imports';
 
   $ui-snackbar-background-color: #323232 !default;
   $ui-snackbar-font-size: rem-calc(14px) !default;
 
   .ui-snackbar {
+    @include font-family-noto;
+
     display: inline-flex;
     align-items: center;
     /* stylelint-disable csstree/validator */
@@ -90,7 +93,6 @@
     min-height: rem-calc(48px);
     padding: rem-calc(14px 24px);
     /* stylelint-enable */
-    font-family: $font-stack;
     background-color: $ui-snackbar-background-color;
     border-radius: $ui-default-border-radius;
     /* stylelint-disable csstree/validator */
@@ -115,6 +117,8 @@
   }
 
   .ui-snackbar-action-button {
+    @include font-family-noto;
+
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -131,7 +135,6 @@
     /* stylelint-enable */
     margin: 0;
     overflow: hidden;
-    font-family: $font-stack;
     font-size: $ui-button-font-size;
     font-weight: bold;
     line-height: 1;

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -788,16 +788,18 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
   @import '~keen-ui/src/styles/imports';
 
   /* stylelint-disable csstree/validator */
 
   .ui-select {
+    @include font-family-noto;
+
     position: relative;
     display: flex;
     align-items: flex-start;
     margin-bottom: $ui-input-margin-bottom;
-    font-family: $font-stack;
     outline: none;
 
     &:hover:not(.is-disabled) {
@@ -940,7 +942,6 @@
     align-items: center;
     width: 100%;
     padding: 0;
-    font-family: $font-stack;
     font-size: $ui-input-text-font-size;
     font-weight: normal;
     color: $ui-input-text-color;
@@ -989,11 +990,12 @@
   }
 
   .ui-select-search-input {
+    @include font-family-noto;
+
     width: 100%;
     height: $ui-input-height + rem-calc(4px);
     padding: rem-calc(0 12px);
     padding-left: rem-calc(40px);
-    font-family: $font-stack;
     font-size: $ui-input-text-font-size - rem-calc(1px);
     font-weight: normal;
     color: $ui-input-text-color;

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelectOption.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelectOption.vue
@@ -114,6 +114,7 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
   @import '~keen-ui/src/styles/imports';
 
   /* stylelint-disable csstree/validator */
@@ -121,9 +122,9 @@
   $ui-select-option-checkbox-color: rgba(black, 0.38) !default;
 
   .ui-select-option {
-    display: flex;
+    @include font-family-noto display: flex;
+
     align-items: center;
-    font-family: $font-stack;
     font-size: $ui-dropdown-item-font-size;
     cursor: pointer;
     user-select: none;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Replaces the Keen UI default of Robot with the 'font-family-noto' mixin in the vendored UiSelect and UiSnackbar components.

![screen shot 2019-02-07 at 11 41 31 am](https://user-images.githubusercontent.com/10248067/52438133-702a6680-2acd-11e9-81be-4a2b1afda144.png)

Fixes #4954 

### Reviewer guidance

1. Check to see if dropdowns and snackbars use Noto

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
