### PR TITLE
No unused Vuex actions and mutations lint rule

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -94,7 +94,7 @@
 
 <script>
 
-  import { mapGetters, mapState, mapActions } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -166,7 +166,6 @@
         this.$emit('showLanguageModal');
         this.userMenuDropdownIsOpen = false;
       },
-      ...mapActions(['kolibriLogout']),
     },
     $trs: {
       userTypeLabel: 'User type',

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -341,7 +341,6 @@
       ...mapActions('examCreation', [
         'addToSelectedExercises',
         'removeFromSelectedExercises',
-        'setSelectedExercises',
         'fetchAdditionalSearchResults',
       ]),
       contentLink(content) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -140,7 +140,7 @@
       },
     },
     methods: {
-      ...mapActions(['createSnackbar', 'clearSnackbar']),
+      ...mapActions(['clearSnackbar']),
       emitUpdatedResources(resources) {
         this.$emit('update:resources', resources);
       },

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelsGrid.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelsGrid.vue
@@ -86,11 +86,7 @@
       },
     },
     methods: {
-      ...mapActions('manageContent', [
-        'startImportWorkflow',
-        'triggerChannelDeleteTask',
-        'refreshChannelList',
-      ]),
+      ...mapActions('manageContent', ['startImportWorkflow', 'triggerChannelDeleteTask']),
       handleDeleteChannel() {
         if (this.channelIsSelected) {
           const channelId = this.selectedChannelId;

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -55,7 +55,6 @@
 
 <script>
 
-  import { mapActions } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import KLinearLoader from 'kolibri.coreVue.components.KLinearLoader';
   import KCircularLoader from 'kolibri.coreVue.components.KCircularLoader';
@@ -159,7 +158,6 @@
       },
     },
     methods: {
-      ...mapActions('manageContent', ['cancelTask', 'refreshChannelList']),
       endTask() {
         this.uiBlocked = true;
         this.$emit('cleartask', () => {

--- a/packages/eslint-plugin-kolibri/lib/constants.js
+++ b/packages/eslint-plugin-kolibri/lib/constants.js
@@ -13,6 +13,11 @@ const PROPERTY_LABEL = {
   [GROUP_METHODS]: 'method',
 };
 
+const VUEX_STATE = 'state';
+const VUEX_GETTER = 'getter';
+const VUEX_MUTATION = 'mutation';
+const VUEX_ACTION = 'action';
+
 module.exports = {
   GROUP_PROPS,
   GROUP_DATA,
@@ -20,4 +25,8 @@ module.exports = {
   GROUP_METHODS,
   GROUP_WATCH,
   PROPERTY_LABEL,
+  VUEX_STATE,
+  VUEX_GETTER,
+  VUEX_MUTATION,
+  VUEX_ACTION,
 };

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -41,16 +41,9 @@ const create = context => {
     utils.executeOnBefoureRouteEnterInstanceProperty(property => {
       befoureRouteEnterInstanceProperties.push(property.name);
     }),
-    /*
-      watch: {
-        counter: 'getCount'
-      }
-    */
-    {
-      'Property[key.name=watch] ObjectExpression[properties] Literal[value]'(node) {
-        watchStringMethods.push(node.value);
-      },
-    },
+    utils.executeOnWatchStringMethod(node => {
+      watchStringMethods.push(node.value);
+    }),
     eslintPluginVueUtils.executeOnVue(context, obj => {
       unusedProperties = Array.from(
         eslintPluginVueUtils.iterateProperties(obj, new Set([GROUP_METHODS]))

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-methods.js
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Disallow unused Vuex mutations and actions.
+ */
+
+'use strict';
+
+const remove = require('lodash/remove');
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
+
+const utils = require('../utils');
+
+const MUTATION = 'mutation';
+const ACTION = 'action';
+
+const reportUnusedVuexProperties = (context, properties) => {
+  if (!properties || !properties.length) {
+    return;
+  }
+
+  properties.forEach(property => {
+    context.report({
+      node: property.node,
+      message: `Unused Vuex ${property.kind} found: "${property.name}"`,
+    });
+  });
+};
+
+const create = context => {
+  let hasTemplate;
+  let unusedVuexProperties = [];
+  let thisExpressionsVariablesNames = [];
+  let befoureRouteEnterInstanceProperties = [];
+  let watchStringMethods = [];
+
+  const initialize = {
+    Program(node) {
+      if (!utils.checkVueEslintParser(context)) {
+        return;
+      }
+
+      hasTemplate = Boolean(node.templateBody);
+    },
+  };
+
+  const scriptVisitor = Object.assign(
+    {},
+    /*
+      methods: mapMutations({
+        add: 'increment'
+      })
+
+      methods: {
+        ...mapMutations({
+          add: 'increment'
+        })
+      }
+    */
+    {
+      'CallExpression[callee.name=mapMutations][arguments] ObjectExpression Property[key.name]'(
+        node
+      ) {
+        unusedVuexProperties.push({
+          kind: MUTATION,
+          name: node.key.name,
+          node,
+        });
+      },
+    },
+    /*
+      methods: mapMutations(['add'])
+
+      methods: {
+        ...mapMutations(['add'])
+      }
+    */
+    {
+      'CallExpression[callee.name=mapMutations][arguments] ArrayExpression Literal[value]'(node) {
+        unusedVuexProperties.push({
+          kind: MUTATION,
+          name: node.value,
+          node,
+        });
+      },
+    },
+    /*
+      methods: mapActions({
+        add: 'increment'
+      })
+
+      methods: {
+        ...mapActions({
+          add: 'increment'
+        })
+      }
+    */
+    {
+      'CallExpression[callee.name=mapActions][arguments] ObjectExpression Property[key.name]'(
+        node
+      ) {
+        unusedVuexProperties.push({
+          kind: ACTION,
+          name: node.key.name,
+          node,
+        });
+      },
+    },
+    /*
+    methods: mapActions(['add'])
+
+    methods: {
+      ...mapActions(['add'])
+    }
+  */
+    {
+      'CallExpression[callee.name=mapActions][arguments] ArrayExpression Literal[value]'(node) {
+        unusedVuexProperties.push({
+          kind: ACTION,
+          name: node.value,
+          node,
+        });
+      },
+    },
+    utils.executeOnThisExpressionProperty(property => {
+      thisExpressionsVariablesNames.push(property.name);
+    }),
+    utils.executeOnBefoureRouteEnterInstanceProperty(property => {
+      befoureRouteEnterInstanceProperties.push(property.name);
+    }),
+    /*
+      watch: {
+        counter: 'add'
+      }
+    */
+    {
+      'Property[key.name=watch] ObjectExpression[properties] Literal[value]'(node) {
+        watchStringMethods.push(node.value);
+      },
+    },
+    eslintPluginVueUtils.executeOnVue(context, () => {
+      remove(unusedVuexProperties, property => {
+        return (
+          thisExpressionsVariablesNames.includes(property.name) ||
+          befoureRouteEnterInstanceProperties.includes(property.name) ||
+          watchStringMethods.includes(property.name)
+        );
+      });
+
+      if (!hasTemplate && unusedVuexProperties.length) {
+        reportUnusedVuexProperties(context, unusedVuexProperties);
+      }
+    })
+  );
+
+  const templateVisitor = Object.assign(
+    {},
+    {
+      'VExpressionContainer[expression!=null][references]'(node) {
+        const referencesNames = utils.getReferencesNames(node.references);
+
+        remove(unusedVuexProperties, property => {
+          return referencesNames.includes(property.name);
+        });
+      },
+    },
+    utils.executeOnRootTemplateEnd(() => {
+      if (unusedVuexProperties.length) {
+        reportUnusedVuexProperties(context, unusedVuexProperties);
+      }
+    })
+  );
+
+  return Object.assign(
+    {},
+    initialize,
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unused Vuex mutations and actions',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -8,22 +8,7 @@ const remove = require('lodash/remove');
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
 const utils = require('../utils');
-
-const GETTER = 'getter';
-const STATE = 'state';
-
-const reportUnusedVuexProperties = (context, properties) => {
-  if (!properties || !properties.length) {
-    return;
-  }
-
-  properties.forEach(property => {
-    context.report({
-      node: property.node,
-      message: `Unused Vuex ${property.kind} found: "${property.name}"`,
-    });
-  });
-};
+const { VUEX_STATE, VUEX_GETTER } = require('../constants');
 
 const create = context => {
   let hasTemplate;
@@ -63,7 +48,7 @@ const create = context => {
     {
       'CallExpression[callee.name=mapState][arguments] ObjectExpression Property[key.name]'(node) {
         unusedVuexProperties.push({
-          kind: STATE,
+          kind: VUEX_STATE,
           name: node.key.name,
           node,
         });
@@ -79,7 +64,7 @@ const create = context => {
     {
       'CallExpression[callee.name=mapState][arguments] ArrayExpression Literal[value]'(node) {
         unusedVuexProperties.push({
-          kind: STATE,
+          kind: VUEX_STATE,
           name: node.value,
           node,
         });
@@ -95,7 +80,7 @@ const create = context => {
     {
       'CallExpression[callee.name=mapGetters][arguments] ArrayExpression Literal[value]'(node) {
         unusedVuexProperties.push({
-          kind: GETTER,
+          kind: VUEX_GETTER,
           name: node.value,
           node,
         });
@@ -115,7 +100,7 @@ const create = context => {
     {
       'CallExpression[callee.name=mapGetters][arguments] ObjectExpression Identifier[name]'(node) {
         unusedVuexProperties.push({
-          kind: GETTER,
+          kind: VUEX_GETTER,
           name: node.name,
           node,
         });
@@ -139,7 +124,7 @@ const create = context => {
       });
 
       if (!hasTemplate && unusedVuexProperties.length) {
-        reportUnusedVuexProperties(context, unusedVuexProperties);
+        utils.reportUnusedVuexProperties(context, unusedVuexProperties);
       }
     })
   );
@@ -157,7 +142,7 @@ const create = context => {
     },
     utils.executeOnRootTemplateEnd(() => {
       if (unusedVuexProperties.length) {
-        reportUnusedVuexProperties(context, unusedVuexProperties);
+        utils.reportUnusedVuexProperties(context, unusedVuexProperties);
       }
     })
   );

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -2,9 +2,7 @@
 
 const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
 
-const constants = require('./constants');
-
-const { GROUP_WATCH, GROUP_METHODS, PROPERTY_LABEL } = constants;
+const { GROUP_WATCH, GROUP_METHODS, PROPERTY_LABEL } = require('./constants');
 
 module.exports = {
   /**
@@ -97,6 +95,20 @@ module.exports = {
   },
 
   /**
+   * Run callback on watch string method literal node, e.g. on `add` literal node in
+   * watch: {
+   *   counter: 'add'
+   * }
+   */
+  executeOnWatchStringMethod(func) {
+    return {
+      'Property[key.name=watch] ObjectExpression[properties] Literal[value]'(node) {
+        func(node);
+      },
+    };
+  },
+
+  /**
    * Run callback when end of the root template reached.
    */
   executeOnRootTemplateEnd(func) {
@@ -142,6 +154,22 @@ module.exports = {
       context.report({
         node: property.node,
         message,
+      });
+    });
+  },
+
+  /**
+   * Report unused Vuex properties.
+   */
+  reportUnusedVuexProperties(context, properties) {
+    if (!properties || !properties.length) {
+      return;
+    }
+
+    properties.forEach(property => {
+      context.report({
+        node: property.node,
+        message: `Unused Vuex ${property.kind} found: "${property.name}"`,
       });
     });
   },

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-methods.spec.js
@@ -297,6 +297,54 @@ tester.run('vue-no-unused-vuex-methods', rule, {
       ],
     },
 
+    // unused aliased mutation
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapMutations({
+              save: 'sav'
+            })
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex mutation found: "save"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused mutation - spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              ...mapMutations(['save'])
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex mutation found: "save"',
+          line: 9,
+        },
+      ],
+    },
+
     // unused action
     {
       filename: 'test.vue',
@@ -315,6 +363,54 @@ tester.run('vue-no-unused-vuex-methods', rule, {
         {
           message: 'Unused Vuex action found: "save"',
           line: 8,
+        },
+      ],
+    },
+
+    // unused aliased action
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapActions({
+              save: 'sav'
+            })
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex action found: "save"',
+          line: 9,
+        },
+      ],
+    },
+
+    // unused action - spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: {
+              ...mapActions(['save'])
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex action found: "save"',
+          line: 9,
         },
       ],
     },

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-methods.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-methods.spec.js
@@ -1,0 +1,322 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-no-unused-vuex-methods');
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+tester.run('vue-no-unused-vuex-methods', rule, {
+  valid: [
+    // a mutation used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapMutations(['save']),
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a mutation passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :increment="add" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapMutations(['add'])
+          };
+        </script>
+      `,
+    },
+
+    // a mutation used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="save" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapMutations(['save'])
+          };
+        </script>
+      `,
+    },
+
+    // a mutation used in a watcher (string method name)
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              counter: 'save'
+            },
+            methods: mapMutations(['save'])
+          };
+        </script>
+      `,
+    },
+
+    // a mutation accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapMutations(['save']),
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                vm.save()
+              })
+            }
+          };
+        </script>
+      `,
+    },
+
+    // namespaced module mutation
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapMutations('module', ['save']),
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a mutation imported with spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              ...mapMutations(['save'])
+            },
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // an aliased mutation
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              ...mapMutations({
+                save: 'store'
+              })
+            },
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // an action used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapActions(['save']),
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // an action passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :increment="add" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapActions(['add'])
+          };
+        </script>
+      `,
+    },
+
+    // an action used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="save" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapActions(['save'])
+          };
+        </script>
+      `,
+    },
+
+    // an action used in a watcher (string method name)
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            watch: {
+              counter: 'save'
+            },
+            methods: mapActions(['save'])
+          };
+        </script>
+      `,
+    },
+
+    // an action accessed via instance parameter in `beforeRouteEnter`
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapActions(['save']),
+            beforeRouteEnter (to, from, next) {
+              next(vm => {
+                vm.save()
+              })
+            }
+          };
+        </script>
+      `,
+    },
+
+    // namespaced module action
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: mapActions('module', ['save']),
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // an action imported with spread operator
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              ...mapActions(['save'])
+            },
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+
+    // an aliased action
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            methods: {
+              ...mapActions({
+                save: 'store'
+              })
+            },
+            created() {
+              this.save()
+            }
+          };
+        </script>
+      `,
+    },
+  ],
+
+  invalid: [
+    // unused mutation
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapMutations(['save'])
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex mutation found: "save"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused action
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div @click="sav" />
+        </template>
+
+        <script>
+          export default {
+            methods: mapActions(['save'])
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex action found: "save"',
+          line: 8,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -155,6 +155,7 @@ module.exports = {
     'kolibri/vue-no-unused-properties': ERROR,
     'kolibri/vue-no-unused-vuex-properties': ERROR,
     'kolibri/vue-no-unused-methods': ERROR,
+    'kolibri/vue-no-unused-vuex-methods': ERROR,
     'kolibri/vue-watch-no-string': ERROR,
   },
 };


### PR DESCRIPTION
### Summary

Last #4992 lint rule that disallows unused Vuex mutations and actions + related cleanup.

### Reviewer guidance

- Works fine?
- Are there more scenarios to be treated?
- Is cleanup ok?

### References

Closes #4992.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
