### PR TITLE
Tweak to versioning logic for kolibri tooling packages.

### DIFF
--- a/packages/kolibri-tools/lib/version.js
+++ b/packages/kolibri-tools/lib/version.js
@@ -45,7 +45,9 @@ function getVersion(prompt = false) {
       dev: 'dev',
     };
 
-    const preid = ['b', 'a', 'dev'].find(pre => remainder.includes(pre));
+    const preid = remainder.includes('dev')
+      ? 'dev'
+      : ['b', 'a'].find(pre => remainder.startsWith(pre));
 
     const prereleaseId = preidMap[preid];
 


### PR DESCRIPTION
### Summary
Properly detects dev versions and prompts for a version number accordingly.

### Reviewer guidance
If you run `yarn run publish-packages` does it prompt you for a version number?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
