### PR TITLE
In showExam handler, redirect to the report if the exam is closed

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -12,7 +12,7 @@ import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import router from 'kolibri.coreVue.router';
 import shuffled from 'kolibri.utils.shuffled';
 import { canViewExam } from '../../utils/exams';
-import { PageNames, ClassesPageNames } from '../../constants';
+import { ClassesPageNames } from '../../constants';
 import { contentState } from '../coreLearn/utils';
 import { calcQuestionsAnswered } from './utils';
 
@@ -47,7 +47,15 @@ export function showExam(store, params) {
         if (examLogs.length > 0 && examLogs.some(log => !log.closed)) {
           store.commit('SET_EXAM_LOG', examLogs.find(log => !log.closed));
         } else if (examLogs.length > 0 && examLogs.some(log => log.closed)) {
-          return router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+          // If exam is closed, then redirect to route for the report
+          return router.replace({
+            name: ClassesPageNames.EXAM_REPORT_VIEWER,
+            params: {
+              ...examParams,
+              questionNumber: 0,
+              questionInteraction: 0,
+            },
+          });
         } else {
           ExamLogResource.createModel({ ...examParams, closed: false })
             .save()


### PR DESCRIPTION
### Summary

Fixes #5097 in probably the simplest way by redirecting a closed/submitted exam to its report page. The original behavior seems to be a holdover when an exam whose main channel was deleted would be redirected to the no content page.

### Reviewer guidance

1. Re-do the scenario in #5097 and make sure it goes to the report (try it also with different values for the `questionNumber` route parameter)
1. Make sure the original case where a not-started or in-progress quiz goes to the normal quiz page works

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
