### PR TITLE
Use float not int to ensure proper coercion.

### DIFF
--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -141,7 +141,7 @@ class MetricsMiddleware(MiddlewareMixin):
             path = request.get_full_path()
             duration, memory_before, memory, load_before, load = self.metrics.get_stats()
             max_time = False
-            if int(duration) > MetricsMiddleware.slowest_request_time:
+            if float(duration) > MetricsMiddleware.slowest_request_time:
                 MetricsMiddleware.slowest_request_time = int(duration)
                 max_time = True
             timestamp = time.strftime('%Y/%m/%d %H:%M:%S.%f')


### PR DESCRIPTION
### Summary
Timedelta passed back from metric stats is a string of a timedelta, which cannot be parsed as an int.

### Reviewer guidance
Can performance stats be logged without throwing an error?

### References
Fixes #5000

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
