### PR TITLE
make group report header dynamic

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -12,11 +12,11 @@
     <KPageContainer>
       <p>
         <BackLink
-          :to="classRoute('ReportsGroupReportPage', {})"
-          text="Group A"
+          :to="classRoute('ReportsGroupReportPage')"
+          :text="group.name"
         />
       </p>
-      <h1>Group A</h1>
+      <h1>{{ lesson.title }}</h1>
       <p>{{ $tr('lessonProgressLabel', {lesson: lesson.title}) }}</p>
       <HeaderTable>
         <HeaderTableRow>
@@ -100,6 +100,9 @@
       },
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
+      },
+      group() {
+        return this.groupMap[this.$route.params.groupId];
       },
       recipients() {
         return this.getLearnersForGroups([this.$route.params.groupId]);


### PR DESCRIPTION

### Summary

fixes issue reported by @khangmach 
> ![image](https://user-images.githubusercontent.com/2367265/52498882-e0e58780-2b8e-11e9-8d1c-f281720634f4.png)
>
> ![image](https://user-images.githubusercontent.com/2367265/52498873-d4f9c580-2b8e-11e9-9bf4-b4360829f3aa.png)


### Reviewer guidance

the new new

> ![image](https://user-images.githubusercontent.com/2367265/52498905-f490ee00-2b8e-11e9-8f0f-75af930abfd1.png)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
