### PR TITLE
Add tests for pre/post migration on bigint/integer field

### DIFF
--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -2,6 +2,7 @@ import tempfile
 import uuid
 
 from django.core.management import call_command
+from django.db import DataError
 from django.test import TestCase
 from django.test import TransactionTestCase
 from le_utils.constants import content_kinds
@@ -656,6 +657,7 @@ class FixMultipleTreesWithIdOneTestCase(TransactionTestCase):
 
 
 class CalculateChannelFieldsTestCase(TestCase):
+
     def setUp(self):
         self.node = ContentNode.objects.create(
             title="test",
@@ -679,3 +681,10 @@ class CalculateChannelFieldsTestCase(TestCase):
         self.assertEqual(
             list(self.channel.included_languages.values_list("id", flat=True)), ["en"]
         )
+
+    def test_published_size_big_integer_field(self):
+        self.channel.published_size = 2150000000  # out of range for integer field on postgres
+        try:
+            self.channel.save()
+        except DataError:
+            self.fail('DataError: integer out of range')

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -657,7 +657,6 @@ class FixMultipleTreesWithIdOneTestCase(TransactionTestCase):
 
 
 class CalculateChannelFieldsTestCase(TestCase):
-
     def setUp(self):
         self.node = ContentNode.objects.create(
             title="test",
@@ -683,8 +682,10 @@ class CalculateChannelFieldsTestCase(TestCase):
         )
 
     def test_published_size_big_integer_field(self):
-        self.channel.published_size = 2150000000  # out of range for integer field on postgres
+        self.channel.published_size = (
+            2150000000
+        )  # out of range for integer field on postgres
         try:
             self.channel.save()
         except DataError:
-            self.fail('DataError: integer out of range')
+            self.fail("DataError: integer out of range")

--- a/kolibri/core/content/test/test_data_migrations.py
+++ b/kolibri/core/content/test/test_data_migrations.py
@@ -1,3 +1,5 @@
+import os
+import unittest
 import uuid
 
 from django.db import DataError
@@ -112,10 +114,15 @@ class ChannelOrderTestCase(TestMigrations):
             self.assertEqual(channel.order, pos)
             pos += 1
 
+    @unittest.skipIf(
+        os.environ.get("TOX_ENV") != "postgres", "Should only be run for postgres"
+    )
     def test_channel_published_size(self):
         # tests the integer field overflow for postgres
         ChannelMetadata = self.apps.get_model("content", "ChannelMetadata")
         channel = ChannelMetadata.objects.first()
-        channel.published_size = 2150000000  # out of range for integer field on postgres
+        channel.published_size = (
+            2150000000
+        )  # out of range for integer field on postgres
         with self.assertRaises(DataError):
             channel.save()

--- a/kolibri/core/content/test/test_data_migrations.py
+++ b/kolibri/core/content/test/test_data_migrations.py
@@ -1,5 +1,7 @@
 import uuid
 
+from django.db import DataError
+
 from kolibri.core.auth.test.migrationtestcase import TestMigrations
 
 
@@ -109,3 +111,11 @@ class ChannelOrderTestCase(TestMigrations):
         for channel in ChannelMetadata.objects.all():
             self.assertEqual(channel.order, pos)
             pos += 1
+
+    def test_channel_published_size(self):
+        # tests the integer field overflow for postgres
+        ChannelMetadata = self.apps.get_model("content", "ChannelMetadata")
+        channel = ChannelMetadata.objects.first()
+        channel.published_size = 2150000000  # out of range for integer field on postgres
+        with self.assertRaises(DataError):
+            channel.save()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We test db state before migration 17 in the content app, to test the overflow error for integer field.
We test the db state after migration 17, to assure there is no overflow error for Big Integer field.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5366

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
