### PR TITLE
Use a disk queue for the async notifications thread

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ django==1.11.20  # pyup: >=1.11,<2
 six==1.11.0
 colorlog==3.2.0 # pyup: <4.0.0
 configobj==5.0.6
+diskcache==3.1.1
 docopt==0.6.2
 django-mptt==0.9.1
 djangorestframework-csv==2.1.0


### PR DESCRIPTION
### Summary
Anticipates possible issues with memory sharing for the async notiifications queue, and implements a disk based queue (with an appropriate dehydration and hydration layer) to continuously store notifications that need updates.

### Reviewer guidance
Does it work?

At the moment this implementation clears the entire queue before moving on, I imagine it might be desirable to have a `queue_chunk_length` to determine how many are processed in one transaction.

### References
Depends on #5224

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
