### PR TITLE
update webpack-bundle-tracker

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13018,9 +13018,10 @@ webpack-bundle-analyzer@^3.0.3:
     ws "^6.0.0"
 
 "webpack-bundle-tracker@https://github.com/learningequality/webpack-bundle-tracker":
-  version "0.0.93"
-  resolved "https://github.com/learningequality/webpack-bundle-tracker#dad5ea24ff38a794893290b4344795d342129afe"
+  version "0.4.2-beta"
+  resolved "https://github.com/learningequality/webpack-bundle-tracker#66e9c785d8d58c4b1d92ab101c6c70ea9fe83143"
   dependencies:
+    deep-extend "^0.6.0"
     mkdirp "^0.5.1"
     strip-ansi "^2.0.1"
 


### PR DESCRIPTION

### Summary

Removes the 'tapable' deprecation warnings from Kolibri build process

### Reviewer guidance

The change was made upstream but we never upgraded Kolibri

### References

https://github.com/learningequality/webpack-bundle-tracker/pull/1

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
