### PR TITLE
[kolibri-tools] make vue-template-compiler a peer dependency

### DIFF
--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -72,7 +72,6 @@
     "vue-jest": "^3.0.0",
     "vue-loader": "^15.7.0",
     "vue-style-loader": "^3.0.3",
-    "vue-template-compiler": "^2.6.8",
     "webpack": "^4.6.0",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-bundle-tracker": "https://github.com/learningequality/webpack-bundle-tracker",
@@ -83,12 +82,16 @@
     "webpack-merge": "^4.1.0",
     "webpack-rtl-plugin": "^1.7.0"
   },
+  "peerDependencies": {
+    "vue-template-compiler": "^2.x"
+  },
   "engines": {
     "node": "10.x",
     "npm": ">= 3"
   },
   "devDependencies": {
-    "readline-sync": "^1.4.9"
+    "readline-sync": "^1.4.9",
+    "vue-template-compiler": "=2.6.8"
   },
   "optionalDependencies": {
     "kolibri": "0.12.0-beta.3.2"


### PR DESCRIPTION
### Summary

This keeps `vue-template-compiler`'s version pinned when installed as a dev dependency (for building `kolibri-tools`), but turns it into a peer dependency for packages using `kolibri-tools`, that way consumers of `kolibri-tools` can decide which versions of `vue`/`vue-template-compiler` they want to depend on and this package doesn't need to care.

### Reviewer guidance
For testing this, I used `yarn add -D '.../path/to/kolibri/packages/kolibri-tools'` any time I made a change to the package.json file.

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
