### PR TITLE
Update exercise notification starting to also start a lesson if needed.

### DIFF
--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -316,19 +316,8 @@ def parse_attemptslog(attemptlog):
                                                    reason=HelpReason.Multiple,
                                                    timestamp=attemptlog.end_timestamp)
                 notifications.append(notification)
-        if not LearnerProgressNotification.objects.filter(user_id=attemptlog.user_id,
-                                                          notification_object=NotificationObjectType.Resource,
-                                                          notification_event=NotificationEventType.Started,
-                                                          lesson_id=lesson.id,
-                                                          classroom_id=lesson.group_or_classroom,
-                                                          contentnode_id=contentnode_id).exists():
-            notification = create_notification(NotificationObjectType.Resource,
-                                               NotificationEventType.Started,
-                                               attemptlog.user_id,
-                                               lesson.group_or_classroom,
-                                               lesson_id=lesson.id,
-                                               contentnode_id=contentnode_id,
-                                               timestamp=attemptlog.start_timestamp)
-            notifications.append(notification)
+        notifications_started = check_and_created_started(lesson, attemptlog.user_id, contentnode_id, attemptlog.start_timestamp)
+
+        notifications += notifications_started
     if notifications:
         save_notifications(notifications)

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -217,13 +217,20 @@ class NotificationsAPITestCase(APITestCase):
                                                 )
         parse_attemptslog(attemptlog1)
         assert save_notifications.called
-        create_notification.assert_called_once_with(NotificationObjectType.Resource,
-                                                    NotificationEventType.Started,
-                                                    attemptlog1.user_id,
-                                                    self.classroom.id,
-                                                    lesson_id=self.lesson_id,
-                                                    contentnode_id=self.node_1.id,
-                                                    timestamp=attemptlog1.start_timestamp)
+        create_notification.assert_any_call(NotificationObjectType.Resource,
+                                            NotificationEventType.Started,
+                                            attemptlog1.user_id,
+                                            self.classroom.id,
+                                            lesson_id=self.lesson_id,
+                                            contentnode_id=self.node_1.id,
+                                            timestamp=attemptlog1.start_timestamp)
+
+        create_notification.assert_any_call(NotificationObjectType.Lesson,
+                                            NotificationEventType.Started,
+                                            attemptlog1.user_id,
+                                            self.classroom.id,
+                                            lesson_id=self.lesson_id,
+                                            timestamp=attemptlog1.start_timestamp)
 
     @patch('kolibri.core.notifications.api.create_notification')
     @patch('kolibri.core.notifications.api.save_notifications')
@@ -247,6 +254,13 @@ class NotificationsAPITestCase(APITestCase):
                                                    classroom_id=self.classroom.id,
                                                    lesson_id=self.lesson_id,
                                                    contentnode_id=self.node_1.id,
+                                                   timestamp=attemptlog1.start_timestamp)
+
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Lesson,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog1.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
                                                    timestamp=attemptlog1.start_timestamp)
 
         attemptlog2 = AttemptLog.objects.create(masterylog=masterylog, sessionlog=log,
@@ -300,6 +314,13 @@ class NotificationsAPITestCase(APITestCase):
                                                    lesson_id=self.lesson_id,
                                                    contentnode_id=self.node_1.id,
                                                    timestamp=attemptlog3.start_timestamp)
+
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Lesson,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog3.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
+                                                   timestamp=attemptlog3.start_timestamp)
         parse_attemptslog(attemptlog3)
         assert save_notifications.called
         create_notification.assert_called_once_with(NotificationObjectType.Resource,
@@ -350,6 +371,13 @@ class NotificationsAPITestCase(APITestCase):
                                                    classroom_id=self.classroom.id,
                                                    lesson_id=self.lesson_id,
                                                    contentnode_id=self.node_1.id,
+                                                   timestamp=attemptlog3.start_timestamp)
+
+        LearnerProgressNotification.objects.create(notification_object=NotificationObjectType.Lesson,
+                                                   notification_event=NotificationEventType.Started,
+                                                   user_id=attemptlog3.user_id,
+                                                   classroom_id=self.classroom.id,
+                                                   lesson_id=self.lesson_id,
                                                    timestamp=attemptlog3.start_timestamp)
         parse_attemptslog(attemptlog3)
         assert save_notifications.called


### PR DESCRIPTION
### Summary
Uses the same function to set a started notification for exercises on an attempt, as when a summarylog is created for other content kinds.

### Reviewer guidance
To test:
1) Create a lesson.
2) Add an exercise.
3) Begin the exercise with an assigned user.
4) Confirm that as soon as you do, you see both an exercise started notification and a lesson started notification.

### References
Addresses an oversight by me from #5198

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
