### PR TITLE
Calculate CherryPy default thread pool depending on the server memory

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -1,5 +1,6 @@
 import logging.config
 import os
+import sys
 
 from configobj import ConfigObj
 from configobj import flatten_errors
@@ -27,6 +28,8 @@ def calculate_thread_pool():
         if total_memory > 2:
             pool = int(45 * total_memory - 80)  # 10 for 2 Gb,100 for 4 Gb
             pool = 200 if pool > 200 else pool
+    elif sys.platform.startswith("darwin"):  # Considering MacOS has at least 4 Gb of RAM
+        pool = 100
     return pool
 
 


### PR DESCRIPTION
### Summary
Sets the default value for CherryPy thread pool depending on the server memory.
Based on tests done on several kolibri installations, it's clear the default value of 10 threads is not enough if there are many connections. However, more threads means more memory in use.
This PR uses a simple rule to set the threads for servers having at least 2 Gb of RAM.
Less than 10 Gb will leave the default  CherryPy value of 10.

Notice this code must not have any effect on MacOS as psutils is not supported in this OS.


### Reviewer guidance

`kolibri start` should work properly in Windows, Linux & MacOs
- In case options.ini has a value set for the threads, it must be kept
- The value for the thread pool must depend on the memory of the machine running kolibri

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
