### PR TITLE
Only gzip and cache static file endpoint

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -195,16 +195,28 @@ def run_server(port):
 
     cherrypy.config.update({
         "environment": "production",
-        "tools.gzip.on": True,
-        "tools.gzip.mime_types": ["text/*", "application/javascript"],
-        "tools.caching.on": True,
-        "tools.caching.maxobj_size": 2000000,
-        "tools.caching.maxsize": 50000000,
     })
 
-    serve_static_dir(settings.STATIC_ROOT, settings.STATIC_URL)
-    serve_static_dir(paths.get_content_dir_path(),
-                     paths.get_content_url(conf.OPTIONS['Deployment']['URL_PATH_PREFIX']))
+    # Mount static files
+    static_files_handler = cherrypy.tools.staticdir.handler(
+        section="/",
+        dir=settings.STATIC_ROOT)
+    cherrypy.tree.mount(static_files_handler, settings.STATIC_URL, config={
+        "/": {
+            "tools.gzip.on": True,
+            "tools.gzip.mime_types": ["text/*", "application/javascript"],
+            "tools.caching.on": True,
+            "tools.caching.maxobj_size": 2000000,
+            "tools.caching.maxsize": 50000000,
+        }
+    })
+
+    # Mount content files
+    content_files_handler = cherrypy.tools.staticdir.handler(
+        section="/",
+        dir=paths.get_content_dir_path())
+    cherrypy.tree.mount(content_files_handler,
+                        paths.get_content_url(conf.OPTIONS['Deployment']['URL_PATH_PREFIX']))
 
     # Unsubscribe the default server
     cherrypy.server.unsubscribe()
@@ -237,15 +249,6 @@ def unlock_after_vacuum():
             os.remove(STARTUP_LOCK)
         except OSError:
             pass  # lock file was deleted by other process
-
-
-def serve_static_dir(root, url):
-
-    static_handler = cherrypy.tools.staticdir.handler(
-        section="/",
-        dir=os.path.split(root)[1],
-        root=os.path.abspath(os.path.split(root)[0]))
-    cherrypy.tree.mount(static_handler, url)
 
 
 def _read_pid_file(filename):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -195,6 +195,8 @@ def run_server(port):
 
     cherrypy.config.update({
         "environment": "production",
+        "tools.expires.on": True,
+        "tools.expires.secs": 31536000,
     })
 
     # Mount static files


### PR DESCRIPTION
### Summary
Do gzipping and caching only on static files in cherrypy.

### Reviewer guidance
Do videos still work?

### References
Fixes #5109 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
