### PR TITLE
Prevent scrollbars on content cards in lesson resource selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -29,7 +29,6 @@
       <TextTruncator
         :text="description"
         :maxHeight="80"
-        :showViewMore="true"
         class="description"
       />
       <CoachContentLabel
@@ -185,7 +184,7 @@
   .description {
     // HACK to get long descriptions to fit in the card
     height: $thumb-height * 0.5;
-    overflow-y: scroll;
+    overflow-y: visible;
     font-size: 14px;
   }
 


### PR DESCRIPTION
### Summary
Uses the tooltip option on the text truncator to provide tooltips instead of the 'view more' button, which would tend to cause scrollbars just to show the view more button.

Sets scroll to visible to allow the tooltip to show.

### Reviewer guidance
Does this seem like a good behaviour pattern?

Before:
Bigger screen:
![image](https://user-images.githubusercontent.com/1680573/53589864-58cb2000-3b45-11e9-82cd-0376b8608b66.png)

Smaller screen:
![image](https://user-images.githubusercontent.com/1680573/53589842-4e108b00-3b45-11e9-834e-c2d9b366dde9.png)


After:
Bigger screen:
![image](https://user-images.githubusercontent.com/1680573/53589629-ba3ebf00-3b44-11e9-8709-d41633442678.png)
Smaller screen:
![image](https://user-images.githubusercontent.com/1680573/53589740-0689ff00-3b45-11e9-82db-d1d00571f850.png)


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
