### PR TITLE
Show error information when reporting server error

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -402,6 +402,9 @@ def get_status():  # noqa: max-complexity=16
 
         if response.status_code != 200:
             # Probably a mis-configured kolibri
+            sys.stderr.write("---Debug information---\n")
+            sys.stderr.write(response.text)
+            sys.stderr.write("\n-----------------------\n")
             raise NotRunning(STATUS_SERVER_CONFIGURATION_ERROR)
 
     else:


### PR DESCRIPTION
### Summary
`kolibri status` didn't provide any info about the error happening when reporting STATUS_SERVER_CONFIGURATION_ERROR

With this PR that command will output the information the web server provides.


### Reviewer guidance
* start kolibri
* cause some problem on it, for example, altering the database, so any request gives an http error code other than 200
* execute `kolibri status`, the output should give information about the error happening in the server

### References
Closes #4926 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
