### PR TITLE
accurate 'started' metric

### DIFF
--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -70,7 +70,7 @@ def content_status_serializer(lesson_data, learners_data, classroom):
         """
         content_id = log["content_id"]
         if content_id in content_map:
-            # Don't try to lookup anything if we don't know the content_id
+            # Don't try to look up anything if we don't know the content_id
             # node_id mapping - might happen if a channel has since been deleted
             key = lookup_key.format(user_id=log["user_id"], node_id=content_map[content_id])
             if key in needs_help:

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -80,8 +80,6 @@ def content_status_serializer(lesson_data, learners_data, classroom):
                     return HELP_NEEDED
         if log["progress"] == 1:
             return COMPLETED
-        elif log["progress"] == 0:
-            return NOT_STARTED
         return STARTED
 
     def map_content_logs(log):


### PR DESCRIPTION
### Summary

exercises with no attempts but time spent are considered 'started'

### Reviewer guidance

look right?

### References

fixes #5032


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
