### PR TITLE
Fix property names of facilityConfig after un-camelcasing  them in #5340

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
@@ -77,6 +77,7 @@
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
     'learner_can_edit_username',
+    'learner_can_edit_password',
     'learner_can_edit_name',
     'learner_can_sign_up',
     'learner_can_login_with_no_password',
@@ -163,10 +164,6 @@
 
   .mb {
     margin-bottom: 2rem;
-  }
-
-  .settings {
-    max-width: 35rem;
   }
 
   .settings > label {

--- a/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
@@ -35,6 +35,24 @@ describe('facility config page view', () => {
     expect(!confirmResetModal().exists()).toEqual(true);
   }
 
+  it('has all of the settings', () => {
+    const wrapper = makeWrapper();
+    const checkboxes = wrapper.findAll({ name: 'KCheckbox' });
+    expect(checkboxes.length).toEqual(7);
+    const labels = [
+      'Allow learners and coaches to edit their username',
+      'Allow learners and coaches to change their password when signed in',
+      'Allow learners and coaches to edit their full name',
+      'Allow learners to create accounts',
+      'Allow learners to sign in with no password',
+      "Show 'download' button with content",
+      'Allow users to access content without signing in',
+    ];
+    labels.forEach((label, idx) => {
+      expect(checkboxes.at(idx).props().label).toEqual(label);
+    });
+  });
+
   it('clicking checkboxes dispatches a modify action', () => {
     const wrapper = makeWrapper();
     const { checkbox } = getElements(wrapper);

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -196,7 +196,7 @@
         return this.content.kind === ContentNodeKinds.TOPIC;
       },
       canDownload() {
-        if (this.facilityConfig.showDownloadButtonInLearn && this.content) {
+        if (this.facilityConfig.show_download_button_in_learn && this.content) {
           return (
             this.downloadableFiles.length &&
             this.content.kind !== ContentNodeKinds.EXERCISE &&

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -217,18 +217,18 @@
       },
       canEditUsername() {
         if (this.isCoach || this.isLearner) {
-          return this.facilityConfig.learnerCanEditUsername;
+          return this.facilityConfig.learner_can_edit_username;
         }
         return true;
       },
       canEditName() {
         if (this.isCoach || this.isLearner) {
-          return this.facilityConfig.learnerCanEditName;
+          return this.facilityConfig.learner_can_edit_name;
         }
         return true;
       },
       canEditPassword() {
-        return this.isSuperuser || this.facilityConfig.learnerCanEditPassword;
+        return this.isSuperuser || this.facilityConfig.learner_can_edit_password;
       },
       nameIsInvalidText() {
         if (this.nameBlurred || this.formSubmitted) {

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -203,7 +203,7 @@
         busy: state => state.core.signInBusy,
       }),
       simpleSignIn() {
-        return this.facilityConfig.learnerCanLoginWithNoPassword;
+        return this.facilityConfig.learner_can_login_with_no_password;
       },
       suggestions() {
         // Filter suggestions on the client side so we don't hammer the server
@@ -248,7 +248,7 @@
         return !this.usernameIsInvalid && !this.passwordIsInvalid;
       },
       canSignUp() {
-        return this.facilityConfig.learnerCanSignUp;
+        return this.facilityConfig.learner_can_sign_up;
       },
       signUpPage() {
         return { name: PageNames.SIGN_UP };
@@ -263,7 +263,7 @@
         return !this.simpleSignIn || this.hasServerError;
       },
       allowGuestAccess() {
-        return this.facilityConfig.allowGuestAccess;
+        return this.facilityConfig.allow_guest_access;
       },
       logoHeight() {
         const CRITICAL_ACTIONS_HEIGHT = 350; // title + form + action buttons


### PR DESCRIPTION
### Summary

1. Goes through all references to `state.core.facilityConfig` or its getter `core/facilityConfig` and makes sure it is using the correct property names.
1. Adds 'learner can edit password' option to the Facility Config Page


### Reviewer guidance

1. Grep through all of the fields in facility config in the their old camel-case version and make sure they are removed from the code after this patch.
1. Manually test to confirm facility settings are being applied.

![Screen Shot 2019-04-26 at 10 39 40 AM](https://user-images.githubusercontent.com/10248067/56826475-2ff79c00-6811-11e9-83f2-c84b968aed68.png)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #5428 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
