### PR TITLE
Custom HTMLHint rules cleanup

### DIFF
--- a/kolibri/core/assets/src/styles/definitions.scss
+++ b/kolibri/core/assets/src/styles/definitions.scss
@@ -64,4 +64,3 @@ $login-overlay: #201a21;
   backface-visibility: hidden;
   perspective: 10000px;
 }
-

--- a/packages/kolibri-tools/lib/htmlhint_custom.js
+++ b/packages/kolibri-tools/lib/htmlhint_custom.js
@@ -43,15 +43,6 @@ HTMLHint.addRule({
               event.raw
             );
           }
-          if (match && match[2].length !== 2) {
-            reporter.error(
-              'Top-level content should be indented two spaces.',
-              event.line,
-              event.col,
-              self,
-              event.raw
-            );
-          }
         }
       }
     });
@@ -75,15 +66,6 @@ HTMLHint.addRule({
             if (match[1].length !== 2) {
               reporter.error(
                 'Top-level content should be surrounded by one empty line.',
-                event.line,
-                event.col,
-                self,
-                event.raw
-              );
-            }
-            if (match[2].length !== 2) {
-              reporter.error(
-                'Top-level content should be indented two spaces.',
                 event.line,
                 event.col,
                 self,

--- a/packages/kolibri-tools/lib/htmlhint_custom.js
+++ b/packages/kolibri-tools/lib/htmlhint_custom.js
@@ -10,32 +10,6 @@ function clean(val) {
 }
 
 /*
-  Based on the existing `tag-self-close` rule
-*/
-HTMLHint.addRule({
-  id: '--no-self-close-common-html5-tags',
-  description: 'Self-closing HTML5 tags are not valid.',
-  init: function(parser, reporter) {
-    var self = this;
-    var commonTags = parser.makeMap(`a,audio,b,body,button,canvas,caption,center,dir,div,dl,em,font,footer,
-      form,h1,h2,h3,h4,h5,h6,head,header,html,iframe,label,li,main,map,menu,nav,object,option,output,p,progress,
-      q,script,section,select,span,strong,style,sub,table,tbody,td,textarea,th,thead,time,title,tr,u,ul,var,video`);
-    parser.addListener('tagstart', function(event) {
-      var tagName = event.tagName.toLowerCase();
-      if (event.close && commonTags[tagName]) {
-        reporter.error(
-          'In : [ ' + event.tagName + ' ] self-closing tags are not valid HTML5.',
-          event.line,
-          event.col,
-          self,
-          event.raw
-        );
-      }
-    });
-  },
-});
-
-/*
   Vue whitespace conventions.
   Based on the existing `tag-pair` rule
 

--- a/packages/kolibri-tools/lib/htmlhint_custom.js
+++ b/packages/kolibri-tools/lib/htmlhint_custom.js
@@ -28,24 +28,6 @@ HTMLHint.addRule({
     var mapEmptyTags = parser.makeMap(
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
     ); //HTML 4.01 + HTML 5
-    parser.addListener('text', function(event) {
-      var eventData = clean(event.raw);
-      var last = event.lastEvent;
-      if (last.type === 'tagstart') {
-        if (stack.length === 1 && last.tagName === 'template') {
-          var match = eventData.match(/^(\n*)( *)/);
-          if (match && match[1].length !== 2) {
-            reporter.error(
-              'Top-level content should be surrounded by one empty line.',
-              event.line,
-              event.col,
-              self,
-              event.raw
-            );
-          }
-        }
-      }
-    });
     // handle script and style tags
     parser.addListener('cdata', function(event) {
       var eventData = clean(event.raw);
@@ -58,31 +40,6 @@ HTMLHint.addRule({
             self,
             event.raw
           );
-        } else {
-          // note - [^] is like . except it matches newlines
-          // http://stackoverflow.com/questions/1068280/javascript-regex-multiline-flag-doesnt-work
-          var match = eventData.match(/^(\n*)( *)[^]+?(\n*)$/);
-          if (match) {
-            if (match[1].length !== 2) {
-              reporter.error(
-                'Top-level content should be surrounded by one empty line.',
-                event.line,
-                event.col,
-                self,
-                event.raw
-              );
-            }
-            if (match[3].length !== 2) {
-              var offset = (eventData.match(/\n/g) || []).length;
-              reporter.error(
-                'Top-level content should be surrounded by one empty line.',
-                event.line + offset,
-                1,
-                self,
-                event.raw
-              );
-            }
-          }
         }
       }
     });
@@ -119,22 +76,6 @@ HTMLHint.addRule({
       }
     });
     parser.addListener('tagend', function(event) {
-      var last = event.lastEvent;
-      var lastData = clean(last.raw);
-      if (last.type === 'text') {
-        if (stack.length === 1 && event.tagName === 'template') {
-          var match = lastData.match(/(\n*)$/);
-          if (match && match[1].length !== 2) {
-            reporter.error(
-              'Top-level content should be surrounded by one empty line.',
-              event.line,
-              event.col,
-              self,
-              event.raw
-            );
-          }
-        }
-      }
       var tagName = event.tagName.toLowerCase();
       for (var pos = stack.length - 1; pos >= 0; pos--) {
         if (stack[pos].tagName === tagName) {

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -220,13 +220,24 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
           let block;
           // First lint the whole vue component with eslint
           formatted = eslint(source);
+
+          let vueComponent = compiler.parseComponent(formatted);
+
+          // Format template block
+          if (vueComponent.template && vueComponent.template.content) {
+            formatted = insertContent(
+              formatted,
+              vueComponent.template,
+              vueComponent.template.content
+            );
+            vueComponent = compiler.parseComponent(formatted);
+          }
+
           // Now run htmlhint on the whole vue component
           let htmlMessages = HTMLHint.verify(formatted, htmlHintConfig);
           if (htmlMessages.length) {
             messages.push(...HTMLHint.format(htmlMessages, { colors: true }));
           }
-
-          let vueComponent = compiler.parseComponent(formatted);
 
           // Format script block
           if (vueComponent.script) {

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -191,9 +191,8 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
               if (linted.trim() !== (stylinted || code).trim()) {
                 notSoPretty = true;
               }
-              if (linted.trim() !== code.trim()) {
-                styleCodeUpdates.push(() => callback(linted));
-              }
+
+              styleCodeUpdates.push(() => callback(linted));
             })
             .catch(err => {
               messages.push(err.toString());

--- a/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
+++ b/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
@@ -42,24 +42,6 @@ function expectRuleName(output, ruleName) {
   expect(output[0].rule.id).toEqual(ruleName);
 }
 
-describe('--no-self-close-common-html5-tags', function() {
-  describe('input is valid', function() {
-    it('should have no errors', function() {
-      const input = '<div></div>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(0);
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --no-self-close-common-html5-tags', function() {
-      const input = '<div />';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--no-self-close-common-html5-tags');
-    });
-  });
-});
-
 describe('--vue-component-conventions', function() {
   describe('input is valid', function() {
     it('should have no errors', function() {

--- a/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
+++ b/packages/kolibri-tools/test/test_htmlhint_custom.spec.js
@@ -51,6 +51,7 @@ describe('--vue-component-conventions', function() {
       expect(output).toHaveLength(0);
     });
   });
+  // single quotes in lang attr
   describe('input is invalid', function() {
     it('should have one error', function() {
       const input =
@@ -59,24 +60,7 @@ describe('--vue-component-conventions', function() {
       expect(output).toHaveLength(1);
     });
   });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n  html\n\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\nhtml\n\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
+  // first block isn't on the first line
   describe('input is invalid', function() {
     it('should have one error with rule id: --vue-component-conventions', function() {
       const input =
@@ -86,15 +70,7 @@ describe('--vue-component-conventions', function() {
       expectRuleName(output, '--vue-component-conventions');
     });
   });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n\n</template>\n\n\n<script>\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
+  // missing space between template and script block
   describe('input is invalid', function() {
     it('should have one error with rule id: --vue-component-conventions', function() {
       const input =
@@ -104,6 +80,7 @@ describe('--vue-component-conventions', function() {
       expectRuleName(output, '--vue-component-conventions');
     });
   });
+  // extra space between script and style block
   describe('input is invalid', function() {
     it('should have one error with rule id: --vue-component-conventions', function() {
       const input =
@@ -113,24 +90,7 @@ describe('--vue-component-conventions', function() {
       expectRuleName(output, '--vue-component-conventions');
     });
   });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n\n</template>\n\n\n<script>\n\n   scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
+  // script block with whitespace characters only
   describe('input is invalid', function() {
     it('should have one error with rule id: --vue-component-conventions', function() {
       const input =
@@ -140,6 +100,7 @@ describe('--vue-component-conventions', function() {
       expectRuleName(output, '--vue-component-conventions');
     });
   });
+  // script block with whitespace characters only
   describe('input is invalid', function() {
     it('should have one error with rule id: --vue-component-conventions', function() {
       const input =
@@ -155,42 +116,6 @@ describe('--vue-component-conventions', function() {
         '<template>\n\n  html\n\n</template>\n\n\n<script></script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
       const output = HTMLHint.verify(input, ruleset);
       expect(output).toHaveLength(0);
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n\n</template>\n\n\n<script>\n\n  scripts\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n\n</template>\n\n\n<script>\n\n  scripts\n\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n  html\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
-    });
-  });
-  describe('input is invalid', function() {
-    it('should have one error with rule id: --vue-component-conventions', function() {
-      const input =
-        '<template>\n\n\n  html\n\n</template>\n\n\n<script>\n\n  scripts\n\n</script>\n\n\n<style lang="stylus" scoped>\n\n  styles\n\n</style>';
-      const output = HTMLHint.verify(input, ruleset);
-      expect(output).toHaveLength(1);
-      expectRuleName(output, '--vue-component-conventions');
     });
   });
   describe('defer unpaired tags', function() {


### PR DESCRIPTION
### Summary

- remove duplicate self-closing check from custom HTMLHint rules
- automatically indent top-level template block (this has already worked for script and style blocks) => I could also remove "top-level content surrounded by one empty line" HTMLHint rule for all blocks

After reviewing how custom linting works in detail, I think that eventually we could get rid of all custom HTMLHint checks and move everything to the format process but I didn't want to deal with it in the scope of HTMLHint duplicates cleanup because it seems that it would require some extra refactoring of _lint.js_ and I am not sure if that would be worthy. I also noticed a couple of minor problems that seemed to be caused by the need to coordinate all those tools and custom checks - I fixed one of them in this PR and skipped others for now because I think that a bit more suitable approach might be to define what conventions we want to actually follow and then maybe prepare the lint process again from scratch while trying to simplify it as much as possible and move more responsibility to external tools in general to save some maintenance time spent on _lint.js_ in the future.

### Reviewer guidance

- Are all adjustments OK?

### References

Closes  #5337.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
