### PR TITLE
Turn on caching in cherrypy

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -197,6 +197,9 @@ def run_server(port):
         "environment": "production",
         "tools.gzip.on": True,
         "tools.gzip.mime_types": ["text/*", "application/javascript"],
+        "tools.caching.on": True,
+        "tools.caching.maxobj_size": 2000000,
+        "tools.caching.maxsize": 50000000,
     })
 
     serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)


### PR DESCRIPTION
### Summary
We gzip our static assets with cherrypy.
This can lead to long response times when the assets are gzipped.
Cherrypy has built in support for a cross-thread process cache.
This PR turns this on to cache our requests.

### Reviewer guidance
A Siege report with 25 concurrent users fetching the default frontend.
For current release-v0.12.x:
```
Transactions:		         500 hits
Availability:		      100.00 %
Elapsed time:		       22.73 secs
Data transferred:	      157.74 MB
Response time:		        1.09 secs
Transaction rate:	       22.00 trans/sec
Throughput:		        6.94 MB/sec
Concurrency:		       23.94
Successful transactions:         500
Failed transactions:	           0
Longest transaction:	        2.11
Shortest transaction:	        0.41
```
For this PR:
```
Transactions:		         500 hits
Availability:		      100.00 %
Elapsed time:		        2.27 secs
Data transferred:	      157.74 MB
Response time:		        0.07 secs
Transaction rate:	      220.26 trans/sec
Throughput:		       69.49 MB/sec
Concurrency:		       14.94
Successful transactions:         500
Failed transactions:	           0
Longest transaction:	        1.40
Shortest transaction:	        0.00
```

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
