### PR TITLE
Proposal of new default values for CherryPy configuration

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -42,9 +42,11 @@ option_spec = {
             "default": True,
             "envvars": ("KOLIBRI_CHERRYPY_START",),
         },
+        # The number of worker threads to start up in the pool. 10 is the default
+        # 60 & 150 should be tested too
         "CHERRYPY_THREAD_POOL": {
             "type": "integer",
-            "default": 10,
+            "default": 100,
             "envvars": ("KOLIBRI_CHERRYPY_THREAD_POOL",),
         },
         "CHERRYPY_SOCKET_TIMEOUT": {
@@ -52,9 +54,12 @@ option_spec = {
             "default": 10,
             "envvars": ("KOLIBRI_CHERRYPY_SOCKET_TIMEOUT",),
         },
+        # The maximum number of requests which will be queued up before
+        # the server refuses to accept it (default -1, meaning no limit).
+        # -1, 30 & 100 should be tested
         "CHERRYPY_QUEUE_SIZE": {
             "type": "integer",
-            "default": 30,
+            "default": 100,
             "envvars": ("KOLIBRI_CHERRYPY_QUEUE_SIZE",),
         },
         "CHERRYPY_QUEUE_TIMEOUT": {


### PR DESCRIPTION
### Summary
After tests done in real cases, this is a proposal of new values for CherryPY server parameter, including some configs to be tested.


### Reviewer guidance
Change the values and test the server performance


### References
References: #3736 


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
