### PR TITLE
Adds support for a redis-cache option.

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -1,0 +1,47 @@
+import sys
+
+from kolibri.utils.conf import OPTIONS
+
+cache_options = OPTIONS["Cache"]
+
+# Default to LocMemCache, as it has the simplest configuration
+default_cache = {
+    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    # Default time out of each cache key
+    "TIMEOUT": cache_options["CACHE_TIMEOUT"],
+}
+
+built_files_prefix = "built_files"
+
+built_files_cache = {
+    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    # Default time out of each cache key
+    "TIMEOUT": cache_options["CACHE_TIMEOUT"],
+}
+
+
+if cache_options["CACHE_BACKEND"] == "redis":
+    if sys.version_info.major == 3 and sys.version_info.minor < 5:
+        raise RuntimeError(
+            "Attempted to use redis cache backend with Python 3.4, please use Python 2.7 or 3.5+"
+        )
+    base_cache = {
+        "BACKEND": "redis_cache.RedisCache",
+        "LOCATION": cache_options["CACHE_LOCATION"],
+        # Default time out of each cache key
+        "TIMEOUT": cache_options["CACHE_TIMEOUT"],
+        "OPTIONS": {"PASSWORD": cache_options["CACHE_PASSWORD"]},
+    }
+    default_cache = dict(base_cache)
+    default_cache["OPTIONS"]["DB"] = 0
+    built_files_cache = dict(base_cache)
+    built_files_cache["OPTIONS"]["DB"] = 1
+
+built_files_cache["KEY_PREFIX"] = built_files_prefix
+
+CACHES = {
+    # Default cache
+    "default": default_cache,
+    # Cache for builtfiles - frontend assets that only change on upgrade.
+    "built_files": built_files_cache,
+}

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -34,9 +34,9 @@ if cache_options["CACHE_BACKEND"] == "redis":
         "OPTIONS": {"PASSWORD": cache_options["CACHE_PASSWORD"]},
     }
     default_cache = copy.deepcopy(base_cache)
-    default_cache["OPTIONS"]["DB"] = 0
+    default_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_MIN_DB"]
     built_files_cache = copy.deepcopy(base_cache)
-    built_files_cache["OPTIONS"]["DB"] = 1
+    built_files_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_MIN_DB"] + 1
 
 built_files_cache["KEY_PREFIX"] = built_files_prefix
 

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -1,3 +1,4 @@
+import copy
 import sys
 
 from kolibri.utils.conf import OPTIONS
@@ -32,9 +33,9 @@ if cache_options["CACHE_BACKEND"] == "redis":
         "TIMEOUT": cache_options["CACHE_TIMEOUT"],
         "OPTIONS": {"PASSWORD": cache_options["CACHE_PASSWORD"]},
     }
-    default_cache = dict(base_cache)
+    default_cache = copy.deepcopy(base_cache)
     default_cache["OPTIONS"]["DB"] = 0
-    built_files_cache = dict(base_cache)
+    built_files_cache = copy.deepcopy(base_cache)
     built_files_cache["OPTIONS"]["DB"] = 1
 
 built_files_cache["KEY_PREFIX"] = built_files_prefix

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -20,8 +20,10 @@ from six.moves.urllib.parse import urljoin
 from tzlocal import get_localzone
 
 import kolibri
+from kolibri.deployment.default.cache import CACHES
 from kolibri.utils import conf
 from kolibri.utils import i18n
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 # import kolibri, so we can get the path to the module.
@@ -103,12 +105,8 @@ QUEUE_JOB_STORAGE_PATH = os.path.join(conf.KOLIBRI_HOME, "job_storage.sqlite3")
 CACHE_MIDDLEWARE_SECONDS = 0
 
 CACHE_MIDDLEWARE_KEY_PREFIX = "pages"
-CACHES = {
-    # Default cache
-    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
-    # Cache for builtfiles - frontend assets that only change on upgrade.
-    "built_files": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
-}
+
+CACHES = CACHES
 
 ROOT_URLCONF = "kolibri.deployment.default.urls"
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -67,6 +67,11 @@ option_spec = {
             "default": "localhost:6379",
             "envvars": ("KOLIBRI_CACHE_LOCATION",),
         },
+        "CACHE_REDIS_MIN_DB": {
+            "type": "integer",
+            "default": 0,
+            "envvars": ("KOLIBRI_CACHE_REDIS_MIN_DB"),
+        },
     },
     "Database": {
         "DATABASE_ENGINE": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -45,6 +45,29 @@ def calculate_thread_pool():
 
 
 option_spec = {
+    "Cache": {
+        "CACHE_BACKEND": {
+            "type": "option",
+            "options": ("memory", "redis"),
+            "default": "memory",
+            "envvars": ("KOLIBRI_CACHE_BACKEND",),
+        },
+        "CACHE_TIMEOUT": {
+            "type": "integer",
+            "default": 300,
+            "envvars": ("KOLIBRI_CACHE_TIMEOUT",),
+        },
+        "CACHE_PASSWORD": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_CACHE_PASSWORD",),
+        },
+        "CACHE_LOCATION": {
+            "type": "string",
+            "default": "kolibri_cache",
+            "envvars": ("KOLIBRI_CACHE_LOCATION",),
+        },
+    },
     "Database": {
         "DATABASE_ENGINE": {
             "type": "option",

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -64,7 +64,7 @@ option_spec = {
         },
         "CACHE_LOCATION": {
             "type": "string",
-            "default": "kolibri_cache",
+            "default": "localhost:6379",
             "envvars": ("KOLIBRI_CACHE_LOCATION",),
         },
     },

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,3 +30,5 @@ ifcfg==0.17
 sqlalchemy==1.2.10
 semver==2.8.1
 sentry-sdk==0.7.9
+django-redis-cache==2.0.0
+redis==3.2.1


### PR DESCRIPTION
### Summary
Adds an option for using django-redis-cache.

### Reviewer guidance
Does it work? If you are running redis with default settings, adding the follow lines to your options.ini should activate it:
```
[Cache]
CACHE_BACKEND = redis
CACHE_LOCATION = localhost:6379
```
`django-redis-cache` dropped support for Python3.4 in 2.0.0 - so this addition throws a runtime error if it detects it being used in Python3.4.


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
