### PR TITLE
Add blob protocol data to the list of allowed sandbox permissions.

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -101,11 +101,11 @@ class ZipContentTestCase(TestCase):
 
     def test_content_security_policy_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
-        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: http://testserver")
 
     def test_content_security_policy_header_http_referer(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1, HTTP_REFERER="http://testserver:1234/iam/a/real/path/#thatsomeonemightuse")
-        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver:1234")
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: http://testserver:1234")
 
     def test_access_control_allow_origin_header(self):
         response = self.client.get(self.zip_file_base_url + self.test_name_1)
@@ -178,7 +178,7 @@ class ZipContentTestCase(TestCase):
     @patch('kolibri.core.content.views.get_hashi_filename', return_value=DUMMY_FILENAME)
     def test_non_xhr_content_security_policy_header(self, filename_patch):
         response = self.non_xhr_client.get(self.zip_file_base_url + self.index_name)
-        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: http://testserver")
+        self.assertEqual(response.get("Content-Security-Policy"), "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: http://testserver")
 
     @patch('kolibri.core.content.views.get_hashi_filename', return_value=DUMMY_FILENAME)
     def test_non_xhr_access_control_allow_origin_header(self, filename_patch):

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -84,7 +84,7 @@ def _add_content_security_policy_header(request, response):
     # restrict CSP to only allow resources to be loaded from the Kolibri host, to prevent info leakage
     # (e.g. via passing user info out as GET parameters to an attacker's server), or inadvertent data usage
     host = get_host(request)
-    response["Content-Security-Policy"] = "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: " + host
+    response["Content-Security-Policy"] = "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: " + host
 
 
 def calculate_zip_content_etag(request, zipped_filename, embedded_filepath):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some HTML5 apps use the blob data protocol to load assets, so add it to the list of allowed protocols in the CSP header.
 
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Since we have no existing content sources that use it (because it would break them), for now please just review and check that tests still pass!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
