### PR TITLE
Make scrolling behaviour more consistent and not rely on setting window properties

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -4,6 +4,8 @@ import store from 'kolibri.coreVue.vuex.store';
 
 const logging = logger.getLogger(__filename);
 
+const scrollPositions = {};
+
 /** Wrapper around Vue Router.
  *  Implements URL mapping to Vuex actions in addition to Vue components.
  *  Otherwise intended as a mostly transparent replacement to vue-router.
@@ -14,8 +16,9 @@ class Router {
    */
   constructor() {
     this._vueRouter = new VueRouter({
-      scrollBehavior(to, from, savedPosition) {
+      scrollBehavior() {
         let y = 0;
+        const savedPosition = scrollPositions[window.history.state.key];
         if (savedPosition) {
           y = savedPosition.y;
         }
@@ -79,6 +82,10 @@ class Router {
 
   enableHandlers() {
     this._vueRouter.beforeEach(this._hook.bind(this));
+  }
+
+  storeScrollPosition({ x, y }) {
+    scrollPositions[window.history.state.key] = { x, y };
   }
 
   /****************************/

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -1,10 +1,7 @@
 import VueRouter from 'vue-router';
 import logger from 'kolibri.lib.logging';
-import store from 'kolibri.coreVue.vuex.store';
 
 const logging = logger.getLogger(__filename);
-
-const scrollPositions = {};
 
 /** Wrapper around Vue Router.
  *  Implements URL mapping to Vuex actions in addition to Vue components.
@@ -15,28 +12,12 @@ class Router {
    * Create a Router instance.
    */
   constructor() {
-    this._vueRouter = new VueRouter({
-      scrollBehavior() {
-        let y = 0;
-        const savedPosition = scrollPositions[window.history.state.key];
-        if (savedPosition) {
-          y = savedPosition.y;
-        }
-        // Set the scroll position in the vuex store
-        // CoreBase is watching for this value to change
-        // to set its initial scroll position.
-        store.commit('SET_SCROLL_POSITION', y);
-      },
-    });
+    this._vueRouter = new VueRouter();
     this._actions = {};
     this._routes = {};
   }
 
   _hook(toRoute, fromRoute, next) {
-    // Set scroll position to 0 by default
-    // Can be updated by the scroll behaviour
-    // hook above.
-    store.commit('SET_SCROLL_POSITION', 0);
     if (this._actions[toRoute.name]) {
       this._actions[toRoute.name](toRoute, fromRoute);
     }
@@ -82,10 +63,6 @@ class Router {
 
   enableHandlers() {
     this._vueRouter.beforeEach(this._hook.bind(this));
-  }
-
-  storeScrollPosition({ x, y }) {
-    scrollPositions[window.history.state.key] = { x, y };
   }
 
   /****************************/

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -15,7 +15,6 @@ export default {
     loginError: null,
     signInBusy: false,
     totalProgress: null,
-    scrollPosition: 0,
     notifications: [],
     channels: {
       list: [],

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -40,9 +40,6 @@ export default {
   CORE_REMOVE_NOTIFICATION(state, notification_id) {
     state.notifications = state.notifications.filter(obj => obj.id !== notification_id);
   },
-  SET_SCROLL_POSITION(state, scrollPosition) {
-    state.scrollPosition = scrollPosition;
-  },
   CORE_SET_PAGE_VISIBILITY(state, visible) {
     state.pageVisible = visible;
   },

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -391,12 +391,21 @@
         }
       },
     },
+    beforeRouteUpdate() {
+      this.recordScroll();
+    },
+    beforeRouteLeave() {
+      this.recordScroll();
+    },
     mounted() {
       this.setScroll();
     },
     methods: {
       handleScroll() {
         this.scrollPosition = this.$el.scrollTop;
+        this.recordScroll();
+      },
+      recordScroll() {
         scrollPositions.setScrollPosition({ y: this.$el.scrollTop });
       },
       dismissUpdateModal() {
@@ -407,6 +416,7 @@
       },
       setScroll() {
         this.$el.scrollTop = scrollPositions.getScrollPosition().y;
+        this.scrollPosition = this.$el.scrollTop;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -130,7 +130,7 @@
     _scrollPositions: {},
     getScrollPosition() {
       // Use key set by Vue Router on the history state.
-      const key = window.history.state.key;
+      const key = (window.history.state || {}).key;
       const defaultPos = { x: 0, y: 0 };
       if (key && this._scrollPositions[key]) {
         return this._scrollPositions[key];
@@ -138,7 +138,7 @@
       return defaultPos;
     },
     setScrollPosition({ x, y }) {
-      const key = window.history.state.key;
+      const key = (window.history.state || {}).key;
       // Only set if we have a vue router key on the state,
       // otherwise we don't do anything.
       if (key) {

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div
+    ref="mainWrapper"
     class="main-wrapper"
     :style="mainWrapperStyles"
     :class="fullScreen ? '' : 'scrolling-pane'"
@@ -108,6 +109,7 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
+  import router from 'kolibri.coreVue.router';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import AppBar from 'kolibri.coreVue.components.AppBar';
@@ -377,13 +379,7 @@
     methods: {
       handleScroll(e) {
         this.scrollPosition = e.target.scrollTop;
-        // Setting this will not affect the page layout,
-        // but this will then get properly stored in the
-        // browser history.
-        try {
-          // This property can sometimes be readonly in older browsers
-          window.pageYOffset = this.scrollPosition;
-        } catch (e) {} // eslint-disable-line no-empty
+        router.storeScrollPosition({ y: this.$refs.mainWrapper.scrollTop });
       },
       dismissUpdateModal() {
         if (this.notifications.length === 0) {
@@ -393,10 +389,7 @@
       },
       setScroll(scrollValue) {
         this.$el.scrollTop = scrollValue;
-        try {
-          // This property can sometimes be readonly in older browsers
-          window.pageYOffset = scrollValue;
-        } catch (e) {} // eslint-disable-line no-empty
+        router.storeScrollPosition({ y: this.$refs.mainWrapper.scrollTop });
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary
* Removes most reliance on vuejs router history scroll behavior
* Utilises the history state key that vuejs uses to independently store a record of scroll positions
* Encapsulates all scroll behaviour inside core base component
* Removes Vuex state for scroll history

### Reviewer guidance
Is scroll state consistent preserved across browser history navigation?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
