### PR TITLE
Don't allow more than 900 ids when querying ContentNodes

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -113,7 +113,9 @@ class IdFilter(FilterSet):
 
     def filter_ids(self, queryset, name, value):
         try:
-            return queryset.filter(pk__in=value.split(','))
+            # SQLITE_MAX_VARIABLE_NUMBER is 999 by default.
+            # It means 999 is the max number of params for a query
+            return queryset.filter(pk__in=value.split(',')[:900])
         except ValueError:
             # Catch in case of a poorly formed UUID
             return queryset.none()


### PR DESCRIPTION
### Summary
Some users are reporting errors when using channels with a lot of nodes ( Hsoub Academy (العربيّة) has 11037 nodes). In these cases, the  Recommended page can produce this error in the backend:

`sqlite3.OperationalError: too many SQL variables`

The reason is sqlite has a 999 limit value in the number of params to be accepted in a query. Kolibri is using one param per node in requests like
`http://localhost:8000/api/content/contentnode_slim/?ids=a9b25ac9814742c883ce1b0579448337%2C000409f81dbe5d1ba67101cb9fed4530%2C0418cc231e9c5513af0fff9f227f7172%2C0d4fd88c4882573caa02110243b94c30%2C197934f144305350b5820c7c4dd8e194%2C310ec19477d15cf7b9fed98551ba1e1f%2C27bb0abc24d44dd9896be50d47b2357e%2C362ecc59a30e53539f7b8d7fd6f1fcc5%2C4f9d1fd5107c50c9a12376b242bcbd21%2C61b75af2bb2c4c0ea850d85dcf88d0fd%2C668a1d198f2e5269939df31dd8c36efb%2Ce66cd89375845ebf864ea00005be902d%2C9c22d36a81ba5eb0842f9192a18d9623%2Cb431ba9f16a3588b89700f3eb8281af0%2Cdd530f50b10e5864bad2f4c4d4050584%2C913efe9f14c65cb1b23402f21f056e99%2Cae35fc2af3365f11a8bae0abbae47585%2C02cf4629326743af81b4a3e9836eaa10%2C0705df55d9745fefa08b20f8bf4cc5bf%2Cc205795819f25567ad7c52b8d3622104%2Cc150ea1d69495d37b5b0ac6f017e9bfb%2C2ac9112b4ec240538e5d3fa93502b51d%2C1a9158aa082a460b9ea693ba329e0770&by_role=true&include_fields=num_coach_contents`
This query has 24 nodes, but users are reaching more than 999.

This PR limits the number of nodes to 900 (it has been reported by users of JOHUD's devices). The change will avoid this problem. 
We might want to set a lower limit anyway, as this kind of query is going to be very, very slow in any case.

Affected endpoints:
- `/api/content/contentnode_slim/` 
- `/api/content/contentnodeprogress/`
- `/api/content/contentnode_slim/channel_id/next_steps/`
- `/api/content/contentnode/node_assessments/`


### Reviewer guidance
Load content from Hsoub Academy channel from Studio.
Browse, using different users, its folders in kolibri to fill the Recommended page.
Without this PR applied, kolibri will break when several users are browsing it.

After this test is applied, kolibri won't fail for this reason. Tests must pass too.

### References
Closes: #4474

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
