### PR TITLE
remove 'back' link

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -10,12 +10,6 @@
     :immersivePageRoute="$router.getRoute('GroupsPage')"
   >
     <KPageContainer>
-      <p>
-        <BackLink
-          :to="$router.getRoute('GroupsPage')"
-          :text="coachStrings.$tr('goBackAction')"
-        />
-      </p>
       <div v-if="!currentGroup">
         {{ $tr('groupDoesNotExist') }}
       </div>


### PR DESCRIPTION

### Summary

removes redundant 'back' link

### Reviewer guidance

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52676678-d5bc8f80-2edf-11e9-8384-db6bc5c0de81.png) | ![image](https://user-images.githubusercontent.com/2367265/52676664-c0476580-2edf-11e9-8e67-7a2c2b9fe45c.png)|


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
