### PR TITLE
pass timestamps to notifications

### DIFF
--- a/kolibri/core/logger/serializers.py
+++ b/kolibri/core/logger/serializers.py
@@ -111,6 +111,12 @@ class AttemptLogSerializer(KolibriModelSerializer):
                   'end_timestamp', 'completion_timestamp', 'item', 'time_spent', 'user',
                   'complete', 'correct', 'hinted', 'answer', 'simple_answer', 'interaction_history', 'error')
 
+    def create(self, validated_data):
+        instance = super(AttemptLogSerializer, self).create(validated_data)
+        # to check if a notification must be created:
+        wrap_to_save_queue(parse_attemptslog, instance)
+        return instance
+
     def update(self, instance, validated_data):
         instance = super(AttemptLogSerializer, self).update(instance, validated_data)
         # to check if a notification must be created:

--- a/kolibri/core/logger/serializers.py
+++ b/kolibri/core/logger/serializers.py
@@ -20,6 +20,7 @@ from kolibri.core.notifications.api import parse_examlog
 from kolibri.core.notifications.api import parse_summarylog
 from kolibri.core.notifications.tasks import wrap_to_save_queue
 from kolibri.core.serializers import KolibriModelSerializer
+from kolibri.utils.time_utils import local_now
 
 
 class ContentSessionLogSerializer(KolibriModelSerializer):
@@ -59,13 +60,13 @@ class ExamLogSerializer(KolibriModelSerializer):
             instance.completion_timestamp = now()
         instance = super(ExamLogSerializer, self).update(instance, validated_data)
         # to check if a notification must be created:
-        wrap_to_save_queue(parse_examlog, instance)
+        wrap_to_save_queue(parse_examlog, instance, local_now())
         return instance
 
     def create(self, validated_data):
         instance = super(ExamLogSerializer, self).create(validated_data)
         # to check if a notification must be created:
-        wrap_to_save_queue(create_examlog, instance)
+        wrap_to_save_queue(create_examlog, instance, local_now())
         return instance
 
 

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -337,6 +337,6 @@ def parse_attemptslog(attemptlog):
                                                lesson.group_or_classroom,
                                                lesson_id=lesson.id,
                                                contentnode_id=contentnode_id,
-                                               reason=HelpReason.Multiple)
+                                               timestamp=attemptlog.start_timestamp)
             notifications.append(notification)
         save_notifications(notifications)

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -194,11 +194,6 @@ def parse_summarylog(summarylog):
     Lesson Completed notification.
     """
 
-    # updating an exercise summary log might mean they made their first attempt in the exercise/lesson
-    # we try to create notifications for this event
-    if summarylog.kind == content_kinds.EXERCISE:
-        create_summarylog(summarylog)
-
     if summarylog.progress < 1.0:
         return
 

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -320,3 +320,23 @@ def parse_attemptslog(attemptlog):
                                                timestamp=attemptlog.end_timestamp)
             notifications.append(notification)
         save_notifications(notifications)
+
+    else:
+        notifications = []
+        for lesson, contentnode_id in lessons:
+            if LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
+                                                          notification_object=NotificationObjectType.Resource,
+                                                          notification_event=NotificationEventType.Started,
+                                                          lesson_id=lesson.id,
+                                                          classroom_id=lesson.group_or_classroom,
+                                                          contentnode_id=contentnode_id).exists():
+                continue
+            notification = create_notification(NotificationObjectType.Resource,
+                                               NotificationEventType.Started,
+                                               attemptlog.user_id,
+                                               lesson.group_or_classroom,
+                                               lesson_id=lesson.id,
+                                               contentnode_id=contentnode_id,
+                                               reason=HelpReason.Multiple)
+            notifications.append(notification)
+        save_notifications(notifications)

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -298,37 +298,30 @@ def parse_attemptslog(attemptlog):
     # More than 3 errors in this mastery log:
     needs_help = len(failed_interactions) > 3
 
-    if needs_help:
-        notifications = []
-        for lesson, contentnode_id in lessons:
+    notifications = []
+    for lesson, contentnode_id in lessons:
+        if needs_help:
             # This Event should be triggered only once
             # TODO: Decide if add a day interval filter, to trigger the event in different days
-            if LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
-                                                          notification_object=NotificationObjectType.Resource,
-                                                          notification_event=NotificationEventType.Help,
-                                                          lesson_id=lesson.id,
-                                                          classroom_id=lesson.group_or_classroom,
-                                                          contentnode_id=contentnode_id).exists():
-                continue
-            notification = create_notification(NotificationObjectType.Resource, NotificationEventType.Help,
-                                               attemptlog.user_id, lesson.group_or_classroom,
-                                               lesson_id=lesson.id,
-                                               contentnode_id=contentnode_id,
-                                               reason=HelpReason.Multiple,
-                                               timestamp=attemptlog.end_timestamp)
-            notifications.append(notification)
-        save_notifications(notifications)
-
-    else:
-        notifications = []
-        for lesson, contentnode_id in lessons:
-            if LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
+            if not LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
+                                                              notification_object=NotificationObjectType.Resource,
+                                                              notification_event=NotificationEventType.Help,
+                                                              lesson_id=lesson.id,
+                                                              classroom_id=lesson.group_or_classroom,
+                                                              contentnode_id=contentnode_id).exists():
+                notification = create_notification(NotificationObjectType.Resource, NotificationEventType.Help,
+                                                   attemptlog.user_id, lesson.group_or_classroom,
+                                                   lesson_id=lesson.id,
+                                                   contentnode_id=contentnode_id,
+                                                   reason=HelpReason.Multiple,
+                                                   timestamp=attemptlog.end_timestamp)
+                notifications.append(notification)
+        if not LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
                                                           notification_object=NotificationObjectType.Resource,
                                                           notification_event=NotificationEventType.Started,
                                                           lesson_id=lesson.id,
                                                           classroom_id=lesson.group_or_classroom,
                                                           contentnode_id=contentnode_id).exists():
-                continue
             notification = create_notification(NotificationObjectType.Resource,
                                                NotificationEventType.Started,
                                                attemptlog.user_id,
@@ -337,4 +330,5 @@ def parse_attemptslog(attemptlog):
                                                contentnode_id=contentnode_id,
                                                timestamp=attemptlog.start_timestamp)
             notifications.append(notification)
+    if notifications:
         save_notifications(notifications)

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -29,6 +29,8 @@ from kolibri.core.notifications.api import get_exam_group
 from kolibri.core.notifications.api import parse_attemptslog
 from kolibri.core.notifications.api import parse_examlog
 from kolibri.core.notifications.api import parse_summarylog
+from kolibri.core.notifications.models import HelpReason
+from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.core.notifications.models import NotificationEventType
 from kolibri.core.notifications.models import NotificationObjectType
 from kolibri.utils.time_utils import local_now
@@ -197,8 +199,9 @@ class NotificationsAPITestCase(APITestCase):
         assert notification.notification_object == NotificationObjectType.Quiz
         assert notification.notification_event == NotificationEventType.Started
 
+    @patch('kolibri.core.notifications.api.create_notification')
     @patch('kolibri.core.notifications.api.save_notifications')
-    def test_parse_attemptslog(self, save_notifications):
+    def test_parse_attemptslog_create_on_new_attempt_with_no_notification(self, save_notifications, create_notification):
         log = ContentSessionLogFactory(user=self.user1, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
         now = local_now()
         masterylog = MasteryLog.objects.create(summarylog=self.summarylog1, user=self.user1,
@@ -210,31 +213,203 @@ class NotificationsAPITestCase(APITestCase):
                                                 end_timestamp=now, time_spent=1.0,
                                                 complete=True, correct=1,
                                                 hinted=False, error=False,
-                                                interaction_history=interactions
+                                                interaction_history=[interactions[0]]
                                                 )
         parse_attemptslog(attemptlog1)
         assert save_notifications.called
-        save_notifications.reset_mock()
+        create_notification.assert_called_once_with(NotificationObjectType.Resource,
+                                                    NotificationEventType.Started,
+                                                    attemptlog1.user_id,
+                                                    self.classroom.id,
+                                                    lesson_id=self.lesson_id,
+                                                    contentnode_id=self.node_1.id,
+                                                    timestamp=attemptlog1.start_timestamp)
+
+    @patch('kolibri.core.notifications.api.create_notification')
+    @patch('kolibri.core.notifications.api.save_notifications')
+    def test_parse_attemptslog_create_on_new_attempt_with_notification(self, save_notifications, create_notification):
+        log = ContentSessionLogFactory(user=self.user1, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+        now = local_now()
+        masterylog = MasteryLog.objects.create(summarylog=self.summarylog1, user=self.user1,
+                                               start_timestamp=now, mastery_level=1,
+                                               complete=True)
+        interactions = [{"type": "answer", "correct": 0} for _ in range(3)]
+        attemptlog1 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                                user=self.user1, start_timestamp=now,
+                                                end_timestamp=now, time_spent=1.0,
+                                                complete=True, correct=1,
+                                                hinted=False, error=False,
+                                                interaction_history=[interactions[0]]
+                                                )
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Resource,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog1.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
+                                                   contentnode_id=self.node_1.id,
+                                                   timestamp=attemptlog1.start_timestamp)
+
         attemptlog2 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
                                                 user=self.user1, start_timestamp=now,
                                                 end_timestamp=now, time_spent=1.0,
                                                 complete=True, correct=1,
                                                 hinted=False, error=False,
-                                                interaction_history=interactions
+                                                interaction_history=[interactions[0]]
                                                 )
         parse_attemptslog(attemptlog2)
-        assert save_notifications.called
+        assert save_notifications.called is False
+        assert create_notification.called is False
+
+    @patch('kolibri.core.notifications.api.create_notification')
+    @patch('kolibri.core.notifications.api.save_notifications')
+    def test_parse_attemptslog_update_attempt_with_three_wrong_attempts(self, save_notifications, create_notification):
+        log = ContentSessionLogFactory(user=self.user1, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+        now = local_now()
+        masterylog = MasteryLog.objects.create(summarylog=self.summarylog1, user=self.user1,
+                                               start_timestamp=now, mastery_level=1,
+                                               complete=True)
+        interactions = [{"type": "answer", "correct": 0}]
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=0,
+                                  hinted=False, error=False,
+                                  interaction_history=interactions
+                                  )
+
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=0,
+                                  hinted=False, error=False,
+                                  interaction_history=interactions
+                                  )
         # more than 3 attempts will trigger the help notification
         interactions.append({"type": "answer", "correct": 0})
-        attemptlog2 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+        attemptlog3 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                                user=self.user1, start_timestamp=now,
+                                                end_timestamp=now, time_spent=1.0,
+                                                complete=True, correct=0,
+                                                hinted=False, error=False,
+                                                interaction_history=interactions
+                                                )
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Resource,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog3.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
+                                                   contentnode_id=self.node_1.id,
+                                                   timestamp=attemptlog3.start_timestamp)
+        parse_attemptslog(attemptlog3)
+        assert save_notifications.called
+        create_notification.assert_called_once_with(NotificationObjectType.Resource,
+                                                    NotificationEventType.Help,
+                                                    attemptlog3.user_id,
+                                                    self.classroom.id,
+                                                    lesson_id=self.lesson_id,
+                                                    contentnode_id=self.node_1.id,
+                                                    reason=HelpReason.Multiple,
+                                                    timestamp=attemptlog3.start_timestamp)
+
+    @patch('kolibri.core.notifications.api.create_notification')
+    @patch('kolibri.core.notifications.api.save_notifications')
+    def test_parse_attemptslog_update_attempt_with_three_wrong_attempts_on_same_attempt(self, save_notifications, create_notification):
+        log = ContentSessionLogFactory(user=self.user1, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+        now = local_now()
+        masterylog = MasteryLog.objects.create(summarylog=self.summarylog1, user=self.user1,
+                                               start_timestamp=now, mastery_level=1,
+                                               complete=True)
+        interactions = [{"type": "answer", "correct": 0} for _ in range(3)]
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=1,
+                                  hinted=False, error=False,
+                                  interaction_history=[interactions[0]]
+                                  )
+
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=1,
+                                  hinted=False, error=False,
+                                  interaction_history=[interactions[0]]
+                                  )
+        # more than 3 attempts will trigger the help notification
+        interactions.append({"type": "answer", "correct": 0})
+        attemptlog3 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
                                                 user=self.user1, start_timestamp=now,
                                                 end_timestamp=now, time_spent=1.0,
                                                 complete=True, correct=1,
                                                 hinted=False, error=False,
                                                 interaction_history=interactions
                                                 )
-        parse_attemptslog(attemptlog2)
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Resource,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog3.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
+                                                   contentnode_id=self.node_1.id,
+                                                   timestamp=attemptlog3.start_timestamp)
+        parse_attemptslog(attemptlog3)
         assert save_notifications.called
-        notification = save_notifications.call_args[0][0][0]
-        assert notification.notification_object == NotificationObjectType.Resource
-        assert notification.notification_event == NotificationEventType.Help
+        create_notification.assert_called_once_with(NotificationObjectType.Resource,
+                                                    NotificationEventType.Help,
+                                                    attemptlog3.user_id,
+                                                    self.classroom.id,
+                                                    lesson_id=self.lesson_id,
+                                                    contentnode_id=self.node_1.id,
+                                                    reason=HelpReason.Multiple,
+                                                    timestamp=attemptlog3.start_timestamp)
+
+    @patch('kolibri.core.notifications.api.create_notification')
+    @patch('kolibri.core.notifications.api.save_notifications')
+    def test_parse_attemptslog_update_attempt_with_three_wrong_attempts_no_started(self, save_notifications, create_notification):
+        log = ContentSessionLogFactory(user=self.user1, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex)
+        now = local_now()
+        masterylog = MasteryLog.objects.create(summarylog=self.summarylog1, user=self.user1,
+                                               start_timestamp=now, mastery_level=1,
+                                               complete=True)
+        interactions = [{"type": "answer", "correct": 0}]
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=0,
+                                  hinted=False, error=False,
+                                  interaction_history=interactions
+                                  )
+
+        AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                  user=self.user1, start_timestamp=now,
+                                  end_timestamp=now, time_spent=1.0,
+                                  complete=True, correct=0,
+                                  hinted=False, error=False,
+                                  interaction_history=interactions
+                                  )
+        # more than 3 attempts will trigger the help notification
+        interactions.append({"type": "answer", "correct": 0})
+        attemptlog3 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
+                                                user=self.user1, start_timestamp=now,
+                                                end_timestamp=now, time_spent=1.0,
+                                                complete=True, correct=0,
+                                                hinted=False, error=False,
+                                                interaction_history=interactions
+                                                )
+        parse_attemptslog(attemptlog3)
+        assert save_notifications.called
+        create_notification.assert_any_call(NotificationObjectType.Resource,
+                                            NotificationEventType.Help,
+                                            attemptlog3.user_id,
+                                            self.classroom.id,
+                                            lesson_id=self.lesson_id,
+                                            contentnode_id=self.node_1.id,
+                                            reason=HelpReason.Multiple,
+                                            timestamp=attemptlog3.start_timestamp)
+
+        create_notification.assert_any_call(NotificationObjectType.Resource,
+                                            NotificationEventType.Started,
+                                            attemptlog3.user_id,
+                                            self.classroom.id,
+                                            lesson_id=self.lesson_id,
+                                            contentnode_id=self.node_1.id,
+                                            timestamp=attemptlog3.start_timestamp)

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -166,12 +166,7 @@ class NotificationsAPITestCase(APITestCase):
     @patch('kolibri.core.notifications.api.save_notifications')
     def test_parse_summarylog_exercise(self, save_notifications):
         parse_summarylog(self.summarylog2)
-        assert save_notifications.called
-        notification = save_notifications.call_args[0][0][0]
-        assert notification.notification_object == NotificationObjectType.Resource
-        assert notification.notification_event == NotificationEventType.Started
-        assert notification.lesson_id == self.lesson.id
-        assert notification.contentnode_id == self.node_2.id
+        assert save_notifications.called is False
 
     @patch('kolibri.core.notifications.api.save_notifications')
     def test_create_summarylog(self, save_notifications):

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -130,14 +130,14 @@ class NotificationsAPITestCase(APITestCase):
         summarylog = ContentSummaryLogFactory.create(user=self.user2,
                                                      content_id=self.node_1.content_id,
                                                      channel_id=self.channel_id)
-        lessons = get_assignments(summarylog, summarylog, attempt=False)
+        lessons = get_assignments(self.user2, summarylog, attempt=False)
         assert lessons == []
         # user1 has one lesson:
-        lessons = get_assignments(self.summarylog1, self.summarylog1, attempt=False)
+        lessons = get_assignments(self.user1, self.summarylog1, attempt=False)
         assert len(lessons) > 0
         assert type(lessons[0][0]) == Lesson
         # being the node an Exercise, it should be available for attempts:
-        lessons = get_assignments(self.summarylog1, self.summarylog1, attempt=True)
+        lessons = get_assignments(self.user1, self.summarylog1, attempt=True)
         assert len(lessons) > 0
 
     def test_get_exam_group(self):

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/index.js
@@ -45,6 +45,11 @@ export default {
           if (!store.state.poller) {
             store.dispatch('startingPolling', { coachesPolling: data.coaches_polling });
           }
+        })
+        .catch(() => {
+          if (!store.state.poller) {
+            store.dispatch('startingPolling', { coachesPolling: 0 });
+          }
         });
     },
     updateNotificationsForClass(store, { classroomId, after }) {
@@ -62,6 +67,9 @@ export default {
             store.dispatch('classSummary/updateWithNotifications', data.results, { root: true });
           }
           store.dispatch('startingPolling', { coachesPolling: data.coaches_polling });
+        })
+        .catch(() => {
+          store.dispatch('startingPolling', { coachesPolling: 0 });
         });
     },
     startingPolling(store, { coachesPolling }) {


### PR DESCRIPTION
### Summary

This attempts to address #5158 and #5079 by explicitly passing timestamps into the notifications rather than generating them at the time the notification object is created

### Reviewer guidance

notification objects are actually created a while after the event occurs, leading to discrepancies between attempt logs and notification history

### References

While working on this, I noticed some very peculiar behaviors in the way that exercise 'started' notifications are (or are not) being sent.

see https://github.com/learningequality/kolibri/issues/5113#issuecomment-467643676

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
