### PR TITLE
Add item filtering to attemptlog and examattemptlog endpoints.

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -170,7 +170,7 @@ class AttemptFilter(BaseLogFilter):
 
     class Meta:
         model = AttemptLog
-        fields = ['masterylog', 'complete', 'user', 'content']
+        fields = ['masterylog', 'complete', 'user', 'content', 'item']
 
 
 class AttemptLogViewSet(LoggerViewSet):
@@ -197,7 +197,7 @@ class ExamAttemptFilter(BaseLogFilter):
 
     class Meta:
         model = ExamAttemptLog
-        fields = ['examlog', 'exam', 'user', 'content']
+        fields = ['examlog', 'exam', 'user', 'content', 'item']
 
 
 class ExamAttemptLogViewSet(LoggerViewSet):


### PR DESCRIPTION
### Summary
For difficult question views, the frontend attempts to filter by the particular question (item) that is being displayed.

The backend did not support filtering by the `item` field.

This PR adds support for filtering by the `item` field.

Everything is now dandy.

### Reviewer guidance
If you have the right content imported, check out some difficult questions under an exercise in a lesson or a quiz, and check that the number of learners shown on the list page before hand is the same as the detail view.

If you don't have the right content, look at the network tab at the query to the `attemptlog` endpoint, and confirm that every returned attemptlog has the same value for the `item` key.

### References
Fixes #5026

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
