### PR TITLE
Don't always show core table scrollbar

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -117,7 +117,7 @@
 
   /deep/ td {
     max-width: 300px;
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   /deep/ tr:not(:last-child) {


### PR DESCRIPTION
### Summary
Uses auto instead of scroll to hide unsightly scrollbars.

### Reviewer guidance
Look ok?

### References
See https://github.com/learningequality/kolibri/pull/5134#issuecomment-467677502

Before:
![image](https://user-images.githubusercontent.com/1680573/53466387-99704f80-3a06-11e9-898e-4a8f2d54a0aa.png)


After:
![image](https://user-images.githubusercontent.com/1680573/53466372-83628f00-3a06-11e9-8b38-0d126fd6131a.png)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
