### PR TITLE
Add default port value when starting webpack server

### DIFF
--- a/packages/kolibri-tools/lib/bundleStats.js
+++ b/packages/kolibri-tools/lib/bundleStats.js
@@ -6,8 +6,6 @@ const logger = require('./logging');
 
 const buildLogging = logger.getLogger('Kolibri Build Stats');
 
-const basePort = 8888;
-
 function buildWebpack(data, index, startCallback, doneCallback, options) {
   const bundle = webpackConfig(data);
   const compiler = webpack(bundle, (err, stats) => {
@@ -15,7 +13,7 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
       buildLogging.error(`There was a build error for ${bundle.name}`);
       process.exit(1);
     } else {
-      const port = (options.port || basePort) + 1 + index;
+      const port = options.port + 1 + index;
       viewer.startServer(stats.toJson(), {
         openBrowser: false,
         port,

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -75,7 +75,12 @@ program
   )
   .option('-s, --single', 'Run using a single core to reduce CPU burden', false)
   .option('-h, --hot', 'Use hot module reloading in the webpack devserver', false)
-  .option('-p, --port', 'Set a port number to start devservers or bundle stats servers on')
+  .option(
+    '-p, --port <port>',
+    'Set a port number to start devservers or bundle stats servers on',
+    Number,
+    3000
+  )
   .action(function(mode, options) {
     const { fork } = require('child_process');
     const buildLogging = logger.getLogger('Kolibri Build');
@@ -115,11 +120,6 @@ program
 
     if (options.hot && mode !== modes.DEV) {
       cliLogging.error('Hot module reloading can only be used in dev mode.');
-      process.exit(1);
-    }
-
-    if (options.port && mode !== modes.DEV && mode !== modes.STATS) {
-      cliLogging.error('Port setting is only used in dev or stats mode');
       process.exit(1);
     }
 

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -25,7 +25,6 @@ function genPublicPath(address, port, basePath) {
 
 const CONFIG = {
   address: 'localhost',
-  port: 3000,
   host: '0.0.0.0',
   basePath: 'js-dist',
 };
@@ -51,7 +50,7 @@ function webpackConfig(pluginData, hot) {
 }
 
 function buildWebpack(data, index, startCallback, doneCallback, options) {
-  const port = (options.port || CONFIG.port) + index;
+  const port = options.port + index;
   const publicPath = genPublicPath(CONFIG.address, port, CONFIG.basePath);
   const hot = options.hot;
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Add default port value and remove instances in where we rely on other port configurations.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Is there other places we rely on a port value other than `options.port`?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
