### PR TITLE
Add empty states to various coach tables and widgets

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -11,6 +11,10 @@
         default: false,
         required: false,
       },
+      emptyMessage: {
+        type: String,
+        required: false,
+      },
     },
     computed: {
       tHeadStyle() {
@@ -38,11 +42,20 @@
       },
     },
     render(createElement) {
+      let tableHasRows = false;
       this.$slots.thead.forEach(thead => {
         thead.data.style = Object.assign(thead.data.style || {}, this.tHeadStyle);
       });
+
       this.$slots.tbody.forEach(tbody => {
+        // Need to check componentOptions if wrapped in <transition-group>, or just children
+        // if in regular <tbody>
+        if (tbody.componentOptions && tbody.componentOptions.children) {
+          tableHasRows = tbody.componentOptions.children.length > 0;
+        }
+
         if (tbody.children) {
+          tableHasRows = tbody.children.length > 0;
           tbody.children.forEach(child => {
             if (!child.data) {
               child.data = {};
@@ -56,12 +69,18 @@
           });
         }
       });
+
+      // Insert an empty message as a <p> at the end if it is provided and the
+      // table has no rows.
+      const showEmptyMessage = this.emptyMessage && !tableHasRows;
+
       return createElement('div', { class: 'core-table-container' }, [
         createElement('table', { class: 'core-table' }, [
           ...(this.$slots.default || []),
           this.$slots.thead,
           this.$slots.tbody,
         ]),
+        showEmptyMessage && createElement('p', this.emptyMessage),
       ]);
     },
   };

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -129,4 +129,8 @@
     }
   }
 
+  /deep/ .core-table-button-col {
+    padding: 4px;
+  }
+
 </style>

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -42,7 +42,7 @@
       },
     },
     render(createElement) {
-      let tableHasRows = false;
+      let tableHasRows = true;
       this.$slots.thead.forEach(thead => {
         thead.data.style = Object.assign(thead.data.style || {}, this.tHeadStyle);
       });

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -53,10 +53,9 @@
     computed: {
       ...mapGetters('coachNotifications', ['summarizedNotifications']),
       notifications() {
-        return orderBy(this.summarizedNotifications, 'lastId', ['desc']).slice(
-          0,
-          MAX_NOTIFICATIONS
-        );
+        return orderBy(this.summarizedNotifications, ({ lastId }) => Number(lastId), [
+          'desc',
+        ]).slice(0, MAX_NOTIFICATIONS);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -19,18 +19,9 @@
         />
       </KGridItem>
 
-      <KGridItem size="75" percentage>
+      <KGridItem size="100" percentage>
         <StatusSummary
           :tally="tally"
-        />
-      </KGridItem>
-
-      <KGridItem size="25" percentage alignment="right">
-        <HelpNeeded
-          v-if="tally.helpNeeded"
-          :count="tally.helpNeeded"
-          :verbose="false"
-          :ratio="false"
         />
       </KGridItem>
     </KGrid>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -9,6 +9,10 @@
       {{ coachStrings.$tr('lessonsLabel') }}
     </KLabeledIcon>
 
+    <p v-if="table.length === 0">
+      {{ coachStrings.$tr('lessonListEmptyState') }}
+    </p>
+
     <BlockItem
       v-for="tableRow in table"
       :key="tableRow.key"

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -9,6 +9,10 @@
       {{ coachStrings.$tr('quizzesLabel') }}
     </KLabeledIcon>
 
+    <p v-if="table.length === 0">
+      {{ coachStrings.$tr('quizListEmptyState') }}
+    </p>
+
     <BlockItem
       v-for="tableRow in table"
       :key="tableRow.key"

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -60,7 +60,7 @@
               <QuizActive :active="exam.active" />
             </td>
 
-            <td class="options">
+            <td class="options core-table-button-col">
               <KDropdownMenu
                 slot="optionsDropdown"
                 :text="examReportPageStrings.$tr('options')"

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -13,7 +13,7 @@
     <td>
       {{ group.users.length }}
     </td>
-    <td class="ta-r">
+    <td class="ta-r core-table-button-col">
       <KDropdownMenu
         v-if="!isUngrouped"
         appearance="flat-button"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
@@ -16,6 +16,7 @@
       <ActivityList
         :notificationParams="notificationParams"
         embeddedPageName="ReportsGroupActivityPage"
+        :noActivityString="coachStrings.$tr('activityListEmptyState')"
       />
 
     </KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -11,7 +11,7 @@
 
     <KPageContainer>
       <ReportsGroupHeader />
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -11,7 +11,7 @@
 
     <KPageContainer>
       <ReportsHeader />
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('groupListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('groupNameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -17,7 +17,7 @@
         <StatusSummary :tally="tally" />
       </p>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -14,7 +14,7 @@
       <ReportsGroupReportLessonExerciseHeader />
 
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('questionListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('questionLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -21,7 +21,7 @@
       <HeaderTable>
         <HeaderTableRow>
           <template slot="key">{{ coachStrings.$tr('statusLabel') }}</template>
-          <template slot="value"><LessonActive :active="true" /></template>
+          <template slot="value"><LessonActive :active="lesson.active" /></template>
         </HeaderTableRow>
         <!-- TODO COACH
         <HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -31,7 +31,7 @@
          -->
       </HeaderTable>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('lessonListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -37,7 +37,7 @@
       <p>
         <StatusSummary :tally="tally" />
       </p>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -13,7 +13,7 @@
 
       <ReportsGroupReportQuizHeader />
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -16,7 +16,7 @@
       <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
-            <th>{{ coachStrings.$tr('titleLabel') }}</th>
+            <th>{{ coachStrings.$tr('nameLabel') }}</th>
             <th>{{ coachStrings.$tr('progressLabel') }}</th>
             <th>{{ coachStrings.$tr('scoreLabel') }}</th>
           </tr>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -14,7 +14,7 @@
       <ReportsGroupReportQuizHeader />
 
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('questionListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('questionLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -16,6 +16,7 @@
       <ActivityList
         :notificationParams="notificationParams"
         embeddedPageName="ReportsLearnerActivityPage"
+        :noActivityString="coachStrings.$tr('activityListEmptyState')"
       />
 
     </KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -15,7 +15,7 @@
       <KCheckbox :label="coachStrings.$tr('viewByGroupsLabel')" />
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
        -->
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -35,7 +35,7 @@
          -->
       </HeaderTable>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>
@@ -78,13 +78,19 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
+  import LessonSummaryPage from '../plan/LessonSummaryPage';
+
+  const LessonSummaryPageStrings = crossComponentTranslator(LessonSummaryPage);
 
   export default {
     name: 'ReportsLearnerReportLessonPage',
-    components: {},
     mixins: [commonCoach],
     computed: {
+      emptyMessage() {
+        return LessonSummaryPageStrings.$tr('noResourcesInLesson');
+      },
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -25,7 +25,7 @@
       <HeaderTable>
         <HeaderTableRow>
           <template slot="key">{{ coachStrings.$tr('statusLabel') }}</template>
-          <template slot="value"><LessonActive :active="true" /></template>
+          <template slot="value"><LessonActive :active="lesson.active" /></template>
         </HeaderTableRow>
         <!-- TODO COACH
         <HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -16,7 +16,7 @@
       <KGrid>
         <KGridItem :sizes="[100, 100, 50]" percentage>
           <h2>{{ coachStrings.$tr('lessonsAssignedLabel') }}</h2>
-          <CoreTable>
+          <CoreTable :emptyMessage="coachStrings.$tr('lessonListEmptyState')">
             <thead slot="thead">
               <tr>
                 <th>{{ coachStrings.$tr('titleLabel') }}</th>
@@ -43,7 +43,7 @@
         </KGridItem>
         <KGridItem :sizes="[100, 100, 50]" percentage>
           <h2>{{ coachStrings.$tr('quizzesAssignedLabel') }}</h2>
-          <CoreTable>
+          <CoreTable :emptyMessage="coachStrings.$tr('quizListEmptyState')">
             <thead slot="thead">
               <tr>
                 <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -22,7 +22,7 @@
         <StatusSummary :tally="tally" />
       </p>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -18,7 +18,7 @@
       -->
 
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('questionListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('questionLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -15,7 +15,7 @@
 
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -18,7 +18,7 @@
       <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
-            <th>{{ coachStrings.$tr('titleLabel') }}</th>
+            <th>{{ coachStrings.$tr('nameLabel') }}</th>
             <th>{{ coachStrings.$tr('progressLabel') }}</th>
             <th>{{ coachStrings.$tr('groupsLabel') }}</th>
           </tr>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -23,7 +23,7 @@
         </KLabeledIcon>
       </h1>
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -16,7 +16,7 @@
         :options="filterOptions"
         :inline="true"
       />
-      <CoreTable :emptyMessage="coachStrings.$tr('lessonListEmptyState')">
+      <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>
@@ -59,8 +59,12 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
+  import LessonsRootPage from '../plan/LessonsRootPage';
   import ReportsHeader from './ReportsHeader';
+
+  const LessonsRootPageStrings = crossComponentTranslator(LessonsRootPage);
 
   export default {
     name: 'ReportsLessonListPage',
@@ -74,6 +78,17 @@
       };
     },
     computed: {
+      emptyMessage() {
+        if (this.filter.value === 'allLessons') {
+          return this.coachStrings.$tr('lessonListEmptyState');
+        }
+        if (this.filter.value === 'activeLessons') {
+          return LessonsRootPageStrings.$tr('noActiveLessons');
+        }
+        if (this.filter.value === 'inactiveLessons') {
+          return LessonsRootPageStrings.$tr('noInactiveLessons');
+        }
+      },
       filterOptions() {
         return [
           {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -16,7 +16,7 @@
         :options="filterOptions"
         :inline="true"
       />
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('lessonListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -13,7 +13,7 @@
 
       <ReportsLessonHeader />
 
-      <CoreTable>
+      <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>
@@ -64,8 +64,12 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
+  import LessonSummaryPage from '../plan/LessonSummaryPage';
   import ReportsLessonHeader from './ReportsLessonHeader';
+
+  const LessonSummaryPageStrings = crossComponentTranslator(LessonSummaryPage);
 
   export default {
     name: 'ReportsLessonReportPage',
@@ -74,6 +78,9 @@
     },
     mixins: [commonCoach],
     computed: {
+      emptyMessage() {
+        return LessonSummaryPageStrings.$tr('noResourcesInLesson');
+      },
       actionOptions() {
         return [
           { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsLessonEditorPage' },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -37,7 +37,7 @@
       <p>
         <StatusSummary :tally="tally" />
       </p>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('nameLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -13,7 +13,7 @@
 
       <ReportsQuizHeader />
 
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -16,7 +16,7 @@
       <CoreTable :emptyMessage="coachStrings.$tr('learnerListEmptyState')">
         <thead slot="thead">
           <tr>
-            <th>{{ coachStrings.$tr('titleLabel') }}</th>
+            <th>{{ coachStrings.$tr('nameLabel') }}</th>
             <th>{{ coachStrings.$tr('progressLabel') }}</th>
             <th>{{ coachStrings.$tr('scoreLabel') }}</th>
             <th>{{ coachStrings.$tr('groupsLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -17,7 +17,7 @@
         :options="filterOptions"
         :inline="true"
       />
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('quizListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -17,7 +17,7 @@
         :options="filterOptions"
         :inline="true"
       />
-      <CoreTable :emptyMessage="coachStrings.$tr('quizListEmptyState')">
+      <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('titleLabel') }}</th>
@@ -62,8 +62,12 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
+  import CoachExamsPage from '../plan/CoachExamsPage';
   import ReportsHeader from './ReportsHeader';
+
+  const CoachExamsPageStrings = crossComponentTranslator(CoachExamsPage);
 
   export default {
     name: 'ReportsQuizListPage',
@@ -77,6 +81,17 @@
       };
     },
     computed: {
+      emptyMessage() {
+        if (this.filter.value === 'allQuizzes') {
+          return this.coachStrings.$tr('lessonListEmptyState');
+        }
+        if (this.filter.value === 'activeQuizzes') {
+          return CoachExamsPageStrings.$tr('noActiveExams');
+        }
+        if (this.filter.value === 'inactiveQuizzes') {
+          return CoachExamsPageStrings.$tr('noInactiveExams');
+        }
+      },
       filterOptions() {
         return [
           {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -14,7 +14,7 @@
       <ReportsQuizHeader />
 
       <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-      <CoreTable>
+      <CoreTable :emptyMessage="coachStrings.$tr('questionListEmptyState')">
         <thead slot="thead">
           <tr>
             <th>{{ coachStrings.$tr('questionLabel') }}</th>


### PR DESCRIPTION
### Summary

1. Extends CoreTable to accept an 'emptyMessage' prop, which it renders in a `<p>` depending on whether it detects any children in its tbody slot.
1. Updates all of the /coach reports pages that use CoreTable to show an appropriate empty message. (Non-coach pages using CoreTable were not updated)
1. Updates other list widgets to also show an empty message
1. Fixes a few tables that was using a "title" header under a column for user names.
1. Vertically align the table cells in CoachExamsPage Fixes #5046 (unless the misalignment happens anywhere else).
1. Fixes Lesson Status Icon always being active Fixes #5056
1. Remove the second Needs Help indicator on ItemProgress widget. Fixes #5059

![screen shot 2019-02-13 at 2 20 35 pm](https://user-images.githubusercontent.com/10248067/52748493-7fad2200-2f9b-11e9-8020-f1ad5a254a04.png)


### Reviewer guidance

1. To manually test, go to as many coach pages as possible and make sure the empty message appears when there is no data, and _does not appear_ when there _is_ data.
1. In the code, make sure any of use `$tr('...')` looks correct (i.e. always has `coachStrings.$tr` and coachstrings is in scope.

### References

Fixes #5022
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
