### PR TITLE
Docs: Update Getting Started instructions to use Node v10.x

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -28,12 +28,12 @@ Install environment dependencies
 
 #. Install `Python <https://www.python.org/downloads/windows/>`__ if you are on Windows, on Linux and OSX Python is preinstalled (recommended versions 2.7+ or 3.4+).
 #. Install `pip <https://pypi.python.org/pypi/pip>`__ package installer.
-#. Install `Node.js <https://nodejs.org/en/>`__ (version 6 is required).
+#. Install `Node.js <https://nodejs.org/en/>`__ (version 10 is required).
 #. Install `Yarn <https://yarnpkg.com/>`__ according the `instructions specific for your OS <https://yarnpkg.com/en/docs/install/>`__.
 #. Install and set up the `Git LFS extension <https://git-lfs.github.com/>`__. Remember to initialize with ``git lfs install`` after installing.
 
 .. note::
-  Installing Node.js version 6.x:
+  Installing Node.js version 10.x:
 
   * On a Mac, you can use the `Homebrew <http://brew.sh/>`__ package manager.
   * On Ubuntu/Debian, either install Node.js via `nvm <https://github.com/creationix/nvm>`__ or use the `apt` package manager to install a system-wide version and block upgrades:
@@ -41,15 +41,12 @@ Install environment dependencies
    .. code-block:: bash
 
      # Add apt sources from nodesource.com
-     curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-     # Verify the latest version 6 of nodejs
-     apt-cache showpkg nodejs-legacy
-     # Install latest version 6 nodejs
-     sudo apt install nodejs=6.14.1-1nodesource1
+     curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+     # Install latest version 10 nodejs
+     sudo apt install nodejs
      # Make sure it doesn't get upgrade to later versions available in
      # the official repos.
      sudo apt-mark hold nodejs
-
 
 Ready for the fun part in the Terminal? Here we go!
 


### PR DESCRIPTION
### Summary

The Getting Started docs currently stipulate that Node v6.x is required to develop Kolibri locally:
https://kolibri-dev.readthedocs.io/en/develop/getting_started.html#install-environment-dependencies

However, in the required Node version was updated to v10.x back in November.

This PR will update the docs to reflect that change, and also update the Ubuntu/Debian install.

### Reviewer guidance

Really the only thing I can think of to test here would be the Ubuntu/Debian instructions. I went through the flow and tested the instructions personally on both Ubuntu 18.04 LTS and Ubuntu 18.10, but I didn't test on Debian.

### References

learningequality/kolibri#4524

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
