### PR TITLE
Add resource preview to LessonSummaryPage and Lesson report page

### DIFF
--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -107,11 +107,22 @@ export default [
     name: LessonsPageNames.RESOURCE_CONTENT_PREVIEW,
     path: path(CLASS, LESSON, '/resource', PREVIEW),
     component: PlanLessonSelectionContentPreview,
-    props: {
-      showSelectOptions: false,
-      backRoute: {
-        name: LessonsPageNames.SUMMARY,
-      },
+    props(data) {
+      let backRoute;
+      // If linked from the Reports section, go back there
+      if (data.query.last === 'LessonReportEditDetailsPage') {
+        backRoute = {
+          name: 'LessonReportEditDetailsPage',
+        };
+      } else {
+        backRoute = {
+          name: LessonsPageNames.SUMMARY,
+        };
+      }
+      return {
+        showSelectOptions: false,
+        backRoute,
+      };
     },
     handler(toRoute) {
       showLessonResourceContentPreview(store, toRoute.params);

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -106,6 +106,13 @@ export default [
   {
     name: LessonsPageNames.RESOURCE_CONTENT_PREVIEW,
     path: path(CLASS, LESSON, '/resource', PREVIEW),
+    component: PlanLessonSelectionContentPreview,
+    props: {
+      showSelectOptions: false,
+      backRoute: {
+        name: LessonsPageNames.SUMMARY,
+      },
+    },
     handler(toRoute) {
       showLessonResourceContentPreview(store, toRoute.params);
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -38,7 +38,12 @@
             <KGridItem size="4">
               <div class="resource-title">
                 <ContentIcon :kind="resource.kind" />
-                {{ resource.title }}
+                <KRouterLink
+                  :text="resource.title"
+                  :to="$router.getRoute('RESOURCE_CONTENT_PREVIEW', {
+                    contentId: resource.id
+                  }, { last: 'LessonReportEditDetailsPage' })"
+                />
                 <p dir="auto" class="channel-title" :style="{ color: $coreTextAnnotation }">
                   <dfn class="visuallyhidden"> {{ $tr('parentChannelLabel') }} </dfn>
                   {{ resource.channelTitle }}
@@ -68,6 +73,7 @@
   import KDragSortWidget from 'kolibri.coreVue.components.KDragSortWidget';
   import KDragContainer from 'kolibri.coreVue.components.KDragContainer';
   import KDragHandle from 'kolibri.coreVue.components.KDragHandle';
+  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KDraggable from 'kolibri.coreVue.components.KDraggable';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KGrid from 'kolibri.coreVue.components.KGrid';
@@ -83,6 +89,7 @@
       KDragContainer,
       KDragHandle,
       KDragSortWidget,
+      KRouterLink,
       KButton,
       KGrid,
       KGridItem,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -30,7 +30,10 @@
             <KGridItem size="4">
               <div class="resource-title">
                 <ContentIcon :kind="resourceKind(resourceId)" />
-                {{ resourceTitle(resourceId) }}
+                <KRouterLink
+                  :text="resourceTitle(resourceId)"
+                  :to="$router.getRoute('RESOURCE_CONTENT_PREVIEW', { contentId: resourceId })"
+                />
                 <p dir="auto" class="channel-title" :style="{ color: $coreTextAnnotation }">
                   <dfn class="visuallyhidden"> {{ $tr('parentChannelLabel') }} </dfn>
                   {{ resourceChannelTitle(resourceId) }}
@@ -68,6 +71,7 @@
   import KDraggable from 'kolibri.coreVue.components.KDraggable';
   import KButton from 'kolibri.coreVue.components.KButton';
   import KGrid from 'kolibri.coreVue.components.KGrid';
+  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
@@ -81,6 +85,7 @@
       KDragContainer,
       KDragHandle,
       KDragSortWidget,
+      KRouterLink,
       CoachContentLabel,
       KButton,
       KGrid,

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -12,7 +12,7 @@
       :currentContentNode="currentContentNode"
       :isSelected="isSelected"
       :questions="preview.questions"
-      :displaySelectOptions="Boolean(workingResources)"
+      :displaySelectOptions="showSelectOptions"
       :completionData="preview.completionData"
       @addResource="handleAddResource"
       @removeResource="handleRemoveResource"
@@ -38,12 +38,26 @@
       LessonContentPreviewPage,
     },
     mixins: [commonCoach],
+    props: {
+      // If set to true, will show the add/remove buttons.
+      showSelectOptions: {
+        type: Boolean,
+        default: true,
+      },
+      // Override the toolbarRoute in vuex
+      backRoute: {
+        type: Object,
+        required: false,
+      },
+    },
     computed: {
       toolbarRoute() {
-        return {
-          ...this.$store.state.toolbarRoute,
-          query: this.$route.query,
-        };
+        return (
+          this.backRoute || {
+            ...this.$store.state.toolbarRoute,
+            query: this.$route.query,
+          }
+        );
       },
       ...mapState('lessonSummary', ['workingResources']),
       ...mapState('lessonSummary/resources', ['currentContentNode', 'preview']),


### PR DESCRIPTION

### Summary

1. Adds back the ability to preview a lesson resource from the lesson summary page
1. Adds the ability to preview from lesson edit page (from the lesson's report page)

This does not fix the design of the immersive appbar (e.g. title and icons)

**From Report version of edit details page**

![Screen Shot 2019-04-24 at 11 55 27 AM](https://user-images.githubusercontent.com/10248067/56686520-03187d00-6689-11e9-896f-25a3c0a956bc.png)

**The preview page**
![Screen Shot 2019-04-24 at 11 35 45 AM](https://user-images.githubusercontent.com/10248067/56686521-03b11380-6689-11e9-9806-0bbd9dd6e498.png)

**From the LessonSummaryPage**

![Screen Shot 2019-04-24 at 11 35 38 AM](https://user-images.githubusercontent.com/10248067/56686522-03b11380-6689-11e9-8ebd-8e716e2d8136.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
