### PR TITLE
adding scroll behavior to individual table cells when the contents are too large

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -132,6 +132,11 @@
 
   /deep/ .core-table-button-col {
     padding: 4px;
+    text-align: right;
+
+    & button {
+      margin: 0;
+    }
   }
 
 </style>

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -110,12 +110,14 @@
 
   /deep/ th,
   /deep/ td {
-    max-width: 300px;
     padding: 12px 8px;
-    overflow-x: hidden;
     line-height: 1.5em;
-    text-overflow: ellipsis;
     vertical-align: top;
+  }
+
+  /deep/ td {
+    max-width: 300px;
+    overflow-x: scroll;
   }
 
   /deep/ tr:not(:last-child) {

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -136,7 +136,7 @@
     padding: 4px;
     text-align: right;
 
-    & button {
+    button {
       margin: 0;
     }
   }

--- a/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
@@ -4,7 +4,7 @@
     <div class="icon">
       <slot name="icon"></slot>
     </div>
-    <div class="label" :style="labelStyle">
+    <div class="label">
       <slot></slot>
     </div>
   </span>
@@ -24,25 +24,6 @@
       nowrap: {
         type: Boolean,
         default: false,
-      },
-      /**
-       * Whether the label should be bold
-       */
-      bold: {
-        type: Boolean,
-        default: false,
-      },
-    },
-    computed: {
-      labelStyle() {
-        const labelStyle = {};
-        if (this.nowrap) {
-          labelStyle.whiteSpace = 'nowrap';
-        }
-        if (this.bold) {
-          labelStyle.fontWeight = 'bold';
-        }
-        return labelStyle;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -36,7 +36,7 @@
         <transition-group slot="tbody" tag="tbody" name="list">
           <tr v-for="classObj in classList" :key="classObj.id">
             <td>
-              <KLabeledIcon bold>
+              <KLabeledIcon>
                 <KIcon slot="icon" classroom />
                 <KRouterLink
                   :text="classObj.name"

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -60,7 +60,7 @@
               <QuizActive :active="exam.active" />
             </td>
 
-            <td class="options core-table-button-col">
+            <td class="core-table-button-col">
               <KDropdownMenu
                 slot="optionsDropdown"
                 :text="examReportPageStrings.$tr('options')"
@@ -389,10 +389,6 @@
 
   .center-text {
     text-align: center;
-  }
-
-  .options {
-    text-align: right;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -71,7 +71,7 @@
               <td>
                 {{ user.username }}
               </td>
-              <td class="button-col">
+              <td class="core-table-button-col">
                 <KButton
                   :text="$tr('removeButton')"
                   appearance="flat-button"
@@ -160,11 +160,4 @@
 </script>
 
 
-<style lang="scss" scoped>
-
-  .button-col {
-    padding: 0;
-    text-align: right;
-  }
-
-</style>
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -13,7 +13,7 @@
     <td>
       {{ group.users.length }}
     </td>
-    <td class="ta-r core-table-button-col">
+    <td class="core-table-button-col">
       <KDropdownMenu
         v-if="!isUngrouped"
         appearance="flat-button"
@@ -117,10 +117,6 @@
 
 
 <style lang="scss" scoped>
-
-  .ta-r {
-    text-align: right;
-  }
 
   .icon {
     margin-right: 8px;

--- a/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/index.vue
@@ -24,7 +24,11 @@
           <th>{{ $tr('className') }}</th>
           <th>{{ $tr('coachesColumnHeader') }}</th>
           <th>{{ $tr('learnersColumnHeader') }}</th>
-          <th class="right">{{ $tr('actions') }}</th>
+          <th>
+            <span class="visuallyhidden">
+              {{ $tr('actions') }}
+            </span>
+          </th>
         </tr>
       </thead>
       <transition-group slot="tbody" tag="tbody" name="list">
@@ -60,7 +64,7 @@
           <td>
             {{ classroom.learner_count }}
           </td>
-          <td class="right button-col">
+          <td class="core-table-button-col">
             <KButton
               appearance="flat-button"
               :text="$tr('deleteClass')"
@@ -204,14 +208,6 @@
   .move-down {
     position: relative;
     margin-top: 24px;
-  }
-
-  .right {
-    text-align: right;
-  }
-
-  .button-col {
-    padding: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -51,7 +51,7 @@
             />
           </td>
           <td>
-            <span dir="auto" class="maxwidth">
+            <span dir="auto">
               <KLabeledIcon>
                 <KIcon
                   slot="icon"
@@ -76,7 +76,7 @@
             {{ user.kind }}
           </td>
           <td>
-            <span dir="auto" class="maxwidth">
+            <span dir="auto">
               {{ user.username }}
             </span>
           </td>
@@ -216,8 +216,6 @@
   }
 
   .role-badge {
-    position: relative;
-    top: -4px;
     display: inline-block;
     padding: 2px;
     padding-right: 8px;
@@ -226,13 +224,6 @@
     font-size: small;
     white-space: nowrap;
     border-radius: 4px;
-  }
-
-  .maxwidth {
-    display: inline-block;
-    max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .overflow-label {

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -80,7 +80,7 @@
               {{ user.username }}
             </span>
           </td>
-          <td v-if="$scopedSlots.action" class="user-action-button">
+          <td v-if="$scopedSlots.action" class="core-table-button-col">
             <slot name="action" :user="user"></slot>
           </td>
         </tr>
@@ -213,12 +213,6 @@
 
   .empty-message {
     margin-bottom: 16px;
-  }
-
-  .user-action-button {
-    padding: 0;
-    text-align: right;
-    vertical-align: middle;
   }
 
   .role-badge {


### PR DESCRIPTION

### Summary

This PR adds nested scrollbars to tables in order to address some outstanding issues around text truncation.

![scroll](https://user-images.githubusercontent.com/2367265/53224543-f72d2200-3629-11e9-9d8e-66807160b311.gif)

It also works to further standardize the tables by making wider use of the new core button class, which should help with button-row alignment especially in Facility tables:


| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/2367265/53225036-90a90380-362b-11e9-865c-0e076d787f78.png)|![image](https://user-images.githubusercontent.com/2367265/53225003-796a1600-362b-11e9-9417-9a7bd54b8d80.png)|

### Reviewer guidance

As much as I hate nested scrollbars, this is the simplest strategy I can think of to handle these edge cases without coding something much more complex in JS.

Previously we were truncating the strings, but this (a) hid potentially important information, and (b) caused issues with nested tooltips

### References

* fixes #5118
* fixes #5106

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
