### PR TITLE
Group notifications

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -13,7 +13,6 @@ export function displayModal(store, modalName) {
 }
 
 export function createGroup(store, { groupName, classId }) {
-  store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
   return LearnerGroupResource.saveModel({
     data: {
       parent: classId,
@@ -28,8 +27,6 @@ export function createGroup(store, { groupName, classId }) {
       LearnerGroupResource.clearCache();
 
       store.commit('SET_GROUPS', groups);
-      store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-      store.commit('SET_GROUP_MODAL', '');
       // We have updated the groups, so update the classSummary
       // to get that back up to date!
       return store.dispatch('classSummary/refreshClassSummary', null, { root: true });

--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -55,15 +55,11 @@ export function renameGroup(store, { groupId, newGroupName }) {
 }
 
 export function deleteGroup(store, groupId) {
-  store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
   return LearnerGroupResource.deleteModel({ id: groupId }).then(
     () => {
       const groups = store.state.groups;
       const updatedGroups = groups.filter(group => group.id !== groupId);
-
       store.commit('SET_GROUPS', updatedGroups);
-      store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-      store.commit('SET_GROUP_MODAL', '');
     },
     error => store.dispatch('handleError', error, { root: true })
   );

--- a/kolibri/plugins/coach/assets/src/views/common/groupManagement/groupManagementStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/groupManagement/groupManagementStrings.js
@@ -26,7 +26,7 @@ const groupMgmtStrings = createTranslator('GroupManagementStrings', {
 
   // notifications
   groupDeletedNotice: 'Group deleted',
-  groupCreatedNotice: 'Group ceated',
+  groupCreatedNotice: 'Group created',
   addedLearnersNotice:
     'Added {value, number, integer} {value, plural, one {learner} other {learners}}',
   removedLearnersNotice:

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -115,6 +115,7 @@
   import ClassEnrollForm from '../../../../../../facility_management/assets/src/views/ClassEnrollForm';
   import LearnerClassEnrollmentPage from '../../../../../../facility_management/assets/src/views/LearnerClassEnrollmentPage';
   import GroupsPage from '../GroupsPage';
+  import { groupMgmtStrings } from '../../common/groupManagement/groupManagementStrings';
 
   const classEnrollFormStrings = crossComponentTranslator(ClassEnrollForm);
   const learnerClassEnrollmentPageStrings = crossComponentTranslator(LearnerClassEnrollmentPage);
@@ -208,12 +209,19 @@
     },
     methods: {
       ...mapActions('groups', ['addUsersToGroup']),
+      ...mapActions(['createSnackbar']),
       addSelectedUsersToGroup() {
+        const value = this.selectedUsers.length;
         this.addUsersToGroup({
           groupId: this.currentGroup.id,
           userIds: this.selectedUsers,
         }).then(() => {
-          this.$router.push(this.$router.getRoute('GroupMembersPage'));
+          this.$router.push(this.$router.getRoute('GroupMembersPage'), () => {
+            this.createSnackbar({
+              text: groupMgmtStrings.$tr('addedLearnersNotice', { value }),
+              autoDismiss: true,
+            });
+          });
         });
       },
       reducePageNum() {

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -109,6 +109,7 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoach from '../../common';
   import ReportsGroupHeader from '../../reports/ReportsGroupHeader';
+  import { groupMgmtStrings } from '../../common/groupManagement/groupManagementStrings';
   import RemoveFromGroupModal from './RemoveFromGroupModal';
 
   const ReportsGroupHeaderStrings = crossComponentTranslator(ReportsGroupHeader);
@@ -148,12 +149,17 @@
     },
     methods: {
       ...mapActions('groups', ['removeUsersFromGroup']),
+      ...mapActions(['createSnackbar']),
       removeSelectedUserFromGroup() {
         if (this.userForRemoval) {
           this.removeUsersFromGroup({
             userIds: [this.userForRemoval.id],
             groupId: this.currentGroup.id,
           }).then(() => {
+            this.createSnackbar({
+              text: groupMgmtStrings.$tr('removedLearnersNotice', { value: 1 }),
+              autoDismiss: true,
+            });
             this.userForRemoval = null;
           });
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/CreateGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/CreateGroupModal.vue
@@ -71,6 +71,7 @@
         return true;
       },
       nameIsInvalidText() {
+        if (this.submitting) return '';
         if (this.nameBlurred || this.formSubmitted) {
           if (this.name === '') {
             return this.$tr('required');
@@ -94,7 +95,9 @@
         this.formSubmitted = true;
         if (this.formIsValid) {
           this.submitting = true;
-          this.createGroup({ groupName: this.name, classId: this.classId });
+          this.createGroup({ groupName: this.name, classId: this.classId }).then(() => {
+            this.$emit('success');
+          });
         } else {
           this.$refs.name.focus();
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
@@ -4,7 +4,7 @@
     :title="$tr('deleteLearnerGroup')"
     :submitText="$tr('deleteGroup')"
     :cancelText="$tr('cancel')"
-    @submit="deleteGroup(groupId)"
+    @submit="handleSubmit"
     @cancel="close"
   >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
@@ -41,6 +41,11 @@
     },
     methods: {
       ...mapActions('groups', ['displayModal', 'deleteGroup']),
+      handleSubmit() {
+        this.deleteGroup(this.groupId).then(() => {
+          this.$emit('success');
+        });
+      },
       close() {
         this.displayModal(false);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -64,6 +64,7 @@
         v-if="showDeleteGroupModal"
         :groupName="selectedGroup.name"
         :groupId="selectedGroup.id"
+        @success="handleSuccessDeleteGroup"
       />
 
     </KPageContainer>
@@ -151,6 +152,13 @@
       handleSuccessCreateGroup() {
         this.createSnackbar({
           text: groupMgmtStrings.$tr('groupCreatedNotice'),
+          autoDismiss: true,
+        });
+        this.displayModal(false);
+      },
+      handleSuccessDeleteGroup() {
+        this.createSnackbar({
+          text: groupMgmtStrings.$tr('groupDeletedNotice'),
           autoDismiss: true,
         });
         this.displayModal(false);

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -50,6 +50,7 @@
       <CreateGroupModal
         v-if="showCreateGroupModal"
         :groups="sortedGroups"
+        @success="handleSuccessCreateGroup"
       />
 
       <RenameGroupModal
@@ -80,6 +81,7 @@
   import commonCoach from '../../common';
   import PlanHeader from '../../plan/PlanHeader';
   import { GroupModals } from '../../../constants';
+  import { groupMgmtStrings } from '../../common/groupManagement/groupManagementStrings';
   import CreateGroupModal from './CreateGroupModal';
   import GroupRowTr from './GroupRow';
   import RenameGroupModal from './RenameGroupModal';
@@ -128,6 +130,7 @@
     },
     methods: {
       ...mapActions('groups', ['displayModal']),
+      ...mapActions(['createSnackbar']),
       openCreateGroupModal() {
         this.displayModal(GroupModals.CREATE_GROUP);
       },
@@ -144,6 +147,13 @@
           id: groupId,
         };
         this.displayModal(GroupModals.DELETE_GROUP);
+      },
+      handleSuccessCreateGroup() {
+        this.createSnackbar({
+          text: groupMgmtStrings.$tr('groupCreatedNotice'),
+          autoDismiss: true,
+        });
+        this.displayModal(false);
       },
     },
   };


### PR DESCRIPTION
### Summary

1. Adds snackbar notifications for Coach > Plan > Group, when a group is created, deleted, or has learners added/removed to/from it. Because there was not a string for it, a snackbar is not shown when a group is renamed.

Fixes #4946

### Reviewer guidance

1. Manually test the 4 workflows in the summary
1. Look over changes to groups/actions. These changes remove certain side-effects like loading or closing modals from the actions and gives them to the components. This was done to fix some animation issues, but is also probably better design.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
