### PR TITLE
Add tests and behaviour for unsetting the language.

### DIFF
--- a/kolibri/core/test/test_setlanguage.py
+++ b/kolibri/core/test/test_setlanguage.py
@@ -1,0 +1,98 @@
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import get_language
+from django.utils.translation import LANGUAGE_SESSION_KEY
+
+
+class I18NTests(TestCase):
+    """
+    Tests set_language view in kolibri/core/views.py
+    Copied from https://github.com/django/django/blob/stable/1.11.x/tests/view_tests/tests/test_i18n.py
+    """
+
+    def _get_inactive_language_code(self):
+        """Return language code for a language which is not activated."""
+        current_language = get_language()
+        return [code for code, name in settings.LANGUAGES if not code == current_language][0]
+
+    def test_setlang(self):
+        """
+        The set_language view can be used to change the session language.
+        The user is redirected to the 'next' argument if provided.
+        """
+        lang_code = self._get_inactive_language_code()
+        post_data = dict(language=lang_code)
+        response = self.client.post(reverse('kolibri:core:set_language'), post_data)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], lang_code)
+
+    def test_setlang_null(self):
+        """
+        The set_language view can be used to change the session language.
+        The user is redirected to the 'next' argument if provided.
+        """
+        lang_code = self._get_inactive_language_code()
+        post_data = dict(language=lang_code)
+        response = self.client.post(reverse('kolibri:core:set_language'), post_data)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], lang_code)
+        post_data = dict(language=None)
+        response = self.client.post(reverse('kolibri:core:set_language'), post_data)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(LANGUAGE_SESSION_KEY in self.client.session)
+
+    def test_setlang_get(self):
+        """
+        The set_language view redirects if accessed via GET
+        """
+        lang_code = self._get_inactive_language_code()
+        post_data = dict(language=lang_code)
+        response = self.client.get(reverse('kolibri:core:set_language'), data=post_data)
+        self.assertEqual(response.url, reverse('kolibri:core:redirect_user'))
+
+    def test_setlang_for_ajax(self):
+        """
+        The set_language view returns 204 for AJAX calls by default.
+        """
+        lang_code = self._get_inactive_language_code()
+        post_data = dict(language=lang_code)
+        response = self.client.post(reverse('kolibri:core:set_language'), post_data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], lang_code)
+
+    def test_setlang_cookie(self):
+        # we force saving language to a cookie rather than a session
+        # by excluding session middleware and those which do require it
+        test_settings = {
+            'MIDDLEWARE': ['django.middleware.common.CommonMiddleware'],
+            'LANGUAGE_COOKIE_NAME': 'mylanguage',
+            'LANGUAGE_COOKIE_AGE': 3600 * 7 * 2,
+            'LANGUAGE_COOKIE_DOMAIN': '.example.com',
+            'LANGUAGE_COOKIE_PATH': '/test/',
+        }
+        with self.settings(**test_settings):
+            post_data = dict(language='pl')
+            response = self.client.post(reverse('kolibri:core:set_language'), data=post_data)
+            language_cookie = response.cookies.get('mylanguage')
+            self.assertEqual(language_cookie.value, 'pl')
+            self.assertEqual(language_cookie['domain'], '.example.com')
+            self.assertEqual(language_cookie['path'], '/test/')
+            self.assertEqual(language_cookie['max-age'], 3600 * 7 * 2)
+
+    def test_setlang_cookie_null(self):
+        # we force saving language to a cookie rather than a session
+        # by excluding session middleware and those which do require it
+        test_settings = {
+            'MIDDLEWARE': ['django.middleware.common.CommonMiddleware'],
+            'LANGUAGE_COOKIE_NAME': 'mylanguage',
+            'LANGUAGE_COOKIE_AGE': 3600 * 7 * 2,
+            'LANGUAGE_COOKIE_DOMAIN': '.example.com',
+            'LANGUAGE_COOKIE_PATH': '/test/',
+        }
+        with self.settings(**test_settings):
+            post_data = dict(language=None)
+            response = self.client.post(reverse('kolibri:core:set_language'), data=post_data)
+            language_cookie = response.cookies.get('mylanguage')
+            self.assertTrue(language_cookie)
+            self.assertEqual(language_cookie.value, '')

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -1,13 +1,11 @@
-from django import http
 from django.conf import settings
 from django.contrib.auth import logout
 from django.core.urlresolvers import reverse
-from django.core.urlresolvers import translate_url
 from django.http import Http404
+from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url
 from django.utils.translation import check_for_language
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation import ugettext_lazy as _
@@ -26,26 +24,15 @@ from kolibri.core.hooks import RoleBasedRedirectHook
 @signin_redirect_exempt
 def set_language(request):
     """
-    Redirect to a given url while setting the chosen language in the
-    session or cookie. The url and the language code need to be
-    specified in the request parameters.
     Since this view changes how the user will see the rest of the site, it must
     only be accessed as a POST request. If called as a GET request, it will
     redirect to the page in the request (the 'next' parameter) without changing
     any state.
     """
-    next = request.POST.get('next', request.GET.get('next'))
-    if not is_safe_url(url=next, host=request.get_host()):
-        next = request.META.get('HTTP_REFERER')
-        if not is_safe_url(url=next, host=request.get_host()):
-            next = reverse('kolibri:core:redirect_user')
-    response = http.HttpResponseRedirect(next)
     if request.method == 'POST':
+        response = HttpResponse(status=204)
         lang_code = request.POST.get(LANGUAGE_QUERY_PARAMETER)
         if lang_code and check_for_language(lang_code):
-            next_trans = translate_url(next, lang_code)
-            if next_trans != next:
-                response = http.HttpResponseRedirect(next_trans)
             if hasattr(request, 'session'):
                 request.session[LANGUAGE_SESSION_KEY] = lang_code
             # Always set cookie
@@ -53,12 +40,18 @@ def set_language(request):
                                 max_age=settings.LANGUAGE_COOKIE_AGE,
                                 path=settings.LANGUAGE_COOKIE_PATH,
                                 domain=settings.LANGUAGE_COOKIE_DOMAIN)
-    return response
+        else:
+            if hasattr(request, 'session'):
+                request.session.pop(LANGUAGE_SESSION_KEY, '')
+            response.delete_cookie(settings.LANGUAGE_COOKIE_NAME)
+        return response
+    else:
+        return HttpResponseRedirect(reverse('kolibri:core:redirect_user'))
 
 
 def logout_view(request):
     logout(request)
-    return http.HttpResponseRedirect(reverse('kolibri:core:redirect_user'))
+    return HttpResponseRedirect(reverse('kolibri:core:redirect_user'))
 
 
 def get_urls_by_role(role):


### PR DESCRIPTION
### Summary
Allows a null value to be passed to the `set_language` endpoint, which will then clear the cookie and session values, and allow the browser headers to determine the language.

### Reviewer guidance
Does the language cookie get cleared when you send null or empty string to the `set_language` endpoint?

### References
Work in support of #5290

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
