### PR TITLE
Raise errors rather than asserting when a storage filename is bad.

### DIFF
--- a/kolibri/core/content/errors.py
+++ b/kolibri/core/content/errors.py
@@ -1,0 +1,5 @@
+from kolibri.core.errors import KolibriError
+
+
+class InvalidStorageFilenameError(KolibriError):
+    pass

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -4,6 +4,7 @@ import os
 from ...utils import import_export_content
 from ...utils import paths
 from ...utils import transfer
+from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
 logger = logging.getLogger(__name__)
@@ -71,8 +72,13 @@ class Command(AsyncCommand):
 
                 filename = f.get_filename()
 
-                srcpath = paths.get_content_storage_file_path(filename)
-                dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
+                try:
+                    srcpath = paths.get_content_storage_file_path(filename)
+                    dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
+                except InvalidStorageFilenameError:
+                    # If any files have an invalid storage file name, don't export them.
+                    overall_progress_update(f.file_size)
+                    continue
 
                 # if the file already exists, add its size to our overall progress, and skip
                 if os.path.isfile(dest) and os.path.getsize(dest) == f.file_size:

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -65,6 +65,7 @@ from mptt.models import TreeForeignKey
 from mptt.querysets import TreeQuerySet
 
 from .utils import paths
+from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.fields import DateTimeTzField
 from kolibri.utils.conf import OPTIONS
@@ -303,7 +304,7 @@ class LocalFileManager(models.Manager):
         for file in self.filter(files__isnull=True):
             try:
                 os.remove(paths.get_content_storage_file_path(file.get_filename()))
-            except (IOError, OSError,):
+            except (IOError, OSError, InvalidStorageFilenameError,):
                 pass
             yield file
 

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -7,6 +7,7 @@ from django.db.models.query import RawQuerySet
 from le_utils.constants import content_kinds
 from rest_framework import serializers
 
+from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
@@ -536,10 +537,14 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
         importable = True
         for f in content_files:
             # Node is importable only if all of its Files are on the external drive
-            file_path = get_content_storage_file_path(f.local_file.get_filename(), datafolder)
-            importable = importable and os.path.exists(file_path)
+            try:
+                file_path = get_content_storage_file_path(f.local_file.get_filename(), datafolder)
+                importable = importable and os.path.exists(file_path)
+            except InvalidStorageFilenameError:
+                importable = False
             if not importable:
                 break
+
         return importable
 
 

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -365,6 +365,15 @@ class LocalFileByDisk(TransactionTestCase):
         self.assertEqual(LocalFile.objects.filter(available=True).count(), 2)
         self.assertEqual(LocalFile.objects.exclude(available=True).count(), 3)
 
+    def test_set_bad_filenames(self):
+        local_files = list(LocalFile.objects.all())
+        LocalFile.objects.all().delete()
+        for i, lf in enumerate(local_files):
+            lf.id = 'bananas' + str(i)
+            lf.save()
+        set_local_file_availability_from_disk()
+        self.assertEqual(LocalFile.objects.filter(available=True).count(), 0)
+
     def tearDown(self):
         call_command('flush', interactive=False)
         super(LocalFileByDisk, self).tearDown()

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -5,11 +5,12 @@ from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 from six.moves.urllib.parse import urljoin
 
+from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.utils import conf
 
 
 # valid storage filenames consist of 32-char hex plus a file extension
-VALID_STORAGE_FILENAME = re.compile("[0-9a-f]{32}(-data)?\.[0-9a-z]+")
+VALID_STORAGE_FILENAME = re.compile("[0-9a-f]{32}(-data)?\\.[0-9a-z]+")
 
 # set of file extensions that should be considered zip files and allow access to internal files
 POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".perseus", ".zip"])
@@ -70,7 +71,8 @@ def get_content_storage_dir_path(datafolder=None):
 
 
 def get_content_storage_file_path(filename, datafolder=None):
-    assert VALID_STORAGE_FILENAME.match(filename), "'{}' is not a valid content storage filename".format(filename)
+    if not VALID_STORAGE_FILENAME.match(filename):
+        raise InvalidStorageFilenameError("'{}' is not a valid content storage filename".format(filename))
     return os.path.join(
         get_content_storage_dir_path(datafolder),
         filename[0],

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -23,6 +23,7 @@ from six.moves.urllib.parse import urlunparse
 
 from .api import cache_forever
 from .utils.paths import get_content_storage_file_path
+from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.utils.conf import OPTIONS
 
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
@@ -89,7 +90,7 @@ def _add_content_security_policy_header(request, response):
 def calculate_zip_content_etag(request, zipped_filename, embedded_filepath):
     try:
         zipped_path = get_content_storage_file_path(zipped_filename)
-    except AssertionError:
+    except InvalidStorageFilenameError:
         return None
 
     # if no path, or a directory, is being referenced, look for an index.html file
@@ -108,7 +109,7 @@ def get_path_or_404(zipped_filename):
     try:
         # calculate the local file path to the zip file
         return get_content_storage_file_path(zipped_filename)
-    except AssertionError:
+    except InvalidStorageFilenameError:
         raise Http404('"%(filename)s" is not a valid zip file' % {'filename': zipped_filename})
 
 


### PR DESCRIPTION
### Summary
Implements an `InvalidStorageFilenameError` to raise when an invalid storage filename is passed.
Adds handling for this behaviour wherever `get_content_storage_file_path` is used.

Adds a test for this handling in the case of content annotation.

### Reviewer guidance
Make sure content import and export flows still function as expected.

This probably needs some more tests, but it can wait.

### References
Fixes #5020

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
