### PR TITLE
Don't redirect the zip content endpoint.

### DIFF
--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -24,6 +24,7 @@ from six.moves.urllib.parse import urlunparse
 from .api import cache_forever
 from .utils.paths import get_content_storage_file_path
 from kolibri.core.content.errors import InvalidStorageFilenameError
+from kolibri.core.decorators import signin_redirect_exempt
 from kolibri.utils.conf import OPTIONS
 
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
@@ -113,6 +114,7 @@ def get_path_or_404(zipped_filename):
         raise Http404('"%(filename)s" is not a valid zip file' % {'filename': zipped_filename})
 
 
+@method_decorator(signin_redirect_exempt, name='dispatch')
 class ZipContentView(View):
 
     @xframe_options_exempt


### PR DESCRIPTION
### Summary
Fixes an issue where the zipcontent endpoint would be redirected when no guest access mode was activated.

### Reviewer guidance
Can you access HTML5 content when no guest access is toggled?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
