### PR TITLE
Adjust toolbar icon and title spacing

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -103,6 +103,7 @@ import navComponents from '../utils/navComponents';
 import CatchErrors from '../utils/CatchErrors';
 import KTooltip from '../views/KTooltip';
 import UiIconButton from '../views/KeenUiIconButton.vue';
+import UiToolbar from '../views/KeenUiToolbar.vue';
 import * as colour from '../utils/colour';
 import shuffled from '../utils/shuffled';
 import themeMixin from '../mixins/theme';
@@ -177,6 +178,7 @@ export default {
       CoreLogo,
       UiAlert,
       UiIconButton,
+      UiToolbar,
       PrivacyInfoModal,
       UserTypeDisplay,
       TechnicalTextBlock,

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -99,7 +99,7 @@
 
   import { mapGetters, mapState, mapActions } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
-  import UiToolbar from 'keen-ui/src/UiToolbar';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -71,7 +71,7 @@
 <script>
 
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
-  import UiToolbar from 'keen-ui/src/UiToolbar';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import { darken } from 'kolibri.utils.colour';
   import { validateLinkObject } from 'kolibri.utils.validators';

--- a/kolibri/core/assets/src/views/KeenUiToolbar.vue
+++ b/kolibri/core/assets/src/views/KeenUiToolbar.vue
@@ -1,0 +1,20 @@
+<script>
+
+  import UiToolbar from 'keen-ui/src/UiToolbar';
+
+  export default {
+    name: 'KeenUiToolbar',
+    extends: UiToolbar,
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  /deep/ .ui-toolbar__nav-icon {
+    margin-right: 27px;
+    margin-left: -5px;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -25,6 +25,7 @@
             type="secondary"
             color="white"
             size="large"
+            class="side-nav-header-icon"
             @click="toggleNav"
           >
             <mat-svg
@@ -286,6 +287,10 @@
     z-index: 17;
     font-size: 14px;
     text-transform: uppercase;
+  }
+
+  .side-nav-header-icon {
+    margin-left: 5px; /* align with a toolbar icon below */
   }
 
   .side-nav-header-close {

--- a/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/side-nav.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`side nav component should be hidden if navShown is false 1`] = `
 <div class="side-nav-wrapper" style="position: relative;">
   <div class="side-nav" style="width: 100px; color: rgb(58, 58, 58); background-color: rgb(255, 255, 255); display: none;" name="side-nav">
-    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
+    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button side-nav-header-icon keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
         <div class="keen-ui-icon-button-icon" style="color: rgb(153, 97, 137);">
           <mat-svg name="close" category="navigation" class="side-nav-header-close"></mat-svg>
         </div>
@@ -50,7 +50,7 @@ exports[`side nav component should be hidden if navShown is false 1`] = `
 exports[`side nav component should show nothing if no components are added and user is not logged in 1`] = `
 <div class="side-nav-wrapper" style="position: relative;">
   <div class="side-nav" style="width: 100px; color: rgb(58, 58, 58); background-color: rgb(255, 255, 255);" name="side-nav">
-    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
+    <div class="side-nav-header" style="height: 20px; width: 100px; padding-top: 8px; background-color: rgb(58, 58, 58);"><button aria-label="Close navigation" type="button" tabindex="0" class="keen-ui-icon-button side-nav-header-icon keen-ui-icon-button--type-secondary keen-ui-icon-button--color-white keen-ui-icon-button--size-large KeenUiIconButton-noKey-0_1e7m9ar">
         <div class="keen-ui-icon-button-icon" style="color: rgb(153, 97, 137);">
           <mat-svg name="close" category="navigation" class="side-nav-header-close"></mat-svg>
         </div>

--- a/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
@@ -4,9 +4,9 @@
     class="progress-toolbar"
     type="clear"
     textColor="white"
+    :removeNavIcon="!displayNavIcon"
   >
     <UiIconButton
-      v-show="currentStep > 1"
       slot="icon"
       type="secondary"
       color="white"
@@ -44,6 +44,11 @@
       totalSteps: {
         type: Number,
         required: true,
+      },
+    },
+    computed: {
+      displayNavIcon() {
+        return this.currentStep > 1;
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
@@ -24,7 +24,7 @@
 
 <script>
 
-  import UiToolbar from 'keen-ui/src/UiToolbar';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
 
   export default {


### PR DESCRIPTION
### Summary

Fix left and right margins of AppBar hamburger as requested in #4931.

I noticed that applying new style within AppBar component only would introduce inconsistency (loud especially when icon is in hovered state) because exactly the same icon + title pattern occurs at more places that use KeenUI toolbar as a base component. So I tried to apply new style to all of them, but I am not sure if that's desired so let's see what you think, I can just move the style back to AppBar only. @khangmach could you please check it? I will ask Aron for access to mockups meanwhile :)

I didn't want to pollute global styles for such purpose so I created a base component in core lib that could serve as a wrapper for all common toolbar modifications.

#### App bar

Before
![AppBar-before](https://user-images.githubusercontent.com/13509191/54478418-19bdef80-4812-11e9-875d-092e4e927e0d.png)

After
![AppBar-after](https://user-images.githubusercontent.com/13509191/54478603-36f3bd80-4814-11e9-841f-434a4dd9b9ee.png)
![AppBar-after-left](https://user-images.githubusercontent.com/13509191/54478422-2b06fc00-4812-11e9-84b9-09dccd45741b.png)
![AppBar-after-right](https://user-images.githubusercontent.com/13509191/54478423-2fcbb000-4812-11e9-94b8-ee9f290da2e0.png)

#### Immersive toolbar
Before
![ImmersiveToolbar-before](https://user-images.githubusercontent.com/13509191/54478450-8df89300-4812-11e9-8fcc-a366da888d82.png)

After
![ImmersiveToolbar-after](https://user-images.githubusercontent.com/13509191/54478452-92bd4700-4812-11e9-986e-cf93a4aee9ca.png)

#### Progress toolbar

Before
![ProgressToolbar-before](https://user-images.githubusercontent.com/13509191/54478475-e0d24a80-4812-11e9-8680-07bbd44f22e7.png)

After
![ProgressToolbar-after](https://user-images.githubusercontent.com/13509191/54478477-e2037780-4812-11e9-8d5b-339a20d50d0c.png)

### Reviewer guidance

- check app toolbar
- visit setup wizard to check progress toolbar
- visit a lesson item to check immersive toolbar

### References

Solves #4931.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
