### PR TITLE
Prevent empty lessons from being shown as anything but 'not started'.

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -104,6 +104,12 @@ export function _statusMap(statuses, key) {
 
 function _lessonStatusForLearner(state, lessonId, learnerId) {
   const lesson = state.lessonMap[lessonId];
+  // Add trap door for lesson status, if a lesson has no resources
+  // make it impossible for a learner to be registered as anything
+  // but not started.
+  if (lesson.node_ids.length === 0) {
+    return STATUSES.notStarted;
+  }
   const statuses = lesson.node_ids.map(node_id => {
     if (!state.contentNodeMap[node_id]) {
       return { status: STATUSES.notStarted };


### PR DESCRIPTION
### Summary
Automatically show a lesson as not started if it has no resources.

### Reviewer guidance
Does creating an empty lesson show a 'not started' lesson in the reports? As opposed to completed.

Before
![image](https://user-images.githubusercontent.com/1680573/53716514-7e15a200-3e55-11e9-9c74-a909144cdc6d.png)


After
![image](https://user-images.githubusercontent.com/1680573/53716491-70601c80-3e55-11e9-9d4f-770aefce598a.png)


### References
Fixes #5096

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
