### PR TITLE
Simplify interface for createSnackbar action + bug fixes

### DIFF
--- a/kolibri/core/assets/src/disconnection.js
+++ b/kolibri/core/assets/src/disconnection.js
@@ -11,6 +11,7 @@ export function createTryingToReconnectSnackbar(store) {
   store.commit('CORE_CREATE_SNACKBAR', {
     text: trs.$tr('tryingToReconnect'),
     backdrop: true,
+    autoDismiss: false,
   });
 }
 
@@ -29,6 +30,7 @@ export function createDisconnectedSnackbar(store, beatCallback) {
     actionCallback: beatCallback,
     backdrop: true,
     forceReuse: true,
+    autoDismiss: false,
   });
   // start timeout
   timer = setInterval(() => {

--- a/kolibri/core/assets/src/disconnection.js
+++ b/kolibri/core/assets/src/disconnection.js
@@ -57,7 +57,5 @@ function clearTimer() {
 
 export function createReconnectedSnackbar(store) {
   clearTimer();
-  store.commit('CORE_CREATE_SNACKBAR', {
-    text: trs.$tr('successfullyReconnected'),
-  });
+  store.dispatch('createSnackbar', trs.$tr('successfullyReconnected'));
 }

--- a/kolibri/core/assets/src/disconnection.js
+++ b/kolibri/core/assets/src/disconnection.js
@@ -59,6 +59,5 @@ export function createReconnectedSnackbar(store) {
   clearTimer();
   store.commit('CORE_CREATE_SNACKBAR', {
     text: trs.$tr('successfullyReconnected'),
-    autoDismiss: true,
   });
 }

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -814,8 +814,9 @@ export function updateMasteryAttemptState(
   });
 }
 
-export function createSnackbar(store, snackbarOptions) {
-  store.commit('CORE_CREATE_SNACKBAR', snackbarOptions);
+// Creates a snackbar that automatically dismisses and has no action buttons.
+export function createSnackbar(store, text) {
+  store.commit('CORE_CREATE_SNACKBAR', { text, autoDismiss: true });
 }
 
 export function clearSnackbar(store) {

--- a/kolibri/core/assets/src/state/modules/snackbar.js
+++ b/kolibri/core/assets/src/state/modules/snackbar.js
@@ -21,6 +21,8 @@ export default {
       state.options = {};
       // set new options
       state.isVisible = true;
+      // options include text, autoDismiss, duration, actionText, actionCallback,
+      // hideCallback
       state.options = snackbarOptions;
     },
     CORE_CLEAR_SNACKBAR(state) {

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -88,7 +88,6 @@
         this.clipboard.on('success', () => {
           this.createSnackbar({
             text: this.$tr('copiedToClipboardConfirmation'),
-            autoDismiss: true,
           });
         });
       }

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -86,9 +86,7 @@
         });
 
         this.clipboard.on('success', () => {
-          this.createSnackbar({
-            text: this.$tr('copiedToClipboardConfirmation'),
-          });
+          this.createSnackbar(this.$tr('copiedToClipboardConfirmation'));
         });
       }
     },

--- a/kolibri/core/assets/src/views/KTextbox/index.vue
+++ b/kolibri/core/assets/src/views/KTextbox/index.vue
@@ -3,7 +3,7 @@
   <div class="mh">
     <KeenUiTextbox
       ref="textbox"
-      v-model.trim="currentText"
+      v-model="currentText"
       class="textbox"
       :label="label"
       :disabled="disabled"

--- a/kolibri/core/assets/src/views/kSortable/KDragContainer.vue
+++ b/kolibri/core/assets/src/views/kSortable/KDragContainer.vue
@@ -60,6 +60,10 @@
       },
       handleStop(event) {
         const { oldIndex, newIndex } = event.data;
+        // Do nothing if the item hasn't been moved
+        if (oldIndex === newIndex) {
+          return;
+        }
         const itemRemovedArray = [
           ...this.items.slice(0, oldIndex),
           ...this.items.slice(oldIndex + 1, this.items.length),

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
@@ -105,13 +105,7 @@ export function createExamAndRoute(store, classId) {
 
   return createExam(store, exam).then(() => {
     router.push({ name: PageNames.EXAMS });
-    store.dispatch(
-      'createSnackbar',
-      {
-        text: snackbarTranslator.$tr('newExamCreated'),
-      },
-      { root: true }
-    );
+    store.dispatch('createSnackbar', snackbarTranslator.$tr('newExamCreated'), { root: true });
   });
 }
 

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
@@ -109,7 +109,6 @@ export function createExamAndRoute(store, classId) {
       'createSnackbar',
       {
         text: snackbarTranslator.$tr('newExamCreated'),
-        autoDismiss: true,
       },
       { root: true }
     );

--- a/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
@@ -12,19 +12,17 @@ const snackbarTranslator = createTranslator('ExamReportSnackbarTexts', {
   examIsNowInactive: 'Quiz is now inactive',
 });
 
+function showSnackbar(store, string) {
+  return store.dispatch('createSnackbar', string, { root: true });
+}
+
 export function copyExam(store, { exam, className }) {
   store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
   return new Promise(resolve => {
     createExam(store, exam).then(
       newExam => {
         store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-        store.dispatch(
-          'createSnackbar',
-          {
-            text: snackbarTranslator.$tr('copiedExamToClass', { className }),
-          },
-          { root: true }
-        );
+        showSnackbar(store, snackbarTranslator.$tr('copiedExamToClass', { className }));
         store.commit('examsRoot/ADD_EXAM', newExam, { root: true });
         resolve(newExam);
       },
@@ -42,13 +40,7 @@ export function updateExamDetails(store, { examId, payload }) {
       () => {
         // Update state.exam if it was just saved.
         // Is this necessary? Where is state.exams used?
-        store.dispatch(
-          'createSnackbar',
-          {
-            text: snackbarTranslator.$tr('changesToExamSaved'),
-          },
-          { root: true }
-        );
+        showSnackbar(store, snackbarTranslator.$tr('changesToExamSaved'));
         resolve();
       },
       error => {
@@ -62,13 +54,7 @@ export function deleteExam(store, examId) {
   return ExamResource.deleteModel({ id: examId }).then(
     () => {
       router.replace({ name: PageNames.EXAMS });
-      store.dispatch(
-        'createSnackbar',
-        {
-          text: snackbarTranslator.$tr('examDeleted'),
-        },
-        { root: true }
-      );
+      showSnackbar(store, snackbarTranslator.$tr('examDeleted'));
     },
     error => store.dispatch('handleError', error, { root: true })
   );

--- a/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
@@ -22,7 +22,6 @@ export function copyExam(store, { exam, className }) {
           'createSnackbar',
           {
             text: snackbarTranslator.$tr('copiedExamToClass', { className }),
-            autoDismiss: true,
           },
           { root: true }
         );
@@ -47,7 +46,6 @@ export function updateExamDetails(store, { examId, payload }) {
           'createSnackbar',
           {
             text: snackbarTranslator.$tr('changesToExamSaved'),
-            autoDismiss: true,
           },
           { root: true }
         );
@@ -68,7 +66,6 @@ export function deleteExam(store, examId) {
         'createSnackbar',
         {
           text: snackbarTranslator.$tr('examDeleted'),
-          autoDismiss: true,
         },
         { root: true }
       );

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -14,6 +14,10 @@ const translator = createTranslator('LessonSummaryActionsTexts', {
   changesToLessonSaved: 'Changes to lesson saved',
 });
 
+function showSnackbar(store, string) {
+  return store.dispatch('createSnackbar', string, { root: true });
+}
+
 export function resetLessonSummaryState(store) {
   store.commit('RESET_STATE');
   store.commit('resources/RESET_STATE');
@@ -110,14 +114,9 @@ export function updateLessonStatus(store, { lessonId, isActive }) {
     .then(lesson => {
       store.commit('SET_CURRENT_LESSON', lesson);
       store.dispatch('setLessonsModal', null);
-      store.dispatch(
-        'createSnackbar',
-        {
-          text: isActive
-            ? translator.$tr('lessonIsNowActive')
-            : translator.$tr('lessonIsNowInactive'),
-        },
-        { root: true }
+      showSnackbar(
+        store,
+        isActive ? translator.$tr('lessonIsNowActive') : translator.$tr('lessonIsNowInactive')
       );
     })
     .catch(err => {
@@ -137,13 +136,7 @@ export function deleteLesson(store, { lessonId, classId }) {
           lessonId,
         },
       });
-      store.dispatch(
-        'createSnackbar',
-        {
-          text: translator.$tr('lessonDeleted'),
-        },
-        { root: true }
-      );
+      showSnackbar(store, translator.$tr('lessonDeleted'));
     })
     .catch(error => {
       // TODO handle error inside the current page
@@ -158,13 +151,7 @@ export function copyLesson(store, { payload, classroomName }) {
       // Update the class summary now that there is a new lesson
       store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
         store.dispatch('setLessonsModal', null);
-        store.dispatch(
-          'createSnackbar',
-          {
-            text: translator.$tr('copiedLessonTo', { classroomName }),
-          },
-          { root: true }
-        );
+        showSnackbar(store, translator.$tr('copiedLessonTo', { classroomName }));
       });
     })
     .catch(error => {
@@ -181,13 +168,7 @@ export function updateLesson(store, { lessonId, payload }) {
     })
       .then(() => {
         store.dispatch('setLessonsModal', null);
-        store.dispatch(
-          'createSnackbar',
-          {
-            text: translator.$tr('changesToLessonSaved'),
-          },
-          { root: true }
-        );
+        showSnackbar(store, translator.$tr('changesToLessonSaved'));
         store.dispatch('updateCurrentLesson', lessonId);
         resolve();
       })

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -116,7 +116,6 @@ export function updateLessonStatus(store, { lessonId, isActive }) {
           text: isActive
             ? translator.$tr('lessonIsNowActive')
             : translator.$tr('lessonIsNowInactive'),
-          autoDismiss: true,
         },
         { root: true }
       );
@@ -142,7 +141,6 @@ export function deleteLesson(store, { lessonId, classId }) {
         'createSnackbar',
         {
           text: translator.$tr('lessonDeleted'),
-          autoDismiss: true,
         },
         { root: true }
       );
@@ -164,7 +162,6 @@ export function copyLesson(store, { payload, classroomName }) {
           'createSnackbar',
           {
             text: translator.$tr('copiedLessonTo', { classroomName }),
-            autoDismiss: true,
           },
           { root: true }
         );
@@ -188,7 +185,6 @@ export function updateLesson(store, { lessonId, payload }) {
           'createSnackbar',
           {
             text: translator.$tr('changesToLessonSaved'),
-            autoDismiss: true,
           },
           { root: true }
         );

--- a/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
@@ -32,13 +32,7 @@ export function createLesson(store, { classId, payload }) {
       },
     })
       .then(newLesson => {
-        store.dispatch(
-          'createSnackbar',
-          {
-            text: translator.$tr('newLessonCreated'),
-          },
-          { root: true }
-        );
+        store.dispatch('createSnackbar', translator.$tr('newLessonCreated'), { root: true });
         // Update the class summary now that we have a new lesson in town!
         store.dispatch('classSummary/refreshClassSummary', null, { root: true }).then(() => {
           router.push(lessonSummaryLink({ classId, lessonId: newLesson.id }));

--- a/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
@@ -36,7 +36,6 @@ export function createLesson(store, { classId, payload }) {
           'createSnackbar',
           {
             text: translator.$tr('newLessonCreated'),
-            autoDismiss: true,
           },
           { root: true }
         );

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -67,7 +67,12 @@
           eventType: notification.event,
           objectType: notification.object,
           resourceType: notification.resource.type,
-          targetPage: notificationLink(notification),
+          targetPage: {
+            ...notificationLink(notification),
+            query: {
+              last: 'homepage',
+            },
+          },
           contentContext: notification.assignment.name,
           learnerContext,
         };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -435,13 +435,11 @@
           this.addToSelectedExercises(this.addableExercises);
           this.createSnackbar({
             text: this.$tr('added', { item: this.topicTitle }),
-            autoDismiss: true,
           });
         } else {
           this.removeFromSelectedExercises(this.allExercises);
           this.createSnackbar({
             text: this.$tr('removed', { item: this.topicTitle }),
-            autoDismiss: true,
           });
         }
       },
@@ -455,7 +453,6 @@
           this.addToSelectedExercises(exercises);
           this.createSnackbar({
             text: this.$tr('added', { item: contentNode.title }),
-            autoDismiss: true,
           });
         } else if (checked && !isTopic) {
           this.showError = false;
@@ -463,21 +460,18 @@
           this.addToSelectedExercises(exercises);
           this.createSnackbar({
             text: this.$tr('added', { item: contentNode.title }),
-            autoDismiss: true,
           });
         } else if (!checked && isTopic) {
           exercises = contentNode.exercises;
           this.removeFromSelectedExercises(exercises);
           this.createSnackbar({
             text: this.$tr('removed', { item: contentNode.title }),
-            autoDismiss: true,
           });
         } else if (!checked && !isTopic) {
           exercises = [contentNode];
           this.removeFromSelectedExercises(exercises);
           this.createSnackbar({
             text: this.$tr('removed', { item: contentNode.title }),
-            autoDismiss: true,
           });
         }
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -467,7 +467,7 @@
         }
 
         if (snackbarString) {
-          this.createSnackbar(snackbarString, { item: contentNode.title });
+          this.createSnackbar(this.$tr(snackbarString, { item: contentNode.title }));
         }
       },
       handleMoreResults() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -430,49 +430,44 @@
         return '';
       },
       toggleTopicInWorkingResources(isChecked) {
+        let snackbarString;
         if (isChecked) {
           this.showError = false;
           this.addToSelectedExercises(this.addableExercises);
-          this.createSnackbar({
-            text: this.$tr('added', { item: this.topicTitle }),
-          });
+          snackbarString = 'added';
         } else {
           this.removeFromSelectedExercises(this.allExercises);
-          this.createSnackbar({
-            text: this.$tr('removed', { item: this.topicTitle }),
-          });
+          snackbarString = 'removed';
         }
+        this.createSnackbar(this.$tr(snackbarString, { item: this.topicTitle }));
       },
       toggleSelected({ checked, contentId }) {
         let exercises;
+        let snackbarString;
         const contentNode = this.contentList.find(item => item.id === contentId);
         const isTopic = contentNode.kind === ContentNodeKinds.TOPIC;
         if (checked && isTopic) {
           this.showError = false;
           exercises = contentNode.exercises;
           this.addToSelectedExercises(exercises);
-          this.createSnackbar({
-            text: this.$tr('added', { item: contentNode.title }),
-          });
+          snackbarString = 'added';
         } else if (checked && !isTopic) {
           this.showError = false;
           exercises = [contentNode];
           this.addToSelectedExercises(exercises);
-          this.createSnackbar({
-            text: this.$tr('added', { item: contentNode.title }),
-          });
+          snackbarString = 'added';
         } else if (!checked && isTopic) {
           exercises = contentNode.exercises;
           this.removeFromSelectedExercises(exercises);
-          this.createSnackbar({
-            text: this.$tr('removed', { item: contentNode.title }),
-          });
+          snackbarString = 'removed';
         } else if (!checked && !isTopic) {
           exercises = [contentNode];
           this.removeFromSelectedExercises(exercises);
-          this.createSnackbar({
-            text: this.$tr('removed', { item: contentNode.title }),
-          });
+          snackbarString = 'removed';
+        }
+
+        if (snackbarString) {
+          this.createSnackbar(snackbarString, { item: contentNode.title });
         }
       },
       handleMoreResults() {

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -219,7 +219,6 @@
           this.$router.push(this.$router.getRoute('GroupMembersPage'), () => {
             this.createSnackbar({
               text: groupMgmtStrings.$tr('addedLearnersNotice', { value }),
-              autoDismiss: true,
             });
           });
         });

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -217,9 +217,7 @@
           userIds: this.selectedUsers,
         }).then(() => {
           this.$router.push(this.$router.getRoute('GroupMembersPage'), () => {
-            this.createSnackbar({
-              text: groupMgmtStrings.$tr('addedLearnersNotice', { value }),
-            });
+            this.createSnackbar(groupMgmtStrings.$tr('addedLearnersNotice', { value }));
           });
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -156,9 +156,7 @@
             userIds: [this.userForRemoval.id],
             groupId: this.currentGroup.id,
           }).then(() => {
-            this.createSnackbar({
-              text: groupMgmtStrings.$tr('removedLearnersNotice', { value: 1 }),
-            });
+            this.createSnackbar(groupMgmtStrings.$tr('removedLearnersNotice', { value: 1 }));
             this.userForRemoval = null;
           });
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -158,7 +158,6 @@
           }).then(() => {
             this.createSnackbar({
               text: groupMgmtStrings.$tr('removedLearnersNotice', { value: 1 }),
-              autoDismiss: true,
             });
             this.userForRemoval = null;
           });

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -150,15 +150,11 @@
         this.displayModal(GroupModals.DELETE_GROUP);
       },
       handleSuccessCreateGroup() {
-        this.createSnackbar({
-          text: groupMgmtStrings.$tr('groupCreatedNotice'),
-        });
+        this.createSnackbar(groupMgmtStrings.$tr('groupCreatedNotice'));
         this.displayModal(false);
       },
       handleSuccessDeleteGroup() {
-        this.createSnackbar({
-          text: groupMgmtStrings.$tr('groupDeletedNotice'),
-        });
+        this.createSnackbar(groupMgmtStrings.$tr('groupDeletedNotice'));
         this.displayModal(false);
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -152,14 +152,12 @@
       handleSuccessCreateGroup() {
         this.createSnackbar({
           text: groupMgmtStrings.$tr('groupCreatedNotice'),
-          autoDismiss: true,
         });
         this.displayModal(false);
       },
       handleSuccessDeleteGroup() {
         this.createSnackbar({
           text: groupMgmtStrings.$tr('groupDeletedNotice'),
-          autoDismiss: true,
         });
         this.displayModal(false);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -239,9 +239,7 @@
         const isSamePage = samePageCheckGenerator(this.$store);
         setTimeout(() => {
           if (isSamePage()) {
-            this.createSnackbar({
-              text: this.$tr('saveBeforeExitSnackbarText'),
-            });
+            this.createSnackbar(this.$tr('saveBeforeExitSnackbarText'));
           }
         }, 500);
 
@@ -284,12 +282,10 @@
         } else {
           text = this.$tr('resourcesRemovedSnackbarText', { count: -difference });
         }
-        this.createSnackbar({ text });
+        this.createSnackbar(text);
       },
       showResourcesChangedError() {
-        this.createSnackbar({
-          text: this.$tr('resourcesChangedErrorSnackbarText'),
-        });
+        this.createSnackbar(this.$tr('resourcesChangedErrorSnackbarText'));
       },
       toggleTopicInWorkingResources(isChecked) {
         if (isChecked) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -284,12 +284,11 @@
         } else {
           text = this.$tr('resourcesRemovedSnackbarText', { count: -difference });
         }
-        this.createSnackbar({ text, autoDismiss: true });
+        this.createSnackbar({ text });
       },
       showResourcesChangedError() {
         this.createSnackbar({
           text: this.$tr('resourcesChangedErrorSnackbarText'),
-          autoDismiss: true,
         });
       },
       toggleTopicInWorkingResources(isChecked) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -168,7 +168,6 @@
           text: this.removalMessage,
           autoDismiss: true,
           duration: removalSnackbarTime,
-          autoDismiss: true,
           actionText: this.$tr('undoActionPrompt'),
           actionCallback: () => {
             this.setWorkingResources(this.workingResourcesBackup);
@@ -200,7 +199,6 @@
 
         this.createSnackbar({
           text: this.$tr('resourceReorderConfirmationMessage'),
-          autoDismiss: true,
         });
       },
       handleDrag({ newArray }) {
@@ -208,7 +206,6 @@
         this.autoSave(this.lessonId, newArray);
         this.createSnackbar({
           text: this.$tr('resourceReorderConfirmationMessage'),
-          autoDismiss: true,
         });
       },
       autoSave(id, resources) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -166,6 +166,7 @@
 
         this.createSnackbar({
           text: this.removalMessage,
+          autoDismiss: true,
           duration: removalSnackbarTime,
           autoDismiss: true,
           actionText: this.$tr('undoActionPrompt'),

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -164,7 +164,7 @@
 
         this.autoSave(this.lessonId, this.workingResources);
 
-        this.createSnackbar({
+        this.$store.commit('CORE_CREATE_SNACKBAR', {
           text: this.removalMessage,
           autoDismiss: true,
           duration: removalSnackbarTime,
@@ -197,16 +197,12 @@
         this.setWorkingResources(resources);
         this.autoSave(this.lessonId, resources);
 
-        this.createSnackbar({
-          text: this.$tr('resourceReorderConfirmationMessage'),
-        });
+        this.createSnackbar(this.$tr('resourceReorderConfirmationMessage'));
       },
       handleDrag({ newArray }) {
         this.setWorkingResources(newArray);
         this.autoSave(this.lessonId, newArray);
-        this.createSnackbar({
-          text: this.$tr('resourceReorderConfirmationMessage'),
-        });
+        this.createSnackbar(this.$tr('resourceReorderConfirmationMessage'));
       },
       autoSave(id, resources) {
         this.saveLessonResources({ lessonId: id, resourceIds: resources }).catch(() => {

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -60,12 +60,12 @@
         this.$store.commit('lessonSummary/ADD_TO_WORKING_RESOURCES', content.id);
         this.addToResourceCache({ node: content });
         const text = indexStrings.$tr('resourcesAddedSnackbarText', { count: 1 });
-        this.createSnackbar({ text, autoDismiss: true });
+        this.createSnackbar({ text });
       },
       handleRemoveResource(content) {
         this.$store.commit('lessonSummary/REMOVE_FROM_WORKING_RESOURCES', content.id);
         const text = indexStrings.$tr('resourcesRemovedSnackbarText', { count: 1 });
-        this.createSnackbar({ text, autoDismiss: true });
+        this.createSnackbar({ text });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -59,13 +59,11 @@
       handleAddResource(content) {
         this.$store.commit('lessonSummary/ADD_TO_WORKING_RESOURCES', content.id);
         this.addToResourceCache({ node: content });
-        const text = indexStrings.$tr('resourcesAddedSnackbarText', { count: 1 });
-        this.createSnackbar({ text });
+        this.createSnackbar(indexStrings.$tr('resourcesAddedSnackbarText', { count: 1 }));
       },
       handleRemoveResource(content) {
         this.$store.commit('lessonSummary/REMOVE_FROM_WORKING_RESOURCES', content.id);
-        const text = indexStrings.$tr('resourcesRemovedSnackbarText', { count: 1 });
-        this.createSnackbar({ text });
+        this.createSnackbar(indexStrings.$tr('resourcesRemovedSnackbarText', { count: 1 }));
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -58,13 +58,11 @@
       ...mapActions('examCreation', ['addToSelectedExercises', 'removeFromSelectedExercises']),
       handleAddResource(content) {
         this.addToSelectedExercises([content]);
-        const text = indexStrings.$tr('added', { item: this.currentContentNode.title });
-        this.createSnackbar({ text });
+        this.createSnackbar(indexStrings.$tr('added', { item: this.currentContentNode.title }));
       },
       handleRemoveResource(content) {
         this.removeFromSelectedExercises([content]);
-        const text = indexStrings.$tr('removed', { item: this.currentContentNode.title });
-        this.createSnackbar({ text });
+        this.createSnackbar(indexStrings.$tr('removed', { item: this.currentContentNode.title }));
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -59,12 +59,12 @@
       handleAddResource(content) {
         this.addToSelectedExercises([content]);
         const text = indexStrings.$tr('added', { item: this.currentContentNode.title });
-        this.createSnackbar({ text, autoDismiss: true });
+        this.createSnackbar({ text });
       },
       handleRemoveResource(content) {
         this.removeFromSelectedExercises([content]);
         const text = indexStrings.$tr('removed', { item: this.currentContentNode.title });
-        this.createSnackbar({ text, autoDismiss: true });
+        this.createSnackbar({ text });
       },
     },
   };

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
@@ -58,15 +58,11 @@
         this.stage = Stages.SELECT_ADDRESS;
       },
       handleAddedAddress() {
-        this.createSnackbar({
-          text: this.$tr('addAddressSnackbarText'),
-        });
+        this.createSnackbar(this.$tr('addAddressSnackbarText'));
         this.goToSelectAddress();
       },
       handleRemovedAddress() {
-        this.createSnackbar({
-          text: this.$tr('removeAddressSnackbarText'),
-        });
+        this.createSnackbar(this.$tr('removeAddressSnackbarText'));
       },
       handleSelectAddressSubmit(address) {
         if (this.isImportingMore) {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
@@ -60,14 +60,12 @@
       handleAddedAddress() {
         this.createSnackbar({
           text: this.$tr('addAddressSnackbarText'),
-          autoDismiss: true,
         });
         this.goToSelectAddress();
       },
       handleRemovedAddress() {
         this.createSnackbar({
           text: this.$tr('removeAddressSnackbarText'),
-          autoDismiss: true,
         });
       },
       handleSelectAddressSubmit(address) {

--- a/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
@@ -209,9 +209,7 @@
           can_manage_content: this.devicePermissionsChecked,
         })
           .then(() => {
-            this.createSnackbar({
-              text: this.$tr('permissionChangeConfirmation'),
-            });
+            this.createSnackbar(this.$tr('permissionChangeConfirmation'));
             this.saveProgress = SUCCESS;
             this.uiBlocked = false;
           })

--- a/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/UserPermissionsPage/index.vue
@@ -211,7 +211,6 @@
           .then(() => {
             this.createSnackbar({
               text: this.$tr('permissionChangeConfirmation'),
-              autoDismiss: true,
             });
             this.saveProgress = SUCCESS;
             this.uiBlocked = false;

--- a/kolibri/plugins/user/assets/src/modules/profile/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/profile/actions.js
@@ -67,13 +67,9 @@ export function updateUserProfilePassword(store, password) {
     () => {
       store.commit('SET_PROFILE_BUSY', false);
       store.commit('SET_PROFILE_PASSWORD_MODAL', false);
-      store.commit(
-        'CORE_CREATE_SNACKBAR',
-        {
-          text: snackbarTranslator.$tr('passwordChangeSuccessMessage'),
-        },
-        { root: true }
-      );
+      store.dispatch('createSnackbar', snackbarTranslator.$tr('passwordChangeSuccessMessage'), {
+        root: true,
+      });
     },
     () => {
       store.commit('SET_PROFILE_BUSY', false);

--- a/kolibri/plugins/user/assets/src/modules/profile/actions.js
+++ b/kolibri/plugins/user/assets/src/modules/profile/actions.js
@@ -71,7 +71,6 @@ export function updateUserProfilePassword(store, password) {
         'CORE_CREATE_SNACKBAR',
         {
           text: snackbarTranslator.$tr('passwordChangeSuccessMessage'),
-          autoDismiss: true,
         },
         { root: true }
       );

--- a/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
@@ -13,6 +13,7 @@ export function showSignInPage(store) {
   if (Lockr.get(SIGNED_OUT_DUE_TO_INACTIVITY)) {
     store.commit('CORE_CREATE_SNACKBAR', {
       text: snackbarTranslator.$tr('signedOut'),
+      autoDismiss: false,
       actionText: snackbarTranslator.$tr('dismiss'),
       actionCallback: () => store.commit('CORE_CLEAR_SNACKBAR'),
     });


### PR DESCRIPTION
### Summary

1. Simplifies the interface of the `createSnackbar` action to reflect how it's used virtually 100% of the time (to show a snackbar with text that auto-dismisses).
1. For the lower-level `CORE_CREATE_SNACKBAR` mutation, enforces that the `autoDismiss` action is always explicitly set.
1. In Lesson Resource List, change the KDraggable container so it doesn't emit a sort/change event when nothing has been moved.
1. Fixes regression where in links from the HomePage didn't have the proper URL pointing back to the previous page (so backlinks went to the wrong place).

Removes a net of 100 lines.

### Reviewer guidance

1. Check each refactored section to see if it reflects the new interfaces.
1. Grep for 'createSnackbar' and 'CORE_CREATE_SNACKBAR' and make sure no call sites have been left out of this update.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
