### PR TITLE
Always show the next resource if one is available.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -99,7 +99,7 @@
     />
 
     <slot name="below_content">
-      <template v-if="progress >= 1 && content.next_content">
+      <template v-if="content.next_content">
         <h2>{{ $tr('nextResource') }}</h2>
         <ContentCardGroupCarousel
           :genContentLink="genContentLink"


### PR DESCRIPTION
### Summary
Always shows a next resource if one is available when accessing content in learn.

### Reviewer guidance
Before
![image](https://user-images.githubusercontent.com/1680573/56745504-547b4780-672f-11e9-8da8-fc4c827025d3.png)

After
![image](https://user-images.githubusercontent.com/1680573/56745460-3e6d8700-672f-11e9-934f-b61507bfb34a.png)


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
