### PR TITLE
proper RTL-alignment of labeled icons

### DIFF
--- a/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
@@ -4,7 +4,7 @@
     <div class="icon">
       <slot name="icon"></slot>
     </div>
-    <div class="label">
+    <div class="label" dir="auto">
       <slot></slot>
     </div>
   </span>
@@ -42,6 +42,7 @@
 
   .icon {
     position: absolute;
+    left: 0;
   }
 
   .label {


### PR DESCRIPTION

### Summary


| before | after |
|--|--|
|  ![image](https://user-images.githubusercontent.com/2367265/54639175-f7161b80-4a49-11e9-9f0d-7f8b289b75f3.png) | ![image](https://user-images.githubusercontent.com/2367265/54639137-e5cd0f00-4a49-11e9-93c2-791bc80eec09.png) |


### Reviewer guidance

works for both RTL and LTR?



### References

fixes #5284

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
