### PR TITLE
Don't show a loading bar on the user signin page.

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -45,7 +45,7 @@
         </slot>
       </AppBar>
       <KLinearLoader
-        v-if="loading"
+        v-if="loading && !fullScreen"
         class="loader"
         :style="{top: `${appbarHeight}px`}"
         type="indeterminate"

--- a/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
@@ -9,6 +9,7 @@ const snackbarTranslator = createTranslator('UserPageSnackbars', {
 });
 
 export function showSignInPage(store) {
+  store.commit('SET_PAGE_NAME', PageNames.SIGN_IN);
   if (Lockr.get(SIGNED_OUT_DUE_TO_INACTIVITY)) {
     store.commit('CORE_CREATE_SNACKBAR', {
       text: snackbarTranslator.$tr('signedOut'),


### PR DESCRIPTION
### Summary
Removes the linear loader in core base when in full screen mode.

### Reviewer guidance
Does the linear loader still appear otherwise? Does it not appear in full screen mode?

![noloader](https://user-images.githubusercontent.com/1680573/53534445-bca50880-3ab3-11e9-9152-8967a8ae9aeb.gif)


### References
Fixes #5211
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
