### PR TITLE
Force-clear snackbars at every navigation in coach page 

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -20,6 +20,11 @@ class CoachToolsModule extends KolibriApp {
   }
   ready() {
     router.beforeEach((to, from, next) => {
+      // Clear the snackbar at every navigation to prevent it from re-appearing
+      // when the next page component mounts.
+      if (this.store.state.core.snackbar.isVisible) {
+        this.store.dispatch('clearSnackbar');
+      }
       this.store.commit('SET_PAGE_NAME', to.name);
       if (!['CoachClassListPage', 'StatusTestPage'].includes(to.name)) {
         this.store

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -31,6 +31,9 @@ export default [
         error => store.dispatch('handleApiError', error)
       );
     },
+    meta: {
+      titleParts: ['classesLabel'],
+    },
   },
   {
     path: '/:classId/home',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -77,6 +77,8 @@
 
   import MultiPaneLayout from 'kolibri.coreVue.components.MultiPaneLayout';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
+  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
+  import KBasicContentIcon from 'kolibri.coreVue.components.KBasicContentIcon';
   import InfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
@@ -93,6 +95,8 @@
       };
     },
     components: {
+      KBasicContentIcon,
+      KLabeledIcon,
       QuestionList,
       ContentArea,
       SelectOptions,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -277,6 +277,9 @@
       }),
       showResourcesDifferenceMessage(difference) {
         let text;
+        if (difference === 0) {
+          return;
+        }
         if (difference > 0) {
           text = this.$tr('resourcesAddedSnackbarText', { count: difference });
         } else {

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -193,6 +193,7 @@
   .user-action-button {
     padding: 0;
     text-align: right;
+    vertical-align: middle;
   }
 
   .role-badge {


### PR DESCRIPTION
### Summary

1. Modifies router in Coach plugin to call 'clearSnackbar' action at every page navigation (only applying to Coach for now since 1) some other plugins don't use snackbars; 2) other plugins aren't refactored to use unique CoreBases at every page). Fixes #4987. 
1. Fixes button layout in Facility User Page
1. Fixes missing page title in Coach - ALl Classes page
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
