### PR TITLE
[kolibri-tools lint] Allow host projects to extend and override stylelint and eslint configs

### DIFF
--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -10,7 +10,7 @@ const colors = require('colors');
 const stylelintFormatter = require('stylelint').formatters.string;
 const defaultStylelintConfig = require('../.stylelintrc.js');
 const prettierOptions = require('../.prettier.js');
-const esLintConfig = require('../.eslintrc.js');
+const defaultEsLintConfig = require('../.eslintrc.js');
 const htmlHintConfig = require('../.htmlhintrc.js');
 const logger = require('./logging');
 
@@ -18,6 +18,13 @@ require('./htmlhint_custom');
 
 const logging = logger.getLogger('Kolibri linter');
 
+
+let esLintConfig;
+try {
+  esLintConfig = require(process.cwd()+'/.eslintrc.js');
+} catch(e) {
+  esLintConfig = defaultEsLintConfig;
+}
 const esLinter = new ESLintCLIEngine({
   baseConfig: esLintConfig,
   fix: true,

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -8,10 +8,10 @@ const esLintFormatter = require('eslint/lib/formatters/stylish');
 const stylelint = require('stylelint');
 const colors = require('colors');
 const stylelintFormatter = require('stylelint').formatters.string;
+const defaultStylelintConfig = require('../.stylelintrc.js');
 const prettierOptions = require('../.prettier.js');
 const esLintConfig = require('../.eslintrc.js');
 const htmlHintConfig = require('../.htmlhintrc.js');
-const stylelintConfig = require('../.stylelintrc.js');
 const logger = require('./logging');
 
 require('./htmlhint_custom');
@@ -27,6 +27,13 @@ const esLinter = new ESLintCLIEngine({
 // Create them here so that we can reuse, rather than creating many many objects.
 const styleLangs = ['scss', 'css', 'less'];
 const styleLinters = {};
+
+let stylelintConfig
+try {
+  stylelintConfig = require(process.cwd()+'/.stylelintrc.js');
+} catch(e) {
+  stylelintConfig = defaultStylelintConfig;
+}
 styleLangs.forEach(lang => {
   styleLinters[lang] = stylelint.createLinter({
     config: stylelintConfig,

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -8,23 +8,33 @@ const esLintFormatter = require('eslint/lib/formatters/stylish');
 const stylelint = require('stylelint');
 const colors = require('colors');
 const stylelintFormatter = require('stylelint').formatters.string;
-const defaultStylelintConfig = require('../.stylelintrc.js');
-const prettierOptions = require('../.prettier.js');
-const defaultEsLintConfig = require('../.eslintrc.js');
-const htmlHintConfig = require('../.htmlhintrc.js');
-const logger = require('./logging');
+
 
 require('./htmlhint_custom');
 
-const logging = logger.getLogger('Kolibri linter');
-
+// check for host project's linting configs, otherwise use defaults
+let hostProjectDir = process.cwd()
 
 let esLintConfig;
-try {
-  esLintConfig = require(process.cwd()+'/.eslintrc.js');
-} catch(e) {
-  esLintConfig = defaultEsLintConfig;
-}
+try { esLintConfig = require(`${hostProjectDir}/.eslintrc.js`); }
+catch(e) { esLintConfig = require('../.eslintrc.js'); }
+
+let stylelintConfig;
+try { stylelintConfig = require(`${hostProjectDir}/.stylelintrc.js`); }
+catch(e) { stylelintConfig = require('../.stylelintrc.js'); }
+
+let htmlHintConfig;
+try { htmlHintConfig = require(`${hostProjectDir}/.htmlhintrc.js`); }
+catch(e) { htmlHintConfig = require('../.htmlhintrc.js'); }
+
+let prettierConfig;
+try { prettierConfig = require(`${hostProjectDir}/.prettier.js`); }
+catch(e) { prettierConfig = require('../.prettier.js'); }
+
+const logger = require('./logging');
+
+const logging = logger.getLogger('Kolibri linter');
+
 const esLinter = new ESLintCLIEngine({
   baseConfig: esLintConfig,
   fix: true,
@@ -34,13 +44,6 @@ const esLinter = new ESLintCLIEngine({
 // Create them here so that we can reuse, rather than creating many many objects.
 const styleLangs = ['scss', 'css', 'less'];
 const styleLinters = {};
-
-let stylelintConfig
-try {
-  stylelintConfig = require(process.cwd()+'/.stylelintrc.js');
-} catch(e) {
-  stylelintConfig = defaultStylelintConfig;
-}
 styleLangs.forEach(lang => {
   styleLinters[lang] = stylelint.createLinter({
     config: stylelintConfig,
@@ -105,7 +108,7 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
           {
             filepath: file,
           },
-          prettierOptions,
+          prettierConfig,
           {
             parser,
           }

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -9,27 +9,38 @@ const stylelint = require('stylelint');
 const colors = require('colors');
 const stylelintFormatter = require('stylelint').formatters.string;
 
-
 require('./htmlhint_custom');
 
 // check for host project's linting configs, otherwise use defaults
-let hostProjectDir = process.cwd()
+let hostProjectDir = process.cwd();
 
 let esLintConfig;
-try { esLintConfig = require(`${hostProjectDir}/.eslintrc.js`); }
-catch(e) { esLintConfig = require('../.eslintrc.js'); }
+try {
+  esLintConfig = require(`${hostProjectDir}/.eslintrc.js`);
+} catch (e) {
+  esLintConfig = require('../.eslintrc.js');
+}
 
 let stylelintConfig;
-try { stylelintConfig = require(`${hostProjectDir}/.stylelintrc.js`); }
-catch(e) { stylelintConfig = require('../.stylelintrc.js'); }
+try {
+  stylelintConfig = require(`${hostProjectDir}/.stylelintrc.js`);
+} catch (e) {
+  stylelintConfig = require('../.stylelintrc.js');
+}
 
 let htmlHintConfig;
-try { htmlHintConfig = require(`${hostProjectDir}/.htmlhintrc.js`); }
-catch(e) { htmlHintConfig = require('../.htmlhintrc.js'); }
+try {
+  htmlHintConfig = require(`${hostProjectDir}/.htmlhintrc.js`);
+} catch (e) {
+  htmlHintConfig = require('../.htmlhintrc.js');
+}
 
 let prettierConfig;
-try { prettierConfig = require(`${hostProjectDir}/.prettier.js`); }
-catch(e) { prettierConfig = require('../.prettier.js'); }
+try {
+  prettierConfig = require(`${hostProjectDir}/.prettier.js`);
+} catch (e) {
+  prettierConfig = require('../.prettier.js');
+}
 
 const logger = require('./logging');
 


### PR DESCRIPTION
This allows Studio and Kolibri (our current "host projects") to extend and override the common set of linting configs provided by kolibri-tools.

As an example, Studio's `.eslintrc.js`:
```js
const esLintConfig = require('kolibri-tools/.eslintrc');
esLintConfig.globals = {
  "$": false,
  "_": false,
...
}
module.exports = esLintConfig;
```
And Studio's `.stylelintrc.js`, (illustrating stylelint's convenient syntax for extending another config file):
```js
module.exports = {
  extends: [
    'kolibri-tools/.stylelintrc',
  ],
  rules: {
    /*
     * Ignored rules
     * Inline comments explain why rule is ignored
     */
    'selector-max-id': null, // This would require a major refactor
    'at-rule-no-unknown': null, // we're using LESS
    'scss/at-rule-no-unknown': null // we're using LESS
  },
};
```

### Note for reviewers:
Please double check to make sure that this wouldn't break linting in Kolibri!