### PR TITLE
Add a text-overflow CSS rule to TruncatedItemList

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
@@ -1,18 +1,20 @@
 <template>
 
   <KEmptyPlaceholder v-if="!items.length" />
-  <span v-else-if="items.length === 1">
-    {{ items[0] }}
-  </span>
-  <span v-else-if="items.length === 2">
-    {{ $tr('twoItems', {item1: items[0], item2: items[1]}) }}
-  </span>
-  <span v-else-if="items.length === 3">
-    {{ $tr('threeItems', {item1: items[0], item2: items[1], item3: items[2]}) }}
-  </span>
-  <span v-else>
-    {{ $tr('manyItems', {item1: items[0], item2: items[1], count: items.length-2}) }}
-  </span>
+  <div v-else class="items-label">
+    <span v-if="items.length === 1">
+      {{ items[0] }}
+    </span>
+    <span v-else-if="items.length === 2">
+      {{ $tr('twoItems', {item1: items[0], item2: items[1]}) }}
+    </span>
+    <span v-else-if="items.length === 3">
+      {{ $tr('threeItems', {item1: items[0], item2: items[1], item3: items[2]}) }}
+    </span>
+    <span v-else>
+      {{ $tr('manyItems', {item1: items[0], item2: items[1], count: items.length - 2}) }}
+    </span>
+  </div>
 
 </template>
 
@@ -42,4 +44,11 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .items-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+</style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Adds a text-overflow rule to TruncatedItemList so that unbroken strings that overflow the container get cut off with an ellipsis.

In screenshot, one of the groups is 'a'x50, which overflows the box.

![screen shot 2019-02-13 at 11 42 45 am](https://user-images.githubusercontent.com/10248067/52739065-f2f76980-2f84-11e9-93fb-110901d9fecc.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #5030 
…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
