### PR TITLE
Do not report properties accessed via instance parameter in `beforeRouteEnter` as unused

### DIFF
--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -14,6 +14,7 @@ const create = context => {
   let hasTemplate;
   let unusedProperties = [];
   let thisExpressionsVariablesNames = [];
+  let befoureRouteEnterInstanceProperties = [];
   let watchStringMethods = [];
 
   const sourceCode = context.getSourceCode();
@@ -37,6 +38,9 @@ const create = context => {
     utils.executeOnThisExpressionProperty(property => {
       thisExpressionsVariablesNames.push(property.name);
     }),
+    utils.executeOnBefoureRouteEnterInstanceProperty(property => {
+      befoureRouteEnterInstanceProperties.push(property.name);
+    }),
     /*
       watch: {
         counter: 'getCount'
@@ -55,6 +59,7 @@ const create = context => {
       remove(unusedProperties, property => {
         return (
           thisExpressionsVariablesNames.includes(property.name) ||
+          befoureRouteEnterInstanceProperties.includes(property.name) ||
           watchStringMethods.includes(property.name)
         );
       });

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -16,6 +16,7 @@ const create = context => {
   let hasTemplate;
   let unusedProperties = [];
   let thisExpressionsVariablesNames = [];
+  let befoureRouteEnterInstanceProperties = [];
 
   const initialize = {
     Program(node) {
@@ -32,6 +33,9 @@ const create = context => {
     utils.executeOnThisExpressionProperty(property => {
       thisExpressionsVariablesNames.push(property.name);
     }),
+    utils.executeOnBefoureRouteEnterInstanceProperty(property => {
+      befoureRouteEnterInstanceProperties.push(property.name);
+    }),
     eslintPluginVueUtils.executeOnVue(context, obj => {
       unusedProperties = Array.from(
         eslintPluginVueUtils.iterateProperties(
@@ -45,6 +49,7 @@ const create = context => {
       remove(unusedProperties, property => {
         return (
           thisExpressionsVariablesNames.includes(property.name) ||
+          befoureRouteEnterInstanceProperties.includes(property.name) ||
           watchersNames.includes(property.name)
         );
       });

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -29,6 +29,7 @@ const create = context => {
   let hasTemplate;
   let unusedVuexProperties = [];
   let thisExpressionsVariablesNames = [];
+  let befoureRouteEnterInstanceProperties = [];
 
   const initialize = {
     Program(node) {
@@ -123,12 +124,16 @@ const create = context => {
     utils.executeOnThisExpressionProperty(property => {
       thisExpressionsVariablesNames.push(property.name);
     }),
+    utils.executeOnBefoureRouteEnterInstanceProperty(property => {
+      befoureRouteEnterInstanceProperties.push(property.name);
+    }),
     eslintPluginVueUtils.executeOnVue(context, obj => {
       const watchersNames = utils.getWatchersNames(obj);
 
       remove(unusedVuexProperties, property => {
         return (
           thisExpressionsVariablesNames.includes(property.name) ||
+          befoureRouteEnterInstanceProperties.includes(property.name) ||
           watchersNames.includes(property.name)
         );
       });

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -77,6 +77,26 @@ module.exports = {
   },
 
   /**
+   * Run callback on beforeRouteEnter component instance property.
+   */
+  executeOnBefoureRouteEnterInstanceProperty(func) {
+    let instanceParamName;
+
+    return {
+      'Property[key.name=beforeRouteEnter] CallExpression[callee.name=next][arguments]'(node) {
+        if (node.arguments.length && node.arguments[0].params && node.arguments[0].params.length) {
+          instanceParamName = node.arguments[0].params[0].name;
+        }
+      },
+      'MemberExpression[object.name]'(node) {
+        if (node.object.name === instanceParamName) {
+          func(node.property);
+        }
+      },
+    };
+  },
+
+  /**
    * Run callback when end of the root template reached.
    */
   executeOnRootTemplateEnd(func) {

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-methods.spec.js
@@ -212,6 +212,27 @@ tester.run('vue-no-unused-methods', rule, {
         </script>
       `,
     },
+
+    // a method accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              getCount() {
+                return 2;
+              }
+            },
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                vm.getCount()
+              })
+            }
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
@@ -588,6 +588,65 @@ tester.run('vue-no-unused-properties', rule, {
         </script>
       `,
     },
+
+    // a property accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: ['count'],
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                alert(vm.count)
+              })
+            }
+          };
+        </script>
+      `,
+    },
+
+    // data accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            data() {
+              return {
+                count: 2
+              }
+            },
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                alert(vm.count)
+              })
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a computed property accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2
+              }
+            },
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                alert(vm.count)
+              })
+            }
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
@@ -479,6 +479,40 @@ tester.run('vue-no-unused-vuex-properties', rule, {
         </script>
       `,
     },
+
+    // a getter accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapGetters(['count']),
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                alert(vm.count)
+              })
+            }
+          };
+        </script>
+      `,
+    },
+
+    // state accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapState(['count']),
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                alert(vm.count)
+              })
+            }
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
### Summary

All `vue-no-unused..` rules are now able to detect properties or methods accessed via `next` instance parameter in `beforeRouteEnter` hook (`this` is not available there).

### Reviewer guidance

Looks good?

### References

Solves  #5385

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
