### PR TITLE
Remove inconsistencies for not started exercises

### DIFF
--- a/kolibri/core/logger/serializers.py
+++ b/kolibri/core/logger/serializers.py
@@ -1,5 +1,6 @@
 from django.db.models import Sum
 from django.utils.timezone import now
+from le_utils.constants import content_kinds
 from le_utils.constants import exercises
 from rest_framework import serializers
 
@@ -158,6 +159,10 @@ class ContentSummaryLogSerializer(KolibriModelSerializer):
 
     def create(self, validated_data):
         instance = super(ContentSummaryLogSerializer, self).create(validated_data)
+        # dont create notifications upon creating a summary log for an exercise
+        # notifications should only be triggered upon first attempting a question in the exercise
+        if instance.kind == content_kinds.EXERCISE:
+            return instance
         # to check if a notification must be created:
         wrap_to_save_queue(create_summarylog, instance)
         return instance

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -190,6 +190,11 @@ def parse_summarylog(summarylog):
     Lesson Completed notification.
     """
 
+    # updating an exercise summary log might mean they made their first attempt in the exercise/lesson
+    # we try to create notifications for this event
+    if summarylog.kind == content_kinds.EXERCISE:
+        create_summarylog(summarylog)
+
     if summarylog.progress < 1.0:
         return
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -91,7 +91,10 @@
         return this._.meanBy(statuses, 'score');
       },
       lastActivity(examStatuses, contentStatuses) {
-        const statuses = [...examStatuses, ...contentStatuses];
+        const statuses = [
+          ...examStatuses,
+          ...contentStatuses.filter(status => status.status !== this.STATUSES.notStarted),
+        ];
         if (!statuses.length) {
           return null;
         }

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -104,7 +104,10 @@
       lastActivity(learnerIds) {
         const statuses = [
           ...this.examStatuses.filter(status => learnerIds.includes(status.learner_id)),
-          ...this.contentStatuses.filter(status => learnerIds.includes(status.learner_id)),
+          ...this.contentStatuses.filter(
+            status =>
+              status.status !== this.STATUSES.notStarted && learnerIds.includes(status.learner_id)
+          ),
         ];
         if (!statuses.length) {
           return null;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -31,7 +31,7 @@
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
               <KRouterLink
-                v-if="tableRow.status.status !== STATUSES.notStarted"
+                v-if="showLink(tableRow.statusObj.status)"
                 :text="tableRow.name"
                 :to="link(tableRow.id)"
               />
@@ -102,6 +102,9 @@
         return this.classRoute(PageNames.REPORTS_GROUP_REPORT_LESSON_EXERCISE_LEARNER_PAGE_ROOT, {
           learnerId,
         });
+      },
+      showLink(status) {
+        return status !== this.STATUSES.notStarted;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -98,7 +98,10 @@
         return this._.meanBy(statuses, 'score');
       },
       lastActivity(examStatuses, contentStatuses) {
-        const statuses = [...examStatuses, ...contentStatuses];
+        const statuses = [
+          ...examStatuses,
+          ...contentStatuses.filter(status => status.status !== this.STATUSES.notStarted),
+        ];
         if (!statuses.length) {
           return null;
         }

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -66,8 +66,7 @@
             </td>
             <td>
               <TimeDuration
-                v-if="tableRow.statusObj.status !== STATUSES.notStarted"
-                :seconds="tableRow.statusObj.time_spent"
+                :seconds="showTime(tableRow)"
               />
             </td>
           </tr>
@@ -83,8 +82,6 @@
 
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
-  import { STATUSES } from '../../modules/classSummary/constants';
-
   import LessonSummaryPage from '../plan/LessonSummaryPage';
 
   const LessonSummaryPageStrings = crossComponentTranslator(LessonSummaryPage);
@@ -119,8 +116,14 @@
       showLink(tableRow) {
         return (
           tableRow.kind === this.ContentNodeKinds.EXERCISE &&
-          tableRow.statusObj.status !== STATUSES.notStarted
+          tableRow.statusObj.status !== this.STATUSES.notStarted
         );
+      },
+      showTime(tableRow) {
+        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
+          return tableRow.statusObj.time_spent;
+        }
+        return undefined;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -49,7 +49,7 @@
               <KLabeledIcon>
                 <KBasicContentIcon slot="icon" :kind="tableRow.kind" />
                 <KRouterLink
-                  v-if="tableRow.kind === 'exercise'"
+                  v-if="showLink(tableRow)"
                   :text="tableRow.title"
                   :to="classRoute(
                     'ReportsLearnerReportLessonExercisePage',
@@ -65,7 +65,10 @@
               <StatusSimple :status="tableRow.statusObj.status" />
             </td>
             <td>
-              <TimeDuration :seconds="tableRow.statusObj.time_spent" />
+              <TimeDuration
+                v-if="tableRow.statusObj.status !== STATUSES.notStarted"
+                :seconds="tableRow.statusObj.time_spent"
+              />
             </td>
           </tr>
         </transition-group>
@@ -80,6 +83,8 @@
 
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
+  import { STATUSES } from '../../modules/classSummary/constants';
+
   import LessonSummaryPage from '../plan/LessonSummaryPage';
 
   const LessonSummaryPageStrings = crossComponentTranslator(LessonSummaryPage);
@@ -108,6 +113,14 @@
           return tableRow;
         });
         return mapped;
+      },
+    },
+    methods: {
+      showLink(tableRow) {
+        return (
+          tableRow.kind === this.ContentNodeKinds.EXERCISE &&
+          tableRow.statusObj.status !== STATUSES.notStarted
+        );
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -36,7 +36,7 @@
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
               <KRouterLink
-                v-if="showComponent(tableRow.statusObj.status)"
+                v-if="showLink(tableRow)"
                 :text="tableRow.name"
                 :to="link(tableRow.id)"
               />
@@ -47,8 +47,7 @@
             </td>
             <td>
               <TimeDuration
-                v-if="showComponent(tableRow.statusObj.status)"
-                :seconds="tableRow.statusObj.time_spent"
+                :seconds="showTimeDuration(tableRow)"
               />
             </td>
             <td>
@@ -56,8 +55,7 @@
             </td>
             <td>
               <ElapsedTime
-                v-if="showComponent(tableRow.statusObj.status)"
-                :date="tableRow.statusObj.last_activity"
+                :date="showElapsedTime(tableRow)"
               />
             </td>
           </tr>
@@ -73,8 +71,6 @@
 
   import commonCoach from '../common';
   import { PageNames } from '../../constants';
-  import { STATUSES } from '../../modules/classSummary/constants';
-
   import ReportsLessonExerciseHeader from './ReportsLessonExerciseHeader';
 
   export default {
@@ -114,8 +110,20 @@
       link(learnerId) {
         return this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, { learnerId });
       },
-      showComponent(status) {
-        return status !== STATUSES.notStarted;
+      showLink(tableRow) {
+        return tableRow.statusObj.status !== this.STATUSES.notStarted;
+      },
+      showTimeDuration(tableRow) {
+        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
+          return tableRow.statusObj.time_spent;
+        }
+        return undefined;
+      },
+      showElapsedTime(tableRow) {
+        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
+          return tableRow.statusObj.last_activity;
+        }
+        return undefined;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -36,24 +36,28 @@
           <tr v-for="tableRow in table" :key="tableRow.id">
             <td>
               <KRouterLink
-                v-if="tableRow.status.status !== STATUSES.notStarted"
+                v-if="showComponent(tableRow.statusObj.status)"
                 :text="tableRow.name"
                 :to="link(tableRow.id)"
               />
               <template v-else>{{ tableRow.name }}</template>
             </td>
             <td>
-              <StatusSimple :status="tableRow.status.status" />
+              <StatusSimple :status="tableRow.statusObj.status" />
             </td>
             <td>
-              <TimeDuration :seconds="tableRow.status.time_spent" />
+              <TimeDuration
+                v-if="showComponent(tableRow.statusObj.status)"
+                :seconds="tableRow.statusObj.time_spent"
+              />
             </td>
             <td>
               <TruncatedItemList :items="tableRow.groups" />
             </td>
             <td>
               <ElapsedTime
-                :date="tableRow.status.last_activity"
+                v-if="showComponent(tableRow.statusObj.status)"
+                :date="tableRow.statusObj.last_activity"
               />
             </td>
           </tr>
@@ -69,6 +73,8 @@
 
   import commonCoach from '../common';
   import { PageNames } from '../../constants';
+  import { STATUSES } from '../../modules/classSummary/constants';
+
   import ReportsLessonExerciseHeader from './ReportsLessonExerciseHeader';
 
   export default {
@@ -93,7 +99,10 @@
         const mapped = sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
-            status: this.getContentStatusObjForLearner(this.$route.params.exerciseId, learner.id),
+            statusObj: this.getContentStatusObjForLearner(
+              this.$route.params.exerciseId,
+              learner.id
+            ),
           };
           Object.assign(tableRow, learner);
           return tableRow;
@@ -104,6 +113,9 @@
     methods: {
       link(learnerId) {
         return this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, { learnerId });
+      },
+      showComponent(status) {
+        return status !== STATUSES.notStarted;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -47,10 +47,11 @@
             <td>
               <StatusSimple :status="tableRow.statusObj.status" />
             </td>
-            <td><TimeDuration
-              v-if="tableRow.statusObj.status !== STATUSES.notStarted"
-              :seconds="tableRow.statusObj.time_spent"
-            /></td>
+            <td>
+              <TimeDuration
+                :seconds="showTimeDuration(tableRow)"
+              />
+            </td>
           </tr>
         </transition-group>
       </CoreTable>
@@ -63,7 +64,6 @@
 <script>
 
   import commonCoach from '../common';
-  import { STATUSES } from '../../modules/classSummary/constants';
   import { PageNames } from './../../constants';
 
   export default {
@@ -97,8 +97,14 @@
       showLink(tableRow) {
         return (
           tableRow.kind === this.ContentNodeKinds.EXERCISE &&
-          tableRow.statusObj.status !== STATUSES.notStarted
+          tableRow.statusObj.status !== this.STATUSES.notStarted
         );
+      },
+      showTimeDuration(tableRow) {
+        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
+          return tableRow.statusObj.time_spent;
+        }
+        return undefined;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -37,7 +37,7 @@
               <KLabeledIcon>
                 <KBasicContentIcon slot="icon" :kind="tableRow.kind" />
                 <KRouterLink
-                  v-if="tableRow.kind === 'exercise'"
+                  v-if="showLink(tableRow)"
                   :text="tableRow.title"
                   :to="exerciseLink(tableRow.content_id)"
                 />
@@ -47,7 +47,10 @@
             <td>
               <StatusSimple :status="tableRow.statusObj.status" />
             </td>
-            <td><TimeDuration :seconds="tableRow.statusObj.time_spent" /></td>
+            <td><TimeDuration
+              v-if="tableRow.statusObj.status !== STATUSES.notStarted"
+              :seconds="tableRow.statusObj.time_spent"
+            /></td>
           </tr>
         </transition-group>
       </CoreTable>
@@ -60,6 +63,7 @@
 <script>
 
   import commonCoach from '../common';
+  import { STATUSES } from '../../modules/classSummary/constants';
   import { PageNames } from './../../constants';
 
   export default {
@@ -89,6 +93,12 @@
     methods: {
       exerciseLink(exerciseId) {
         return this.classRoute(PageNames.REPORTS_LESSON_LEARNER_EXERCISE_PAGE_ROOT, { exerciseId });
+      },
+      showLink(tableRow) {
+        return (
+          tableRow.kind === this.ContentNodeKinds.EXERCISE &&
+          tableRow.statusObj.status !== STATUSES.notStarted
+        );
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -83,7 +83,7 @@
     computed: {
       emptyMessage() {
         if (this.filter.value === 'allQuizzes') {
-          return this.coachStrings.$tr('lessonListEmptyState');
+          return this.coachStrings.$tr('quizListEmptyState');
         }
         if (this.filter.value === 'activeQuizzes') {
           return CoachExamsPageStrings.$tr('noActiveExams');

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models import Max
 from django.db.models import Sum
 from django.shortcuts import get_object_or_404
@@ -36,8 +37,9 @@ def content_status_serializer(lesson_data, learners_data, classroom):
     # Get all the values we need from the summary logs to be able to summarize current status on the
     # relevant content items.
     content_log_values = logger_models.ContentSummaryLog.objects.filter(
-        content_id__in=set(content_map.keys()), user__in=[learner["id"] for learner in learners_data]
-    ).values("user_id", "content_id", "end_timestamp", "time_spent", "progress", "kind")
+        content_id__in=set(content_map.keys()), user__in=[learner["id"] for learner in learners_data]) \
+        .annotate(attempts=Count('masterylogs__attemptlogs')) \
+        .values("user_id", "content_id", "end_timestamp", "time_spent", "progress", "kind", "attempts")
 
     # In order to make the lookup speedy, generate a unique key for each user/node that we find
     # listed in the needs help notifications that are relevant. We can then just check
@@ -83,7 +85,7 @@ def content_status_serializer(lesson_data, learners_data, classroom):
             return COMPLETED
         if log["kind"] == content_kinds.EXERCISE:
             # if there are no attempt logs for this exercise, status is NOT_STARTED
-            if logger_models.AttemptLog.objects.filter(user_id=log['user_id'], sessionlog__content_id=log['content_id']).count() == 0:
+            if log["attempts"] == 0:
                 return NOT_STARTED
         return STARTED
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

BEFORE, if a user clicks into an exercise in a lesson, they are marked as having started even if they have not made any attempts. Coach notifications were also triggered.
NOW, there should be no progress data for a lesson if a learner has not made any attempts with an exercise in that lesson. Also no coach notifications will be triggered until they make an attempt.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create lesson with exercises.
2. Assign learner and log in as learner.
3. Click into exercise but do not answer.
4. In incognito tab, log in as admin and go to coach reports page.
5. Observe lessons/users/exercises progress as not started.
6. Log back in as learner and answer a question in the exercise.
7. Observe lessons/users/exercises progress as started. 

AND Try to replicate the issues below. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/5032, https://github.com/learningequality/kolibri/issues/5111, https://github.com/learningequality/kolibri/issues/5099.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
