### PR TITLE
styling for disabled buttons

### DIFF
--- a/kolibri/core/assets/src/views/buttons-and-links/buttonMixin.js
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttonMixin.js
@@ -61,7 +61,8 @@ export default {
         },
         ':focus': this.$coreOutline,
         ':disabled': {
-          color: `rgba(${this.$coreActionNormal}, 0.5)`,
+          color: this.$coreActionNormal,
+          opacity: 0.5,
         },
       };
     },
@@ -76,7 +77,8 @@ export default {
         ':disabled': Object.assign(
           {
             color: $primaryRaisedDisabledColor,
-            backgroundColor: `rgba(${this.$coreActionNormal}, 0.75)`,
+            backgroundColor: this.$coreActionNormal,
+            opacity: 0.5,
             svg: {
               fill: $primaryRaisedDisabledColor,
             },
@@ -97,9 +99,10 @@ export default {
         ':focus': { ...this.$coreOutline, outlineOffset: 0 },
         ':disabled': Object.assign(
           {
-            color: `rgba(${this.$coreActionNormal}, 0.5)`,
+            color: this.$coreActionNormal,
+            opacity: 0.5,
             svg: {
-              fill: `rgba(${this.$coreActionNormal}, 0.5)`,
+              fill: this.$coreActionNormal,
             },
           },
           disabledStyle
@@ -119,10 +122,11 @@ export default {
         ':focus': { ...this.$coreOutline, outlineOffset: '6px' },
         ':disabled': Object.assign(
           {
-            color: `rgba(${this.$coreTextDefault}, 0.25)`,
-            backgroundColor: `rgba(${this.$coreTextDefault}, 0.1)`,
+            color: this.$coreTextDefault,
+            opacity: 0.25,
+            backgroundColor: this.$coreTextDefault,
             svg: {
-              fill: `rgba(${this.$coreTextDefault}, 0.25)`,
+              fill: this.$coreTextDefault,
             },
           },
           disabledStyle
@@ -141,7 +145,8 @@ export default {
         ':focus': { ...this.$coreOutline, outlineOffset: 0 },
         ':disabled': Object.assign(
           {
-            color: `rgba(${this.$coreTextDefault}, 0.25)`,
+            color: this.$coreTextDefault,
+            opacity: 0.25,
             svg: {
               fill: this.$coreTextDefault,
             },

--- a/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
@@ -28,7 +28,7 @@ exports[`side nav component should be hidden if navShown is false 1`] = `
         <div class="side-nav-scrollable-area-footer-info">
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
-          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_khtjim link">Usage and privacy
+          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_5bbo9m link">Usage and privacy
               <!----></a></p>
         </div>
       </div>
@@ -75,7 +75,7 @@ exports[`side nav component should show nothing if no components are added and u
         <div class="side-nav-scrollable-area-footer-info">
           <p>Kolibri testversion</p>
           <p>© 2018 Learning Equality</p>
-          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_khtjim link">Usage and privacy
+          <p><a dir="auto" type="button" tabindex="0" class="privacy-link KButton-noKey-0_5bbo9m link">Usage and privacy
               <!----></a></p>
         </div>
       </div>


### PR DESCRIPTION
### Summary

fixes #5104


| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/2367265/53111781-a1a22980-34f2-11e9-9c08-9a1546a7b1e3.png)|![image](https://user-images.githubusercontent.com/2367265/53111765-97802b00-34f2-11e9-9515-9370238596c2.png)|

### Reviewer guidance

the `rbga` values weren't being calculated correctly, presumably because the dynamic color was a hex value? I tried setting the alpha as a single 8-digit hex number but that didn't work either, so I gave up and switched to this strategy.

The alphas are a little different, but I think they should be more consistent now



### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
