### PR TITLE
Add unused methods eslint rule

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/index.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/index.vue
@@ -211,6 +211,10 @@
       stopTracking(...args) {
         this.$emit('stopTracking', ...args);
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       checkAnswer() {
         if (this.assessment && this.$refs.contentView && this.$refs.contentView.checkAnswer) {
           return this.$refs.contentView.checkAnswer();

--- a/kolibri/core/assets/src/views/ContentRenderer/index.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/index.vue
@@ -214,7 +214,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       checkAnswer() {
         if (this.assessment && this.$refs.contentView && this.$refs.contentView.checkAnswer) {
           return this.$refs.contentView.checkAnswer();

--- a/kolibri/core/assets/src/views/CoreFullscreen.vue
+++ b/kolibri/core/assets/src/views/CoreFullscreen.vue
@@ -54,7 +54,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       toggleFullscreen() {
         if (!this.toggling) {
           let fullScreenPromise;

--- a/kolibri/core/assets/src/views/CoreFullscreen.vue
+++ b/kolibri/core/assets/src/views/CoreFullscreen.vue
@@ -51,6 +51,10 @@
       }
     },
     methods: {
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       toggleFullscreen() {
         if (!this.toggling) {
           let fullScreenPromise;

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -69,18 +69,6 @@
     },
 
     methods: {
-      selectOption(option) {
-        if (option.disabled || option.type === 'divider') {
-          return;
-        }
-        this.$emit('select', option);
-        this.closeMenu();
-      },
-
-      closeMenu() {
-        this.$emit('close');
-      },
-
       redirectFocus(e) {
         e.stopPropagation();
         this.$el.querySelector('.ui-menu-option').focus();

--- a/kolibri/core/assets/src/views/KRadioButton.vue
+++ b/kolibri/core/assets/src/views/KRadioButton.vue
@@ -131,6 +131,10 @@
     },
 
     methods: {
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focus() {
         this.$refs.input.focus();
       },

--- a/kolibri/core/assets/src/views/KRadioButton.vue
+++ b/kolibri/core/assets/src/views/KRadioButton.vue
@@ -134,7 +134,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       focus() {
         this.$refs.input.focus();
       },

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -771,6 +771,10 @@
         });
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       reset() {
         this.setValue(JSON.parse(this.initialValue));
         this.clearQuery();

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -774,7 +774,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       reset() {
         this.setValue(JSON.parse(this.initialValue));
         this.clearQuery();

--- a/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
+++ b/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
@@ -332,7 +332,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       reset() {
         // Blur the input if it's focused to prevent required errors
         // when it's value is reset
@@ -354,7 +353,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       refreshSize() {
         if (this.autosizeInitialized) {
           autosize.update(this.$refs.textarea);

--- a/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
+++ b/kolibri/core/assets/src/views/KTextbox/KeenUiTextbox.vue
@@ -329,6 +329,10 @@
         this.$emit('keydown-enter', e);
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       reset() {
         // Blur the input if it's focused to prevent required errors
         // when it's value is reset
@@ -347,6 +351,10 @@
         this.isTouched = options.touched;
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       refreshSize() {
         if (this.autosizeInitialized) {
           autosize.update(this.$refs.textarea);

--- a/kolibri/core/assets/src/views/KTextbox/index.vue
+++ b/kolibri/core/assets/src/views/KTextbox/index.vue
@@ -149,6 +149,10 @@
          */
         this.$emit('input', this.currentText);
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       reset() {
         this.$refs.textbox.reset();
       },
@@ -162,6 +166,7 @@
        * @public
        * Focuses on the textbox
        */
+      // eslint-disable-next-line
       focus() {
         this.$refs.textbox.$el.querySelector('input').focus();
       },

--- a/kolibri/core/assets/src/views/KTextbox/index.vue
+++ b/kolibri/core/assets/src/views/KTextbox/index.vue
@@ -152,7 +152,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       reset() {
         this.$refs.textbox.reset();
       },
@@ -166,7 +165,6 @@
        * @public
        * Focuses on the textbox
        */
-      // eslint-disable-next-line
       focus() {
         this.$refs.textbox.$el.querySelector('input').focus();
       },

--- a/kolibri/core/assets/src/views/KeenUiIconButton.vue
+++ b/kolibri/core/assets/src/views/KeenUiIconButton.vue
@@ -199,7 +199,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       openDropdown() {
         if (this.$refs.dropdown) {
           this.$refs.dropdown.open();
@@ -219,7 +218,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       toggleDropdown() {
         if (this.$refs.dropdown) {
           this.$refs.dropdown.toggle();

--- a/kolibri/core/assets/src/views/KeenUiIconButton.vue
+++ b/kolibri/core/assets/src/views/KeenUiIconButton.vue
@@ -196,18 +196,30 @@
         this.$emit('dropdown-close');
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       openDropdown() {
         if (this.$refs.dropdown) {
           this.$refs.dropdown.open();
         }
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       closeDropdown() {
         if (this.$refs.dropdown) {
           this.$refs.dropdown.close();
         }
       },
 
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       toggleDropdown() {
         if (this.$refs.dropdown) {
           this.$refs.dropdown.toggle();

--- a/kolibri/core/assets/src/views/MultiPaneLayout.vue
+++ b/kolibri/core/assets/src/views/MultiPaneLayout.vue
@@ -67,7 +67,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       scrollMainToTop() {
         this.$refs.main.scrollTop = 0;
       },

--- a/kolibri/core/assets/src/views/MultiPaneLayout.vue
+++ b/kolibri/core/assets/src/views/MultiPaneLayout.vue
@@ -64,6 +64,10 @@
       },
     },
     methods: {
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       scrollMainToTop() {
         this.$refs.main.scrollTop = 0;
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -333,12 +333,6 @@
           this.showDeleteModal = false;
         });
       },
-      genExamRoute(examId) {
-        return {
-          name: PageNames.EXAM_PREVIEW,
-          params: { examId },
-        };
-      },
       genRecipientsString(groups) {
         if (!groups.length) {
           return this.$tr('entireClass');

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -205,20 +205,8 @@
           });
         });
       },
-      reducePageNum() {
-        while (this.visibleFilteredUsers.length === 0 && this.pageNum > 1) {
-          this.pageNum = this.pageNum - 1;
-        }
-      },
       goToPage(page) {
         this.pageNum = page;
-      },
-      pageWithinRange(page) {
-        const maxOnEachSide = 1;
-        if (this.pageNum === 1 || this.pageNum === this.numPages) {
-          return Math.abs(this.pageNum - page) <= maxOnEachSide + 1;
-        }
-        return Math.abs(this.pageNum - page) <= maxOnEachSide;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -222,12 +222,18 @@
       closeModal() {
         this.$emit('cancel');
       },
-      // NOTE: These methods are not used inside the component, but may be called
-      // from a parent component
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       handleSubmitFailure() {
         this.formIsSubmitted = false;
         this.showServerError = true;
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       handleSubmitTitleFailure() {
         this.formIsSubmitted = false;
         this.showTitleError = true;

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -225,7 +225,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       handleSubmitFailure() {
         this.formIsSubmitted = false;
         this.showServerError = true;
@@ -233,7 +232,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       handleSubmitTitleFailure() {
         this.formIsSubmitted = false;
         this.showTitleError = true;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
@@ -95,9 +95,11 @@
       },
     },
     methods: {
+      /* TODO COACH
       goTo(page) {
         this.$router.push({ name: 'NEW_COACH_PAGES', params: { page } });
       },
+      */
     },
     $trs: {
       back: 'All lessons',

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
@@ -77,9 +77,6 @@
         }
         return driveLabel;
       },
-      disabledDriveLabel(drive) {
-        return `${drive.name} (${this.disabledMsg})`;
-      },
     },
     $trs: {
       drivesFound: 'Drives found',

--- a/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
@@ -175,7 +175,10 @@
       },
     },
     methods: {
-      // Called from parent
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focusOnInput() {
         this.$refs.searchInput.focus();
       },

--- a/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SearchSideBar.vue
@@ -178,7 +178,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       focusOnInput() {
         this.$refs.searchInput.focus();
       },

--- a/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
@@ -96,12 +96,24 @@
       },
     },
     methods: {
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focusOnTocButton() {
         this.$refs.tocButton.$el.focus();
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focusOnSettingsButton() {
         this.$refs.settingsButton.$el.focus();
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focusOnSearchButton() {
         this.$refs.searchButton.$el.focus();
       },

--- a/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
@@ -99,21 +99,18 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       focusOnTocButton() {
         this.$refs.tocButton.$el.focus();
       },
       /**
        * @public
        */
-      // eslint-disable-next-line
       focusOnSettingsButton() {
         this.$refs.settingsButton.$el.focus();
       },
       /**
        * @public
        */
-      // eslint-disable-next-line
       focusOnSearchButton() {
         this.$refs.searchButton.$el.focus();
       },

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
@@ -159,20 +159,8 @@
       },
     },
     methods: {
-      reducePageNum() {
-        while (this.visibleFilteredUsers.length === 0 && this.pageNum > 1) {
-          this.pageNum = this.pageNum - 1;
-        }
-      },
       goToPage(page) {
         this.pageNum = page;
-      },
-      pageWithinRange(page) {
-        const maxOnEachSide = 1;
-        if (this.pageNum === 1 || this.pageNum === this.numPages) {
-          return Math.abs(this.pageNum - page) <= maxOnEachSide + 1;
-        }
-        return Math.abs(this.pageNum - page) <= maxOnEachSide;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -47,14 +47,6 @@
       ...mapState({ attemptLogs: 'examAttemptLogs' }),
     },
     methods: {
-      daysElapsedText(daysElapsed) {
-        if (daysElapsed > 1) {
-          return this.$tr('daysAgo', { daysElapsed });
-        } else if (daysElapsed === 1) {
-          return this.$tr('yesterday');
-        }
-        return this.$tr('today');
-      },
       questionText(num) {
         return this.$tr('question', { num });
       },

--- a/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
@@ -67,7 +67,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { PageNames } from '../constants';
@@ -92,9 +92,6 @@
     },
     mixins: [responsiveWindow],
     computed: {
-      ...mapGetters({
-        channels: 'getChannels',
-      }),
       ...mapState('recommended', ['nextSteps', 'popular', 'resume']),
       carouselLimit() {
         return this.windowIsSmall ? mobileCarouselLimit : desktopCarouselLimit;
@@ -133,12 +130,6 @@
             last: this.$store.state.pageName,
           },
         };
-      },
-      trimContent(content) {
-        return content.slice(0, this.carouselLimit);
-      },
-      getChannelTitle(channel_id) {
-        return this.channels.find(channel => channel.id === channel_id).title;
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
@@ -48,6 +48,10 @@
       validateFacilityName() {
         this.fieldVisited = true;
       },
+      /**
+       * @public
+       */
+      // eslint-disable-next-line
       focus() {
         if (this.$refs['facilityName']) {
           this.$refs['facilityName'].focus();

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
@@ -51,7 +51,6 @@
       /**
        * @public
        */
-      // eslint-disable-next-line
       focus() {
         if (this.$refs['facilityName']) {
           this.$refs['facilityName'].focus();

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -286,7 +286,9 @@
       },
     },
     watch: {
-      username: 'setSuggestionTerm',
+      username() {
+        this.setSuggestionTerm();
+      },
     },
     mounted() {
       /*

--- a/packages/eslint-plugin-kolibri/lib/constants.js
+++ b/packages/eslint-plugin-kolibri/lib/constants.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const GROUP_PROPS = 'props';
+const GROUP_DATA = 'data';
+const GROUP_COMPUTED = 'computed';
+const GROUP_METHODS = 'methods';
+const GROUP_WATCH = 'watch';
+
+const PROPERTY_LABEL = {
+  [GROUP_PROPS]: 'property',
+  [GROUP_DATA]: 'data',
+  [GROUP_COMPUTED]: 'computed property',
+  [GROUP_METHODS]: 'method',
+};
+
+module.exports = {
+  GROUP_PROPS,
+  GROUP_DATA,
+  GROUP_COMPUTED,
+  GROUP_METHODS,
+  GROUP_WATCH,
+  PROPERTY_LABEL,
+};

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -8,25 +8,9 @@ const remove = require('lodash/remove');
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const utils = require('../utils');
+const constants = require('../constants');
 
-const GROUP_METHODS = 'methods';
-
-const PROPERTY_LABEL = {
-  [GROUP_METHODS]: 'method',
-};
-
-const reportUnusedProperties = (context, properties) => {
-  if (!properties || !properties.length) {
-    return;
-  }
-
-  properties.forEach(property => {
-    context.report({
-      node: property.node,
-      message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
-    });
-  });
-};
+const { GROUP_METHODS } = constants;
 
 const create = context => {
   let hasTemplate;
@@ -58,7 +42,7 @@ const create = context => {
       });
 
       if (!hasTemplate && unusedProperties.length) {
-        reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties);
       }
     })
   );
@@ -76,7 +60,7 @@ const create = context => {
     },
     utils.executeOnRootTemplateEnd(() => {
       if (unusedProperties.length) {
-        reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties);
       }
     })
   );

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Disallow unused methods.
+ */
+
+'use strict';
+
+const remove = require('lodash/remove');
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
+
+const utils = require('../utils');
+
+const GROUP_METHODS = 'methods';
+
+const PROPERTY_LABEL = {
+  [GROUP_METHODS]: 'method',
+};
+
+const reportUnusedProperties = (context, properties) => {
+  if (!properties || !properties.length) {
+    return;
+  }
+
+  properties.forEach(property => {
+    context.report({
+      node: property.node,
+      message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
+    });
+  });
+};
+
+const create = context => {
+  let hasTemplate;
+  let unusedProperties = [];
+  let thisExpressionsVariablesNames = [];
+
+  const initialize = {
+    Program(node) {
+      if (!utils.checkVueEslintParser(context)) {
+        return;
+      }
+
+      hasTemplate = Boolean(node.templateBody);
+    },
+  };
+
+  const scriptVisitor = Object.assign(
+    {},
+    utils.executeOnThisExpressionProperty(property => {
+      thisExpressionsVariablesNames.push(property.name);
+    }),
+    eslintPluginVueUtils.executeOnVue(context, obj => {
+      unusedProperties = Array.from(
+        eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_METHODS]))
+      );
+
+      remove(unusedProperties, property => {
+        return thisExpressionsVariablesNames.includes(property.name);
+      });
+
+      if (!hasTemplate && unusedProperties.length) {
+        reportUnusedProperties(context, unusedProperties);
+      }
+    })
+  );
+
+  const templateVisitor = Object.assign(
+    {},
+    {
+      'VExpressionContainer[expression!=null][references]'(node) {
+        const referencesNames = utils.getReferencesNames(node.references);
+
+        remove(unusedProperties, property => {
+          return referencesNames.includes(property.name);
+        });
+      },
+    },
+    utils.executeOnRootTemplateEnd(() => {
+      if (unusedProperties.length) {
+        reportUnusedProperties(context, unusedProperties);
+      }
+    })
+  );
+
+  return Object.assign(
+    {},
+    initialize,
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unused methods',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -8,9 +8,7 @@ const remove = require('lodash/remove');
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const utils = require('../utils');
-const constants = require('../constants');
-
-const { GROUP_METHODS } = constants;
+const { GROUP_METHODS } = require('../constants');
 
 const create = context => {
   let hasTemplate;

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -17,6 +17,12 @@ const create = context => {
   let unusedProperties = [];
   let thisExpressionsVariablesNames = [];
 
+  const sourceCode = context.getSourceCode();
+  const comments = sourceCode.getAllComments();
+
+  const publicCommentsEnds = utils.getPublicCommentsEnds(comments);
+  const disabledLines = publicCommentsEnds.map(value => value + 1);
+
   const initialize = {
     Program(node) {
       if (!utils.checkVueEslintParser(context)) {
@@ -42,7 +48,7 @@ const create = context => {
       });
 
       if (!hasTemplate && unusedProperties.length) {
-        utils.reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties, disabledLines);
       }
     })
   );
@@ -60,7 +66,7 @@ const create = context => {
     },
     utils.executeOnRootTemplateEnd(() => {
       if (unusedProperties.length) {
-        utils.reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties, disabledLines);
       }
     })
   );

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -8,29 +8,9 @@ const remove = require('lodash/remove');
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const utils = require('../utils');
+const constants = require('../constants');
 
-const GROUP_PROPERTY = 'props';
-const GROUP_DATA = 'data';
-const GROUP_COMPUTED_PROPERTY = 'computed';
-
-const PROPERTY_LABEL = {
-  [GROUP_PROPERTY]: 'property',
-  [GROUP_DATA]: 'data',
-  [GROUP_COMPUTED_PROPERTY]: 'computed property',
-};
-
-const reportUnusedProperties = (context, properties) => {
-  if (!properties || !properties.length) {
-    return;
-  }
-
-  properties.forEach(property => {
-    context.report({
-      node: property.node,
-      message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
-    });
-  });
-};
+const { GROUP_PROPS, GROUP_DATA, GROUP_COMPUTED } = constants;
 
 const create = context => {
   let hasTemplate;
@@ -56,7 +36,7 @@ const create = context => {
       unusedProperties = Array.from(
         eslintPluginVueUtils.iterateProperties(
           obj,
-          new Set([GROUP_PROPERTY, GROUP_DATA, GROUP_COMPUTED_PROPERTY])
+          new Set([GROUP_PROPS, GROUP_DATA, GROUP_COMPUTED])
         )
       );
 
@@ -70,7 +50,7 @@ const create = context => {
       });
 
       if (!hasTemplate && unusedProperties.length) {
-        reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties);
       }
     })
   );
@@ -88,7 +68,7 @@ const create = context => {
     },
     utils.executeOnRootTemplateEnd(() => {
       if (unusedProperties.length) {
-        reportUnusedProperties(context, unusedProperties);
+        utils.reportUnusedProperties(context, unusedProperties);
       }
     })
   );

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -54,6 +54,16 @@ module.exports = {
   },
 
   /**
+   * Return an array containing end locations of all comments containing
+   * jsdoc's `@public`
+   */
+  getPublicCommentsEnds(comments) {
+    return comments
+      .filter(comment => comment.value.includes('@public'))
+      .map(comment => comment.loc.end.line);
+  },
+
+  /**
    * Run callback on this expression properties nodes.
    */
   executeOnThisExpressionProperty(func) {
@@ -92,13 +102,18 @@ module.exports = {
 
   /**
    * Report unused Vue component properties.
+   * @param {Array} disabledLines An array of lines to not be reported, e.g. [14, 24]
    */
-  reportUnusedProperties(context, properties) {
+  reportUnusedProperties(context, properties, disabledLines) {
     if (!properties || !properties.length) {
       return;
     }
 
     properties.forEach(property => {
+      if (disabledLines && disabledLines.includes(property.node.loc.start.line)) {
+        return;
+      }
+
       context.report({
         node: property.node,
         message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -2,7 +2,9 @@
 
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
-const GROUP_WATCHER = 'watch';
+const constants = require('./constants');
+
+const { GROUP_WATCH, PROPERTY_LABEL } = constants;
 
 module.exports = {
   /**
@@ -46,7 +48,7 @@ module.exports = {
    */
   getWatchersNames(obj) {
     const watchers = Array.from(
-      eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCHER]))
+      eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_WATCH]))
     );
     return watchers.map(watcher => watcher.name);
   },
@@ -86,5 +88,21 @@ module.exports = {
         func();
       },
     };
+  },
+
+  /**
+   * Report unused Vue component properties.
+   */
+  reportUnusedProperties(context, properties) {
+    if (!properties || !properties.length) {
+      return;
+    }
+
+    properties.forEach(property => {
+      context.report({
+        node: property.node,
+        message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
+      });
+    });
   },
 };

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -4,7 +4,7 @@ const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const constants = require('./constants');
 
-const { GROUP_WATCH, PROPERTY_LABEL } = constants;
+const { GROUP_WATCH, GROUP_METHODS, PROPERTY_LABEL } = constants;
 
 module.exports = {
   /**
@@ -114,9 +114,14 @@ module.exports = {
         return;
       }
 
+      let message = `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`;
+      if (property.groupName === GROUP_METHODS) {
+        message = `${message}. If the method is supposed to be public, you might forget to add @public tag.`;
+      }
+
       context.report({
         node: property.node,
-        message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`,
+        message,
       });
     });
   },

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -116,7 +116,7 @@ module.exports = {
 
       let message = `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`;
       if (property.groupName === GROUP_METHODS) {
-        message = `${message}. If the method is supposed to be public, you might forget to add @public tag.`;
+        message = `${message}. If the method is supposed to be public, you might have forgotten to add a @public tag.`;
       }
 
       context.report({

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -217,7 +217,7 @@ tester.run('vue-no-unused-methods', rule, {
       errors: [
         {
           message:
-            'Unused method found: "getCount". If the method is supposed to be public, you might forget to add @public tag.',
+            'Unused method found: "getCount". If the method is supposed to be public, you might have forgotten to add a @public tag.',
           line: 9,
         },
       ],

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -174,6 +174,25 @@ tester.run('vue-no-unused-methods', rule, {
         </script>
       `,
     },
+
+    // a public method
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              /**
+               * @public
+               */
+              getCount() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -175,6 +175,25 @@ tester.run('vue-no-unused-methods', rule, {
       `,
     },
 
+    // a method used in a watcher (string method name)
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              counter: 'getCount'
+            },
+            methods: {
+              getCount() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
     // a public method
     {
       filename: 'test.vue',

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-no-unused-methods');
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+tester.run('vue-no-unused-methods', rule, {
+  valid: [
+    // a method used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              getCount() {
+                return 2;
+              }
+            },
+            created() {
+              alert(this.getCount() + 1)
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method used in a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ getCount() }}</div>
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getCount() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `,
+    },
+
+    // methods used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ getCount1() + getCount2() }}</div>
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getCount1() {
+                return 1;
+              },
+              getCount2() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="getCount() > 0"></div>
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getCount() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in getColors()">{{ color }}</div>
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getColors() {
+                return ['blue', 'green', 'violet'];
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="getMessage()" />
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getMessage() {
+                return 'Hey!';
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :handler="countHandler" />
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              countHandler(count) {
+                alert(count);
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a method used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="showMessage" />
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              showMessage() {
+                alert('Hey!')
+              }
+            }
+          };
+        </script>
+      `,
+    },
+  ],
+
+  invalid: [
+    // unused method
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ getCont() }}</div>
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              getCount() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused method found: "getCount"',
+          line: 9,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -216,7 +216,8 @@ tester.run('vue-no-unused-methods', rule, {
       `,
       errors: [
         {
-          message: 'Unused method found: "getCount"',
+          message:
+            'Unused method found: "getCount". If the method is supposed to be public, you might forget to add @public tag.',
           line: 9,
         },
       ],

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var OFF = 0;
+var WARNING = 1;
 var ERROR = 2;
 
 module.exports = {
@@ -154,5 +155,6 @@ module.exports = {
     'kolibri/vue-component-registration-casing': ERROR,
     'kolibri/vue-no-unused-properties': ERROR,
     'kolibri/vue-no-unused-vuex-properties': ERROR,
+    'kolibri/vue-no-unused-methods': WARNING,
   },
 };

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var OFF = 0;
-var WARNING = 1;
 var ERROR = 2;
 
 module.exports = {
@@ -155,6 +154,6 @@ module.exports = {
     'kolibri/vue-component-registration-casing': ERROR,
     'kolibri/vue-no-unused-properties': ERROR,
     'kolibri/vue-no-unused-vuex-properties': ERROR,
-    'kolibri/vue-no-unused-methods': WARNING,
+    'kolibri/vue-no-unused-methods': ERROR,
   },
 };


### PR DESCRIPTION
### Summary

- Implement eslint rule that reports unused Vue component methods
- Turn it on + related cleanup

When dealing with public methods, I noticed that there was one occurrence of jsdoc's `@public` tag from the past. I really liked that idea so I used it for documenting all public methods. Then I noticed that in case there's `@public` tag available, `// eslint-disabled-next-line` is somewhat duplicate information. So I experimented with `@public` comment detection in the rule which is now able to ignore methods marked with it. This also gave me enough confidence to turn the rule in error mode instead of warnings only. Does this sound useful?

### Reviewer guidance

As usual :)

- Works fine?
- Are there more scenarios to be treated?
- Is cleanup ok?

### References

Solves third part of #4992.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.rst
