### PR TITLE
Fix data folder not recognized in external drive list

### DIFF
--- a/kolibri/core/discovery/test/dummydata/linux_data.py
+++ b/kolibri/core/discovery/test/dummydata/linux_data.py
@@ -43,9 +43,10 @@ os_access_read = {
 
 os_access_write = {
     "/": True,
-    "/media/user/F571-7814": True,
+    "/media/user/F571-7814": False,
     "/media/user/KEEPOD": False,
     "/media/user/disk": False,
+    "/media/user/F571-7814/KOLIBRI_DATA": True,
 }
 
 has_kolibri_data_folder = {

--- a/kolibri/core/discovery/test/dummydata/osx_data.py
+++ b/kolibri/core/discovery/test/dummydata/osx_data.py
@@ -125,8 +125,9 @@ os_access_read = {
 
 os_access_write = {
     "/": False,
-    "/Volumes/HP v125w": True,
+    "/Volumes/HP v125w": False,
     "/Volumes/NO NAME": False,
+    "/Volumes/HP v125w/KOLIBRI_DATA": True,
 }
 
 has_kolibri_data_folder = {

--- a/kolibri/core/discovery/test/dummydata/windows_data.py
+++ b/kolibri/core/discovery/test/dummydata/windows_data.py
@@ -13,6 +13,7 @@ os_access_write = {
     "C:\\": True,
     "D:\\": False,
     "E:\\": False,
+    "D:\\KOLIBRI_DATA": True,
 }
 
 has_kolibri_data_folder = {

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -145,7 +145,7 @@ class WindowsFilesystemTestCase(TestCase):
 
     def test_drive_writability(self):
         self.assertTrue(self.c_drive.writable)
-        self.assertFalse(self.d_drive.writable)
+        self.assertTrue(self.d_drive.writable)
 
     def test_drive_data_folders(self):
         self.assertEqual(self.c_drive.datafolder, "C:\\" + EXPORT_FOLDER_NAME)

--- a/kolibri/core/discovery/utils/filesystem/__init__.py
+++ b/kolibri/core/discovery/utils/filesystem/__init__.py
@@ -47,13 +47,22 @@ def enumerate_mounted_disk_partitions():
 
         path = drive["path"]
         drive_id = hashlib.sha1((drive["guid"] or path).encode('utf-8')).hexdigest()[:32]
+        datafolder = get_kolibri_data_dir_path(path)
+
+        # If the Kolibri data directory has been manually created by the user,
+        # check if the data directory is writable. Otherwise, check if the path
+        # is writable so Kolibri can create the data directory there.
+        if os.path.exists(datafolder):
+            check_writable_path = datafolder
+        else:
+            check_writable_path = path
 
         drives[drive_id] = DriveData(
             id=drive_id,
             path=path,
             name=drive["name"],
-            writable=os.access(path, os.W_OK),
-            datafolder=get_kolibri_data_dir_path(path),
+            writable=os.access(check_writable_path, os.W_OK),
+            datafolder=datafolder,
             freespace=drive["freespace"],
             totalspace=drive["totalspace"],
             filesystem=drive["filesystem"],


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue https://github.com/learningequality/kolibri/issues/3274. 
In the issue, the user claims that he has KOLIBRI_DATA folders `/KOLIBRI_DATA`, `/run/media/me/KOLIBRI_DATA`, `/home/KOLIBRI_DATA`, `
/run/media/me/ACASIS/KOLIBRI_DATA` and `
/mnt/HD02-1T/KOLIBRI_DATA` which have the owner `kolibri` but these folder are not found in the external drive list. 

The problem here is that although he grants permissions of `parent/KOLIBRI_DATA` folders to user `kolibri`, the user `kolibri` may not have the write permission of the `parent` folders.

In the original code, the writability of an external drive is determined by the variable `writable`, which checks if we can write in the parent folder (since we need to create KOLIBRI_DATA folder there). 

However, in this specific case, the user who reported this issue manually created the KOLIBRI_DATA folder by himself and tried to export content from kolibri to there. 

To fix this issue, the variable `writable` is determined by the writability of KOLIBRI_DATA folder if exists or the writability of the parent folder if the data folder does not exist.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test the changes:
1. run kolibri start
2. import some content to kolibri from studio
3. check localhost:port/api/tasks/tasks/localdrive and see that the writable value for `/` folder is false
4. check that `/` does not exist in the external drive list after clicking the button `Export`
5. run `sudo mkdir -p /KOLIBRI_DATA`
6. RUN `sudo chown -R <current_user> /KOLIBRI_DATA`. (<current_user> is `kolibri` in the user's case)
7. check localhost:port/api/tasks/tasks/localdrive and see that the writable value for `/` folder is now true
8. check that `/` now exists in the external drive list after clicking the button `Export`, and we are able to successfully export content there

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3274

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
