### PR TITLE
Fix detail views

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -61,6 +61,10 @@ function convertExamQuestionSourcesV0V1(questionSources, seed, questionIds) {
     exercise_id: question.exercise_id,
     question_id: shuffledExerciseQuestions[question.exercise_id][question.questionNumber],
     title: question.title,
+    counterInExercise:
+      questionIds[question.exercise_id].findIndex(
+        id => id === shuffledExerciseQuestions[question.exercise_id][question.questionNumber]
+      ) + 1,
   }));
 }
 

--- a/kolibri/core/assets/test/exams/utils.spec.js
+++ b/kolibri/core/assets/test/exams/utils.spec.js
@@ -110,51 +110,61 @@ describe('exam utils', function() {
       */
       const expectedOutput = [
         {
+          counterInExercise: 16,
           question_id: 'fc60ecb9f83f505fa31e734e517e6523',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 13,
           question_id: 'd4623921a2ef5ddaa39048c0f7a6fe06',
           exercise_id: 'b186a2a3ae8e51dd867614db03eb3783',
           title: 'Find 1 more or 1 less than a number',
         },
         {
+          counterInExercise: 6,
           question_id: '2f5fdbc49ce35310abf49971867ac94e',
           exercise_id: 'b186a2a3ae8e51dd867614db03eb3783',
           title: 'Find 1 more or 1 less than a number',
         },
         {
+          counterInExercise: 15,
           question_id: '19421254d90d520d981bd07fd6ede9b2',
           exercise_id: 'b9444e7d11395946b2e14edb5dc4670f',
           title: 'Count in order',
         },
         {
+          counterInExercise: 1,
           question_id: '1e0ce47a58465b2cb298acd3b893dce5',
           exercise_id: 'b9444e7d11395946b2e14edb5dc4670f',
           title: 'Count in order',
         },
         {
+          counterInExercise: 10,
           question_id: 'd3ac055fa4ad599bbd30a00eaeb93e5e',
           exercise_id: 'b186a2a3ae8e51dd867614db03eb3783',
           title: 'Find 1 more or 1 less than a number',
         },
         {
+          counterInExercise: 1,
           question_id: 'a5f508eb2ba05d429812dc43b577ef03',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 17,
           question_id: '8358fbbd0a285e9d99da558094eabd4c',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 2,
           question_id: '3aeb023925e35001865091de1fb4d3ae',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 3,
           question_id: 'a654dec351af5bdf937566e46b7c2fc3',
           exercise_id: 'b9444e7d11395946b2e14edb5dc4670f',
           title: 'Count in order',
@@ -175,51 +185,61 @@ describe('exam utils', function() {
       const converted = convertExamQuestionSourcesV0V1(questionSources, seed, QUESTION_IDS);
       const expectedOutput = [
         {
+          counterInExercise: 20,
           question_id: 'fc5958e2a67d5cd2bd48962e9e1c35c3',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 3,
           question_id: 'beb5eae9491c564fb6bc5b9c1421d085',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 2,
           question_id: '3aeb023925e35001865091de1fb4d3ae',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 17,
           question_id: '8358fbbd0a285e9d99da558094eabd4c',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 6,
           question_id: '4dd2526065ee572998a06b1fdae9cb4b',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 5,
           question_id: '10e6239f9cf35b75b0cf75ca7f7e6a14',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 12,
           question_id: 'e92a277052cf56e2aaae44338fa0bfec',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 9,
           question_id: '6ef7996754de54ad92b660d06436976c',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 4,
           question_id: 'b19341ebca9a5bdb817cdc31b8d62993',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 8,
           question_id: 'e226724765085214acfb807942918fed',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
@@ -249,16 +269,19 @@ describe('exam utils', function() {
       const converted = convertExamQuestionSourcesV0V1(questionSources, seed, QUESTION_IDS);
       const expectedOutput = [
         {
+          counterInExercise: 9,
           question_id: '6ef7996754de54ad92b660d06436976c',
           exercise_id: '69e5e6abf479581483d441b83d7d76f4',
           title: 'Count with small numbers',
         },
         {
+          counterInExercise: 2,
           question_id: '952857e446b95c5da36226f59237ffcc',
           exercise_id: 'b9444e7d11395946b2e14edb5dc4670f',
           title: 'Count in order',
         },
         {
+          counterInExercise: 7,
           question_id: '5a56a46b261d5ff7b3f870cf09c6952f',
           exercise_id: 'b186a2a3ae8e51dd867614db03eb3783',
           title: 'Find 1 more or 1 less than a number',

--- a/kolibri/plugins/coach/assets/src/modules/exerciseDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/exerciseDetail/actions.js
@@ -1,14 +1,15 @@
 import { AttemptLogResource } from 'kolibri.resources';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 
-export function setAttemptLogs(store, params) {
-  const { learnerId, exercise } = params;
+export function setAttemptLogs(store) {
+  const { learnerId, exercise, attemptId } = store.state;
   return AttemptLogResource.fetchCollection({
     getParams: {
       user: learnerId,
       content: exercise.content_id,
     },
-    force: true,
+    // Only force when accessing the root url
+    force: attemptId === null,
   }).then(attemptLogs => {
     const exerciseQuestions = assessmentMetaDataState(exercise).assessmentIds;
     // Add their question number
@@ -17,7 +18,6 @@ export function setAttemptLogs(store, params) {
         attemptLog.questionNumber = exerciseQuestions.indexOf(attemptLog.item) + 1;
       });
     }
-
     // Re-set the attempt logs.
     store.commit('SET_ATTEMPT_LOGS', attemptLogs);
     return store.getters.attemptLogs;

--- a/kolibri/plugins/coach/assets/src/modules/exerciseDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/exerciseDetail/handlers.js
@@ -47,18 +47,13 @@ function showExerciseDetailView({ learnerId, exerciseId, attemptId = null, inter
         interactionIndex,
         learnerId,
       });
-      return store
-        .dispatch('exerciseDetail/setAttemptLogs', {
-          learnerId,
-          exercise,
-        })
-        .then(attemptLogs => {
-          // No attemptId was passed in, so we should trigger a url redirect
-          // to the first attempt.
-          if (attemptId === null) {
-            return attemptLogs[0].id;
-          }
-        });
+      return store.dispatch('exerciseDetail/setAttemptLogs').then(attemptLogs => {
+        // No attemptId was passed in, so we should trigger a url redirect
+        // to the first attempt.
+        if (attemptId === null) {
+          return attemptLogs[0].id;
+        }
+      });
     },
     error => {
       store.dispatch('handleCoachPageError', error);

--- a/kolibri/plugins/coach/assets/src/modules/exerciseDetail/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/exerciseDetail/index.js
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import * as actions from './actions';
 
 function defaultState() {
@@ -49,9 +48,11 @@ export default {
       Object.assign(state, defaultState());
     },
     SET_ATTEMPT_LOGS(state, attemptLogs) {
+      const attemptLogMap = {};
       attemptLogs.forEach(attemptLog => {
-        Vue.set(state.attemptLogMap, attemptLog.id, attemptLog);
+        attemptLogMap[attemptLog.id] = attemptLog;
       });
+      state.attemptLogMap = attemptLogMap;
     },
   },
 };

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
@@ -23,8 +23,6 @@ export function setLearners(store, params) {
       force: !learnerId,
     })
     .then(attemptLogs => {
-      attemptLogs = attemptLogs.filter(attemptLog => !attemptLog.correct);
-
       let learners;
       // Add learner information to each attemptLog to turn this into
       // a list of learners with attempt information intermixed.
@@ -61,6 +59,8 @@ export function setLearners(store, params) {
           };
         });
       }
+
+      learners = learners.filter(learner => !learner.correct);
 
       // Re-set the learner data.
       store.commit('SET_LEARNERS', learners);

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
@@ -9,7 +9,7 @@ export function setLearners(store, params) {
   };
   if (quizId) {
     resource = ExamAttemptLogResource;
-    getParams.examId = quizId;
+    getParams.exam = quizId;
   }
   if (classId) {
     getParams.classroom = classId;

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
@@ -1,6 +1,7 @@
 import { AttemptLogResource, ExamAttemptLogResource } from 'kolibri.resources';
 
-export function setLearners(store, { questionId, exerciseId, quizId, classId, groupId }) {
+export function setLearners(store, params) {
+  const { questionId, exerciseId, quizId, classId, groupId, learnerId } = params;
   let resource = AttemptLogResource;
   const getParams = {
     item: questionId,
@@ -19,7 +20,7 @@ export function setLearners(store, { questionId, exerciseId, quizId, classId, gr
   return resource
     .fetchCollection({
       getParams,
-      force: true,
+      force: !learnerId,
     })
     .then(attemptLogs => {
       attemptLogs = attemptLogs.filter(attemptLog => !attemptLog.correct);

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -59,24 +59,25 @@ function showQuestionDetailView(params) {
     .then(exam => {
       return ContentNodeResource.fetchModel({ id: exerciseId }).then(exercise => {
         exercise.assessmentmetadata = assessmentMetaDataState(exercise);
-        let questionNumber;
+        let title;
         if (exam) {
-          questionNumber = Math.max(
-            1,
-            exam.question_sources
-              .filter(source => source.exercise_id === exerciseId)
-              .findIndex(source => source.question_id === questionId)
+          const question = exam.question_sources.find(
+            source => source.question_id === questionId && source.exercise_id === exerciseId
           );
+          title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
+            name: question.title,
+            number: question.counterInExercise,
+          });
         } else {
-          questionNumber = Math.max(
+          const questionNumber = Math.max(
             1,
             exercise.assessmentmetadata.assessmentIds.indexOf(questionId)
           );
+          title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
+            name: exercise.title,
+            number: questionNumber,
+          });
         }
-        const title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
-          name: exercise.title,
-          number: questionNumber,
-        });
         store.commit('questionDetail/SET_STATE', {
           learnerId,
           interactionIndex,

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -40,7 +40,7 @@ function showQuestionDetailView(params) {
   let { exerciseId, learnerId, interactionIndex, questionId, quizId } = params;
   interactionIndex = Number(interactionIndex);
   let promise;
-  if (!exerciseId) {
+  if (quizId) {
     // If this is showing for a quiz, then no exerciseId will be passed in
     // set the appropriate exerciseId here based on the question sources
     const baseExam = store.state.classSummary.examMap[quizId];
@@ -88,6 +88,7 @@ function showQuestionDetailView(params) {
         return store
           .dispatch('questionDetail/setLearners', {
             ...params,
+            exerciseId,
             exercise,
           })
           .then(learners => {

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/index.js
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import sortBy from 'lodash/sortBy';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import * as actions from './actions';
@@ -50,9 +49,11 @@ export default {
       Object.assign(state, defaultState());
     },
     SET_LEARNERS(state, learners) {
+      const learnerMap = {};
       learners.forEach(learner => {
-        Vue.set(state.learnerMap, learner.id, learner);
+        learnerMap[learner.id] = learner;
       });
+      state.learnerMap = learnerMap;
     },
   },
 };

--- a/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
@@ -1,8 +1,10 @@
 import { ContentNodeResource, ExamResource } from 'kolibri.resources';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { fetchNodeDataAndConvertExam } from 'kolibri.utils.exams';
+import { crossComponentTranslator } from 'kolibri.utils.i18n';
 import ExerciseDifficulties from './../../apiResources/exerciseDifficulties';
 import QuizDifficulties from './../../apiResources/quizDifficulties';
+import AssessmentQuestionListItem from './../../views/plan/CreateExamPage/AssessmentQuestionListItem';
 
 export function setItemStats(store, { classId, exerciseId, quizId, lessonId, groupId }) {
   let resource = ExerciseDifficulties;
@@ -45,19 +47,35 @@ export function setItemStats(store, { classId, exerciseId, quizId, lessonId, gro
           correct: 0,
           total: (stats[0] || {}).total || 0,
         };
+        const title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
+          name: source.title,
+          number: source.counterInExercise,
+        });
         return {
           ...stat,
           ...source,
+          title,
         };
       });
     } else {
       item.assessmentmetadata = assessmentMetaDataState(item);
       store.commit('SET_STATE', { exercise: item });
-      stats = stats.map(stat => ({
-        ...stat,
-        exercise_id: exerciseId,
-        question_id: stat.item,
-      }));
+      stats = stats.map(stat => {
+        const questionNumber = Math.max(
+          1,
+          item.assessmentmetadata.assessmentIds.indexOf(stat.item)
+        );
+        const title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
+          name: item.title,
+          number: questionNumber,
+        });
+        return {
+          ...stat,
+          exercise_id: exerciseId,
+          question_id: stat.item,
+          title,
+        };
+      });
     }
 
     // Set the ItemStat data

--- a/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
@@ -1,5 +1,6 @@
 import { ContentNodeResource, ExamResource } from 'kolibri.resources';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
+import { fetchNodeDataAndConvertExam } from 'kolibri.utils.exams';
 import ExerciseDifficulties from './../../apiResources/exerciseDifficulties';
 import QuizDifficulties from './../../apiResources/quizDifficulties';
 
@@ -15,7 +16,7 @@ export function setItemStats(store, { classId, exerciseId, quizId, lessonId, gro
     promises.push(
       ExamResource.fetchModel({
         id: quizId,
-      })
+      }).then(fetchNodeDataAndConvertExam)
     );
   } else {
     promises.push(
@@ -35,11 +36,20 @@ export function setItemStats(store, { classId, exerciseId, quizId, lessonId, gro
   return Promise.all(promises).then(([item, stats]) => {
     if (quizId) {
       store.commit('SET_STATE', { exam: item });
-      stats = stats.map(stat => ({
-        ...stat,
-        exercise_id: stat.content_id,
-        question_id: stat.item,
-      }));
+      // If no one attempted one of the questions, it could get missed out of the list
+      // of difficult questions, so use the exam data to fill in the blanks here.
+      stats = item.question_sources.map(source => {
+        const stat = stats.find(
+          stat => stat.item === source.question_id && stat.content_id === source.exercise_id
+        ) || {
+          correct: 0,
+          total: (stats[0] || {}).total || 0,
+        };
+        return {
+          ...stat,
+          ...source,
+        };
+      });
     } else {
       item.assessmentmetadata = assessmentMetaDataState(item);
       store.commit('SET_STATE', { exercise: item });

--- a/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
@@ -3,9 +3,11 @@ import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import ExerciseDifficulties from './../../apiResources/exerciseDifficulties';
 import QuizDifficulties from './../../apiResources/quizDifficulties';
 
-export function setItemStats(store, { exerciseId, quizId, classId, groupId }) {
+export function setItemStats(store, { classId, exerciseId, quizId, lessonId, groupId }) {
   let resource = ExerciseDifficulties;
-  const getParams = {};
+  const getParams = {
+    classroom_id: classId,
+  };
   const promises = [];
   const pk = exerciseId || quizId;
   if (quizId) {
@@ -22,7 +24,12 @@ export function setItemStats(store, { exerciseId, quizId, classId, groupId }) {
       })
     );
   }
-  getParams.collection_id = groupId || classId;
+  if (lessonId) {
+    getParams.lesson_id = lessonId;
+  }
+  if (groupId) {
+    getParams.group_id = groupId;
+  }
 
   promises.push(resource.fetchDetailCollection('detail', pk, getParams, true));
   return Promise.all(promises).then(([item, stats]) => {

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
@@ -66,12 +66,8 @@
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import MultiPaneLayout from 'kolibri.coreVue.components.MultiPaneLayout';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
-  import ExamReport from 'kolibri.coreVue.components.ExamReport';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonCoach from '../common';
   import QuestionDetailLearnerList from './QuestionDetailLearnerList';
-
-  const examStrings = crossComponentTranslator(ExamReport);
 
   export default {
     name: 'QuestionLearnersReport',
@@ -118,9 +114,6 @@
           return this.currentInteraction.answer;
         }
         return null;
-      },
-      questionTitle() {
-        return examStrings.$tr('question', { questionNumber: this.questionNumber });
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -22,12 +22,12 @@
           </tr>
         </thead>
         <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="(tableRow, index) in table" :key="tableRow.question_id">
+          <tr v-for="tableRow in table" :key="tableRow.question_id">
             <td>
               <KLabeledIcon>
                 <KIcon slot="icon" person />
                 <KRouterLink
-                  :text="questionTitle(index + 1)"
+                  :text="tableRow.title"
                   :to="questionLink(tableRow.question_id)"
                 />
               </KLabeledIcon>
@@ -53,14 +53,10 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import commonCoach from '../common';
   import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
   import ReportsGroupReportLessonExerciseHeader from './ReportsGroupReportLessonExerciseHeader';
   import { PageNames } from './../../constants';
-
-  const examStrings = crossComponentTranslator(ExamReport);
 
   export default {
     name: 'ReportsGroupReportLessonExerciseQuestionListPage',
@@ -86,9 +82,6 @@
           questionId,
           exerciseId: this.$route.params.exerciseId,
         });
-      },
-      questionTitle(questionNumber) {
-        return examStrings.$tr('question', { questionNumber });
       },
     },
     $trs: {},

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -22,12 +22,12 @@
           </tr>
         </thead>
         <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="(tableRow, index) in table" :key="tableRow.question_id">
+          <tr v-for="tableRow in table" :key="tableRow.question_id">
             <td>
               <KLabeledIcon>
                 <KIcon slot="icon" question />
                 <KRouterLink
-                  :text="questionTitle(index + 1)"
+                  :text="tableRow.title"
                   :to="questionLink(tableRow.question_id)"
                 />
               </KLabeledIcon>
@@ -53,14 +53,10 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import commonCoach from '../common';
   import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
   import ReportsGroupReportQuizHeader from './ReportsGroupReportQuizHeader';
   import { PageNames } from './../../constants';
-
-  const examStrings = crossComponentTranslator(ExamReport);
 
   export default {
     name: 'ReportsGroupReportQuizQuestionListPage',
@@ -86,9 +82,6 @@
           questionId,
           quizId: this.$route.params.quizId,
         });
-      },
-      questionTitle(questionNumber) {
-        return examStrings.$tr('question', { questionNumber });
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -26,10 +26,10 @@
           </tr>
         </thead>
         <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="(tableRow, index) in table" :key="tableRow.question_id">
+          <tr v-for="tableRow in table" :key="tableRow.question_id">
             <td>
               <KRouterLink
-                :text="questionTitle(index + 1)"
+                :text="tableRow.title"
                 :to="questionLink(tableRow.question_id)"
               />
             </td>
@@ -54,14 +54,10 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import commonCoach from '../common';
   import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
   import ReportsLessonExerciseHeader from './ReportsLessonExerciseHeader';
   import { PageNames } from './../../constants';
-
-  const examStrings = crossComponentTranslator(ExamReport);
 
   export default {
     name: 'ReportsLessonExerciseQuestionListPage',
@@ -87,9 +83,6 @@
           questionId,
           exerciseId: this.$route.params.exerciseId,
         });
-      },
-      questionTitle(questionNumber) {
-        return examStrings.$tr('question', { questionNumber });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -22,12 +22,12 @@
           </tr>
         </thead>
         <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="(tableRow, index) in table" :key="tableRow.question_id">
+          <tr v-for="tableRow in table" :key="tableRow.question_id">
             <td>
               <KLabeledIcon>
                 <KIcon slot="icon" question />
                 <KRouterLink
-                  :text="questionTitle(index + 1)"
+                  :text="tableRow.title"
                   :to="questionLink(tableRow.question_id)"
                 />
               </KLabeledIcon>
@@ -53,14 +53,10 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import commonCoach from '../common';
   import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
   import ReportsQuizHeader from './ReportsQuizHeader';
   import { PageNames } from './../../constants';
-
-  const examStrings = crossComponentTranslator(ExamReport);
 
   export default {
     name: 'ReportsQuizQuestionListPage',
@@ -86,9 +82,6 @@
           questionId,
           quizId: this.$route.params.quizId,
         });
-      },
-      questionTitle(questionNumber) {
-        return examStrings.$tr('question', { questionNumber });
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/test/showPageActions.spec.js
+++ b/kolibri/plugins/coach/assets/test/showPageActions.spec.js
@@ -337,14 +337,14 @@ describe('exam report state', () => {
       exerciseContentNodes,
     };
     const questions = [
-      { exercise_id: '12345', question_id: 14, title: 'exercise title 1' },
-      { exercise_id: '12345', question_id: 16, title: 'exercise title 1' },
-      { exercise_id: '12345', question_id: 13, title: 'exercise title 1' },
-      { exercise_id: '54321', question_id: 18, title: 'exercise title 2' },
-      { exercise_id: '12345', question_id: 0, title: 'exercise title 1' },
-      { exercise_id: '54321', question_id: 0, title: 'exercise title 2' },
-      { exercise_id: '12345', question_id: 18, title: 'exercise title 1' },
-      { exercise_id: '12345', question_id: 12, title: 'exercise title 1' },
+      { exercise_id: '12345', question_id: 14, title: 'exercise title 1', counterInExercise: 15 },
+      { exercise_id: '12345', question_id: 16, title: 'exercise title 1', counterInExercise: 17 },
+      { exercise_id: '12345', question_id: 13, title: 'exercise title 1', counterInExercise: 14 },
+      { exercise_id: '54321', question_id: 18, title: 'exercise title 2', counterInExercise: 19 },
+      { exercise_id: '12345', question_id: 0, title: 'exercise title 1', counterInExercise: 1 },
+      { exercise_id: '54321', question_id: 0, title: 'exercise title 2', counterInExercise: 1 },
+      { exercise_id: '12345', question_id: 18, title: 'exercise title 1', counterInExercise: 19 },
+      { exercise_id: '12345', question_id: 12, title: 'exercise title 1', counterInExercise: 13 },
     ];
     expect(examReportStore.getters.examQuestions(state)).toEqual(questions);
   });
@@ -357,16 +357,16 @@ describe('exam report state', () => {
       exerciseContentNodes,
     };
     const questions = [
-      { exercise_id: '123', question_id: 10, title: 'exercise title 5' },
-      { exercise_id: 'xyz', question_id: 8, title: 'exercise title 3' },
-      { exercise_id: 'xyz', question_id: 10, title: 'exercise title 3' },
-      { exercise_id: '123', question_id: 13, title: 'exercise title 5' },
-      { exercise_id: 'abc', question_id: 8, title: 'exercise title 4' },
-      { exercise_id: 'abc', question_id: 17, title: 'exercise title 4' },
-      { exercise_id: '123', question_id: 8, title: 'exercise title 5' },
-      { exercise_id: 'xyz', question_id: 17, title: 'exercise title 3' },
-      { exercise_id: '123', question_id: 17, title: 'exercise title 5' },
-      { exercise_id: 'abc', question_id: 10, title: 'exercise title 4' },
+      { exercise_id: '123', question_id: 10, title: 'exercise title 5', counterInExercise: 11 },
+      { exercise_id: 'xyz', question_id: 8, title: 'exercise title 3', counterInExercise: 9 },
+      { exercise_id: 'xyz', question_id: 10, title: 'exercise title 3', counterInExercise: 11 },
+      { exercise_id: '123', question_id: 13, title: 'exercise title 5', counterInExercise: 14 },
+      { exercise_id: 'abc', question_id: 8, title: 'exercise title 4', counterInExercise: 9 },
+      { exercise_id: 'abc', question_id: 17, title: 'exercise title 4', counterInExercise: 18 },
+      { exercise_id: '123', question_id: 8, title: 'exercise title 5', counterInExercise: 9 },
+      { exercise_id: 'xyz', question_id: 17, title: 'exercise title 3', counterInExercise: 18 },
+      { exercise_id: '123', question_id: 17, title: 'exercise title 5', counterInExercise: 18 },
+      { exercise_id: 'abc', question_id: 10, title: 'exercise title 4', counterInExercise: 11 },
     ];
     expect(examReportStore.getters.examQuestions(state)).toEqual(questions);
   });

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -1,0 +1,535 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import json
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import ExamAttemptLog
+from kolibri.core.logger.models import ExamLog
+from kolibri.core.logger.models import MasteryLog
+
+
+class ExerciseDifficultQuestionTestCase(APITestCase):
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name='My Facility')
+        self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
+        self.group = LearnerGroup.objects.create(name='My Group', parent=self.classroom)
+
+        self.coach_user = FacilityUser.objects.create(username='admin', facility=self.facility)
+        self.coach_user.set_password('password')
+        self.coach_user.save()
+
+        self.learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
+        self.learner_user.set_password('password')
+        self.learner_user.save()
+
+        self.facility.add_coach(self.coach_user)
+        self.classroom.add_coach(self.coach_user)
+        self.classroom.add_member(self.learner_user)
+        self.group.add_member(self.learner_user)
+
+        # Need ContentNodes
+        self.channel_id = '15f32edcec565396a1840c5413c92450'
+        self.lesson_id = '15f32edcec565396a1840c5413c92452'
+
+        self.content_ids = [
+            '15f32edcec565396a1840c5413c92451',
+            '15f32edcec565396a1840c5413c92452',
+            '15f32edcec565396a1840c5413c92453',
+        ]
+        self.contentnode_ids = [
+            '25f32edcec565396a1840c5413c92451',
+            '25f32edcec565396a1840c5413c92452',
+            '25f32edcec565396a1840c5413c92453',
+        ]
+        self.node_1 = ContentNode.objects.create(
+            title='Node 1',
+            available=True,
+            id=self.contentnode_ids[0],
+            content_id=self.content_ids[0],
+            channel_id=self.channel_id
+        )
+        self.lesson = Lesson.objects.create(
+            id=self.lesson_id,
+            title='My Lesson',
+            created_by=self.coach_user,
+            collection=self.classroom,
+            resources=json.dumps([{
+                'contentnode_id': self.node_1.id,
+                'content_id': self.node_1.content_id,
+                'channel_id': self.channel_id
+            }])
+        )
+        self.assignment_1 = LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.coach_user,
+            collection=self.classroom,
+        )
+        self.exercise_difficulties_basename = 'kolibri:coach:exercisedifficulties'
+
+    def test_learner_cannot_access_by_classroom_id(self):
+        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
+        learner_user.set_password('password')
+        learner_user.save()
+        self.client.login(username='learner', password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_by_lesson_id(self):
+        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
+        learner_user.set_password('password')
+        learner_user.save()
+        self.client.login(username='learner', password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_by_group_id(self):
+        self.client.login(username='learner', password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(response.status_code, 403)
+
+    def test_coach_classroom_id_required(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail', kwargs={'pk': self.content_ids[0]}))
+        self.assertEqual(response.status_code, 412)
+
+    def test_coach_no_progress_by_classroom_id(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_no_progress_by_lesson_id(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_no_progress_by_group_id(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 0)
+
+    def _set_one_difficult(self, user):
+        self.sessionlog = ContentSessionLog.objects.create(
+            user=user,
+            content_id=self.content_ids[0],
+            channel_id=self.node_1.channel_id,
+            kind='exercise',
+            progress=0.1,
+            start_timestamp=datetime.datetime.now(),
+        )
+
+        self.summarylog = ContentSummaryLog.objects.create(
+            user=user,
+            content_id=self.content_ids[0],
+            channel_id=self.node_1.channel_id,
+            kind='exercise',
+            progress=0.1,
+            start_timestamp=datetime.datetime.now(),
+        )
+
+        self.masterylog = MasteryLog.objects.create(
+            user=user,
+            summarylog=self.summarylog,
+            start_timestamp=datetime.datetime.now(),
+            mastery_level=1,
+        )
+
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=0,
+            user=user,
+            item='test',
+        )
+
+    def test_coach_one_difficult_by_classroom_id(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_difficult_by_lesson_id(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_difficult_by_lesson_id_repeated_assignment(self):
+        LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.coach_user,
+            collection=self.group,
+        )
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_difficult_by_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_two_difficult_by_lesson_id(self):
+        self._set_one_difficult(self.learner_user)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=0,
+            user=self.learner_user,
+            item='nottest',
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+        self.assertEqual(response.data[1]['total'], 1)
+        self.assertEqual(response.data[1]['correct'], 0)
+
+    def test_coach_one_difficult_one_not_by_lesson_id(self):
+        self._set_one_difficult(self.learner_user)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=1,
+            user=self.learner_user,
+            item='nottest',
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 0, response.data)))
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
+
+    def test_coach_difficult_no_assigned_by_lesson_id(self):
+        self._set_one_difficult(self.learner_user)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=1,
+            user=self.learner_user,
+            item='nottest',
+        )
+        LessonAssignment.objects.all().delete()
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_difficult_no_assigned_by_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=1,
+            user=self.learner_user,
+            item='nottest',
+        )
+        LessonAssignment.objects.all().delete()
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 0, response.data)))
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
+
+    def test_coach_difficult_both_assigned_by_lesson_id_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
+        self.classroom.add_member(learner2)
+        self._set_one_difficult(learner2)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}),
+            data={'lesson_id': self.lesson.id, 'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_difficult_group_id_not_in_lesson(self):
+        self._set_one_difficult(self.learner_user)
+        learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
+        self.classroom.add_member(learner2)
+        self._set_one_difficult(learner2)
+        self.group.remove_member(self.learner_user)
+        self.assignment_1.delete()
+        LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.coach_user,
+            collection=self.group,
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.exercise_difficulties_basename + '-detail',
+            kwargs={'pk': self.content_ids[0]}),
+            data={'lesson_id': self.lesson.id, 'group_id': self.group.id, 'classroom_id': self.classroom.id})
+        self.assertEqual(len(response.data), 0)
+
+
+class QuizDifficultQuestionTestCase(APITestCase):
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name='My Facility')
+        self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
+        self.group = LearnerGroup.objects.create(name='My Group', parent=self.classroom)
+
+        self.coach_user = FacilityUser.objects.create(username='admin', facility=self.facility)
+        self.coach_user.set_password('password')
+        self.coach_user.save()
+
+        self.learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
+        self.learner_user.set_password('password')
+        self.learner_user.save()
+
+        self.facility.add_coach(self.coach_user)
+        self.classroom.add_coach(self.coach_user)
+        self.classroom.add_member(self.learner_user)
+        self.group.add_member(self.learner_user)
+
+        self.quiz = Exam.objects.create(
+            title='My Lesson',
+            creator=self.coach_user,
+            collection=self.classroom,
+            question_count=5,
+        )
+        self.assignment_1 = ExamAssignment.objects.create(
+            exam=self.quiz,
+            assigned_by=self.coach_user,
+            collection=self.classroom,
+        )
+        self.quiz_difficulties_basename = 'kolibri:coach:quizdifficulties'
+        self.content_id = '25f32edcec565396a1840c5413c92451'
+
+    def test_learner_cannot_access(self):
+        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
+        learner_user.set_password('password')
+        learner_user.save()
+        self.client.login(username='learner', password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_by_group_id(self):
+        self.client.login(username='learner', password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail',
+            kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
+        self.assertEqual(response.status_code, 403)
+
+    def test_coach_no_progress(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_no_progress_by_group_id(self):
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail',
+            kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
+        self.assertEqual(len(response.data), 0)
+
+    def _set_one_difficult(self, user):
+        self.examlog = ExamLog.objects.create(
+            user=user,
+            exam=self.quiz,
+        )
+
+        ExamAttemptLog.objects.create(
+            examlog=self.examlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=0,
+            user=user,
+            item='test',
+            content_id=self.content_id,
+        )
+
+    def test_coach_one_difficult(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_two_started_difficult(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_difficult_repeated_assignment(self):
+        ExamAssignment.objects.create(
+            exam=self.quiz,
+            assigned_by=self.coach_user,
+            collection=self.group,
+        )
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_one_difficult_by_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail',
+            kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+
+    def test_coach_two_difficult(self):
+        self._set_one_difficult(self.learner_user)
+        ExamAttemptLog.objects.create(
+            examlog=self.examlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=0,
+            user=self.learner_user,
+            item='notatest',
+            content_id=self.content_id,
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)
+        self.assertEqual(response.data[1]['total'], 1)
+        self.assertEqual(response.data[1]['correct'], 0)
+
+    def test_coach_one_difficult_one_not(self):
+        self._set_one_difficult(self.learner_user)
+        ExamAttemptLog.objects.create(
+            examlog=self.examlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=1,
+            user=self.learner_user,
+            item='notatest',
+            content_id=self.content_id,
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 0, response.data)))
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
+
+    def test_coach_difficult_by_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        ExamAttemptLog.objects.create(
+            examlog=self.examlog,
+            start_timestamp=datetime.datetime.now(),
+            end_timestamp=datetime.datetime.now(),
+            complete=True,
+            correct=1,
+            user=self.learner_user,
+            item='notatest',
+            content_id=self.content_id,
+        )
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail',
+            kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 0, response.data)))
+        self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
+
+    def test_coach_difficult_both_assigned_by_group_id(self):
+        self._set_one_difficult(self.learner_user)
+        learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
+        self.classroom.add_member(learner2)
+        self._set_one_difficult(learner2)
+        self.client.login(username=self.coach_user.username, password='password')
+        response = self.client.get(reverse(
+            self.quiz_difficulties_basename + '-detail',
+            kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['total'], 1)
+        self.assertEqual(response.data[0]['correct'], 0)


### PR DESCRIPTION
### Summary
Detail views for difficult questions and for exercises were not working correctly.
In addition, the list views for difficult questions were not being appropriately filtered based on the context.
This PR fixes this and other related behaviour in several ways.

Commit 1) Only calls a force fetch on the root redirect to the exercise detail view to prevent requesting the same attemptlogs twice.
Commit 2) Only calls a force fetch on the root redirect for the difficult question detail view to prevent requesting the same attemptlogs twice.
Commit 3) Fixes the filtering for the API endpoints that provide statistics for the difficult questions list pages.
Commit 4) Resets the attemptLogMap and the learnerMap state objects on every page navigation, to prevent navigation history from causing contamination of the displayed attempts or learners.
Commit 5) Fixes two issues were the incorrect params were being passed, or not being passed, between handlers, actions, and fetches from the backend.
Commit 6) Adds in additional handling for quiz difficult question lists, to show questions that *no-one* answered, as these are a _difficult_ question, but the backend returns no stats indicating such.
Commit 7) Filters out correct answers after we have set 'no attempt' for quiz detail question views, to prevent correct answers being accidentally infilled as 'no attempt'.
Commit 8) Update the way that we generate question titles, by relying on the `counterInExercise` property set in the exercise data. Update the v0 to v1 mapping function to provide this data also.

### Reviewer guidance
Run through the gherkin stories for difficult questions and for the exercise detail views.

### References
Fixes #5052 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
