### PR TITLE
Epub settings style

### DIFF
--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubConstants.js
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubConstants.js
@@ -15,4 +15,12 @@ export const THEMES = {
     backgroundColor: '#171717',
     textColor: '#bebebe',
   },
+  YELLOW: {
+    backgroundColor: '#202020',
+    textColor: '#FFFF00',
+  },
+  BLUE: {
+    backgroundColor: '#FFFFFF',
+    textColor: '#0000FF',
+  },
 };

--- a/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
@@ -57,8 +57,11 @@
           :percentage="false"
         >
           <KButton
-            :class="['settings-button', 'theme-button', $computedClass(settingsButtonFocus)]"
-            :style="{ backgroundColor: value.backgroundColor }"
+            :class="[
+              'settings-button',
+              'theme-button',
+              $computedClass(generateStyle(value.backgroundColor))
+            ]"
             :aria-label="generateThemeAriaLabel(key)"
             @click="$emit('setTheme', value)"
           >
@@ -158,6 +161,12 @@
           theme.textColor === this.theme.textColor
         );
       },
+      generateStyle(backgroundColor) {
+        return {
+          ...this.settingsButtonFocus,
+          backgroundColor,
+        };
+      },
     },
   };
 
@@ -168,7 +177,7 @@
 
   @import './EpubStyles';
 
-  .settings-button.button.secondary.raised {
+  .settings-button {
     width: calc(100% - 4px);
     min-width: unset;
     padding: 8px;

--- a/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
@@ -53,7 +53,7 @@
         <KGridItem
           v-for="(value, key) in themes"
           :key="key"
-          :size="12 / Object.keys(themes).length"
+          :size="3"
           :percentage="false"
         >
           <KButton


### PR DESCRIPTION
### Summary
Fixes styling on Epub settings side bar.
Adds high contrast themes (but with no aria labels).

### Reviewer guidance
Do the settings look correct?

![image](https://user-images.githubusercontent.com/1680573/52546366-67f35500-2d73-11e9-969c-f43510a20888.png)


### References
Fixes #4985

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
