### PR TITLE
Don't try to translate messages in the module closure.

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -264,11 +264,11 @@ export function i18nSetup(skipPolyfill = false) {
       resolve();
     } else {
       Promise.all([
-        new Promise(resolve => {
+        new Promise(res => {
           require.ensure(
             ['intl'],
             require => {
-              resolve(() => require('intl'));
+              res(() => require('intl'));
             },
             'intl'
           );

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -42,7 +42,7 @@
 
   const MAX_LESSONS = 3;
 
-  const viewAllString = crossComponentTranslator(ActivityBlock).$tr('viewAll');
+  const translator = crossComponentTranslator(ActivityBlock);
 
   export default {
     name: 'LessonsBlock',
@@ -69,7 +69,7 @@
         });
       },
       viewAllString() {
-        return viewAllString;
+        return translator.$tr('viewAll');
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -39,7 +39,7 @@
   import ItemProgressDisplay from './ItemProgressDisplay';
   import ActivityBlock from './ActivityBlock';
 
-  const viewAllString = crossComponentTranslator(ActivityBlock).$tr('viewAll');
+  const translator = crossComponentTranslator(ActivityBlock);
   const MAX_QUIZZES = 3;
 
   export default {
@@ -67,7 +67,7 @@
         });
       },
       viewAllString() {
-        return viewAllString;
+        return translator.$tr('viewAll');
       },
     },
     methods: {

--- a/kolibri/plugins/user/assets/src/views/UserIndex.vue
+++ b/kolibri/plugins/user/assets/src/views/UserIndex.vue
@@ -23,7 +23,7 @@
   import SignUpPage from './SignUpPage';
   import ProfilePage from './ProfilePage';
 
-  const createAccountString = crossComponentTranslator(SignUpPage).$tr('createAccount');
+  const translator = crossComponentTranslator(SignUpPage);
 
   const pageNameComponentMap = {
     [PageNames.SIGN_IN]: SignInPage,
@@ -42,7 +42,7 @@
         if (this.pageName === PageNames.PROFILE) {
           return this.$tr('userProfileTitle');
         } else if (this.pageName === PageNames.SIGN_UP) {
-          return createAccountString;
+          return translator.$tr('createAccount');
         }
         return this.$tr('userSignInTitle');
       },


### PR DESCRIPTION
### Summary
Moves all invocations of `$tr` out of the module scope, as this was causing an issue where if the Intl polyfill was being loaded, it would attempt to translate a message before Intl had been loaded.

### Reviewer guidance
Does it work on iOS 9.3 Safari?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
