### PR TITLE
Layout changes for the ContentPage in Learn pages

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -56,19 +56,8 @@ function _showRecSubpage(store, getContentPromise, pageName, channelId = null) {
   ]).then(([content, channels]) => [_mapContentSet(content), channels]);
 
   pagePrep.then(
-    ([recommendations, channels]) => {
-      if (!channels.length) {
-        return;
-      }
-      const recommendedState = {
-        recommendations,
-      };
-      if (channelId) {
-        const currentChannel = store.getters.getChannelObject(channelId);
-        const channelTitle = currentChannel.title;
-        recommendedState.channelTitle = channelTitle;
-      }
-      store.commit('recommended/subpage/SET_STATE', recommendedState);
+    ([recommendations]) => {
+      store.commit('recommended/subpage/SET_STATE', { recommendations });
       store.commit('SET_PAGE_NAME', pageName);
       store.commit('CORE_SET_PAGE_LOADING', false);
       store.commit('CORE_SET_ERROR', null);

--- a/kolibri/plugins/learn/assets/src/modules/recommended/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/index.js
@@ -31,16 +31,13 @@ export default {
     subpage: {
       namespaced: true,
       state: {
-        channelTitle: '',
         recommendations: [],
       },
       mutations: {
         SET_STATE(state, payload) {
-          state.channelTitle = payload.channelTitle;
           state.recommendations = payload.recommendations;
         },
         RESET_STATE(state) {
-          state.channelTitle = '';
           state.recommendations = [];
         },
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -249,8 +249,9 @@
         return this.$tr('recommended');
       },
       parentTopic() {
-        if (this.content.breadcrumbs.length > 0) {
-          return this.content.breadcrumbs[this.content.breadcrumbs.length - 1];
+        const { breadcrumbs = [] } = this.content;
+        if (breadcrumbs.length > 0) {
+          return breadcrumbs[breadcrumbs.length - 1];
         }
       },
       progress() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -14,22 +14,13 @@
     />
 
     <div v-if="parentTopic" class="topic-link">
-      <mat-svg
-        ref="folderIcon"
-        class="folder-svg"
-        category="file"
-        name="folder"
-      />
-      <KTooltip
-        reference="folderIcon"
-        :refs="$refs"
-      >
-        {{ $tr('topicLocationTooltip') }}
-      </KTooltip>
-      <KRouterLink
-        :text="parentTopic.title"
-        :to="$router.getRoute('TOPICS_TOPIC', { id: parentTopic.id })"
-      />
+      <KLabeledIcon :tooltipText="$tr('topicLocationTooltip')">
+        <KIcon slot="icon" topic />
+        <KRouterLink
+          :text="parentTopic.title"
+          :to="$router.getRoute('TOPICS_TOPIC', { id: parentTopic.id })"
+        />
+      </KLabeledIcon>
     </div>
 
     <ContentRenderer
@@ -155,7 +146,8 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
-  import KTooltip from 'kolibri.coreVue.components.KTooltip';
+  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
+  import KIcon from 'kolibri.coreVue.components.KIcon';
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
@@ -189,8 +181,9 @@
       AssessmentWrapper,
       MasteredSnackbars,
       UiIconButton,
+      KIcon,
+      KLabeledIcon,
       KRouterLink,
-      KTooltip,
     },
     metaInfo() {
       // Do not overwrite metaInfo of LessonResourceViewer
@@ -356,12 +349,6 @@
 
 
 <style lang="scss" scoped>
-
-  .folder-svg {
-    margin-right: 8px;
-    margin-bottom: -2px;
-    vertical-align: bottom;
-  }
 
   .coach-content-label {
     margin: 8px 0;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -13,16 +13,6 @@
       :isTopic="isTopic"
     />
 
-    <div v-if="parentTopic" class="topic-link">
-      <KLabeledIcon :tooltipText="$tr('topicLocationTooltip')">
-        <KIcon slot="icon" topic />
-        <KRouterLink
-          :text="parentTopic.title"
-          :to="$router.getRoute('TOPICS_TOPIC', { id: parentTopic.id })"
-        />
-      </KLabeledIcon>
-    </div>
-
     <ContentRenderer
       v-if="!content.assessment"
       :id="content.id"
@@ -145,9 +135,6 @@
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
-  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
-  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
-  import KIcon from 'kolibri.coreVue.components.KIcon';
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
@@ -181,9 +168,6 @@
       AssessmentWrapper,
       MasteredSnackbars,
       UiIconButton,
-      KIcon,
-      KLabeledIcon,
-      KRouterLink,
     },
     metaInfo() {
       // Do not overwrite metaInfo of LessonResourceViewer

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -13,6 +13,25 @@
       :isTopic="isTopic"
     />
 
+    <div v-if="parentTopic" class="topic-link">
+      <mat-svg
+        ref="folderIcon"
+        class="folder-svg"
+        category="file"
+        name="folder"
+      />
+      <KTooltip
+        reference="folderIcon"
+        :refs="$refs"
+      >
+        {{ $tr('topicLocationTooltip') }}
+      </KTooltip>
+      <KRouterLink
+        :text="parentTopic.title"
+        :to="$router.getRoute('TOPICS_TOPIC', { id: parentTopic.id })"
+      />
+    </div>
+
     <ContentRenderer
       v-if="!content.assessment"
       :id="content.id"
@@ -135,6 +154,8 @@
   import ContentRenderer from 'kolibri.coreVue.components.ContentRenderer';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
+  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
+  import KTooltip from 'kolibri.coreVue.components.KTooltip';
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
@@ -157,6 +178,7 @@
       copyrightHolder: 'Copyright holder: {copyrightHolder}',
       nextResource: 'Next resource',
       documentTitle: '{ contentTitle } - { channelTitle }',
+      topicLocationTooltip: 'Resource is located in this topic',
     },
     components: {
       CoachContentLabel,
@@ -167,6 +189,8 @@
       AssessmentWrapper,
       MasteredSnackbars,
       UiIconButton,
+      KRouterLink,
+      KTooltip,
     },
     metaInfo() {
       // Do not overwrite metaInfo of LessonResourceViewer
@@ -223,6 +247,11 @@
       },
       recommendedText() {
         return this.$tr('recommended');
+      },
+      parentTopic() {
+        if (this.content.breadcrumbs.length > 0) {
+          return this.content.breadcrumbs[this.content.breadcrumbs.length - 1];
+        }
       },
       progress() {
         if (this.isUserLoggedIn) {
@@ -326,6 +355,12 @@
 
 
 <style lang="scss" scoped>
+
+  .folder-svg {
+    margin-right: 8px;
+    margin-bottom: -2px;
+    vertical-align: bottom;
+  }
 
   .coach-content-label {
     margin: 8px 0;

--- a/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
+++ b/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
@@ -94,6 +94,9 @@
         return {
           name: PageNames.TOPICS_CONTENT,
           params: { id },
+          query: {
+            searchTerm: this.$route.query.searchTerm || '',
+          },
         };
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -26,6 +26,8 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
+  import lastItem from 'lodash/last';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
@@ -46,6 +48,8 @@
   import LessonResourceViewer from './classes/LessonResourceViewer';
   import ActionBarSearchBox from './ActionBarSearchBox';
   import LearnTopNav from './LearnTopNav';
+
+  const RecommendedSubpageStrings = crossComponentTranslator(RecommendedSubpage);
 
   // Bottom toolbar is 111px high on mobile, 113px normally.
   // We reserve the smaller number so there is no gap on either screen size.
@@ -85,6 +89,7 @@
       ...mapGetters(['isUserLoggedIn']),
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
+        currentLesson: 'currentLesson',
       }),
       ...mapState('topicsTree', {
         topicsTreeContent: 'content',
@@ -100,7 +105,7 @@
       immersivePageProps() {
         if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
           return {
-            appBarTitle: this.lessonContent.title || '',
+            appBarTitle: this.currentLesson.title || '',
             immersivePage: true,
             immersivePageRoute: this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST),
             immersivePagePrimary: false,
@@ -123,6 +128,7 @@
 
         if (this.pageName === PageNames.TOPICS_CONTENT) {
           let immersivePageRoute = {};
+          let appBarTitle;
           const { searchTerm, last } = this.$route.query;
           if (searchTerm) {
             immersivePageRoute = this.$router.getRoute(
@@ -135,14 +141,22 @@
           } else if (last) {
             // 'last' should only be route names for Recommended Page and its subpages
             immersivePageRoute = this.$router.getRoute(last);
+            const trString = {
+              [PageNames.RECOMMENDED_POPULAR]: 'documentTitleForPopular',
+              [PageNames.RECOMMENDED_RESUME]: 'documentTitleForResume',
+              [PageNames.RECOMMENDED_NEXT_STEPS]: 'documentTitleForNextSteps',
+              [PageNames.RECOMMENDED]: 'recommended',
+            }[last];
+            appBarTitle = RecommendedSubpageStrings.$tr(trString);
           } else if (this.topicsTreeContent.parent) {
             // Need to guard for parent being non-empty to avoid console errors
             immersivePageRoute = this.$router.getRoute('TOPICS_TOPIC', {
               id: this.topicsTreeContent.parent,
             });
+            appBarTitle = lastItem(this.topicsTreeContent.breadcrumbs).title;
           }
           return {
-            appBarTitle: this.topicsTreeContent.title,
+            appBarTitle,
             immersivePage: true,
             immersivePageRoute,
             immersivePagePrimary: false,

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -123,14 +123,18 @@
 
         if (this.pageName === PageNames.TOPICS_CONTENT) {
           let immersivePageRoute = {};
-          if (this.$route.query.searchTerm) {
+          const { searchTerm, last } = this.$route.query;
+          if (searchTerm) {
             immersivePageRoute = this.$router.getRoute(
               PageNames.SEARCH,
               {},
               {
-                searchTerm: this.$route.query.searchTerm,
+                searchTerm: searchTerm,
               }
             );
+          } else if (last) {
+            // 'last' should only be route names for Recommended Page and its subpages
+            immersivePageRoute = this.$router.getRoute(last);
           } else if (this.topicsTreeContent.parent) {
             // Need to guard for parent being non-empty to avoid console errors
             immersivePageRoute = this.$router.getRoute('TOPICS_TOPIC', {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -1,13 +1,9 @@
 <template>
 
   <CoreBase
-    :appBarTitle="appBarTitle"
     :marginBottom="bottomSpaceReserved"
-    :immersivePage="isImmersivePage"
-    :immersivePageIcon="immersivePageIcon"
-    :immersivePagePrimary="immersivePageIsPrimary"
-    :immersivePageRoute="immersiveToolbarRoute"
     :showSubNav="topNavIsVisible"
+    v-bind="immersivePageProps"
   >
     <template slot="app-bar-actions">
       <ActionBarSearchBox v-if="!isWithinSearchPage" />
@@ -18,7 +14,7 @@
     <TotalPoints slot="totalPointsMenuItem" />
 
     <div>
-      <Breadcrumbs />
+      <Breadcrumbs v-if="currentPage.name !== 'ContentPage'" />
       <component :is="currentPage" />
     </div>
 
@@ -71,12 +67,6 @@
     [ClassesPageNames.LESSON_RESOURCE_VIEWER]: LessonResourceViewer,
   };
 
-  const immersivePages = [
-    ClassesPageNames.LESSON_RESOURCE_VIEWER,
-    ClassesPageNames.EXAM_REPORT_VIEWER,
-    PageNames.TOPICS_CONTENT,
-  ];
-
   export default {
     name: 'LearnIndex',
     $trs: {
@@ -107,55 +97,46 @@
         }
         return pageNameToComponentMap[this.pageName] || null;
       },
-      appBarTitle() {
+      immersivePageProps() {
         if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-          return this.lessonContent.title || '';
-        } else if (this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER) {
+          return {
+            appBarTitle: this.lessonContent.title || '',
+            immersivePage: true,
+            immersivePageRoute: this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST),
+            immersivePagePrimary: false,
+            immersivePageIcon: 'arrow_back',
+          };
+        }
+        if (this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER) {
           if (this.exam) {
-            return this.$tr('examReportTitle', {
-              examTitle: this.exam.title,
-            });
+            return {
+              appBarTitle: this.$tr('examReportTitle', {
+                examTitle: this.exam.title,
+              }),
+              immersivePage: true,
+              immersivePageRoute: this.$router.getRoute(ClassesPageNames.EXAM_REPORT_VIEWER),
+              immersivePagePrimary: false,
+              immersivePageIcon: 'arrow_back',
+            };
           }
-        } else if (this.pageName === PageNames.TOPICS_CONTENT) {
-          return this.topicsTreeContent.title;
         }
-        return this.$tr('learnTitle');
-      },
-      isImmersivePage() {
-        return immersivePages.includes(this.pageName);
-      },
-      immersiveToolbarRoute() {
-        if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
+
+        if (this.pageName === PageNames.TOPICS_CONTENT && this.topicsTreeContent.parent) {
           return {
-            name: ClassesPageNames.LESSON_PLAYLIST,
+            appBarTitle: this.topicsTreeContent.title,
+            immersivePage: true,
+            immersivePageRoute: this.$router.getRoute('TOPICS_TOPIC', {
+              id: this.topicsTreeContent.parent,
+            }),
+            immersivePagePrimary: false,
+            immersivePageIcon: 'arrow_back',
           };
-        } else if (this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER) {
-          return {
-            name: ClassesPageNames.CLASS_ASSIGNMENTS,
-          };
-        } else if (this.pageName === PageNames.TOPICS_CONTENT) {
-          return this.$router.getRoute('TOPICS_TOPIC', { id: this.topicsTreeContent.parent });
         }
-      },
-      immersivePageIsPrimary() {
-        if (
-          this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER ||
-          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER ||
-          this.pageName === PageNames.TOPICS_CONTENT
-        ) {
-          return false;
-        }
-        return true;
-      },
-      immersivePageIcon() {
-        if (
-          this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER ||
-          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER ||
-          this.pageName === PageNames.TOPICS_CONTENT
-        ) {
-          return 'arrow_back';
-        }
-        return null;
+
+        return {
+          appBarTitle: this.$tr('learnTitle'),
+          immersivePage: false,
+        };
       },
       isWithinSearchPage() {
         return this.pageName === PageNames.SEARCH;

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -74,6 +74,7 @@
   const immersivePages = [
     ClassesPageNames.LESSON_RESOURCE_VIEWER,
     ClassesPageNames.EXAM_REPORT_VIEWER,
+    PageNames.TOPICS_CONTENT,
   ];
 
   export default {
@@ -115,6 +116,8 @@
               examTitle: this.exam.title,
             });
           }
+        } else if (this.pageName === PageNames.TOPICS_CONTENT) {
+          return this.topicsTreeContent.title;
         }
         return this.$tr('learnTitle');
       },
@@ -130,12 +133,15 @@
           return {
             name: ClassesPageNames.CLASS_ASSIGNMENTS,
           };
+        } else if (this.pageName === PageNames.TOPICS_CONTENT) {
+          return this.$router.getRoute('TOPICS_TOPIC', { id: this.topicsTreeContent.parent });
         }
       },
       immersivePageIsPrimary() {
         if (
           this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER ||
-          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER
+          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER ||
+          this.pageName === PageNames.TOPICS_CONTENT
         ) {
           return false;
         }
@@ -144,7 +150,8 @@
       immersivePageIcon() {
         if (
           this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER ||
-          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER
+          this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER ||
+          this.pageName === PageNames.TOPICS_CONTENT
         ) {
           return 'arrow_back';
         }

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -14,7 +14,7 @@
     <TotalPoints slot="totalPointsMenuItem" />
 
     <div>
-      <Breadcrumbs v-if="currentPage.name !== 'ContentPage'" />
+      <Breadcrumbs v-if="pageName !== 'TOPICS_CONTENT'" />
       <component :is="currentPage" />
     </div>
 
@@ -121,13 +121,26 @@
           }
         }
 
-        if (this.pageName === PageNames.TOPICS_CONTENT && this.topicsTreeContent.parent) {
+        if (this.pageName === PageNames.TOPICS_CONTENT) {
+          let immersivePageRoute = {};
+          if (this.$route.query.searchTerm) {
+            immersivePageRoute = this.$router.getRoute(
+              PageNames.SEARCH,
+              {},
+              {
+                searchTerm: this.$route.query.searchTerm,
+              }
+            );
+          } else if (this.topicsTreeContent.parent) {
+            // Need to guard for parent being non-empty to avoid console errors
+            immersivePageRoute = this.$router.getRoute('TOPICS_TOPIC', {
+              id: this.topicsTreeContent.parent,
+            });
+          }
           return {
             appBarTitle: this.topicsTreeContent.title,
             immersivePage: true,
-            immersivePageRoute: this.$router.getRoute('TOPICS_TOPIC', {
-              id: this.topicsTreeContent.parent,
-            }),
+            immersivePageRoute,
             immersivePagePrimary: false,
             immersivePageIcon: 'arrow_back',
           };
@@ -145,7 +158,7 @@
         return (
           this.pageName !== PageNames.CONTENT_UNAVAILABLE &&
           this.pageName !== PageNames.SEARCH &&
-          !this.isImmersivePage
+          !this.immersivePageProps.immersivePage
         );
       },
       bottomSpaceReserved() {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -150,7 +150,7 @@
             appBarTitle = RecommendedSubpageStrings.$tr(trString);
           } else if (this.topicsTreeContent.parent) {
             // Need to guard for parent being non-empty to avoid console errors
-            immersivePageRoute = this.$router.getRoute('TOPICS_TOPIC', {
+            immersivePageRoute = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
               id: this.topicsTreeContent.parent,
             });
             appBarTitle = lastItem(this.topicsTreeContent.breadcrumbs).title;

--- a/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
@@ -134,6 +134,9 @@
         return {
           name: kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT,
           params: { id },
+          query: {
+            last: this.$store.state.pageName,
+          },
         };
       },
       trimContent(content) {

--- a/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
@@ -30,7 +30,6 @@
       documentTitleForPopular: 'Popular',
       documentTitleForResume: 'Resume',
       documentTitleForNextSteps: 'Next Steps',
-      documentTitleForFeatured: 'Featured - { channelTitle }',
     },
     components: {
       ContentCardGroupGrid,
@@ -43,7 +42,7 @@
     },
     computed: {
       ...mapState(['pageName']),
-      ...mapState('recommended/subpage', ['channelTitle', 'recommendations']),
+      ...mapState('recommended/subpage', ['recommendations']),
       documentTitle() {
         switch (this.pageName) {
           case PageNames.RECOMMENDED_POPULAR:
@@ -52,8 +51,6 @@
             return this.$tr('documentTitleForResume');
           case PageNames.RECOMMENDED_NEXT_STEPS:
             return this.$tr('documentTitleForNextSteps');
-          case PageNames.RECOMMENDED_FEATURED:
-            return this.$tr('documentTitleForFeatured', { channelTitle: this.channelTitle });
           default:
             return '';
         }
@@ -74,9 +71,7 @@
         return [
           {
             text: this.$tr('recommended'),
-            link: {
-              name: PageNames.RECOMMENDED,
-            },
+            link: this.$router.getRoute(PageNames.RECOMMENDED),
           },
           {
             text: this.header,
@@ -86,13 +81,9 @@
     },
     methods: {
       genContentLink(id, kind) {
-        return {
-          name: kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT,
-          params: { id },
-          query: {
-            last: this.pageName,
-          },
-        };
+        const pageName =
+          kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT;
+        return this.$router.getRoute(pageName, { id }, { last: this.pageName });
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
@@ -89,6 +89,9 @@
         return {
           name: kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT,
           params: { id },
+          query: {
+            last: this.pageName,
+          },
         };
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -96,6 +96,9 @@
           params: {
             id: contentId,
           },
+          query: {
+            searchTerm: this.searchTerm,
+          },
         };
       },
       loadMore() {

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -46,6 +46,9 @@
       contentNodeId() {
         return this.content.id;
       },
+      parentTopic() {
+        return null;
+      },
       channelId() {
         return this.content.channel_id;
       },


### PR DESCRIPTION

### Summary

1. Implements layout changes for ContentPage (where you view videos, exercises, etc.), per #4706 

![Screen Shot 2019-03-12 at 12 11 31 PM](https://user-images.githubusercontent.com/10248067/54229424-77280880-44c1-11e9-82c6-4110784fa924.png)


### Reviewer guidance

1. Verify that parent topic links only appear when browsing content
1. Verify that parent topic links do not appear when viewing a lesson resource
1. Check on the link for the back arrow "<-" as make sure it behaves as described in #4706 for all of the different situations

### References

Fixes #4706 
Fixes #3664 

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
