### PR TITLE
Move async notifications thread invocation into server start.

### DIFF
--- a/kolibri/core/notifications/apps.py
+++ b/kolibri/core/notifications/apps.py
@@ -4,13 +4,8 @@ from __future__ import unicode_literals
 
 from django.apps import AppConfig
 
-from .tasks import AsyncNotificationsThread
-
 
 class KolibriNotificationsConfig(AppConfig):
     name = 'kolibri.core.notifications'
     label = 'notifications'
     verbose_name = 'Kolibri Notifications'
-
-    def ready(self):
-        AsyncNotificationsThread.start_command()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -79,6 +79,10 @@ def start(port=8080, run_cherrypy=True):
     # Do a db vacuum periodically
     VacuumThread.start_command()
 
+    from kolibri.core.notifications.tasks import AsyncNotificationsThread
+
+    AsyncNotificationsThread.start_command()
+
     # Write the new PID
     with open(PID_FILE, 'w') as f:
         f.write("%d\n%d" % (os.getpid(), port))


### PR DESCRIPTION
### Summary
In production mode, the async notifications thread seems to shut down, this may well be because it gets started during Django initialization, which happens prior to daemonization.

This PR fixes this by moving the async notification thread starting to `server.py` `start`. This has the disadvantage of not logging notifications in dev mode, but a workaround can be found.

### Reviewer guidance
Do notifications now get logged in production mode, always?

### References
Fixes #5217 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
