### PR TITLE
makes 'back' link on Plan page point to Home

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
@@ -6,7 +6,7 @@
       class="icon"
       tabIndex="-1"
       aria-hidden="true"
-      @click="$emit('navIconClick')"
+      @click="go"
     >
       <mat-svg
         v-if="!isRtl"
@@ -48,6 +48,11 @@
       to: {
         type: Object,
         required: true,
+      },
+    },
+    methods: {
+      go() {
+        this.$router.push(this.to);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -4,8 +4,8 @@
     <p>
       <BackLink
         v-if="classListPageEnabled"
-        :to="$router.getRoute(PageNames.REPORTS_PAGE)"
-        :text="coachStrings.$tr('reportsLabel')"
+        :to="$router.getRoute('HomePage')"
+        :text="navStrings.$tr('home')"
       />
     </p>
     <h1>{{ $tr('planYourClassLabel') }}</h1>
@@ -31,9 +31,13 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { mapGetters } from 'vuex';
   import commonCoach from '../common';
   import { LessonsPageNames } from '../../constants/lessonsConstants';
+  import TopNavbar from '../TopNavbar';
+
+  const navStrings = crossComponentTranslator(TopNavbar);
 
   export default {
     name: 'PlanHeader',
@@ -43,6 +47,9 @@
       ...mapGetters(['classListPageEnabled']),
       LessonsPageNames() {
         return LessonsPageNames;
+      },
+      navStrings() {
+        return navStrings;
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary

Based on the discussion in https://github.com/learningequality/kolibri/issues/4989 my understanding is that this is the desired behavior:

| home | reports | plan |
|--|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52767938-cc671c00-2fe0-11e9-88f4-c3cd2565a247.png) | ![image](https://user-images.githubusercontent.com/2367265/52767953-d6891a80-2fe0-11e9-9dd3-77610f683f91.png) | ![image](https://user-images.githubusercontent.com/2367265/52767967-de48bf00-2fe0-11e9-8994-efcdebd5c7fc.png) |


* fixes #5053
* fixes #4989

### Reviewer guidance

is this correct?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
