### PR TITLE
Create a started notification for exercises as soon as an attempt log is created

### DIFF
--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -315,3 +315,23 @@ def parse_attemptslog(attemptlog):
                                                reason=HelpReason.Multiple)
             notifications.append(notification)
         save_notifications(notifications)
+
+    else:
+        notifications = []
+        for lesson, contentnode_id in lessons:
+            if LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
+                                                          notification_object=NotificationObjectType.Resource,
+                                                          notification_event=NotificationEventType.Started,
+                                                          lesson_id=lesson.id,
+                                                          classroom_id=lesson.group_or_classroom,
+                                                          contentnode_id=contentnode_id).exists():
+                continue
+            notification = create_notification(NotificationObjectType.Resource,
+                                               NotificationEventType.Started,
+                                               attemptlog.user_id,
+                                               lesson.group_or_classroom,
+                                               lesson_id=lesson.id,
+                                               contentnode_id=contentnode_id,
+                                               reason=HelpReason.Multiple)
+            notifications.append(notification)
+        save_notifications(notifications)


### PR DESCRIPTION
### Summary
Create a started notification for exercises when an attempt is updated.

### Reviewer guidance
Does it seem to fix issues described in #5113 ?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
