### PR TITLE
remove unnecessary steps in tox tests?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,19 +37,11 @@ deps =
     -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/cext.txt
 commands =
-    # Enable the plugins to ensure the configuration is read without error
-    coverage run -p kolibri plugin kolibri.plugins.learn enable
-    coverage run -p kolibri plugin kolibri.plugins.facility_management enable
-    coverage run -p kolibri plugin kolibri.plugins.device_management enable
     coverage run -p kolibri start --port=8081
     coverage run -p kolibri stop
     sh -c 'kolibri manage makemigrations --check'
     # Run the actual tests
     py.test {posargs:--cov=kolibri --cov-report= --cov-append --color=no}
-    # This is currently disabled because some process seems to be locking
-    # the directory:
-    # /bin/rm: cannot remove `/home/travis/build/learningequality/kolibri/.tox/py3.5/tmp/.kolibri': Directory not empty
-    # rm -rf {env:KOLIBRI_HOME}
 
 # Running w/o C extensions is slow, so we just do a
 # limited amount of testing


### PR DESCRIPTION
### Summary

looks like these steps are unnecessary, and presumably waste time during test execution?

### Reviewer guidance

look right? tests pass?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
