### PR TITLE
Backport corruption fixes

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import requests
 from django.core.management.base import BaseCommand
+from django.db import connection
 from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.timezone import get_current_timezone
 from django.utils.timezone import localtime
@@ -61,6 +62,8 @@ class Command(BaseCommand):
                     logger.info("Ping succeeded! (response: {})".format(data))
                     if "id" in data:
                         self.perform_statistics(server, data["id"])
+                    connection.close()
+
                 if once:
                     break
                 logger.info("Sleeping for {} minutes.".format(interval))

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 
+from django.db import connection
 from le_utils.constants import content_kinds
 from sqlalchemy import and_
 from sqlalchemy import exists
@@ -48,6 +49,7 @@ def update_channel_metadata():
             except (InvalidSchemaVersionError, FutureSchemaError):
                 logger.warning("Tried to import channel {channel_id}, but database file was incompatible".format(channel_id=channel_id))
     fix_multiple_trees_with_id_one()
+    connection.close()
 
 
 def fix_multiple_trees_with_id_one():

--- a/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuumsqlite.py
@@ -58,7 +58,6 @@ class Command(BaseCommand):
             cursor.execute('vacuum;')
             connection.close()
         except Exception as e:
-            logger.error(e)
             new_msg = (
                 "Vacuum of database {db_name} couldn't be executed. Possible reasons:\n"
                 "  * There is an open transaction in the db.\n"

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -12,6 +12,7 @@ from sqlite3 import DatabaseError as SQLite3DatabaseError
 import django
 from django.core.exceptions import AppRegistryNotReady
 from django.core.management import call_command
+from django.db import connections
 from django.db.utils import DatabaseError
 from docopt import docopt
 
@@ -308,6 +309,11 @@ def start(port=None, daemon=True):
         )
         kwargs['out_log'] = server.DAEMON_LOG
         kwargs['err_log'] = server.DAEMON_LOG
+
+        # close all connections before forking, to avoid SQLite corruption:
+        # https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_
+        connections.close_all()
+
         become_daemon(**kwargs)
 
     server.start(port=port)


### PR DESCRIPTION
Working with 0.12 release we've fixed the corruption problems in #5159  and #5201 
While 0.12 is finally released as stable, and considering some clients are having problems with 0.11 and can keep it using for some time, I think we should backport these fixes and build an updated 0.11.2 compilation.

This PR backports the relevant code from the mentioned PRs


### Summary

Explained in #5159 and #5201 descriptions
…

### Reviewer guidance
Same as decribed in #5201 


### References
Infamous #3825 



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
