### PR TITLE
Fix quiz question detail views.

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/actions.js
@@ -1,7 +1,7 @@
 import { AttemptLogResource, ExamAttemptLogResource } from 'kolibri.resources';
 
 export function setLearners(store, params) {
-  const { questionId, exerciseId, quizId, classId, groupId, learnerId } = params;
+  const { questionId, exerciseId, exerciseNodeId, quizId, classId, groupId, learnerId } = params;
   let resource = AttemptLogResource;
   const getParams = {
     item: questionId,
@@ -10,6 +10,7 @@ export function setLearners(store, params) {
   if (quizId) {
     resource = ExamAttemptLogResource;
     getParams.exam = quizId;
+    getParams.content = exerciseNodeId;
   }
   if (classId) {
     getParams.classroom = classId;

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -91,6 +91,7 @@ function showQuestionDetailView(params) {
           .dispatch('questionDetail/setLearners', {
             ...params,
             exercise,
+            exerciseNodeId,
           })
           .then(learners => {
             // No learnerId was passed in, so we should trigger a url redirect

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -63,7 +63,7 @@ function showQuestionDetailView(params) {
         let title;
         if (exam) {
           const question = exam.question_sources.find(
-            source => source.question_id === questionId && source.exercise_id === exerciseId
+            source => source.question_id === questionId && source.exercise_id === exerciseNodeId
           );
           title = crossComponentTranslator(AssessmentQuestionListItem).$tr('nthExerciseName', {
             name: question.title,

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
@@ -121,7 +121,6 @@
         this.showCorrectAnswer = false;
         const learnerId = this.learners[learnerIndex].id;
         this.$emit('navigate', {
-          exerciseId: this.exercise.content_id,
           questionId: this.questionId,
           learnerId,
           interactionIndex: 0,
@@ -130,7 +129,6 @@
       },
       navigateToNewInteraction(interactionIndex) {
         this.$emit('navigate', {
-          exerciseId: this.exercise.content_id,
           questionId: this.questionId,
           learnerId: this.learnerId,
           interactionIndex,


### PR DESCRIPTION
### Summary
Filter quiz questions by exercise node id not the exercise content_id.

### Reviewer guidance
Does this fix the difficult question detail view for quizzes? Does the difficult question detail view still work for exercises?

### References
Fixes #5133 for quizzes (the previous fix for #5133 fixed it for exercises, and broke it for quizzes).

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
