### PR TITLE
Have kolibri-tools htmlhint custom linting rules defer to standard rules on unpaired tags

### DIFF
--- a/packages/kolibri-tools/lib/htmlhint_custom.js
+++ b/packages/kolibri-tools/lib/htmlhint_custom.js
@@ -189,7 +189,12 @@ HTMLHint.addRule({
       for (var i = stack.length - 1; i > pos; i--) {
         arrTags.push('</' + stack[i].tagName + '>');
       }
-      stack.length = pos;
+      try {
+        stack.length = pos;
+      } catch (e) {
+        // if this fails, it's because `pos < 0`, i.e. more tags are closed than were ever opened
+        // this should get caught by the standard linting rules, so we'll let it slide here.
+      }
     });
   },
 });

--- a/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
+++ b/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
@@ -211,4 +211,13 @@ describe('--vue-component-conventions', function() {
       expectRuleName(output, '--vue-component-conventions');
     });
   });
+  describe('defer unpaired tags', function() {
+    it('should not check for, or fail on, unpaired tags', function() {
+      const input =
+        '<template>\n\n  </div>\n\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
+      const output = HTMLHint.verify(input, ruleset);
+      expect(output).toHaveLength(1);
+      expectRuleName(output, 'tag-pair');
+    });
+  });
 });


### PR DESCRIPTION
### Summary
The kolibri-tools htmlhint linter was failing on unpaired tags, which should be handled by standard htmlhint rules.

### Reviewer guidance
I wrote a test for this!

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
