### PR TITLE
fixes language modal positioning

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -72,7 +72,7 @@
             <component :is="component" v-for="component in menuOptions" :key="component.name" />
             <CoreMenuOption
               :label="$tr('languageSwitchMenuOption')"
-              @select="showLanguageModal = true"
+              @select="handleChangeLanguage"
             >
               <mat-svg
                 slot="icon"
@@ -85,11 +85,6 @@
 
         </CoreMenu>
 
-        <LanguageSwitcherModal
-          v-if="showLanguageModal"
-          :style="{ color: $coreTextDefault }"
-          @close="showLanguageModal = false"
-        />
       </div>
     </UiToolbar>
     <div class="subpage-nav">
@@ -114,7 +109,6 @@
   import navComponents from 'kolibri.utils.navComponents';
   import { NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import navComponentsMixin from '../mixins/nav-components';
-  import LanguageSwitcherModal from './language-switcher/LanguageSwitcherModal';
   import LogoutSideNavEntry from './LogoutSideNavEntry';
 
   export default {
@@ -124,7 +118,6 @@
       UiIconButton,
       CoreMenu,
       UiButton,
-      LanguageSwitcherModal,
       CoreMenuOption,
       LogoutSideNavEntry,
       UserTypeDisplay,
@@ -147,7 +140,6 @@
     },
     data() {
       return {
-        showLanguageModal: false,
         userMenuDropdownIsOpen: false,
       };
     },
@@ -163,13 +155,13 @@
       },
     },
     created() {
-      window.addEventListener('click', this.handleClick);
+      window.addEventListener('click', this.handleWindowClick);
     },
     beforeDestroy() {
-      window.removeEventListener('click', this.handleClick);
+      window.removeEventListener('click', this.handleWindowClick);
     },
     methods: {
-      handleClick(event) {
+      handleWindowClick(event) {
         if (
           !this.$refs.userMenuDropdown.$el.contains(event.target) &&
           !this.$refs.userMenuButton.$el.contains(event.target) &&
@@ -178,6 +170,10 @@
           this.userMenuDropdownIsOpen = false;
         }
         return event;
+      },
+      handleChangeLanguage() {
+        this.$emit('showLanguageModal');
+        this.userMenuDropdownIsOpen = false;
       },
       ...mapActions(['kolibriLogout']),
     },

--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -286,6 +286,8 @@
   @import '~kolibri.styles.definitions';
 
   .scrolling-header {
+    @extend %enable-gpu-acceleration;
+
     top: 0;
     right: 0;
     left: 0;

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -30,7 +30,8 @@
         :title="toolbarTitle || appBarTitle"
         :height="headerHeight"
         :navShown="navShown"
-        @toggleSideNav="navShown=!navShown"
+        @toggleSideNav="navShown = !navShown"
+        @showLanguageModal="languageModalShown = true"
       >
         <slot slot="totalPointsMenuItem" name="totalPointsMenuItem"></slot>
         <div slot="app-bar-actions" class="app-bar-actions">
@@ -89,6 +90,11 @@
       :linkUrl="mostRecentNotification.linkUrl"
       @closeModal="dismissUpdateModal"
     />
+    <LanguageSwitcherModal
+      v-if="languageModalShown"
+      :style="{ color: $coreTextDefault }"
+      @close="languageModalShown = false"
+    />
 
   </div>
 
@@ -112,6 +118,7 @@
   import GlobalSnackbar from '../GlobalSnackbar';
   import ImmersiveToolbar from '../ImmersiveToolbar';
   import UpdateNotification from '../UpdateNotification';
+  import LanguageSwitcherModal from '../language-switcher/LanguageSwitcherModal';
   import ScrollingHeader from './ScrollingHeader';
 
   export default {
@@ -131,6 +138,7 @@
       KLinearLoader,
       ScrollingHeader,
       UpdateNotification,
+      LanguageSwitcherModal,
     },
     mixins: [responsiveWindow, themeMixin],
     props: {
@@ -233,7 +241,8 @@
       return {
         navShown: false,
         scrollPosition: 0,
-        updateModalShown: true,
+        notificationModalShown: true,
+        languageModalShown: false,
       };
     },
     computed: {
@@ -300,7 +309,7 @@
         if (
           (this.isAdmin || this.isSuperuser) &&
           !Lockr.get(UPDATE_MODAL_DISMISSED) &&
-          this.updateModalShown &&
+          this.notificationModalShown &&
           this.notifications.length !== 0
         ) {
           return true;
@@ -339,7 +348,7 @@
       },
       dismissUpdateModal() {
         if (this.notifications.length === 0) {
-          this.updateModalShown = false;
+          this.notificationModalShown = false;
           Lockr.set(UPDATE_MODAL_DISMISSED, true);
         }
       },

--- a/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
@@ -54,7 +54,6 @@ exports[`app bar component drop down user menu should show the language modal li
             <div tabindex="0" class="ui-menu-focus-redirector"></div>
           </ul>
         </div>
-        <!---->
       </div>
     </div>
     <div class="ui-progress-linear ui-toolbar__progress ui-progress-linear--color-white ui-progress-linear--type-indeterminate" name="ui-progress-linear--transition-fade" style="display: none;">


### PR DESCRIPTION

### Summary

* fixes #4739
* fixes #4757

### Reviewer guidance

The original issue (#4755) was caused because transformations (used by the app bar) and fixed positioning (used by the modal) don't play nicely with each other, because the fixed positioning gets a new coordinate frame of reference.

This change moves the modal outside of the app bar so that it's not affected by the new coordinate system

### References

See https://stackoverflow.com/a/15256339

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
