### PR TITLE
Devserver cleanup

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -255,7 +255,7 @@ def update():
     # import settings. Otherwise the updated configuration will not be used
     # during this runtime.
 
-    call_command("collectstatic", interactive=False)
+    call_command("collectstatic", interactive=False, verbosity=0)
 
     from kolibri.core.settings import SKIP_AUTO_DATABASE_MIGRATION
 

--- a/packages/kolibri-tools/lib/bundleStats.js
+++ b/packages/kolibri-tools/lib/bundleStats.js
@@ -25,9 +25,10 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   return compiler;
 }
 
-if (require.main === module) {
-  const data = JSON.parse(process.env.data);
-  const index = JSON.parse(process.env.index);
+const data = JSON.parse(process.env.data);
+const index = JSON.parse(process.env.index);
+const start = JSON.parse(process.env.start);
+function build() {
   buildWebpack(
     data,
     index,
@@ -38,6 +39,24 @@ if (require.main === module) {
       process.send('done');
     }
   );
+}
+
+let waitToBuild;
+
+waitToBuild = msg => {
+  if (msg === 'start') {
+    build();
+  } else {
+    process.once('message', waitToBuild);
+  }
+};
+
+if (require.main === module) {
+  if (start) {
+    build();
+  } else {
+    waitToBuild();
+  }
 }
 
 module.exports = buildWebpack;

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const os = require('os');
 const path = require('path');
 const program = require('commander');
 const version = require('../package.json').version;
@@ -116,7 +117,12 @@ program
       program.help();
       process.exit(1);
     }
-    const multi = !options.single && !process.env.KOLIBRI_BUILD_SINGLE;
+    // Use one less than the number of cpus to allow other
+    // processes to carry on.
+    const numberOfCPUs = Math.max(1, os.cpus().length - 1);
+    // Don't bother using multiprocessor mode if there is only one processor that we can
+    // use without bogging down the system.
+    const multi = !options.single && !process.env.KOLIBRI_BUILD_SINGLE && numberOfCPUs > 1;
 
     if (options.hot && mode !== modes.DEV) {
       cliLogging.error('Hot module reloading can only be used in dev mode.');
@@ -180,6 +186,9 @@ program
               ...process.env,
               data,
               index,
+              // Only start a number of processes equal to the number of
+              // available CPUs.
+              start: Math.floor(index / numberOfCPUs) === 0,
               options: options_data,
             },
             stdio: 'inherit',
@@ -198,6 +207,10 @@ program
               startCallback();
             } else if (msg === 'done') {
               doneCallback();
+              const nextIndex = index + numberOfCPUs;
+              if (children[nextIndex]) {
+                children[nextIndex].send('start');
+              }
             }
           });
         } else {

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -147,6 +147,8 @@ program
     function spawnWebpackProcesses({ completionCallback = null, persistent = true } = {}) {
       const numberOfBundles = bundleData.length;
       let currentlyCompiling = numberOfBundles;
+      let firstRun = true;
+      const start = new Date();
       // The way we are binding this callback to the webpack compilation hooks
       // it seems to miss this on first compilation, so we will only use this for
       // watched builds where rebuilds are possible.
@@ -156,7 +158,12 @@ program
       function doneCallback() {
         currentlyCompiling -= 1;
         if (currentlyCompiling === 0) {
-          buildLogging.info('All builds complete!');
+          if (firstRun) {
+            firstRun = false;
+            buildLogging.info(`Initial build complete in ${(new Date() - start) / 1000} seconds`);
+          } else {
+            buildLogging.info('All builds complete!');
+          }
           if (completionCallback) {
             completionCallback(bundleData, buildOptions);
           }

--- a/packages/kolibri-tools/lib/i18n.js
+++ b/packages/kolibri-tools/lib/i18n.js
@@ -30,9 +30,10 @@ function buildWebpack(data, index, startCallback, doneCallback) {
   return compiler;
 }
 
-if (require.main === module) {
-  const data = JSON.parse(process.env.data);
-  const index = JSON.parse(process.env.index);
+const data = JSON.parse(process.env.data);
+const index = JSON.parse(process.env.index);
+const start = JSON.parse(process.env.start);
+function build() {
   buildWebpack(
     data,
     index,
@@ -43,6 +44,24 @@ if (require.main === module) {
       process.send('done');
     }
   );
+}
+
+let waitToBuild;
+
+waitToBuild = msg => {
+  if (msg === 'start') {
+    build();
+  } else {
+    process.once('message', waitToBuild);
+  }
+};
+
+if (require.main === module) {
+  if (start) {
+    build();
+  } else {
+    waitToBuild();
+  }
 }
 
 module.exports = buildWebpack;

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -44,7 +44,7 @@ try {
 
 const logger = require('./logging');
 
-const logging = logger.getLogger('Kolibri linter');
+const logging = logger.getLogger('Kolibri Linter');
 
 const esLinter = new ESLintCLIEngine({
   baseConfig: esLintConfig,

--- a/packages/kolibri-tools/lib/production.js
+++ b/packages/kolibri-tools/lib/production.js
@@ -40,9 +40,10 @@ function buildWebpack(data, index, startCallback, doneCallback) {
   return compiler;
 }
 
-if (require.main === module) {
-  const data = JSON.parse(process.env.data);
-  const index = JSON.parse(process.env.index);
+const data = JSON.parse(process.env.data);
+const index = JSON.parse(process.env.index);
+const start = JSON.parse(process.env.start);
+function build() {
   buildWebpack(
     data,
     index,
@@ -53,6 +54,24 @@ if (require.main === module) {
       process.send('done');
     }
   );
+}
+
+let waitToBuild;
+
+waitToBuild = msg => {
+  if (msg === 'start') {
+    build();
+  } else {
+    process.once('message', waitToBuild);
+  }
+};
+
+if (require.main === module) {
+  if (start) {
+    build();
+  } else {
+    waitToBuild();
+  }
 }
 
 module.exports = buildWebpack;

--- a/packages/kolibri-tools/lib/webpackMessages.js
+++ b/packages/kolibri-tools/lib/webpackMessages.js
@@ -1,7 +1,9 @@
 /*
  * Vendored from https://github.com/lukeed/webpack-messages and https://github.com/lukeed/webpack-format-messages
  */
-const logging = require('./logging');
+const logger = require('./logging');
+
+const logging = logger.getLogger('Kolibri Build');
 
 const errorLabel = 'Syntax error:';
 const isLikelyASyntaxError = str => str.includes(errorLabel);

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -111,10 +111,11 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   return compiler;
 }
 
-if (require.main === module) {
-  const data = JSON.parse(process.env.data);
-  const index = JSON.parse(process.env.index);
-  const options = JSON.parse(process.env.options);
+const data = JSON.parse(process.env.data);
+const index = JSON.parse(process.env.index);
+const options = JSON.parse(process.env.options);
+const start = JSON.parse(process.env.start);
+function build() {
   buildWebpack(
     data,
     index,
@@ -126,6 +127,24 @@ if (require.main === module) {
     },
     options
   );
+}
+
+let waitToBuild;
+
+waitToBuild = msg => {
+  if (msg === 'start') {
+    build();
+  } else {
+    process.once('message', waitToBuild);
+  }
+};
+
+if (require.main === module) {
+  if (start) {
+    build();
+  } else {
+    waitToBuild();
+  }
 }
 
 module.exports = buildWebpack;

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -15,6 +15,8 @@ const openInEditor = require('launch-editor-middleware');
 const webpackBaseConfig = require('./webpack.config.base');
 const logger = require('./logging');
 
+const buildLogging = logger.getLogger('Kolibri Webpack Dev Server');
+
 function genPublicPath(address, port, basePath) {
   const baseURL = `http://${address}:${port}/`;
   if (basePath) {
@@ -66,7 +68,7 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
     if (typeof bundleConfig.entry[data.name] === 'string') {
       bundleConfig.entry[data.name] = [bundleConfig.entry[data.name]];
     } else if (!Array.isArray(bundleConfig.entry[data.name])) {
-      logger.error('Unhandled data type for bundle entries');
+      buildLogging.error('Unhandled data type for bundle entries');
       process.exit(1);
     }
     // Next, prepend two hot-reload-related entry points to the config:
@@ -104,9 +106,7 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
     server.use('/__open-in-editor', openInEditor());
   }
 
-  server.listen(port, CONFIG.host, () => {
-    logger.info(`webpack dev server listening on port ${port}`);
-  });
+  server.listen(port, CONFIG.host, () => {});
 
   return compiler;
 }

--- a/packages/kolibri-tools/test/test_webpack.config.base.spec.js
+++ b/packages/kolibri-tools/test/test_webpack.config.base.spec.js
@@ -9,6 +9,11 @@ jest.mock('../lib/apiSpecExportTools', () => ({
 
 jest.mock('../lib/logging', () => ({
   error: () => {},
+  getLogger: () => {
+    return {
+      error: () => {},
+    };
+  },
 }));
 
 const baseData = {


### PR DESCRIPTION
### Summary
* Adds a total time report to webpack builds.
* Limits the number of parallel webpack jobs on initial build to prevent hogging all system resources.
* Adds no additional build time by doing this.
* Cleans up and standardizes devserver logging to reduce noise.
* Sets the verbosity of collectstatic to 0 to reduce noise to devs and users.

### Reviewer guidance
Does the devserver now run without hogging all your system resources?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
