### PR TITLE
ignore and clean sqlite file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ build_tools/crowdin-cli.jar
 *.ttf
 *.ttc
 *.otf
+
+# SQLite file
+SQLITE_MAX_VARIABLE_NUMBER.cache

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ clean-build:
 	rm -fr *.egg-info
 	rm -fr .eggs
 	rm -fr .cache
-	rm -r kolibri/dist/* || true # remove everything
+	rm -f SQLITE_MAX_VARIABLE_NUMBER.cache
+	rm -fr kolibri/dist/* || true # remove everything
 	git checkout -- kolibri/dist # restore __init__.py
 	rm -r kolibri/utils/build_config/* || true # remove everything
 	git checkout -- kolibri/utils/build_config # restore __init__.py


### PR DESCRIPTION

### Summary

recently started seeing `SQLITE_MAX_VARIABLE_NUMBER.cache`. This change should ignore it from git and clear it on `make clean`

### Reviewer guidance

make sense?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
