### PR TITLE
add 'needs help' info to progress bar

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/ProgressSummaryBar.vue
@@ -1,12 +1,8 @@
 <template>
 
   <div class="bar-wrapper">
+    <div class="bar help" :style="helpLineStyle"></div>
     <div class="bar" :style="barStyleStarted"></div>
-    <div
-      v-if="showErrorBar"
-      class="help-line"
-      :style="helpLineStyle"
-    ></div>
     <div class="bar" :style="barStyleCompleted"></div>
   </div>
 
@@ -21,12 +17,6 @@
   export default {
     name: 'ProgressSummaryBar',
     mixins: [tallyMixin, themeMixin],
-    props: {
-      showErrorBar: {
-        type: Boolean,
-        default: false,
-      },
-    },
     computed: {
       barStyleCompleted() {
         return {
@@ -46,7 +36,7 @@
         // add on 'completed' for offset
         const widthRatio = this.helpNeeded / this.total;
         return {
-          marginLeft: `${Math.ceil((100 * this.completed) / this.total)}%`,
+          marginLeft: `${Math.ceil((100 * (this.completed + this.started)) / this.total)}%`,
           width: `${Math.ceil(100 * widthRatio)}%`,
           backgroundColor: this.$coreStatusWrong,
         };
@@ -74,18 +64,12 @@
     position: absolute;
     height: 100%;
     margin-right: auto;
-    opacity: 0.55;
+    opacity: 0.75;
     transition: all $core-time ease;
   }
 
-  .help-line {
-    position: absolute;
-    bottom: 0;
-    width: 45%;
-    height: 2px;
-    margin-right: auto;
-    background-color: red;
-    transition: all $core-time ease;
+  .help {
+    opacity: 0.85;
   }
 
 </style>


### PR DESCRIPTION

### Summary

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/52828666-8f516700-307e-11e9-82dd-cd2859516d72.png) | ![image](https://user-images.githubusercontent.com/2367265/52828655-8365a500-307e-11e9-8c0d-0e1d56d12dbd.png) |


### Reviewer guidance

@khangmach @jtamiace thoughts?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
