### PR TITLE
Fix buildkite docker image cache error

### DIFF
--- a/docker/build_debian.dockerfile
+++ b/docker/build_debian.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 # Fetch some additional build requirements
-RUN apt-get -y update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       adduser \
       build-essential \
@@ -12,7 +12,9 @@ RUN apt-get -y update && \
 
 # Use the published kolibri-proposed PPA
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AD405B4A && \
-    add-apt-repository -y -u -s ppa:learningequality/kolibri-proposed && \
+    add-apt-repository -y -u -s ppa:learningequality/kolibri-proposed
+
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y build-dep kolibri
 
 RUN adduser --system --shell /bin/bash --home "/kolibribuild" kolibribuild && \

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -y && \
       sudo \
       software-properties-common \
       ttf-mscorefonts-installer \
-      wine-stable
+      wine-stable \
+      wine32
 
 RUN git lfs install
 

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -8,14 +8,11 @@ RUN apt-get update -y && \
       git \
       git-lfs \
       sudo \
-      software-properties-common
-
-RUN git lfs install
-
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      software-properties-common \
       ttf-mscorefonts-installer \
       wine-stable
+
+RUN git lfs install
 
 VOLUME /kolibridist/
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pull request is to fix the buildkite build failures we currently have due to docker image caches. To fix them and prevent future errors, we need to add `apt-get update &&` every time `apt-get install` is called.
<img width="316" alt="Screen Shot 2019-03-26 at 12 27 48 PM" src="https://user-images.githubusercontent.com/19424916/55027476-98f5b500-4fc2-11e9-8a6c-687f2357405d.png">

I added `wine32` package because we uses 32 bit windows in https://github.com/learningequality/kolibri-installer-windows/blob/master/windows/README.md
`wine-stable` installs `wine64` instead. Previously without `wine32` installed, I got the error:
<img width="317" alt="Screen Shot 2019-03-26 at 12 31 59 PM" src="https://user-images.githubusercontent.com/19424916/55027719-2b965400-4fc3-11e9-8059-2a2ad8cbd04f.png">


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the build passes

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Failed buildkite builds

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
