### PR TITLE
Update the documentation link in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,4 +2,4 @@
 Contributing
 ============
 
-Please see the 'contributing' section of our `online documentation <https://kolibri-dev.readthedocs.io/en/develop/contributing/index.html>`__.
+Please see the 'contributing' section of our `online developer documentation <https://kolibri-dev.readthedocs.io>`__.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,4 +2,4 @@
 Contributing
 ============
 
-Please see the 'contributing' section of our `online documentation <http://kolibri-dev.readthedocs.io/en/develop/start/contributing/index.html>`__.
+Please see the 'contributing' section of our `online documentation <https://kolibri-dev.readthedocs.io/en/develop/contributing/index.html>`__.


### PR DESCRIPTION
### Summary

As I was setting up a local dev environment for Kolibri, I found that the current link to Kolibri's documentation (introduced in 62974dc) leads potential contributors to a 404:
https://kolibri-dev.readthedocs.io/en/develop/start/contributing/index.html

This Pull Request will update the link so that it points to the main "Contributing" page here: https://kolibri-dev.readthedocs.io/en/develop/contributing/index.html

### Reviewer guidance

This shouldn't be a risky change (unless I've missed something) and the change can be tested by [clicking the link in my branches rendered `CONTRIBUTING.rst` file](https://github.com/nickcannariato/kolibri/blob/docs/fix-contributing-url/CONTRIBUTING.rst): 

---

### Contributor Checklist

PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
