### PR TITLE
Add directive dynamic argument support to no-unused-.. rules

### DIFF
--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -71,6 +71,13 @@ const create = context => {
         });
       },
     },
+    utils.executeOnDirectiveDynamicArg(node => {
+      const argName = utils.getDirectiveDynamicArgName(node);
+
+      remove(unusedProperties, property => {
+        return argName === property.name;
+      });
+    }),
     utils.executeOnRootTemplateEnd(() => {
       if (unusedProperties.length) {
         utils.reportUnusedProperties(context, unusedProperties);

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -140,6 +140,13 @@ const create = context => {
         });
       },
     },
+    utils.executeOnDirectiveDynamicArg(node => {
+      const argName = utils.getDirectiveDynamicArgName(node);
+
+      remove(unusedVuexProperties, property => {
+        return argName === property.name;
+      });
+    }),
     utils.executeOnRootTemplateEnd(() => {
       if (unusedVuexProperties.length) {
         utils.reportUnusedVuexProperties(context, unusedVuexProperties);

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -62,6 +62,23 @@ module.exports = {
   },
 
   /**
+   * Extract name from a directive dynamic argument node.
+   */
+  getDirectiveDynamicArgName(node) {
+    if (!node.raw || !node.raw.argument || !node.raw.argument.length) {
+      return null;
+    }
+
+    const rawArg = node.raw.argument;
+
+    if (rawArg[0] !== '[' || rawArg.slice(-1) !== ']') {
+      return null;
+    }
+
+    return rawArg.slice(1, rawArg.length - 1);
+  },
+
+  /**
    * Run callback on this expression properties nodes.
    */
   executeOnThisExpressionProperty(func) {
@@ -103,6 +120,27 @@ module.exports = {
   executeOnWatchStringMethod(func) {
     return {
       'Property[key.name=watch] ObjectExpression[properties] Literal[value]'(node) {
+        func(node);
+      },
+    };
+  },
+
+  /**
+   * Run callback on directive dynamic argument node, e.g. on
+   * <a :[attributeName]="..."> ... </a>
+   */
+  executeOnDirectiveDynamicArg(func) {
+    return {
+      'VDirectiveKey[argument]'(node) {
+        if (!node.raw || !node.raw.argument || !node.raw.argument.length) {
+          return;
+        }
+
+        const rawArg = node.raw.argument;
+        if (rawArg[0] !== '[' || rawArg.slice(-1) !== ']') {
+          return;
+        }
+
         func(node);
       },
     };

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-properties.spec.js
@@ -647,6 +647,62 @@ tester.run('vue-no-unused-properties', rule, {
         </script>
       `,
     },
+
+    // a property used as a dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeName]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            props: ['attributeName']
+          };
+        </script>
+      `,
+    },
+
+    // data used as a dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeName]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            data() {
+              return {
+                attributeName: 'href'
+              };
+            }
+          };
+        </script>
+      `,
+    },
+
+    // a computed property used as a dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeName]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            computed: {
+              attributeName() {
+                return 'href';
+              }
+            }
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [
@@ -720,6 +776,28 @@ tester.run('vue-no-unused-properties', rule, {
         {
           message: 'Unused computed property found: "count"',
           line: 9,
+        },
+      ],
+    },
+
+    // unused property - dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeNam]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            props: ['attributeName']
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused property found: "attributeName"',
+          line: 8,
         },
       ],
     },

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
@@ -513,6 +513,38 @@ tester.run('vue-no-unused-vuex-properties', rule, {
         </script>
       `,
     },
+
+    // a getter used as a dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeName]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['attributeName']),
+          };
+        </script>
+      `,
+    },
+
+    // state used as a dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeName]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState(['attributeName']),
+          };
+        </script>
+      `,
+    },
   ],
 
   invalid: [
@@ -727,6 +759,50 @@ tester.run('vue-no-unused-vuex-properties', rule, {
       errors: [
         {
           message: 'Unused Vuex state found: "count"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused getter - dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeNam]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            computed: mapGetters(['attributeName']),
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex getter found: "attributeName"',
+          line: 8,
+        },
+      ],
+    },
+
+    // unused state - dynamic directive argument
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <a :[attributeNam]="url"> ... </a>
+        </template>
+
+        <script>
+          export default {
+            computed: mapState(['attributeName']),
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused Vuex state found: "attributeName"',
           line: 8,
         },
       ],


### PR DESCRIPTION
### Summary

Add support for a[ new directive dynamic arguments syntax](https://vuejs.org/v2/guide/syntax.html#Dynamic-Arguments) to `vue-no-unused-properties` and `vue-no-unused-vuex-properties`.

@jonboiser This should solve the issue you reported.

### Reviewer guidance

Does it work well?

### References

None.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
