### PR TITLE
Fix question numbering errors on exercise detail reports and question detail reports

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -67,7 +67,7 @@ export class Model {
       Promise.all(this.promises).then(
         () => {
           if (!force && this.synced) {
-            resolve(this.attributes);
+            resolve(this.data);
           } else {
             this.synced = false;
             // Do a fetch on the URL.
@@ -129,7 +129,7 @@ export class Model {
           }
           if (!Object.keys(payload).length) {
             // Nothing to save, so just resolve the promise now.
-            resolve(this.attributes);
+            resolve(this.data);
           } else {
             this.synced = false;
             let url;


### PR DESCRIPTION
### Summary
An issue in our client side javascript caching was causing exercise objects to be modified when converting their assessmentmetadata attributes to something more readable by the client side.

This caused repeated operations on these objects to return an unusable object. This manifested as question numbers that were either `1` (due to some default logic) or `NaN` (when there was no default set).

This PR fixes this by fixing the API Resource layer caching behaviour.
(and deepening my resolve to eliminate or restructure this behaviour).

### Reviewer guidance
To replicate these behaviours, do the following:
1. Create a Lesson.
2. Add an exercise to the lesson.
3. Interact with the exercise within the lesson as a learner (and no other learners).
4. Get at least one question wrong.

For #5271:
5. Go the the Lessons report.
6. Click on the exercise.
7. Click on the difficult questions tab.
8. Click on a question that you got wrong.
Without this fix, it should turn all question numbers to `1`, as soon as you do step 8, and then move back to the list. With this fix, the question number should remain constant.

Before:
![image](https://user-images.githubusercontent.com/1680573/54773948-e4295580-4bc7-11e9-9439-535f8a3f8d2b.png)

After:
![image](https://user-images.githubusercontent.com/1680573/54773732-65341d00-4bc7-11e9-996c-47304da247f4.png)


For #5247 - the easiest way to replicate this is to follow the steps above and then:
9. Click on 'back to lesson' link.
10. Click on 'Learners' tab.
11. Click on the learner you did the exercise with.
12. Click on the exercise to see the detail report.
Without this fix, it should turn all the question numbers to `NaN`, as soon as you do step 8. With this fix, the question numbers should have values.

Before:
![image](https://user-images.githubusercontent.com/1680573/54773989-fb684300-4bc7-11e9-9bff-b19736144de4.png)

After:
![image](https://user-images.githubusercontent.com/1680573/54773689-4df52f80-4bc7-11e9-939f-603741713875.png)


### References
Fixes #5271 
Fixes #5247 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
