### PR TITLE
cleans up notification layouts a bit

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -393,9 +393,7 @@
 
   // Copied from BlockItem.vue
   .notification-card {
-    padding-right: 24px;
     padding-bottom: 16px;
-    padding-left: 24px;
 
     &:not(:last-child) {
       border-bottom: 1px solid #dedede;

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -3,36 +3,33 @@
   <div class="notification">
     <p class="context icon-spacer">{{ context }}</p>
     <KGrid>
-      <KGridItem :size="time ? 50 : 100" percentage>
+      <KGridItem :sizes="mainColSizes">
         <CoachStatusIcon
           :icon="statusIcon"
           class="icon"
         />
         <div class="icon-spacer">
-          <KLabeledIcon>
-            <ContentIcon
-              slot="icon"
-              class="content-icon"
-              :kind="contentIcon"
-              :showTooltip="false"
-            />
-            <KRouterLink
-              v-if="targetPage && targetPage.name"
-              :text="linkText"
-              :to="getRoute(targetPage)"
-            />
-            <span v-else>
-              {{ linkText }}
-            </span>
-          </KLabeledIcon>
+          <ContentIcon
+            slot="icon"
+            class="content-icon"
+            :kind="contentIcon"
+            :showTooltip="false"
+          />
+          <KRouterLink
+            v-if="targetPage && targetPage.name"
+            :text="linkText"
+            :to="getRoute(targetPage)"
+          />
+          <span v-else>
+            {{ linkText }}
+          </span>
         </div>
       </KGridItem>
 
       <KGridItem
         v-if="time"
-        :size="50"
-        percentage
-        alignment="center"
+        sizes="1, 2, 3"
+        alignment="right"
       >
         <ElapsedTime :date="parseDate(time)" />
       </KGridItem>
@@ -69,7 +66,6 @@
       ContentIcon,
       CoachStatusIcon,
       ElapsedTime,
-      KLabeledIcon,
       KGrid,
       KGridItem,
       KRouterLink,
@@ -143,6 +139,12 @@
         }
         return '';
       },
+      mainColSizes() {
+        if (this.time) {
+          return [3, 6, 9];
+        }
+        return [4, 8, 12];
+      },
     },
     methods: {
       parseDate(dateString) {
@@ -163,8 +165,8 @@
 
   .icon {
     position: absolute;
-    top: 32px;
-    left: 2px;
+    top: 33px;
+    left: 4px;
     width: 1.5em;
     height: 1.5em;
   }

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -28,7 +28,7 @@
 
       <KGridItem
         v-if="time"
-        sizes="1, 2, 3"
+        :sizes="[1, 2, 3]"
         alignment="right"
       >
         <ElapsedTime :date="parseDate(time)" />

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -1,13 +1,13 @@
 <template>
 
   <div class="notification">
+    <CoachStatusIcon
+      :icon="statusIcon"
+      class="icon"
+    />
     <p class="context icon-spacer">{{ context }}</p>
     <KGrid>
       <KGridItem :sizes="mainColSizes">
-        <CoachStatusIcon
-          :icon="statusIcon"
-          class="icon"
-        />
         <div class="icon-spacer">
           <ContentIcon
             slot="icon"
@@ -45,7 +45,6 @@
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
-  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import CoachStatusIcon from '../status/CoachStatusIcon';
@@ -164,15 +163,17 @@
   @import '~kolibri.styles.definitions';
 
   .icon {
+    // vertically align icon
     position: absolute;
-    top: 33px;
-    left: 4px;
+    top: 50%;
+    left: 2px;
     width: 1.5em;
     height: 1.5em;
+    margin-top: -0.75em; // offset height
   }
 
   .icon-spacer {
-    margin-left: 40px;
+    margin-left: 48px;
   }
 
   .content-icon {

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/NotificationCard.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/NotificationCard.spec.js
@@ -50,8 +50,7 @@ describe('NotificationCard component', () => {
 
     const link = wrapper.find({ name: 'KRouterLink' });
     expect(link.exists()).toEqual(false);
-    const linkText = wrapper.find('.icon-spacer span');
-    expect(linkText.text()).toEqual('JB finished a lesson');
+    expect(wrapper.text()).toEqual('JB finished a lesson');
   });
 
   it('has a single KGridItem if no time is provided', () => {
@@ -60,7 +59,7 @@ describe('NotificationCard component', () => {
     });
     const gridItems = wrapper.findAll({ name: 'KGridItem' });
     expect(gridItems.length).toEqual(1);
-    expect(gridItems.at(0).props().size).toEqual(100);
+    expect(gridItems.at(0).props().sizes).toEqual([4, 8, 12]);
   });
 
   it('has a second KGridItem with the time if it is provided', () => {
@@ -72,8 +71,8 @@ describe('NotificationCard component', () => {
     });
     const gridItems = wrapper.findAll({ name: 'KGridItem' });
     expect(gridItems.length).toEqual(2);
-    expect(gridItems.at(0).props().size).toEqual(50);
-    expect(gridItems.at(1).props().size).toEqual(50);
+    expect(gridItems.at(0).props().sizes).toEqual([3, 6, 9]);
+    expect(gridItems.at(1).props().sizes).toEqual([1, 2, 3]);
 
     const elapsedTime = wrapper.find({ name: 'ElapsedTime' });
     const timeObject = new Date(timeString).getTime();

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/BlockItem.vue
@@ -25,8 +25,9 @@
 <style lang="scss" scoped>
 
   .block-item {
+    padding-top: 8px;
     padding-right: 24px;
-    padding-bottom: 16px;
+    padding-bottom: 8px;
     padding-left: 24px;
     margin-right: -24px;
     margin-left: -24px;

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -1,7 +1,7 @@
 <template>
 
-  <router-link class="item" :style="{color: $coreTextDefault}" :to="to">
-    <KGrid>
+  <router-link class="link" :style="{color: $coreTextDefault}" :to="to">
+    <KGrid class="wrapper">
       <KGridItem size="75" percentage>
         <h3 class="title">{{ name }}</h3>
       </KGridItem>
@@ -105,8 +105,12 @@
     right: -12px;
   }
 
-  .item {
+  .link {
     text-decoration: none;
+  }
+
+  .wrapper {
+    margin-bottom: 8px;
   }
 
 </style>


### PR DESCRIPTION

### Summary


**Before:**

> ![before](https://user-images.githubusercontent.com/2367265/53229584-82fa7a80-3639-11e9-8c02-837685b8bfc2.gif) 

**After:**

> ![after](https://user-images.githubusercontent.com/2367265/53229606-90b00000-3639-11e9-9c7c-a80e45b8a22c.gif) |


### Reviewer guidance

look and work correctly?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
