### PR TITLE
Update more documentation for lint/auto-format changes

### DIFF
--- a/docs/frontend_architecture/conventions.rst
+++ b/docs/frontend_architecture/conventions.rst
@@ -1,16 +1,16 @@
 Frontend code conventions
 =========================
 
-Establishing code conventions is important in order to keep a more consistent codebase.
+Establishing code conventions is important in order to keep a more consistent codebase. Therefore the goal for the tools and principles below is to help ensure any committed code is properly aligned with the conventions.
 
 Linting and auto formatting
 ---------------------------
 
-Many of our conventions are enforced through various linters including `ESLint <https://eslint.org/>`__, `ESLint Vue plugin <https://github.com/vuejs/eslint-plugin-vue>`__, `stylelint <https://stylelint.io/>`__, and `HTMLHint <https://htmlhint.io/>`__. The enforced rules are located in the ``.eslintrc.js``, ``.stylelintrc.js``, and ``.htmlhintrc`` files located at the root of the project. Many of these rules are auto fixed during the Webpack dev server.
+Many of our conventions are enforced through various linters including `ESLint <https://eslint.org/>`__, `ESLint Vue plugin <https://github.com/vuejs/eslint-plugin-vue>`__, `stylelint <https://stylelint.io/>`__, and `HTMLHint <https://htmlhint.io/>`__. The enforced rules are located in the ``.eslintrc.js``, ``.stylelintrc.js``, and ``.htmlhintrc`` files located at the root of the project.
 
-We use `Prettier <https://prettier.io/>`__ to auto-format ``.vue``, ``.js``, and ``.scss`` files. We use `Black <https://github.com/ambv/black>`__ to auto-format ``.py`` files.
+Also available are options and tools that enable auto-formatting of ``.vue``, ``.js``, ``.scss``, and ``.py`` files to conform to code conventions. To facilitate this, we use `Black <https://github.com/ambv/black>`__ to auto-format ``.py`` files, and  `Prettier <https://prettier.io/>`__ to auto-format the others. Auto-formatting runs by default while running the dev server, otherwise be sure to run the dev server with ``-warn`` as described in :doc:`/getting_started` to prevent it from auto-formatting.
 
-The linting and auto formating is incorporated into the dev server and pre commit hooks, so make sure you've set up `pre-commit` as described in :doc:`/getting_started`.
+In addition, ``pre-commit`` hooks can be installed to perform linting and auto-formatting. To enable the hooks, be sure to follow the directions described in :doc:`/getting_started`.
 
 You can also install the appropriate editor plugins for the various linters to see linting warnings/errors inline.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -358,9 +358,9 @@ Development workflows
 Linting and auto-formatting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Linting and code auto-formatting provided by Prettier and Black are run in the background automatically when you run the dev server.  It is a good to monitor for linting errors in the build process: while the build may complete, it will also issue warnings to the terminal.
+Linting and code auto-formatting provided by Prettier and Black are run in the background automatically by default when you run the dev server.  It is a good to monitor for linting errors in the build process: while the build may complete, it will also issue warnings to the terminal.
 
-Linting and auto-formatting should also be run by the pre-commit hooks (installed earlier). If those are bypassed or not triggered, our Travis CI builds will also fail for unformatted code.
+Linting and auto-formatting can also be run by the pre-commit hooks (installed earlier). If those are bypassed or not triggered, our Travis CI builds will also fail for unformatted code.
 
 You can manually run the auto-formatters using:
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
In feedback on [this PR](https://github.com/learningequality/kolibri/pull/5405), there was some additional documentation that could use clarification regarding the changes to automatic formatting.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Do the changes to the documentation make sense?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/pull/5405
https://learningequality.slack.com/archives/CB37UM23A/p1555759651088400

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
