### PR TITLE
Manually blur text-link-style KButtons when they are clicked or enter-keyed

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -201,9 +201,6 @@
       },
       handleClickPrivacyLink() {
         this.privacyModalVisible = true;
-        // HACK to fix https://github.com/learningequality/kolibri/issues/4973.
-        // For some reason, the button maintains focus even when the modal is opened.
-        this.$refs.privacyLink.$el.blur();
       },
       compareMenuComponents(navComponentA, navComponentB) {
         // Compare menu items to allow sorting by the following priority:

--- a/kolibri/core/assets/src/views/buttons-and-links/KButton.vue
+++ b/kolibri/core/assets/src/views/buttons-and-links/KButton.vue
@@ -9,7 +9,7 @@
     :disabled="disabled"
     tabindex="0"
     @click="handleClick"
-    @keyup.enter.stop.prevent="handlePress"
+    @keyup.enter.stop.prevent="handelPressEnter"
   >
     <slot v-if="$slots.default"></slot>
     <template v-else>{{ text }}</template>
@@ -83,12 +83,22 @@
         /**
          * Emitted when the button is triggered
          */
+        this.blurWhenClicked();
         this.$emit('click', event);
       },
-      handlePress(event) {
+      handelPressEnter(event) {
+        this.blurWhenClicked();
         // HACK: for 'a' tags, the 'click' event is not getting fired
         if (this.htmlTag === 'a') {
           this.$emit('click', event);
+        }
+      },
+      // To prevent the <a> from maintaining focus when link does not
+      // destroy parent component (e.g. opens a modal), we need to blur it,
+      // because it will be "clicked" again when the user hits the Enter key.
+      blurWhenClicked() {
+        if (this.htmlTag === 'a') {
+          this.$el.blur();
         }
       },
     },


### PR DESCRIPTION
### Summary

Fixes #5103 and the root cause of #4973 by manually blurring the component when it is clicked or enter-keyed. This prevents the link/button from being re-clicked when the user dismisses/submits a modal by hitting Enter (but has the other, hopefully less noticeable side effect of removing focus from that link, so the user will need to refocus it if a keyboard-only user).

### Reviewer guidance

In #5103, there is a list of all the pages where there was a problem with dismissing a modal by keyboard. Go to all of them and test that

1. If you click the link and dismiss the modal with a keyboard, the modal does not re-appear
1. If you "click" the link via keyboard, it''s the same.

And, until you are satisfied, check that other k-button text links that do something other than open a modal still work properly (if they exist).
### References

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
