### PR TITLE
Update exercise learner progress in line with notifications

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -566,10 +566,10 @@ export function updateProgress(store, { progressPercent, forceSave = false }) {
 /**
 summary and session log progress update for exercise
 **/
-export function updateExerciseProgress(store, { progressPercent, forceSave = false }) {
+export function updateExerciseProgress(store, { progressPercent }) {
   /* Update the logging state with new progress information */
   progressPercent = progressPercent || 0;
-  return _updateProgress(store, progressPercent, progressPercent, forceSave);
+  return _updateProgress(store, progressPercent, progressPercent, true);
 }
 
 /**

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -267,7 +267,7 @@ oriented data synchronization.
         if (this.mastered) {
           return 1;
         }
-        if (this.pastattempts) {
+        if (this.pastattempts.length) {
           let calculatedMastery;
           if (this.pastattempts.length > this.attemptsWindowN) {
             calculatedMastery = Math.min(

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -268,17 +268,22 @@ oriented data synchronization.
           return 1;
         }
         if (this.pastattempts) {
+          let calculatedMastery;
           if (this.pastattempts.length > this.attemptsWindowN) {
-            return Math.min(
+            calculatedMastery = Math.min(
               this.pastattempts.slice(0, this.attemptsWindowN).reduce((a, b) => a + b.correct, 0) /
                 this.totalCorrectRequiredM,
               1
             );
+          } else {
+            calculatedMastery = Math.min(
+              this.pastattempts.reduce((a, b) => a + b.correct, 0) / this.totalCorrectRequiredM,
+              1
+            );
           }
-          return Math.min(
-            this.pastattempts.reduce((a, b) => a + b.correct, 0) / this.totalCorrectRequiredM,
-            1
-          );
+          // If there are any attempts at all, set some progress on the exercise
+          // because they have now started the exercise.
+          return Math.max(calculatedMastery, 0.001);
         }
         return 0;
       },
@@ -402,6 +407,8 @@ oriented data synchronization.
           });
           // Save attempt log on first attempt
           this.saveAttemptLogMasterLog();
+          // Update exercise progress when the first answer is given
+          this.updateExerciseProgressMethod();
         } else {
           this.updateAttemptLogMasteryLog({
             complete: this.complete,


### PR DESCRIPTION
### Summary
Marks an exercise as 'in progress' to a learner as soon as any attempt has been made.

### Reviewer guidance
This now sets the progress for a started exercise to 0.001. Do you anticipate this causing any issues?

![exerciseprogress](https://user-images.githubusercontent.com/1680573/53575536-98ceda80-3b26-11e9-85ed-f186d5359978.gif)

### References
Fixes #5204

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst

