### PR TITLE
Localize the File Download button underneath Resources

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -65,6 +65,7 @@ import * as serverClock from '../serverClock';
 import * as resources from '../api-resources';
 import * as i18n from '../utils/i18n';
 import * as browser from '../utils/browser';
+import bytesForHumans from '../utils/bytesForHumans';
 import UserType from '../utils/UserType';
 import samePageCheckGenerator from '../utils/samePageCheckGenerator';
 import AppBar from '../views/AppBar';
@@ -218,5 +219,6 @@ export default {
     CatchErrors,
     UserType,
     shuffled,
+    bytesForHumans,
   },
 };

--- a/kolibri/core/assets/src/utils/__test__/bytesForHumans.spec.js
+++ b/kolibri/core/assets/src/utils/__test__/bytesForHumans.spec.js
@@ -1,4 +1,4 @@
-import bytesForHumans from '../src/views/ManageContentPage/bytesForHumans';
+import bytesForHumans from '../bytesForHumans';
 
 const ONE_KB = 10 ** 3;
 const ONE_MB = 10 ** 6;

--- a/kolibri/core/assets/src/utils/bytesForHumans.js
+++ b/kolibri/core/assets/src/utils/bytesForHumans.js
@@ -1,4 +1,4 @@
-import { createTranslator } from 'kolibri.utils.i18n';
+import { createTranslator } from './i18n';
 
 const translator = createTranslator('BytesForHumansStrings', {
   fileSizeInBytes: '{n, number, integer} B',

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -11,8 +11,8 @@
 
 <script>
 
-  import filesize from 'filesize';
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
+  import { getFilePresetString } from './filePresetStrings';
 
   export default {
     name: 'DownloadButton',
@@ -29,7 +29,7 @@
     computed: {
       fileOptions() {
         return this.files.map(file => ({
-          label: `${file.preset} (${filesize(file.file_size)})`,
+          label: getFilePresetString(file),
           url: file.download_url,
         }));
       },

--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -3,7 +3,9 @@ import { createTranslator } from 'kolibri.utils.i18n';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
 // Strings are the _READABLE strings in le_utils.constants.format_presets,
-// with ' ({fileSize})' appended
+// with ' ({fileSize})' appended.
+// NOTE: Strings for 'Exercise Image', 'Exercise Graphie', and 'Channel Thumbnail'
+// are excluded, as they are not downloadable in Kolibri.
 const filePresetStrings = {
   highResolutionVideo: 'High Resolution ({fileSize})',
   lowResolutionVideo: 'Low Resolution ({fileSize})',
@@ -14,9 +16,6 @@ const filePresetStrings = {
   audio: 'Audio ({fileSize})',
   document: 'Document ({fileSize})',
   exercise: 'Exercise ({fileSize})',
-  exerciseImage: 'Exercise Image ({fileSize})',
-  exerciseGraphie: 'Exercise Graphie ({fileSize})',
-  channelThumbnail: 'Channel Thumbnail ({fileSize})',
   html5Zip: 'HTML5 Zip ({fileSize})',
   html5Thumbnail: 'HTML5 Thumbnail ({fileSize})',
 };

--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -1,6 +1,6 @@
 import findKey from 'lodash/findKey';
 import { createTranslator } from 'kolibri.utils.i18n';
-import bytesForHumans from 'kolibri.utils.bytesForHumans'
+import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
 // Strings are the _READABLE strings in le_utils.constants.format_presets,
 // with ' ({fileSize})' appended

--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -1,8 +1,9 @@
-import filesize from 'filesize';
 import findKey from 'lodash/findKey';
 import { createTranslator } from 'kolibri.utils.i18n';
+import bytesForHumans from 'kolibri.utils.bytesForHumans'
 
-// Strings are the _READABLE strings in le_utils.constants.format_presets
+// Strings are the _READABLE strings in le_utils.constants.format_presets,
+// with ' ({fileSize})' appended
 const filePresetStrings = {
   highResolutionVideo: 'High Resolution ({fileSize})',
   lowResolutionVideo: 'Low Resolution ({fileSize})',
@@ -29,7 +30,7 @@ export function getFilePresetString(file) {
   const { preset, file_size } = file;
   const trKey = findKey(filePresetStrings, x => x.startsWith(preset));
   if (trKey) {
-    return filePresetTranslator.$tr(trKey, { fileSize: filesize(file_size) });
+    return filePresetTranslator.$tr(trKey, { fileSize: bytesForHumans(file_size) });
   }
   return '';
 }

--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -1,0 +1,35 @@
+import filesize from 'filesize';
+import findKey from 'lodash/findKey';
+import { createTranslator } from 'kolibri.utils.i18n';
+
+// Strings are the _READABLE strings in le_utils.constants.format_presets
+const filePresetStrings = {
+  highResolutionVideo: 'High Resolution ({fileSize})',
+  lowResolutionVideo: 'Low Resolution ({fileSize})',
+  vectorizedVideo: 'Vectorized ({fileSize})',
+  // Same 'thumbnail' string is used for video, audio, document, exercise, and topic
+  thumbnail: 'Thumbnail ({fileSize})',
+  videoSubtitle: 'Subtitle ({fileSize})',
+  audio: 'Audio ({fileSize})',
+  document: 'Document ({fileSize})',
+  exercise: 'Exercise ({fileSize})',
+  exerciseImage: 'Exercise Image ({fileSize})',
+  exerciseGraphie: 'Exercise Graphie ({fileSize})',
+  channelThumbnail: 'Channel Thumbnail ({fileSize})',
+  html5Zip: 'HTML5 Zip ({fileSize})',
+  html5Thumbnail: 'HTML5 Thumbnail ({fileSize})',
+};
+
+const filePresetTranslator = createTranslator('FilePresetStrings', filePresetStrings);
+
+// 'file.preset' is an enum equal to the values in the filePresetStrings map, so this function
+// searches on the values in filePresetStrings, then uses the matching key on filePreset
+// translator to return the localized string.
+export function getFilePresetString(file) {
+  const { preset, file_size } = file;
+  const trKey = findKey(filePresetStrings, x => x.startsWith(preset));
+  if (trKey) {
+    return filePresetTranslator.$tr(trKey, { fileSize: filesize(file_size) });
+  }
+  return '';
+}

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -13,7 +13,6 @@
     "css-element-queries": "1.0.1",
     "d3-color": "^1.2.3",
     "date-fns": "^1.28.2",
-    "filesize": "^3.3.0 ",
     "fontfaceobserver": "^2.0.13",
     "frame-throttle": "^2.0.1",
     "intl": "^1.2.4",

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -107,7 +107,7 @@ export default {
         // otherwise refresh but don't block
         return store
           .dispatch('classSummary/loadClassSummary', classId)
-          .catch(error => this.store.dispatch('handleApiError', error));
+          .catch(error => store.dispatch('handleApiError', error));
       }
     },
   },

--- a/kolibri/plugins/device_management/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/deviceInfo/handlers.js
@@ -2,7 +2,7 @@ import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
-import bytesForHumans from '../../views/ManageContentPage/bytesForHumans';
+import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
 /* Function to fetch device info from the backend
  * and resolve validated data

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -82,7 +82,7 @@
   import KDropdownMenu from 'kolibri.coreVue.components.KDropdownMenu';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiIcon from 'keen-ui/src/UiIcon';
-  import bytesForHumans from './bytesForHumans';
+  import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import { selectContentPageLink } from './manageContentLinks';
   import ChannelListItemLarge from './ChannelListItemLarge';
   import ChannelListItemSmall from './ChannelListItemSmall';

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -51,7 +51,7 @@
 <script>
 
   import UiIcon from 'keen-ui/src/UiIcon';
-  import bytesForHumans from '../ManageContentPage/bytesForHumans';
+  import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
   export default {
     name: 'ChannelContentsSummary',

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
@@ -46,7 +46,7 @@
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import UiAlert from 'keen-ui/src/UiAlert';
-  import bytesForHumans from '../ManageContentPage/bytesForHumans';
+  import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
   const RequiredNumber = { type: Number, required: true };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4542,7 +4542,7 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
-"filesize@^3.3.0 ", filesize@^3.6.1:
+filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
   integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Adds some code to localize the file type/preset labels used for the Resource Download button
1. Moves the `bytesForHumans` utility to the core module, and replaces the use of the `filesize` library in the DownloadButton
1. Fixes a typo making a reference to an undefined `this.store`

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References

Fixes #2394
----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
