### PR TITLE
Notification tests

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="tab-block" :class="{small : windowIsSmall }">
+  <div class="tab-block" :class="{ small: windowIsSmall }">
     <slot></slot>
   </div>
 

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -4,6 +4,7 @@
     <NotificationsFilter
       :resourceFilter.sync="resourceFilter"
       :progressFilter.sync="progressFilter"
+      :enabledFilters="enabledFilters"
     />
     <br>
 
@@ -49,6 +50,8 @@
   import find from 'lodash/find';
   import maxBy from 'lodash/maxBy';
   import get from 'lodash/get';
+  import uniq from 'lodash/uniq';
+  import map from 'lodash/map';
   import { mapState } from 'vuex';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -138,6 +141,15 @@
           default:
             return {};
         }
+      },
+      enabledFilters() {
+        return {
+          resource: [
+            ...uniq(map(this.notifications, 'object')),
+            ...uniq(map(this.notifications, 'resource.type')),
+          ],
+          progress: uniq(map(this.notifications, 'event')),
+        };
       },
     },
     watch: {

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -8,7 +8,7 @@
     />
     <br>
 
-    <div>
+    <div class="notifications">
       <p v-if="!loading && nextPage === 2 && notifications.length === 0">
         {{ noActivityString }}
       </p>
@@ -54,13 +54,14 @@
   import map from 'lodash/map';
   import { mapState } from 'vuex';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
+  import KButton from 'kolibri.coreVue.components.KButton';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import commonCoach from '../../common';
-  import { nStringsMixin } from '../notifications/notificationStrings';
+  import { cardTextForNotification } from '../notifications/notificationStrings';
   import notificationsResource from '../../../apiResources/notifications';
   import { NotificationObjects } from '../../../constants/notificationsConstants';
   import { CollectionTypes } from '../../../constants/lessonsConstants';
   import { notificationLink } from '../../../modules/coachNotifications/gettersUtils';
+  import { coachStrings } from '../../common/commonCoachStrings';
   import NotificationCard from './NotificationCard';
   import NotificationsFilter from './NotificationsFilter';
 
@@ -69,11 +70,11 @@
   export default {
     name: 'ActivityList',
     components: {
+      KButton,
       KLinearLoader,
       NotificationsFilter,
       NotificationCard,
     },
-    mixins: [commonCoach, nStringsMixin],
     props: {
       // getParams for NotificationsResource.fetchCollection
       notificationParams: {
@@ -113,11 +114,17 @@
           LESSON: 'lesson',
           QUIZ: 'quiz',
         },
+        coachStrings,
       };
     },
     computed: {
       ...mapState('coachNotifications', {
         allNotifications: 'notifications',
+      }),
+      ...mapState('classSummary', ['examMap', 'lessonMap', 'groupMap', 'contentNodeMap']),
+      ...mapState('classSummary', {
+        classId: 'id',
+        className: 'name',
       }),
       noFiltersApplied() {
         return this.progressFilter === this.filters.ALL && this.resourceFilter === this.filters.ALL;
@@ -167,6 +174,8 @@
       this.fetchNotifications();
     },
     methods: {
+      cardTextForNotification,
+      notificationLink,
       fetchNotifications() {
         this.loading = true;
         return notificationsResource
@@ -334,7 +343,7 @@
           },
         };
 
-        const targetPage = notificationLink(baseNotification);
+        const targetPage = this.notificationLink(baseNotification);
 
         // This query parameter is used to adjust the 'back' button for different reports
         if (targetPage) {

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -19,11 +19,11 @@
             <KRouterLink
               v-if="targetPage && targetPage.name"
               :text="linkText"
-              :to="$router.getRoute(targetPage.name, targetPage.params, targetPage.query)"
+              :to="getRoute(targetPage)"
             />
-            <template v-else>
+            <span v-else>
               {{ linkText }}
-            </template>
+            </span>
           </KLabeledIcon>
         </div>
       </KGridItem>
@@ -45,8 +45,12 @@
 <script>
 
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
+  import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
+  import KGrid from 'kolibri.coreVue.components.KGrid';
+  import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
+  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import commonCoach from '../../common';
   import CoachStatusIcon from '../status/CoachStatusIcon';
   import {
     NotificationEvents,
@@ -64,8 +68,12 @@
     components: {
       ContentIcon,
       CoachStatusIcon,
+      ElapsedTime,
+      KLabeledIcon,
+      KGrid,
+      KGridItem,
+      KRouterLink,
     },
-    mixins: [commonCoach],
     props: {
       targetPage: {
         type: Object,
@@ -139,6 +147,9 @@
     methods: {
       parseDate(dateString) {
         return new Date(dateString);
+      },
+      getRoute({ name, params, query }) {
+        return this.$router.getRoute(name, params, query);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationsFilter.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationsFilter.vue
@@ -22,11 +22,12 @@
 
 <script>
 
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { NotificationEvents } from '../../../constants/notificationsConstants';
   import commonCoach from '../../common';
 
   export default {
     name: 'NotificationsFilter',
-    components: {},
     mixins: [commonCoach],
     $trs: {
       allLabel: 'All',
@@ -58,15 +59,15 @@
           },
           {
             label: this.coachStrings.$tr('helpNeededLabel'),
-            value: 'HelpNeeded',
+            value: NotificationEvents.HELP_NEEDED,
           },
           {
             label: this.coachStrings.$tr('startedLabel'),
-            value: 'Started',
+            value: NotificationEvents.STARTED,
           },
           {
             label: this.coachStrings.$tr('completedLabel'),
-            value: 'Completed',
+            value: NotificationEvents.COMPLETED,
           },
         ];
       },
@@ -78,7 +79,7 @@
           },
           {
             label: this.coachStrings.$tr('lessonsLabel'),
-            value: 'lesson',
+            value: ContentNodeKinds.LESSON,
           },
           {
             label: this.coachStrings.$tr('quizzesLabel'),
@@ -86,23 +87,23 @@
           },
           {
             label: this.$tr('exercisesLabel'),
-            value: 'exercise',
+            value: ContentNodeKinds.EXERCISE,
           },
           {
             label: this.$tr('videosLabel'),
-            value: 'video',
+            value: ContentNodeKinds.VIDEO,
           },
           {
             label: this.$tr('audioLabel'),
-            value: 'audio',
+            value: ContentNodeKinds.AUDIO,
           },
           {
             label: this.$tr('documentsLabel'),
-            value: 'document',
+            value: ContentNodeKinds.DOCUMENT,
           },
           {
             label: this.$tr('appsLabel'),
-            value: 'html5',
+            value: ContentNodeKinds.HTML5,
           },
         ];
       },

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationsFilter.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationsFilter.vue
@@ -23,7 +23,10 @@
 <script>
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { NotificationEvents } from '../../../constants/notificationsConstants';
+  import {
+    NotificationEvents,
+    NotificationObjects,
+  } from '../../../constants/notificationsConstants';
   import commonCoach from '../../common';
 
   export default {
@@ -44,6 +47,12 @@
       typeLabel: 'Type',
       videosLabel: 'Videos',
     },
+    props: {
+      enabledFilters: {
+        type: Object,
+        required: true,
+      },
+    },
     data() {
       return {
         progressType: null,
@@ -60,14 +69,17 @@
           {
             label: this.coachStrings.$tr('helpNeededLabel'),
             value: NotificationEvents.HELP_NEEDED,
+            disabled: this.progressIsDisabled(NotificationEvents.HELP_NEEDED),
           },
           {
             label: this.coachStrings.$tr('startedLabel'),
             value: NotificationEvents.STARTED,
+            disabled: this.progressIsDisabled(NotificationEvents.STARTED),
           },
           {
             label: this.coachStrings.$tr('completedLabel'),
             value: NotificationEvents.COMPLETED,
+            disabled: this.progressIsDisabled(NotificationEvents.COMPLETED),
           },
         ];
       },
@@ -80,30 +92,37 @@
           {
             label: this.coachStrings.$tr('lessonsLabel'),
             value: ContentNodeKinds.LESSON,
+            disabled: this.resourceIsDisabled(NotificationObjects.LESSON),
           },
           {
             label: this.coachStrings.$tr('quizzesLabel'),
             value: 'quiz',
+            disabled: this.resourceIsDisabled(NotificationObjects.QUIZ),
           },
           {
             label: this.$tr('exercisesLabel'),
             value: ContentNodeKinds.EXERCISE,
+            disabled: this.resourceIsDisabled(ContentNodeKinds.EXERCISE),
           },
           {
             label: this.$tr('videosLabel'),
             value: ContentNodeKinds.VIDEO,
+            disabled: this.resourceIsDisabled(ContentNodeKinds.VIDEO),
           },
           {
             label: this.$tr('audioLabel'),
             value: ContentNodeKinds.AUDIO,
+            disabled: this.resourceIsDisabled(ContentNodeKinds.AUDIO),
           },
           {
             label: this.$tr('documentsLabel'),
             value: ContentNodeKinds.DOCUMENT,
+            disabled: this.resourceIsDisabled(ContentNodeKinds.DOCUMENT),
           },
           {
             label: this.$tr('appsLabel'),
             value: ContentNodeKinds.HTML5,
+            disabled: this.resourceIsDisabled(ContentNodeKinds.HTML5),
           },
         ];
       },
@@ -111,6 +130,14 @@
     beforeMount() {
       this.progressType = this.progressTypeOptions[0];
       this.resourceType = this.resourceTypeOptions[0];
+    },
+    methods: {
+      resourceIsDisabled(value) {
+        return !this.enabledFilters.resource.includes(value);
+      },
+      progressIsDisabled(value) {
+        return !this.enabledFilters.progress.includes(value);
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
@@ -1,0 +1,246 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import makeStore from '../../../../../test/makeStore';
+import ActivityList from '../ActivityList';
+import notificationsResource from '../../../../apiResources/notifications';
+
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
+// Need a fake route to test backLinkQuery method
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/fakereport/:groupId/:learnerId',
+      name: 'FakeReportPage',
+    },
+  ],
+});
+
+jest.mock('../../../../apiResources/notifications', () => {
+  return {
+    fetchCollection: jest.fn(),
+  };
+});
+
+function makeWrapper(options) {
+  const store = makeStore();
+  store.state.classSummary.lessonMap = {
+    lesson_1: {
+      groups: [],
+    },
+  };
+
+  const wrapper = mount(ActivityList, {
+    store,
+    localVue,
+    router,
+    propsData: {
+      ...(options.propsData || {}),
+    },
+    stubs: {
+      NotificationsFilter: {
+        props: ['enabledFilters'],
+        template: '<div></div>',
+      },
+      NotificationCard: {
+        props: ['targetPage'],
+        template: '<div></div>',
+      },
+    },
+  });
+  return { wrapper };
+}
+
+describe('ActivityList component', () => {
+  beforeEach(() => {
+    notificationsResource.fetchCollection.mockClear();
+    notificationsResource.fetchCollection.mockResolvedValue({
+      results: [],
+      next: null,
+    });
+  });
+
+  it('on first render, calls the notification resource with the parameters provided', async () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        notificationParams: {
+          collection_id: 'class_001',
+        },
+      },
+    });
+    expect(notificationsResource.fetchCollection).toHaveBeenCalledWith({
+      getParams: {
+        collection_id: 'class_001',
+        page_size: 10,
+        page: 1,
+      },
+      force: true,
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.nextPage).toEqual(2);
+  });
+
+  it('shows an empty state when there are no notifications', async () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        noActivityString: 'No activity in this classroom',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    const noActivity = wrapper.find('.notifications p');
+    expect(noActivity.text()).toEqual('No activity in this classroom');
+  });
+
+  it('has a "show more" button if there are more pages of notifications', async () => {
+    notificationsResource.fetchCollection.mockResolvedValue({
+      results: [],
+      next: 'http://more.stuff.com&page=2',
+    });
+    const { wrapper } = makeWrapper({});
+    await wrapper.vm.$nextTick();
+    const showMoreButton = wrapper.find({ name: 'KButton' });
+    expect(showMoreButton.exists()).toEqual(true);
+  });
+
+  it('does not have a "show more" button if there are no more pages of notifications', async () => {
+    notificationsResource.fetchCollection.mockResolvedValue({
+      results: [],
+      next: null,
+    });
+    const { wrapper } = makeWrapper({});
+    await wrapper.vm.$nextTick();
+    const showMoreButton = wrapper.find({ name: 'KButton' });
+    expect(showMoreButton.exists()).toEqual(false);
+  });
+
+  it('disables the "show more" button if any filters are activated', async () => {
+    const { wrapper } = makeWrapper({});
+    const showMoreButton = () => wrapper.find({ name: 'KButton' });
+    await wrapper.vm.$nextTick();
+    wrapper.setData({
+      loading: false,
+      moreResults: true,
+    });
+    expect(showMoreButton().exists()).toBe(true);
+    wrapper.setData({
+      progressFilter: 'Completed',
+    });
+    expect(showMoreButton().exists()).toBe(false);
+  });
+
+  it('enables filters based on what is in the current notifications array', async () => {
+    notificationsResource.fetchCollection.mockResolvedValue({
+      results: [
+        {
+          lesson_id: 'lesson_1',
+          object: 'Lesson',
+          event: 'Started',
+          contentnode_kind: 'video',
+        },
+        {
+          lesson_id: 'lesson_1',
+          object: 'Resource',
+          event: 'Started',
+          contentnode_kind: 'exercise',
+        },
+        {
+          lesson_id: 'lesson_1',
+          object: 'Resource',
+          event: 'Completed',
+          contentnode_kind: 'exercise',
+        },
+      ],
+      next: null,
+    });
+    const { wrapper } = makeWrapper({});
+
+    await wrapper.vm.$nextTick();
+
+    const filters = wrapper.find({ name: 'NotificationsFilter' });
+    // Logic is very simple: just find the unique values in the notifications
+    // and disable anything that isn't there.
+    expect(filters.props().enabledFilters.progress.sort()).toMatchObject(['Completed', 'Started']);
+    expect(filters.props().enabledFilters.resource.sort()).toMatchObject([
+      'Lesson',
+      'Resource',
+      'exercise',
+      'video',
+    ]);
+  });
+
+  it('appends the correct back link query to links, depending on the embedded page', async () => {
+    notificationsResource.fetchCollection.mockResolvedValue({
+      results: [
+        {
+          lesson_id: 'lesson_1',
+          object: 'Lesson',
+          event: 'Started',
+          contentnode_kind: 'video',
+        },
+      ],
+      next: null,
+    });
+    const { wrapper } = makeWrapper({});
+
+    wrapper.setMethods({
+      notificationLink: () => ({}),
+      cardTextForNotification: () => '',
+      cardPropsForNotification: n => ({ targetPage: n.targetPage }),
+    });
+
+    // Need to set up a route, since backLinkQuery depends on $route.params
+    wrapper.vm.$router.push({
+      name: 'FakeReportPage',
+      params: {
+        groupId: 'group_001',
+        learnerId: 'learner_001',
+      },
+    });
+
+    const notificationCard = () => wrapper.find({ name: 'NotificationCard' });
+
+    // Need to simulate a refresh since the notifications are not reactively
+    // updated when backLinkQuery changes
+    function reloadNotifications() {
+      wrapper.setData({
+        notifications: [],
+      });
+      return wrapper.vm.fetchNotifications();
+    }
+
+    // Embed in Home Activity Page
+    wrapper.setProps({
+      embeddedPageName: 'HomeActivityPage',
+    });
+    await reloadNotifications();
+    expect(notificationCard().props().targetPage.query).toEqual({
+      last: 'homeactivity',
+    });
+
+    // Embed in Learner Activity Page
+    wrapper.setProps({
+      embeddedPageName: 'ReportsLearnerActivityPage',
+    });
+    await reloadNotifications();
+    expect(notificationCard().props().targetPage.query).toEqual({
+      last: 'learneractivity',
+      last_id: 'learner_001',
+    });
+
+    // Embed in Group Activity Page
+    wrapper.setProps({
+      embeddedPageName: 'ReportsGroupActivityPage',
+    });
+    await reloadNotifications();
+    expect(notificationCard().props().targetPage.query).toEqual({
+      last: 'groupactivity',
+      last_id: 'group_001',
+    });
+  });
+
+  // Not tested:
+  // Filtering NotificationCards
+  // All props passed to NotificationCards
+  // Live-updating notifications from coachNotifications module
+});

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/NotificationCard.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/NotificationCard.spec.js
@@ -1,0 +1,138 @@
+import { mount } from '@vue/test-utils';
+import NotificationCard from '../NotificationCard';
+
+NotificationCard.methods.getRoute = x => x;
+
+function makeWrapper(options) {
+  const wrapper = mount(NotificationCard, {
+    stubs: {
+      CoachStatusIcon: {
+        props: ['icon'],
+        template: '<div></div>',
+      },
+      KRouterLink: {
+        props: ['to', 'text'],
+        template: '<div></div>',
+      },
+    },
+    propsData: {
+      eventType: 'Completed',
+      objectType: 'Lesson',
+      targetPage: {},
+      linkText: 'JB finished a lesson',
+      ...options.propsData,
+    },
+  });
+  return { wrapper };
+}
+
+describe('NotificationCard component', () => {
+  it('shows a link if a full targetPage prop is provided', () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        targetPage: {
+          name: 'CoolReport',
+          params: {},
+        },
+      },
+    });
+    const link = wrapper.find({ name: 'KRouterLink' });
+    expect(link.props().to.name).toEqual('CoolReport');
+    expect(link.props('text')).toEqual('JB finished a lesson');
+  });
+
+  it('shows text only if an empty targetPage prop is provided', () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        targetPage: {},
+      },
+    });
+
+    const link = wrapper.find({ name: 'KRouterLink' });
+    expect(link.exists()).toEqual(false);
+    const linkText = wrapper.find('.icon-spacer span');
+    expect(linkText.text()).toEqual('JB finished a lesson');
+  });
+
+  it('has a single KGridItem if no time is provided', () => {
+    const { wrapper } = makeWrapper({
+      propsData: {},
+    });
+    const gridItems = wrapper.findAll({ name: 'KGridItem' });
+    expect(gridItems.length).toEqual(1);
+    expect(gridItems.at(0).props().size).toEqual(100);
+  });
+
+  it('has a second KGridItem with the time if it is provided', () => {
+    const timeString = '2019-01-17 01:29:04.016364';
+    const { wrapper } = makeWrapper({
+      propsData: {
+        time: timeString,
+      },
+    });
+    const gridItems = wrapper.findAll({ name: 'KGridItem' });
+    expect(gridItems.length).toEqual(2);
+    expect(gridItems.at(0).props().size).toEqual(50);
+    expect(gridItems.at(1).props().size).toEqual(50);
+
+    const elapsedTime = wrapper.find({ name: 'ElapsedTime' });
+    const timeObject = new Date(timeString).getTime();
+    expect(elapsedTime.props().date.getTime()).toEqual(timeObject);
+  });
+
+  it('shows the correct status icon for Started, HelpNeeded, and Completed events', () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        eventType: 'Started',
+      },
+    });
+
+    const icon = wrapper.find({ name: 'CoachStatusIcon' });
+    expect(icon.props().icon).toEqual('clock');
+
+    wrapper.setProps({ eventType: 'HelpNeeded' });
+    expect(icon.props().icon).toEqual('help');
+
+    wrapper.setProps({ eventType: 'Completed' });
+    expect(icon.props().icon).toEqual('star');
+  });
+
+  it('shows the correct content icon if the assignment is a quiz, lesson, or resource', () => {
+    const { wrapper } = makeWrapper({
+      propsData: {
+        objectType: 'Lesson',
+        resourceType: 'video',
+      },
+    });
+    const contentIcon = wrapper.find({ name: 'ContentIcon' });
+    expect(contentIcon.props().kind).toEqual('lesson');
+
+    wrapper.setProps({ objectType: 'Quiz' });
+    expect(contentIcon.props().kind).toEqual('exam');
+
+    wrapper.setProps({ objectType: 'Resource' });
+    expect(contentIcon.props().kind).toEqual('video');
+  });
+
+  it('formats the header message when the learner context, content context, none, or both are provided', () => {
+    const { wrapper } = makeWrapper({});
+    const header = wrapper.find('.context');
+
+    expect(header.text()).toEqual('');
+
+    wrapper.setProps({ learnerContext: 'Group 1' });
+    expect(header.text()).toEqual('Group 1');
+
+    wrapper.setProps({
+      learnerContext: 'Group 1',
+      contentContext: 'Lesson 1',
+    });
+    expect(header.text()).toEqual('Group 1 • Lesson 1');
+
+    wrapper.setProps({
+      learnerContext: '',
+      contentContext: 'Lesson 1',
+    });
+    expect(header.text()).toEqual('Lesson 1');
+  });
+});

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
@@ -90,7 +90,7 @@ function cardTextForNotification(notification) {
     }
   }
 
-  return this.nStrings.$tr(stringType, stringDetails);
+  return nStrings.$tr(stringType, stringDetails);
 }
 
 export { nStrings, nStringsMixin, cardTextForNotification };

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
@@ -2,7 +2,7 @@
 
   <div
     class="block-item"
-    :class="{small : windowIsSmall }"
+    :class="{ small : windowIsSmall }"
   >
     <slot></slot>
   </div>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportQuizPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportQuizPage.vue
@@ -30,7 +30,8 @@
     computed: {
       ...mapState('examReportDetail', ['exam']),
       toolbarRoute() {
-        return this.classRoute('ReportsLearnerReportPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLearnerReportPage', {});
       },
     },
     $trs: {},


### PR DESCRIPTION
### Summary

1. Adds tests for ActivityList and NotificationCard components. Refactors them to not use commonCoach and nStringsMixin.
1. Fixes a Quiz detail page to have the correct "X" back link
1. Adds very simple logic to disable certain filters in the ActivityList (it is naive in that it allows certain filter combos that have no results).
1.

### Reviewer guidance

1. Manually test the Class, Learner, and Group Activity feeds to make sure mixin removal did not break the ActivityList and NotificationCard

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
