### PR TITLE
run pytest using a temp home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ build_tools/crowdin-cli.jar
 
 # Ignore pytest cache directory
 .pytest_cache/
+.pytest_kolibri_home
 
 # ignore source font files
 *.ttf

--- a/kolibri/conftest.py
+++ b/kolibri/conftest.py
@@ -1,0 +1,14 @@
+import os
+import shutil
+
+import pytest
+
+# referenced in pytest.ini
+TEMP_KOLIBRI_HOME = "./.pytest_kolibri_home"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def global_fixture():
+    yield  # wait until the test ended
+    if os.path.exists(TEMP_KOLIBRI_HOME):
+        shutil.rmtree(TEMP_KOLIBRI_HOME)

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,6 @@ django_find_project = false
 DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
 # Settings for pytest-pythonpath
 python_paths = kolibri/dist
+env =
+    # cleaned up in conftest.py fixture
+    KOLIBRI_HOME=./.pytest_kolibri_home

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,5 +7,6 @@ mixer==6.0.1
 pytest==3.7.1 # pyup: < 4.0.0
 pytest-cov==2.5.1
 pytest-django==3.3.3
+pytest-env==0.6.2
 pytest-pythonpath==0.7.2
 sh==1.12.14


### PR DESCRIPTION
### Summary

Attempted quick fix for #4024 and #4738

### Reviewer guidance

globally sets a new kolibri home folder and then kills it at the end

let's see if the tests pass...

### References

first attempt: #4753

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
