### PR TITLE
Fix client side 'server' time setting to prevent spooky interactions in the future

### DIFF
--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -154,7 +154,7 @@ export class HeartBeat {
       );
     }
     // Log the time at the start of the request for time diff setting.
-    const pollStart = new Date();
+    const pollStart = Date.now();
     return client({
       params: {
         // Only send active when both connected and activity has been registered.
@@ -165,7 +165,7 @@ export class HeartBeat {
     })
       .then(response => {
         // Log the time that the poll of the session endpoint ended.
-        const pollEnd = new Date();
+        const pollEnd = Date.now();
         const session = response.entity;
         // If our session is already defined, check the user id in the response
         if (store.state.core.session.id && session.user_id !== currentUserId) {
@@ -189,7 +189,7 @@ export class HeartBeat {
           // frame of reference. If the client is moving relative to the server at speeds
           // approaching the speed of light, this may produce some odd results,
           // but I think that was always true.
-          clientNow: new Date((pollEnd.getTime() + pollStart.getTime()) / 2),
+          clientNow: new Date((pollEnd + pollStart) / 2),
         });
       })
       .catch(error => {

--- a/kolibri/core/assets/src/serverClock.js
+++ b/kolibri/core/assets/src/serverClock.js
@@ -1,12 +1,11 @@
 // The currently known difference between server time and local clock time.
 let diff = 0;
 
-function setServerTime(time) {
-  let clientTime = new Date();
-  if (window.performance && window.performance.timing) {
-    clientTime = window.performance.timing.requestStart;
-  }
-  diff = new Date(time) - clientTime;
+function setServerTime(serverNow, clientNow) {
+  // Set the offset between the server now and the client now
+  // so that we can consistently offset client generated
+  // date objects to match the server.
+  diff = new Date(serverNow) - clientNow;
 }
 
 function now() {

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -198,11 +198,11 @@ export function blockDoubleClicks(store) {
   }
 }
 
-export function setSession(store, sessionObj) {
-  const serverTime = sessionObj.server_time;
-  setServerTime(serverTime);
-  sessionObj = pick(sessionObj, Object.keys(baseSessionState));
-  store.commit('CORE_SET_SESSION', sessionObj);
+export function setSession(store, { session, clientNow }) {
+  const serverTime = session.server_time;
+  setServerTime(serverTime, clientNow);
+  session = pick(session, Object.keys(baseSessionState));
+  store.commit('CORE_SET_SESSION', session);
 }
 
 /**

--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span v-if="date">
-    {{ $formatRelative(date, { now: now }) }}
+    {{ $formatRelative(ceilingDate, { now: now }) }}
   </span>
   <KEmptyPlaceholder v-else />
 
@@ -28,6 +28,14 @@
       now: now(),
       timer: null,
     }),
+    computed: {
+      ceilingDate() {
+        if (this.date > this.now) {
+          return this.now;
+        }
+        return this.date;
+      },
+    },
     mounted() {
       this.timer = setInterval(() => {
         this.now = now();

--- a/kolibri/core/assets/test/views/elapsed-time.spec.js
+++ b/kolibri/core/assets/test/views/elapsed-time.spec.js
@@ -30,6 +30,19 @@ describe('elapsed time component', () => {
     const timeText = getTimeText(wrapper);
     expect(timeText).toEqual('—');
   });
+  it('should ceiling the time at now if the time is bigger than now', () => {
+    const date20SecondsInTheFuture = new Date(DUMMY_CURRENT_DATE);
+    date20SecondsInTheFuture.setSeconds(date20SecondsInTheFuture.getSeconds() + 20);
+    const wrapper = makeWrapper({
+      propsData: {
+        date: date20SecondsInTheFuture,
+      },
+    });
+    wrapper.vm.now = DUMMY_CURRENT_DATE;
+    const timeText = getTimeText(wrapper);
+    expect(/now/.test(timeText)).toEqual(true);
+  });
+
   it('should use seconds if the date passed in 1 second ago', () => {
     const date1SecondAgo = new Date(DUMMY_CURRENT_DATE);
     date1SecondAgo.setSeconds(date1SecondAgo.getSeconds() - 1);


### PR DESCRIPTION
### Summary
We now set the 'server time' not at page load, but through the session object.
This meant that it was being updated more than once during a session.
Previously, we were using the performance timing API to calculate the start of the page load request, in order to give a time for diffing.
This meant that as time moved on in the client side without a page load, the diff became larger and larger, proportional to the length of time since page load.
This made time stamps in the future as a result.

### Reviewer guidance
Follow steps to reproduce here: https://github.com/learningequality/kolibri/issues/5079#issuecomment-468082659

See that this no longer occurs.

### References
Fixes #5079 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
