### PR TITLE
Format microseconds correctly when profiling

### DIFF
--- a/kolibri/core/analytics/management/commands/profile.py
+++ b/kolibri/core/analytics/management/commands/profile.py
@@ -2,6 +2,7 @@ import csv
 import os.path
 import sys
 import time
+from datetime import datetime
 from os import getpid
 
 from django.core.management.base import BaseCommand
@@ -118,7 +119,7 @@ class Command(BaseCommand):
 
         active_sessions, active_users, active_users_minute = get_db_info()
         used_cpu, used_memory, total_memory, total_processes = get_machine_info()
-        timestamp = time.strftime('%Y/%m/%d %H:%M:%S.%f')
+        timestamp = datetime.now().strftime('%Y/%m/%d %H:%M:%S.%f')
         collected_information = (timestamp, active_sessions, active_users, active_users_minute, used_cpu,
                                  used_memory, total_memory, total_processes, kolibri_cpu, kolibri_mem)
 

--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import csv
 import os
 import time
+from datetime import datetime
 
 from django.conf import settings
 from django.core.cache import caches
@@ -144,7 +145,7 @@ class MetricsMiddleware(MiddlewareMixin):
             if float(duration) > MetricsMiddleware.slowest_request_time:
                 MetricsMiddleware.slowest_request_time = float(duration)
                 max_time = True
-            timestamp = time.strftime('%Y/%m/%d %H:%M:%S.%f')
+            timestamp = datetime.now().strftime('%Y/%m/%d %H:%M:%S.%f')
             collected_information = (timestamp, path, duration, memory_before, memory, load_before, load, str(max_time))
             with open(self.requests_profiling_file, mode='a') as profile_file:
                 profile_writer = csv.writer(profile_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)


### PR DESCRIPTION
### Summary
Current time formatting when generating performance logs was not right. 
It uses `time` and `strftime` with time, and this combination does not have microseconds formatting.
This was harmless in Linux but breaks profiling in Windows.

This PR just replaces the use of `time` by `datetime.datetime.now` , that allows `%f` formatting when using the `strftime` function.

### Reviewer guidance
1. In `options.ini` ,set 
```
[Server]
PROFILE = true
```

2. Restart kolibri

3. Execute
`kolibri manage profile`

Everything should go fine now.


### References
References #4276

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
