### PR TITLE
Set on save, not before.

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -121,10 +121,11 @@ export class Model {
                 payload[key] = attrs[key];
               }
             });
-            this.set(payload);
           } else {
-            this.set(attrs);
-            payload = this.attributes;
+            payload = {
+              ...this.attributes,
+              ...attrs,
+            };
           }
           if (!Object.keys(payload).length) {
             // Nothing to save, so just resolve the promise now.

--- a/kolibri/core/assets/test/api-resource.spec.js
+++ b/kolibri/core/assets/test/api-resource.spec.js
@@ -1145,10 +1145,10 @@ describe('Model', function() {
             done();
           });
         });
-        it('should call set twice', function(done) {
+        it('should call set once', function(done) {
           model.synced = false;
           model.save(payload).then(() => {
-            expect(setSpy).toHaveBeenCalledTimes(2);
+            expect(setSpy).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -1237,6 +1237,14 @@ describe('Model', function() {
           model.synced = false;
           model.save().catch(() => {
             expect(model.promises).toEqual([]);
+            done();
+          });
+        });
+        it('should not set data on the model', function(done) {
+          model.synced = false;
+          model.attributes.test = 'notatest';
+          model.save({ test: 'test' }).catch(() => {
+            expect(model.attributes.test).toEqual('notatest');
             done();
           });
         });


### PR DESCRIPTION
### Summary
Fixes a subtle bug whereby we would set data on a model before saving. If the save was rejected, this would not roll back.

Fixes this by only setting on the model after the save is successful.

### Reviewer guidance
I have written a test for this behaviour, but one place in the UI is in the user profile:
1. Try to change your username to a username that already exists on the server.
2. Press save.
3. Be told that this is not a valid username.
4. Change Full name to another name.
5. Change username back to original username.
6. Save again.
7. Prior to this fix it would give you the validation error, because the original, invalid username would still be being sent to the client. After this fix, it works as expected.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
