### PR TITLE
0.12beta9 fixes (heartbeat callback, coach auth message, admin filter)

### DIFF
--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -147,7 +147,7 @@ export class HeartBeat {
               // Multiply the previous interval by our multiplier, but max out at a high interval.
               Math.min(RECONNECT_MULTIPLIER * reconnect, MAX_RECONNECT_TIME)
             );
-            createDisconnectedSnackbar(store, heartbeat.beat);
+            createDisconnectedSnackbar(store, heartbeat.pollSessionEndPoint);
             return response;
           },
         })

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -100,13 +100,15 @@ export default {
           store.dispatch('setClassList'),
           store.dispatch('classSummary/loadClassSummary', classId),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
-        ]);
+        ]).catch(error => {
+          store.dispatch('handleError', error);
+        });
+      } else {
+        // otherwise refresh but don't block
+        return store
+          .dispatch('classSummary/loadClassSummary', classId)
+          .catch(error => this.store.dispatch('handleApiError', error));
       }
-      // otherwise refresh but don't block
-      store
-        .dispatch('classSummary/loadClassSummary', classId)
-        .catch(error => this.store.dispatch('handleApiError', error));
-      return Promise.resolve();
     },
   },
   modules: {

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 from django.db.models import Sum
 from django.shortcuts import get_object_or_404
 from le_utils.constants import content_kinds
+from rest_framework import permissions
 from rest_framework import serializers
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -207,6 +208,10 @@ def data(Serializer, queryset):
 
 
 class ClassSummaryViewSet(viewsets.ViewSet):
+
+    # TODO use more granular permissions. Not sure if KolibriReportPermissions will
+    # work as is, though.
+    permission_classes = (permissions.IsAuthenticated,)
 
     def retrieve(self, request, pk):
         classroom = get_object_or_404(auth_models.Classroom, id=pk)

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -165,6 +165,9 @@
         if (user.kind === UserKinds.ASSIGNABLE_COACH) {
           return filterKind === UserKinds.COACH;
         }
+        if (filterKind === UserKinds.ADMIN) {
+          return user.kind === UserKinds.ADMIN || user.kind === UserKinds.SUPERUSER;
+        }
         return filterKind === user.kind;
       },
       manageUserOptions(userId) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Fixes  'undefined' callback for the disconnected snackbar's "try again" button Fixes #5194 
1. "Admin" filter on Facility > User page now includes superusers in filtered results Fixes #5195 
1. Adds basic permissions to the ClassSummaryViewset (still too permissive, see the TODO in the code) and modifies `initClassSummary` to handle promise rejections. Half fixes #5196 


### Reviewer guidance

1. Test the "Try again" button on the snackbar
1. Try the "admin" filter on the user page
1. Access the Coach pages as an (un)authenticated user. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
