### PR TITLE
Remove camel/snakeCaser functions, refactor facility settings page

### DIFF
--- a/kolibri/core/assets/src/state/mappers.js
+++ b/kolibri/core/assets/src/state/mappers.js
@@ -1,6 +1,4 @@
-import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
-import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
 
 function ensureTypeSnakeCase(value) {
@@ -10,7 +8,7 @@ function ensureTypeSnakeCase(value) {
   return value;
 }
 
-function assessmentMetaDataState(data) {
+export function assessmentMetaDataState(data) {
   const blankState = {
     assessment: false,
     assessmentIds: [],
@@ -37,13 +35,3 @@ function assessmentMetaDataState(data) {
     randomize: assessmentMetaData.randomize,
   };
 }
-
-function convertKeysToCamelCase(object) {
-  return mapKeys(object, (value, key) => camelCase(key));
-}
-
-function convertKeysToSnakeCase(object) {
-  return mapKeys(object, (value, key) => snakeCase(key));
-}
-
-export { assessmentMetaDataState, convertKeysToCamelCase, convertKeysToSnakeCase };

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -1,6 +1,5 @@
 import debounce from 'lodash/debounce';
 import pick from 'lodash/pick';
-import * as CoreMappers from 'kolibri.coreVue.vuex.mappers';
 import logger from 'kolibri.lib.logging';
 import {
   SessionResource,
@@ -309,7 +308,7 @@ export function getFacilityConfig(store, facilityId) {
     let config = {};
     const facility = facilityConfig[0];
     if (facility) {
-      config = CoreMappers.convertKeysToCamelCase(facility);
+      config = { ...facility };
     }
     store.commit('CORE_SET_FACILITY_CONFIG', config);
   });

--- a/kolibri/plugins/facility_management/assets/src/constants.js
+++ b/kolibri/plugins/facility_management/assets/src/constants.js
@@ -21,17 +21,6 @@ export const Modals = {
   DELETE_USER: 'DELETE_USER',
 };
 
-export const defaultFacilityConfig = {
-  learnerCanEditUsername: true,
-  learnerCanEditName: true,
-  learnerCanEditPassword: true,
-  learnerCanSignUp: true,
-  learnerCanDeleteAccount: true,
-  learnerCanLoginWithNoPassword: false,
-  showDownloadButtonInLearn: false,
-  allowGuestAccess: true,
-};
-
 export const notificationTypes = {
   PAGELOAD_FAILURE: 'PAGELOAD_FAILURE',
   SAVE_FAILURE: 'SAVE_FAILURE',

--- a/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/actions.js
@@ -1,4 +1,3 @@
-import { convertKeysToSnakeCase } from 'kolibri.coreVue.vuex.mappers';
 import { FacilityDatasetResource } from 'kolibri.resources';
 import { defaultFacilityConfig, notificationTypes } from '../../constants';
 
@@ -8,7 +7,7 @@ export function saveFacilityConfig(store) {
   const resourceRequests = [
     FacilityDatasetResource.saveModel({
       id: facilityDatasetId,
-      data: convertKeysToSnakeCase(settings),
+      data: settings,
     }),
   ];
   return Promise.all(resourceRequests)

--- a/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/actions.js
@@ -1,5 +1,5 @@
 import { FacilityDatasetResource } from 'kolibri.resources';
-import { defaultFacilityConfig, notificationTypes } from '../../constants';
+import { notificationTypes } from '../../constants';
 
 export function saveFacilityConfig(store) {
   store.commit('CONFIG_PAGE_NOTIFY', null);
@@ -22,6 +22,15 @@ export function saveFacilityConfig(store) {
 }
 
 export function resetFacilityConfig(store) {
-  store.commit('CONFIG_PAGE_MODIFY_ALL_SETTINGS', defaultFacilityConfig);
+  store.commit('CONFIG_PAGE_MODIFY_ALL_SETTINGS', {
+    learner_can_edit_username: true,
+    learner_can_edit_name: true,
+    learner_can_edit_password: true,
+    learner_can_sign_up: true,
+    learner_can_delete_account: true,
+    learner_can_login_with_no_password: false,
+    show_download_button_in_learn: false,
+    allow_guest_access: true,
+  });
   return saveFacilityConfig(store);
 }

--- a/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/facilityConfig/handlers.js
@@ -1,5 +1,4 @@
 import { FacilityResource, FacilityDatasetResource } from 'kolibri.resources';
-import { convertKeysToCamelCase } from 'kolibri.coreVue.vuex.mappers';
 import { PageNames, notificationTypes } from '../../constants';
 
 export function showFacilityConfigPage(store) {
@@ -19,9 +18,9 @@ export function showFacilityConfigPage(store) {
         facilityDatasetId: dataset.id,
         facilityName: facility.name,
         // this part of state is mutated as user interacts with form
-        settings: convertKeysToCamelCase(dataset),
+        settings: { ...dataset },
         // this copy is kept for the purpose of undoing if save fails
-        settingsCopy: convertKeysToCamelCase(dataset),
+        settingsCopy: { ...dataset },
         notification: null,
       });
       store.commit('CORE_SET_PAGE_LOADING', false);

--- a/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
@@ -25,7 +25,7 @@
           <template v-for="setting in settingsList">
             <KCheckbox
               :key="setting"
-              :label="$tr(setting)"
+              :label="$tr(camelCase(setting))"
               :checked="settings[setting]"
               @change="toggleSetting(setting)"
             />
@@ -67,19 +67,21 @@
 <script>
 
   import { mapState, mapActions, mapMutations } from 'vuex';
+  import camelCase from 'lodash/camelCase';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import KButton from 'kolibri.coreVue.components.KButton';
   import isEqual from 'lodash/isEqual';
   import ConfirmResetModal from './ConfirmResetModal';
   import Notifications from './ConfigPageNotifications';
 
+  // See FacilityDataset in core.auth.models for details
   const settingsList = [
-    'learnerCanEditUsername',
-    'learnerCanEditName',
-    'learnerCanSignUp',
-    'learnerCanLoginWithNoPassword',
-    'showDownloadButtonInLearn',
-    'allowGuestAccess',
+    'learner_can_edit_username',
+    'learner_can_edit_name',
+    'learner_can_sign_up',
+    'learner_can_login_with_no_password',
+    'show_download_button_in_learn',
+    'allow_guest_access',
   ];
 
   export default {
@@ -117,6 +119,7 @@
         configPageModifySetting: 'CONFIG_PAGE_MODIFY_SETTING',
         configPageNotify: 'CONFIG_PAGE_NOTIFY',
       }),
+      camelCase,
       toggleSetting(settingName) {
         this.configPageModifySetting({
           name: settingName,

--- a/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
@@ -66,7 +66,7 @@
 
 <script>
 
-  import { mapState, mapActions, mapMutations } from 'vuex';
+  import { mapState } from 'vuex';
   import camelCase from 'lodash/camelCase';
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -114,29 +114,24 @@
       this.copySettings();
     },
     methods: {
-      ...mapActions('facilityConfig', ['saveFacilityConfig', 'resetFacilityConfig']),
-      ...mapMutations('facilityConfig', {
-        configPageModifySetting: 'CONFIG_PAGE_MODIFY_SETTING',
-        configPageNotify: 'CONFIG_PAGE_NOTIFY',
-      }),
       camelCase,
       toggleSetting(settingName) {
-        this.configPageModifySetting({
+        this.$store.commit('facilityConfig/CONFIG_PAGE_MODIFY_SETTING', {
           name: settingName,
           value: !this.settings[settingName],
         });
       },
       dismissNotification() {
-        this.configPageNotify(null);
+        this.$store.commit('facilityConfig/CONFIG_PAGE_NOTIFY', null);
       },
       resetToDefaultSettings() {
         this.showModal = false;
-        this.resetFacilityConfig().then(() => {
+        this.$store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
           this.copySettings();
         });
       },
       saveConfig() {
-        this.saveFacilityConfig().then(() => {
+        this.$store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
           this.copySettings();
         });
       },

--- a/kolibri/plugins/facility_management/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility_management/assets/test/state/facilityConfig.spec.js
@@ -48,18 +48,18 @@ describe('facility config page actions', () => {
         facilityDatasetId: 'dataset_2',
         facilityName: 'Nalanda Maths',
         settings: expect.objectContaining({
-          learnerCanEditName: true,
-          learnerCanEditUsername: false,
-          learnerCanEditPassword: true,
-          learnerCanDeleteAccount: true,
-          learnerCanSignUp: true,
+          learner_can_edit_name: true,
+          learner_can_edit_username: false,
+          learner_can_edit_password: true,
+          learner_can_delete_account: true,
+          learner_can_sign_up: true,
         }),
         settingsCopy: expect.objectContaining({
-          learnerCanEditName: true,
-          learnerCanEditUsername: false,
-          learnerCanEditPassword: true,
-          learnerCanDeleteAccount: true,
-          learnerCanSignUp: true,
+          learner_can_edit_name: true,
+          learner_can_edit_username: false,
+          learner_can_edit_password: true,
+          learner_can_delete_account: true,
+          learner_can_sign_up: true,
         }),
       };
 
@@ -107,11 +107,11 @@ describe('facility config page actions', () => {
       store.commit('facilityConfig/SET_STATE', {
         facilityDatasetId: 1000,
         settings: {
-          learnerCanEditName: true,
-          learnerCanEditUsername: false,
-          learnerCanEditPassword: true,
-          learnerCanDeleteAccount: true,
-          learnerCanSignUp: false,
+          learner_can_edit_name: true,
+          learner_can_edit_username: false,
+          learner_can_edit_password: true,
+          learner_can_delete_account: true,
+          learner_can_sign_up: false,
         },
       });
     });
@@ -140,11 +140,11 @@ describe('facility config page actions', () => {
         expect(saveStub).toHaveBeenCalled();
         expect(store.state.facilityConfig.notification).toEqual('SAVE_FAILURE');
         expect(store.state.facilityConfig.settings).toEqual({
-          learnerCanEditName: true,
-          learnerCanEditUsername: false,
-          learnerCanEditPassword: true,
-          learnerCanDeleteAccount: true,
-          learnerCanSignUp: false,
+          learner_can_edit_name: true,
+          learner_can_edit_username: false,
+          learner_can_edit_password: true,
+          learner_can_delete_account: true,
+          learner_can_sign_up: false,
         });
       });
     });
@@ -154,14 +154,14 @@ describe('facility config page actions', () => {
       return store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
         expect(saveStub).toHaveBeenCalled();
         expect(store.state.facilityConfig.settings).toEqual({
-          allowGuestAccess: true,
-          learnerCanEditUsername: true,
-          learnerCanEditName: true,
-          learnerCanEditPassword: true,
-          learnerCanSignUp: true,
-          learnerCanDeleteAccount: true,
-          learnerCanLoginWithNoPassword: false,
-          showDownloadButtonInLearn: false,
+          allow_guest_access: true,
+          learner_can_edit_username: true,
+          learner_can_edit_name: true,
+          learner_can_edit_password: true,
+          learner_can_sign_up: true,
+          learner_can_delete_account: true,
+          learner_can_login_with_no_password: false,
+          show_download_button_in_learn: false,
         });
       });
     });

--- a/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
@@ -6,7 +6,7 @@ function makeWrapper(propsData = {}) {
   const store = makeStore();
   store.commit('facilityConfig/SET_STATE', {
     settings: {
-      learnerCanEditUsername: false,
+      learner_can_edit_username: false,
     },
   });
   return mount(ConfigPage, { propsData, store });
@@ -39,15 +39,16 @@ describe('facility config page view', () => {
     const wrapper = makeWrapper();
     const { checkbox } = getElements(wrapper);
     checkbox().trigger('click');
-    expect(wrapper.vm.$store.state.facilityConfig.settings.learnerCanEditUsername).toEqual(true);
+    expect(wrapper.vm.$store.state.facilityConfig.settings.learner_can_edit_username).toEqual(true);
   });
 
   it('clicking save button dispatches a save action', async () => {
     const wrapper = makeWrapper();
-    const { mock } = (wrapper.vm.saveFacilityConfig = jest.fn().mockResolvedValue());
+    const mock = (wrapper.vm.$store.dispatch = jest.fn().mockResolvedValue());
     const { saveButton } = getElements(wrapper);
     saveButton().trigger('click');
-    expect(mock.calls).toHaveLength(1);
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('facilityConfig/saveFacilityConfig');
   });
 
   it('clicking reset button brings up the confirmation modal', () => {
@@ -71,11 +72,12 @@ describe('facility config page view', () => {
   it('confirming reset calls the reset action and closes modal', () => {
     const wrapper = makeWrapper();
     const { resetButton, confirmResetModal } = getElements(wrapper);
-    const { mock } = (wrapper.vm.resetFacilityConfig = jest.fn().mockResolvedValue());
+    const mock = (wrapper.vm.$store.dispatch = jest.fn().mockResolvedValue());
     resetButton().trigger('click');
     assertModalIsUp(wrapper);
     confirmResetModal().vm.$emit('submit');
-    expect(mock.calls).toHaveLength(1);
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('facilityConfig/resetFacilityConfig');
     assertModalIsDown(wrapper);
   });
   // not tested: notifications


### PR DESCRIPTION
### Summary

1. Removes the camelCase/snakeCase transformer functions that were basically used to convert the keys in the FacilityDataset model from snake case to camel case.
1. Updates the components/codes/tests, and do some basic refactors.

### Reviewer guidance

1. Manually test the FacilitySettingsPAge, as it is the only page affected by this.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
