### PR TITLE
Kolibri tools updates

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -39,7 +39,7 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
-    "kolibri-tools": "0.12.0-dev.1",
+    "kolibri-tools": "0.12.0-beta.3.2",
     "responselike": "^1.0.2",
     "vue-color": "^2.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "kolibri-tools": "0.12.0-dev.1",
+    "kolibri-tools": "0.12.0-beta.3.2",
     "yarn-run-all": "^3.1.1"
   },
   "optionalDependencies": {

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.12.0-dev.1",
+  "version": "0.12.0-beta.3.2",
   "description": "Custom rules.",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -1,16 +1,20 @@
 {
   "name": "kolibri",
-  "version": "0.12.0-dev.1",
+  "version": "0.12.0-beta.3.2",
   "description": "The Kolibri core API",
   "repository": "github.com/learningequality/kolibri",
   "author": "Learning Equality",
   "license": "MIT",
   "private": false,
   "dependencies": {
+    "@sentry/browser": "4.5.3",
+    "@shopify/draggable": "^1.0.0-beta.8",
+    "aphrodite": "https://github.com/learningequality/aphrodite/",
     "array-includes": "^3.0.3",
     "clipboard": "^2.0.1",
     "core-js": "^2.4.1",
     "css-element-queries": "1.0.1",
+    "d3-color": "^1.2.3",
     "date-fns": "^1.28.2",
     "filesize": "^3.3.0 ",
     "fontfaceobserver": "^2.0.13",
@@ -18,15 +22,16 @@
     "intl": "^1.2.4",
     "js-cookie": "^2.1.2",
     "keen-ui": "https://github.com/learningequality/Keen-UI/",
+    "knuth-shuffle-seeded": "^1.0.6",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",
     "markdown-it": "^8.3.1",
     "material-design-icons": "^3.0.1",
+    "popper.js": "^1.14.6",
     "purecss": "^0.6.2",
     "rest": "^1.3.2",
-    "screenfull": "^3.3.2",
-    "seededshuffle": "^0.1.1",
+    "screenfull": "^4.0.0",
     "shave": "^2.1.3",
     "vue": "^2.5.17",
     "vue-intl": "3.0.0",
@@ -37,6 +42,6 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
-    "kolibri-tools": "0.12.0-dev.1"
+    "kolibri-tools": "0.12.0-beta.3.2"
   }
 }

--- a/packages/kolibri-tools/build.js
+++ b/packages/kolibri-tools/build.js
@@ -20,7 +20,7 @@ __builder.buildApiSpec();
  * Step 3: Generate the exported copy of the Core API itself, to constitute the `kolibri` package.
  */
 
-__builder.exportApiSpec(path.resolve(__dirname, '../kolibri'));
+__builder.exportApiSpec(path.resolve(__dirname, '../kolibri-core-for-export'));
 
 /*
  * Step 4: Copy the kolibri-core module dependencies to the exported kolibri module.
@@ -28,7 +28,7 @@ __builder.exportApiSpec(path.resolve(__dirname, '../kolibri'));
 
 const kolibriCorePkg = require(path.resolve(__dirname, '../../kolibri/core/package.json'));
 
-const kolibriPackageFile = path.resolve(__dirname, '../kolibri/package.json');
+const kolibriPackageFile = path.resolve(__dirname, '../kolibri-core-for-export/package.json');
 
 const kolibriPkg = require(kolibriPackageFile);
 

--- a/packages/kolibri-tools/lib/apiSpecExportTools.js
+++ b/packages/kolibri-tools/lib/apiSpecExportTools.js
@@ -123,10 +123,12 @@ const baseAliasSourcePaths = {
   ),
 };
 
+const baseAliasDistPath = path.resolve(__dirname, '../dist');
+
 const baseAliasDistPaths = {
-  kolibri_module: path.resolve(__dirname, '../dist/kolibri_module'),
-  kolibri_app: path.resolve(__dirname, '../dist/kolibri_app'),
-  content_renderer_module: path.resolve(__dirname, '../dist/content_renderer_module'),
+  kolibri_module: path.resolve(baseAliasDistPath, 'kolibri_module'),
+  kolibri_app: path.resolve(baseAliasDistPath, 'kolibri_app'),
+  content_renderer_module: path.resolve(baseAliasDistPath, 'content_renderer_module'),
 };
 
 // Assume if kolibri_module is not available on the source path, then we need to use the dist
@@ -134,6 +136,182 @@ if (fs.existsSync(baseAliasSourcePaths.kolibri_module + '.js')) {
   baseAliases = baseAliasSourcePaths;
 } else {
   baseAliases = baseAliasDistPaths;
+}
+
+function recurseAndCopySpecObject(specObj, targetPath) {
+  const knownAliases = coreAliases();
+
+  const distPath = targetPath;
+
+  // Keep track of all the external dependencies so that they can be added to the package.json
+  // for the exported API spec.
+  const externalDependencies = {};
+  const files = [];
+
+  function parseJSDependencies(sourceContents, destinationFolder, sourceFolder) {
+    const sourceTree = espree.parse(sourceContents, { sourceType: 'module', ecmaVersion: 2018 });
+    const importNodes = esquery.query(
+      sourceTree,
+      '[type=/(ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration)/]'
+    );
+    importNodes.forEach(node => {
+      if (node.source) {
+        const importPath = node.source.value;
+        // Prefix any resolved files with an underscore as they are not part of the core spec
+        const replacePath = resolveDependenciesAndCopy({
+          sourcePath: importPath,
+          destinationFolder,
+          sourceFolder,
+          prefix: '_',
+        });
+        sourceContents = sourceContents.replace(importPath, replacePath);
+      }
+    });
+    return sourceContents;
+  }
+
+  function parseScssDependencies(sourceContents, destinationFolder, sourceFolder) {
+    const sourceTree = scssParser.parse(sourceContents);
+    const scssWrapper = createQueryWrapper(sourceTree);
+    const importNodes = scssWrapper('atrule')
+      .has(wrapper => wrapper.node.value === 'import')
+      .children('string_single').nodes;
+    importNodes.forEach(node => {
+      // This should be the path for the import statement
+      const importPath = node.node.value;
+      // Prefix any resolved files with an underscore as they are not part of the core spec
+      const replacePath = resolveDependenciesAndCopy({
+        sourcePath: importPath,
+        destinationFolder,
+        sourceFolder,
+        prefix: '_',
+      });
+      sourceContents.replace(importPath, replacePath);
+    });
+    return sourceContents;
+  }
+
+  function parseVueDependencies(sourceContents, destinationFolder, sourceFolder) {
+    let template = vueTemplateCompiler.parseComponent(sourceContents);
+    function insertContent(source, block, newCode) {
+      const start = block.start;
+      const end = block.end;
+      return source.replace(source.slice(start, end), newCode);
+    }
+    const args = [destinationFolder, sourceFolder];
+    if (template.script) {
+      const newJs = parseJSDependencies(template.script.content, ...args);
+      sourceContents = insertContent(sourceContents, template.script, newJs);
+      template = vueTemplateCompiler.parseComponent(sourceContents);
+    }
+    template.styles.forEach(style => {
+      const newStyle = parseScssDependencies(style.content, ...args);
+      sourceContents = insertContent(sourceContents, style, newStyle);
+      template = vueTemplateCompiler.parseComponent(sourceContents);
+    });
+    return sourceContents;
+  }
+
+  function resolveDependenciesAndCopy({
+    sourcePath,
+    destinationFolder,
+    sourceFolder = '',
+    prefix = '',
+    destinationFileBase = '',
+  } = {}) {
+    // The source file path must be an absolute or relative path, otherwise it is a library external to Kolibri
+    // like vue, vuex etc. Do not copy these. Alternatively it is a kolibri API spec reference.
+    // Create a path without ~ because this is used for node_module or alias import resolution in SCSS/CSS
+    if (sourcePath.startsWith('/') || sourcePath.startsWith('.')) {
+      source = path.join(sourceFolder, sourcePath);
+      // Find the actual source file name, as many path references do not have an extension.
+      const sourceFile = resolve.sync(source, {
+        extensions: ['.js', '.json', '.vue', '.scss', '.css'],
+      });
+
+      let extraPath = '';
+
+      // Possible that the resolved file is actually an index file inside a folder
+      // Check for that case.
+      if (path.basename(sourceFile).startsWith('index')) {
+        extraPath = path
+          .dirname(sourceFile)
+          .split(path.sep)
+          .slice(-1)[0];
+      }
+      // Create the destination file name based on the source file name base name, copy it exactly.
+      const destinationFile = path.join(
+        destinationFolder,
+        extraPath,
+        prefix +
+          (destinationFileBase
+            ? destinationFileBase + path.extname(sourceFile)
+            : path.basename(sourceFile))
+      );
+      // Copy from the source to the destination.
+      const sourceContents = fs.readFileSync(sourceFile, { encoding: 'utf-8' });
+
+      const extension = path.extname(sourceFile);
+
+      let finalSource;
+
+      const newDestFolder = path.join(destinationFolder, extraPath);
+
+      mkdirp.sync(newDestFolder);
+
+      const newSourceFolder = path.dirname(sourceFile);
+
+      const args = [sourceContents, newDestFolder, newSourceFolder];
+
+      if (extension === '.js') {
+        finalSource = parseJSDependencies(...args);
+      } else if (extension === '.vue') {
+        finalSource = parseVueDependencies(...args);
+      } else if (extension === '.scss' || extension === '.css') {
+        // SCSS is a superset of CSS
+        finalSource = parseScssDependencies(...args);
+      } else {
+        finalSource = sourceContents;
+      }
+      // Write out the final contents of the file to disk
+      fs.writeFileSync(destinationFile, finalSource, { encoding: 'utf-8' });
+      files.push(destinationFile);
+      // Return a relative path to the copied file
+      return './' + prefix + path.basename(sourceFile);
+    } else {
+      const exportSourcePath = (sourcePath.startsWith('~')
+        ? sourcePath.slice(1)
+        : sourcePath
+      ).split('/')[0];
+      if (!knownAliases[exportSourcePath] && !externalDependencies[exportSourcePath]) {
+        externalDependencies[exportSourcePath] = true;
+      }
+    }
+    // If we have not already returned, return the original sourcePath unmodified.
+    return sourcePath;
+  }
+
+  function recurseSpecAndCopy(pathsArray, obj) {
+    Object.keys(obj).forEach(key => {
+      if (typeof obj[key] === 'object') {
+        recurseSpecAndCopy([...pathsArray, key], obj[key]);
+      } else {
+        // Make a folder so that we have a directory structure that maps to the core API object structure
+        const destinationFolder = path.resolve(path.join(distPath, ...pathsArray));
+        mkdirp.sync(destinationFolder);
+        resolveDependenciesAndCopy({
+          sourcePath: obj[key],
+          destinationFolder,
+          destinationFileBase: key,
+        });
+      }
+    });
+  }
+  recurseSpecAndCopy([], specObj);
+  return {
+    files,
+    externalDependencies,
+  };
 }
 
 const __builder = {
@@ -186,13 +364,7 @@ const __builder = {
     fs.writeFileSync(distSpecFilePath, JSON.stringify(specObj, undefined, 2), {
       encoding: 'utf-8',
     });
-    Object.keys(baseAliasSourcePaths).forEach(key => {
-      // Paths above have no extensions so resolve the source and then use extension on the destination.
-      const source = resolve.sync(baseAliasSourcePaths[key], {
-        extensions: ['.js', '.json', '.vue', '.scss', '.css'],
-      });
-      fs.copyFileSync(source, baseAliasDistPaths[key] + path.extname(source));
-    });
+    recurseAndCopySpecObject(baseAliasSourcePaths, baseAliasDistPath);
   },
   exportApiSpec(distPath) {
     /*
@@ -203,173 +375,7 @@ const __builder = {
      */
     this.checkSrc();
 
-    const knownAliases = coreAliases();
-
-    // Keep track of all the external dependencies so that they can be added to the package.json
-    // for the exported API spec.
-    const externalDependencies = {};
-    const files = [];
-
-    function parseJSDependencies(sourceContents, destinationFolder, sourceFolder) {
-      const sourceTree = espree.parse(sourceContents, { sourceType: 'module', ecmaVersion: 2018 });
-      const importNodes = esquery.query(
-        sourceTree,
-        '[type=/(ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration)/]'
-      );
-      importNodes.forEach(node => {
-        if (node.source) {
-          const importPath = node.source.value;
-          // Prefix any resolved files with an underscore as they are not part of the core spec
-          const replacePath = resolveDependenciesAndCopy({
-            sourcePath: importPath,
-            destinationFolder,
-            sourceFolder,
-            prefix: '_',
-          });
-          sourceContents = sourceContents.replace(importPath, replacePath);
-        }
-      });
-      return sourceContents;
-    }
-
-    function parseScssDependencies(sourceContents, destinationFolder, sourceFolder) {
-      const sourceTree = scssParser.parse(sourceContents);
-      const scssWrapper = createQueryWrapper(sourceTree);
-      const importNodes = scssWrapper('atrule')
-        .has(wrapper => wrapper.node.value === 'import')
-        .children('string_single').nodes;
-      importNodes.forEach(node => {
-        // This should be the path for the import statement
-        const importPath = node.node.value;
-        // Prefix any resolved files with an underscore as they are not part of the core spec
-        const replacePath = resolveDependenciesAndCopy({
-          sourcePath: importPath,
-          destinationFolder,
-          sourceFolder,
-          prefix: '_',
-        });
-        sourceContents.replace(importPath, replacePath);
-      });
-      return sourceContents;
-    }
-
-    function parseVueDependencies(sourceContents, destinationFolder, sourceFolder) {
-      let template = vueTemplateCompiler.parseComponent(sourceContents);
-      function insertContent(source, block, newCode) {
-        const start = block.start;
-        const end = block.end;
-        return source.replace(source.slice(start, end), newCode);
-      }
-      const args = [destinationFolder, sourceFolder];
-      if (template.script) {
-        const newJs = parseJSDependencies(template.script.content, ...args);
-        sourceContents = insertContent(sourceContents, template.script, newJs);
-        template = vueTemplateCompiler.parseComponent(sourceContents);
-      }
-      template.styles.forEach(style => {
-        const newStyle = parseScssDependencies(style.content, ...args);
-        sourceContents = insertContent(sourceContents, style, newStyle);
-        template = vueTemplateCompiler.parseComponent(sourceContents);
-      });
-      return sourceContents;
-    }
-
-    function resolveDependenciesAndCopy({
-      sourcePath,
-      destinationFolder,
-      sourceFolder = '',
-      prefix = '',
-      destinationFileBase = '',
-    } = {}) {
-      // The source file path must be an absolute or relative path, otherwise it is a library external to Kolibri
-      // like vue, vuex etc. Do not copy these. Alternatively it is a kolibri API spec reference.
-      // Create a path without ~ because this is used for node_module or alias import resolution in SCSS/CSS
-      if (sourcePath.startsWith('/') || sourcePath.startsWith('.')) {
-        source = path.join(sourceFolder, sourcePath);
-        // Find the actual source file name, as many path references do not have an extension.
-        const sourceFile = resolve.sync(source, {
-          extensions: ['.js', '.json', '.vue', '.scss', '.css'],
-        });
-
-        let extraPath = '';
-
-        // Possible that the resolved file is actually an index file inside a folder
-        // Check for that case.
-        if (path.basename(sourceFile).startsWith('index')) {
-          extraPath = path
-            .dirname(sourceFile)
-            .split(path.sep)
-            .slice(-1)[0];
-        }
-        // Create the destination file name based on the source file name base name, copy it exactly.
-        const destinationFile = path.join(
-          destinationFolder,
-          extraPath,
-          prefix +
-            (destinationFileBase
-              ? destinationFileBase + path.extname(sourceFile)
-              : path.basename(sourceFile))
-        );
-        // Copy from the source to the destination.
-        const sourceContents = fs.readFileSync(sourceFile, { encoding: 'utf-8' });
-
-        const extension = path.extname(sourceFile);
-
-        let finalSource;
-
-        const newDestFolder = path.join(destinationFolder, extraPath);
-
-        mkdirp.sync(newDestFolder);
-
-        const newSourceFolder = path.dirname(sourceFile);
-
-        const args = [sourceContents, newDestFolder, newSourceFolder];
-
-        if (extension === '.js') {
-          finalSource = parseJSDependencies(...args);
-        } else if (extension === '.vue') {
-          finalSource = parseVueDependencies(...args);
-        } else if (extension === '.scss' || extension === '.css') {
-          // SCSS is a superset of CSS
-          finalSource = parseScssDependencies(...args);
-        } else {
-          finalSource = sourceContents;
-        }
-        // Write out the final contents of the file to disk
-        fs.writeFileSync(destinationFile, finalSource, { encoding: 'utf-8' });
-        files.push(destinationFile);
-        // Return a relative path to the copied file
-        return './' + prefix + path.basename(sourceFile);
-      } else {
-        const exportSourcePath = (sourcePath.startsWith('~')
-          ? sourcePath.slice(1)
-          : sourcePath
-        ).split('/')[0];
-        if (!knownAliases[exportSourcePath] && !externalDependencies[exportSourcePath]) {
-          externalDependencies[exportSourcePath] = true;
-        }
-      }
-      // If we have not already returned, return the original sourcePath unmodified.
-      return sourcePath;
-    }
-
-    function recurseSpecAndCopy(pathsArray, obj) {
-      Object.keys(obj).forEach(key => {
-        if (typeof obj[key] === 'object') {
-          recurseSpecAndCopy([...pathsArray, key], obj[key]);
-        } else {
-          // Make a folder so that we have a directory structure that maps to the core API object structure
-          const destinationFolder = path.resolve(path.join(distPath, ...pathsArray));
-          mkdirp.sync(destinationFolder);
-          resolveDependenciesAndCopy({
-            sourcePath: obj[key],
-            destinationFolder,
-            destinationFileBase: key,
-          });
-        }
-      });
-    }
-    recurseSpecAndCopy([], apiSpec);
+    const { files, externalDependencies } = recurseAndCopySpecObject(apiSpec, distPath);
     return {
       dependencies: Object.keys(externalDependencies),
       files,

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.12.0-dev.1",
+  "version": "0.12.0-beta.3.2",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": "github.com/learningequality/kolibri",
@@ -31,7 +31,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.1",
-    "eslint-plugin-kolibri": "0.12.0-dev.1",
+    "eslint-plugin-kolibri": "0.12.0-beta.3.2",
     "eslint-plugin-vue": "^5.0.0-beta.3",
     "espree": "^4.1.0",
     "esquery": "^1.0.1",
@@ -92,6 +92,6 @@
     "readline-sync": "^1.4.9"
   },
   "optionalDependencies": {
-    "kolibri": "0.12.0-dev.1"
+    "kolibri": "0.12.0-beta.3.2"
   }
 }

--- a/packages/publish.js
+++ b/packages/publish.js
@@ -6,7 +6,9 @@ const versionTools = require('./kolibri-tools/lib/version');
  * Step 1 - Set the version of the kolibri package by the current Kolibri version
  */
 
-const version = versionTools.setVersion(path.resolve(__dirname, 'kolibri/package.json'));
+const version = versionTools.setVersion(
+  path.resolve(__dirname, 'kolibri-core-for-export/package.json')
+);
 
 /*
  * Step 2 - Set the version of the kolibri-tools package by the current Kolibri version
@@ -26,7 +28,7 @@ versionTools.setVersion(path.resolve(__dirname, 'eslint-plugin-kolibri/package.j
 
 versionTools.setDependencyVersion(
   'kolibri-tools',
-  path.resolve(__dirname, 'kolibri/package.json'),
+  path.resolve(__dirname, 'kolibri-core-for-export/package.json'),
   version
 );
 


### PR DESCRIPTION
### Summary
Updates to Kolibri-tools building and publishing tooling.

### Reviewer guidance
If nothing looks horrendously odd in here, please merge. This works and is responsible for the `kolibri-tools@beta-3.2` release on npm https://www.npmjs.com/package/kolibri-tools/v/0.12.0-beta.3.2

(Although, I had to do a couple of manual hacks to get the `.2` suffix, because I screwed up a couple of times first).

### References
This was necessary to enable this: https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/181

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
