### PR TITLE
Add vue-watch-no-string eslint rule

### DIFF
--- a/kolibri/plugins/document_pdf_render/assets/src/views/PdfPage.vue
+++ b/kolibri/plugins/document_pdf_render/assets/src/views/PdfPage.vue
@@ -83,9 +83,15 @@
       },
     },
     watch: {
-      scale: 'renderPage',
-      pdfPage: 'renderPage',
-      pageReady: 'renderPage',
+      scale(newVal, oldVal) {
+        this.renderPage(newVal, oldVal);
+      },
+      pdfPage(newVal, oldVal) {
+        this.renderPage(newVal, oldVal);
+      },
+      pageReady(newVal, oldVal) {
+        this.renderPage(newVal, oldVal);
+      },
     },
     mounted() {
       this.renderPage();

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -288,7 +288,11 @@ oriented data synchronization.
         return null;
       },
     },
-    watch: { exerciseProgress: 'updateExerciseProgressMethod' },
+    watch: {
+      exerciseProgress() {
+        this.updateExerciseProgressMethod();
+      },
+    },
     beforeDestroy() {
       if (this.currentInteractions > 0) {
         this.saveAttemptLogMasterLog(false);

--- a/kolibri/plugins/learn/assets/src/views/TotalPoints.vue
+++ b/kolibri/plugins/learn/assets/src/views/TotalPoints.vue
@@ -22,7 +22,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import PointsIcon from 'kolibri.coreVue.components.PointsIcon';
   import KTooltip from 'kolibri.coreVue.components.KTooltip';
@@ -37,9 +37,16 @@
     computed: {
       ...mapGetters(['totalPoints', 'currentUserId', 'isUserLoggedIn']),
     },
-    watch: { currentUserId: 'fetchPoints' },
+    watch: {
+      currentUserId() {
+        this.fetchPoints();
+      },
+    },
     created() {
-      this.$store.dispatch('fetchPoints');
+      this.fetchPoints();
+    },
+    methods: {
+      ...mapActions(['fetchPoints']),
     },
     $trs: { pointsTooltip: 'You earned { points, number } points' },
   };

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-watch-no-string.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-watch-no-string.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Disallow string method syntax in watchers.
+ */
+
+'use strict';
+
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
+
+const create = context => {
+  const scriptVisitor = {
+    'ExportDefaultDeclaration > ObjectExpression > Property[key.name=watch] > ObjectExpression > Property[value.type=Literal]'(
+      node
+    ) {
+      context.report({
+        node,
+        message:
+          'String method name syntax is not allowed in watchers. Please use a function instead.',
+      });
+    },
+  };
+
+  const templateVisitor = {};
+
+  return Object.assign(
+    {},
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow string method syntax in watchers',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-watch-no-string.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-watch-no-string.spec.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-watch-no-string');
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+tester.run('vue-watch-no-string', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              username() {
+                this.setSuggestionTerm()
+              }
+            }
+          };
+        </script>
+      `,
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              username: {
+                handler(newVal, OldVal) {
+                  this.setSuggestionTerm()
+                },
+                immediate: true
+              }
+            }
+          };
+        </script>
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              username: 'setSuggestionTerm',
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'String method name syntax is not allowed in watchers. Please use a function instead.',
+          line: 5,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -155,5 +155,6 @@ module.exports = {
     'kolibri/vue-no-unused-properties': ERROR,
     'kolibri/vue-no-unused-vuex-properties': ERROR,
     'kolibri/vue-no-unused-methods': ERROR,
+    'kolibri/vue-watch-no-string': ERROR,
   },
 };


### PR DESCRIPTION
### Summary

- implement `vue-watch-no-string` rule that disallow string methods syntax in watchers
- related cleanup

### Reviewer guidance

- Works fine?
- Are there more scenarios to be treated?
- Is cleanup ok?

### References

 #5374 follow-up.
Closes #5380.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
