### PR TITLE
Use Q object instead of empty queryset

### DIFF
--- a/kolibri/core/content/utils/content_types_tools.py
+++ b/kolibri/core/content/utils/content_types_tools.py
@@ -2,10 +2,10 @@ from django.db.models import Q
 from le_utils.constants import content_kinds
 
 from kolibri.core.content.hooks import ContentRendererHook
-from kolibri.core.content.models import ContentNode
 
-# Start with an empty queryset, as we'll be using OR to add conditions
-renderable_contentnodes_without_topics_q_filter = ContentNode.objects.none()
+# Start with an empty Q object, as we'll be using OR to add conditions
+renderable_contentnodes_without_topics_q_filter = Q()
+
 
 # loop through all the registered content renderer hooks
 for hook in ContentRendererHook().registered_hooks:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When running just the devserver, such as `kolibri --debug manage runserver --settings=kolibri.deployment.default.settings.dev` it would fail to start.
Before we were trying to OR a queryset and a Q object, which is not allowed.
Q objects could only be conditioned with other Q objects.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try  `kolibri --debug manage runserver --settings=kolibri.deployment.default.settings.dev` before and after the change.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
