### PR TITLE
Add import from token for studio local import

### DIFF
--- a/kolibri/plugins/device_management/assets/src/constants.js
+++ b/kolibri/plugins/device_management/assets/src/constants.js
@@ -41,6 +41,11 @@ export const TransferTypes = {
   REMOTEIMPORT: 'remoteimport',
 };
 
+export const ApplicationTypes = {
+  KOLIBRI: 'kolibri',
+  STUDIO: 'studio',
+};
+
 export const ContentWizardErrors = {
   INVALID_PARAMETERS: 'INVALID_PARAMETERS',
   CHANNEL_NOT_FOUND_ON_SERVER: 'CHANNEL_NOT_FOUND_ON_SERVER',

--- a/kolibri/plugins/device_management/assets/src/constants.js
+++ b/kolibri/plugins/device_management/assets/src/constants.js
@@ -41,6 +41,7 @@ export const TransferTypes = {
   REMOTEIMPORT: 'remoteimport',
 };
 
+// maps to possible network applications that we import/export content from
 export const ApplicationTypes = {
   KOLIBRI: 'kolibri',
   STUDIO: 'studio',

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/getters.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/getters.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
-import { TransferTypes } from '../../constants';
+import { ApplicationTypes, TransferTypes } from '../../constants';
 
 export function cachedTopicPath(state) {
   return function getPath(id) {
@@ -50,6 +50,10 @@ export function inRemoteImportMode(state) {
 
 export function inPeerImportMode(state) {
   return state.transferType === TransferTypes.PEERIMPORT;
+}
+
+export function isStudioApplication(state) {
+  return state.selectedPeer.application === ApplicationTypes.STUDIO;
 }
 
 export function driveCanBeUsedForTransfer(state, getters, rootState, rootGetters) {

--- a/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/AvailableChannelsPage/index.vue
@@ -142,6 +142,7 @@
         'inLocalImportMode',
         'inRemoteImportMode',
         'inExportMode',
+        'isStudioApplication',
       ]),
       ...mapState('manageContent/wizard', [
         'availableChannels',
@@ -184,7 +185,7 @@
         return !this.channelsAreLoading && this.availableChannels.length > 0;
       },
       showUnlistedChannels() {
-        return this.channelsAreAvailable && this.inRemoteImportMode;
+        return this.channelsAreAvailable && (this.inRemoteImportMode || this.isStudioApplication);
       },
       allLanguagesOption() {
         return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds token channel lookup when in local import mode, AND pointing to studio application instance.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Add https://develop.studio.learningequality.org/ as a local network or internet source.
Should see the add token option.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/4925

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x]  If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
