### PR TITLE
Fix broken appBarTitle when resource parent is the channel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -93,6 +93,7 @@
       }),
       ...mapState('topicsTree', {
         topicsTreeContent: 'content',
+        topicsTreeChannel: 'channel',
       }),
       ...mapState('examReportViewer', ['exam']),
       ...mapState(['pageName']),
@@ -153,7 +154,14 @@
             immersivePageRoute = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
               id: this.topicsTreeContent.parent,
             });
-            appBarTitle = lastItem(this.topicsTreeContent.breadcrumbs).title;
+
+            if (this.topicsTreeContent.breadcrumbs.length > 0) {
+              appBarTitle = lastItem(this.topicsTreeContent.breadcrumbs).title;
+            } else {
+              // `breadcrumbs` is empty if the direct parent is the channel, so pull
+              // channel info from state.topicsTree.channel
+              appBarTitle = this.topicsTreeChannel.title;
+            }
           }
           return {
             appBarTitle,


### PR DESCRIPTION
### Summary

This fixes a breakage in LearnIndex > ImmersiveToolbar when viewing a resource whose parent is actually the channel. The `topicsTree` vuex module has different structures when the parent is (not) a non-root topic.


### Reviewer guidance

1. Use this channel `zasad-zihog` which has some pdfs that are children of the rootnode/channel.
1. View them and before and after the patch to confirm the problem has been fixed.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
