### PR TITLE
add perseus protection and update docs

### DIFF
--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -447,7 +447,9 @@ def command_stats(branch):
     total_untranslated_strings = sum([row[2] for row in untranslated_table])
     total_unapproved_strings = sum([row[2] for row in needs_approval_table])
 
-    avg_untranslated_strings = round(total_untranslated_strings / len(untranslated_table))
+    avg_untranslated_strings = round(
+        total_untranslated_strings / len(untranslated_table)
+    )
     avg_unapproved_strings = round(total_unapproved_strings / len(needs_approval_table))
 
     total_untranslated_words = sum([row[1] for row in untranslated_table])
@@ -469,8 +471,12 @@ def command_stats(branch):
         STATS_TEMPLATE.format(
             branch=branch,
             summary_table=tabulate(summary_table, headers=summary_table_headers),
-            untranslated_table=tabulate(untranslated_table, headers=untranslated_table_headers),
-            needs_approval_table=tabulate(needs_approval_table, headers=needs_approval_table_headers),
+            untranslated_table=tabulate(
+                untranslated_table, headers=untranslated_table_headers
+            ),
+            needs_approval_table=tabulate(
+                needs_approval_table, headers=needs_approval_table_headers
+            ),
         )
     )
 

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -383,18 +383,14 @@ Branch: {branch}
 {summary_table}
 
 =================================================================
-==  Word counts  ================================================
+==  Untranslated  ===============================================
 
-Total words: {words_total}
-
-{words_table}
+{untranslated_table}
 
 =================================================================
-==  String counts  ==============================================
+==  Needs Approval  =============================================
 
-Total strings: {strings_total}
-
-{strings_table}
+{needs_approval_table}
 
 =================================================================
 """
@@ -409,9 +405,9 @@ def command_stats(branch):
     def _is_branch_node(node):
         return node["node_type"] == "branch" and node["name"] == branch
 
-    strings_table = []
+    needs_approval_table = []
     strings_total = 0
-    words_table = []
+    untranslated_table = []
     words_total = 0
 
     sorted_languages = sorted(
@@ -430,53 +426,51 @@ def command_stats(branch):
             logging.error("Branch '{}' not found on Crowdin".format(branch))
             sys.exit(1)
 
-        strings_table.append(
+        needs_approval_table.append(
             (
                 lang[utils.KEY_ENG_NAME],
-                branch_node["phrases"] - branch_node["translated"],
+                branch_node["words_translated"] - branch_node["words_approved"],
                 branch_node["translated"] - branch_node["approved"],
             )
         )
-        words_table.append(
+        untranslated_table.append(
             (
                 lang[utils.KEY_ENG_NAME],
                 branch_node["words"] - branch_node["words_translated"],
-                branch_node["words_translated"] - branch_node["words_approved"],
+                branch_node["phrases"] - branch_node["translated"],
             )
         )
 
         strings_total = branch_node["phrases"]  # should be the same across languages
         words_total = branch_node["words"]  # should be the same across languages
 
-    total_untranslated_strings = sum([row[1] for row in strings_table])
-    total_unapproved_strings = sum([row[2] for row in strings_table])
-    avg_untranslated_strings = round(total_untranslated_strings / len(strings_table))
-    avg_unapproved_strings = round(total_unapproved_strings / len(strings_table))
-    strings_table.append(
-        ("Average - all languages", avg_untranslated_strings, avg_unapproved_strings)
-    )
-    total_untranslated_words = sum([row[1] for row in words_table])
-    total_unapproved_words = sum([row[2] for row in words_table])
-    avg_untranslated_words = round(total_untranslated_words / len(words_table))
-    avg_unapproved_words = round(total_unapproved_words / len(words_table))
-    words_table.append(
-        ("Average - all languages", avg_untranslated_words, avg_unapproved_words)
-    )
-    summary_table_headers = ["", "Untranslated", "Needs approval"]
+    total_untranslated_strings = sum([row[2] for row in untranslated_table])
+    total_unapproved_strings = sum([row[2] for row in needs_approval_table])
+
+    avg_untranslated_strings = round(total_untranslated_strings / len(untranslated_table))
+    avg_unapproved_strings = round(total_unapproved_strings / len(needs_approval_table))
+
+    total_untranslated_words = sum([row[1] for row in untranslated_table])
+    total_unapproved_words = sum([row[1] for row in needs_approval_table])
+
+    avg_untranslated_words = round(total_untranslated_words / len(untranslated_table))
+    avg_unapproved_words = round(total_unapproved_words / len(needs_approval_table))
+
+    summary_table_headers = ["", "Words", "Strings"]
     summary_table = [
-        ("Words", total_untranslated_words, total_unapproved_words),
-        ("Strings", total_untranslated_strings, total_unapproved_strings),
+        ("Avg. Untranslated", avg_untranslated_words, avg_untranslated_strings),
+        ("Avg. Needs Approval", avg_unapproved_words, avg_unapproved_strings),
+        ("Total (for a new language)", words_total, strings_total),
     ]
-    strings_table_headers = ["Language", "Untranslated", "Needs approval"]
-    words_table_headers = ["Language", "Untranslated", "Needs approval"]
+    needs_approval_table_headers = ["Language", "Words", "Strings"]
+    untranslated_table_headers = ["Language", "Words", "Strings"]
+
     logging.info(
         STATS_TEMPLATE.format(
             branch=branch,
             summary_table=tabulate(summary_table, headers=summary_table_headers),
-            words_total=words_total,
-            words_table=tabulate(words_table, headers=words_table_headers),
-            strings_total=strings_total,
-            strings_table=tabulate(strings_table, headers=strings_table_headers),
+            untranslated_table=tabulate(untranslated_table, headers=untranslated_table_headers),
+            needs_approval_table=tabulate(needs_approval_table, headers=needs_approval_table_headers),
         )
     )
 

--- a/build_tools/i18n/utils.py
+++ b/build_tools/i18n/utils.py
@@ -23,17 +23,26 @@ PERSEUS_LOCALE_PATH = os.path.join(
 )
 PERSEUS_SOURCE_PATH = os.path.join(PERSEUS_LOCALE_PATH, "en", "LC_MESSAGES")
 
-PERSEUS_NOT_FOUND = """Cannot find Perseus locale directory.
-Please ensure that you've installed the Perseus plugin in development mode using
+PERSEUS_NOT_INSTALLED_FOR_DEV = """
+Clone https://github.com/learningequality/kolibri-exercise-perseus-plugin/
+and ensure that it has been checked out the the correct commit.
+
+Install it in Kolibri in development mode:
 
     pip install -e [local_path_to_perseus_repo]
 
-Also, please ensure that Perseus has been checked out the the correct commit.
+For more information see:
+https://kolibri-dev.readthedocs.io/en/develop/i18n.html#updating-the-perseus-plugin
 """
 
 
 if not (os.path.exists(PERSEUS_LOCALE_PATH)):
-    logging.error(PERSEUS_NOT_FOUND)
+    logging.error("Cannot find Perseus locale directory.")
+    logging.info(PERSEUS_NOT_INSTALLED_FOR_DEV)
+    sys.exit(1)
+elif '/site-packages/' in PERSEUS_LOCALE_PATH:
+    logging.error("It appears that Perseus is not installed for development.")
+    logging.info(PERSEUS_NOT_INSTALLED_FOR_DEV)
     sys.exit(1)
 
 

--- a/build_tools/i18n/utils.py
+++ b/build_tools/i18n/utils.py
@@ -40,7 +40,7 @@ if not (os.path.exists(PERSEUS_LOCALE_PATH)):
     logging.error("Cannot find Perseus locale directory.")
     logging.info(PERSEUS_NOT_INSTALLED_FOR_DEV)
     sys.exit(1)
-elif '/site-packages/' in PERSEUS_LOCALE_PATH:
+elif "/site-packages/" in PERSEUS_LOCALE_PATH:
     logging.error("It appears that Perseus is not installed for development.")
     logging.info(PERSEUS_NOT_INSTALLED_FOR_DEV)
     sys.exit(1)

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -121,6 +121,8 @@ Note that you have to specify branch names for most commands.
 
 .. note:: These notes are only for the Kolibri application. For translation of user documentation, please see the `kolibri-docs repository <https://github.com/learningequality/kolibri-docs/>`__.
 
+.. note:: The Kolibri Crowdin workflow relies on the project having the "Duplicate strings" setting set to "Show – translators will translate each instance separately". If this is not set, the workflow will not function as expected!
+
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -131,29 +133,29 @@ First, you'll need to have GNU ``gettext`` available on your path. You may be ab
 
 Next, ensure you have an environment variable ``CROWDIN_API_KEY`` set to the Learning Equality organization `account API key <https://support.crowdin.com/api/api-integration-setup/>`__.
 
+Finally, you'll need to install the Perseus Plugin (``kolibri_exercise_perseus_plugin`` Python package) in development mode. This is done by `checking out the repo <https://github.com/learningequality/kolibri-exercise-perseus-plugin#development-guide>`__ and then installing it to Kolibri by running:
 
-.. _i18n-perseus:
+.. code-block:: bash
 
-Updating the Perseus plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  pip install -e [local_path_to_perseus_repo]
 
-The `perseus exercise plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__ has its own translated files that also need to be updated.
-
-To do this, you'll need to install the Perseus Plugin in development mode (using ``pip install -e``). This will allow the scripts to properly upload sources and download translations from and to the Perseus plugin, which may then need to be released.
+This will allow the scripts to properly upload sources and download translations from and to the Perseus plugin, which may then need to be released if any strings have changed or if new languages were added.
 
 See the `Perseus plugin development guide <https://github.com/learningequality/kolibri-exercise-perseus-plugin#development-guide>`__ for more information on setup and publication.
 
+When uploading or downloading strings, ensure that your Perseus repo is in a clean checkout state with the correct Perseus branch.
 
-Extracting and uploading
-~~~~~~~~~~~~~~~~~~~~~~~~
 
-Typically, strings will be uploaded when a new release branch is cut from ``develop``, signifying the beginning of string freeze and the ``beta`` releases.
+Extracting and uploading sources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Typically, strings will be uploaded when a new release branch is cut from ``develop``, signifying the beginning of string freeze and the ``beta`` releases. (See :ref:`release_process`.)
 
 Before translators can begin working on the strings in our application, they need to be uploaded to Crowdin. Translations are maintained in release branches on Crowdin in the `Crowdin kolibri project <http://crowdin.com/project/kolibri>`__.
 
-.. note:: You must have the Perseus plugin installed for development as described above, or not all strings will be extracted.
+.. warning:: You *must* have the Perseus plugin installed for development as described above, or not all strings will be extracted!
 
-This command will extract front- and backend strings and upload them to Crowdin:
+This command will extract front- and backend strings and upload them to Crowdin, and may take a while:
 
 .. code-block:: bash
 
@@ -161,7 +163,26 @@ This command will extract front- and backend strings and upload them to Crowdin:
 
 The branch name will typically look something like: ``release-v0.8.x``
 
-After uploading, this will also apply 'pre-translation' (which can take some time). This copies over translations for strings that have the same text but different IDs.
+Pre-translation
+~~~~~~~~~~~~~~~
+
+After running the ``i18n-upload`` command above, the newly created branch should have some percentage of strings in supported languages shown as both translated and approved. These strings are the *exact* matches from the previous release, meaning that both the string IDs and the English text is exactly the same.
+
+At this point, it is often desirable to apply some form of pre-translation to the remaining strings using Crowdin's "translation memory" functionality. There are two ways to do this: with and without auto-approval.
+
+To run pre-translation without auto-approval **(recommended)**:
+
+.. code-block:: bash
+
+  make i18n-pretranslate branch=[release-branch-name]
+
+Or to run pre-translation with auto-approval:
+
+.. code-block:: bash
+
+  make i18n-pretranslate-approve-all branch=[release-branch-name]
+
+.. warning:: The exact behavior of Crowdin's translation memory is not specified. Given some English phrase, it is not always possible to predict what suggested translation it will make. Therefore, auto-approval be used with caution.
 
 
 Displaying stats
@@ -199,10 +220,12 @@ This will give you some output like this:
 This information can be provided to translators; it's also available on the Crowdin website.
 
 
-Updating i18n files
-~~~~~~~~~~~~~~~~~~~
+Downloading translations to Kolibri
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before fetching and building the internationalization files, you need to download source fonts from Google. In order to do this, run:
+As translators work on Crowdin, we will periodically retrieve the latest updates and commit them to Kolibri's codebase. In the process, we'll also update the custom fonts that are generated based on the translated application text.
+
+First, you need to download source fonts from Google. In order to do this, run:
 
 .. code-block:: bash
 
@@ -224,7 +247,7 @@ This will do a number of things for you:
 
 Check in all the updated files to git and submit them in a PR to the release branch.
 
-.. note:: This may also require submitting a separate PR for the Perseus plugin, releasing a new version of it, and referencing the new version in Kolibri's base.txt Pip requirements file.
+.. note:: Remember about Perseus! Check if files in that repo have changed too, and submit a separate PR. It will be necessary to release a new version and referencing it in Kolibri's ``base.txt`` requirements file.
 
 
 .. _new_language:

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -35,7 +35,7 @@ Each minor release (``N.N.*``) is maintained in a CrowdIn Version Branch, follow
 
 On the string freeze date, the strings for the upcoming release should be uploaded to crowdin as described in :ref:`crowdin`. You can run ``make i18n-stats branch=<release-vN.N.x>`` to get figures on the translation work. Send the stats to the i18n team, whom can use them for communication with translators to measure the translation efforts needed.
 
-Strings from the Perseus plugin should also be revisited. They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from CrowdIn such as ``exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`i18n-perseus`.
+Strings from the Perseus plugin should also be revisited. They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from CrowdIn such as ``exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`crowdin`.
 
 Before the translation start date, provide time to do one final review of all user-facing strings. This can be done e.g. in the course of doing a preliminary translation into Spanish.
 


### PR DESCRIPTION

### Summary

* Adds logic to ensure that Perseus is installed for dev before uploading or downloading strings
* Update documentation to reflect current practices w.r.t. pre-translation

### Reviewer guidance

please make sure these changes make sense?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
