### PR TITLE
Notifications signals learner groups 

### DIFF
--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -51,6 +51,10 @@ def get_assignments(instance, summarylog, attempt=False):
             del lesson_contentnode[lesson_id]
     # Returns all the affected lessons with the touched contentnode_id, Resource must be inside a lesson
     lesson_resources = [(lesson, lesson_contentnode[lesson.id]) for lesson in filtered_lessons if lesson.id in lesson_contentnode]
+    for lesson in lesson_resources:
+        groups = [g.id for g in learner_groups if g.id in [l.collection_id for l in lesson[0].lesson_assignments.all()]]
+        lesson[0].group_or_classroom = groups[0] if groups else lesson.collection_id
+
     return lesson_resources
 
 
@@ -104,7 +108,7 @@ def check_and_created_completed_resource(lesson, user_id, contentnode_id):
         notification = create_notification(NotificationObjectType.Resource,
                                            NotificationEventType.Completed,
                                            user_id,
-                                           lesson.collection_id,
+                                           lesson.group_or_classroom,
                                            lesson_id=lesson.id,
                                            contentnode_id=contentnode_id)
     return notification
@@ -117,11 +121,11 @@ def check_and_created_completed_lesson(lesson, user_id):
                                                       notification_object=NotificationObjectType.Lesson,
                                                       notification_event=NotificationEventType.Completed,
                                                       lesson_id=lesson.id,
-                                                      classroom_id=lesson.collection_id).exists():
+                                                      classroom_id=lesson.group_or_classroom).exists():
         # Let's create an Lesson Completion notification
         notification = create_notification(NotificationObjectType.Lesson, NotificationEventType.Completed,
                                            user_id,
-                                           lesson.collection_id, lesson_id=lesson.id)
+                                           lesson.group_or_classroom, lesson_id=lesson.id)
     return notification
 
 
@@ -139,7 +143,7 @@ def check_and_created_started(lesson, user_id, contentnode_id):
     notifications.append(create_notification(NotificationObjectType.Resource,
                                              NotificationEventType.Started,
                                              user_id,
-                                             lesson.collection_id,
+                                             lesson.group_or_classroom,
                                              lesson_id=lesson.id,
                                              contentnode_id=contentnode_id))
 
@@ -148,11 +152,11 @@ def check_and_created_started(lesson, user_id, contentnode_id):
                                                       notification_object=NotificationObjectType.Lesson,
                                                       notification_event=NotificationEventType.Started,
                                                       lesson_id=lesson.id,
-                                                      classroom_id=lesson.collection_id).exists():
+                                                      classroom_id=lesson.group_or_classroom).exists():
         # and create it if that's not the case
         notifications.append(create_notification(NotificationObjectType.Lesson, NotificationEventType.Started,
                                                  user_id,
-                                                 lesson.collection_id, lesson_id=lesson.id))
+                                                 lesson.group_or_classroom, lesson_id=lesson.id))
     return notifications
 
 
@@ -279,11 +283,11 @@ def parse_attemptslog(attemptlog):
                                                           notification_object=NotificationObjectType.Resource,
                                                           notification_event=NotificationEventType.Help,
                                                           lesson_id=lesson.id,
-                                                          classroom_id=lesson.collection_id,
+                                                          classroom_id=lesson.group_or_classroom,
                                                           contentnode_id=contentnode_id).exists():
                 continue
             notification = create_notification(NotificationObjectType.Resource, NotificationEventType.Help,
-                                               attemptlog.user_id, lesson.collection_id,
+                                               attemptlog.user_id, lesson.group_or_classroom,
                                                lesson_id=lesson.id,
                                                contentnode_id=contentnode_id,
                                                reason=HelpReason.Multiple)

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -51,6 +51,8 @@ def get_assignments(instance, summarylog, attempt=False):
             del lesson_contentnode[lesson_id]
     # Returns all the affected lessons with the touched contentnode_id, Resource must be inside a lesson
     lesson_resources = [(lesson, lesson_contentnode[lesson.id]) for lesson in filtered_lessons if lesson.id in lesson_contentnode]
+
+    # Try to find out if the lesson is being executed assigned to a Classroom or to a LearnerGroup:
     for lesson in lesson_resources:
         groups = [g.id for g in learner_groups if g.id in [l.collection_id for l in lesson[0].lesson_assignments.all()]]
         lesson[0].group_or_classroom = groups[0] if groups else lesson.collection_id

--- a/kolibri/core/notifications/models.py
+++ b/kolibri/core/notifications/models.py
@@ -103,7 +103,7 @@ class LearnerProgressNotification(models.Model):
     notification_object = models.CharField(max_length=200, choices=NotificationObjectType.choices(), blank=True)
     notification_event = models.CharField(max_length=200, choices=NotificationEventType.choices(), blank=True)
     user_id = UUIDField()
-    classroom_id = UUIDField()
+    classroom_id = UUIDField()  # This can be either a Classroom or a LearnerGroup id
     contentnode_id = UUIDField(null=True)
     lesson_id = UUIDField(null=True)
     quiz_id = UUIDField(null=True)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -151,8 +151,8 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
         if after:
             notifications_query = notifications_query.filter(id__gt=after)
         elif self.request.query_params.get('page', None) is None:
-            today = datetime.datetime.combine(datetime.datetime.now(), datetime.time(0))
-            notifications_query = notifications_query.filter(timestamp__gte=today)
+            last_24h = datetime.datetime.now() - datetime.timedelta(days=1)
+            notifications_query = notifications_query.filter(timestamp__gte=last_24h)
 
         return notifications_query.order_by('-id')
 

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -151,12 +151,12 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
         if after:
             notifications_query = notifications_query.filter(id__gt=after)
         elif self.request.query_params.get('page', None) is None:
-            last_id_record = notifications_query.latest('id')
-            if last_id_record:
+            try:
+                last_id_record = notifications_query.latest('id')
                 # returns all the notifications 24 hours older than the latest
                 last_24h = last_id_record.timestamp - datetime.timedelta(days=1)
                 notifications_query = notifications_query.filter(timestamp__gte=last_24h)
-            else:
+            except (LearnerProgressNotification.DoesNotExist):
                 return []
 
         return notifications_query.order_by('-id')

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -151,8 +151,13 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
         if after:
             notifications_query = notifications_query.filter(id__gt=after)
         elif self.request.query_params.get('page', None) is None:
-            last_24h = datetime.datetime.now() - datetime.timedelta(days=1)
-            notifications_query = notifications_query.filter(timestamp__gte=last_24h)
+            last_id_record = notifications_query.latest('id')
+            if last_id_record:
+                # returns all the notifications 24 hours older than the latest
+                last_24h = last_id_record.timestamp - datetime.timedelta(days=1)
+                notifications_query = notifications_query.filter(timestamp__gte=last_24h)
+            else:
+                return []
 
         return notifications_query.order_by('-id')
 

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -24,7 +24,6 @@ from kolibri.core.logger.models import ExamLog
 from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.core.notifications.models import NotificationsLog
 
-
 collection_kind_choices = tuple([choice[0] for choice in collection_kinds.choices] + ['user'])
 
 
@@ -139,7 +138,7 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
                 collection = Collection.objects.get(pk=classroom_id)
             except (Collection.DoesNotExist, ValueError):
                 return []
-        if collection.kind  == collection_kinds.CLASSROOM:
+        if collection.kind == collection_kinds.CLASSROOM:
             classroom_groups = LearnerGroup.objects.filter(parent=collection)
             learner_groups = [group.id for group in classroom_groups]
             learner_groups.append(classroom_id)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -131,20 +131,20 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
         :param: page_size integer: sets the number of notifications to provide for pagination (defaults: 10)
         :param: page integer: sets the page to provide when paginating.
         """
-        classroom_id = self.kwargs['collection_id']
+        collection_id = self.kwargs['collection_id']
 
-        if classroom_id:
+        if collection_id:
             try:
-                collection = Collection.objects.get(pk=classroom_id)
+                collection = Collection.objects.get(pk=collection_id)
             except (Collection.DoesNotExist, ValueError):
                 return []
         if collection.kind == collection_kinds.CLASSROOM:
             classroom_groups = LearnerGroup.objects.filter(parent=collection)
             learner_groups = [group.id for group in classroom_groups]
-            learner_groups.append(classroom_id)
+            learner_groups.append(collection_id)
             notifications_query = LearnerProgressNotification.objects.filter(classroom_id__in=learner_groups)
         else:
-            notifications_query = LearnerProgressNotification.objects.filter(classroom_id=classroom_id)
+            notifications_query = LearnerProgressNotification.objects.filter(classroom_id=collection_id)
         notifications_query = self.apply_learner_filter(notifications_query)
         after = self.check_after()
         self.remove_default_page_size()


### PR DESCRIPTION
### Summary
Note1: this PR have been done to continue #4957 work after the release-v0.12.x branch instead of develop. 

Note2: This PR also changes the rules to provide notifications: instead of providing all the notifications of the current day by default, it provides all the notifications 24 hours older than the last one.

As Lessons always saved the classroom_id even if they are created in a learner group, notification were not reporting the learner groups.
After this PR notifications store the id of the learner group, and the serializer looks for all the groups in a classroom if the passed id is a classroom.
Example:
Being `99ed0578aa53a66c188206912afbf1a5` a group inside the classroom `9da65157a8603788fd3db890d2035a9f`

http://localhost:8000/coach/api/notifications/?collection_id=99ed0578aa53a66c188206912afbf1a5 
returns all the notifications for the group.

http://localhost:8000/coach/api/notifications/?collection_id=9da65157a8603788fd3db890d2035a9f
returns all the  notifications for the classroom and for any of  the groups in the classroom:
```
{
    "coaches_polling": 0,
    "results": [
        {
            "id": 42,
            "timestamp": "2019-02-07T19:15:20.966867+01:00",
            "user_id": "3de11e54312e3c40a3253c2f5d1687d2",
            "classroom_id": "99ed0578aa53a66c188206912afbf1a5",
            "lesson_id": "01f8b11d340fbc691a3b58e03aa73ac5",
            "contentnode_id": "aeeee5efdc895be3b2c9683f07ce89f0",
            "contentnode_kind": "html5",
            "resource": "States of Matter: Basics",
            "lesson": "pruebagrupo",
            "object": "Resource",
            "event": "Completed",
            "type": "ResourceCompleted",
            "user": "alumno4"
        },
...
        {
            "id": 39,
            "timestamp": "2019-02-07T17:15:59.586532+01:00",
            "user_id": "a7202e424608f8eeb0b9d0f9e041d7a8",
            "classroom_id": "9da65157a8603788fd3db890d2035a9f",
            "lesson_id": "01f8b11d340fbc691a3b58e03aa73ac5",
            "lesson": "pruebagrupo",
            "object": "Lesson",
            "event": "Started",
            "type": "LessonStarted",
            "user": "alumno3"
        },
…
```

### Reviewer guidance
Do some lessons assigned to a group and check the api request.
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Gherkin stories have been updated
- [ ] Unit tests have been updated

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
