### PR TITLE
Add safety measures for quizzes and lessons with deleted content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Internationalization and localization
 
  - Languages: English, Arabic, Bengali, Bulgarian, Chinyanja, Farsi, French, Fulfulde Mbororoore, Hindi, Marathi, Portuguese (Brazilian), Spanish, Swahili, Telugu, Urdu, Vietnamese, and Yoruba
 
+Changed or fixed
+~~~~~~~~~~~~~~~~
+
+ - Quizzes with content from deleted channels will now show an error message when a learner or coach is viewing the problems in the quiz or quiz report.
+ - Lessons with content from deleted channels will have those contents automatically removed. If you have created lessons with deleted content prior to 0.12, learner playlists and coach reports for those lessons will be broken. To fix the lesson, simply view it as a coach under Coach > Plan, and it will be fixed and updated automatically.
 
 See a `full list <https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.0>`__ of changes on Github
 

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -17,7 +17,12 @@
       @select="handleNavigateToQuestion"
     />
 
-    <div slot="main" class="exercise-container" :style="{ backgroundColor: $coreBgLight }">
+    <div
+      v-if="exercise"
+      slot="main"
+      class="exercise-container"
+      :style="{ backgroundColor: $coreBgLight }"
+    >
       <h3>{{ $tr('question', {questionNumber: questionNumber + 1}) }}</h3>
 
       <KCheckbox
@@ -32,6 +37,7 @@
         @select="navigateToQuestionAttempt"
       />
       <ContentRenderer
+        v-if="exercise"
         :id="exercise.id"
         :itemId="itemId"
         :allowHints="false"
@@ -46,6 +52,10 @@
         :showCorrectAnswer="showCorrectAnswer"
       />
     </div>
+
+    <p v-else slot="main">
+      {{ noItemIdString }}
+    </p>
   </MultiPaneLayout>
 
 </template>
@@ -53,6 +63,7 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import AttemptLogList from 'kolibri.coreVue.components.AttemptLogList';
@@ -60,7 +71,10 @@
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import find from 'lodash/find';
   import MultiPaneLayout from 'kolibri.coreVue.components.MultiPaneLayout';
+  import ExamPage from '../../../../../plugins/learn/assets/src/views/ExamPage';
   import PageStatus from './PageStatus';
+
+  const ExamPageStrings = crossComponentTranslator(ExamPage);
 
   export default {
     name: 'ExamReport',
@@ -148,14 +162,18 @@
     data() {
       return {
         showCorrectAnswer: false,
+        noItemIdString: ExamPageStrings.$tr('noItemId'),
       };
     },
     computed: {
       attemptLogs() {
         return this.examAttempts.map(attempt => {
+          let num_coach_contents = 0;
           const exerciseId = this.questions[attempt.questionNumber - 1].exercise_id;
-          const num_coach_contents = find(this.exerciseContentNodes, { id: exerciseId })
-            .num_coach_contents;
+          const exerciseMatch = find(this.exerciseContentNodes, { id: exerciseId });
+          if (exerciseMatch) {
+            num_coach_contents = exerciseMatch.num_coach_contents;
+          }
           return { ...attempt, num_coach_contents };
         });
       },

--- a/kolibri/core/content/signals.py
+++ b/kolibri/core/content/signals.py
@@ -29,7 +29,7 @@ def reorder_channels_upon_deletion(sender, instance=None, *args, **kwargs):
 def update_lesson_resources_before_delete(sender, instance=None, *args, **kwargs):
     # Update the resources array of all lessons to ensure they don't have
     # any deleted content
-    lessons = Lesson.objects.all()
+    lessons = Lesson.objects.filter(resources__contains=instance.id)
     for lesson in lessons:
         updated_resources = [r for r in lesson.resources if r['channel_id'] != instance.id]
         if len(updated_resources) < len(lesson.resources):

--- a/kolibri/core/content/signals.py
+++ b/kolibri/core/content/signals.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from .models import ChannelMetadata
 from .models import ContentNode
 from kolibri.core.notifications.models import LearnerProgressNotification
+from kolibri.core.lessons.models import Lesson
 
 
 @receiver(pre_delete, sender=ContentNode)
@@ -22,3 +23,15 @@ def reorder_channels_upon_deletion(sender, instance=None, *args, **kwargs):
     For a given channel, decrement the order of all channels that come after this channel.
     """
     ChannelMetadata.objects.filter(order__gt=instance.order).update(order=F('order') - 1)
+
+
+@receiver(pre_delete, sender=ChannelMetadata)
+def update_lesson_resources_before_delete(sender, instance=None, *args, **kwargs):
+    # Update the resources array of all lessons to ensure they don't have
+    # any deleted content
+    lessons = Lesson.objects.all()
+    for lesson in lessons:
+        updated_resources = [r for r in lesson.resources if r['channel_id'] != instance.id]
+        if len(updated_resources) < len(lesson.resources):
+            lesson.resources = updated_resources
+            lesson.save()

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/utils.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/utils.js
@@ -16,11 +16,12 @@ export function normalizeContentNode(node, ancestors = []) {
   };
 }
 
-export function contentState(data, next_content = [], ancestors = []) {
+export function contentState(node, next_content = [], ancestors = []) {
+  if (!node) return null;
   return {
     next_content,
-    ...normalizeContentNode(data, ancestors),
-    ...assessmentMetaDataState(data),
+    ...normalizeContentNode(node, ancestors),
+    ...assessmentMetaDataState(node),
   };
 }
 

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -17,7 +17,7 @@ import { contentState } from '../coreLearn/utils';
 import { calcQuestionsAnswered } from './utils';
 
 export function showExam(store, params) {
-  let questionNumber = params.questionNumber;
+  const questionNumber = Number(params.questionNumber);
   const { classId, examId } = params;
   store.commit('CORE_SET_PAGE_LOADING', true);
   store.commit('SET_PAGE_NAME', ClassesPageNames.EXAM_VIEWER);
@@ -30,8 +30,6 @@ export function showExam(store, params) {
     store.commit('CORE_SET_ERROR', 'You must be logged in as a learner to view this page');
     store.commit('CORE_SET_PAGE_LOADING', false);
   } else {
-    questionNumber = Number(questionNumber); // eslint-disable-line no-param-reassign
-
     const promises = [
       ExamResource.fetchModel({ id: examId }),
       ExamLogResource.fetchCollection({ getParams: examParams }),
@@ -68,16 +66,6 @@ export function showExam(store, params) {
         if (!canViewExam(exam, store.state.examLog)) {
           return router.replace({ name: ClassesPageNames.CLASS_ASSIGNMENTS, params: { classId } });
         }
-        // Sort through all the exam attempt logs retrieved and organize them into objects
-        // keyed first by content_id and then item id under that.
-        examAttemptLogs.forEach(log => {
-          const { content_id, item } = log;
-          if (!attemptLogs[content_id]) {
-            attemptLogs[content_id] = {};
-          }
-          attemptLogs[content_id][item] = { ...log };
-        });
-
         // Sort through all the exam attempt logs retrieved and organize them into objects
         // keyed first by content_id and then item id under that.
         examAttemptLogs.forEach(log => {
@@ -138,22 +126,21 @@ export function showExam(store, params) {
             }
 
             const currentQuestion = questions[questionNumber];
-            const itemId = currentQuestion.question_id;
-            const contentId = currentQuestion.exercise_id;
+            const { question_id, exercise_id } = currentQuestion;
             const questionsAnswered = Math.max(
               store.state.examViewer.questionsAnswered || 0,
               calcQuestionsAnswered(attemptLogs)
             );
 
-            if (!attemptLogs[currentQuestion.exercise_id]) {
-              attemptLogs[currentQuestion.exercise_id] = {};
+            if (!attemptLogs[exercise_id]) {
+              attemptLogs[exercise_id] = {};
             }
-            if (!attemptLogs[contentId][itemId]) {
-              attemptLogs[contentId][itemId] = {
+            if (!attemptLogs[exercise_id][question_id]) {
+              attemptLogs[exercise_id][question_id] = {
                 start_timestamp: now(),
                 completion_timestamp: null,
                 end_timestamp: null,
-                item: itemId,
+                item: question_id,
                 complete: false,
                 time_spent: 0,
                 correct: 0,
@@ -161,16 +148,16 @@ export function showExam(store, params) {
                 simple_answer: '',
                 interaction_history: [],
                 hinted: false,
-                content_id: contentId,
+                content_id: exercise_id,
               };
             }
             store.commit('SET_EXAM_ATTEMPT_LOGS', attemptLogs);
             store.commit('examViewer/SET_STATE', {
-              content: contentState(contentNodes.find(node => node.id === contentId)),
-              currentAttempt: attemptLogs[contentId][itemId],
+              content: contentState(contentNodes.find(node => node.id === exercise_id)),
+              currentAttempt: attemptLogs[exercise_id][question_id],
               currentQuestion,
               exam,
-              itemId,
+              itemId: question_id,
               questionNumber,
               questions,
               questionsAnswered,

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -40,7 +40,7 @@
         :style="{ background: $coreBgLight }"
       >
         <ContentRenderer
-          v-if="itemId"
+          v-if="content && itemId"
           :id="content.id"
           ref="contentRenderer"
           :kind="content.kind"

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
@@ -62,7 +62,11 @@
         this.$nextTick().then(() => {
           const { modalButton } = this.$refs;
           if (modalButton.$refs.button) {
-            modalButton.$refs.button.focus();
+            // HACK to prevent the modal from opening from an keyup.enter event from
+            // previous form, we have to delay focusing the "More information" button.
+            setTimeout(() => {
+              modalButton.$refs.button.focus();
+            }, 200);
           }
         });
       },


### PR DESCRIPTION
### Summary

By "broken" lesson or quiz i mean the assignment has items that have been deleted through a channel deletion and may cause issues if trying to interact with it through a report or a viewer.

**For broken quizzes**

For quizzes with deleted exercises, the quiz viewer and quiz report still list the deleted question, but provides a basic error message when the user is attempting to view it.

![screen shot 2019-02-21 at 10 54 08 am](https://user-images.githubusercontent.com/10248067/53276520-3a33d780-36b4-11e9-82cb-8dd6ce85d238.png)
![screen shot 2019-02-21 at 10 40 36 am](https://user-images.githubusercontent.com/10248067/53276521-3a33d780-36b4-11e9-8a86-cff6d36cd1b8.png)

**For broken lessons**

Unlike a broken quiz, where major problems are relatively isolated, the downstream effects of a broken lesson are more widespread, so the solution here is to 

1. prevent broken lessons in the first place, by implementing a pre_delete side effect for channels, which automatically updates all lessons that have a dependency on that channel. ideally, no lesson created after 0.12 should be broken by channel deletion
1. provide an easier path for users with broken lessons to fix them. users with broken lessons can simply go to the relevant page in plan, and the lesson will fix itself (this is documented in the changelog).

### Reviewer guidance

1. Make quizzes and lessons with resources from different channels. Delete one or more (or all) of the channels. Check to see that all things emanating from the assignment still work (reports, viewers, notifications).

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
