### PR TITLE
Show correct messages on ClassListPage when there are no classes

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -42,7 +42,9 @@ export default {
   },
   getters: {
     classListPageEnabled(state) {
-      return state.classList.length > 1;
+      // If the number of classes is exactly 1, then redirect to its home page,
+      // otherwise show the whole class list
+      return state.classList.length !== 1;
     },
   },
   actions: {

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -14,7 +14,18 @@
       <h1>{{ coachStrings.$tr('classesLabel') }}</h1>
       <p>{{ $tr('classPageSubheader') }}</p>
 
-      <CoreTable>
+      <p v-if="classList.length === 0">
+        <KExternalLink
+          v-if="isAdmin && createClassUrl"
+          :text="$tr('noClassesDetailsForAdmin')"
+          :href="createClassUrl"
+        />
+        <span v-else>
+          {{ emptyStateDetails }}
+        </span>
+      </p>
+
+      <CoreTable v-else>
         <thead slot="thead">
           <tr>
             <th>{{ $tr('classNameLabel') }}</th>
@@ -51,13 +62,39 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
+  import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
+  import urls from 'kolibri.urls';
   import commonCoach from './common';
 
   export default {
     name: 'CoachClassListPage',
-    components: {},
+    components: {
+      KExternalLink,
+    },
     mixins: [commonCoach],
+    computed: {
+      ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach']),
+      ...mapState(['classList']),
+      // Message that shows up when state.classList is empty
+      emptyStateDetails() {
+        if (this.isClassCoach) {
+          return this.$tr('noAssignedClassesDetails');
+        }
+        if (this.isAdmin) {
+          return this.$tr('noClassesDetailsForAdmin');
+        }
+        if (this.isFacilityCoach) {
+          return this.$tr('noClassesDetailsForFacilityCoach');
+        }
+      },
+      createClassUrl() {
+        const facilityUrl = urls['kolibri:facilitymanagementplugin:facility_management'];
+        if (facilityUrl) {
+          return facilityUrl();
+        }
+      },
+    },
     $trs: {
       classPageSubheader: 'View learner progress and class performance',
       classNameLabel: 'Class name',
@@ -67,9 +104,6 @@
       noClassesDetailsForAdmin: 'Create a class and enroll learners',
       noClassesDetailsForFacilityCoach: 'Please consult your Kolibri administrator',
       noClassesInFacility: 'There are no classes yet',
-    },
-    computed: {
-      ...mapState(['classList']),
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -8,7 +8,6 @@
     :appBarTitle="coachStrings.$tr('coachLabel')"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
     :pageTitle="pageTitle"
   >
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Copies back some logic from this point in time https://github.com/learningequality/kolibri/blob/874e0bfad2f7d97070b2645422005f1e5889d9af/kolibri/plugins/coach/assets/src/views/ClassListPage.vue .But it presents the message as plain text or a link (instead of using AuthMessage)
1. Turns off the showSubNav property of ResourceSelectionPage (fixes #5031 )

![screen shot 2019-02-12 at 5 05 12 pm](https://user-images.githubusercontent.com/10248067/52679235-4a47fc00-2ee9-11e9-8d8d-ce1ffd2a01ab.png)

### Reviewer guidance

If there are Gherkin stories for the case when a Coach or Admin user has no access to any classes, follow those. The basic scenarios to go to /coach when

1. I am an admin and I have no classes (at all) in the facility
1. I am class coach and I am not assigned to any classes
1. I am a facility coach and there are no classes at all in the facility (but I do not have high enough permissions to go create some).

Then do the same for
1. Exactly one class (Coach page should redirect to the home page for that class)
1. Two or more classes (user should go to the ClassListPage).

### References

Fixes #5012

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
