### PR TITLE
Return calculated masterylog id and avoid constraint failed error

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -11,6 +11,7 @@ from django_filters.rest_framework import FilterSet
 from rest_framework import filters
 from rest_framework import status
 from rest_framework import viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from .models import AttemptLog
@@ -107,7 +108,7 @@ class LoggerViewSet(viewsets.ModelViewSet):
             obj.id = obj.calculate_uuid()
             final_obj = self.get_serializer(obj)
             return Response(final_obj.data)
-        except Exception as e:
+        except ValidationError as e:
             logger.error("Failed to validate data: {}".format(e))
             return Response(request.data, status.HTTP_400_BAD_REQUEST)
 

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -1,11 +1,15 @@
+import logging
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query import F
+from django.db.utils import IntegrityError
 from django.http import Http404
 from django_filters import ModelChoiceFilter
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from rest_framework import filters
+from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -35,6 +39,8 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.content.api import OptionalPageNumberPagination
 from kolibri.core.exams.models import Exam
+
+logger = logging.getLogger(__name__)
 
 
 class BaseLogFilter(FilterSet):
@@ -89,6 +95,21 @@ class LoggerViewSet(viewsets.ModelViewSet):
                 method = getattr(serializer.root, method_name)
                 default_response[field] = method(instance)
         return Response(default_response)
+
+    def create(self, request, *args, **kwargs):
+        try:
+            return super(LoggerViewSet, self).create(request, *args, **kwargs)
+        except IntegrityError:
+            # The object has been created previously: let's calculate its id and return it
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            obj = serializer.Meta.model(**serializer.validated_data)
+            obj.id = obj.calculate_uuid()
+            final_obj = self.get_serializer(obj)
+            return Response(final_obj.data)
+        except Exception as e:
+            logger.error("Failed to validate data: {}".format(e))
+            return Response(request.data, status.HTTP_400_BAD_REQUEST)
 
 
 class ContentSessionLogFilter(BaseLogFilter):


### PR DESCRIPTION
### Summary
Sometimes the frontend sends two different requests for the same logger to be saved. It seems to happen on high concurrency , probably because two different backend threads receive the same request after the user refreshes the page or insists sending it. Also #4119 gives more reasons for this to happen.

Taking the frontend reasons to do it apart, this PR deals with the backend to avoid the server sending a wrong response, disconnecting the user and avoiding him to continue the normal exercises flow.

On one side, it adds logging for the 400 errors. This will help understanding why this kind of error happens.
On the other side, if the object has already been created by the backend returns it, with its calculated id.
Using create_or_get strategy has not been possible due to the way the id is calculated in the model.



### Reviewer guidance
1. Using  _postman_ or any other REST util, doing a request like http://localhost:8000/api/logger/masterylog/?1555673658140=1555673658140 should returns a 400 error. `kolibri.log` should contain the information of the reasons for the error, indicating the fields that are missed or malformed
2. Using _Firefox_, in the network tab, filter the requests using the '`masterylog`' word. Browsing to the learn tab, when doing non-previously run exercises one request will appear. Then, using the "Edit and resend" option Firefox  has, resend the same request. Before applying this PR a 500 error will happen and the "Sorry! Something went wrong! " message will appear. After applying this PR the user won't notice anything and no error will happen.


### References
Closes: #5147 
Relates: #4119 
Probably will close #5377 because their logs show this same error.



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
