### PR TITLE
Don't cause errors when assigning or enrolling users

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/modules/classAssignMembers/actions.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/classAssignMembers/actions.js
@@ -1,12 +1,13 @@
 import { MembershipResource, RoleResource } from 'kolibri.resources';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+import uniq from 'lodash/uniq';
 
 export function enrollLearnersInClass(store, { classId, users }) {
   return MembershipResource.saveCollection({
     getParams: {
       collection: classId,
     },
-    data: users.map(userId => ({
+    data: uniq(users).map(userId => ({
       collection: classId,
       user: userId,
     })),
@@ -20,7 +21,7 @@ export function assignCoachesToClass(store, { classId, coaches }) {
     getParams: {
       collection: classId,
     },
-    data: coaches.map(userId => ({
+    data: uniq(coaches).map(userId => ({
       collection: classId,
       user: userId,
       kind: UserKinds.COACH,

--- a/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/handlers.js
@@ -12,7 +12,7 @@ export function showClassEditPage(store, classId) {
   const facilityId = store.getters.currentFacilityId;
   const promises = [
     FacilityUserResource.fetchCollection({ getParams: { member_of: classId }, force: true }),
-    ClassroomResource.fetchModel({ id: classId }),
+    ClassroomResource.fetchModel({ id: classId, force: true }),
     ClassroomResource.fetchCollection({ getParams: { parent: facilityId }, force: true }),
   ];
 


### PR DESCRIPTION
### Summary
* Uniqifies learner and coach lists before sending them to the backend to prevent constraint violations.
* Force fetches the classroom model to update on coach assignment.

### Reviewer guidance
* Follow steps to replicate from #5321 
* Enroll coaches in a class, return to the class page, see coaches enrolled.

### References
Fixes #5321 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
