### PR TITLE
Add unused state and getters eslint rule

### DIFF
--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -32,7 +32,7 @@
 
 <script>
 
-  import { mapState, mapActions } from 'vuex';
+  import { mapActions } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KButton from 'kolibri.coreVue.components.KButton';
   import ClipboardJS from 'clipboard';
@@ -63,9 +63,6 @@
       },
     },
     computed: {
-      ...mapState({
-        error: state => state.core.error,
-      }),
       clipboardCapable() {
         return ClipboardJS.isSupported();
       },

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -97,7 +97,6 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -163,10 +162,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'isSuperuser', 'isAdmin', 'isCoach', 'canManageContent']),
-      ...mapState({
-        session: state => state.core.session,
-      }),
       footerMsg() {
         return this.$tr('poweredBy', { version: __version });
       },

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
@@ -40,7 +40,6 @@
     mixins: [commonCoach],
     $trs: {},
     computed: {
-      ...mapState(['classId']),
       ...mapState('classSummary', ['learnerMap']),
       ...mapState('examReportDetail', [
         'currentAttempt',
@@ -54,7 +53,6 @@
         'questionNumber',
         'questions',
         'learnerId',
-        'pageTitle',
       ]),
       ...mapState('examReportDetail', {
         closed: state => state.examLog.closed,

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionLearnersReport.vue
@@ -89,7 +89,6 @@
         'exercise',
         'interactionIndex',
         'learnerId',
-        'questionNumber',
         'questionId',
         'title',
       ]),

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -222,19 +222,14 @@
     },
     computed: {
       ...mapState(['pageName', 'toolbarRoute']),
-      ...mapGetters({
-        channels: 'getChannels',
-      }),
       ...mapGetters('examCreation', ['numRemainingSearchResults']),
       ...mapState('examCreation', [
-        'title',
         'numberOfQuestions',
         'contentList',
         'selectedExercises',
         'availableQuestions',
         'searchResults',
         'ancestors',
-        'examsModalSet',
       ]),
       maxQs() {
         return MAX_QUESTIONS;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -137,7 +137,7 @@
     computed: {
       ...mapState(['pageName', 'toolbarRoute']),
       ...mapState('classSummary', { classId: 'id' }),
-      ...mapState('lessonSummary', ['currentLesson', 'workingResources', 'resourceCache']),
+      ...mapState('lessonSummary', ['currentLesson', 'workingResources']),
       ...mapState('lessonSummary/resources', [
         'ancestorCounts',
         'contentList',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -77,7 +77,7 @@
     },
     computed: {
       ...mapState(['classList']),
-      ...mapState('classSummary', { classId: 'id', className: 'name' }),
+      ...mapState('classSummary', { classId: 'id' }),
       ...mapState('lessonSummary', ['currentLesson', 'lessonsModalSet', 'learnerGroups']),
       AssignmentActions() {
         return AssignmentActions;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
@@ -119,7 +119,6 @@
         lessonActive: state => state.currentLesson.is_active,
         lessonDescription: state => state.currentLesson.description,
         lessonAssignments: state => state.currentLesson.lesson_assignments,
-        lessonResources: state => state.currentLesson.resources,
         learnerGroups: state => state.learnerGroups,
         workingResources: state => state.workingResources,
       }),

--- a/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/LearnerExerciseDetailPage/LearnerExerciseReportOld.vue
@@ -88,7 +88,6 @@
     },
     computed: {
       ...mapState(['pageName', 'reportRefreshInterval']),
-      ...mapState('classSummary', { classId: 'id' }),
       ...mapGetters('exerciseDetail', [
         'currentAttemptLog',
         'currentInteraction',

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
@@ -62,7 +62,7 @@
     },
     computed: {
       ...mapGetters('manageContent/wizard', ['driveCanBeUsedForTransfer', 'isImportingMore']),
-      ...mapState('manageContent/wizard', ['driveList', 'transferType', 'transferredChannel']),
+      ...mapState('manageContent/wizard', ['driveList', 'transferType']),
       inImportMode() {
         return this.transferType === TransferTypes.LOCALIMPORT;
       },

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -49,7 +49,7 @@
 
 <script>
 
-  import { mapActions, mapGetters, mapMutations } from 'vuex';
+  import { mapActions, mapMutations } from 'vuex';
   import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
   import { RemoteChannelResource } from 'kolibri.resources';
   import KModal from 'kolibri.coreVue.components.KModal';
@@ -71,9 +71,6 @@
         kolibriStudioIsOffline: false,
         ContentSources,
       };
-    },
-    computed: {
-      ...mapGetters('manageContent/wizard', ['isImportingMore']),
     },
     created() {
       setTimeout(() => {

--- a/kolibri/plugins/device_management/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManagePermissionsPage/index.vue
@@ -27,7 +27,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapGetters } from 'vuex';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import KFilterTextbox from 'kolibri.coreVue.components.KFilterTextbox';
   import UserGrid from './UserGrid';
@@ -51,7 +51,6 @@
     },
     computed: {
       ...mapGetters(['isSuperuser']),
-      ...mapState('managePermissions', ['facilityUsers']),
     },
     $trs: {
       devicePermissionsHeader: 'Device permissions',

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -207,11 +207,7 @@ oriented data synchronization.
     },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
-      ...mapState('topicsTree', {
-        topicsTreeContent: 'content',
-      }),
       ...mapState({
-        pageName: state => state.pageName,
         mastered: state => state.core.logging.mastery.complete,
         currentInteractions: state => state.core.logging.attempt.interaction_history.length,
         totalattempts: state => state.core.logging.mastery.totalattempts,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -188,7 +188,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'contentPoints', 'pageMode']),
+      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'pageMode']),
       ...mapState(['pageName']),
       ...mapState('topicsTree', ['content', 'channel', 'recommended']),
       ...mapState('topicsTree', {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -144,9 +144,7 @@
       };
     },
     computed: {
-      ...mapState(['examAttemptLogs']),
       ...mapState('examViewer', [
-        'channelId',
         'exam',
         'content',
         'itemId',

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -25,7 +25,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import lastItem from 'lodash/last';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
@@ -86,7 +86,6 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
         currentLesson: 'currentLesson',

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonResourceViewer.vue
@@ -71,7 +71,6 @@
     },
     computed: {
       ...mapState('lessonPlaylist/resource', {
-        currentLesson: state => state.currentLesson,
         currentLessonResource: state => state.content,
         nextLessonResource: state => state.content.next_content,
       }),

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -199,7 +199,7 @@
       ...mapState({
         session: state => state.core.session,
       }),
-      ...mapState('profile', ['busy', 'errorCode', 'passwordState', 'success']),
+      ...mapState('profile', ['busy', 'passwordState', 'success']),
       ...mapState('profile', {
         profileErrors: 'errors',
       }),

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -164,7 +164,7 @@
       privacyModalVisible: false,
     }),
     computed: {
-      ...mapGetters(['facilities', 'session']),
+      ...mapGetters(['facilities']),
       ...mapState('signUp', ['errors', 'busy']),
       facilityList() {
         return this.facilities.map(facility => ({

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const remove = require('lodash/remove');
-const utils = require('eslint-plugin-vue/lib/utils');
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const GROUP_PROPERTY = 'props';
 const GROUP_DATA = 'data';
@@ -75,12 +75,17 @@ const create = context => {
         thisExpressionsVariablesNames.push(node.property.name);
       },
     },
-    utils.executeOnVue(context, obj => {
+    eslintPluginVueUtils.executeOnVue(context, obj => {
       unusedProperties = Array.from(
-        utils.iterateProperties(obj, new Set([GROUP_PROPERTY, GROUP_DATA, GROUP_COMPUTED_PROPERTY]))
+        eslintPluginVueUtils.iterateProperties(
+          obj,
+          new Set([GROUP_PROPERTY, GROUP_DATA, GROUP_COMPUTED_PROPERTY])
+        )
       );
 
-      const watchers = Array.from(utils.iterateProperties(obj, new Set([GROUP_WATCHER])));
+      const watchers = Array.from(
+        eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCHER]))
+      );
       const watchersNames = watchers.map(watcher => watcher.name);
 
       remove(unusedProperties, property => {
@@ -127,7 +132,7 @@ const create = context => {
   return Object.assign(
     {},
     initialize,
-    utils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
   );
 };
 

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -1,0 +1,208 @@
+/**
+ * @fileoverview Disallow unused Vuex state and getters.
+ */
+
+'use strict';
+
+const remove = require('lodash/remove');
+const utils = require('eslint-plugin-vue/lib/utils');
+
+const GROUP_WATCHER = 'watch';
+const GETTER = 'getter';
+const STATE = 'state';
+
+const getReferencesNames = references => {
+  if (!references || !references.length) {
+    return [];
+  }
+
+  return references.map(reference => {
+    if (!reference.id || !reference.id.name) {
+      return;
+    }
+
+    return reference.id.name;
+  });
+};
+
+const reportUnusedVuexProperties = (context, properties) => {
+  if (!properties || !properties.length) {
+    return;
+  }
+
+  properties.forEach(property => {
+    context.report({
+      node: property.node,
+      message: `Unused Vuex ${property.kind} found: "${property.name}"`,
+    });
+  });
+};
+
+const create = context => {
+  let hasTemplate;
+  let rootTemplateEnd;
+  let unusedVuexProperties = [];
+  let thisExpressionsVariablesNames = [];
+
+  const initialize = {
+    Program(node) {
+      if (context.parserServices.getTemplateBodyTokenStore == null) {
+        context.report({
+          loc: { line: 1, column: 0 },
+          message:
+            'Use the latest vue-eslint-parser. See also https://vuejs.github.io/eslint-plugin-vue/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.',
+        });
+        return;
+      }
+
+      hasTemplate = Boolean(node.templateBody);
+    },
+  };
+
+  const scriptVisitor = Object.assign(
+    {
+      'MemberExpression[object.type="ThisExpression"][property.type="Identifier"][property.name]'(
+        node
+      ) {
+        thisExpressionsVariablesNames.push(node.property.name);
+      },
+    },
+    /*
+      computed: mapState({
+        count: state => state.todosCount
+      })
+
+      computed: {
+        ...mapState({
+          count: state => state.todosCount
+        })
+      }
+
+      computed: mapState({
+        count (state) {
+          return state.todosCount
+        }
+      })
+    */
+    {
+      'CallExpression[callee.name=mapState][arguments] ObjectExpression Property[key.name]'(node) {
+        unusedVuexProperties.push({
+          kind: STATE,
+          name: node.key.name,
+          node,
+        });
+      },
+    },
+    /*
+      computed: mapState(['count'])
+
+      computed: {
+        ...mapState(['count'])
+      }
+    */
+    {
+      'CallExpression[callee.name=mapState][arguments] ArrayExpression Literal[value]'(node) {
+        unusedVuexProperties.push({
+          kind: STATE,
+          name: node.value,
+          node,
+        });
+      },
+    },
+    /*
+      computed: mapGetters(['count1', 'count2'])
+
+      computed: {
+        ...mapGetters(['count']),
+      }
+    */
+    {
+      'CallExpression[callee.name=mapGetters][arguments] ArrayExpression Literal[value]'(node) {
+        unusedVuexProperties.push({
+          kind: GETTER,
+          name: node.value,
+          node,
+        });
+      },
+    },
+    /*
+      computed: mapGetters({
+        count: 'todosCount'
+      })
+
+      computed: {
+        ...mapGetters({
+          count: 'todosCount'
+        })
+      }
+    */
+    {
+      'CallExpression[callee.name=mapGetters][arguments] ObjectExpression Identifier[name]'(node) {
+        unusedVuexProperties.push({
+          kind: GETTER,
+          name: node.name,
+          node,
+        });
+      },
+    },
+    utils.executeOnVue(context, obj => {
+      const watchers = Array.from(utils.iterateProperties(obj, new Set([GROUP_WATCHER])));
+      const watchersNames = watchers.map(watcher => watcher.name);
+
+      remove(unusedVuexProperties, property => {
+        return (
+          thisExpressionsVariablesNames.includes(property.name) ||
+          watchersNames.includes(property.name)
+        );
+      });
+
+      if (!hasTemplate && unusedVuexProperties.length) {
+        reportUnusedVuexProperties(context, unusedVuexProperties);
+      }
+    })
+  );
+
+  const templateVisitor = {
+    'VExpressionContainer[expression!=null][references]'(node) {
+      const referencesNames = getReferencesNames(node.references);
+
+      remove(unusedVuexProperties, property => {
+        return referencesNames.includes(property.name);
+      });
+    },
+    // save root template end location - just a helper to be used
+    // for a decision if a parser reached the end of the root template
+    "VElement[name='template']"(node) {
+      if (rootTemplateEnd) {
+        return;
+      }
+
+      rootTemplateEnd = node.loc.end;
+    },
+    "VElement[name='template']:exit"(node) {
+      if (node.loc.end !== rootTemplateEnd) {
+        return;
+      }
+
+      if (unusedVuexProperties.length) {
+        reportUnusedVuexProperties(context, unusedVuexProperties);
+      }
+    },
+  };
+
+  return Object.assign(
+    {},
+    initialize,
+    utils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unused Vuex state and getters',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const remove = require('lodash/remove');
-const utils = require('eslint-plugin-vue/lib/utils');
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const GROUP_WATCHER = 'watch';
 const GETTER = 'getter';
@@ -145,8 +145,10 @@ const create = context => {
         });
       },
     },
-    utils.executeOnVue(context, obj => {
-      const watchers = Array.from(utils.iterateProperties(obj, new Set([GROUP_WATCHER])));
+    eslintPluginVueUtils.executeOnVue(context, obj => {
+      const watchers = Array.from(
+        eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCHER]))
+      );
       const watchersNames = watchers.map(watcher => watcher.name);
 
       remove(unusedVuexProperties, property => {
@@ -193,7 +195,7 @@ const create = context => {
   return Object.assign(
     {},
     initialize,
-    utils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
   );
 };
 

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -7,23 +7,10 @@
 const remove = require('lodash/remove');
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
-const GROUP_WATCHER = 'watch';
+const utils = require('../utils');
+
 const GETTER = 'getter';
 const STATE = 'state';
-
-const getReferencesNames = references => {
-  if (!references || !references.length) {
-    return [];
-  }
-
-  return references.map(reference => {
-    if (!reference.id || !reference.id.name) {
-      return;
-    }
-
-    return reference.id.name;
-  });
-};
 
 const reportUnusedVuexProperties = (context, properties) => {
   if (!properties || !properties.length) {
@@ -40,18 +27,12 @@ const reportUnusedVuexProperties = (context, properties) => {
 
 const create = context => {
   let hasTemplate;
-  let rootTemplateEnd;
   let unusedVuexProperties = [];
   let thisExpressionsVariablesNames = [];
 
   const initialize = {
     Program(node) {
-      if (context.parserServices.getTemplateBodyTokenStore == null) {
-        context.report({
-          loc: { line: 1, column: 0 },
-          message:
-            'Use the latest vue-eslint-parser. See also https://vuejs.github.io/eslint-plugin-vue/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.',
-        });
+      if (!utils.checkVueEslintParser(context)) {
         return;
       }
 
@@ -60,13 +41,7 @@ const create = context => {
   };
 
   const scriptVisitor = Object.assign(
-    {
-      'MemberExpression[object.type="ThisExpression"][property.type="Identifier"][property.name]'(
-        node
-      ) {
-        thisExpressionsVariablesNames.push(node.property.name);
-      },
-    },
+    {},
     /*
       computed: mapState({
         count: state => state.todosCount
@@ -145,11 +120,11 @@ const create = context => {
         });
       },
     },
+    utils.executeOnThisExpressionProperty(property => {
+      thisExpressionsVariablesNames.push(property.name);
+    }),
     eslintPluginVueUtils.executeOnVue(context, obj => {
-      const watchers = Array.from(
-        eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCHER]))
-      );
-      const watchersNames = watchers.map(watcher => watcher.name);
+      const watchersNames = utils.getWatchersNames(obj);
 
       remove(unusedVuexProperties, property => {
         return (
@@ -164,33 +139,23 @@ const create = context => {
     })
   );
 
-  const templateVisitor = {
-    'VExpressionContainer[expression!=null][references]'(node) {
-      const referencesNames = getReferencesNames(node.references);
+  const templateVisitor = Object.assign(
+    {},
+    {
+      'VExpressionContainer[expression!=null][references]'(node) {
+        const referencesNames = utils.getReferencesNames(node.references);
 
-      remove(unusedVuexProperties, property => {
-        return referencesNames.includes(property.name);
-      });
+        remove(unusedVuexProperties, property => {
+          return referencesNames.includes(property.name);
+        });
+      },
     },
-    // save root template end location - just a helper to be used
-    // for a decision if a parser reached the end of the root template
-    "VElement[name='template']"(node) {
-      if (rootTemplateEnd) {
-        return;
-      }
-
-      rootTemplateEnd = node.loc.end;
-    },
-    "VElement[name='template']:exit"(node) {
-      if (node.loc.end !== rootTemplateEnd) {
-        return;
-      }
-
+    utils.executeOnRootTemplateEnd(() => {
       if (unusedVuexProperties.length) {
         reportUnusedVuexProperties(context, unusedVuexProperties);
       }
-    },
-  };
+    })
+  );
 
   return Object.assign(
     {},

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
+
+const GROUP_WATCHER = 'watch';
+
+module.exports = {
+  /**
+   * Extract names from references objects
+   */
+  getReferencesNames(references) {
+    if (!references || !references.length) {
+      return [];
+    }
+
+    return references.map(reference => {
+      if (!reference.id || !reference.id.name) {
+        return;
+      }
+
+      return reference.id.name;
+    });
+  },
+
+  /**
+   * Check if there's vue-eslint-parser available.
+   * If not, report a problem.
+   */
+  checkVueEslintParser(context) {
+    if (context.parserServices.getTemplateBodyTokenStore == null) {
+      context.report({
+        loc: { line: 1, column: 0 },
+        message:
+          'Use the latest vue-eslint-parser. See also https://vuejs.github.io/eslint-plugin-vue/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.',
+      });
+
+      return false;
+    }
+
+    return true;
+  },
+
+  /**
+   * Get an array of watchers names.
+   * @param {Object} obj Vue objec
+   */
+  getWatchersNames(obj) {
+    const watchers = Array.from(
+      eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCHER]))
+    );
+    return watchers.map(watcher => watcher.name);
+  },
+
+  /**
+   * Run callback on this expression properties nodes.
+   */
+  executeOnThisExpressionProperty(func) {
+    return {
+      'MemberExpression[object.type="ThisExpression"][property.type="Identifier"][property.name]'(
+        node
+      ) {
+        func(node.property);
+      },
+    };
+  },
+
+  /**
+   * Run callback when end of the root template reached.
+   */
+  executeOnRootTemplateEnd(func) {
+    let rootTemplateEnd;
+
+    return {
+      "VElement[name='template']"(node) {
+        if (rootTemplateEnd) {
+          return;
+        }
+
+        rootTemplateEnd = node.loc.end;
+      },
+      "VElement[name='template']:exit"(node) {
+        if (node.loc.end !== rootTemplateEnd) {
+          return;
+        }
+
+        func();
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
@@ -1,0 +1,701 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-no-unused-vuex-properties');
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+tester.run('vue-no-unused-vuex-properties', rule, {
+  valid: [
+    // a getter used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapGetters(['count']),
+            created() {
+              alert(this.count)
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a getter being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapGetters(['count']),
+            watch: {
+              count() {
+                alert('Increased!');
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a getter used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count'])
+          }
+        </script>
+      `,
+    },
+
+    // getters used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count1', 'count2'])
+          };
+        </script>
+      `,
+    },
+
+    // a getter used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count'])
+          };
+        </script>
+      `,
+    },
+
+    // a getter used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['colors'])
+          };
+        </script>
+      `,
+    },
+
+    // a getter used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['message'])
+          };
+        </script>
+      `,
+    },
+
+    // a getter passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count'])
+          };
+        </script>
+      `,
+    },
+
+    // a getter used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="alert(count)" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count'])
+          };
+        </script>
+      `,
+    },
+
+    // namespaced module getter
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters('module', ['count'])
+          }
+        </script>
+      `,
+    },
+
+    // a getter imported with spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapGetters(['count'])
+            }
+          }
+        </script>
+      `,
+    },
+
+    // an aliased getter
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapGetters({
+                count: 'todosCount'
+              })
+            }
+          }
+        </script>
+      `,
+    },
+
+    // state used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount,
+            }),
+            mounted() {
+              alert(this.count)
+            }
+          };
+        </script>
+      `,
+    },
+
+    // state being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount,
+            }),
+            watch: {
+              count() {
+                alert('Increased!');
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // state used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount,
+            })
+          }
+        </script>
+      `,
+    },
+
+    // state used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count1: state => state.todosCount,
+              count2: state => state.anotherCount
+            })
+          };
+        </script>
+      `,
+    },
+
+    // state used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount
+            })
+          };
+        </script>
+      `,
+    },
+
+    // state used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              colors: state => state.themeColors
+            })
+          };
+        </script>
+      `,
+    },
+
+    // state used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              message: state => state.msg
+            })
+          };
+        </script>
+      `,
+    },
+
+    // state passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount
+            })
+          };
+        </script>
+      `,
+    },
+
+    // state used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="alert(count)" />
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.count
+            })
+          };
+        </script>
+      `,
+    },
+
+    // namespaced module state
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState('module', {
+              count: state => state.todosCount
+            })
+          }
+        </script>
+      `,
+    },
+
+    // state imported with spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapState({
+                count: state => state.todosCount
+              })
+            }
+          }
+        </script>
+      `,
+    },
+
+    // state function
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ countPlusLocalState }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              countPlusLocalState (state) {
+                return state.count + this.localCount
+              }
+            })
+          }
+        </script>
+      `,
+    },
+
+    // state as an array
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState(['count'])
+          }
+        </script>
+      `,
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ notificationsCount }}</div>
+          <p>{{ message }}</p>
+
+          <ul>
+            <li v-for="user in users">{{ user.name }}</li>
+          </ul>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapState(['notificationsCount']),
+              ...mapState('messages', {
+                message: state => state.message
+              }),
+              ...mapGetters(['users']),
+              ...mapGetters('todos', {
+                todosCount: 'count'
+              })
+            },
+            created() {
+              alert(this.todosCount)
+            }
+          }
+        </script>
+      `,
+    },
+  ],
+
+  invalid: [
+    // unused getter
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['count'])
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex getter found: "count"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused namespaced module getter
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters('module', ['count'])
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex getter found: "count"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused getter - spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapGetters(['count'])
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex getter found: "count"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused aliased getter
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapGetters({
+                count: 'todosCount'
+              })
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex getter found: "count"',
+          line: 10,
+        },
+      ],
+    },
+
+    // unused state
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ todosCount }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              count: state => state.todosCount
+            })
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "count"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused namespaced module state
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState('module', {
+              count: state => state.todosCount
+            })
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "count"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused state - spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ todosCount }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              ...mapState({
+                count: state => state.todosCount
+              })
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "count"',
+          line: 10,
+        },
+      ],
+    },
+
+    // unused state function
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ contPlusLocalState }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState({
+              countPlusLocalState (state) {
+                return state.count + this.localCount
+              }
+            })
+          }
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "countPlusLocalState"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused state as an array
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState(['count'])
+          }
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "count"',
+          line: 8,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -122,5 +122,6 @@ module.exports = {
     'kolibri/vue-filename-and-component-name-match': ERROR,
     'kolibri/vue-component-registration-casing': ERROR,
     'kolibri/vue-no-unused-properties': ERROR,
+    'kolibri/vue-no-unused-vuex-properties': ERROR,
   },
 };


### PR DESCRIPTION
- Implement eslint rule that reports unused mapped Vuex state and getters
- Turn it on + related cleanup

### Reviewer guidance
- Works fine?
- Is there more scenarios to be treated?
- Is cleanup ok?

### References

Solves another part of #4992.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
