### PR TITLE
Fixes to heartbeat behaviour.

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -40,8 +40,15 @@ const loginTimeoutDetection = interceptor({
     // client code is still trying to access data that they would be allowed to see
     // if they were logged in.
     if (response.status && response.status.code === 403) {
-      // In this case, we should check right now if they are still logged in
-      heartbeat.beat();
+      if (!store.state.core.session.id) {
+        // Don't have any session information, so assume that this
+        // page has just been reopened and the session has expired.
+        // Redirect now!
+        heartbeat.signOutDueToInactivity();
+      } else {
+        // In this case, we should check right now if they are still logged in
+        heartbeat.pollSessionEndPoint();
+      }
     }
     return Promise.reject(response);
   },

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -48,7 +48,7 @@ export class HeartBeat {
     // Do this to have a consistent callback that has 'this' properly bound
     // but can be repeatedly referenced to add and remove listeners.
     this.setUserActive = this.setUserActive.bind(this);
-    this._pollSessionEndPoint = this._pollSessionEndPoint.bind(this);
+    this.pollSessionEndPoint = this.pollSessionEndPoint.bind(this);
     this.setUserInactive();
     this._enabled = false;
   }
@@ -58,7 +58,7 @@ export class HeartBeat {
       this._enabled = true;
       this._setActivityListeners();
       // Do an immediate check to populate session info
-      return this._pollSessionEndPoint();
+      return this.pollSessionEndPoint();
     }
     // Either return the promise for the current session endpoint
     // poll, or return an immediately resolved promise, if that
@@ -106,7 +106,7 @@ export class HeartBeat {
 
   _wait() {
     // Convert delay to milliseconds for use in setTimeout
-    this._timerId = setTimeout(this._pollSessionEndPoint, this._delay * 1000);
+    this._timerId = setTimeout(this.pollSessionEndPoint, this._delay * 1000);
     return this._timerId;
   }
   /*
@@ -167,7 +167,7 @@ export class HeartBeat {
         if (store.state.core.session.id && session.user_id !== currentUserId) {
           if (session.user_id === null) {
             // If it is different, and the user_id is now null then our user has been signed out.
-            return this._signOutDueToInactivity();
+            return this.signOutDueToInactivity();
           } else {
             // Otherwise someone has logged in as another user within the same browser session
             // Redirect them and let that page sort them out.
@@ -209,7 +209,7 @@ export class HeartBeat {
         reconnectionTime = TIMEOUT_RECONNECT_TIME;
       }
       store.commit('CORE_SET_RECONNECT_TIME', reconnectionTime);
-      createDisconnectedSnackbar(store, this._pollSessionEndPoint);
+      createDisconnectedSnackbar(store, this.pollSessionEndPoint);
       this._wait();
     }
   }
@@ -226,7 +226,7 @@ export class HeartBeat {
   /*
    * Method to signout when automatic signout has been detected.
    */
-  _signOutDueToInactivity() {
+  signOutDueToInactivity() {
     // Store that this sign out was for inactivity in local storage.
     Lockr.set(SIGNED_OUT_DUE_TO_INACTIVITY, true);
     // Redirect the user to let the server sort out where they should
@@ -242,7 +242,7 @@ export class HeartBeat {
    * catching any errors and then setting off a timeout for the next
    * session endpoint poll.
    */
-  _pollSessionEndPoint() {
+  pollSessionEndPoint() {
     if (!this._activePromise) {
       if (this._active) {
         this._setActivityListeners();

--- a/kolibri/core/assets/test/heartbeat.spec.js
+++ b/kolibri/core/assets/test/heartbeat.spec.js
@@ -15,9 +15,9 @@ describe('HeartBeat', function() {
       const test = new HeartBeat();
       expect(HeartBeat.prototype.setUserActive).not.toEqual(test.setUserActive);
     });
-    it('should set the _pollSessionEndPoint method to a bound method', function() {
+    it('should set the pollSessionEndPoint method to a bound method', function() {
       const test = new HeartBeat();
-      expect(HeartBeat.prototype._pollSessionEndPoint).not.toEqual(test._pollSessionEndPoint);
+      expect(HeartBeat.prototype.pollSessionEndPoint).not.toEqual(test.pollSessionEndPoint);
     });
     it('should call the setUserInactive method', function() {
       const spy = jest.spyOn(HeartBeat.prototype, 'setUserInactive');
@@ -34,22 +34,22 @@ describe('HeartBeat', function() {
   });
   describe('startPolling method', function() {
     let heartBeat;
-    let _pollSessionEndPointStub;
+    let pollSessionEndPointStub;
     beforeEach(function() {
       heartBeat = new HeartBeat();
-      _pollSessionEndPointStub = jest
-        .spyOn(heartBeat, '_pollSessionEndPoint')
+      pollSessionEndPointStub = jest
+        .spyOn(heartBeat, 'pollSessionEndPoint')
         .mockReturnValue(Promise.resolve());
     });
-    it('should call __pollSessionEndPoint if not currently enabled', function() {
+    it('should call pollSessionEndPoint if not currently enabled', function() {
       heartBeat._enabled = false;
       heartBeat.startPolling();
-      expect(_pollSessionEndPointStub).toHaveBeenCalledTimes(1);
+      expect(pollSessionEndPointStub).toHaveBeenCalledTimes(1);
     });
-    it('should not call __pollSessionEndPoint if currently enabled', function() {
+    it('should not call pollSessionEndPoint if currently enabled', function() {
       heartBeat._enabled = true;
       heartBeat.startPolling();
-      expect(_pollSessionEndPointStub).toHaveBeenCalledTimes(0);
+      expect(pollSessionEndPointStub).toHaveBeenCalledTimes(0);
     });
     it('should return _activePromise if currently defined and _enabled true', function() {
       heartBeat._enabled = true;
@@ -62,7 +62,7 @@ describe('HeartBeat', function() {
       expect(heartBeat.startPolling()).toBeInstanceOf(Promise);
     });
   });
-  describe('_pollSessionEndPoint method', function() {
+  describe('pollSessionEndPoint method', function() {
     let heartBeat;
     let _checkSessionStub;
     beforeEach(function() {
@@ -73,61 +73,61 @@ describe('HeartBeat', function() {
     });
     it('should call setUserInactive', function() {
       const spy = jest.spyOn(heartBeat, 'setUserInactive');
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
     it('should call _wait', function() {
       const spy = jest.spyOn(heartBeat, '_wait');
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
     it('should set _timerId to a setTimeout identifier', function() {
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(typeof heartBeat._timerId).toEqual('number');
       });
     });
     it('should call _checkSession if no _activePromise property', function() {
-      heartBeat._pollSessionEndPoint();
+      heartBeat.pollSessionEndPoint();
       expect(_checkSessionStub).toHaveBeenCalledTimes(1);
     });
     it('should call remove _activePromise property once the session check is complete', function() {
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(heartBeat._activePromise).toBeUndefined();
       });
     });
     it('should call setUserInactive once the session check is complete if enabled', function() {
       const setUserInactiveStub = jest.spyOn(heartBeat, 'setUserInactive');
       heartBeat._enabled = true;
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(setUserInactiveStub).toHaveBeenCalledTimes(1);
       });
     });
     it('should not call setUserInactive once the session check is complete if not enabled', function() {
       const setUserInactiveStub = jest.spyOn(heartBeat, 'setUserInactive');
       heartBeat._enabled = false;
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(setUserInactiveStub).toHaveBeenCalledTimes(0);
       });
     });
     it('should call _wait once the session check is complete if enabled', function() {
       const _waitStub = jest.spyOn(heartBeat, '_wait');
       heartBeat._enabled = true;
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(_waitStub).toHaveBeenCalledTimes(1);
       });
     });
     it('should not call _wait once the session check is complete if not enabled', function() {
       const _waitStub = jest.spyOn(heartBeat, '_wait');
       heartBeat._enabled = false;
-      return heartBeat._pollSessionEndPoint().then(() => {
+      return heartBeat.pollSessionEndPoint().then(() => {
         expect(_waitStub).toHaveBeenCalledTimes(0);
       });
     });
     it('should not call _checkSession if there is an _activePromise property', function() {
       heartBeat._activePromise = Promise.resolve();
-      heartBeat._pollSessionEndPoint();
+      heartBeat.pollSessionEndPoint();
       expect(_checkSessionStub).toHaveBeenCalledTimes(0);
     });
     describe('and activity is detected', function() {
@@ -136,7 +136,7 @@ describe('HeartBeat', function() {
       });
       it('should call _setActivityListeners', function() {
         const spy = jest.spyOn(heartBeat, '_setActivityListeners');
-        heartBeat._pollSessionEndPoint();
+        heartBeat.pollSessionEndPoint();
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
@@ -180,7 +180,7 @@ describe('HeartBeat', function() {
       http.__setCode(200);
       http.__setHeaders({ 'Content-Type': 'application/json' });
       http.__setEntity({ user_id: null, id: 'current' });
-      const stub = jest.spyOn(heartBeat, '_signOutDueToInactivity');
+      const stub = jest.spyOn(heartBeat, 'signOutDueToInactivity');
       return heartBeat._checkSession().finally(() => {
         expect(stub).toHaveBeenCalledTimes(1);
       });
@@ -202,7 +202,7 @@ describe('HeartBeat', function() {
       http.__setCode(200);
       http.__setHeaders({ 'Content-Type': 'application/json' });
       http.__setEntity({ user_id: null, id: 'current' });
-      const stub = jest.spyOn(heartBeat, '_signOutDueToInactivity');
+      const stub = jest.spyOn(heartBeat, 'signOutDueToInactivity');
       return heartBeat._checkSession().finally(() => {
         expect(stub).toHaveBeenCalledTimes(0);
       });


### PR DESCRIPTION
### Summary
Fix failure to rename call to heartbeat.beat.
Make two methods on heartbeat public.
Conditionalise 403 redirect behaviour on existence of a session.

### Reviewer guidance
What happens if you shut the window then reopen it after 10 minutes have elapsed?

### References
Fixes #5014
Does cleanup from #4984

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
