### PR TITLE
Adds some but not all of the creative commons translations

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -4,6 +4,8 @@ import logger from 'kolibri.lib.logging';
 import importIntlLocale from './intl-locale-data';
 import importVueIntlLocaleData from './vue-intl-locale-data';
 
+export { licenseTranslations } from './licenseTranslations';
+
 const logging = logger.getLogger(__filename);
 
 function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {

--- a/kolibri/core/assets/src/utils/licenseTranslations.js
+++ b/kolibri/core/assets/src/utils/licenseTranslations.js
@@ -1,0 +1,166 @@
+// except where specified, these are from
+// https://creativecommons.org/licenses/?lang=ar
+
+export const licenseTranslations = {
+  ar: {
+    'CC BY': {
+      name: 'نَسب المُصنَّف',
+      description:
+        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك، سواء أكان ذلك لأغراض تجارية أو غير تجارية، طالما ينسبون العمل الأصلي لك. هذه هي الرخصة الأكثر تسامحاً في مجموعة الرخص المعروضة. وهي الأنسب لضمان أكبر انتشار واستخدام ممكن للمواد المرخَّصة.',
+    },
+    'CC BY-SA': {
+      name: 'نَسب المُصنَّف - الترخيص بالمثل',
+      description:
+        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك، سواء أكان ذلك لأغراض تجارية أو غير تجارية، طالما ينسبون العمل الأصلي لك ويرخصون أعمالهم المشتقة تحت نفس الشروط. وهذه الرخصة غالباً تضاهي رخص "الحقوق المتروكة" للبرمجيات الحرة والمفتوحة المصدر. كل الأعمال المشتقة من عملك ستحمل نفس الرخصة، بالتالي جميع الأعمال المشتقة تسمح بالاستخدام التجاري. هذه الرخصة هي المستخدمة من قبل ويكيبيديا، وننصح بها للمواد التي قد تستفيد من الاشتقاق من ويكيبيديا والمشاريع المماثلة في الترخيص.',
+    },
+    'CC BY-ND': {
+      name: 'نسب المصنف - منع الاشتقاق',
+      // unofficial translation:
+      description:
+        'َهذه الرخصة تسمح بإعادة التوزیع، الاستخدام التجاري وغیر التجاري، بشرط عدم التعدیل، ون',
+    },
+    'CC BY-NC': {
+      name: 'نسب المصنف - غير تجاري',
+      description:
+        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك في غير الأغراض التجارية، وبالرغم من أن الأعمال المشتقة يجب أن تنسب العمل الأصلي إليك وأن تكون غير تجارية، فإنه لا يلزم أن يتم ترخيصها بنفس الشروط.',
+    },
+    'CC BY-NC-SA': {
+      name: 'نَسب المُصنَّف - غير تجاري - الترخيص بالمثل',
+      description:
+        'هذه الرخصة تتيح للآخرين التعديل، التحسين، وبناء نسخ مشتقة من المُصنَّف ولكن في غير الأغراض التجارية، بشرط نَسب العمل الأصلي إليك وترخيص الأعمال الجديدة بنفس الرخصة.',
+    },
+    'CC BY-NC-ND': {
+      name: 'نَسب المُصنَّف - غير تجاري - منع الاشتقاق',
+      description:
+        'هذه الرخصة هي الأكثر قيوداً في رخصنا الستة الأساسية، إنها تتيح فقط للآخرين تحميل أعمالك ومشاركتها مع الآخرين بشرط نَسب العمل الأصلي إليك، ودون القيام بأي تعديل أو استخدامها لأغراض تجارية.',
+    },
+  },
+  en: {
+    'CC BY': {
+      name: 'Attribution',
+      description:
+        'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.',
+    },
+    'CC BY-SA': {
+      name: 'Attribution-ShareAlike',
+      description:
+        'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
+    },
+    'CC BY-ND': {
+      name: 'Attribution-NoDerivs',
+      description:
+        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+    },
+    'CC BY-NC': {
+      name: 'Attribution-NonCommercial',
+      description:
+        'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
+    },
+    'CC BY-NC-SA': {
+      name: 'Attribution-NonCommercial-ShareAlike',
+      description:
+        'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
+    },
+    'CC BY-NC-ND': {
+      name: 'Attribution-NonCommercial-NoDerivs',
+      description:
+        'This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
+    },
+  },
+  'fr-fr': {
+    'CC BY': {
+      name: 'Attribution',
+      description:
+        'Cette licence permet aux autres de distribuer, remixer, arranger, et adapter votre œuvre, même à des fins commerciales, tant qu’on vous accorde le mérite de la création originale en citant votre nom. C’est le contrat le plus souple proposé. Recommandé pour la diffusion et l’utilisation maximales d’œuvres licenciées sous CC.',
+    },
+    'CC BY-SA': {
+      name: 'Attribution - Partage dans les Mêmes Conditions',
+      description:
+        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre, même à des fins commerciales, tant qu’on vous accorde le mérite en citant votre nom et qu’on diffuse les nouvelles créations selon des conditions identiques. Cette licence est souvent comparée aux licences de logiciels libres, “open source” ou “copyleft”. Toutes les nouvelles œuvres basées sur les vôtres auront la même licence, et toute œuvre dérivée pourra être utilisée même à des fins commerciales. C’est la licence utilisée par Wikipédia ; elle est recommandée pour des œuvres qui pourraient bénéficier de l’incorporation de contenu depuis Wikipédia et d’autres projets sous licence similaire.',
+    },
+    'CC BY-ND': {
+      name: 'Attribution - Pas de Modification',
+      description:
+        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+    },
+    'CC BY-NC': {
+      name: 'Attribution - Pas d’Utilisation Commerciale',
+      description:
+        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre à des fins non commerciales et, bien que les nouvelles œuvres doivent vous créditer en citant votre nom et ne pas constituer une utilisation commerciale, elles n’ont pas à être diffusées selon les mêmes conditions.',
+    },
+    'CC BY-NC-SA': {
+      name: 'Attribution - Pas d’Utilisation Commerciale - Partage dans les Mêmes Conditions',
+      description:
+        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre à des fins non commerciales tant qu’on vous crédite en citant votre nom et que les nouvelles œuvres sont diffusées selon les mêmes conditions.',
+    },
+    'CC BY-NC-ND': {
+      name: 'Attribution - Pas d’Utilisation Commerciale - Pas de Modification',
+      description:
+        'Cette licence est la plus restrictive de nos six licences principales, n’autorisant les autres qu’à télécharger vos œuvres et à les partager tant qu’on vous crédite en citant votre nom, mais on ne peut les modifier de quelque façon que ce soit ni les utiliser à des fins commerciales.',
+    },
+  },
+  'es-es': {
+    'CC BY': {
+      name: 'Atribución',
+      description:
+        'Esta licencia permite a otras distribuir, remezclar, retocar, y crear a partir de su obra, incluso con fines comerciales, siempre y cuando den crédito por la creación original. Esta es la más flexible de las licencias ofrecidas. Se recomienda para la máxima difusión y utilización de los materiales licenciados.',
+    },
+    'CC BY-SA': {
+      name: 'Atribución-CompartirIgual',
+      description:
+        'Esta licencia permite a otras remezclar, retocar, y crear a partir de su obra, incluso con fines comerciales, siempre y cuando den crédito y licencien sus nuevas creaciones bajo los mismos términos. Esta licencia suele ser comparada con las licencias «copyleft» de software libre y de código abierto. Todas las nuevas obras basadas en la suya portarán la misma licencia, así que cualesquiera obras derivadas permitirán también uso comercial. Esta es la licencia que usa Wikipedia, y se recomienda para materiales que se beneficiarían de incorporar contenido de Wikipedia y proyectos con licencias similares.',
+    },
+    'CC BY-ND': {
+      name: 'Atribución-SinDerivadas',
+      description:
+        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+    },
+    'CC BY-NC': {
+      name: 'Atribución-NoComercial',
+      description:
+        'Esta licencia permite a otras distribuir, remezclar, retocar, y crear a partir de su obra de forma no comercial y, a pesar de que sus nuevas obras deben siempre mencionarle y ser no comerciales, no están obligadas a licenciar sus obras derivadas bajo los mismos términos.',
+    },
+    'CC BY-NC-SA': {
+      name: 'Atribución-NoComercial-CompartirIgual',
+      description:
+        'Esta licencia permite a otras remezclar, retocar, y crear a partir de su obra de forma no comercial, siempre y cuando den crédito y licencien sus nuevas creaciones bajo los mismos términos.',
+    },
+    'CC BY-NC-ND': {
+      name: 'Atribución-NoComercial-SinDerivadas',
+      description:
+        'Esta licencia es la más restrictiva de nuestras seis licencias principales, permitiendo a otras sólo descargar sus obras y compartirlas con otras siempre y cuando den crédito, pero no pueden cambiarlas de forma alguna ni usarlas de forma comercial.',
+    },
+  },
+  'pt-br': {
+    'CC BY': {
+      name: 'Atribuição',
+      description:
+        'Esta licença permite que outros distribuam, remixem, adaptem e criem a partir do seu trabalho, mesmo para fins comerciais, desde que lhe atribuam o devido crédito pela criação original. É a licença mais flexível de todas as licenças disponíveis. É recomendada para maximizar a disseminação e uso dos materiais licenciados.',
+    },
+    'CC BY-SA': {
+      name: 'Atribuição-CompartilhaIgual',
+      description:
+        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho, mesmo para fins comerciais, desde que lhe atribuam o devido crédito e que licenciem as novas criações sob termos idênticos. Esta licença costuma ser comparada com as licenças de software livre e de código aberto "copyleft". Todos os trabalhos novos baseados no seu terão a mesma licença, portanto quaisquer trabalhos derivados também permitirão o uso comercial. Esta é a licença usada pela Wikipédia e é recomendada para materiais que seriam beneficiados com a incorporação de conteúdos da Wikipédia e de outros projetos com licenciamento semelhante.',
+    },
+    'CC BY-ND': {
+      name: 'Atribuição-SemDerivações',
+      description:
+        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+    },
+    'CC BY-NC': {
+      name: 'Atribuição-NãoComercial',
+      description:
+        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho para fins não comerciais, e embora os novos trabalhos tenham de lhe atribuir o devido crédito e não possam ser usados para fins comerciais, os usuários não têm de licenciar esses trabalhos derivados sob os mesmos termos.',
+    },
+    'CC BY-NC-SA': {
+      name: 'Atribuição-NãoComercial-CompartilhaIgual',
+      description:
+        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho para fins não comerciais, desde que atribuam a você o devido crédito e que licenciem as novas criações sob termos idênticos.',
+    },
+    'CC BY-NC-ND': {
+      name: 'Atribuição-SemDerivações-SemDerivados',
+      description:
+        'Esta é a mais restritiva das nossas seis licenças principais, só permitindo que outros façam download dos seus trabalhos e os compartilhem desde que atribuam crédito a você, mas sem que possam alterá-los de nenhuma forma ou utilizá-los para fins comerciais.',
+    },
+  },
+};

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -82,7 +82,7 @@
   import InfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
-  import { licenseTranslations } from 'kolibri.utils.i18n';
+  import { currentLanguage, licenseTranslations } from 'kolibri.utils.i18n';
   import markdownIt from 'markdown-it';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
@@ -173,10 +173,10 @@
       },
       translatedLicense() {
         if (
-          licenseTranslations[global.languageCode] &&
-          licenseTranslations[global.languageCode][this.content.license_name]
+          licenseTranslations[currentLanguage] &&
+          licenseTranslations[currentLanguage][this.content.license_name]
         ) {
-          return licenseTranslations[global.languageCode][this.content.license_name];
+          return licenseTranslations[currentLanguage][this.content.license_name];
         }
         return null;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -39,7 +39,7 @@
             {{ content.license_name }}
             <InfoIcon
               v-if="content.license_description"
-              :tooltipText="content.license_description"
+              :tooltipText="licenseHelpText"
               :iconAriaLabel="content.license_description"
             />
           </li>
@@ -82,6 +82,7 @@
   import InfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import { licenseTranslations } from 'kolibri.utils.i18n';
   import markdownIt from 'markdown-it';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
@@ -169,6 +170,21 @@
       },
       content() {
         return this.currentContentNode;
+      },
+      translatedLicense() {
+        if (
+          licenseTranslations[global.languageCode] &&
+          licenseTranslations[global.languageCode][this.content.license_name]
+        ) {
+          return licenseTranslations[global.languageCode][this.content.license_name];
+        }
+        return null;
+      },
+      licenseHelpText() {
+        if (this.translatedLicense) {
+          return `${this.translatedLicense.name} – ${this.translatedLicense.description}`;
+        }
+        return this.content.license_description;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -64,7 +64,6 @@
       <p v-if="content.author">
         {{ $tr('author', {author: content.author}) }}
       </p>
-
       <p v-if="content.license_name">
         {{ $tr('license', {license: content.license_name}) }}
 
@@ -78,9 +77,13 @@
             <mat-svg v-if="licenceDescriptionIsVisible" name="expand_less" category="navigation" />
             <mat-svg v-else name="expand_more" category="navigation" />
           </UiIconButton>
-          <p v-if="licenceDescriptionIsVisible" dir="auto">
-            {{ content.license_description }}
-          </p>
+          <div v-if="licenceDescriptionIsVisible" dir="auto" class="license-details">
+            <template v-if="translatedLicense">
+              <p class="license-details-name">{{ licenseName }}</p>
+              <p>{{ licenseDescription }}</p>
+            </template>
+            <p v-else>{{ content.license_description }}</p>
+          </div>
         </template>
       </p>
 
@@ -135,6 +138,7 @@
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
+  import { licenseTranslations } from 'kolibri.utils.i18n';
   import { PageNames, PageModes, ClassesPageNames } from '../constants';
   import { updateContentNodeProgress } from '../modules/coreLearn/utils';
   import PageHeader from './PageHeader';
@@ -251,6 +255,27 @@
           params: { id: this.content.next_content.id },
         };
       },
+      translatedLicense() {
+        if (
+          licenseTranslations[global.languageCode] &&
+          licenseTranslations[global.languageCode][this.content.license_name]
+        ) {
+          return licenseTranslations[global.languageCode][this.content.license_name];
+        }
+        return null;
+      },
+      licenseName() {
+        if (this.translatedLicense) {
+          return this.translatedLicense.name;
+        }
+        return this.content.license_name;
+      },
+      licenseDescription() {
+        if (this.translatedLicense) {
+          return this.translatedLicense.description;
+        }
+        return this.content.license_description;
+      },
     },
     beforeDestroy() {
       this.stopTracking();
@@ -316,6 +341,15 @@
 
   .download-button {
     display: block;
+  }
+
+  .license-details {
+    margin-bottom: 24px;
+    margin-left: 16px;
+  }
+
+  .license-details-name {
+    font-weight: bold;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -138,7 +138,7 @@
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
-  import { licenseTranslations } from 'kolibri.utils.i18n';
+  import { currentLanguage, licenseTranslations } from 'kolibri.utils.i18n';
   import { PageNames, PageModes, ClassesPageNames } from '../constants';
   import { updateContentNodeProgress } from '../modules/coreLearn/utils';
   import PageHeader from './PageHeader';
@@ -257,10 +257,10 @@
       },
       translatedLicense() {
         if (
-          licenseTranslations[global.languageCode] &&
-          licenseTranslations[global.languageCode][this.content.license_name]
+          licenseTranslations[currentLanguage] &&
+          licenseTranslations[currentLanguage][this.content.license_name]
         ) {
-          return licenseTranslations[global.languageCode][this.content.license_name];
+          return licenseTranslations[currentLanguage][this.content.license_name];
         }
         return null;
       },


### PR DESCRIPTION

### Summary

hard-codes CC license translations into the code-base, based on https://creativecommons.org/licenses/

Adds:

* arabic
* english (official from CC)
* french
* spanish
* brazilian portuguese

| coach | learner |
|--|--|
|![image](https://user-images.githubusercontent.com/2367265/53478182-19101580-3a2b-11e9-97ce-68b23ba0cc17.png) | ![image](https://user-images.githubusercontent.com/2367265/53478216-2a592200-3a2b-11e9-8d0a-bedff1f603c5.png) |



### Reviewer guidance

This updates the learner content view and the coach lesson management view. Those are the only places I could find license display.

Some notes:

* current implementation embeds full descriptions license descriptions and names within the content, which seems possibly incorrect
* current implementation doesn't distinguish license names vs license IDs, but CC does (e.g. CC BY-NC vs Attribution-NonCommercial)
* this PR does nothing to address non-CC licenses or placeholders like "special permission to use in kolibri"

### References

issues:

* fixes #5148
* refs #2371 but does not fix it

code:

* https://github.com/learningequality/le-utils/blob/master/le_utils/constants/licenses.py#L10
* https://github.com/learningequality/le-utils/blob/master/le_utils/resources/licenselookup.json#L1

internal docs:

* https://drive.google.com/file/d/1FgwHiDY4w2_70tan966lizdbL4yksDPr/view
* https://drive.google.com/file/d/1Fx_6SrglhbHOKajtWU1tzYj2r_WrtJr1/view


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
