### PR TITLE
Fixes Device info page when CherryPy is not running

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -356,14 +356,16 @@ def get_status():  # noqa: max-complexity=16
             # Probably a mis-configured kolibri
             raise NotRunning(STATUS_SERVER_CONFIGURATION_ERROR)
 
-        return pid, LISTEN_ADDRESS, listen_port  # Correct PID !
-
     else:
         try:
             requests.get(check_url, timeout=3)
+        except (requests.exceptions.ReadTimeout,
+                requests.exceptions.ConnectionError):
+            raise NotRunning(STATUS_NOT_RESPONDING)
         except (requests.exceptions.RequestException):
             return pid, '', ''
 
+    return pid, LISTEN_ADDRESS, listen_port  # Correct PID !
     # We don't detect this at present:
     # Could be detected because we fetch the PID directly via HTTP, but this
     # is dumb because kolibri could be running in a worker pool with different


### PR DESCRIPTION
 ### Summary
Running kolibri using nginx, with CherryPy disabled gave a server error message when calling the api to get the device info.
This PR fixes  `get_status` function when CherryPy is not started by Kolibri.

### Reviewer guidance
1. Disable CherryPy in `options.ini`
2. Start kolibri
3. In a separate console, execute `kolibri status`
It should give the right info. Before applying this PR,  it raised an exception.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
