### PR TITLE
Fix exercise question detail rendering

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -40,24 +40,25 @@ function showQuestionDetailView(params) {
   let { exerciseId, learnerId, interactionIndex, questionId, quizId } = params;
   interactionIndex = Number(interactionIndex);
   let promise;
+  let exerciseNodeId;
   if (quizId) {
     // If this is showing for a quiz, then no exerciseId will be passed in
     // set the appropriate exerciseId here based on the question sources
     const baseExam = store.state.classSummary.examMap[quizId];
     promise = fetchNodeDataAndConvertExam(baseExam).then(exam => {
-      exerciseId = exam.question_sources.find(source => source.question_id === questionId)
+      exerciseNodeId = exam.question_sources.find(source => source.question_id === questionId)
         .exercise_id;
       return exam;
     });
   } else {
     // Passed in exerciseId is the content_id of the contentNode
     // Map this to the id of the content node to do this fetch
-    exerciseId = store.state.classSummary.contentMap[exerciseId].node_id;
+    exerciseNodeId = store.state.classSummary.contentMap[exerciseId].node_id;
     promise = Promise.resolve();
   }
   return promise
     .then(exam => {
-      return ContentNodeResource.fetchModel({ id: exerciseId }).then(exercise => {
+      return ContentNodeResource.fetchModel({ id: exerciseNodeId }).then(exercise => {
         exercise.assessmentmetadata = assessmentMetaDataState(exercise);
         let title;
         if (exam) {
@@ -89,7 +90,6 @@ function showQuestionDetailView(params) {
         return store
           .dispatch('questionDetail/setLearners', {
             ...params,
-            exerciseId,
             exercise,
           })
           .then(learners => {


### PR DESCRIPTION
### Summary
Prevents reassignment of exerciseId to allow proper filtering of attemptlogs.

### Reviewer guidance
Can you view the details of a difficult question in a lesson?

### References
Fixes #5133

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
