### PR TITLE
Remove obsolete code related to app bar title icon

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -21,11 +21,6 @@
         />
       </UiIconButton>
 
-      <div>
-        <div class="app-bar-title-icon"></div>
-        {{ title }}
-      </div>
-
       <div slot="actions">
         <slot name="app-bar-actions"></slot>
 

--- a/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
+++ b/kolibri/core/assets/test/views/__snapshots__/app-bar.spec.js.snap
@@ -17,10 +17,7 @@ exports[`app bar component drop down user menu should show the language modal li
       <!---->
     </div>
     <div class="ui-toolbar__body">
-      <div>
-        <div class="app-bar-title-icon"></div>
-        test
-      </div>
+      <div class="ui-toolbar__title">test</div>
     </div>
     <div class="ui-toolbar__right">
       <div> <button type="submit" class="ui-button user-menu-button ui-button--type-primary ui-button--color-clear ui-button--icon-position-left ui-button--size-normal" arialabel="User menu">


### PR DESCRIPTION
### Summary

When working on #5279 I noticed that the following place seems to be dead code related to [one of previous implementations of the app bar](https://github.com/learningequality/kolibri/blob/2566eac930198119ef34332796d42d762378e668/kolibri/core/assets/src/views/app-bar/index.vue). It was probably meant for customizing a title icon but in a current version, it cannot be even reached from any parent component and hamburger is rendered there all the time.

### References

 #5280

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
