### PR TITLE
more import styling updates

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -126,6 +126,7 @@
     width: 40px;
     .k-checkbox-container {
       margin: 0 0 0 2px;
+      line-height: 1em;
     }
   }
 

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -8,9 +8,9 @@
         :src="channel.thumbnail"
       >
       <div class="channel-name">
-        <h2 class="title">
+        <h1>
           {{ channel.name }}
-        </h2>
+        </h1>
         <UiIcon
           v-if="channel.public === false"
           class="lock-icon"
@@ -21,7 +21,7 @@
       <p class="version">
         {{ $tr('version', { version: versionNumber }) }}
       </p>
-      <p class="description">
+      <p>
         {{ channel.description }}
       </p>
     </div>
@@ -32,15 +32,13 @@
         <th>{{ $tr('resourcesCol') }}</th>
         <th>{{ $tr('sizeCol') }}</th>
       </tr>
-
-      <tr class="total-size">
-        <td>{{ $tr('totalSizeRow') }}</td>
+      <tr>
+        <th>{{ $tr('totalSizeRow') }}</th>
         <td>{{ $tr('resourceCount', { count: channel.total_resources || 0 }) }}</td>
         <td>{{ bytesForHumans(channel.total_file_size || 0) }}</td>
       </tr>
-
-      <tr class="on-device">
-        <td>{{ $tr('onDeviceRow') }}</td>
+      <tr>
+        <th>{{ $tr('onDeviceRow') }}</th>
         <td>{{ $tr('resourceCount', { count: channel.on_device_resources || 0 }) }}</td>
         <td>{{ bytesForHumans(channel.on_device_file_size || 0) }}</td>
       </tr>
@@ -102,53 +100,36 @@
     max-width: 200px;
   }
 
-  .description {
-    max-width: 66%;
-  }
-
-  .title {
-    display: inline;
-    font-size: 32px;
-    font-weight: bold;
-  }
-
   .lock-icon {
     font-size: 32px;
     vertical-align: sub;
   }
 
-  .channel-title {
-    margin-bottom: 8px;
-  }
-
   .version {
     margin-bottom: 32px;
     font-size: 14px;
+    font-weight: bold;
   }
 
   .channel-statistics {
-    margin: 36px 0;
+    min-width: 150px;
+    margin: 16px 0;
   }
 
-  tr.headers > th {
-    min-width: 125px;
-    padding: 8px 0;
-    font-weight: normal;
+  th,
+  td {
+    height: 2em;
+    padding-right: 24px;
+    font-size: 14px;
+  }
+
+  th {
+    text-align: left;
+  }
+
+  .headers th,
+  td {
     text-align: right;
-    &:nth-child(1) {
-      min-width: 175px;
-    }
-  }
-
-  tr.total-size,
-  tr.on-device {
-    td {
-      padding: 8px 0;
-      text-align: right;
-      &:first-of-type {
-        text-align: left;
-      }
-    }
   }
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentNodeRow.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentNodeRow.vue
@@ -2,16 +2,14 @@
 
   <tr>
     <td class="core-table-checkbox-col">
-      <div class="checkbox">
-        <KCheckbox
-          :label="node.title"
-          :showLabel="false"
-          :checked="checked"
-          :indeterminate="indeterminate"
-          :disabled="disabled"
-          @change="$emit('changeselection', node)"
-        />
-      </div>
+      <KCheckbox
+        :label="node.title"
+        :showLabel="false"
+        :checked="checked"
+        :indeterminate="indeterminate"
+        :disabled="disabled"
+        @change="$emit('changeselection', node)"
+      />
     </td>
 
     <td class="title">
@@ -104,10 +102,6 @@
 
 
 <style lang="scss" scoped>
-
-  .checkbox {
-    max-height: 24px;
-  }
 
   .coach-content-label {
     display: inline-block;

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -41,10 +41,7 @@
           v-if="transferredChannel && onDeviceInfoIsReady"
           class="updates"
         >
-          <div
-            v-if="newVersionAvailable"
-            class="updates-available"
-          >
+          <div v-if="newVersionAvailable">
             <span>
               {{ $tr('newVersionAvailable', { version: transferredChannel.version }) }}
             </span>
@@ -86,8 +83,10 @@
           :spaceOnDrive="availableSpace"
           @clickconfirm="startContentTransfer()"
         />
-        <hr>
-        <ContentTreeViewer />
+        <ContentTreeViewer
+          class="block-item"
+          :class="{ small : windowIsSmall }"
+        />
       </template>
     </template>
   </div>
@@ -103,6 +102,7 @@
   import { TaskResource } from 'kolibri.resources';
   import isEmpty from 'lodash/isEmpty';
   import find from 'lodash/find';
+  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import TaskProgress from '../ManageContentPage/TaskProgress';
   import { ContentWizardErrors, TaskStatuses, TaskTypes } from '../../constants';
   import { manageContentPageLink } from '../ManageContentPage/manageContentLinks';
@@ -128,6 +128,7 @@
       TaskProgress,
       UiAlert,
     },
+    mixins: [responsiveWindow],
     data() {
       return {
         showUpdateProgressBar: false,
@@ -282,8 +283,30 @@
 
 <style lang="scss" scoped>
 
+  .notifications {
+    margin-top: 8px;
+  }
+
   .updates {
     text-align: right;
+  }
+
+  .block-item {
+    padding-top: 16px;
+    padding-right: 24px;
+    padding-bottom: 16px;
+    padding-left: 24px;
+    margin-top: 24px;
+    margin-right: -24px;
+    margin-left: -24px;
+    border-top: 1px solid #dedede;
+  }
+
+  .small .block-item {
+    padding-right: 16px;
+    padding-left: 16px;
+    margin-right: -16px;
+    margin-left: -16px;
   }
 
 </style>

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -41,7 +41,10 @@
           v-if="transferredChannel && onDeviceInfoIsReady"
           class="updates"
         >
-          <div v-if="newVersionAvailable">
+          <div
+            v-if="newVersionAvailable"
+            class="updates-available"
+          >
             <span>
               {{ $tr('newVersionAvailable', { version: transferredChannel.version }) }}
             </span>

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -1,6 +1,7 @@
 import VueRouter from 'vue-router';
 import { mount } from '@vue/test-utils';
 import SelectContentPage from '../../src/views/SelectContentPage';
+import ChannelContentsSummary from '../../src/views/SelectContentPage/ChannelContentsSummary';
 import SelectedResourcesSize from '../../src/views/SelectContentPage/SelectedResourcesSize';
 import { makeSelectContentPageStore } from '../utils/makeStore';
 
@@ -23,24 +24,6 @@ function makeWrapper(options) {
   return wrapper;
 }
 
-// prettier-ignore
-function getElements(wrapper) {
-  return {
-    description: () => wrapper.find('.description').text().trim(),
-    notificationsSection: () => wrapper.find('section.notifications'),
-    onDeviceRows: () => wrapper.findAll('tr.on-device td'),
-    resourcesSize: () => wrapper.find(SelectedResourcesSize),
-    thumbnail: () => wrapper.find('.thumbnail'),
-    title: () => wrapper.find('.title').text().trim(),
-    totalSizeRows: () => wrapper.findAll('tr.total-size td'),
-    treeView: () => wrapper.find('section.resources-tree-view'),
-    updateSection: () => wrapper.find('.updates-available'),
-    updateButton: () => wrapper.find('button[name="update"]'),
-    version: () => wrapper.find('.version').text().trim(),
-    versionAvailable: () => wrapper.find('.updates-available span').text().trim(),
-  };
-}
-
 function updateMetaChannel(store, updates) {
   const { transferredChannel } = store.state.manageContent.wizard;
   store.commit('manageContent/wizard/SET_TRANSFERRED_CHANNEL', {
@@ -59,52 +42,44 @@ describe('selectContentPage', () => {
   it('shows the thumbnail, title, descripton, and version of the channel', () => {
     const fakeImage = 'data:image/png;base64,abcd1234';
     updateMetaChannel(store, { thumbnail: fakeImage });
-    const wrapper = makeWrapper({ store });
-    const { thumbnail, version, title, description } = getElements(wrapper);
-    // prettier-ignore
-    expect(thumbnail().find('img').attributes().src).toEqual(fakeImage);
-    expect(title()).toEqual('Awesome Channel');
-    expect(version()).toEqual('Version 10');
-    expect(description()).toEqual('An awesome channel');
+    const summary = makeWrapper({ store }).find(ChannelContentsSummary);
+    expect(summary.find('img').attributes().src).toEqual(fakeImage);
+    expect(summary.find('h1').text()).toEqual('Awesome Channel');
+    const pTags = summary.findAll('p');
+    expect(pTags.at(0).text()).toEqual('Version 10');
+    expect(pTags.at(1).text()).toEqual('An awesome channel');
   });
 
   it('shows the total size of the channel', () => {
-    const wrapper = makeWrapper({ store });
-    const { totalSizeRows } = getElements(wrapper);
-    const rows = totalSizeRows();
-    expect(rows.at(1).text()).toEqual('1,000');
-    expect(rows.at(2).text()).toEqual('5 GB');
+    const rows = makeWrapper({ store })
+      .find(ChannelContentsSummary)
+      .findAll('tr');
+    expect(rows.at(1).text()).toEqual('Total size 1,000 5 GB');
   });
 
-  it('if resources are on the device, it shows the total size of those', () => {
-    const wrapper = makeWrapper({ store });
-    const { onDeviceRows } = getElements(wrapper);
-    const rows = onDeviceRows();
-    expect(rows.at(1).text()).toEqual('2,000');
-    expect(rows.at(2).text()).toEqual('95 MB');
+  it('shows the total size of any resources on the device', () => {
+    const rows = makeWrapper({ store })
+      .find(ChannelContentsSummary)
+      .findAll('tr');
+    expect(rows.at(2).text()).toEqual('On your device 2,000 95 MB');
   });
 
-  it('if channel is not on device, it shows size and resources as 0', () => {
+  it('shows size and resources as 0 if channel is not on device', () => {
     updateMetaChannel(store, {
       id: 'not_awesome_channel',
       on_device_resources: 0,
       on_device_file_size: 0,
     });
-    const wrapper = makeWrapper({ store });
-    const { onDeviceRows } = getElements(wrapper);
-    const rows = onDeviceRows();
-    expect(rows.at(1).text()).toEqual('0');
-    expect(rows.at(2).text()).toEqual('0 B');
+    const rows = makeWrapper({ store })
+      .find(ChannelContentsSummary)
+      .findAll('tr');
+    expect(rows.at(2).text()).toEqual('On your device 0 0 B');
   });
 
-  it('if a new version is available, a update notification and button appear', () => {
+  it('shows a update notification if a new version is available', () => {
     updateMetaChannel(store, { version: 1000 });
     const wrapper = makeWrapper({ store });
-    const { updateSection, notificationsSection, versionAvailable } = getElements(wrapper);
-    expect(updateSection().exists()).toEqual(true);
-    expect(notificationsSection().is('section')).toEqual(true);
-    // { useGrouping: false } intl option not working, but probably won't see such a large number
-    expect(versionAvailable()).toEqual('Version 1,000 available');
+    expect(wrapper.text()).toContain('Version 1,000 available');
   });
 
   it('in LOCALIMPORT, clicking the "update" button triggers a downloadChannelMetadata action', () => {
@@ -114,9 +89,9 @@ describe('selectContentPage', () => {
       driveId: 'drive_1',
     };
     const wrapper = makeWrapper({ store });
-    const { updateButton } = getElements(wrapper);
+    const updateButton = wrapper.find('button[name="update"]');
     const stub = jest.spyOn(wrapper.vm, 'downloadChannelMetadata').mockResolvedValue();
-    updateButton().trigger('click');
+    updateButton.trigger('click');
     expect(stub).toHaveBeenCalled();
   });
 
@@ -124,17 +99,15 @@ describe('selectContentPage', () => {
     updateMetaChannel(store, { version: 1000 });
     store.state.manageContent.wizard.transferType = 'remoteimport';
     const wrapper = makeWrapper({ store });
-    const { updateButton } = getElements(wrapper);
+    const updateButton = wrapper.find('button[name="update"]');
     const stub = jest.spyOn(wrapper.vm, 'downloadChannelMetadata').mockResolvedValue();
-    updateButton().trigger('click');
+    updateButton.trigger('click');
     expect(stub).toHaveBeenCalled();
   });
 
   it('if a new version is not available, then no notification/button appear', () => {
     updateMetaChannel(store, { version: 10 }); // same version
     const wrapper = makeWrapper({ store });
-    const { updateSection, notificationsSection } = getElements(wrapper);
-    expect(notificationsSection().isEmpty()).toEqual(true);
-    expect(updateSection().exists()).toEqual(false);
+    expect(wrapper.text()).not.toMatch(/Version \S+ available/);
   });
 });

--- a/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-content-page.spec.js
@@ -2,7 +2,6 @@ import VueRouter from 'vue-router';
 import { mount } from '@vue/test-utils';
 import SelectContentPage from '../../src/views/SelectContentPage';
 import ChannelContentsSummary from '../../src/views/SelectContentPage/ChannelContentsSummary';
-import SelectedResourcesSize from '../../src/views/SelectContentPage/SelectedResourcesSize';
 import { makeSelectContentPageStore } from '../utils/makeStore';
 
 SelectContentPage.methods.getAvailableSpaceOnDrive = () => {};


### PR DESCRIPTION

### Summary

make more tweaks for consistency with reports

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52828233-cb83c800-307c-11e9-8d1d-6e1911ae8cb9.png) | ![image](https://user-images.githubusercontent.com/2367265/52828209-b444da80-307c-11e9-832d-97b7ec7937c1.png) |

### Reviewer guidance

look good?


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
