### PR TITLE
Anchor ancestor collection to the lesson assignment collection

### DIFF
--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -1,5 +1,6 @@
 from django.db.models import Q
 from django.db.models import Sum
+from django.db.models.query import F
 from rest_framework.serializers import JSONField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import SerializerMethodField
@@ -106,7 +107,7 @@ class LearnerClassroomSerializer(ModelSerializer):
         lesson_assignments = HierarchyRelationsFilter(LessonAssignment.objects.all()) \
             .filter_by_hierarchy(
                 target_user=current_user,
-                ancestor_collection=instance
+                ancestor_collection=F('collection')
         )
         filtered_lessons = Lesson.objects.filter(
             lesson_assignments__in=lesson_assignments,
@@ -116,7 +117,7 @@ class LearnerClassroomSerializer(ModelSerializer):
         exam_assignments = HierarchyRelationsFilter(ExamAssignment.objects.all()) \
             .filter_by_hierarchy(
                 target_user=current_user,
-                ancestor_collection=instance
+                ancestor_collection=F('collection')
         )
 
         filtered_exams = Exam.objects.filter(

--- a/kolibri/plugins/learn/serializers.py
+++ b/kolibri/plugins/learn/serializers.py
@@ -111,7 +111,8 @@ class LearnerClassroomSerializer(ModelSerializer):
         )
         filtered_lessons = Lesson.objects.filter(
             lesson_assignments__in=lesson_assignments,
-            is_active=True
+            is_active=True,
+            collection=instance,
         ).distinct()
 
         exam_assignments = HierarchyRelationsFilter(ExamAssignment.objects.all()) \

--- a/kolibri/plugins/learn/test/test_learner_classroom.py
+++ b/kolibri/plugins/learn/test/test_learner_classroom.py
@@ -161,3 +161,20 @@ class LearnerClassroomTestCase(APITestCase):
         self.client.login(username='learner', password='password')
         get_response = self.client.get(reverse(self.basename + '-detail', kwargs={'pk': self.own_classroom.id}))
         self.assertEqual(len(get_response.data['assignments']['lessons']), 1)
+
+    def test_learner_only_sees_lessons_for_own_classroom(self):
+        classroom = Classroom.objects.create(name="Other Classroom", parent=self.facility)
+        lesson = Lesson.objects.create(
+            title='Lesson',
+            collection=classroom,
+            created_by=self.coach_user,
+            is_active=True,
+        )
+        LessonAssignment.objects.create(
+            lesson=lesson,
+            collection=classroom,
+            assigned_by=self.coach_user,
+        )
+        self.client.login(username='learner', password='password')
+        get_response = self.client.get(reverse(self.basename + '-list'))
+        self.assertEqual(len(get_response.data[0]['assignments']['lessons']), 0)

--- a/kolibri/plugins/learn/test/test_learner_classroom.py
+++ b/kolibri/plugins/learn/test/test_learner_classroom.py
@@ -162,7 +162,7 @@ class LearnerClassroomTestCase(APITestCase):
         get_response = self.client.get(reverse(self.basename + '-detail', kwargs={'pk': self.own_classroom.id}))
         self.assertEqual(len(get_response.data['assignments']['lessons']), 1)
 
-    def test_learner_only_sees_lessons_for_own_classroom(self):
+    def test_learner_only_sees_lessons_for_enrolled_classroom(self):
         classroom = Classroom.objects.create(name="Other Classroom", parent=self.facility)
         lesson = Lesson.objects.create(
             title='Lesson',
@@ -178,3 +178,22 @@ class LearnerClassroomTestCase(APITestCase):
         self.client.login(username='learner', password='password')
         get_response = self.client.get(reverse(self.basename + '-list'))
         self.assertEqual(len(get_response.data[0]['assignments']['lessons']), 0)
+
+    def test_learner_only_sees_lessons_for_single_classroom_when_enrolled_in_multiple(self):
+        classroom = Classroom.objects.create(name="Other Classroom", parent=self.facility)
+        classroom.add_member(self.learner_user)
+        lesson = Lesson.objects.create(
+            title='Lesson',
+            collection=self.own_classroom,
+            created_by=self.coach_user,
+            is_active=True,
+        )
+        LessonAssignment.objects.create(
+            lesson=lesson,
+            collection=self.own_classroom,
+            assigned_by=self.coach_user,
+        )
+        self.client.login(username='learner', password='password')
+        get_response = self.client.get(reverse(self.basename + '-list'))
+        total_lessons = len(get_response.data[0]['assignments']['lessons']) + len(get_response.data[1]['assignments']['lessons'])
+        self.assertEqual(total_lessons, Lesson.objects.count())


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Lessons should be filtered by the requesting user's classrooms.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Follow `steps to reproduce` in https://github.com/learningequality/kolibri/issues/5311.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/5311.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
