### PR TITLE
Notifications async thread is launched on demand

### DIFF
--- a/kolibri/core/notifications/tasks.py
+++ b/kolibri/core/notifications/tasks.py
@@ -18,14 +18,19 @@ class AsyncNotificationQueue():
         # Where new log saving functions are appended
         self.queue = []
 
-        # Where the to be executed log saving functions are stored
+        # Where the to be executed notifications calculating functions are stored
         # once a batch save has been invoked
         self.running = []
+
+        # flag to decide if the async queue must be started
+        self.started = False
 
     def append(self, fn):
         """
         Convenience method to append log saving function to the current queue
         """
+        if not self.started:
+            AsyncNotificationsThread.start_command()
         self.queue.append(fn)
 
     def toggle_queue(self):
@@ -62,6 +67,7 @@ class AsyncNotificationQueue():
             connection.close()
 
     def start(self):
+        self.started = True
         while True:
             self.toggle_queue()
             self.run()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -79,10 +79,6 @@ def start(port=8080, run_cherrypy=True):
     # Do a db vacuum periodically
     VacuumThread.start_command()
 
-    from kolibri.core.notifications.tasks import AsyncNotificationsThread
-
-    AsyncNotificationsThread.start_command()
-
     # Write the new PID
     with open(PID_FILE, 'w') as f:
         f.write("%d\n%d" % (os.getpid(), port))


### PR DESCRIPTION
### Summary
The async thread to compute notifications is not started when using uwsgi.
This PR changes the thread to be started on demand, thus it will work both when using `kolibri start`or when starting the application using any other method supported by Django

### Reviewer guidance
After adding this PR notifications will be computed when, as an example, starting the application in develop mode using
`yarn devserver` 
Before this PR is applied, they only work if 
`kolibri start` is used.




### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
