### PR TITLE
More semantically handle malformed zipcontent paths by returning 404s.

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -90,6 +90,10 @@ class ZipContentTestCase(TestCase):
         response = self.client.get(self.zip_file_base_url + "qqq" + self.test_name_1)
         self.assertEqual(response.status_code, 404)
 
+    def test_non_allowed_file_internal_file_access(self):
+        response = self.client.get(self.zip_file_base_url.replace('zip', 'png') + self.test_name_1)
+        self.assertEqual(response.status_code, 404)
+
     def test_not_modified_response_when_if_modified_since_header_set(self):
         caching_client = Client(HTTP_IF_MODIFIED_SINCE="Sat, 10-Sep-2016 19:14:07 GMT")
         response = caching_client.get(self.zip_file_base_url + self.test_name_1)


### PR DESCRIPTION
### Summary
Previously both the etag and get on the zipcontent endpoint would raise a 500 error because of an assertion error in the calculation of the local storage path.

This PR catches these assertion errors and raises a 404.

### Reviewer guidance
Does the zipcontent endpoint work as expected? Do the tests pass?

### References
Fixes #5002

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
