### PR TITLE
Fix for notification version-checking and database corruption

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -12,6 +12,7 @@ from sqlite3 import DatabaseError as SQLite3DatabaseError
 import django
 from django.core.exceptions import AppRegistryNotReady
 from django.core.management import call_command
+from django.db import connections
 from django.db.utils import DatabaseError
 from docopt import docopt
 
@@ -318,6 +319,11 @@ def start(port=None, daemon=True):
         )
         kwargs['out_log'] = server.DAEMON_LOG
         kwargs['err_log'] = server.DAEMON_LOG
+
+        # close all connections before forking, to avoid SQLite corruption:
+        # https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_
+        connections.close_all()
+
         become_daemon(**kwargs)
 
     server.start(port=port, run_cherrypy=run_cherrypy)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some fixes to issues in the notification message/version-checking logic uncovered during changes to nutritionfacts being made to support https://github.com/learningequality/kolibri/pull/4828#issuecomment-462215605

Plus: a tiny fix that should eliminate the database corruption issues we've been seeing for years.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The version-parsing error can be triggered by calling this on the old code (before this PR):
```KOLIBRI_RUN_MODE=msg-test kolibri --debug manage ping --once --server http://nutritionfacts-staging.nanoapp.io```
and then logging into the UI as an admin. It creates a message with empty string as version_range, which blew up the former logic we had in Kolibri.

I replicated the corruption issue by running `kolibri start` in one terminal, and this in another:
`while true; do KOLIBRI_RUN_MODE=msg-test9 kolibri --debug manage ping --once --server http://nutritionfacts-staging.nanoapp.io; done`
Then clicking around in the UI and logging/in out. After a while it leads to a 500 in the web UI.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
