### PR TITLE
Fix IE 11 Compatibility

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -3,6 +3,7 @@ require('array-includes').shim();
 // polyfill for older browsers
 // TODO: rtibbles whittle down these polyfills to only what is needed for the application
 require('core-js');
+require('url-polyfill');
 
 // Do this before any async imports to ensure that public paths
 // are set correctly

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -30,6 +30,7 @@
     "rest": "^1.3.2",
     "screenfull": "^4.0.0",
     "shave": "^2.1.3",
+    "url-polyfill": "^1.1.3",
     "vue": "^2.5.17",
     "vue-intl": "3.0.0",
     "vue-markdown": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12046,6 +12046,11 @@ url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-polyfill@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.3.tgz#ce0bdf2e923aa6f66bc198ab776323dfc5a91e62"
+  integrity sha512-xIAXc0DyXJCd767sSeRu4eqisyYhR0z0sohWArCn+WPwIatD39xGrc09l+tluIUi6jGkpGa8Gz8TKwkKYxMQvQ==
+
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"


### PR DESCRIPTION
### Summary
We now rely on the URL constructor.
IE11 does not properly support this interface.
This polyfills this interface.

### Reviewer guidance
Can you load pages in production in IE11 (for some reason it works in dev builds)?

### References
Fixes #4964

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
