### PR TITLE
Proposal: Simple vuex validation setup with demo code

### DIFF
--- a/kolibri/plugins/user/assets/src/modules/signUp/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signUp/index.js
@@ -11,6 +11,28 @@ function defaultState() {
 export default {
   namespaced: true,
   state: defaultState(),
+  schema: {
+    busy: {
+      default: false,
+      type: Boolean,
+    },
+    errors: {
+      default: [],
+      type: Array,
+      validator: function(value) {
+        return value.reduce((acc, val) => {
+          if (!(val instanceof String)) {
+            return false;
+          }
+          return acc;
+        }, true);
+      },
+    },
+    unrecognizedError: {
+      default: false,
+      type: Boolean,
+    },
+  },
   mutations: {
     SET_STATE(state, payload) {
       Object.assign(state, payload);


### PR DESCRIPTION
### Summary
Allows for vuex state to have an optional schema that specifies the structure and validation of the state, to allow for warnings in dev mode, similarly to Vue prop component validation. Implemented as an optional additional key, for ease, but could be embellished to generate the default state also.

### Reviewer guidance
Does this seem like a useful enhancement?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
