### PR TITLE
Add Learner Can Edit Password  to FacilityConfigPage

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/FacilityConfigPage/index.vue
@@ -75,6 +75,7 @@
 
   const settingsList = [
     'learnerCanEditUsername',
+    'learnerCanEditPassword',
     'learnerCanEditName',
     'learnerCanSignUp',
     'learnerCanLoginWithNoPassword',
@@ -165,10 +166,6 @@
 
   .mb {
     margin-bottom: 2rem;
-  }
-
-  .settings {
-    max-width: 35rem;
   }
 
   .settings > label {

--- a/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility_management/assets/test/views/facility-config-page.spec.js
@@ -35,6 +35,24 @@ describe('facility config page view', () => {
     expect(!confirmResetModal().exists()).toEqual(true);
   }
 
+  it('has all of the settings', () => {
+    const wrapper = makeWrapper();
+    const checkboxes = wrapper.findAll({ name: 'KCheckbox' });
+    expect(checkboxes.length).toEqual(7);
+    const labels = [
+      'Allow learners and coaches to edit their username',
+      'Allow learners and coaches to change their password when signed in',
+      'Allow learners and coaches to edit their full name',
+      'Allow learners to create accounts',
+      'Allow learners to sign in with no password',
+      "Show 'download' button with content",
+      'Allow users to access content without signing in',
+    ];
+    labels.forEach((label, idx) => {
+      expect(checkboxes.at(idx).props().label).toEqual(label);
+    });
+  });
+
   it('clicking checkboxes dispatches a modify action', () => {
     const wrapper = makeWrapper();
     const { checkbox } = getElements(wrapper);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
1. Adds this config setting back to the FacilityConfigPage
1. Adds a test to verify all settings are available on UI

![Screen Shot 2019-05-01 at 6 05 38 PM](https://user-images.githubusercontent.com/10248067/57052480-4bf9a400-6c3c-11e9-93f2-30441f75b74c.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
