### PR TITLE
Fixes behaviour for multiple lesson assignment

### DIFF
--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -4,9 +4,12 @@ from rest_framework.serializers import JSONField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import SerializerMethodField
 
+from kolibri.core.auth.filters import HierarchyRelationsFilter
 from kolibri.core.auth.models import Classroom
 from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import ExamLog
 
@@ -95,19 +98,27 @@ class LearnerClassroomSerializer(ModelSerializer):
         Returns all Exams and Lessons (and progress) assigned to the requesting User
         """
         current_user = self.context['request'].user
-        memberships = current_user.memberships.all()
-        learner_groups = [m.collection for m in memberships]
 
         # Return only active Lessons that are assigned to the requesting user's groups
         # TODO move this to a permission_class on Lesson
+        lesson_assignments = HierarchyRelationsFilter(LessonAssignment.objects.all()) \
+            .filter_by_hierarchy(
+                target_user=current_user,
+                ancestor_collection=instance
+        )
         filtered_lessons = Lesson.objects.filter(
-            lesson_assignments__collection__in=learner_groups,
-            collection=instance,
-            is_active=True,
+            lesson_assignments__in=lesson_assignments,
+            is_active=True
         ).distinct()
 
+        exam_assignments = HierarchyRelationsFilter(ExamAssignment.objects.all()) \
+            .filter_by_hierarchy(
+                target_user=current_user,
+                ancestor_collection=instance
+        )
+
         filtered_exams = Exam.objects.filter(
-            assignments__collection__in=learner_groups,
+            assignments__in=exam_assignments,
             collection=instance,
         ).filter(Q(active=True) | Q(examlogs__user=current_user)).distinct()
 

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -21,11 +21,10 @@ class LearnerClassroomViewset(ReadOnlyModelViewSet):
     serializer_class = LearnerClassroomSerializer
 
     def get_queryset(self):
-        current_user = self.request.user
-        memberships = current_user.memberships.filter(
-            collection__kind='classroom',
-        ).values('collection_id')
-        return Classroom.objects.filter(id__in=memberships)
+        return HierarchyRelationsFilter(Classroom.objects.all()).filter_by_hierarchy(
+            target_user=self.request.user,
+            ancestor_collection=F('id')
+        )
 
 
 class LearnerLessonViewset(ReadOnlyModelViewSet):

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -45,4 +45,4 @@ class LearnerLessonViewset(ReadOnlyModelViewSet):
         return Lesson.objects.filter(
             lesson_assignments__in=assignments,
             is_active=True
-        )
+        ).distinct()


### PR DESCRIPTION
### Summary
Fixes an issue that would occur when the same lesson was assigned to one user through multiple assignments. Does this by adding a `.distinct` clause and writing a test to confirm behaviour.

Additionally, this cleans up some other aspects of the learn viewsets and serializers by using the `HiearchyRelationsFilter` class to filter.

### Reviewer guidance
Check that the existing tests work and new test does also. Do the updates to the filtering make sense?

### References
Fixes #4998

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
