### PR TITLE
Consistent style for auth messages

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -77,7 +77,10 @@
           :details="authorizationErrorDetails"
         />
       </KPageContainer>
-      <AppError v-else-if="error" />
+      <KPageContainer v-else-if="error">
+        <AppError />
+      </KPageContainer>
+
       <slot v-else></slot>
     </div>
 

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -70,12 +70,13 @@
         <div>{{ routePath }}</div>
       </div>
 
-      <AuthMessage
-        v-if="notAuthorized"
-        :authorizedRole="authorizedRole"
-        :header="authorizationErrorHeader"
-        :details="authorizationErrorDetails"
-      />
+      <KPageContainer v-if="notAuthorized">
+        <AuthMessage
+          :authorizedRole="authorizedRole"
+          :header="authorizationErrorHeader"
+          :details="authorizationErrorDetails"
+        />
+      </KPageContainer>
       <AppError v-else-if="error" />
       <slot v-else></slot>
     </div>
@@ -110,6 +111,7 @@
   import SideNav from 'kolibri.coreVue.components.SideNav';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
+  import KPageContainer from 'kolibri.coreVue.components.KPageContainer';
   import { throttle } from 'frame-throttle';
   import Lockr from 'lockr';
   import { UPDATE_MODAL_DISMISSED } from 'kolibri.coreVue.vuex.constants';
@@ -136,6 +138,7 @@
       AuthMessage,
       GlobalSnackbar,
       KLinearLoader,
+      KPageContainer,
       ScrollingHeader,
       UpdateNotification,
       LanguageSwitcherModal,


### PR DESCRIPTION
### Summary

Wrap all auth messages in a container component to achieve visual consistency - some messages were wrapped and some weren't before - e.g. Device pages:

<img width="1440" alt="device" src="https://user-images.githubusercontent.com/13509191/56083932-ef208000-5e2b-11e9-8d2c-6ddc71834aaa.png">


I noticed that Device pages were the only exception actually (and it could be just a side effect of routing pages inside of `KPageContainer`) - so another solution would be to remove the wrapper there but I think I still like the version with a wrapper a bit more, it makes the text to stand out a bit better.

#### Changes screenshots

| | Before  | After |
| ------------- | ------------- | ------------- |
| Facility | <img width="1440" alt="facility_before" src="https://user-images.githubusercontent.com/13509191/56083886-280c2500-5e2b-11e9-9e22-a1435ddef6df.png"> | <img width="1440" alt="facility_after" src="https://user-images.githubusercontent.com/13509191/56083902-7b7e7300-5e2b-11e9-9004-7bd2ffe55891.png"> |
| Coach | <img width="1437" alt="coach_before" src="https://user-images.githubusercontent.com/13509191/56083884-1f1b5380-5e2b-11e9-8713-4241525d11c9.png"> | <img width="1440" alt="coach_after" src="https://user-images.githubusercontent.com/13509191/56083907-80432700-5e2b-11e9-9e68-051dcbe2ad5d.png"> |

I also found another auth message to be wrapped - the one to be displayed when an unauthenticated user tries to visit Learn classes. But it seems to never be displayed right now - reported as #5360.

### Reviewer guidance

- visit `/coach` and `/facility` as logged out user

### References

Solves #5309

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
