### PR TITLE
Prevent Epub top bar floating over app bar

### DIFF
--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -788,6 +788,7 @@
   }
 
   .column {
+    position: relative;
     display: inline-block;
     height: 100%;
     overflow: hidden;

--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubStyles.scss
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubStyles.scss
@@ -39,10 +39,13 @@ $bottom-bar-height: 54px;
 }
 
 @mixin navigation-button {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   z-index: 2;
-  width: 100%;
-  height: 100%;
+  margin: 0;
   border-radius: unset;
+  transform: translate(-50%, -50%);
 
   /deep/ .ui-icon-button__focus-ring {
     position: absolute;

--- a/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
@@ -119,7 +119,7 @@
   @import './EpubStyles';
 
   .top-bar {
-    z-index: 4;
+    z-index: 2;
     box-shadow: $epub-box-shadow;
   }
 


### PR DESCRIPTION
### Summary
This PR fixes an issue with z-index for the top bar of the epub renderer, whereby it would overlap the scrolling header due to their having equal z-index. This is fixed by downgrading the Epub renderer topbar to z-index 2 (contained button in material spec), which matches the other contained buttons for previous and next page (and has to redo the positioning logic for these to prevent overlap).


### Reviewer guidance
Does the epub renderer top bar float over the appbar any more?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
