### PR TITLE
remove instructions that made corruption worse not better

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -636,7 +636,6 @@ def main(args=None):  # noqa: max-complexity=13
                 "end in .sqlite3, .sqlite3-shm, .sqlite3-wal, or .log and then"
                 "contact Learning Equality. Thank you!"
             )
-            sys.exit(1)
         raise
 
     # Alias

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -629,26 +629,12 @@ def main(args=None):  # noqa: max-complexity=13
     try:
         initialize(debug=debug)
     except (DatabaseError, SQLite3DatabaseError) as e:
-        from django.conf import settings
         if "malformed" in str(e):
-            recover_cmd = (
-                "    sqlite3 {path} .dump | sqlite3 fixed.db \n"
-                "    cp fixed.db {path}"
-                ""
-            ).format(
-                path=settings.DATABASES['default']['NAME'],
-            )
             logger.error(
-                "\n"
-                "Your database is corrupted. This is a "
-                "known issue that is usually fixed by running this "
-                "command: "
-                "\n\n"
-                + recover_cmd
-                + "\n\n"
-                "Notice that you need the 'sqlite3' command available "
-                "on your system prior to running this."
-                "\n\n"
+                "Your database appears to be corrupted. If you encounter this,"
+                "please immediately back up all files in the .kolibri folder that"
+                "end in .sqlite3, .sqlite3-shm, .sqlite3-wal, or .log and then"
+                "contact Learning Equality. Thank you!"
             )
             sys.exit(1)
         raise


### PR DESCRIPTION
### Summary

In the case of DB corruption, the current instructions advise users to:

```bash
sqlite3 {path} .dump | sqlite3 fixed.db
cp fixed.db {path}
```

User who run these commands will add another layer of corruption on top of the first.

From the docs in [1.4. Mispairing database files and hot journals](https://www.sqlite.org/howtocorrupt.html), the following actions are all likely to lead to corruption:

* Swapping journal files between two different databases.
* Overwritting a journal file with a different journal file.
* Moving a journal file from one database to another.
* Copying a database file without also copying its journal.
* Overwriting a database file with another without also deleting any hot journal associated with the original database. 

Furthermore by having the user overwrite the old DB without backing it up, it made it impossible for us to get a copy of the original corrupted DB.

### Reviewer guidance

Do the new instructions make sense?

### References

* Hopeful fix for DB corruption in #5201
* Refs #3825

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
