### PR TITLE
Fix undefined env vars for non-process based frontend building.

### DIFF
--- a/packages/kolibri-tools/lib/build.js
+++ b/packages/kolibri-tools/lib/build.js
@@ -1,0 +1,20 @@
+function getEnvVar(variable) {
+  try {
+    return JSON.parse(process.env[variable]);
+  } catch (e) {
+    return process.env[variable];
+  }
+}
+
+function getEnvVars() {
+  return {
+    data: getEnvVar('data'),
+    index: getEnvVar('index'),
+    options: getEnvVar('options'),
+    start: getEnvVar('start'),
+  };
+}
+
+module.exports = {
+  getEnvVars,
+};

--- a/packages/kolibri-tools/lib/bundleStats.js
+++ b/packages/kolibri-tools/lib/bundleStats.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 // Import the production configuration so that we remain consistent
 const webpackConfig = require('./production').webpackConfig;
 const logger = require('./logging');
+const { getEnvVars } = require('./build');
 
 const buildLogging = logger.getLogger('Kolibri Build Stats');
 
@@ -25,9 +26,8 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   return compiler;
 }
 
-const data = JSON.parse(process.env.data);
-const index = JSON.parse(process.env.index);
-const start = JSON.parse(process.env.start);
+const { data, index, start } = getEnvVars();
+
 function build() {
   buildWebpack(
     data,

--- a/packages/kolibri-tools/lib/i18n.js
+++ b/packages/kolibri-tools/lib/i18n.js
@@ -6,6 +6,7 @@ const os = require('os');
 const webpack = require('webpack');
 const logger = require('./logging');
 const webpackBaseConfig = require('./webpack.config.base');
+const { getEnvVars } = require('./build');
 
 function webpackConfig(pluginData) {
   const pluginBundle = webpackBaseConfig(pluginData);
@@ -30,9 +31,8 @@ function buildWebpack(data, index, startCallback, doneCallback) {
   return compiler;
 }
 
-const data = JSON.parse(process.env.data);
-const index = JSON.parse(process.env.index);
-const start = JSON.parse(process.env.start);
+const { data, index, start } = getEnvVars();
+
 function build() {
   buildWebpack(
     data,

--- a/packages/kolibri-tools/lib/production.js
+++ b/packages/kolibri-tools/lib/production.js
@@ -5,6 +5,7 @@
 const webpack = require('webpack');
 const webpackBaseConfig = require('./webpack.config.base');
 const logger = require('./logging');
+const { getEnvVars } = require('./build');
 
 function webpackConfig(pluginData) {
   const pluginBundle = webpackBaseConfig(pluginData, {
@@ -40,9 +41,8 @@ function buildWebpack(data, index, startCallback, doneCallback) {
   return compiler;
 }
 
-const data = JSON.parse(process.env.data);
-const index = JSON.parse(process.env.index);
-const start = JSON.parse(process.env.start);
+const { data, index, start } = getEnvVars();
+
 function build() {
   buildWebpack(
     data,

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -14,6 +14,7 @@ const webpack = require('webpack');
 const openInEditor = require('launch-editor-middleware');
 const webpackBaseConfig = require('./webpack.config.base');
 const logger = require('./logging');
+const { getEnvVars } = require('./build');
 
 const buildLogging = logger.getLogger('Kolibri Webpack Dev Server');
 
@@ -111,10 +112,8 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   return compiler;
 }
 
-const data = JSON.parse(process.env.data);
-const index = JSON.parse(process.env.index);
-const options = JSON.parse(process.env.options);
-const start = JSON.parse(process.env.start);
+const { data, index, options, start } = getEnvVars();
+
 function build() {
   buildWebpack(
     data,


### PR DESCRIPTION
### Summary
To make builds less resource hoggy, some changes were made: #5402 
This introduced a regression: #5450, because it moved env var parsing into the module scope for our different build modules, and failed to take into account that this would break in the case where the module was not invoked in the context of a separate build process.
This PR fixes this regression by adding a function that either parses the env var or just returns the value/undefined.

### Reviewer guidance
Do different build commands (watch, build etc.) work using the env var `KOLIBRI_BUILD_SINGLE=true`?

### References
Fixes #5450 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
