### PR TITLE
Update unit tests info in getting started docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -399,17 +399,17 @@ We strive for 100% code coverage in Kolibri. When you open a Pull Request, code 
 
 Then, open the generated ./htmlcov/index.html file in your browser.
 
-Kolibri comes with a Javascript test suite based on ``mocha``. To run all tests:
+Kolibri comes with a Javascript test suite based on ``jest``. To run all tests:
 
 .. code-block:: bash
 
-  yarn test
+  yarn test-jest
 
-This includes tests of the bundling functions that are used in creating front end assets. To do continuous unit testing for code, and jshint running:
+This includes tests of the bundling functions that are used in creating front end assets. To do continuous unit testing for Javascript code:
 
 .. code-block:: bash
 
-  yarn run test-karma:watch
+  yarn run test
 
 To run specific tests only, you can add the filepath of the file. To further filter either by TestClass name or test method name, you can add `-k` followed by a string to filter classes or methods by. For example, to only run a test named ``test_admin_can_delete_membership`` in kolibri/auth/test/test_permissions.py:
 


### PR DESCRIPTION
### Summary

Update FE unit tests commands  and framework information in [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html#automated-testing) documentation

**Before**
<img width="754" alt="Screenshot 2019-03-23 at 19 58 33" src="https://user-images.githubusercontent.com/13509191/54870392-4fc91980-4da6-11e9-89b5-9c7fef18abef.png">

**After**

<img width="756" alt="Screenshot 2019-03-23 at 19 57 54" src="https://user-images.githubusercontent.com/13509191/54870393-522b7380-4da6-11e9-95fa-11763c3270e2.png">

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
