### PR TITLE
Ensure connections are closed on threads to avoid locks in the database

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import requests
 from django.core.management.base import BaseCommand
+from django.db import connection
 from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.timezone import get_current_timezone
 from django.utils.timezone import localtime
@@ -65,6 +66,7 @@ class Command(BaseCommand):
                     if "id" in data:
                         stat_data = self.perform_statistics(server, data["id"])
                         create_and_update_notifications(stat_data, nutrition_endpoints.STATISTICS)
+                    connection.close()
                 if once:
                     break
                 logger.info("Sleeping for {} minutes.".format(interval))

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 
+from django.db import connection
 from le_utils.constants import content_kinds
 from sqlalchemy import and_
 from sqlalchemy import exists
@@ -49,6 +50,7 @@ def update_channel_metadata():
             except (InvalidSchemaVersionError, FutureSchemaError):
                 logger.warning("Tried to import channel {channel_id}, but database file was incompatible".format(channel_id=channel_id))
     fix_multiple_trees_with_id_one()
+    connection.close()
 
 
 def fix_multiple_trees_with_id_one():

--- a/kolibri/core/notifications/tasks.py
+++ b/kolibri/core/notifications/tasks.py
@@ -2,6 +2,7 @@ import logging as logger
 import threading
 import time
 
+from django.db import connection
 from django.db import transaction
 
 logging = logger.getLogger(__name__)
@@ -58,6 +59,7 @@ class AsyncNotificationQueue():
                         # Catch all exceptions and log, otherwise the background process will end
                         # and no more logs will be saved!
                         logging.debug("Exception raised during background notification calculation: ", e)
+            connection.close()
 
     def start(self):
         while True:


### PR DESCRIPTION
### Summary
When the database is accessed from a thread, Django creates a new connection that is not closed when the thread ends, or if the thread is kept alive to perform some periodic task.
This causes two problems:
1. Vacuum does not work as the database is always locked while the threads are alive
2. Sqlite corruption when using threads is described in some of the cases at https://www.sqlite.org/howtocorrupt.html and https://www.sqlite.org/wal.html . Without being able to reproduce these problems we can't ensure this PR will solve them, but keeping the database clean, defragmented, with the wal reduced to 0 most of the time will decrease the probability of having these problems.

There were several cases affected in the code: ping & vacuum commands were leaving 2 connections open permanently. 
From version 0.12, notifications thread were leaving four more connections open.

This PR ensure all the connections are closed inside the threads and clean all the connections before executing vacuum.


### Reviewer guidance
Before applying the code from this PR, executing 
`lsof db.sqlite3` 
the list of open connections will be visible

After applying this PR, the list of connections must be zero whenever no requests are made or vacuum has finished.
Also, sqlite wal must be small or zero, because vacuum works correctly.

### References

Closes #5149 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
