### PR TITLE
Update scanforcontent command and annotation to handle missing files properly

### DIFF
--- a/kolibri/core/content/management/commands/scanforcontent.py
+++ b/kolibri/core/content/management/commands/scanforcontent.py
@@ -1,9 +1,16 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
-from ...utils.annotation import set_local_file_availability_from_disk
-from ...utils.annotation import update_content_metadata
+from ...utils.annotation import annotate_content
+from ...utils.channel_import import FutureSchemaError
+from ...utils.channel_import import import_channel_from_local_db
+from ...utils.channel_import import InvalidSchemaVersionError
 from ...utils.channels import get_channel_ids_for_content_database_dir
+from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.utils.paths import get_content_database_dir_path
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -12,10 +19,18 @@ class Command(BaseCommand):
     reviewing the availability of all the existing files, to recover
     content that's not visible in Kolibri.
     """
-    help = "Scan content in Kolibri folder and updates the database to show it available"
+    help = "Scan content and databases in Kolibri folder and updates the database to show if available"
 
     def handle(self, *args, **options):
-        channel_ids = get_channel_ids_for_content_database_dir(get_content_database_dir_path())
-        set_local_file_availability_from_disk()
-        for channel_id in channel_ids:
-            update_content_metadata(channel_id)
+        storage_channel_ids = get_channel_ids_for_content_database_dir(get_content_database_dir_path())
+        database_channel_ids = list(ChannelMetadata.objects.all().values_list('id', flat=True))
+        all_channel_ids = set(storage_channel_ids + database_channel_ids)
+        for channel_id in all_channel_ids:
+            if channel_id not in database_channel_ids:
+                try:
+                    import_channel_from_local_db(channel_id)
+                    annotate_content(channel_id)
+                except (InvalidSchemaVersionError, FutureSchemaError):
+                    logger.warning("Tried to import channel {channel_id}, but database file was incompatible".format(channel_id=channel_id))
+            else:
+                annotate_content(channel_id)


### PR DESCRIPTION
### Summary
* Updates local file annotation to mark localfiles as unavailable when they do not exist on disk.
* Updates the scanforcontent command to import all locally available content databases and 

### Reviewer guidance
Does the `scanforcontent` command now mark content nodes as unavailable if their primary files are removed?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
