### PR TITLE
scroll app bar for short windows

### DIFF
--- a/kolibri/core/assets/src/mixins/responsive-window.js
+++ b/kolibri/core/assets/src/mixins/responsive-window.js
@@ -124,6 +124,7 @@ export default {
       */
       windowBreakpoint: undefined,
       windowGutter: 16,
+      windowIsShort: false,
     };
   },
   watch: {
@@ -133,6 +134,7 @@ export default {
     },
     windowHeight() {
       this._updateGutter();
+      this.windowIsShort = this.windowHeight < 600;
     },
   },
   computed: {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -99,7 +99,6 @@
 
   import { mapGetters, mapState, mapActions } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
-  import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiToolbar from 'keen-ui/src/UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
@@ -122,7 +121,7 @@
       LogoutSideNavEntry,
       UserTypeDisplay,
     },
-    mixins: [responsiveWindow, navComponentsMixin, themeMixin],
+    mixins: [navComponentsMixin, themeMixin],
     $trs: {
       userTypeLabel: 'User type',
       languageSwitchMenuOption: 'Change language',

--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -34,7 +34,6 @@
 
   export default {
     name: 'ScrollingHeader',
-    components: {},
     props: {
       // height of the bar being passed into the slot
       height: {

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -300,8 +300,7 @@
         };
       },
       fixedAppBar() {
-        return this.windowIsLarge;
-        // return this.windowIsLarge || this.immersivePage;
+        return this.windowIsLarge && !this.windowIsShort;
       },
       // calls handleScroll no more than every 17ms
       throttledHandleScroll() {


### PR DESCRIPTION

### Summary

Previously, short & wide windows were considered 'large' and the app bar would not hide, even though it would be useful:

![image](https://user-images.githubusercontent.com/2367265/52875169-860cdc80-3108-11e9-8170-4b25dd0b1459.png)

This PR allows the app bar to scroll offscreen when the window is shorter than 600px, regardless of width

### Reviewer guidance

also cleans up some dead code

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
