### PR TITLE
Hover focus state for epub theme buttons

### DIFF
--- a/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
@@ -137,7 +137,11 @@
       },
       settingsButtonFocus() {
         return {
-          ':focus': this.$coreOutline,
+          ':focus': {
+            ...this.$coreOutline,
+            outlineOffset: '0px',
+            outlineWidth: '2px',
+          },
         };
       },
     },

--- a/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SettingsSideBar.vue
@@ -89,6 +89,7 @@
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import isEqual from 'lodash/isEqual';
   import KButton from 'kolibri.coreVue.components.KButton';
+  import { darken } from 'kolibri.utils.colour';
   import { THEMES } from './EpubConstants';
   import SideBar from './SideBar';
 
@@ -165,6 +166,9 @@
         return {
           ...this.settingsButtonFocus,
           backgroundColor,
+          ':hover': {
+            backgroundColor: darken(backgroundColor, '10%'),
+          },
         };
       },
     },


### PR DESCRIPTION
### Summary
Adds a background colour to epub theme buttons for hover states.
Updates outlines for focus states.

### Reviewer guidance
Check how epub settings buttons look.

![hover_focus_theme](https://user-images.githubusercontent.com/1680573/53375371-ec1b1000-390f-11e9-9be7-c547e5d2c65f.gif)


### References
Fixes #5120

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
