### PR TITLE
Don't check ports if CherryPy is  not going to start

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -617,7 +617,8 @@ def main(args=None):  # noqa: max-complexity=13
 
     if arguments['start']:
         port = _get_port(arguments['--port'])
-        check_other_kolibri_running(port)
+        if OPTIONS["Server"]["CHERRYPY_START"]:
+            check_other_kolibri_running(port)
 
     try:
         initialize(debug=debug)


### PR DESCRIPTION
### Summary
In version 0.12 we have added the option CHERRYPY_START to disable CherryPY server when starting kolibri.
If this option is not enabled we should not check available ports, thus not raising an error if the port selected to run kolibri is already open (when using kolibri-server it will be open by nginx)


### Reviewer guidance
Simple fix looking at the code 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
