### PR TITLE
skip/remove broken symlink or corrupted db files

### DIFF
--- a/kolibri/core/content/test/test_enumerate_channel.py
+++ b/kolibri/core/content/test/test_enumerate_channel.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+
+from django.test import TestCase
+from mock import patch
+
+from kolibri.core.content.utils.annotation import update_channel_metadata
+from kolibri.core.content.utils.channels import get_channel_ids_for_content_database_dir
+from kolibri.core.content.utils.channels import get_channels_for_data_folder
+from kolibri.core.content.utils.paths import get_content_database_dir_path
+
+
+class EnumerateChannelTestCase(TestCase):
+    """
+    Testcase for enumerating channel database files to find if they are corrupted
+    or have broken symbolic links.
+    """
+    def test_broken_symlink_database_file(self):
+        src_dir = tempfile.mkdtemp()
+        dst_dir = get_content_database_dir_path()
+        src_db_file = os.path.join(src_dir, "6199dde695db4ee4ab392222d5af1e5c.sqlite3")
+        dst_db_file = os.path.join(dst_dir, "6199dde695db4ee4ab392222d5af1e5c.sqlite3")
+        # Make sure that both files do not exist before creating the symlink
+        self.assertFalse(os.path.exists(src_db_file))
+        self.assertFalse(os.path.exists(dst_db_file))
+        os.symlink(src_db_file, dst_db_file)
+
+        channel_ids = get_channel_ids_for_content_database_dir(dst_dir)
+        self.assertTrue("6199dde695db4ee4ab392222d5af1e5c" not in channel_ids)
+
+    # Helper function
+    def create_corrupted_database_file(self, db_dir):
+        db_file = os.path.join(db_dir, "6199dde695db4ee4ab392222d5af1e5c.sqlite3")
+        with open(db_file, "w") as f:
+            f.write("test corrupted database file")
+        return db_file
+
+    @patch('kolibri.core.content.utils.annotation.logger.warning')
+    def test_corrupted_database_file_server_start(self, logger_mock):
+        db_file = self.create_corrupted_database_file(get_content_database_dir_path())
+        update_channel_metadata()
+        message_list = [message[0][0] for message in logger_mock.call_args_list]
+        error_message = "Tried to import channel 6199dde695db4ee4ab392222d5af1e5c, but database file was corrupted."
+        self.assertTrue(error_message in message_list)
+        os.remove(db_file)  # Remove database file for future tests
+
+    def test_corrupted_database_file_local_import(self):
+        datafolder = tempfile.mkdtemp()
+        db_file = self.create_corrupted_database_file(get_content_database_dir_path(datafolder))
+        channels = get_channels_for_data_folder(datafolder)
+
+        # Make sure that the corrupted database file is not going to be listed
+        self.assertTrue("6199dde695db4ee4ab392222d5af1e5c" not in channels)
+        os.remove(db_file)  # Remove database file for future tests

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -8,6 +8,7 @@ from sqlalchemy import and_
 from sqlalchemy import exists
 from sqlalchemy import func
 from sqlalchemy import select
+from sqlalchemy.exc import DatabaseError
 
 from .channels import get_channel_ids_for_content_database_dir
 from .paths import get_content_database_file_path
@@ -49,6 +50,8 @@ def update_channel_metadata():
                 annotate_content(channel_id)
             except (InvalidSchemaVersionError, FutureSchemaError):
                 logger.warning("Tried to import channel {channel_id}, but database file was incompatible".format(channel_id=channel_id))
+            except DatabaseError:
+                logger.warning("Tried to import channel {channel_id}, but database file was corrupted.".format(channel_id=channel_id))
     fix_multiple_trees_with_id_one()
     connection.close()
 

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -6,7 +6,6 @@ from sqlalchemy.exc import DatabaseError
 
 from .paths import get_content_database_dir_path
 from .sqlalchemybridge import Bridge
-from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.discovery.utils.filesystem import enumerate_mounted_disk_partitions
 from kolibri.utils.uuids import is_valid_uuid
 
@@ -42,11 +41,7 @@ def get_channel_ids_for_content_database_dir(content_database_dir):
         if not os.path.exists(filename) or os.path.getsize(filename) == 0:
             db_files_to_remove.add(db_name)
             os.remove(filename)
-            # Delete the channel metadata from the database if exists, so that
-            # users can download the database file again from the channel import page.
-            channel = ChannelMetadata.objects.filter(id=db_name)
-            if channel:
-                channel.delete()
+
     if db_files_to_remove:
         err_msg = (
             "Removing nonexistent or empty databases in content database directory "


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that database files are corrupted or have broken symlinks when enumerating channels.
There are three cases:
1. The database file in the kolibri home directory is corrupted and the channel is not imported to kolibri --> start kolibri --> kolibri enumerates channels in the home directory data folder --> kolibri finds the corrupted database file and raises a Database error --> error gets caught by the program so kolibri skips reading the channel

2. The database file in the USB data folder is corrupted and the channel is not imported to kolibri --> start kolibri and try to import channels from USB --> kolibri enumerates channels in the USB data folder --> kolibri finds the corrupted database file and raises a Database error --> error gets caught by the program so kolibri skips reading the channel

3. The database file has a symbolic link that is broken --> start kolibri --> kolibri enumerates channels in the home directory data folder --> kolibri finds that the database file with broken symlink actually does not exist --> raise FileNotFoundError --> error gets caught by the program and the database file is removed

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Case 1:
1. create a file `~/.kolibri/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3` and write string `test file` inside to make the file corrupted. 
2. start kolibri
3. Check that there is a warning message in the log: `WARNING  Tried to import channel 000409f81dbe5d1ba67101cb9fed4530, but database file was corrupted.`

Case 2:
1. create a file `000409f81dbe5d1ba67101cb9fed4530.sqlite3` inside the USB data folder and write string `test file` inside to make the file corrupted.
2. start kolibri
3. import content from USB
4. Check that there is a warning message in the log: `WARNING  Tried to import channel from database file <USB>/KOLIBRI_DATA/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3, but the file was corrupted.`

Case 3:
1. make sure that the files `/path/000409f81dbe5d1ba67101cb9fed4530.sqlite3` and `<kolibri_home>/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3` do not exist
2. run 
```
import os
os.symlink("/path/000409f81dbe5d1ba67101cb9fed4530.sqlite3", "<kolibri_home>/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3")
```
3. check that `<kolibri_home>/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3` now exists and has a symlink
4. start kolibri
5. check that there is a warning message in the log: `WARNING  Removing nonexistent or empty databases in content database directory '/Users/lingyiwang/.kolibri/content/databases' with IDs: set(['000409f81dbe5d1ba67101cb9fed4530']).
Please import the channels again.`
6. check that the database file `<kolibri_home>/content/databases/000409f81dbe5d1ba67101cb9fed4530.sqlite3` does not exist now

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5370

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
