### PR TITLE
Class summary permissions

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -271,7 +271,7 @@
       },
       notAuthorized() {
         // catch "not authorized" error, display AuthMessage
-        if (this.error && this.error.code == 403) {
+        if (this.error && this.error.status && this.error.status.code == 403) {
           return true;
         }
         return !this.authorized;

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -76,10 +76,25 @@ class LessonReportViewset(viewsets.ReadOnlyModelViewSet):
     queryset = Lesson.objects.all()
 
 
+class ClassroomNotificationsPermissions(permissions.BasePermission):
+    """
+    Allow only users with admin/coach permissions on a collection.
+    """
+
+    def has_permission(self, request, view):
+        collection_id = view.kwargs.get('collection_id')
+
+        allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
+        try:
+            return request.user.has_role_for(allowed_roles, Collection.objects.get(pk=collection_id))
+        except (Collection.DoesNotExist, ValueError):
+            return False
+
+
 @query_params_required(collection_id=str)
 class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
 
-    permission_classes = (KolibriReportPermissions,)
+    permission_classes = (ClassroomNotificationsPermissions,)
     serializer_class = LearnerNotificationSerializer
     pagination_class = OptionalPageNumberPagination
     pagination_class.page_size = 10

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -38,38 +38,6 @@ class OptionalPageNumberPagination(pagination.PageNumberPagination):
     page_size_query_param = "page_size"
 
 
-class KolibriReportPermissions(permissions.BasePermission):
-
-    # check if requesting user has permission for collection or user
-    def has_permission(self, request, view):
-        if isinstance(view, LessonReportViewset):
-            report_pk = view.kwargs.get('pk', None)
-            if report_pk is None:
-                # If requesting list view, check if requester has coach/admin permissions on whole facility
-                collection_kind = 'facility'
-                collection_or_user_pk = request.user.facility_id
-            else:
-                # If requesting detail view, only check if requester has permissions on the Classroom
-                collection_kind = 'classroom'
-                collection_or_user_pk = Lesson.objects.get(pk=report_pk).collection.id
-
-        else:
-            if isinstance(view, ClassroomNotificationsViewset):
-                collection_kind = 'classroom'
-            else:
-                collection_kind = view.kwargs.get('collection_kind', 'user')
-            collection_or_user_pk = view.kwargs.get('collection_id', view.kwargs.get('pk'))
-
-        allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
-        try:
-            if 'user' == collection_kind:
-                return request.user.has_role_for(allowed_roles, FacilityUser.objects.get(pk=collection_or_user_pk))
-            else:
-                return request.user.has_role_for(allowed_roles, Collection.objects.get(pk=collection_or_user_pk))
-        except (FacilityUser.DoesNotExist, Collection.DoesNotExist, ValueError):
-            return False
-
-
 class LessonReportPermissions(permissions.BasePermission):
     """
     List - check if requester has coach/admin permissions on whole facility.

--- a/kolibri/plugins/coach/test/helpers.py
+++ b/kolibri/plugins/coach/test/helpers.py
@@ -1,0 +1,55 @@
+from kolibri.core.auth.models import FacilityUser
+
+
+def create_learner(username, password, facility, classroom=None, learner_group=None):
+    """
+    Create a facility learner.
+    Assign them a classroom if specified.
+    Assign them a learner group if specified.
+    """
+
+    learner = FacilityUser.objects.create(username=username, facility=facility)
+    learner.set_password(password)
+    learner.save()
+
+    if classroom is not None:
+        classroom.add_member(learner)
+
+    if learner_group is not None:
+        learner_group.add_member(learner)
+
+    return learner
+
+
+def create_coach(username, password, facility, classroom=None, is_facility_coach=False):
+    """
+    Create a coach.
+    Assign them a classroom if specified.
+    Grant facility permissions if is_facility_coach is True.
+    """
+
+    coach = FacilityUser.objects.create(username=username, facility=facility)
+    coach.set_password(password)
+    coach.save()
+
+    if classroom is not None:
+        classroom.add_coach(coach)
+
+    if is_facility_coach:
+        facility.add_coach(coach)
+
+    return coach
+
+
+def create_facility_admin(username, password, facility):
+    """
+    Create a facility admin.
+    """
+
+    admin = FacilityUser.objects.create(username=username, facility=facility)
+    admin.set_password(password)
+    admin.save()
+
+    facility.add_admin(admin)
+
+    return admin

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -27,9 +27,33 @@ class ClassSummaryTestCase(APITestCase):
         provision_device()
         self.facility = Facility.objects.create(name="MyFac")
         self.classroom = Classroom.objects.create(name='classrom', parent=self.facility)
+        self.another_classroom = Classroom.objects.create(name='another classrom', parent=self.facility)
 
         self.facility_admin = helpers.create_facility_admin(
             username="facility_admin",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+        self.facility_coach = helpers.create_coach(
+            username="facility_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            is_facility_coach=True
+        )
+        self.classroom_coach = helpers.create_coach(
+            username="classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom
+        )
+        self.another_classroom_coach = helpers.create_coach(
+            username="another_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.another_classroom
+        )
+        self.learner = helpers.create_learner(
+            username="learner",
             password=DUMMY_PASSWORD,
             facility=self.facility
         )
@@ -41,6 +65,9 @@ class ClassSummaryTestCase(APITestCase):
             created_by=self.facility_admin
         )
 
+        self.basename = "kolibri:coach:classsummary"
+        self.detail_name = self.basename + "-detail"
+
     def test_non_existent_nodes_dont_show_up_in_lessons(self):
         node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).first()
         last_node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).last()
@@ -51,9 +78,44 @@ class ClassSummaryTestCase(APITestCase):
         self.lesson.save()
 
         self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:coach:classsummary-detail", kwargs={'pk': self.classroom.id}))
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
         node_ids = response.data['lessons'][0]['node_ids']
         self.assertIn(real_data['contentnode_id'], node_ids)
         # swapped data
         self.assertIn(last_node.id, node_ids)
         self.assertNotIn(fake_data['contentnode_id'], node_ids)
+
+    def test_anon_user_cannot_access_detail(self):
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_detail(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_another_classroom_coach_cannot_access_detail(self):
+        self.client.login(username=self.another_classroom_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_classroom_coach_can_access_detail(self):
+        self.client.login(username=self.classroom_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_coach_can_access_detail(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_admin_can_access_detail(self):
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.detail_name, kwargs={'pk': self.classroom.id}))
+
+        self.assertEqual(response.status_code, 200)

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from . import helpers
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.test.helpers import provision_device
+
+DUMMY_PASSWORD = "password"
+
+
+class ClassroomNotificationsTestCase(APITestCase):
+
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name='My Facility')
+        self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
+        self.another_classroom = Classroom.objects.create(name='My Another Classroom', parent=self.facility)
+
+        self.facility_admin = helpers.create_facility_admin(
+            username="facility_admin",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+        self.facility_coach = helpers.create_coach(
+            username="facility_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            is_facility_coach=True
+        )
+        self.classroom_coach = helpers.create_coach(
+            username="classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom
+        )
+        self.another_classroom_coach = helpers.create_coach(
+            username="another_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.another_classroom
+        )
+        self.learner = helpers.create_learner(
+            username="learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+
+        self.basename = "kolibri:coach:notifications"
+        self.list_name = self.basename + "-list"
+
+    def test_anon_user_cannot_access_list(self):
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_list(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_another_classroom_coach_cannot_access_list(self):
+        self.client.login(username=self.another_classroom_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_classroom_coach_can_access_list(self):
+        self.client.login(username=self.classroom_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_coach_can_access_list(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_admin_can_access_list(self):
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse(self.list_name), {'collection_id': self.classroom.id})
+
+        self.assertEqual(response.status_code, 200)

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -8,6 +8,7 @@ import json
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 
+from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -25,6 +26,8 @@ from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
 from kolibri.core.logger.models import MasteryLog
 
+DUMMY_PASSWORD = "password"
+
 
 class ExerciseDifficultQuestionTestCase(APITestCase):
 
@@ -34,18 +37,25 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
         self.group = LearnerGroup.objects.create(name='My Group', parent=self.classroom)
 
-        self.coach_user = FacilityUser.objects.create(username='admin', facility=self.facility)
-        self.coach_user.set_password('password')
-        self.coach_user.save()
-
-        self.learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        self.learner_user.set_password('password')
-        self.learner_user.save()
-
-        self.facility.add_coach(self.coach_user)
-        self.classroom.add_coach(self.coach_user)
-        self.classroom.add_member(self.learner_user)
-        self.group.add_member(self.learner_user)
+        self.facility_and_classroom_coach = helpers.create_coach(
+            username="facility_and_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            is_facility_coach=True
+        )
+        self.learner = helpers.create_learner(
+            username="learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+        self.classroom_group_learner = helpers.create_learner(
+            username="classroom_group_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            learner_group=self.group
+        )
 
         # Need ContentNodes
         self.channel_id = '15f32edcec565396a1840c5413c92450'
@@ -71,7 +81,7 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.lesson = Lesson.objects.create(
             id=self.lesson_id,
             title='My Lesson',
-            created_by=self.coach_user,
+            created_by=self.facility_and_classroom_coach,
             collection=self.classroom,
             resources=json.dumps([{
                 'contentnode_id': self.node_1.id,
@@ -81,60 +91,54 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         )
         self.assignment_1 = LessonAssignment.objects.create(
             lesson=self.lesson,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.classroom,
         )
         self.exercise_difficulties_basename = 'kolibri:coach:exercisedifficulties'
 
     def test_learner_cannot_access_by_classroom_id(self):
-        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        learner_user.set_password('password')
-        learner_user.save()
-        self.client.login(username='learner', password='password')
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
         self.assertEqual(response.status_code, 403)
 
     def test_learner_cannot_access_by_lesson_id(self):
-        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        learner_user.set_password('password')
-        learner_user.save()
-        self.client.login(username='learner', password='password')
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
         self.assertEqual(response.status_code, 403)
 
     def test_learner_cannot_access_by_group_id(self):
-        self.client.login(username='learner', password='password')
+        self.client.login(username='learner', password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
         self.assertEqual(response.status_code, 403)
 
     def test_coach_classroom_id_required(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail', kwargs={'pk': self.content_ids[0]}))
         self.assertEqual(response.status_code, 412)
 
     def test_coach_no_progress_by_classroom_id(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
         self.assertEqual(len(response.data), 0)
 
     def test_coach_no_progress_by_lesson_id(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
         self.assertEqual(len(response.data), 0)
 
     def test_coach_no_progress_by_group_id(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
@@ -178,8 +182,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         )
 
     def test_coach_one_difficult_by_classroom_id(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'classroom_id': self.classroom.id})
@@ -188,8 +192,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_one_difficult_by_lesson_id(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
@@ -200,11 +204,11 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_lesson_id_repeated_assignment(self):
         LessonAssignment.objects.create(
             lesson=self.lesson,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.group,
         )
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
@@ -213,8 +217,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_one_difficult_by_group_id(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
@@ -223,7 +227,7 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_two_difficult_by_lesson_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         AttemptLog.objects.create(
             masterylog=self.masterylog,
             sessionlog=self.sessionlog,
@@ -231,10 +235,10 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=0,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='nottest',
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
@@ -245,7 +249,7 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[1]['correct'], 0)
 
     def test_coach_one_difficult_one_not_by_lesson_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         AttemptLog.objects.create(
             masterylog=self.masterylog,
             sessionlog=self.sessionlog,
@@ -253,10 +257,10 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=1,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='nottest',
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
@@ -265,7 +269,7 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
 
     def test_coach_difficult_no_assigned_by_lesson_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         AttemptLog.objects.create(
             masterylog=self.masterylog,
             sessionlog=self.sessionlog,
@@ -273,18 +277,18 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=1,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='nottest',
         )
         LessonAssignment.objects.all().delete()
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'lesson_id': self.lesson.id, 'classroom_id': self.classroom.id})
         self.assertEqual(len(response.data), 0)
 
     def test_coach_difficult_no_assigned_by_group_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         AttemptLog.objects.create(
             masterylog=self.masterylog,
             sessionlog=self.sessionlog,
@@ -292,11 +296,11 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=1,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='nottest',
         )
         LessonAssignment.objects.all().delete()
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}), data={'group_id': self.group.id, 'classroom_id': self.classroom.id})
@@ -305,11 +309,11 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
 
     def test_coach_difficult_both_assigned_by_lesson_id_group_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
         self.classroom.add_member(learner2)
         self._set_one_difficult(learner2)
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}),
@@ -319,18 +323,18 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_difficult_group_id_not_in_lesson(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
         self.classroom.add_member(learner2)
         self._set_one_difficult(learner2)
-        self.group.remove_member(self.learner_user)
+        self.group.remove_member(self.classroom_group_learner)
         self.assignment_1.delete()
         LessonAssignment.objects.create(
             lesson=self.lesson,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.group,
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.exercise_difficulties_basename + '-detail',
             kwargs={'pk': self.content_ids[0]}),
@@ -346,57 +350,61 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
         self.group = LearnerGroup.objects.create(name='My Group', parent=self.classroom)
 
-        self.coach_user = FacilityUser.objects.create(username='admin', facility=self.facility)
-        self.coach_user.set_password('password')
-        self.coach_user.save()
-
-        self.learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        self.learner_user.set_password('password')
-        self.learner_user.save()
-
-        self.facility.add_coach(self.coach_user)
-        self.classroom.add_coach(self.coach_user)
-        self.classroom.add_member(self.learner_user)
-        self.group.add_member(self.learner_user)
+        self.facility_and_classroom_coach = helpers.create_coach(
+            username="facility_and_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            is_facility_coach=True
+        )
+        self.learner = helpers.create_learner(
+            username="learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+        self.classroom_group_learner = helpers.create_learner(
+            username="classroom_group_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            learner_group=self.group
+        )
 
         self.quiz = Exam.objects.create(
             title='My Lesson',
-            creator=self.coach_user,
+            creator=self.facility_and_classroom_coach,
             collection=self.classroom,
             question_count=5,
         )
         self.assignment_1 = ExamAssignment.objects.create(
             exam=self.quiz,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.classroom,
         )
         self.quiz_difficulties_basename = 'kolibri:coach:quizdifficulties'
         self.content_id = '25f32edcec565396a1840c5413c92451'
 
     def test_learner_cannot_access(self):
-        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        learner_user.set_password('password')
-        learner_user.save()
-        self.client.login(username='learner', password='password')
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(response.status_code, 403)
 
     def test_learner_cannot_access_by_group_id(self):
-        self.client.login(username='learner', password='password')
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail',
             kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
         self.assertEqual(response.status_code, 403)
 
     def test_coach_no_progress(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 0)
 
     def test_coach_no_progress_by_group_id(self):
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail',
             kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
@@ -420,8 +428,8 @@ class QuizDifficultQuestionTestCase(APITestCase):
         )
 
     def test_coach_one_difficult(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 1)
@@ -429,8 +437,8 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_one_two_started_difficult(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 1)
@@ -440,11 +448,11 @@ class QuizDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_repeated_assignment(self):
         ExamAssignment.objects.create(
             exam=self.quiz,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.group,
         )
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 1)
@@ -452,8 +460,8 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_one_difficult_by_group_id(self):
-        self._set_one_difficult(self.learner_user)
-        self.client.login(username=self.coach_user.username, password='password')
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail',
             kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
@@ -462,18 +470,18 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]['correct'], 0)
 
     def test_coach_two_difficult(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         ExamAttemptLog.objects.create(
             examlog=self.examlog,
             start_timestamp=datetime.datetime.now(),
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=0,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='notatest',
             content_id=self.content_id,
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 2)
@@ -483,18 +491,18 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[1]['correct'], 0)
 
     def test_coach_one_difficult_one_not(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         ExamAttemptLog.objects.create(
             examlog=self.examlog,
             start_timestamp=datetime.datetime.now(),
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=1,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='notatest',
             content_id=self.content_id,
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail', kwargs={'pk': self.quiz.id}))
         self.assertEqual(len(response.data), 2)
@@ -502,18 +510,18 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
 
     def test_coach_difficult_by_group_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         ExamAttemptLog.objects.create(
             examlog=self.examlog,
             start_timestamp=datetime.datetime.now(),
             end_timestamp=datetime.datetime.now(),
             complete=True,
             correct=1,
-            user=self.learner_user,
+            user=self.classroom_group_learner,
             item='notatest',
             content_id=self.content_id,
         )
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail',
             kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})
@@ -522,11 +530,11 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertTrue(any(map(lambda x: x['total'] == 1 and x['correct'] == 1, response.data)))
 
     def test_coach_difficult_both_assigned_by_group_id(self):
-        self._set_one_difficult(self.learner_user)
+        self._set_one_difficult(self.classroom_group_learner)
         learner2 = FacilityUser.objects.create(username='learner2', facility=self.facility)
         self.classroom.add_member(learner2)
         self._set_one_difficult(learner2)
-        self.client.login(username=self.coach_user.username, password='password')
+        self.client.login(username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse(
             self.quiz_difficulties_basename + '-detail',
             kwargs={'pk': self.quiz.id}), data={'group_id': self.group.id})

--- a/kolibri/plugins/coach/test/test_lesson_report.py
+++ b/kolibri/plugins/coach/test/test_lesson_report.py
@@ -8,14 +8,16 @@ import json
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 
+from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
-from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
 from kolibri.core.logger.models import ContentSummaryLog
+
+DUMMY_PASSWORD = "password"
 
 
 class LessonReportTestCase(APITestCase):
@@ -25,17 +27,25 @@ class LessonReportTestCase(APITestCase):
         self.facility = Facility.objects.create(name='My Facility')
         self.classroom = Classroom.objects.create(name='My Classroom', parent=self.facility)
 
-        self.coach_user = FacilityUser.objects.create(username='admin', facility=self.facility)
-        self.coach_user.set_password('password')
-        self.coach_user.save()
-
-        self.learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        self.learner_user.set_password('password')
-        self.learner_user.save()
-
-        self.facility.add_coach(self.coach_user)
-        self.classroom.add_coach(self.coach_user)
-        self.classroom.add_member(self.learner_user)
+        self.facility_admin = helpers.create_facility_admin(
+            username="facility_admin",
+            password=DUMMY_PASSWORD,
+            facility=self.facility
+        )
+        self.facility_and_classroom_coach = helpers.create_coach(
+            username="facility_and_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            is_facility_coach=True
+        )
+        self.classroom_learner = helpers.create_learner(
+            username="classroom_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom
+        )
+        self.learner = helpers.create_learner(username="learner", password=DUMMY_PASSWORD, facility=self.facility)
 
         # Need ContentNodes
         self.channel_id = '15f32edcec565396a1840c5413c92450'
@@ -61,7 +71,7 @@ class LessonReportTestCase(APITestCase):
         self.lesson = Lesson.objects.create(
             id=self.lesson_id,
             title='My Lesson',
-            created_by=self.coach_user,
+            created_by=self.facility_and_classroom_coach,
             collection=self.classroom,
             resources=json.dumps([{
                 'contentnode_id': self.node_1.id,
@@ -71,22 +81,19 @@ class LessonReportTestCase(APITestCase):
         )
         self.assignment_1 = LessonAssignment.objects.create(
             lesson=self.lesson,
-            assigned_by=self.coach_user,
+            assigned_by=self.facility_and_classroom_coach,
             collection=self.classroom,
         )
         self.lessonreport_basename = 'kolibri:coach:lessonreport'
         # Need ContentSummaryLog
 
     def test_learner_cannot_access(self):
-        learner_user = FacilityUser.objects.create(username='learner', facility=self.facility)
-        learner_user.set_password('password')
-        learner_user.save()
-        self.client.login(username='learner', password='password')
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
         get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         self.assertEqual(get_response.status_code, 403)
 
     def test_no_progress_logged(self):
-        self.client.login(username='admin', password='password')
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
         get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(len(progress), 1)
@@ -97,14 +104,14 @@ class LessonReportTestCase(APITestCase):
 
     def test_some_partial_progress_logged(self):
         ContentSummaryLog.objects.create(
-            user=self.learner_user,
+            user=self.classroom_learner,
             content_id=self.node_1.content_id,
             channel_id=self.node_1.channel_id,
             kind='video',
             progress=0.5,
             start_timestamp=datetime.datetime.now(),
         )
-        self.client.login(username='admin', password='password')
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
         get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(progress[0], {
@@ -114,14 +121,14 @@ class LessonReportTestCase(APITestCase):
 
     def test_some_complete_progress_logged(self):
         ContentSummaryLog.objects.create(
-            user=self.learner_user,
+            user=self.classroom_learner,
             content_id=self.node_1.content_id,
             channel_id=self.node_1.channel_id,
             kind='video',
             progress=1.0,
             start_timestamp=datetime.datetime.now(),
         )
-        self.client.login(username='admin', password='password')
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
         get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         progress = get_response.data['progress']
         self.assertEqual(progress[0], {
@@ -130,6 +137,6 @@ class LessonReportTestCase(APITestCase):
         })
 
     def test_total_learners_value(self):
-        self.client.login(username='admin', password='password')
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
         get_response = self.client.get(reverse(self.lessonreport_basename + '-detail', kwargs={'pk': self.lesson.id}))
         self.assertEqual(get_response.data['total_learners'], 1)


### PR DESCRIPTION
### Summary

- a classroom summary can be accessed only by admins, facility coaches or class coaches granted with the classroom permissions
- FE authorized messages condition fix

A couple of first commits include some related refactoring of `KolibriReportPermissions`. At first, I tried to use it as is, but I found out that I would have to add a third view condition in it to be able to use it and it wasn't very readable after this change. Also, every view seemed to have a quite different auth conditions. So I divided it into two permissions classes - `LessonReportPermissions` and `ClassroomNotificationsPermissions`. Initially, I was planning re-using `LessonReportPermissions` for a new class summary auth checks but it showed up that there are still quite important differences and using another permissions class seemed like a bit better option to me.

#### Manual verification steps performed

I visited classroom summary as a facility admin (can access), a facility coach (can access), a class coach (can access), an another class coach (cannot access), a learner (cannot access) and an anonymous user (cannot access).

#### Screenshots of UI changes introduced with this PR

| Learner - before  | Learner - after |
| ------------- | ------------- |
| <img width="1440" alt="Learner-before" src="https://user-images.githubusercontent.com/13509191/54867771-75452b80-4d84-11e9-97f0-fdb34de4424f.png">  | <img width="1440" alt="Learner-after" src="https://user-images.githubusercontent.com/13509191/54867768-68c0d300-4d84-11e9-80f0-1213a42a42fb.png">
  |

| Another class coach - before  | Another class coach - after |
| ------------- | ------------- |
| <img width="1438" alt="AnotherClassCoach-before" src="https://user-images.githubusercontent.com/13509191/54867816-fbfa0880-4d84-11e9-92d7-504c832d6143.png"> | <img width="1440" alt="AnotherClassCoach-after" src="https://user-images.githubusercontent.com/13509191/54867820-0e744200-4d85-11e9-8cc8-49381d5697bd.png">  |


### Reviewer guidance

- Does new class summary permission make sense? Does it work?
- Do lesson report and classroom notifications permissions still work as expected?

It's my first task related to auth and permissions in Kolibri - I tried to be careful and study all those roles as much as possible, but I don't feel confident about all possible relationships and also it's been a while since I worked on BE so please check everything thoroughly. Thanks in advance :) 
…

### References

Solves #5196 
Follow-up issue #5309
…

----

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
