### PR TITLE
Make Plan > Group/Lesson look more like Report > Group/Lesson

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -11,7 +11,6 @@
     <KPageContainer>
       <PlanHeader />
 
-      <h1>{{ $tr('exams') }}</h1>
       <div class="filter-and-button">
         <KSelect
           v-model="statusSelected"

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -1,15 +1,22 @@
 <template>
 
   <CoreBase
-    :immersivePage="true"
-    immersivePageIcon="arrow_back"
-    :immersivePagePrimary="true"
-    :primary="true"
-    :toolbarTitle="$tr('groupsHeader')"
-    :appBarTitle="$tr('groupsHeader')"
-    :immersivePageRoute="$router.getRoute('GroupsPage')"
+    :immersivePage="false"
+    :authorized="userIsAuthorized"
+    authorizedRole="adminOrCoach"
+    :showSubNav="true"
   >
+    <TopNavbar slot="sub-nav" />
+
     <KPageContainer>
+      <p>
+        <BackLink
+          :to="$router.getRoute('GroupsPage')"
+          :text="backLinkString"
+        />
+
+      </p>
+
       <div v-if="!currentGroup">
         {{ $tr('groupDoesNotExist') }}
       </div>
@@ -98,9 +105,13 @@
 <script>
 
   import { mapState, mapActions } from 'vuex';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoach from '../../common';
+  import ReportsGroupHeader from '../../reports/ReportsGroupHeader';
   import RemoveFromGroupModal from './RemoveFromGroupModal';
+
+  const ReportsGroupHeaderStrings = crossComponentTranslator(ReportsGroupHeader);
 
   export default {
     name: 'GroupMembersPage',
@@ -128,6 +139,9 @@
     },
     computed: {
       ...mapState('groups', ['groups']),
+      backLinkString() {
+        return ReportsGroupHeaderStrings.$tr('back');
+      },
       currentGroup() {
         return this.groups.find(g => g.id === this.$route.params.groupId);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -15,7 +15,6 @@
     </td>
     <td class="core-table-button-col">
       <KDropdownMenu
-        v-if="!isUngrouped"
         appearance="flat-button"
         :text="coachStrings.$tr('optionsLabel')"
         :options="menuOptions"
@@ -29,13 +28,11 @@
 
 <script>
 
-  import { mapState } from 'vuex';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
-  import sortBy from 'lodash/sortBy';
   import commonCoach from '../../common';
 
   export default {
@@ -55,60 +52,21 @@
           return group.name && group.users;
         },
       },
-      isUngrouped: {
-        type: Boolean,
-        default: false,
-      },
-      canMove: {
-        type: Boolean,
-        default: true,
-      },
     },
     computed: {
-      ...mapState('groups', ['groupModalShown']),
-      sortedGroupUsers() {
-        return sortBy(this.group.users, user => user.full_name.toLowerCase());
-      },
       menuOptions() {
         return [this.coachStrings.$tr('renameAction'), this.coachStrings.$tr('deleteAction')];
-      },
-      allUsersAreSelected() {
-        return (
-          this.group.users.length === this.selectedUsers.length && this.selectedUsers.length !== 0
-        );
-      },
-      someUsersAreSelected() {
-        return !this.allUsersAreSelected && this.selectedUsers.length !== 0;
       },
     },
     methods: {
       handleSelection(selectedOption) {
+        let emitted;
         if (selectedOption === this.coachStrings.$tr('renameAction')) {
-          this.$emit('rename', this.group.name, this.group.id);
+          emitted = 'rename';
         } else if (selectedOption === this.coachStrings.$tr('deleteAction')) {
-          this.$emit('delete', this.group.name, this.group.id);
+          emitted = 'delete';
         }
-      },
-      isSelected(userId) {
-        return this.selectedUsers.includes(userId);
-      },
-      toggleSelection(userId) {
-        const index = this.selectedUsers.indexOf(userId);
-        if (index === -1) {
-          this.selectedUsers.push(userId);
-        } else {
-          this.selectedUsers.splice(index, 1);
-        }
-      },
-      toggleSelectAll() {
-        if (this.allUsersAreSelected) {
-          this.selectedUsers = [];
-        } else {
-          this.selectedUsers = this.group.users.map(user => user.id);
-        }
-      },
-      emitMove() {
-        this.$emit('move', this.group.name, this.group.id, this.selectedUsers, this.isUngrouped);
+        this.$emit(emitted, this.group.name, this.group.id);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -109,11 +109,10 @@
           name: '',
           id: '',
         },
-        usersToMove: [],
       };
     },
     computed: {
-      ...mapState('groups', ['classUsers', 'groupModalShown', 'groups']),
+      ...mapState('groups', ['groupModalShown', 'groups']),
       showCreateGroupModal() {
         return this.groupModalShown === GroupModals.CREATE_GROUP;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -10,7 +10,6 @@
 
     <KPageContainer>
       <PlanHeader />
-      <h1>{{ $tr('classGroups') }}</h1>
       <div class="ta-r">
         <KButton
           class="new-group-button"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
@@ -9,8 +9,13 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <PlanHeader />
+      <p>
+        <BackLink
+          :to="$router.getRoute('PLAN_LESSONS_ROOT', { classId: classId })"
+          :text="backLinkString"
+        />
 
+      </p>
       <div class="lesson-summary">
 
         <AssignmentSummary
@@ -69,17 +74,20 @@
 
   import { mapState, mapActions } from 'vuex';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import map from 'lodash/map';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoach from '../../common';
-  import PlanHeader from '../../plan/PlanHeader';
   import { AssignmentActions } from '../../../constants/assignmentsConstants';
   import { selectionRootLink } from '../../../routes/planLessonsRouterUtils';
   import AssignmentSummary from '../../plan/assignments/AssignmentSummary';
+  import ReportsLessonHeader from '../../reports/ReportsLessonHeader';
   import ManageLessonModals from './ManageLessonModals';
   import ResourceListTable from './ResourceListTable';
+
+  const ReportsLessonHeaderStrings = crossComponentTranslator(ReportsLessonHeader);
 
   export default {
     name: 'LessonSummaryPage',
@@ -89,7 +97,6 @@
       };
     },
     components: {
-      PlanHeader,
       KDropdownMenu,
       ResourceListTable,
       ManageLessonModals,
@@ -98,6 +105,9 @@
     },
     mixins: [commonCoach],
     computed: {
+      backLinkString() {
+        return ReportsLessonHeaderStrings.$tr('back');
+      },
       ...mapState(['reportRefreshInterval']),
       ...mapState('classSummary', { classId: 'id' }),
       ...mapState('lessonSummary', {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -11,7 +11,6 @@
     <KPageContainer>
       <PlanHeader />
 
-      <h1>{{ $tr('classLessons') }}</h1>
       <div class="filter-and-button">
         <KSelect
           v-model="filterSelection"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
@@ -4,7 +4,10 @@
     <div class="lesson-summary-header">
       <div class="lesson-summary-header-title-block">
         <h1 class="lesson-summary-header-title" dir="auto">
-          {{ title }}
+          <KLabeledIcon>
+            <KIcon slot="icon" lesson />
+            {{ title }}
+          </KLabeledIcon>
         </h1>
       </div>
       <slot name="optionsDropdown"></slot>
@@ -77,6 +80,8 @@
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import KButton from 'kolibri.coreVue.components.KButton';
+  import KIcon from 'kolibri.coreVue.components.KIcon';
+  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import { CollectionKinds, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import HeaderTable from '../../common/HeaderTable';
   import HeaderTableRow from '../../common/HeaderTable/HeaderTableRow';
@@ -90,6 +95,8 @@
       LessonActive,
       QuizActive,
       KButton,
+      KIcon,
+      KLabeledIcon,
       HeaderTable,
       HeaderTableRow,
     },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
@@ -27,6 +27,9 @@
               </KLabeledIcon>
             </li>
           </ul>
+          <p v-if="lessonsList.length === 0">
+            {{ coachStrings.$tr('lessonListEmptyState') }}
+          </p>
         </KGridItem>
         <KGridItem :sizes="[100, 100, 50]" percentage>
           <h2>{{ coachStrings.$tr('quizzesAssignedLabel') }}</h2>
@@ -41,6 +44,9 @@
               </KLabeledIcon>
             </li>
           </ul>
+          <p v-if="examsList.length === 0">
+            {{ coachStrings.$tr('quizListEmptyState') }}
+          </p>
         </KGridItem>
       </KGrid>
 

--- a/kolibri/plugins/user/assets/src/modules/profile/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/profile/actions.js
@@ -36,7 +36,7 @@ export function updateUserProfile(store, { edits, session }) {
     exists: true,
   }).then(
     () => {
-      store.dispatch('getCurrentSession', true, { root: true });
+      store.commit('CORE_SET_SESSION', changedValues, { root: true });
       store.commit('SET_PROFILE_SUCCESS', true);
       store.commit('SET_PROFILE_BUSY', false);
       store.commit('SET_PROFILE_ERRORS', { isError: false });

--- a/kolibri/plugins/user/assets/src/modules/profile/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/profile/actions.js
@@ -39,7 +39,7 @@ export function updateUserProfile(store, { edits, session }) {
       store.commit('CORE_SET_SESSION', changedValues, { root: true });
       store.commit('SET_PROFILE_SUCCESS', true);
       store.commit('SET_PROFILE_BUSY', false);
-      store.commit('SET_PROFILE_ERRORS', { isError: false });
+      store.commit('SET_PROFILE_ERRORS', []);
     },
     error => {
       const errorsCaught = CatchErrors(error, [ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS]);

--- a/kolibri/plugins/user/assets/src/modules/profile/index.js
+++ b/kolibri/plugins/user/assets/src/modules/profile/index.js
@@ -4,7 +4,7 @@ function defaultState() {
   return {
     busy: false,
     success: false,
-    errors: false,
+    errors: [],
     errorCode: null,
     errorMessage: '',
     passwordState: {

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -186,7 +186,10 @@
       ...mapState({
         session: state => state.core.session,
       }),
-      ...mapState('profile', ['busy', 'errorCode', 'passwordState', 'success', 'profileErrors']),
+      ...mapState('profile', ['busy', 'errorCode', 'passwordState', 'success']),
+      ...mapState('profile', {
+        profileErrors: 'errors',
+      }),
       userPermissions() {
         return pickBy(this.getUserPermissions);
       },
@@ -253,10 +256,7 @@
         return Boolean(this.usernameIsInvalidText);
       },
       usernameAlreadyExists() {
-        if (this.profileErrors) {
-          return this.profileErrors.includes(ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS);
-        }
-        return false;
+        return this.profileErrors.includes(ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS);
       },
       formIsValid() {
         return !this.usernameIsInvalid;


### PR DESCRIPTION
### Summary

1. Makes the layout of Plan > Group/Lesson look more like counterparts in Report
1. Removes the h1s in the Plan top-level pages (since the report counterparts don't have them)
1. Adds an empty state message to the ReportsGroupReportPage
1. Fixes #5156 
1. Fixes #5089
![screen shot 2019-02-26 at 10 08 56 am](https://user-images.githubusercontent.com/10248067/53435944-d7418980-39ae-11e9-9a57-5592ddba7de1.png)
![screen shot 2019-02-26 at 10 08 32 am](https://user-images.githubusercontent.com/10248067/53435945-d7418980-39ae-11e9-81f7-464316d7c4b2.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References

Fixes #5143 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
