### PR TITLE
Fix HTML5 apps on Firefox

### DIFF
--- a/packages/hashi/src/replaceScript.js
+++ b/packages/hashi/src/replaceScript.js
@@ -23,17 +23,18 @@ export const runScriptTypes = [
 ];
 
 export default function replaceScript($script, callback) {
-  const s = document.createElement('script');
-  s.type = 'text/javascript';
-  [].forEach.call($script.attributes, attribute => {
-    // Set src later when everything else
-    // has been set.
-    if (attribute.name !== 'src') {
-      s.setAttribute(attribute.name, attribute.value);
-    }
-  });
-  if ($script.src) {
-    if (!$script.async) {
+  if (!$script.loaded) {
+    $script.loaded = true;
+    const s = document.createElement('script');
+    s.type = 'text/javascript';
+    [].forEach.call($script.attributes, attribute => {
+      // Set src later when everything else
+      // has been set.
+      if (attribute.name !== 'src') {
+        s.setAttribute(attribute.name, attribute.value);
+      }
+    });
+    if ($script.src) {
       const cb = () => {
         // Clean up onload and onerror handlers
         // after they have been triggered to avoid
@@ -44,28 +45,29 @@ export default function replaceScript($script, callback) {
       };
       s.onload = cb;
       s.onerror = cb;
+      s.src = $script.src;
+      s.async = false;
+    } else {
+      s.innerHTML = $script.innerHTML;
     }
-    s.src = $script.src;
-  } else {
-    s.innerHTML = $script.innerHTML;
-  }
 
-  const parentNode = $script.parentNode;
+    const parentNode = $script.parentNode;
 
-  const typeAttr = $script.getAttribute('type');
+    const typeAttr = $script.getAttribute('type');
 
-  // only run script tags without the type attribute
-  // or with a javascript mime attribute value
-  if (!typeAttr || runScriptTypes.indexOf(typeAttr) !== -1) {
-    // Remove the element so that we don't clutter the DOM
-    // with duplicates.
-    parentNode.removeChild($script);
-    // re-insert the script tag so it executes.
-    parentNode.appendChild(s);
-  }
+    // only run script tags without the type attribute
+    // or with a javascript mime attribute value
+    if (!typeAttr || runScriptTypes.indexOf(typeAttr) !== -1) {
+      // Remove the element so that we don't clutter the DOM
+      // with duplicates.
+      parentNode.removeChild($script);
+      // re-insert the script tag so it executes.
+      parentNode.appendChild(s);
+    }
 
-  // run the callback immediately for inline scripts
-  if (!$script.src || $script.async) {
-    callback();
+    // run the callback immediately for inline scripts
+    if (!$script.src) {
+      callback();
+    }
   }
 }


### PR DESCRIPTION
### Summary
* Remove support for async script loading, as Firefox sets async on all dynamically injected script tags.
* Prevent repeated loading of the same tags.

### Reviewer guidance
Test HTML5 apps in Firefox:
* African Storybook
* PhET
* CK-12
* Funza

### References
Fixes #5269 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
