### PR TITLE
fixing storage file urls when custom KOLIBRI_URL_PATH_PREFIX is set

### DIFF
--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -141,7 +141,7 @@ def get_content_storage_file_url(filename, baseurl=None):
         )
     else:
         return "/{}{}/{}/{}".format(
-            get_content_storage_url(baseurl).lstrip("/"),
+            get_content_storage_url(baseurl),
             filename[0],
             filename[1],
             filename,

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -141,7 +141,7 @@ def get_content_storage_file_url(filename, baseurl=None):
         )
     else:
         return "/{}{}/{}/{}".format(
-            get_content_storage_url(baseurl).lstrip(),
+            get_content_storage_url(baseurl).lstrip("/"),
             filename[0],
             filename[1],
             filename,

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -141,5 +141,8 @@ def get_content_storage_file_url(filename, baseurl=None):
         )
     else:
         return "/{}{}/{}/{}".format(
-            get_content_storage_url(baseurl).lstrip('/'), filename[0], filename[1], filename
+            get_content_storage_url(baseurl).lstrip("/"),
+            filename[0],
+            filename[1],
+            filename,
         )

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -140,6 +140,6 @@ def get_content_storage_file_url(filename, baseurl=None):
             kwargs={"zipped_filename": filename, "embedded_filepath": ""},
         )
     else:
-        return "{}{}/{}/{}".format(
-            get_content_storage_url(baseurl), filename[0], filename[1], filename
+        return "/{}{}/{}/{}".format(
+            get_content_storage_url(baseurl).lstrip('/'), filename[0], filename[1], filename
         )

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -141,7 +141,7 @@ def get_content_storage_file_url(filename, baseurl=None):
         )
     else:
         return "/{}{}/{}/{}".format(
-            get_content_storage_url(baseurl),
+            get_content_storage_url(baseurl).lstrip(),
             filename[0],
             filename[1],
             filename,

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -263,7 +263,7 @@ def run_server(port):
 
     cherrypy.tree.mount(
         content_files_handler,
-        "/{}".format(paths.get_content_url(url_path_prefix).lstrip()),
+        "/{}".format(paths.get_content_url(url_path_prefix).lstrip("/")),
         config={"/": {"tools.caching.on": False}},
     )
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -263,7 +263,7 @@ def run_server(port):
 
     cherrypy.tree.mount(
         content_files_handler,
-        "/{}".format(paths.get_content_url(url_path_prefix)),
+        "/{}".format(paths.get_content_url(url_path_prefix).lstrip()),
         config={"/": {"tools.caching.on": False}},
     )
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -263,7 +263,7 @@ def run_server(port):
 
     cherrypy.tree.mount(
         content_files_handler,
-        "/" + paths.get_content_url(url_path_prefix).lstrip("/"),
+        "/{}".format(paths.get_content_url(url_path_prefix)),
         config={"/": {"tools.caching.on": False}},
     )
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -260,7 +260,7 @@ def run_server(port):
     )
     cherrypy.tree.mount(
         content_files_handler,
-        paths.get_content_url(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]),
+        "/" + paths.get_content_url(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]).lstrip('/'),
         config={"/": {"tools.caching.on": False}},
     )
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -258,9 +258,12 @@ def run_server(port):
     content_files_handler = cherrypy.tools.staticdir.handler(
         section="/", dir=paths.get_content_dir_path()
     )
+
+    url_path_prefix = conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+
     cherrypy.tree.mount(
         content_files_handler,
-        "/" + paths.get_content_url(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]).lstrip('/'),
+        "/" + paths.get_content_url(url_path_prefix).lstrip("/"),
         config={"/": {"tools.caching.on": False}},
     )
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fix for [Cannot serve resources in storage when a custom KOLIBRI_URL_PATH_PREFIX is used](https://github.com/learningequality/kolibri/issues/5414)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See issue above to test the fix

### References
Closes #5414

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
