### PR TITLE
Fixes for 0.12b5 bugs

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -409,7 +409,6 @@
     left: 0;
     overflow-x: auto;
     overflow-y: scroll; // has to be scroll, not auto
-    -webkit-overflow-scrolling: touch; // iOS momentum scrolling
   }
 
   .click-mask {

--- a/kolibri/core/assets/src/views/InteractionList/index.vue
+++ b/kolibri/core/assets/src/views/InteractionList/index.vue
@@ -12,11 +12,8 @@
       />
     </div>
 
-    <p v-if="interactions.length">
-      {{ $tr('currAnswer', {value: selectedInteractionIndex + 1 }) }}
-    </p>
-    <p v-else>
-      {{ $tr('noInteractions') }}
+    <p>
+      {{ interactionsMessage }}
     </p>
 
   </div>
@@ -45,6 +42,18 @@
       selectedInteractionIndex: {
         type: Number,
         required: true,
+      },
+    },
+    computed: {
+      interactionsMessage() {
+        const numAttempts = this.interactions.length;
+        if (numAttempts === 0) {
+          return this.$tr('noInteractions');
+        }
+        if (numAttempts > 1) {
+          return this.$tr('currAnswer', { value: this.selectedInteractionIndex + 1 });
+        }
+        return '';
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -17,6 +17,7 @@
         v-for="notification in notifications"
         v-show="showNotification(notification)"
         :key="notification.id"
+        class="notification-card"
         v-bind="cardPropsForNotification(notification)"
         :linkText="cardTextForNotification(notification)"
       />
@@ -388,6 +389,17 @@
 
   .show-more {
     height: 100px;
+  }
+
+  // Copied from BlockItem.vue
+  .notification-card {
+    padding-right: 24px;
+    padding-bottom: 16px;
+    padding-left: 24px;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid #dedede;
+    }
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -5,7 +5,7 @@
     immersivePageIcon="arrow_back"
     immersivePagePrimary
     :immersivePageRoute="toolbarRoute"
-    :appBarTitle="coachStrings.$tr('coachLabel')"
+    :appBarTitle="$tr('createNewExam')"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
     :pageTitle="$tr('documentTitle')"

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -10,84 +10,86 @@
     :immersivePageRoute="$router.getRoute('GroupMembersPage')"
     :pageTitle="pageTitle"
   >
-    <h1>
-      {{ learnerClassEnrollmentPageStrings.$tr('pageHeader', { className: currentGroup.name }) }}
-    </h1>
-    <form @submit.prevent="addSelectedUsersToGroup">
-      <div class="actions-header">
-        <KFilterTextbox
-          v-model.trim="filterInput"
-          :placeholder="classEnrollFormStrings.$tr('searchForUser')"
-          @input="pageNum = 1"
+    <KPageContainer>
+      <h1>
+        {{ learnerClassEnrollmentPageStrings.$tr('pageHeader', { className: currentGroup.name }) }}
+      </h1>
+      <form @submit.prevent="addSelectedUsersToGroup">
+        <div class="actions-header">
+          <KFilterTextbox
+            v-model.trim="filterInput"
+            :placeholder="classEnrollFormStrings.$tr('searchForUser')"
+            @input="pageNum = 1"
+          />
+        </div>
+
+        <h2>{{ classEnrollFormStrings.$tr('userTableLabel') }}</h2>
+
+        <UserTable
+          v-model="selectedUsers"
+          :users="visibleFilteredUsers"
+          :selectable="true"
+          :selectAllLabel="classEnrollFormStrings.$tr('selectAllOnPage')"
+          :userCheckboxLabel="classEnrollFormStrings.$tr('selectUser')"
+          :emptyMessage="emptyMessage"
         />
-      </div>
 
-      <h2>{{ classEnrollFormStrings.$tr('userTableLabel') }}</h2>
+        <nav>
+          <span>
+            {{ classEnrollFormStrings.$tr('pagination', {
+              visibleStartRange,
+              visibleEndRange,
+              numFilteredUsers
+            }) }}
+          </span>
+          <UiIconButton
+            type="primary"
+            :ariaLabel="classEnrollFormStrings.$tr('previousResults')"
+            :disabled="pageNum === 1"
+            size="small"
+            @click="goToPage(pageNum - 1)"
+          >
+            <mat-svg
+              v-if="isRtl"
+              name="chevron_right"
+              category="navigation"
+            />
+            <mat-svg
+              v-else
+              name="chevron_left"
+              category="navigation"
+            />
+          </UiIconButton>
+          <UiIconButton
+            type="primary"
+            :ariaLabel="classEnrollFormStrings.$tr('nextResults')"
+            :disabled="pageNum === numPages"
+            size="small"
+            @click="goToPage(pageNum + 1)"
+          >
+            <mat-svg
+              v-if="isRtl"
+              name="chevron_left"
+              category="navigation"
+            />
+            <mat-svg
+              v-else
+              name="chevron_right"
+              category="navigation"
+            />
+          </UiIconButton>
+        </nav>
 
-      <UserTable
-        v-model="selectedUsers"
-        :users="visibleFilteredUsers"
-        :selectable="true"
-        :selectAllLabel="classEnrollFormStrings.$tr('selectAllOnPage')"
-        :userCheckboxLabel="classEnrollFormStrings.$tr('selectUser')"
-        :emptyMessage="emptyMessage"
-      />
-
-      <nav>
-        <span>
-          {{ classEnrollFormStrings.$tr('pagination', {
-            visibleStartRange,
-            visibleEndRange,
-            numFilteredUsers
-          }) }}
-        </span>
-        <UiIconButton
-          type="primary"
-          :ariaLabel="classEnrollFormStrings.$tr('previousResults')"
-          :disabled="pageNum === 1"
-          size="small"
-          @click="goToPage(pageNum - 1)"
-        >
-          <mat-svg
-            v-if="isRtl"
-            name="chevron_right"
-            category="navigation"
+        <div class="footer">
+          <KButton
+            :text="classEnrollFormStrings.$tr('confirmSelectionButtonLabel')"
+            :primary="true"
+            type="submit"
+            :disabled="selectedUsers.length === 0"
           />
-          <mat-svg
-            v-else
-            name="chevron_left"
-            category="navigation"
-          />
-        </UiIconButton>
-        <UiIconButton
-          type="primary"
-          :ariaLabel="classEnrollFormStrings.$tr('nextResults')"
-          :disabled="pageNum === numPages"
-          size="small"
-          @click="goToPage(pageNum + 1)"
-        >
-          <mat-svg
-            v-if="isRtl"
-            name="chevron_left"
-            category="navigation"
-          />
-          <mat-svg
-            v-else
-            name="chevron_right"
-            category="navigation"
-          />
-        </UiIconButton>
-      </nav>
-
-      <div class="footer">
-        <KButton
-          :text="classEnrollFormStrings.$tr('confirmSelectionButtonLabel')"
-          :primary="true"
-          type="submit"
-          :disabled="selectedUsers.length === 0"
-        />
-      </div>
-    </form>
+        </div>
+      </form>
+    </KPageContainer>
 
 
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
@@ -8,7 +8,6 @@
     @cancel="close"
   >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
-    <p>{{ $tr('learnersWillBecomeUngrouped') }}</p>
   </KModal>
 
 </template>
@@ -24,7 +23,6 @@
     $trs: {
       deleteLearnerGroup: 'Delete group',
       areYouSure: "Are you sure you want to delete '{ groupName }'?",
-      learnersWillBecomeUngrouped: "Learners within this group will become 'Ungrouped'.",
       cancel: 'Cancel',
       deleteGroup: 'Delete',
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -160,6 +160,12 @@
     padding: 16px;
   }
 
+  .description {
+    // HACK to get long descriptions to fit in the card
+    height: $thumb-height * 0.5;
+    overflow-y: scroll;
+  }
+
   .title,
   .description {
     margin: 0;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -160,12 +160,6 @@
     padding: 16px;
   }
 
-  .description {
-    // HACK to get long descriptions to fit in the card
-    height: $thumb-height * 0.5;
-    overflow-y: scroll;
-  }
-
   .title,
   .description {
     margin: 0;
@@ -189,6 +183,9 @@
   }
 
   .description {
+    // HACK to get long descriptions to fit in the card
+    height: $thumb-height * 0.5;
+    overflow-y: scroll;
     font-size: 14px;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -41,7 +41,7 @@
         <KRouterLink
           v-if="!isTopic"
           :text="$tr('previewButtonLabel')"
-          :to="{}"
+          :to="link"
         />
       </p>
     </div>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -2,6 +2,7 @@
 
   <form
     class="box"
+    :class="searchClasses"
     @submit.prevent="search"
     @keydown.esc.prevent="clearSearchTerm"
   >
@@ -84,6 +85,11 @@
       };
     },
     computed: {
+      searchClasses() {
+        return this.$computedClass({
+          borderColor: this.$coreTextAnnotation,
+        });
+      },
       searchTermHasChanged() {
         return this.searchTerm !== this.$route.params.searchTerm;
       },
@@ -115,6 +121,8 @@
 
   .box {
     margin-right: 8px;
+    border-style: solid;
+    border-width: 1px;
   }
 
   .box-within-action-bar {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -11,7 +11,7 @@
     :pageTitle="pageTitle"
   >
 
-    <div>
+    <KPageContainer>
       <h1>
         {{ $tr('documentTitle', { lessonName: currentLesson.title }) }}
       </h1>
@@ -65,7 +65,7 @@
         @moreresults="handleMoreResults"
       />
 
-    </div>
+    </KPageContainer>
 
     <Bottom>
       <KRouterLink

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -5,7 +5,7 @@
     immersivePageIcon="close"
     immersivePagePrimary
     :immersivePageRoute="toolbarRoute"
-    :appBarTitle="coachStrings.$tr('coachLabel')"
+    :appBarTitle="coachStrings.$tr('manageResourcesAction')"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
     :pageTitle="pageTitle"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -43,7 +43,6 @@
       v-else-if="lessonsModalSet === AssignmentActions.DELETE"
       :modalTitle="$tr('deleteLessonTitle')"
       :modalDescription="$tr('deleteLessonConfirmation', { title: currentLesson.title })"
-      :modalConfirmation="$tr('deleteLessonReassurance')"
       @delete="deleteLesson({ lessonId: currentLesson.id, classId })"
       @cancel="setLessonsModal(null)"
     />
@@ -143,7 +142,6 @@
       assignmentQuestion: 'Assign lesson to',
       deleteLessonTitle: 'Delete lesson',
       deleteLessonConfirmation: "Are you sure you want to delete '{ title }'?",
-      deleteLessonReassurance: 'You can still view progress on these resources from Channels',
       editLessonDetails: 'Edit lesson details',
       newLesson: 'Create new lesson',
       saveLessonError: 'There was a problem saving this lesson',

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -4,7 +4,7 @@
     :immersivePage="true"
     immersivePageIcon="arrow_back"
     :immersivePageRoute="toolbarRoute"
-    :appBarTitle="coachStrings.$tr('coachLabel')"
+    :appBarTitle="coachStrings.$tr('manageResourcesAction')"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
   >

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -4,7 +4,7 @@
     :immersivePage="true"
     immersivePageIcon="arrow_back"
     :immersivePageRoute="toolbarRoute"
-    :appBarTitle="coachStrings.$tr('coachLabel')"
+    :appBarTitle="appBarTitle"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
   >
@@ -29,8 +29,10 @@
   import commonCoach from '../common';
   import LessonContentPreviewPage from '../plan/LessonContentPreviewPage';
   import Index from '../CoachIndex';
+  import CreateExamPage from './CreateExamPage';
 
   const indexStrings = crossComponentTranslator(Index);
+  const CreateExamPageStrings = crossComponentTranslator(CreateExamPage);
 
   export default {
     name: 'PlanQuizPreviewPage',
@@ -38,12 +40,14 @@
       LessonContentPreviewPage,
     },
     mixins: [commonCoach],
-    $trs: {},
     computed: {
       ...mapState(['toolbarRoute']),
       ...mapState('examCreation', ['preview', 'selectedExercises', 'currentContentNode']),
       isSelected() {
         return Boolean(this.selectedExercises[this.currentContentNode.id]);
+      },
+      appBarTitle() {
+        return CreateExamPageStrings.$tr('createNewExam');
       },
     },
     beforeDestroy() {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
@@ -8,7 +8,7 @@
     @cancel="closeModal"
   >
     <p>{{ modalDescription }}</p>
-    <p>{{ modalConfirmation }}</p>
+    <p v-if="modalConfirmation">{{ modalConfirmation }}</p>
   </KModal>
 
 </template>

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -221,6 +221,8 @@
 <style lang="scss" scoped>
 
   .select-all {
+    // Overrides overflow-x: hidden rule for CoreTable th's
+    overflow-x: visible;
     white-space: nowrap;
     .k-checkbox-container {
       margin-right: -70px;

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -13,11 +13,16 @@
               :label="selectAllLabel"
               :showLabel="true"
               :checked="allAreSelected"
+              class="overflow-label"
               @change="selectAll($event)"
             />
           </th>
-          <!-- "Full name" header is empty if checkbox is on -->
-          <th v-else> {{ $tr('fullName') }}</th>
+          <th>
+            <!-- "Full name" header visually hidden if checkbox is on -->
+            <span :class="{visuallyhidden: selectable}">
+              {{ $tr('fullName') }}
+            </span>
+          </th>
           <th>
             <span class="visuallyhidden">
               {{ $tr('role') }}
@@ -191,8 +196,10 @@
 <style lang="scss" scoped>
 
   .select-all {
+    position: relative;
     // Overrides overflow-x: hidden rule for CoreTable th's
     overflow-x: visible;
+
     // white-space: nowrap;
     .k-checkbox-container {
       margin-right: -70px;
@@ -232,6 +239,12 @@
     max-width: 200px;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .overflow-label {
+    position: absolute;
+    top: 8px;
+    white-space: nowrap;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -5,15 +5,19 @@
 
       <thead slot="thead">
         <tr>
-          <th v-if="selectable" class="core-table-checkbox-col">
+          <th
+            v-if="selectable"
+            class="core-table-checkbox-col select-all"
+          >
             <KCheckbox
               :label="selectAllLabel"
-              :showLabel="false"
+              :showLabel="true"
               :checked="allAreSelected"
               @change="selectAll($event)"
             />
           </th>
-          <th>{{ $tr('fullName') }}</th>
+          <!-- "Full name" header is empty -->
+          <th></th>
           <th>
             <span class="visuallyhidden">
               {{ $tr('role') }}
@@ -185,6 +189,20 @@
 
 
 <style lang="scss" scoped>
+
+  .select-all {
+    // Overrides overflow-x: hidden rule for CoreTable th's
+    overflow-x: visible;
+    // white-space: nowrap;
+    .k-checkbox-container {
+      margin-right: -70px;
+    }
+
+    .k-checkbox-label {
+      // Add extra padding to align label with table headers
+      padding-top: 4px;
+    }
+  }
 
   .empty-message {
     margin-bottom: 16px;

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -16,8 +16,8 @@
               @change="selectAll($event)"
             />
           </th>
-          <!-- "Full name" header is empty -->
-          <th></th>
+          <!-- "Full name" header is empty if checkbox is on -->
+          <th v-else> {{ $tr('fullName') }}</th>
           <th>
             <span class="visuallyhidden">
               {{ $tr('role') }}


### PR DESCRIPTION
### Summary
1. Fixes #4825 (but reverts fix for #2279) to fix app-bar issues on iOS
1. Fixes #5087 by removing secondary message on Lesson Deletion modal
1. Fixes #5084 by removing "ungrouped learners" message on Group Deletion modal
1. Wrap GroupEnrollPage main area in a KPageContainer
1. Fixes #5098 by providing proper link object to the "view" link component
1. Fixes #5082 by overriding, in the ContentTreeViewer, the rule that hides x-overflow in the checkbox column
1. Fixes #5055 by only showing the "Attempt N" label when a (quiz) exercise has logged 2+ attempts
1. Fixes #5085 by replacing "Full name" column with the "select all" checkbox label and adjusting it to align better with rest of header. (it uses the somewhat verbose "select all on page" string that was already on the component).

![screen shot 2019-02-19 at 2 33 22 pm](https://user-images.githubusercontent.com/10248067/53052999-0ad35f80-3455-11e9-836a-819c8c812841.png)

1. Fix strings (fixes #5086) and layout in lesson resource management workflow (fix strings on immersive app bar, wrap contents in KPageContainer, make adjustments to contentcards with long descriptions, adjust searchbox)
1. Fixes the strings  for exam Creation (similar to #5086)

**Before**

![screen shot 2019-02-19 at 3 28 31 pm](https://user-images.githubusercontent.com/10248067/53055036-36594880-345b-11e9-80f9-2375457affdd.png)

**After**

![screen shot 2019-02-19 at 3 30 57 pm](https://user-images.githubusercontent.com/10248067/53055101-66085080-345b-11e9-86ee-b4669b2bf0b4.png)

### Reviewer guidance
1. Go over the original issues and manually verify that they are resolved by this patch.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
