### PR TITLE
In GroupEnrollmentPage, dedupe user IDs sent to Membership API

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -1,3 +1,4 @@
+import uniq from 'lodash/uniq';
 import { LearnerGroupResource, MembershipResource } from 'kolibri.resources';
 
 function _groupState(group) {
@@ -66,17 +67,15 @@ export function deleteGroup(store, groupId) {
 }
 
 function _addMultipleUsersToGroup(store, groupId, userIds) {
-  const memberships = userIds.map(userId => ({
-    collection: groupId,
-    user: userId,
-  }));
-
   return new Promise((resolve, reject) => {
     MembershipResource.saveCollection({
       getParams: {
         collection: groupId,
       },
-      data: memberships,
+      data: uniq(userIds).map(userId => ({
+        collection: groupId,
+        user: userId,
+      })),
     }).then(
       () => {
         const groups = Array(...store.state.groups);

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -63,7 +63,7 @@
           <UiIconButton
             type="primary"
             :ariaLabel="$tr('nextResults')"
-            :disabled="pageNum === numPages"
+            :disabled="numPages === 0 || pageNum === numPages"
             size="small"
             @click="goToPage(pageNum + 1)"
           >

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
@@ -45,7 +45,7 @@
       <UiIconButton
         type="primary"
         :ariaLabel="$tr('nextResults')"
-        :disabled="pageNum === numPages"
+        :disabled="pageNum === 0 || pageNum === numPages"
         size="small"
         @click="goToPage(pageNum + 1)"
       >

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -14,6 +14,7 @@
               :showLabel="true"
               :checked="allAreSelected"
               class="overflow-label"
+              :disabled="users.length === 0"
               @change="selectAll($event)"
             />
           </th>

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -37,7 +37,7 @@
         </tr>
       </thead>
 
-      <transition-group slot="tbody" tag="tbody" name="list">
+      <tbody slot="tbody">
         <tr
           v-for="user in users"
           :key="user.id"
@@ -84,7 +84,7 @@
             <slot name="action" :user="user"></slot>
           </td>
         </tr>
-      </transition-group>
+      </tbody>
     </CoreTable>
 
     <p
@@ -200,7 +200,6 @@
     // Overrides overflow-x: hidden rule for CoreTable th's
     overflow-x: visible;
 
-    // white-space: nowrap;
     .k-checkbox-container {
       margin-right: -70px;
     }


### PR DESCRIPTION
### Summary

1. Fixes #5350 
1. Disables select-all and next-page buttons in UserTable when there are no users
1. Removes a transition-group in UserTable to avoid in-out transition that moves lines around when changing pages.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
