### PR TITLE
Add eslint rule to find unused properties, data and computed properties

### DIFF
--- a/kolibri/core/assets/src/views/ContentIcon.vue
+++ b/kolibri/core/assets/src/views/ContentIcon.vue
@@ -120,7 +120,7 @@
           return validateContentNodeKind(value, [USER]);
         },
       },
-      colorstyle: {
+      colorStyle: {
         type: String,
         default: 'action',
       },

--- a/kolibri/core/assets/src/views/ContentRenderer/index.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/index.vue
@@ -67,10 +67,6 @@
       UiAlert,
     },
     props: {
-      id: {
-        type: String,
-        required: true,
-      },
       kind: {
         type: String,
         required: true,
@@ -78,14 +74,6 @@
       files: {
         type: Array,
         default: () => [],
-      },
-      contentId: {
-        type: String,
-        default: '',
-      },
-      channelId: {
-        type: String,
-        default: '',
       },
       available: {
         type: Boolean,

--- a/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
+++ b/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
@@ -43,7 +43,6 @@
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
 
@@ -95,9 +94,6 @@
       progress() {
         // Either return in completed or in progress
         return this.completed ? 1 : 0.1;
-      },
-      kind() {
-        return ContentNodeKinds.EXAM;
       },
     },
   };

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -38,12 +38,10 @@
       />
       <ContentRenderer
         v-if="exercise"
-        :id="exercise.id"
         :itemId="itemId"
         :allowHints="false"
         :kind="exercise.kind"
         :files="exercise.files"
-        :contentId="exercise.content_id"
         :available="exercise.available"
         :extraFields="exercise.extra_fields"
         :interactive="false"

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -389,14 +389,6 @@
         return this.options.findIndex(option => looseEqual(this.highlightedOption, option));
       },
 
-      // Returns the index of the currently selected option, -1 if multi-select
-      selectedIndex() {
-        if (this.multiple) {
-          return -1;
-        }
-        return this.options.findIndex(option => looseEqual(this.value, option));
-      },
-
       // Returns an array containing the options and extra annotations
       annotatedOptions() {
         const options = JSON.parse(JSON.stringify(this.options));

--- a/kolibri/core/assets/src/views/KTooltip/Popper.vue
+++ b/kolibri/core/assets/src/views/KTooltip/Popper.vue
@@ -185,7 +185,6 @@
         referenceElm: null,
         popperJS: null,
         showPopper: false,
-        currentPlacement: '',
         popperOptions: {
           placement: 'bottom',
           computeStyle: {

--- a/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
@@ -17,15 +17,6 @@
   export default {
     name: 'KLabeledIcon',
     components: {},
-    props: {
-      /**
-       * Whether the label should wrap
-       */
-      nowrap: {
-        type: Boolean,
-        default: false,
-      },
-    },
   };
 
 </script>

--- a/kolibri/core/assets/test/content-renderer.spec.js
+++ b/kolibri/core/assets/test/content-renderer.spec.js
@@ -23,7 +23,6 @@ describe('ContentRenderer Component', () => {
 
   function defaultPropsDataFromFiles(files = defaultFiles) {
     return {
-      id: 'testing',
       kind: 'test',
       files,
     };

--- a/kolibri/core/assets/test/views/KTooltipExample.vue
+++ b/kolibri/core/assets/test/views/KTooltipExample.vue
@@ -32,11 +32,6 @@
         required: false,
         default: () => {},
       },
-      kTooltipText: {
-        type: String,
-        required: false,
-        default: '',
-      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
@@ -33,11 +33,6 @@
         required: true,
       },
     },
-    data() {
-      return {
-        active: null,
-      };
-    },
     computed: {
       activeClasses() {
         // return both fixed and dynamic classes

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
@@ -58,13 +58,11 @@
         />
         <ContentRenderer
           v-if="currentInteraction"
-          :id="exercise.id"
           :itemId="currentAttemptLog.item"
           :assessment="true"
           :allowHints="false"
           :kind="exercise.kind"
           :files="exercise.files"
-          :contentId="exercise.content_id"
           :available="exercise.available"
           :answerState="answerState"
           :showCorrectAnswer="showCorrectAnswer"

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
@@ -37,13 +37,11 @@
         />
         <ContentRenderer
           v-if="currentInteraction"
-          :id="exercise.id"
           :itemId="currentLearner.item"
           :assessment="true"
           :allowHints="false"
           :kind="exercise.kind"
           :files="exercise.files"
-          :contentId="exercise.content_id"
           :available="exercise.available"
           :answerState="answerState"
           :showCorrectAnswer="showCorrectAnswer"

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -104,7 +104,6 @@
     data() {
       return {
         loading: true,
-        error: false,
         moreResults: true,
         nextPage: 1,
         progressFilter: 'all',

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -58,10 +58,6 @@
         type: Object,
         required: true,
       },
-      isLast: {
-        type: Boolean,
-        default: false,
-      },
       to: {
         type: Object,
         required: false,

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/ExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/ExamPreview.vue
@@ -52,11 +52,9 @@
           >
             <ContentRenderer
               v-if="content && itemId"
-              :id="content.id"
               ref="contentRenderer"
               :kind="content.kind"
               :files="content.files"
-              :contentId="content.content_id"
               :available="content.available"
               :extraFields="content.extra_fields"
               :itemId="itemId"

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -138,7 +138,7 @@
   import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { ContentNodeKinds, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
+  import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
@@ -215,9 +215,6 @@
       },
       manageExamModalStrings() {
         return manageExamModalStrings;
-      },
-      examKind() {
-        return ContentNodeKinds.EXAM;
       },
       sortedExams() {
         return this.exams.slice().reverse();

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -158,11 +158,9 @@
           </h3>
           <ContentRenderer
             v-if="content && questionId"
-            :id="content.id"
             ref="contentRenderer"
             :kind="content.kind"
             :files="content.files"
-            :contentId="content.content_id"
             :available="content.available"
             :extraFields="content.extra_fields"
             :itemId="questionId"

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -300,13 +300,6 @@
       previewQuizStrings() {
         return previewQuizStrings;
       },
-      draggableOptions() {
-        return {
-          animation: 150,
-          touchStartThreshold: 3,
-          direction: 'vertical',
-        };
-      },
       currentQuestion() {
         return this.selectedQuestions[this.currentQuestionIndex] || {};
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -166,9 +166,6 @@
       usersNotInClass() {
         return differenceWith(this.classUsers, this.currentGroupUsers, (a, b) => a.id === b.id);
       },
-      filteredUsers() {
-        return this.usersNotInClass.filter(user => userMatchesFilter(user, this.filterInput));
-      },
       sortedFilteredUsers() {
         return filterAndSortUsers(this.usersNotInClass, user =>
           userMatchesFilter(user, this.filterInput)
@@ -194,9 +191,6 @@
       },
       visibleFilteredUsers() {
         return this.sortedFilteredUsers.slice(this.startRange, this.endRange);
-      },
-      showConfirmEnrollmentModal() {
-        return this.modalShown === true;
       },
       emptyMessage() {
         if (this.classUsers.length === 0) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -55,11 +55,6 @@
         default: '',
       },
     },
-    computed: {
-      hasHeader() {
-        return Boolean(this.header);
-      },
-    },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -5,15 +5,12 @@
       {{ header }}
     </h2>
     <ContentRenderer
-      :id="content.id"
       :class="{ hof: isExercise}"
       :showCorrectAnswer="true"
       :itemId="selectedQuestion"
       :allowHints="false"
       :kind="content.kind"
       :files="content.files"
-      :contentId="content.content_id"
-      :channelId="content.channel_id"
       :available="content.available"
       :extraFields="content.extra_fields"
       :interactive="false"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/QuestionList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/QuestionList.vue
@@ -60,13 +60,6 @@
         validator: value => typeof value(0) === 'string',
       },
     },
-    computed: {
-      buttonAndHeaderBorder() {
-        return {
-          borderBottom: `2px solid ${this.$coreTextDisabled}`,
-        };
-      },
-    },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -109,11 +109,7 @@
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
-  import {
-    ContentNodeKinds,
-    CollectionKinds,
-    ERROR_CONSTANTS,
-  } from 'kolibri.coreVue.vuex.constants';
+  import { CollectionKinds, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import LessonActive from '../../common/LessonActive';
@@ -148,7 +144,6 @@
     data() {
       return {
         showModal: false,
-        lessonKind: ContentNodeKinds.LESSON,
         filterSelection: {},
       };
     },

--- a/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
@@ -30,14 +30,11 @@
         />
         <ContentRenderer
           v-if="currentInteraction"
-          :id="exercise.id"
           :itemId="currentAttemptLog.item"
           :assessment="true"
           :allowHints="false"
           :kind="exercise.kind"
           :files="exercise.files"
-          :contentId="exercise.content_id"
-          :channelId="channelId"
           :available="exercise.available"
           :answerState="answerState"
           :showCorrectAnswer="showCorrectAnswer"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
@@ -79,6 +79,7 @@
       group() {
         return this.groupMap[this.$route.params.groupId];
       },
+      /** TODO COACH
       recipients() {
         return this.group.member_ids;
       },
@@ -92,6 +93,7 @@
         }
         return this._.meanBy(statuses, 'score');
       },
+      */
     },
     $trs: {
       back: 'All groups',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -73,9 +73,6 @@
     },
     mixins: [commonCoach],
     computed: {
-      lesson() {
-        return this.lessonMap[this.$route.params.lessonId];
-      },
       recipients() {
         return this.getLearnersForGroups([this.$route.params.groupId]);
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -93,6 +93,7 @@
     components: {},
     mixins: [commonCoach],
     computed: {
+      /** TODO COACH
       actionOptions() {
         return [
           { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsLessonEditorPage' },
@@ -102,6 +103,7 @@
           },
         ];
       },
+      */
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -98,9 +98,6 @@
       recipients() {
         return this.getLearnersForGroups([this.$route.params.groupId]);
       },
-      avgTime() {
-        return this.getContentAvgTimeSpent(this.$route.params.resourceId, this.recipients);
-      },
       tally() {
         return this.getContentStatusTally(this.$route.params.resourceId, this.recipients);
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -13,7 +13,7 @@
       <p>
         <BackLink
           :to="classRoute('ReportsGroupReportLessonPage', {})"
-          :text="$tr('back', { lesson: 'Lesson 1' })"
+          :text="$tr('back', { lesson: lesson.title })"
         />
       </p>
       <h1>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
@@ -73,9 +73,6 @@
       recipients() {
         return this.getLearnersForGroups([this.$route.params.groupId]);
       },
-      tally() {
-        return this.getExamStatusTally(this.exam.id, this.recipients);
-      },
     },
     $trs: {
       back: 'All quizzes',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonEditorPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonEditorPage.vue
@@ -33,16 +33,6 @@
       LessonDetailEditor,
     },
     mixins: [commonCoach],
-    data() {
-      return {
-        lessonTitle: 'Lesson A',
-        lessonDescription: 'Ipsum lorem',
-        selectedCollectionIds: ['a'],
-        availableGroups: [{ name: 'Group A', id: 'a' }, { name: 'Group B', id: 'b' }],
-        selectedClassroomId: 'x',
-        isActive: true,
-      };
-    },
     $trs: {},
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
@@ -79,6 +79,7 @@
     components: {},
     mixins: [commonCoach],
     computed: {
+      /** TODO COACH
       actionOptions() {
         return [
           { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsLessonEditorPage' },
@@ -88,6 +89,7 @@
           },
         ];
       },
+      */
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -81,6 +81,7 @@
       emptyMessage() {
         return LessonSummaryPageStrings.$tr('noResourcesInLesson');
       },
+      /** TODO COACH
       actionOptions() {
         return [
           { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsLessonEditorPage' },
@@ -90,6 +91,7 @@
           },
         ];
       },
+      */
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizEditorPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizEditorPage.vue
@@ -30,16 +30,6 @@
       QuizDetailEditor,
     },
     mixins: [commonCoach],
-    data() {
-      return {
-        lessonTitle: 'Lesson A',
-        lessonDescription: 'Ipsum lorem',
-        selectedCollectionIds: ['a'],
-        availableGroups: [{ name: 'Group A', id: 'a' }, { name: 'Group B', id: 'b' }],
-        selectedClassroomId: 'x',
-        isActive: true,
-      };
-    },
     $trs: {},
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
@@ -80,12 +80,14 @@
       avgScore() {
         return this.getExamAvgScore(this.$route.params.quizId, this.recipients);
       },
+      /** TODO COACH
       actionOptions() {
         return [
           { label: this.coachStrings.$tr('previewAction'), value: 'ReportsQuizPreviewPage' },
           { label: this.coachStrings.$tr('editDetailsAction'), value: 'ReportsQuizEditorPage' },
         ];
       },
+      */
       exam() {
         return this.examMap[this.$route.params.quizId];
       },

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -90,6 +90,7 @@
         selectedAddressId: '',
         showUiAlerts: false,
         stage: '',
+        Stages,
       };
     },
     computed: {
@@ -98,23 +99,26 @@
       submitDisabled() {
         return (
           this.selectedAddressId === '' ||
-          this.stage === Stages.FETCHING_ADDRESSES ||
-          this.stage === Stages.DELETING_ADDRESS
+          this.stage === this.Stages.FETCHING_ADDRESSES ||
+          this.stage === this.Stages.DELETING_ADDRESS
         );
       },
       newAddressButtonDisabled() {
-        return this.stage === Stages.FETCHING_ADDRESSES;
+        return this.stage === this.Stages.FETCHING_ADDRESSES;
       },
       requestsSucessful() {
         return (
-          this.stage === Stages.FETCHING_SUCCESSFUL || this.stage === Stages.DELETING_SUCCESSFUL
+          this.stage === this.Stages.FETCHING_SUCCESSFUL ||
+          this.stage === this.Stages.DELETING_SUCCESSFUL
         );
       },
       requestsFailed() {
-        return this.stage === Stages.FETCHING_FAILED || this.stage === Stages.DELETING_FAILED;
+        return (
+          this.stage === this.Stages.FETCHING_FAILED || this.stage === this.Stages.DELETING_FAILED
+        );
       },
       uiAlertProps() {
-        if (this.stage === Stages.FETCHING_ADDRESSES) {
+        if (this.stage === this.Stages.FETCHING_ADDRESSES) {
           return {
             text: this.$tr('fetchingAddressesText'),
             type: 'info',
@@ -126,13 +130,13 @@
             type: 'info',
           };
         }
-        if (this.stage === Stages.FETCHING_FAILED) {
+        if (this.stage === this.Stages.FETCHING_FAILED) {
           return {
             text: this.$tr('fetchingFailedText'),
             type: 'error',
           };
         }
-        if (this.stage === Stages.DELETING_FAILED) {
+        if (this.stage === this.Stages.DELETING_FAILED) {
           return {
             text: this.$tr('deletingFailedText'),
             type: 'error',
@@ -153,16 +157,16 @@
     },
     methods: {
       refreshAddressList() {
-        this.stage = Stages.FETCHING_ADDRESSES;
+        this.stage = this.Stages.FETCHING_ADDRESSES;
         this.addresses = [];
         return fetchAddresses(this.isImportingMore ? this.transferredChannel.id : '')
           .then(addresses => {
             this.addresses = addresses;
             this.resetSelectedAddress();
-            this.stage = Stages.FETCHING_SUCCESSFUL;
+            this.stage = this.Stages.FETCHING_SUCCESSFUL;
           })
           .catch(() => {
-            this.stage = Stages.FETCHING_FAILED;
+            this.stage = this.Stages.FETCHING_FAILED;
           });
       },
       resetSelectedAddress() {
@@ -174,16 +178,16 @@
         }
       },
       removeAddress(id) {
-        this.stage = Stages.DELETING_ADDRESS;
+        this.stage = this.Stages.DELETING_ADDRESS;
         return deleteAddress(id)
           .then(() => {
             this.addresses = this.addresses.filter(a => a.id !== id);
             this.resetSelectedAddress(this.addresses);
-            this.stage = Stages.DELETING_SUCCESSFUL;
+            this.stage = this.Stages.DELETING_SUCCESSFUL;
             this.$emit('removed_address');
           })
           .catch(() => {
-            this.stage = Stages.DELETING_FAILED;
+            this.stage = this.Stages.DELETING_FAILED;
           });
       },
       handleSubmit() {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -90,7 +90,6 @@
         selectedAddressId: '',
         showUiAlerts: false,
         stage: '',
-        Stages,
       };
     },
     computed: {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
@@ -58,7 +58,6 @@
       return {
         driveStatus: '',
         selectedDriveId: '',
-        showError: false,
       };
     },
     computed: {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -97,6 +97,7 @@
       };
     },
     computed: {
+      TaskStatuses: () => TaskStatuses,
       stageText() {
         // Special case for Channel DB downloading, since they never go into RUNNING
         if (this.type === 'UPDATING_CHANNEL') {
@@ -106,7 +107,7 @@
           return this.$tr('downloadingChannelContents');
         }
 
-        if (this.status === TaskStatuses.RUNNING) {
+        if (this.status === this.TaskStatuses.RUNNING) {
           switch (this.type) {
             case TaskTypes.REMOTE_IMPORT:
             case TaskTypes.LOCAL_IMPORT:
@@ -137,13 +138,15 @@
         return '';
       },
       taskHasFailed() {
-        return this.status === TaskStatuses.FAILED;
+        return this.status === this.TaskStatuses.FAILED;
       },
       taskHasCompleted() {
-        return this.status === TaskStatuses.COMPLETED;
+        return this.status === this.TaskStatuses.COMPLETED;
       },
       taskIsPreparing() {
-        return this.status === TaskStatuses.QUEUED || this.status === TaskStatuses.SCHEDULED;
+        return (
+          this.status === this.TaskStatuses.QUEUED || this.status === this.TaskStatuses.SCHEDULED
+        );
       },
       formattedPercentage() {
         return this.percentage * 100;

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -97,7 +97,6 @@
       };
     },
     computed: {
-      TaskStatuses: () => TaskStatuses,
       stageText() {
         // Special case for Channel DB downloading, since they never go into RUNNING
         if (this.type === 'UPDATING_CHANNEL') {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -82,7 +82,6 @@
         type: Number,
         required: true,
       },
-      id: RequiredString,
       cancellable: {
         type: Boolean,
         required: true,

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -61,7 +61,6 @@
   import KCheckbox from 'kolibri.coreVue.components.KCheckbox';
   import KBreadcrumbs from 'kolibri.coreVue.components.KBreadcrumbs';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import last from 'lodash/last';
   import every from 'lodash/every';
   import omit from 'lodash/omit';
   import { navigateToTopicUrl } from '../../routes/wizardTransitionRoutes';
@@ -156,11 +155,6 @@
           selections,
           !this.inExportMode
         );
-      },
-      breadcrumbItems() {
-        const items = [...this.breadcrumbs];
-        delete last(items).link;
-        return items;
       },
     },
     methods: {

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -9,7 +9,6 @@
     <template v-else>
       <TaskProgress
         v-if="showUpdateProgressBar"
-        id="updatingchannel"
         type="UPDATING_CHANNEL"
         status="QUEUED"
         :percentage="0"

--- a/kolibri/plugins/document_pdf_render/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/PdfRendererIndex.vue
@@ -125,17 +125,11 @@
     }),
     computed: {
       ...mapGetters(['sessionTimeSpent']),
-      pdfURL() {
-        return this.defaultFile.storage_url;
-      },
       targetTime() {
         return this.totalPages * 30;
       },
       documentLoading() {
         return this.progress < 1;
-      },
-      pdfPositionKey() {
-        return `pdfPosition-${this.files[0].id}`;
       },
       itemHeight() {
         return this.firstPageHeight * this.scale + MARGIN;

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
@@ -85,7 +85,6 @@
   import KFilterTextbox from 'kolibri.coreVue.components.KFilterTextbox';
   import { userMatchesFilter, filterAndSortUsers } from '../userSearchUtils';
   import UserTable from './UserTable';
-  import { Modals } from './../constants';
 
   export default {
     name: 'ClassEnrollForm',
@@ -139,9 +138,6 @@
       usersNotInClass() {
         return differenceWith(this.facilityUsers, this.classUsers, (a, b) => a.id === b.id);
       },
-      filteredUsers() {
-        return this.usersNotInClass.filter(user => userMatchesFilter(user, this.filterInput));
-      },
       sortedFilteredUsers() {
         return filterAndSortUsers(this.usersNotInClass, user =>
           userMatchesFilter(user, this.filterInput)
@@ -167,9 +163,6 @@
       },
       visibleFilteredUsers() {
         return this.sortedFilteredUsers.slice(this.startRange, this.endRange);
-      },
-      showConfirmEnrollmentModal() {
-        return this.modalShown === Modals.CONFIRM_ENROLLMENT;
       },
       emptyMessage() {
         if (this.facilityUsers.length === 0) {

--- a/kolibri/plugins/facility_management/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/DataPage/index.vue
@@ -100,11 +100,6 @@
       DataPageTaskProgress,
     },
     mixins: [themeMixin],
-    data() {
-      return {
-        lista: urls,
-      };
-    },
     metaInfo() {
       return {
         title: this.$tr('documentTitle'),
@@ -143,9 +138,6 @@
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       cannotDownload() {
         return isAndroidWebView();
-      },
-      generatingCSVFile() {
-        return this.inSummaryCSVCreation || this.inSessionCSVCreation;
       },
       inDataExportPage() {
         return this.pageName === PageNames.DATA_EXPORT_PAGE;

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/DeleteUserModal.vue
@@ -37,10 +37,6 @@
         type: String,
         required: true,
       },
-      name: {
-        type: String,
-        required: true,
-      },
       username: {
         type: String,
         required: true,

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/ResetUserPasswordModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/ResetUserPasswordModal.vue
@@ -51,10 +51,6 @@
         type: String,
         required: true,
       },
-      name: {
-        type: String,
-        required: true,
-      },
       username: {
         type: String,
         required: true,

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -69,7 +69,6 @@
     <DeleteUserModal
       v-if="modalShown===Modals.DELETE_USER"
       :id="selectedUser.id"
-      :name="selectedUser.full_name"
       :username="selectedUser.username"
     />
 

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -62,7 +62,6 @@
     <ResetUserPasswordModal
       v-if="modalShown===Modals.RESET_USER_PASSWORD"
       :id="selectedUser.id"
-      :name="selectedUser.full_name"
       :username="selectedUser.username"
     />
 

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -124,9 +124,6 @@
         type: Array,
         required: true,
       },
-      title: {
-        type: String,
-      },
       emptyMessage: {
         type: String,
       },

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -20,13 +20,10 @@ oriented data synchronization.
     </UiAlert>
     <div>
       <ContentRenderer
-        :id="id"
         ref="contentRenderer"
         :kind="kind"
         :lang="lang"
         :files="files"
-        :contentId="contentId"
-        :channelId="channelId"
         :available="available"
         :extraFields="extraFields"
         :assessment="true"
@@ -163,10 +160,6 @@ oriented data synchronization.
       files: {
         type: Array,
         default: () => [],
-      },
-      contentId: {
-        type: String,
-        default: '',
       },
       channelId: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -112,8 +112,6 @@
         panBackwards: false,
         // tracks whether the carousel has been interacted with
         interacted: false,
-        contentCardWidth,
-        gutterWidth,
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -112,6 +112,8 @@
         panBackwards: false,
         // tracks whether the carousel has been interacted with
         interacted: false,
+        contentCardWidth,
+        gutterWidth,
       };
     },
     computed: {
@@ -119,10 +121,10 @@
         return this.isRtl ? 'right' : 'left';
       },
       contentSetSize() {
-        if (this.elementWidth > 2 * contentCardWidth) {
-          const numOfCards = Math.floor(this.elementWidth / contentCardWidth);
+        if (this.elementWidth > 2 * this.contentCardWidth) {
+          const numOfCards = Math.floor(this.elementWidth / this.contentCardWidth);
           const numOfGutters = numOfCards - 1;
-          const totalWidth = numOfCards * contentCardWidth + numOfGutters * gutterWidth;
+          const totalWidth = numOfCards * this.contentCardWidth + numOfGutters * this.gutterWidth;
           if (this.elementWidth >= totalWidth) {
             return numOfCards;
           }
@@ -140,26 +142,26 @@
         return this.contentSetEnd >= this.contents.length - 1;
       },
       contentSetStyles() {
-        const cards = this.contentSetSize * contentCardWidth + horizontalShadowOffset;
-        const gutters = (this.contentSetSize - 1) * gutterWidth;
+        const cards = this.contentSetSize * this.contentCardWidth + horizontalShadowOffset;
+        const gutters = (this.contentSetSize - 1) * this.gutterWidth;
         const maxCardShadowOffset = 14; // determined by css styles on cards
         const topShadowOffset = 10;
         return {
-          'min-width': `${contentCardWidth}px`,
+          'min-width': `${this.contentCardWidth}px`,
           'overflow-x': 'hidden',
           width: `${cards + gutters + maxCardShadowOffset}px`,
           // Bottom shadow is a little bit bigger, so add a few pixels more
-          height: `${contentCardWidth + maxCardShadowOffset + topShadowOffset + 3}px`,
+          height: `${this.contentCardWidth + maxCardShadowOffset + topShadowOffset + 3}px`,
           position: 'relative',
           'padding-top': `${topShadowOffset}px`,
         };
       },
       contentControlsContainerStyles() {
-        const cards = this.contentSetSize * contentCardWidth;
-        const gutters = (this.contentSetSize - 1) * gutterWidth;
+        const cards = this.contentSetSize * this.contentCardWidth;
+        const gutters = (this.contentSetSize - 1) * this.gutterWidth;
         return {
           width: `${cards + gutters}px`,
-          height: `${contentCardWidth}px`,
+          height: `${this.contentCardWidth}px`,
           overflow: 'visible',
           position: 'relative',
         };
@@ -209,8 +211,8 @@
     methods: {
       positionCalc(index) {
         const indexInSet = index - this.contentSetStart;
-        const gutterOffset = indexInSet * gutterWidth;
-        const cardOffset = indexInSet * contentCardWidth;
+        const gutterOffset = indexInSet * this.gutterWidth;
+        const cardOffset = indexInSet * this.contentCardWidth;
         return { [this.animationAttr]: `${cardOffset + gutterOffset + horizontalShadowOffset}px` };
       },
       setStartPosition(el) {
@@ -218,8 +220,8 @@
           // sets the initial spot from which cards will be sliding into place from
           // direction depends on `panBackwards`
           const originalPosition = parseInt(el.style[this.animationAttr], 10);
-          const cards = this.contentSetSize * contentCardWidth;
-          const gutters = this.contentSetSize * gutterWidth;
+          const cards = this.contentSetSize * this.contentCardWidth;
+          const gutters = this.contentSetSize * this.gutterWidth;
           const carouselContainerOffset = cards + gutters;
           const sign = this.panBackwards ? -1 : 1;
 
@@ -231,8 +233,8 @@
           // moves cards from their starting point by their offset
           // direction depends on `panBackwards`
           const originalPosition = parseInt(el.style[this.animationAttr], 10);
-          const cards = this.contentSetSize * contentCardWidth;
-          const gutters = this.contentSetSize * gutterWidth;
+          const cards = this.contentSetSize * this.contentCardWidth;
+          const gutters = this.contentSetSize * this.gutterWidth;
           const carouselContainerOffset = cards + gutters;
           const sign = this.panBackwards ? 1 : -1;
 

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -15,13 +15,10 @@
 
     <ContentRenderer
       v-if="!content.assessment"
-      :id="content.id"
       class="content-renderer"
       :kind="content.kind"
       :lang="content.lang"
       :files="content.files"
-      :contentId="contentId"
-      :channelId="channelId"
       :available="content.available"
       :extraFields="extraFields"
       :initSession="initSession"
@@ -42,7 +39,6 @@
       :randomize="content.randomize"
       :masteryModel="content.masteryModel"
       :assessmentIds="content.assessmentIds"
-      :contentId="contentId"
       :channelId="channelId"
       :available="content.available"
       :extraFields="extraFields"

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -229,14 +229,6 @@
       recommendedText() {
         return this.$tr('recommended');
       },
-      parentTopic() {
-        const { breadcrumbs = [] } = this.content;
-        if (breadcrumbs.length > 0) {
-          return breadcrumbs[breadcrumbs.length - 1];
-        }
-
-        return undefined;
-      },
       progress() {
         if (this.isUserLoggedIn) {
           // if there no attempts for this exercise, there is no progress

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -43,12 +43,9 @@
       >
         <ContentRenderer
           v-if="content && itemId"
-          :id="content.id"
           ref="contentRenderer"
           :kind="content.kind"
           :files="content.files"
-          :contentId="content.content_id"
-          :channelId="channelId"
           :available="content.available"
           :extraFields="content.extra_fields"
           :itemId="itemId"

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -164,7 +164,6 @@
         searchQuery: this.$store.state.search.searchTerm,
         contentKindFilterSelection: {},
         channelFilterSelection: {},
-        test: 10,
       };
     },
     computed: {

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -115,7 +115,6 @@
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import PrivacyInfoModal from 'kolibri.coreVue.components.PrivacyInfoModal';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
-  import { PageNames } from '../constants';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
 
   export default {
@@ -167,9 +166,6 @@
     computed: {
       ...mapGetters(['facilities', 'session']),
       ...mapState('signUp', ['errors', 'busy']),
-      signInPage() {
-        return { name: PageNames.SIGN_IN };
-      },
       facilityList() {
         return this.facilities.map(facility => ({
           label: facility.name,

--- a/kolibri/plugins/user/assets/src/views/UserIndex.vue
+++ b/kolibri/plugins/user/assets/src/views/UserIndex.vue
@@ -49,9 +49,6 @@
       currentPage() {
         return pageNameComponentMap[this.pageName] || null;
       },
-      navBarNeeded() {
-        return this.pageName !== PageNames.SIGN_IN && this.pageName !== PageNames.SIGN_UP;
-      },
       PageNames() {
         return PageNames;
       },

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -7,6 +7,17 @@
 const remove = require('lodash/remove');
 const utils = require('eslint-plugin-vue/lib/utils');
 
+const GROUP_PROPERTY = 'props';
+const GROUP_DATA = 'data';
+const GROUP_COMPUTED_PROPERTY = 'computed';
+const GROUP_WATCHER = 'watch';
+
+const PROPERTY_LABEL = {
+  [GROUP_PROPERTY]: 'property',
+  [GROUP_DATA]: 'data',
+  [GROUP_COMPUTED_PROPERTY]: 'computed property',
+};
+
 const getReferencesNames = references => {
   if (!references || !references.length) {
     return [];
@@ -27,16 +38,9 @@ const reportUnusedProperties = (context, properties) => {
   }
 
   properties.forEach(property => {
-    let kind = 'property';
-    if (property.groupName === 'data') {
-      kind = 'data';
-    } else if (property.groupName === 'computed') {
-      kind = 'computed property';
-    }
-
     context.report({
       node: property.node,
-      message: `Unused ${kind} found: "${property.name}"`,
+      message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
     });
   });
 };
@@ -73,10 +77,10 @@ const create = context => {
     },
     utils.executeOnVue(context, obj => {
       unusedProperties = Array.from(
-        utils.iterateProperties(obj, new Set(['props', 'data', 'computed']))
+        utils.iterateProperties(obj, new Set([GROUP_PROPERTY, GROUP_DATA, GROUP_COMPUTED_PROPERTY]))
       );
 
-      const watchers = Array.from(utils.iterateProperties(obj, new Set(['watch'])));
+      const watchers = Array.from(utils.iterateProperties(obj, new Set([GROUP_WATCHER])));
       const watchersNames = watchers.map(watcher => watcher.name);
 
       remove(unusedProperties, property => {

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Disallow unused properties, data or computed properties.
+ */
+
+'use strict';
+
+const remove = require('lodash/remove');
+const utils = require('eslint-plugin-vue/lib/utils');
+
+const getReferencesNames = references => {
+  if (!references || !references.length) {
+    return [];
+  }
+
+  return references.map(reference => {
+    if (!reference.id || !reference.id.name) {
+      return;
+    }
+
+    return reference.id.name;
+  });
+};
+
+const reportUnusedProperties = (context, properties) => {
+  if (!properties || !properties.length) {
+    return;
+  }
+
+  properties.forEach(property => {
+    let kind = 'property';
+    if (property.groupName === 'data') {
+      kind = 'data';
+    } else if (property.groupName === 'computed') {
+      kind = 'computed property';
+    }
+
+    context.report({
+      node: property.node,
+      message: `Unused ${kind} found: "${property.name}"`,
+    });
+  });
+};
+
+const create = context => {
+  let hasTemplate;
+  let rootTemplateEnd;
+  let unusedProperties = [];
+  let thisExpressionsVariablesNames = [];
+
+  const initialize = {
+    Program(node) {
+      if (context.parserServices.getTemplateBodyTokenStore == null) {
+        context.report({
+          loc: { line: 1, column: 0 },
+          message:
+            'Use the latest vue-eslint-parser. See also https://vuejs.github.io/eslint-plugin-vue/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.',
+        });
+        return;
+      }
+
+      hasTemplate = Boolean(node.templateBody);
+    },
+  };
+
+  const scriptVisitor = Object.assign(
+    {},
+    {
+      'MemberExpression[object.type="ThisExpression"][property.type="Identifier"][property.name]'(
+        node
+      ) {
+        thisExpressionsVariablesNames.push(node.property.name);
+      },
+    },
+    utils.executeOnVue(context, obj => {
+      unusedProperties = Array.from(
+        utils.iterateProperties(obj, new Set(['props', 'data', 'computed']))
+      );
+
+      const watchers = Array.from(utils.iterateProperties(obj, new Set(['watch'])));
+      const watchersNames = watchers.map(watcher => watcher.name);
+
+      remove(unusedProperties, property => {
+        return (
+          thisExpressionsVariablesNames.includes(property.name) ||
+          watchersNames.includes(property.name)
+        );
+      });
+
+      if (!hasTemplate && unusedProperties.length) {
+        reportUnusedProperties(context, unusedProperties);
+      }
+    })
+  );
+
+  const templateVisitor = {
+    'VExpressionContainer[expression!=null][references]'(node) {
+      const referencesNames = getReferencesNames(node.references);
+
+      remove(unusedProperties, property => {
+        return referencesNames.includes(property.name);
+      });
+    },
+    // save root template end location - just a helper to be used
+    // for a decision if a parser reached the end of the root template
+    "VElement[name='template']"(node) {
+      if (rootTemplateEnd) {
+        return;
+      }
+
+      rootTemplateEnd = node.loc.end;
+    },
+    "VElement[name='template']:exit"(node) {
+      if (node.loc.end !== rootTemplateEnd) {
+        return;
+      }
+
+      if (unusedProperties.length) {
+        reportUnusedProperties(context, unusedProperties);
+      }
+    },
+  };
+
+  return Object.assign(
+    {},
+    initialize,
+    utils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unused properties, data or computed properties',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
@@ -1,0 +1,668 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-no-unused-properties');
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+tester.run('vue-no-unused-properties', rule, {
+  valid: [
+    // a property used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: ['count'],
+            created() {
+              alert(this.count + 1)
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a property being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: {
+              count: {
+                type: Number,
+                default: 0
+              }
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `,
+    },
+
+    // a property used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            props: ['count']
+          }
+        </script>
+      `,
+    },
+
+    // properties used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+
+        <script>
+          export default {
+            props: ['count1', 'count2']
+          };
+        </script>
+      `,
+    },
+
+    // a property used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            props: {
+              count: {
+                type: Number
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a property used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            props: {
+              colors: {
+                type: Array,
+                default: () => []
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a property used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+
+        <script>
+          export default {
+            props: ['message']
+          };
+        </script>
+      `,
+    },
+
+    // a property passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `,
+    },
+
+    // a property used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="alert(count)" />
+        </template>
+
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `,
+    },
+
+    // data used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            },
+            created() {
+              alert(this.count + 1)
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            data() {
+              return {
+                count: 2
+              };
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `,
+    },
+
+    // data used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          }
+        </script>
+      `,
+    },
+
+    // data used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count1: 1,
+                count2: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                colors: ["purple", "green"]
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                message: "<span>Hey!</span>"
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data used in v-model
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <input v-model="count" />
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="count++" />
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // computed property used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            },
+            created() {
+              const dummy = this.count + 1;
+            }
+          };
+        </script>
+      `,
+    },
+
+    // computed property being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `,
+    },
+
+    // computed property used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `,
+    },
+
+    // computed properties used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              count1() {
+                return 1;
+              },
+              count2() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `,
+    },
+
+    // computed property used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `,
+    },
+
+    // computed property used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              colors() {
+                return ["purple", "green"];
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // computed property used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              message() {
+                return "<span>Hey!</span>";
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // computed property used in v-model
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <input v-model="fullName" />
+        </template>
+
+        <script>
+          export default {
+            data() {
+              return {
+                firstName: "David",
+                lastName: "Attenborough"
+              }
+            },
+            computed: {
+              fullName: {
+                get() {
+                  return this.firstName + ' ' + this.lastName
+                },
+                set(newValue) {
+                  var names = newValue.split(' ')
+                  this.firstName = names[0]
+                  this.lastName = names[names.length - 1]
+                }
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // computed property passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `,
+    },
+
+    // ignores unused data when marked with eslint-disable
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                // eslint-disable-next-line
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+    },
+  ],
+
+  invalid: [
+    // unused property
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused property found: "count"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused data
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused data found: "count"',
+          line: 10,
+        },
+      ],
+    },
+
+    // unused computed property
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused computed property found: "count"',
+          line: 9,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -121,5 +121,6 @@ module.exports = {
     // Custom vue rules
     'kolibri/vue-filename-and-component-name-match': ERROR,
     'kolibri/vue-component-registration-casing': ERROR,
+    'kolibri/vue-no-unused-properties': ERROR,
   },
 };


### PR DESCRIPTION
### Summary

1. Implement eslint rule that reports unused properties, data, and computed properties
2. Turn it on and deal with it
3. The last commit contains fix for the following issue: One of the reported errors showed that there was a development mock label in a group exercise lesson report link leading back to a parent lesson page (Coach -> Reports -> Groups –> select a group lesson <lesson_title> -> select an exercise belonging to this lesson and watch backlink label (should be 'Back to "<lesson_title>"' but was 'Back to “Lesson 1"')

**Before**
![before](https://user-images.githubusercontent.com/13509191/55672231-f4fceb00-5898-11e9-9f24-0f20c430374c.gif)

**After**
![after](https://user-images.githubusercontent.com/13509191/55672234-fb8b6280-5898-11e9-9959-05117bf3ca34.gif)

### Reviewer guidance
- Break it :)! Any ideas about possibly untreated situations or edge cases?
- I tried to be careful and check that there is no hidden usage for all properties removed in 
055bfc3 , though I would appreciate if someone had a look
- In 582dcab I removed constants from properties. This could also be solved be leaving them in properties but referencing them using `this`. I guess there's no need to save them to an instance and it's also a bit more visible that they are some common definitions and constants, but I don't have any preference so if someone prefers the second solution, no problem.
- In 9ca2dae I commented out all unused properties related to to commented out template TODO code. I could remove everything but I suppose that it is under development? If it's not the case, I'll remove everything including those template parts.

### References

Partially solves  #4992.

----

As discussed in #4992, as soon as it's ready, I would like to open the rule PR directly in eslint-plugin-vue repo where there's already an issue for this rule opened and proposal accepted.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
