### PR TITLE
Add group-level reports for an exercise/resource learners

### DIFF
--- a/kolibri/plugins/coach/assets/src/constants/lastPagesConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/lastPagesConstants.js
@@ -1,0 +1,7 @@
+export const LastPages = {
+  HOME_PAGE: 'homepage',
+  HOME_ACTIVITY: 'homeactivity',
+  GROUP_ACTIVITY: 'groupactivity',
+  LEARNER_ACTIVITY: 'learneractivity',
+  EXERCISE_LEARNER_LIST_BY_GROUPS: 'exerciselearnerlistbygroups',
+};

--- a/kolibri/plugins/coach/assets/src/constants/lastPagesConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/lastPagesConstants.js
@@ -3,5 +3,8 @@ export const LastPages = {
   HOME_ACTIVITY: 'homeactivity',
   GROUP_ACTIVITY: 'groupactivity',
   LEARNER_ACTIVITY: 'learneractivity',
+  EXERCISE_LEARNER_LIST: 'exerciselearnerlist',
   EXERCISE_LEARNER_LIST_BY_GROUPS: 'exerciselearnerlistbygroups',
+  RESOURCE_LEARNER_LIST: 'resourcelearnerlist',
+  RESOURCE_LEARNER_LIST_BY_GROUPS: 'resourcelearnerlistbygroups',
 };

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -245,8 +245,34 @@ export default {
           return this.classRoute('ReportsLearnerActivityPage', {
             learnerId: this.$route.query.last_id,
           });
+        case LastPages.EXERCISE_LEARNER_LIST:
+          return this.classRoute('ReportsLessonExerciseLearnerListPage', {
+            exerciseId: this.$route.query.exerciseId,
+          });
         case LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS:
-          return this.classRoute('ReportsLessonExerciseLearnerListPage', {}, { groups: 'true' });
+          return this.classRoute(
+            'ReportsLessonExerciseLearnerListPage',
+            {
+              exerciseId: this.$route.query.exerciseId,
+            },
+            {
+              groups: 'true',
+            }
+          );
+        case LastPages.RESOURCE_LEARNER_LIST:
+          return this.classRoute('ReportsLessonResourceLearnerListPage', {
+            resourceId: this.$route.query.resourceId,
+          });
+        case LastPages.RESOURCE_LEARNER_LIST_BY_GROUPS:
+          return this.classRoute(
+            'ReportsLessonResourceLearnerListPage',
+            {
+              resourceId: this.$route.query.resourceId,
+            },
+            {
+              groups: 'true',
+            }
+          );
         default:
           return null;
       }

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -23,6 +23,7 @@ import KPageContainer from 'kolibri.coreVue.components.KPageContainer';
 import filter from 'lodash/filter';
 import sortBy from 'lodash/sortBy';
 import { PageNames } from '../constants';
+import { LastPages } from '../constants/lastPagesConstants';
 import { STATUSES } from '../modules/classSummary/constants';
 import TopNavbar from './TopNavbar';
 import { coachStrings, coachStringsMixin } from './common/commonCoachStrings';
@@ -232,19 +233,19 @@ export default {
       const lastPage = query.last;
 
       switch (lastPage) {
-        case 'homepage':
+        case LastPages.HOME_PAGE:
           return this.classRoute('HomePage', {});
-        case 'homeactivity':
+        case LastPages.HOME_ACTIVITY:
           return this.classRoute('HomeActivityPage', {});
-        case 'groupactivity':
+        case LastPages.GROUP_ACTIVITY:
           return this.classRoute('ReportsGroupActivityPage', {
             groupId: this.$route.query.last_id,
           });
-        case 'learneractivity':
+        case LastPages.LEARNER_ACTIVITY:
           return this.classRoute('ReportsLearnerActivityPage', {
             learnerId: this.$route.query.last_id,
           });
-        case 'exerciselearnerlistbygroups':
+        case LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS:
           return this.classRoute('ReportsLessonExerciseLearnerListPage', {}, { groups: 'true' });
         default:
           return null;

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -220,16 +220,17 @@ export default {
     },
   },
   methods: {
-    classRoute(name, params = {}) {
+    classRoute(name, params = {}, query = {}) {
       if (this.classId) {
         params.classId = this.classId;
       }
-      return router.getRoute(name, params);
+      return router.getRoute(name, params, query);
     },
-    // In ActivityList, set the backLinkQuery to set the correct exit behavior
+    // Set the backLinkQuery to set the correct exit behavior
     // for ReportsLessonExerciseLearnerPage and ReportsQuizLearnerPage.
     backRouteForQuery(query) {
       const lastPage = query.last;
+
       switch (lastPage) {
         case 'homepage':
           return this.classRoute('HomePage', {});
@@ -243,6 +244,8 @@ export default {
           return this.classRoute('ReportsLearnerActivityPage', {
             learnerId: this.$route.query.last_id,
           });
+        case 'exerciselearnerlistbygroups':
+          return this.classRoute('ReportsLessonExerciseLearnerListPage', {}, { groups: 'true' });
         default:
           return null;
       }

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -61,6 +61,7 @@
   import notificationsResource from '../../../apiResources/notifications';
   import { NotificationObjects } from '../../../constants/notificationsConstants';
   import { CollectionTypes } from '../../../constants/lessonsConstants';
+  import { LastPages } from '../../../constants/lastPagesConstants';
   import { notificationLink } from '../../../modules/coachNotifications/gettersUtils';
   import { coachStrings } from '../../common/commonCoachStrings';
   import NotificationCard from './NotificationCard';
@@ -140,11 +141,11 @@
       backLinkQuery() {
         switch (this.embeddedPageName) {
           case 'HomeActivityPage':
-            return { last: 'homeactivity' };
+            return { last: LastPages.HOME_ACTIVITY };
           case 'ReportsLearnerActivityPage':
-            return { last: 'learneractivity', last_id: this.$route.params.learnerId };
+            return { last: LastPages.LEARNER_ACTIVITY, last_id: this.$route.params.learnerId };
           case 'ReportsGroupActivityPage':
-            return { last: 'groupactivity', last_id: this.$route.params.groupId };
+            return { last: LastPages.GROUP_ACTIVITY, last_id: this.$route.params.groupId };
           default:
             return {};
         }

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router';
 import makeStore from '../../../../../test/makeStore';
 import ActivityList from '../ActivityList';
 import notificationsResource from '../../../../apiResources/notifications';
+import { LastPages } from '../../../../constants/lastPagesConstants';
 
 const localVue = createLocalVue();
 localVue.use(VueRouter);
@@ -215,7 +216,7 @@ describe('ActivityList component', () => {
     });
     await reloadNotifications();
     expect(notificationCard().props().targetPage.query).toEqual({
-      last: 'homeactivity',
+      last: LastPages.HOME_ACTIVITY,
     });
 
     // Embed in Learner Activity Page
@@ -224,7 +225,7 @@ describe('ActivityList component', () => {
     });
     await reloadNotifications();
     expect(notificationCard().props().targetPage.query).toEqual({
-      last: 'learneractivity',
+      last: LastPages.LEARNER_ACTIVITY,
       last_id: 'learner_001',
     });
 
@@ -234,7 +235,7 @@ describe('ActivityList component', () => {
     });
     await reloadNotifications();
     expect(notificationCard().props().targetPage.query).toEqual({
-      last: 'groupactivity',
+      last: LastPages.GROUP_ACTIVITY,
       last_id: 'group_001',
     });
   });

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusSummary.vue
@@ -8,7 +8,7 @@
     tuned for readability over consistency. This means that it has a few intentional
     and perhaps a few unintentional edge cases.
 
-    See locahost:8000/coach/#/about/learnerStatusTypes for a parametric overview
+    See localhost:8000/coach/#/about/statuses for a parametric overview
     of the possible behaviors.
    -->
   <div :class="verbose ? 'multi-line' : 'single-line'">

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -36,6 +36,7 @@
   import NotificationCard from '../../common/notifications/NotificationCard';
   import { nStringsMixin } from '../../common/notifications/notificationStrings';
   import { CollectionTypes } from '../../../constants/lessonsConstants';
+  import { LastPages } from '../../../constants/lastPagesConstants';
   import { notificationLink } from '../../../modules/coachNotifications/gettersUtils';
   import Block from './Block';
   import BlockItem from './BlockItem';
@@ -70,7 +71,7 @@
           targetPage: {
             ...notificationLink(notification),
             query: {
-              last: 'homepage',
+              last: LastPages.HOME_PAGE,
             },
           },
           contentContext: notification.assignment.name,

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -54,6 +54,10 @@
     },
     computed: {
       toolbarRoute() {
+        if (this.$route.query && this.$route.query.last) {
+          return this.backRouteForQuery(this.$route.query);
+        }
+
         return (
           this.backRoute || {
             ...this.$store.state.toolbarRoute,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -18,7 +18,7 @@
           <KRouterLink
             v-if="showLink(entry)"
             :text="entry.name"
-            :to="entry.exerciseLink"
+            :to="entry.exerciseLearnerLink"
           />
           <template v-else>
             {{ entry.name }}

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -33,7 +33,7 @@
           />
         </td>
         <td v-if="showGroupsColumn">
-          <TruncatedItemList :items="entry.groups" />
+          <TruncatedItemList :items="getGroupNames(entry)" />
         </td>
         <td>
           <ElapsedTime
@@ -101,6 +101,13 @@
         }
 
         return null;
+      },
+      getGroupNames(entry) {
+        if (!entry || !entry.groups) {
+          return [];
+        }
+
+        return entry.groups.map(group => group.name);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -13,7 +13,7 @@
       </tr>
     </thead>
     <transition-group slot="tbody" tag="tbody" name="list">
-      <tr v-for="entry in entries" ref="entry" :key="entry.id">
+      <tr v-for="entry in entries" :key="entry.id" data-test="entry">
         <td>
           <KRouterLink
             v-if="showLink(entry)"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -1,0 +1,108 @@
+<template>
+
+  <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
+    <thead slot="thead">
+      <tr>
+        <th>{{ coachStrings.$tr('nameLabel') }}</th>
+        <th>{{ coachStrings.$tr('progressLabel') }}</th>
+        <th>{{ coachStrings.$tr('timeSpentLabel') }}</th>
+        <th v-if="showGroupsColumn">
+          {{ coachStrings.$tr('groupsLabel') }}
+        </th>
+        <th>{{ coachStrings.$tr('lastActivityLabel') }}</th>
+      </tr>
+    </thead>
+    <transition-group slot="tbody" tag="tbody" name="list">
+      <tr v-for="entry in entries" ref="entry" :key="entry.id">
+        <td>
+          <KRouterLink
+            v-if="showLink(entry)"
+            :text="entry.name"
+            :to="entry.exerciseLink"
+          />
+          <template v-else>
+            {{ entry.name }}
+          </template>
+        </td>
+        <td>
+          <StatusSimple :status="entry.statusObj.status" />
+        </td>
+        <td>
+          <TimeDuration
+            :seconds="timeDuration(entry)"
+          />
+        </td>
+        <td v-if="showGroupsColumn">
+          <TruncatedItemList :items="entry.groups" />
+        </td>
+        <td>
+          <ElapsedTime
+            :date="elapsedTime(entry)"
+          />
+        </td>
+      </tr>
+    </transition-group>
+  </CoreTable>
+
+</template>
+
+
+<script>
+
+  import CoreTable from 'kolibri.coreVue.components.CoreTable';
+  import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
+  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
+
+  import { coachStringsMixin } from '../common/commonCoachStrings';
+  import StatusSimple from '../common/status/StatusSimple';
+  import TimeDuration from '../common/TimeDuration';
+  import TruncatedItemList from '../common/TruncatedItemList';
+  import { STATUSES } from '../../modules/classSummary/constants';
+
+  export default {
+    name: 'ReportsExerciseLearners',
+    components: {
+      CoreTable,
+      ElapsedTime,
+      KRouterLink,
+      StatusSimple,
+      TimeDuration,
+      TruncatedItemList,
+    },
+    mixins: [coachStringsMixin],
+    props: {
+      entries: {
+        type: Array,
+      },
+      showGroupsColumn: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    data() {
+      return {
+        STATUSES,
+      };
+    },
+    methods: {
+      showLink(entry) {
+        return entry.statusObj.status !== this.STATUSES.notStarted;
+      },
+      timeDuration(entry) {
+        if (entry.statusObj.status !== this.STATUSES.notStarted) {
+          return entry.statusObj.time_spent;
+        }
+
+        return null;
+      },
+      elapsedTime(entry) {
+        if (entry.statusObj.status !== this.STATUSES.notStarted) {
+          return entry.statusObj.last_activity;
+        }
+
+        return null;
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
@@ -8,21 +8,23 @@
         :text="$tr('back', { lesson: lesson.title })"
       />
     </p>
-    <h1>
-      <KLabeledIcon>
-        <KIcon slot="icon" exercise />
-        {{ exercise.title }}
-      </KLabeledIcon>
-    </h1>
 
-    <!-- TODO COACH
-    <p>{{ exercise.description }}</p>
-    <p>
-      {{ coachStrings.$tr('masteryModelLabel') }}
-      <MasteryModel model="num_correct_in_a_row_5" />
-    </p>
-    <KButton :text="coachStrings.$tr('previewAction')" />
-     -->
+    <KGrid cols="2">
+      <KGridItem size="1">
+        <h1>
+          <KLabeledIcon>
+            <KIcon slot="icon" exercise />
+            {{ exercise.title }}
+          </KLabeledIcon>
+        </h1>
+      </KGridItem>
+      <KGridItem size="1" alignment="right">
+        <KButton
+          :text="coachStrings.$tr('previewAction')"
+          @click="$emit('previewClick')"
+        />
+      </KGridItem>
+    </KGrid>
 
     <HeaderTabs>
       <HeaderTab

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
@@ -2,29 +2,26 @@
 
   <div>
 
-    <p>
-      <BackLink
-        :to="classRoute('ReportsLessonReportPage')"
-        :text="$tr('back', { lesson: lesson.title })"
-      />
-    </p>
-
-    <KGrid cols="2">
-      <KGridItem size="1">
-        <h1>
-          <KLabeledIcon>
-            <KIcon slot="icon" exercise />
-            {{ exercise.title }}
-          </KLabeledIcon>
-        </h1>
-      </KGridItem>
-      <KGridItem size="1" alignment="right">
+    <section>
+      <BackLinkWithOptions>
+        <BackLink
+          slot="backlink"
+          :to="classRoute('ReportsLessonReportPage')"
+          :text="$tr('back', { lesson: lesson.title })"
+        />
         <KButton
+          slot="options"
           :text="coachStrings.$tr('previewAction')"
           @click="$emit('previewClick')"
         />
-      </KGridItem>
-    </KGrid>
+      </BackLinkWithOptions>
+      <h1>
+        <KLabeledIcon>
+          <KIcon slot="icon" exercise />
+          {{ exercise.title }}
+        </KLabeledIcon>
+      </h1>
+    </section>
 
     <HeaderTabs>
       <HeaderTab
@@ -45,10 +42,13 @@
 <script>
 
   import commonCoach from '../common';
+  import BackLinkWithOptions from '../common/BackLinkWithOptions';
 
   export default {
     name: 'ReportsLessonExerciseHeader',
-    components: {},
+    components: {
+      BackLinkWithOptions,
+    },
     mixins: [commonCoach],
     computed: {
       lesson() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -19,7 +19,17 @@
         @change="toggleGroupsView"
       />
 
-      <template v-if="viewByGroups"></template>
+      <template v-if="viewByGroups">
+        <div v-for="group in nonEmptyGroups" :key="group.id">
+          <h2>{{ group.name }}</h2>
+
+          <ReportsExerciseLearners
+            :entries="getTableEntries([group.id])"
+            :showGroupsColumn="false"
+          />
+        </div>
+      </template>
+
       <template v-else>
         <p>
           <StatusSummary :tally="summaryTally" />
@@ -59,6 +69,15 @@
       summaryTally() {
         const recipients = this.getLearnersForGroups(this.lesson.groups);
         return this.getContentStatusTally(this.$route.params.exerciseId, recipients);
+      },
+      nonEmptyGroups() {
+        if (!this.groups || !this.groups.length) {
+          return [];
+        }
+
+        return this.groups.filter(group => {
+          return group.member_ids.length > 0;
+        });
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -30,7 +30,10 @@
             class="group-title"
             data-test="group-title"
           >
-            {{ group.name }}
+            <KLabeledIcon>
+              <KIcon slot="icon" group />
+              {{ group.name }}
+            </KLabeledIcon>
           </h2>
 
           <p>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -23,6 +23,13 @@
         <div v-for="group in nonEmptyGroups" :key="group.id">
           <h2>{{ group.name }}</h2>
 
+          <p>
+            <StatusSummary
+              :tally="getGroupTally(group.id)"
+              :verbose="false"
+            />
+          </p>
+
           <ReportsExerciseLearners
             :entries="getTableEntries([group.id])"
             :showGroupsColumn="false"
@@ -104,6 +111,10 @@
         }
 
         return link;
+      },
+      getGroupTally(groupId) {
+        const recipients = this.getLearnersForGroups([groupId]);
+        return this.getContentStatusTally(this.$route.params.exerciseId, recipients);
       },
       // Return table entries for recipients belonging to groups.
       // If no group ids passed in, return entries for all lesson recipients.

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -22,47 +22,8 @@
         <StatusSummary :tally="tally" />
       </p>
 
-      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachStrings.$tr('nameLabel') }}</th>
-            <th>{{ coachStrings.$tr('progressLabel') }}</th>
-            <th>{{ coachStrings.$tr('timeSpentLabel') }}</th>
-            <th>{{ coachStrings.$tr('groupsLabel') }}</th>
-            <th>{{ coachStrings.$tr('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KRouterLink
-                v-if="showLink(tableRow)"
-                :text="tableRow.name"
-                :to="link(tableRow.id)"
-              />
-              <template v-else>
-                {{ tableRow.name }}
-              </template>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration
-                :seconds="showTimeDuration(tableRow)"
-              />
-            </td>
-            <td>
-              <TruncatedItemList :items="tableRow.groups" />
-            </td>
-            <td>
-              <ElapsedTime
-                :date="showElapsedTime(tableRow)"
-              />
-            </td>
-          </tr>
-        </transition-group>
-      </CoreTable>
+      <ReportsExerciseLearners :entries="table" />
+
     </KPageContainer>
   </CoreBase>
 
@@ -74,11 +35,13 @@
   import commonCoach from '../common';
   import { PageNames } from '../../constants';
   import ReportsLessonExerciseHeader from './ReportsLessonExerciseHeader';
+  import ReportsExerciseLearners from './ReportsExerciseLearners';
 
   export default {
     name: 'ReportsLessonExerciseLearnerListPage',
     components: {
       ReportsLessonExerciseHeader,
+      ReportsExerciseLearners,
     },
     mixins: [commonCoach],
     computed: {
@@ -101,31 +64,14 @@
               this.$route.params.exerciseId,
               learner.id
             ),
+            exerciseLink: this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, {
+              learnerId: learner.id,
+            }),
           };
           Object.assign(tableRow, learner);
           return tableRow;
         });
         return mapped;
-      },
-    },
-    methods: {
-      link(learnerId) {
-        return this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, { learnerId });
-      },
-      showLink(tableRow) {
-        return tableRow.statusObj.status !== this.STATUSES.notStarted;
-      },
-      showTimeDuration(tableRow) {
-        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
-          return tableRow.statusObj.time_spent;
-        }
-        return undefined;
-      },
-      showElapsedTime(tableRow) {
-        if (tableRow.statusObj.status !== this.STATUSES.notStarted) {
-          return tableRow.statusObj.last_activity;
-        }
-        return undefined;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -24,8 +24,12 @@
           v-for="group in lessonGroups"
           :key="group.id"
           class="group"
+          :data-test="`group-${group.id}`"
         >
-          <h2 class="group-title">
+          <h2
+            class="group-title"
+            data-test="group-title"
+          >
             {{ group.name }}
           </h2>
 
@@ -46,7 +50,10 @@
           v-if="ungroupedEntries.length"
           class="group"
         >
-          <h2 class="group-title">
+          <h2
+            class="group-title"
+            data-test="group-title"
+          >
             {{ coachStrings.$tr('ungroupedLearnersLabel') }}
           </h2>
 
@@ -59,7 +66,10 @@
 
       <div v-else>
         <p>
-          <StatusSummary :tally="summaryTally" />
+          <StatusSummary
+            :tally="summaryTally"
+            data-test="summary-tally"
+          />
         </p>
 
         <ReportsExerciseLearners :entries="allEntries" />
@@ -130,6 +140,11 @@
       },
       ungroupedEntries() {
         return this.allEntries.filter(entry => !entry.groups || !entry.groups.length);
+      },
+    },
+    watch: {
+      $route() {
+        this.viewByGroups = Boolean(this.$route.query && this.$route.query.groups);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -11,7 +11,7 @@
 
     <KPageContainer>
 
-      <ReportsLessonExerciseHeader />
+      <ReportsLessonExerciseHeader @previewClick="onPreviewClick" />
 
       <KCheckbox
         :label="coachStrings.$tr('viewByGroupsLabel')"
@@ -104,6 +104,9 @@
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },
+      exercise() {
+        return this.contentMap[this.$route.params.exerciseId];
+      },
       summaryTally() {
         return this.getContentStatusTally(this.$route.params.exerciseId, this.recipients);
       },
@@ -166,7 +169,11 @@
         });
 
         if (this.viewByGroups) {
-          link.query = { ...link.query, last: LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS };
+          link.query = {
+            ...link.query,
+            last: LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS,
+            exerciseId: this.exercise.content_id,
+          };
         }
 
         return link;
@@ -183,6 +190,25 @@
           const entryGroupIds = entry.groups.map(group => group.id);
           return entryGroupIds.includes(groupId);
         });
+      },
+      onPreviewClick() {
+        let lastPage = LastPages.EXERCISE_LEARNER_LIST;
+        if (this.viewByGroups) {
+          lastPage = LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS;
+        }
+
+        this.$router.push(
+          this.$router.getRoute(
+            'RESOURCE_CONTENT_PREVIEW',
+            {
+              contentId: this.exercise.node_id,
+            },
+            {
+              last: lastPage,
+              exerciseId: this.exercise.content_id,
+            }
+          )
+        );
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -13,17 +13,20 @@
 
       <ReportsLessonExerciseHeader />
 
-      <!-- TODO COACH
-      <KCheckbox :label="coachStrings.$tr('viewByGroupsLabel')" />
-      <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-       -->
+      <KCheckbox
+        :label="coachStrings.$tr('viewByGroupsLabel')"
+        :checked="viewByGroups"
+        @change="toggleGroupsView"
+      />
 
-      <p>
-        <StatusSummary :tally="tally" />
-      </p>
+      <template v-if="viewByGroups"></template>
+      <template v-else>
+        <p>
+          <StatusSummary :tally="tally" />
+        </p>
 
-      <ReportsExerciseLearners :entries="table" />
-
+        <ReportsExerciseLearners :entries="table" />
+      </template>
     </KPageContainer>
   </CoreBase>
 
@@ -44,6 +47,11 @@
       ReportsExerciseLearners,
     },
     mixins: [commonCoach],
+    data() {
+      return {
+        viewByGroups: false,
+      };
+    },
     computed: {
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
@@ -72,6 +80,11 @@
           return tableRow;
         });
         return mapped;
+      },
+    },
+    methods: {
+      toggleGroupsView() {
+        this.viewByGroups = !this.viewByGroups;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -59,7 +59,7 @@
     mixins: [commonCoach],
     data() {
       return {
-        viewByGroups: false,
+        viewByGroups: Boolean(this.$route.query && this.$route.query.groups),
       };
     },
     computed: {
@@ -83,6 +83,26 @@
     methods: {
       toggleGroupsView() {
         this.viewByGroups = !this.viewByGroups;
+
+        let query;
+        if (this.viewByGroups) {
+          query = { ...this.$route.query, groups: 'true' };
+        } else {
+          query = { ...this.$route.query, groups: undefined };
+        }
+
+        this.$router.replace({ query });
+      },
+      getExerciseLearnerLink(learnerId) {
+        const link = this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, {
+          learnerId,
+        });
+
+        if (this.viewByGroups) {
+          link.query = { ...link.query, last: 'exerciselearnerlistbygroups' };
+        }
+
+        return link;
       },
       // Return table entries for recipients belonging to groups.
       // If no group ids passed in, return entries for all lesson recipients.
@@ -102,10 +122,9 @@
               this.$route.params.exerciseId,
               learner.id
             ),
-            exerciseLink: this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_LEARNER_PAGE_ROOT, {
-              learnerId: learner.id,
-            }),
+            exerciseLink: this.getExerciseLearnerLink(learner.id),
           };
+
           Object.assign(tableRow, learner);
 
           return tableRow;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -158,10 +158,6 @@
 
 <style lang="scss" scoped>
 
-  .stats {
-    margin-right: 16px;
-  }
-
   .group:not(:first-child) {
     margin-top: 42px;
   }

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -47,6 +47,7 @@
 
   import commonCoach from '../common';
   import { PageNames } from '../../constants';
+  import { LastPages } from '../../constants/lastPagesConstants';
   import ReportsLessonExerciseHeader from './ReportsLessonExerciseHeader';
   import ReportsExerciseLearners from './ReportsExerciseLearners';
 
@@ -99,7 +100,7 @@
         });
 
         if (this.viewByGroups) {
-          link.query = { ...link.query, last: 'exerciselearnerlistbygroups' };
+          link.query = { ...link.query, last: LastPages.EXERCISE_LEARNER_LIST_BY_GROUPS };
         }
 
         return link;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -21,7 +21,7 @@
 
       <div v-if="viewByGroups">
         <div
-          v-for="group in nonEmptyGroups"
+          v-for="group in lessonGroups"
           :key="group.id"
           class="group"
         >
@@ -84,14 +84,12 @@
         const recipients = this.getLearnersForGroups(this.lesson.groups);
         return this.getContentStatusTally(this.$route.params.exerciseId, recipients);
       },
-      nonEmptyGroups() {
-        if (!this.groups || !this.groups.length) {
-          return [];
+      lessonGroups() {
+        if (!this.lesson.groups.length) {
+          return this.groups;
         }
 
-        return this.groups.filter(group => {
-          return group.member_ids.length > 0;
-        });
+        return this.groups.filter(group => this.lesson.groups.includes(group.id));
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -19,9 +19,15 @@
         @change="toggleGroupsView"
       />
 
-      <template v-if="viewByGroups">
-        <div v-for="group in nonEmptyGroups" :key="group.id">
-          <h2>{{ group.name }}</h2>
+      <div v-if="viewByGroups">
+        <div
+          v-for="group in nonEmptyGroups"
+          :key="group.id"
+          class="group"
+        >
+          <h2 class="group-title">
+            {{ group.name }}
+          </h2>
 
           <p>
             <StatusSummary
@@ -35,15 +41,15 @@
             :showGroupsColumn="false"
           />
         </div>
-      </template>
+      </div>
 
-      <template v-else>
+      <div v-else>
         <p>
           <StatusSummary :tally="summaryTally" />
         </p>
 
         <ReportsExerciseLearners :entries="getTableEntries()" />
-      </template>
+      </div>
     </KPageContainer>
   </CoreBase>
 
@@ -154,6 +160,14 @@
 
   .stats {
     margin-right: 16px;
+  }
+
+  .group:not(:first-child) {
+    margin-top: 42px;
+  }
+
+  .group-title {
+    margin-bottom: 42px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -25,7 +25,7 @@
           <StatusSummary :tally="summaryTally" />
         </p>
 
-        <ReportsExerciseLearners :entries="table" />
+        <ReportsExerciseLearners :entries="getTableEntries()" />
       </template>
     </KPageContainer>
   </CoreBase>
@@ -56,14 +56,25 @@
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
       },
-      recipients() {
-        return this.getLearnersForGroups(this.lesson.groups);
-      },
       summaryTally() {
-        return this.getContentStatusTally(this.$route.params.exerciseId, this.recipients);
+        const recipients = this.getLearnersForGroups(this.lesson.groups);
+        return this.getContentStatusTally(this.$route.params.exerciseId, recipients);
       },
-      table() {
-        const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
+    },
+    methods: {
+      toggleGroupsView() {
+        this.viewByGroups = !this.viewByGroups;
+      },
+      // Return table entries for recipients belonging to groups.
+      // If no group ids passed in, return entries for all lesson recipients.
+      getTableEntries(groupIds) {
+        if (!groupIds || !groupIds.length) {
+          groupIds = this.lesson.groups;
+        }
+
+        const recipients = this.getLearnersForGroups(groupIds);
+        const learners = recipients.map(learnerId => this.learnerMap[learnerId]);
+
         const sorted = this._.sortBy(learners, ['name']);
         const mapped = sorted.map(learner => {
           const tableRow = {
@@ -77,14 +88,11 @@
             }),
           };
           Object.assign(tableRow, learner);
+
           return tableRow;
         });
+
         return mapped;
-      },
-    },
-    methods: {
-      toggleGroupsView() {
-        this.viewByGroups = !this.viewByGroups;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -97,7 +97,7 @@
     mixins: [commonCoach],
     data() {
       return {
-        viewByGroups: Boolean(this.$route.query && this.$route.query.groups),
+        viewByGroups: Boolean(this.$route.query.groups),
       };
     },
     computed: {
@@ -147,7 +147,7 @@
     },
     watch: {
       $route() {
-        this.viewByGroups = Boolean(this.$route.query && this.$route.query.groups);
+        this.viewByGroups = Boolean(this.$route.query.groups);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -41,6 +41,20 @@
             :showGroupsColumn="false"
           />
         </div>
+
+        <div
+          v-if="ungroupedEntries.length"
+          class="group"
+        >
+          <h2 class="group-title">
+            {{ coachStrings.$tr('ungroupedLearnersLabel') }}
+          </h2>
+
+          <ReportsExerciseLearners
+            :entries="ungroupedEntries"
+            :showGroupsColumn="false"
+          />
+        </div>
       </div>
 
       <div v-else>
@@ -113,6 +127,9 @@
         });
 
         return mapped;
+      },
+      ungroupedEntries() {
+        return this.allEntries.filter(entry => !entry.groups || !entry.groups.length);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -122,7 +122,7 @@
               this.$route.params.exerciseId,
               learner.id
             ),
-            exerciseLink: this.getExerciseLearnerLink(learner.id),
+            exerciseLearnerLink: this.getExerciseLearnerLink(learner.id),
           };
 
           Object.assign(tableRow, learner);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -22,7 +22,7 @@
       <template v-if="viewByGroups"></template>
       <template v-else>
         <p>
-          <StatusSummary :tally="tally" />
+          <StatusSummary :tally="summaryTally" />
         </p>
 
         <ReportsExerciseLearners :entries="table" />
@@ -59,7 +59,7 @@
       recipients() {
         return this.getLearnersForGroups(this.lesson.groups);
       },
-      tally() {
+      summaryTally() {
         return this.getContentStatusTally(this.$route.params.exerciseId, this.recipients);
       },
       table() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -33,6 +33,7 @@
         <div
           v-for="group in lessonGroups"
           :key="group.id"
+          :data-test="`group-${group.id}`"
           class="group"
         >
           <h2
@@ -41,6 +42,14 @@
           >
             {{ group.name }}
           </h2>
+
+          <p>
+            <StatusSummary
+              :tally="getGroupTally(group.id)"
+              :showNeedsHelp="false"
+              :verbose="false"
+            />
+          </p>
 
           <ReportsResourceLearners
             :entries="getGroupEntries(group.id)"
@@ -70,7 +79,10 @@
         <ReportsResourcesStats :avgTime="allRecipientsAvgTime" />
 
         <p>
-          <StatusSummary :tally="tally" />
+          <StatusSummary
+            :tally="tally"
+            data-test="summary-tally"
+          />
         </p>
 
         <ReportsResourceLearners :entries="allEntries" />
@@ -168,6 +180,10 @@
           const entryGroupIds = entry.groups.map(group => group.id);
           return entryGroupIds.includes(groupId);
         });
+      },
+      getGroupTally(groupId) {
+        const recipients = this.getLearnersForGroups([groupId]);
+        return this.getContentStatusTally(this.$route.params.resourceId, recipients);
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -22,27 +22,33 @@
           {{ resource.title }}
         </KLabeledIcon>
       </h1>
-      <!-- TODO COACH
-      <KButton :text="coachStrings.$tr('previewAction')" />
-      <KCheckbox :label="coachStrings.$tr('viewByGroupsLabel')" />
-      <h2>{{ coachStrings.$tr('overallLabel') }}</h2>
-       -->
-      <HeaderTable v-if="avgTime">
-        <HeaderTableRow>
-          <template slot="key">
-            {{ coachStrings.$tr('avgTimeSpentLabel') }}
-          </template>
-          <template slot="value">
-            <TimeDuration :seconds="avgTime" />
-          </template>
-        </HeaderTableRow>
-      </HeaderTable>
 
-      <p>
-        <StatusSummary :tally="tally" />
-      </p>
+      <KCheckbox
+        :label="coachStrings.$tr('viewByGroupsLabel')"
+        :checked="viewByGroups"
+        @change="toggleGroupsView"
+      />
 
-      <ReportsResourceLearners :entries="table" />
+      <template v-if="viewByGroups"></template>
+
+      <template v-else>
+        <HeaderTable v-if="avgTime">
+          <HeaderTableRow>
+            <template slot="key">
+              {{ coachStrings.$tr('avgTimeSpentLabel') }}
+            </template>
+            <template slot="value">
+              <TimeDuration :seconds="avgTime" />
+            </template>
+          </HeaderTableRow>
+        </HeaderTable>
+
+        <p>
+          <StatusSummary :tally="tally" />
+        </p>
+
+        <ReportsResourceLearners :entries="table" />
+      </template>
     </KPageContainer>
   </CoreBase>
 
@@ -60,6 +66,11 @@
       ReportsResourceLearners,
     },
     mixins: [commonCoach],
+    data() {
+      return {
+        viewByGroups: Boolean(this.$route.query && this.$route.query.groups),
+      };
+    },
     computed: {
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
@@ -91,6 +102,25 @@
           return tableRow;
         });
         return mapped;
+      },
+    },
+    watch: {
+      $route() {
+        this.viewByGroups = Boolean(this.$route.query && this.$route.query.groups);
+      },
+    },
+    methods: {
+      toggleGroupsView() {
+        this.viewByGroups = !this.viewByGroups;
+
+        let query;
+        if (this.viewByGroups) {
+          query = { ...this.$route.query, groups: 'true' };
+        } else {
+          query = { ...this.$route.query, groups: undefined };
+        }
+
+        this.$router.replace({ query });
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -67,7 +67,7 @@
       </div>
 
       <template v-else>
-        <ReportsResourcesStats :avgTime="avgTime" />
+        <ReportsResourcesStats :avgTime="allRecipientsAvgTime" />
 
         <p>
           <StatusSummary :tally="tally" />
@@ -109,7 +109,7 @@
       recipients() {
         return this.getLearnersForGroups(this.lesson.groups);
       },
-      avgTime() {
+      allRecipientsAvgTime() {
         return this.getContentAvgTimeSpent(this.$route.params.resourceId, this.recipients);
       },
       tally() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -128,7 +128,7 @@
     mixins: [commonCoach],
     data() {
       return {
-        viewByGroups: Boolean(this.$route.query && this.$route.query.groups),
+        viewByGroups: Boolean(this.$route.query.groups),
       };
     },
     computed: {
@@ -176,7 +176,7 @@
     },
     watch: {
       $route() {
-        this.viewByGroups = Boolean(this.$route.query && this.$route.query.groups);
+        this.viewByGroups = Boolean(this.$route.query.groups);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -10,29 +10,26 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <p>
-        <BackLink
-          :to="classRoute('ReportsLessonReportPage', {})"
-          :text="$tr('back', { lesson: lesson.title })"
-        />
-      </p>
-
-      <KGrid cols="2">
-        <KGridItem size="1">
-          <h1>
-            <KLabeledIcon>
-              <KBasicContentIcon slot="icon" :kind="resource.kind" />
-              {{ resource.title }}
-            </KLabeledIcon>
-          </h1>
-        </KGridItem>
-        <KGridItem size="1" alignment="right">
+      <section>
+        <BackLinkWithOptions>
+          <BackLink
+            slot="backlink"
+            :to="classRoute('ReportsLessonReportPage', {})"
+            :text="$tr('back', { lesson: lesson.title })"
+          />
           <KButton
+            slot="options"
             :text="coachStrings.$tr('previewAction')"
             @click="onPreviewClick"
           />
-        </KGridItem>
-      </KGrid>
+        </BackLinkWithOptions>
+        <h1>
+          <KLabeledIcon>
+            <KBasicContentIcon slot="icon" :kind="resource.kind" />
+            {{ resource.title }}
+          </KLabeledIcon>
+        </h1>
+      </section>
 
       <KCheckbox
         :label="coachStrings.$tr('viewByGroupsLabel')"
@@ -119,12 +116,14 @@
 
   import { LastPages } from '../../constants/lastPagesConstants';
   import commonCoach from '../common';
+  import BackLinkWithOptions from '../common/BackLinkWithOptions';
   import ReportsResourceLearners from './ReportsResourceLearners';
   import ReportsResourcesStats from './ReportsResourcesStats';
 
   export default {
     name: 'ReportsLessonResourceLearnerListPage',
     components: {
+      BackLinkWithOptions,
       ReportsResourceLearners,
       ReportsResourcesStats,
     },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -29,7 +29,42 @@
         @change="toggleGroupsView"
       />
 
-      <template v-if="viewByGroups"></template>
+      <div v-if="viewByGroups">
+        <div
+          v-for="group in lessonGroups"
+          :key="group.id"
+          class="group"
+        >
+          <h2
+            class="group-title"
+            data-test="group-title"
+          >
+            {{ group.name }}
+          </h2>
+
+          <ReportsResourceLearners
+            :entries="getGroupEntries(group.id)"
+            :showGroupsColumn="false"
+          />
+        </div>
+
+        <div
+          v-if="ungroupedEntries.length"
+          class="group"
+        >
+          <h2
+            class="group-title"
+            data-test="group-title"
+          >
+            {{ coachStrings.$tr('ungroupedLearnersLabel') }}
+          </h2>
+
+          <ReportsResourceLearners
+            :entries="ungroupedEntries"
+            :showGroupsColumn="false"
+          />
+        </div>
+      </div>
 
       <template v-else>
         <HeaderTable v-if="avgTime">
@@ -110,6 +145,9 @@
         });
         return mapped;
       },
+      ungroupedEntries() {
+        return this.allEntries.filter(entry => !entry.groups || !entry.groups.length);
+      },
     },
     watch: {
       $route() {
@@ -132,6 +170,12 @@
       getLearnerLessonGroups(learnerId) {
         return this.lessonGroups.filter(group => group.member_ids.includes(learnerId));
       },
+      getGroupEntries(groupId) {
+        return this.allEntries.filter(entry => {
+          const entryGroupIds = entry.groups.map(group => group.id);
+          return entryGroupIds.includes(groupId);
+        });
+      },
     },
     $trs: {
       back: "Back to '{lesson}'",
@@ -142,4 +186,14 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .group:not(:first-child) {
+    margin-top: 42px;
+  }
+
+  .group-title {
+    margin-bottom: 42px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -47,7 +47,7 @@
           <StatusSummary :tally="tally" />
         </p>
 
-        <ReportsResourceLearners :entries="table" />
+        <ReportsResourceLearners :entries="allEntries" />
       </template>
     </KPageContainer>
   </CoreBase>
@@ -87,12 +87,19 @@
       tally() {
         return this.getContentStatusTally(this.$route.params.resourceId, this.recipients);
       },
-      table() {
+      lessonGroups() {
+        if (!this.lesson.groups.length) {
+          return this.groups;
+        }
+
+        return this.groups.filter(group => this.lesson.groups.includes(group.id));
+      },
+      allEntries() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
         const mapped = sorted.map(learner => {
           const tableRow = {
-            groups: this.getGroupNamesForLearner(learner.id),
+            groups: this.getLearnerLessonGroups(learner.id),
             statusObj: this.getContentStatusObjForLearner(
               this.$route.params.resourceId,
               learner.id
@@ -121,6 +128,9 @@
         }
 
         this.$router.replace({ query });
+      },
+      getLearnerLessonGroups(learnerId) {
+        return this.lessonGroups.filter(group => group.member_ids.includes(learnerId));
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -43,13 +43,18 @@
             {{ group.name }}
           </h2>
 
-          <p>
-            <StatusSummary
-              :tally="getGroupTally(group.id)"
-              :showNeedsHelp="false"
-              :verbose="false"
-            />
-          </p>
+          <KGrid cols="2">
+            <KGridItem size="1">
+              <StatusSummary
+                :tally="getGroupTally(group.id)"
+                :showNeedsHelp="false"
+                :verbose="false"
+              />
+            </KGridItem>
+            <KGridItem size="1">
+              <ReportsResourcesStats :avgTime="getGroupRecipientsAvgTime(group.id)" />
+            </KGridItem>
+          </KGrid>
 
           <ReportsResourceLearners
             :entries="getGroupEntries(group.id)"
@@ -76,7 +81,10 @@
       </div>
 
       <template v-else>
-        <ReportsResourcesStats :avgTime="allRecipientsAvgTime" />
+        <ReportsResourcesStats
+          :avgTime="allRecipientsAvgTime"
+          data-test="summary-resources-stats"
+        />
 
         <p>
           <StatusSummary
@@ -185,6 +193,10 @@
         const recipients = this.getLearnersForGroups([groupId]);
         return this.getContentStatusTally(this.$route.params.resourceId, recipients);
       },
+      getGroupRecipientsAvgTime(groupId) {
+        const recipients = this.getLearnersForGroups([groupId]);
+        return this.getContentAvgTimeSpent(this.$route.params.resourceId, recipients);
+      },
     },
     $trs: {
       back: "Back to '{lesson}'",
@@ -203,6 +215,13 @@
 
   .group-title {
     margin-bottom: 42px;
+  }
+
+  .stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -67,16 +67,7 @@
       </div>
 
       <template v-else>
-        <HeaderTable v-if="avgTime">
-          <HeaderTableRow>
-            <template slot="key">
-              {{ coachStrings.$tr('avgTimeSpentLabel') }}
-            </template>
-            <template slot="value">
-              <TimeDuration :seconds="avgTime" />
-            </template>
-          </HeaderTableRow>
-        </HeaderTable>
+        <ReportsResourcesStats :avgTime="avgTime" />
 
         <p>
           <StatusSummary :tally="tally" />
@@ -94,11 +85,13 @@
 
   import commonCoach from '../common';
   import ReportsResourceLearners from './ReportsResourceLearners';
+  import ReportsResourcesStats from './ReportsResourcesStats';
 
   export default {
     name: 'ReportsLessonResourceLearnerListPage',
     components: {
       ReportsResourceLearners,
+      ReportsResourcesStats,
     },
     mixins: [commonCoach],
     data() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -51,7 +51,10 @@
             class="group-title"
             data-test="group-title"
           >
-            {{ group.name }}
+            <KLabeledIcon>
+              <KIcon slot="icon" group />
+              {{ group.name }}
+            </KLabeledIcon>
           </h2>
 
           <KGrid cols="2">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -16,12 +16,23 @@
           :text="$tr('back', { lesson: lesson.title })"
         />
       </p>
-      <h1>
-        <KLabeledIcon>
-          <KBasicContentIcon slot="icon" :kind="resource.kind" />
-          {{ resource.title }}
-        </KLabeledIcon>
-      </h1>
+
+      <KGrid cols="2">
+        <KGridItem size="1">
+          <h1>
+            <KLabeledIcon>
+              <KBasicContentIcon slot="icon" :kind="resource.kind" />
+              {{ resource.title }}
+            </KLabeledIcon>
+          </h1>
+        </KGridItem>
+        <KGridItem size="1" alignment="right">
+          <KButton
+            :text="coachStrings.$tr('previewAction')"
+            @click="onPreviewClick"
+          />
+        </KGridItem>
+      </KGrid>
 
       <KCheckbox
         :label="coachStrings.$tr('viewByGroupsLabel')"
@@ -103,6 +114,7 @@
 
 <script>
 
+  import { LastPages } from '../../constants/lastPagesConstants';
   import commonCoach from '../common';
   import ReportsResourceLearners from './ReportsResourceLearners';
   import ReportsResourcesStats from './ReportsResourcesStats';
@@ -196,6 +208,25 @@
       getGroupRecipientsAvgTime(groupId) {
         const recipients = this.getLearnersForGroups([groupId]);
         return this.getContentAvgTimeSpent(this.$route.params.resourceId, recipients);
+      },
+      onPreviewClick() {
+        let lastPage = LastPages.RESOURCE_LEARNER_LIST;
+        if (this.viewByGroups) {
+          lastPage = LastPages.RESOURCE_LEARNER_LIST_BY_GROUPS;
+        }
+
+        this.$router.push(
+          this.$router.getRoute(
+            'RESOURCE_CONTENT_PREVIEW',
+            {
+              contentId: this.resource.node_id,
+            },
+            {
+              last: lastPage,
+              resourceId: this.resource.content_id,
+            }
+          )
+        );
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -80,7 +80,7 @@
 
         <p>
           <StatusSummary
-            :tally="tally"
+            :tally="summaryTally"
             data-test="summary-tally"
           />
         </p>
@@ -124,7 +124,7 @@
       allRecipientsAvgTime() {
         return this.getContentAvgTimeSpent(this.$route.params.resourceId, this.recipients);
       },
-      tally() {
+      summaryTally() {
         return this.getContentStatusTally(this.$route.params.resourceId, this.recipients);
       },
       lessonGroups() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -41,39 +41,8 @@
       <p>
         <StatusSummary :tally="tally" />
       </p>
-      <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachStrings.$tr('nameLabel') }}</th>
-            <th>{{ coachStrings.$tr('statusLabel') }}</th>
-            <th>{{ coachStrings.$tr('timeSpentLabel') }}</th>
-            <th>{{ coachStrings.$tr('groupsLabel') }}</th>
-            <th>{{ coachStrings.$tr('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon>
-                <KIcon slot="icon" person />
-                {{ tableRow.name }}
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration :seconds="tableRow.statusObj.time_spent" />
-            </td>
-            <td>
-              <TruncatedItemList :items="tableRow.groups" />
-            </td>
-            <td>
-              <ElapsedTime :date="tableRow.statusObj.last_activity" />
-            </td>
-          </tr>
-        </transition-group>
-      </CoreTable>
+
+      <ReportsResourceLearners :entries="table" />
     </KPageContainer>
   </CoreBase>
 
@@ -83,10 +52,13 @@
 <script>
 
   import commonCoach from '../common';
+  import ReportsResourceLearners from './ReportsResourceLearners';
 
   export default {
     name: 'ReportsLessonResourceLearnerListPage',
-    components: {},
+    components: {
+      ReportsResourceLearners,
+    },
     mixins: [commonCoach],
     computed: {
       lesson() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -248,11 +248,4 @@
     margin-bottom: 42px;
   }
 
-  .stats {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-  }
-
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
@@ -27,7 +27,7 @@
           <TimeDuration :seconds="entry.statusObj.time_spent" />
         </td>
         <td v-if="showGroupsColumn">
-          <TruncatedItemList :items="entry.groups" />
+          <TruncatedItemList :items="getGroupNames(entry)" />
         </td>
         <td>
           <ElapsedTime :date="entry.statusObj.last_activity" />
@@ -70,6 +70,15 @@
       showGroupsColumn: {
         type: Boolean,
         default: true,
+      },
+    },
+    methods: {
+      getGroupNames(entry) {
+        if (!entry || !entry.groups) {
+          return [];
+        }
+
+        return entry.groups.map(group => group.name);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
@@ -1,0 +1,77 @@
+<template>
+
+  <CoreTable :emptyMessage="coachStrings.$tr('activityListEmptyState')">
+    <thead slot="thead">
+      <tr>
+        <th>{{ coachStrings.$tr('nameLabel') }}</th>
+        <th>{{ coachStrings.$tr('statusLabel') }}</th>
+        <th>{{ coachStrings.$tr('timeSpentLabel') }}</th>
+        <th v-if="showGroupsColumn">
+          {{ coachStrings.$tr('groupsLabel') }}
+        </th>
+        <th>{{ coachStrings.$tr('lastActivityLabel') }}</th>
+      </tr>
+    </thead>
+    <transition-group slot="tbody" tag="tbody" name="list">
+      <tr v-for="entry in entries" :key="entry.id">
+        <td>
+          <KLabeledIcon>
+            <KIcon slot="icon" person />
+            {{ entry.name }}
+          </KLabeledIcon>
+        </td>
+        <td>
+          <StatusSimple :status="entry.statusObj.status" />
+        </td>
+        <td>
+          <TimeDuration :seconds="entry.statusObj.time_spent" />
+        </td>
+        <td v-if="showGroupsColumn">
+          <TruncatedItemList :items="entry.groups" />
+        </td>
+        <td>
+          <ElapsedTime :date="entry.statusObj.last_activity" />
+        </td>
+      </tr>
+    </transition-group>
+  </CoreTable>
+
+</template>
+
+
+<script>
+
+  import CoreTable from 'kolibri.coreVue.components.CoreTable';
+  import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
+  import KIcon from 'kolibri.coreVue.components.KIcon';
+  import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
+
+  import { coachStringsMixin } from '../common/commonCoachStrings';
+  import StatusSimple from '../common/status/StatusSimple';
+  import TimeDuration from '../common/TimeDuration';
+  import TruncatedItemList from '../common/TruncatedItemList';
+
+  export default {
+    name: 'ReportsResourceLearners',
+    components: {
+      CoreTable,
+      ElapsedTime,
+      KIcon,
+      KLabeledIcon,
+      StatusSimple,
+      TimeDuration,
+      TruncatedItemList,
+    },
+    mixins: [coachStringsMixin],
+    props: {
+      entries: {
+        type: Array,
+      },
+      showGroupsColumn: {
+        type: Boolean,
+        default: true,
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourcesStats.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourcesStats.vue
@@ -1,0 +1,39 @@
+<template>
+
+  <HeaderTable v-if="avgTime">
+    <HeaderTableRow>
+      <template slot="key">
+        {{ coachStrings.$tr('avgTimeSpentLabel') }}
+      </template>
+      <template slot="value">
+        <TimeDuration :seconds="avgTime" />
+      </template>
+    </HeaderTableRow>
+  </HeaderTable>
+
+</template>
+
+
+<script>
+
+  import { coachStringsMixin } from '../common/commonCoachStrings';
+  import HeaderTable from '../common/HeaderTable';
+  import HeaderTableRow from '../common/HeaderTable/HeaderTableRow';
+  import TimeDuration from '../common/TimeDuration';
+
+  export default {
+    name: 'ReportsResourcesStats',
+    components: {
+      HeaderTable,
+      HeaderTableRow,
+      TimeDuration,
+    },
+    mixins: [coachStringsMixin],
+    props: {
+      avgTime: {
+        type: Number,
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -57,7 +57,7 @@ describe('ReportsExerciseLearners', () => {
       entries,
     });
 
-    const rows = wrapper.findAll({ ref: 'entry' });
+    const rows = wrapper.findAll('[data-test="entry"]');
     expect(rows.length).toBe(2);
 
     const firstRow = rows.at(0);
@@ -106,7 +106,7 @@ describe('ReportsExerciseLearners', () => {
         ],
       });
 
-      row = wrapper.find({ ref: 'entry' });
+      row = wrapper.find('[data-test="entry"]');
     });
 
     it("renders learner's name as a link to an exercise", () => {
@@ -144,7 +144,7 @@ describe('ReportsExerciseLearners', () => {
         ],
       });
 
-      row = wrapper.find({ ref: 'entry' });
+      row = wrapper.find('[data-test="entry"]');
     });
 
     it("renders learner's name as a plain value", () => {

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -8,7 +8,7 @@ const entries = [
     id: 'd4b',
     name: 'learner1',
     username: 'learner1',
-    groups: ['group1', 'group2'],
+    groups: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
     exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
     statusObj: {
       learner_id: 'd4b',
@@ -22,7 +22,7 @@ const entries = [
     id: 'a5d',
     name: 'learner2',
     username: 'learner2',
-    groups: ['group2'],
+    groups: [{ id: '23s', name: 'group2' }],
     exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/a5d',
     statusObj: {
       learner_id: 'a5d',

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -9,7 +9,7 @@ const entries = [
     name: 'learner1',
     username: 'learner1',
     groups: ['group1', 'group2'],
-    exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+    exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
     statusObj: {
       learner_id: 'd4b',
       content_id: 'a97',
@@ -23,7 +23,7 @@ const entries = [
     name: 'learner2',
     username: 'learner2',
     groups: ['group2'],
-    exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/a5d',
+    exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/a5d',
     statusObj: {
       learner_id: 'a5d',
       content_id: 'a97',
@@ -96,7 +96,7 @@ describe('ReportsExerciseLearners', () => {
           {
             name: 'learner1',
             groups: [],
-            exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+            exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
             statusObj: {
               status: STATUSES.completed,
               last_activity: new Date('2019-05-05T08:13:22Z'),
@@ -136,7 +136,7 @@ describe('ReportsExerciseLearners', () => {
           {
             name: 'learner1',
             groups: [],
-            exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+            exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
             statusObj: {
               status: STATUSES.notStarted,
             },

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -1,0 +1,163 @@
+import { shallowMount, mount } from '@vue/test-utils';
+
+import { STATUSES } from '../../../src/modules/classSummary/constants';
+import ReportsExerciseLearners from '../../../src/views/reports/ReportsExerciseLearners';
+
+const entries = [
+  {
+    id: 'd4b',
+    name: 'learner1',
+    username: 'learner1',
+    groups: ['group1', 'group2'],
+    exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+    statusObj: {
+      learner_id: 'd4b',
+      content_id: 'a97',
+      status: STATUSES.completed,
+      last_activity: new Date('2019-05-05T07:13:22Z'),
+      time_spent: 92.5,
+    },
+  },
+  {
+    id: 'a5d',
+    name: 'learner2',
+    username: 'learner2',
+    groups: ['group2'],
+    exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/a5d',
+    statusObj: {
+      learner_id: 'a5d',
+      content_id: 'a97',
+      status: STATUSES.started,
+      last_activity: new Date('2019-05-05T08:13:22Z'),
+      time_spent: 17.14,
+    },
+  },
+];
+
+const initWrapper = propsData => {
+  return mount(ReportsExerciseLearners, {
+    propsData,
+    stubs: ['router-link'],
+  });
+};
+
+const getCol = (row, colIndex) => {
+  return row.findAll('td').at(colIndex);
+};
+
+describe('ReportsExerciseLearners', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(ReportsExerciseLearners);
+
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('renders all entries', () => {
+    const wrapper = initWrapper({
+      entries,
+    });
+
+    const rows = wrapper.findAll({ ref: 'entry' });
+    expect(rows.length).toBe(2);
+
+    const firstRow = rows.at(0);
+    const secondRow = rows.at(1);
+
+    expect(getCol(firstRow, 0).html()).toContain('learner1');
+    expect(getCol(firstRow, 1).html()).toContain(STATUSES.completed);
+    expect(getCol(firstRow, 2).html()).toContain('92 seconds');
+    expect(getCol(firstRow, 3).html()).toContain('group1, group2');
+    expect(getCol(firstRow, 4).html()).toContain(' hours ago');
+
+    expect(getCol(secondRow, 0).html()).toContain('learner2');
+    expect(getCol(secondRow, 1).html()).toContain(STATUSES.started);
+    expect(getCol(secondRow, 2).html()).toContain('17 seconds');
+    expect(getCol(secondRow, 3).html()).toContain('group2');
+    expect(getCol(secondRow, 4).html()).toContain(' hours ago');
+  });
+
+  it("doesn't render groups information when show groups set to false", () => {
+    const wrapper = initWrapper({
+      entries,
+      showGroupsColumn: false,
+    });
+
+    expect(wrapper.html()).not.toContain('Groups');
+    expect(wrapper.html()).not.toContain('group1');
+    expect(wrapper.html()).not.toContain('group2');
+  });
+
+  describe('when an exercise has started', () => {
+    let row;
+
+    beforeAll(() => {
+      const wrapper = initWrapper({
+        entries: [
+          {
+            name: 'learner1',
+            groups: [],
+            exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+            statusObj: {
+              status: STATUSES.completed,
+              last_activity: new Date('2019-05-05T08:13:22Z'),
+              time_spent: 17.14,
+            },
+          },
+        ],
+      });
+
+      row = wrapper.find({ ref: 'entry' });
+    });
+
+    it("renders learner's name as a link to an exercise", () => {
+      expect(getCol(row, 0).html()).toContain('router-link');
+      expect(
+        getCol(row, 0)
+          .find('router-link-stub')
+          .attributes().to
+      ).toBe('#/2e3/reports/lessons/79b/exercises/a97/learners/d4b');
+    });
+
+    it('renders time spent', () => {
+      expect(getCol(row, 2).text()).toBe('17 seconds');
+    });
+
+    it('renders last activity time', () => {
+      expect(getCol(row, 4).text()).toContain(' hours ago');
+    });
+  });
+
+  describe('when an exercise has not yet started', () => {
+    let row;
+
+    beforeAll(() => {
+      const wrapper = initWrapper({
+        entries: [
+          {
+            name: 'learner1',
+            groups: [],
+            exerciseLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
+            statusObj: {
+              status: STATUSES.notStarted,
+            },
+          },
+        ],
+      });
+
+      row = wrapper.find({ ref: 'entry' });
+    });
+
+    it("renders learner's name as a plain value", () => {
+      expect(getCol(row, 0).text()).toBe('learner1');
+      expect(getCol(row, 0).html()).not.toContain('router-link');
+    });
+
+    it("doesn't render time spent", () => {
+      expect(getCol(row, 2).text()).toBe('—');
+    });
+
+    it('renders last activity time', () => {
+      expect(getCol(row, 4).text()).toBe('—');
+    });
+  });
+});

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -37,7 +37,12 @@ const entries = [
 const initWrapper = propsData => {
   return mount(ReportsExerciseLearners, {
     propsData,
-    stubs: ['router-link'],
+    stubs: {
+      KRouterLink: {
+        props: ['to', 'text'],
+        template: '<div>{{ text }}</div>',
+      },
+    },
   });
 };
 
@@ -110,12 +115,9 @@ describe('ReportsExerciseLearners', () => {
     });
 
     it("renders learner's name as a link to an exercise", () => {
-      expect(getCol(row, 0).html()).toContain('router-link');
-      expect(
-        getCol(row, 0)
-          .find('router-link-stub')
-          .attributes().to
-      ).toBe('#/2e3/reports/lessons/79b/exercises/a97/learners/d4b');
+      const link = getCol(row, 0).find({ name: 'KRouterLink' });
+      expect(link.props().to).toEqual('#/2e3/reports/lessons/79b/exercises/a97/learners/d4b');
+      expect(link.props('text')).toEqual('learner1');
     });
 
     it('renders time spent', () => {

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonExerciseLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonExerciseLearnerListPage.spec.js
@@ -1,0 +1,318 @@
+import { mount, createLocalVue, RouterLinkStub } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+
+import { STATUSES } from '../../../src/modules/classSummary/constants';
+import makeStore from '../../makeStore';
+import ReportsLessonExerciseLearnerListPage from '../../../src/views/reports/ReportsLessonExerciseLearnerListPage';
+
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
+// commonCoach mixin imports kolibri customized router and uses getRoute method
+jest.mock('kolibri.coreVue.router', () => {
+  return {
+    getRoute: (name, params, query) => {
+      return { name, params, query };
+    },
+  };
+});
+
+const LESSON_ID = 'lesson-id';
+const EXERCISE_ID = 'exercise-id';
+
+const LEARNER_1 = {
+  id: 'learner1',
+  name: 'learner1 name',
+};
+
+const LEARNER_2 = {
+  id: 'learner2',
+  name: 'learner2 name',
+};
+
+const LEARNER_3 = {
+  id: 'learner3',
+  name: 'learner3 name',
+};
+
+const GROUP_1 = {
+  id: 'group1',
+  name: 'group1 name',
+  member_ids: [LEARNER_1.id, LEARNER_2.id],
+};
+
+const GROUP_2 = {
+  id: 'group2',
+  name: 'group2 name',
+  member_ids: [LEARNER_2.id],
+};
+
+const GROUP_3 = {
+  id: 'group3',
+  name: 'group3 name',
+  member_ids: [],
+};
+
+const ROUTE_ALL_LEARNERS = {
+  name: 'FakeReportsLessonExerciseLearnerListPage',
+  params: {
+    lessonId: LESSON_ID,
+    exerciseId: EXERCISE_ID,
+  },
+};
+
+const ROUTE_LEARNERS_BY_GROUP = {
+  ...ROUTE_ALL_LEARNERS,
+  query: {
+    groups: 'true',
+  },
+};
+
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/reports/lessons/:lessonId/exercises/:exerciseId/learners',
+      name: 'FakeReportsLessonExerciseLearnerListPage',
+    },
+  ],
+});
+
+const getViewByGroupsCheckbox = wrapper => {
+  return wrapper.find({ name: 'KCheckbox' }).find('input');
+};
+
+const getGroupTitles = wrapper => {
+  return wrapper.findAll('[data-test="group-title"]');
+};
+
+const getSummaryTally = wrapper => {
+  return wrapper.find('[data-test="summary-tally"]');
+};
+
+const getGroup = (wrapper, groupId) => {
+  return wrapper.find(`[data-test="group-${groupId}"]`);
+};
+
+const getGroupTally = (wrapper, groupId) => {
+  return getGroup(wrapper, groupId).find({ name: 'StatusSummary' });
+};
+
+const initWrapper = lessonMap => {
+  if (!lessonMap) {
+    lessonMap = {
+      [LESSON_ID]: {
+        groups: [],
+      },
+    };
+  }
+
+  const groupMap = {
+    group1: GROUP_1,
+    group2: GROUP_2,
+    group3: GROUP_3,
+  };
+
+  const learnerMap = {
+    learner1: LEARNER_1,
+    learner2: LEARNER_2,
+    learner3: LEARNER_3,
+  };
+
+  const contentLearnerStatusMap = {
+    [EXERCISE_ID]: {
+      [LEARNER_1.id]: {
+        learner_id: LEARNER_1.id,
+        content_id: EXERCISE_ID,
+        status: STATUSES.started,
+        last_activity: new Date('2019-05-04T07:00:00Z'),
+        time_spent: 300,
+      },
+      [LEARNER_2.id]: {
+        learner_id: LEARNER_2.id,
+        content_id: EXERCISE_ID,
+        status: STATUSES.completed,
+        last_activity: new Date('2019-05-05T08:00:00Z'),
+        time_spent: 120,
+      },
+      [LEARNER_3.id]: {
+        learner_id: LEARNER_3.id,
+        content_id: EXERCISE_ID,
+        status: STATUSES.notStarted,
+        last_activity: new Date('2019-05-05T08:30:00Z'),
+        time_spent: 760,
+      },
+    },
+  };
+
+  const contentMap = {
+    [EXERCISE_ID]: {
+      title: 'Compare 3-digit numbers',
+    },
+  };
+
+  const store = makeStore();
+
+  store.state.classSummary = {
+    ...store.state.classSummary,
+    lessonMap,
+    groupMap,
+    learnerMap,
+    contentMap,
+    contentLearnerStatusMap,
+  };
+
+  router.push(ROUTE_ALL_LEARNERS);
+
+  const wrapper = mount(ReportsLessonExerciseLearnerListPage, {
+    store,
+    localVue,
+    router,
+    stubs: {
+      CoreBase: true, // avoid auth setup etc. for now since specs are currently
+      // dealing mostly with grouping
+      TopNavbar: true, // same as above
+      RouterLink: RouterLinkStub,
+    },
+  });
+
+  return wrapper;
+};
+
+describe('ReportsLessonExerciseLearnerListPage', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = initWrapper();
+  });
+
+  it('renders view by groups checkbox as unchecked when group not in url query', () => {
+    expect(getViewByGroupsCheckbox(wrapper).element.checked).toBe(false);
+  });
+
+  it('renders view by groups checkbox as checked when group in url query', () => {
+    router.push(ROUTE_LEARNERS_BY_GROUP);
+    expect(getViewByGroupsCheckbox(wrapper).element.checked).toBe(true);
+  });
+
+  it('toggles url query on view by groups click', () => {
+    getViewByGroupsCheckbox(wrapper).setChecked(true);
+    expect(wrapper.vm.$route.query.groups).toBe('true');
+
+    getViewByGroupsCheckbox(wrapper).setChecked(false);
+    expect(wrapper.vm.$route.query.groups).toBeUndefined();
+  });
+
+  describe('for an entire class lesson', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders all class learners', () => {
+        expect(wrapper.html()).toContain(LEARNER_1.name);
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+        expect(wrapper.html()).toContain(LEARNER_3.name);
+      });
+
+      it('renders a correct summary tally', () => {
+        expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
+      });
+    });
+
+    describe('when displaying learners by groups', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+        router.push(ROUTE_LEARNERS_BY_GROUP);
+      });
+
+      it('renders all class learners', () => {
+        expect(wrapper.html()).toContain(LEARNER_1.name);
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+        expect(wrapper.html()).toContain(LEARNER_3.name);
+      });
+
+      it('renders all lesson groups including empty ones and ungrouped learners section', () => {
+        const groupTitles = getGroupTitles(wrapper);
+
+        expect(groupTitles.length).toBe(4);
+
+        expect(groupTitles.at(0).text()).toBe(GROUP_1.name);
+        expect(groupTitles.at(1).text()).toBe(GROUP_2.name);
+        expect(groupTitles.at(2).text()).toBe(GROUP_3.name);
+        expect(groupTitles.at(3).text()).toBe('Ungrouped learners');
+      });
+
+      it('renders a correct group tally', () => {
+        expect(getGroupTally(wrapper, GROUP_1.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('for a lesson restricted to some groups recipents only', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [GROUP_2.id, GROUP_3.id],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders only class learners assigned to a lesson groups', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+      });
+
+      it('renders a correct summary tally', () => {
+        expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
+      });
+    });
+
+    describe('when displaying learners by groups', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+        router.push(ROUTE_LEARNERS_BY_GROUP);
+      });
+
+      it('renders only class learners assigned to a lesson groups', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+      });
+
+      it('renders only lesson groups including empty ones', () => {
+        const groupTitles = getGroupTitles(wrapper);
+
+        expect(groupTitles.length).toBe(2);
+        expect(groupTitles.at(0).text()).toBe(GROUP_2.name);
+        expect(groupTitles.at(1).text()).toBe(GROUP_3.name);
+      });
+
+      it('renders a correct group tally', () => {
+        expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
@@ -1,6 +1,7 @@
 import { mount, createLocalVue, RouterLinkStub } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 
+import { STATUSES } from '../../../src/modules/classSummary/constants';
 import makeStore from '../../makeStore';
 import ReportsLessonResourceLearnerListPage from '../../../src/views/reports/ReportsLessonResourceLearnerListPage';
 
@@ -86,6 +87,18 @@ const getGroupTitles = wrapper => {
   return wrapper.findAll('[data-test="group-title"]');
 };
 
+const getSummaryTally = wrapper => {
+  return wrapper.find('[data-test="summary-tally"]');
+};
+
+const getGroup = (wrapper, groupId) => {
+  return wrapper.find(`[data-test="group-${groupId}"]`);
+};
+
+const getGroupTally = (wrapper, groupId) => {
+  return getGroup(wrapper, groupId).find({ name: 'StatusSummary' });
+};
+
 const initWrapper = lessonMap => {
   if (!lessonMap) {
     lessonMap = {
@@ -107,6 +120,32 @@ const initWrapper = lessonMap => {
     learner3: LEARNER_3,
   };
 
+  const contentLearnerStatusMap = {
+    [RESOURCE_ID]: {
+      [LEARNER_1.id]: {
+        learner_id: LEARNER_1.id,
+        content_id: RESOURCE_ID,
+        status: STATUSES.started,
+        last_activity: new Date('2019-05-04T07:00:00Z'),
+        time_spent: 300,
+      },
+      [LEARNER_2.id]: {
+        learner_id: LEARNER_2.id,
+        content_id: RESOURCE_ID,
+        status: STATUSES.completed,
+        last_activity: new Date('2019-05-05T08:00:00Z'),
+        time_spent: 120,
+      },
+      [LEARNER_3.id]: {
+        learner_id: LEARNER_3.id,
+        content_id: RESOURCE_ID,
+        status: STATUSES.notStarted,
+        last_activity: new Date('2019-05-05T08:30:00Z'),
+        time_spent: 760,
+      },
+    },
+  };
+
   const contentMap = {
     [RESOURCE_ID]: {
       title: 'Boys’ Clothing',
@@ -121,6 +160,7 @@ const initWrapper = lessonMap => {
     groupMap,
     learnerMap,
     contentMap,
+    contentLearnerStatusMap,
   };
 
   router.push(ROUTE_ALL_LEARNERS);
@@ -184,6 +224,10 @@ describe('ReportsLessonResourceLearnerListPage', () => {
         expect(wrapper.html()).toContain(LEARNER_2.name);
         expect(wrapper.html()).toContain(LEARNER_3.name);
       });
+
+      it('renders a correct summary tally', () => {
+        expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
+      });
     });
 
     describe('when displaying learners by groups', () => {
@@ -207,6 +251,12 @@ describe('ReportsLessonResourceLearnerListPage', () => {
         expect(groupTitles.at(1).text()).toBe(GROUP_2.name);
         expect(groupTitles.at(2).text()).toBe(GROUP_3.name);
         expect(groupTitles.at(3).text()).toBe('Ungrouped learners');
+      });
+
+      it('renders a correct group tally', () => {
+        expect(getGroupTally(wrapper, GROUP_1.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
       });
     });
   });
@@ -233,6 +283,10 @@ describe('ReportsLessonResourceLearnerListPage', () => {
 
         expect(wrapper.html()).toContain(LEARNER_2.name);
       });
+
+      it('renders a correct summary tally', () => {
+        expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
+      });
     });
 
     describe('when displaying learners by groups', () => {
@@ -254,6 +308,11 @@ describe('ReportsLessonResourceLearnerListPage', () => {
         expect(groupTitles.length).toBe(2);
         expect(groupTitles.at(0).text()).toBe(GROUP_2.name);
         expect(groupTitles.at(1).text()).toBe(GROUP_3.name);
+      });
+
+      it('renders a correct group tally', () => {
+        expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
       });
     });
   });

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
@@ -91,12 +91,20 @@ const getSummaryTally = wrapper => {
   return wrapper.find('[data-test="summary-tally"]');
 };
 
+const getSummaryResourcesStats = wrapper => {
+  return wrapper.find('[data-test="summary-resources-stats"]');
+};
+
 const getGroup = (wrapper, groupId) => {
   return wrapper.find(`[data-test="group-${groupId}"]`);
 };
 
 const getGroupTally = (wrapper, groupId) => {
   return getGroup(wrapper, groupId).find({ name: 'StatusSummary' });
+};
+
+const getGroupResourcesStats = (wrapper, groupId) => {
+  return getGroup(wrapper, groupId).find({ name: 'ReportsResourcesStats' });
 };
 
 const initWrapper = lessonMap => {
@@ -228,6 +236,10 @@ describe('ReportsLessonResourceLearnerListPage', () => {
       it('renders a correct summary tally', () => {
         expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
       });
+
+      it('renders correct resources stats', () => {
+        expect(getSummaryResourcesStats(wrapper).html()).toMatchSnapshot();
+      });
     });
 
     describe('when displaying learners by groups', () => {
@@ -258,6 +270,12 @@ describe('ReportsLessonResourceLearnerListPage', () => {
         expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
         expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
       });
+
+      it('renders correct group resources stats', () => {
+        expect(getGroupResourcesStats(wrapper, GROUP_1.id).html()).toMatchSnapshot();
+        expect(getGroupResourcesStats(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupResourcesStats(wrapper, GROUP_3.id).html()).toMatchSnapshot();
+      });
     });
   });
 
@@ -287,6 +305,10 @@ describe('ReportsLessonResourceLearnerListPage', () => {
       it('renders a correct summary tally', () => {
         expect(getSummaryTally(wrapper).html()).toMatchSnapshot();
       });
+
+      it('renders correct resources stats', () => {
+        expect(getSummaryResourcesStats(wrapper).html()).toMatchSnapshot();
+      });
     });
 
     describe('when displaying learners by groups', () => {
@@ -313,6 +335,11 @@ describe('ReportsLessonResourceLearnerListPage', () => {
       it('renders a correct group tally', () => {
         expect(getGroupTally(wrapper, GROUP_2.id).html()).toMatchSnapshot();
         expect(getGroupTally(wrapper, GROUP_3.id).html()).toMatchSnapshot();
+      });
+
+      it('renders correct group resources stats', () => {
+        expect(getGroupResourcesStats(wrapper, GROUP_2.id).html()).toMatchSnapshot();
+        expect(getGroupResourcesStats(wrapper, GROUP_3.id).html()).toMatchSnapshot();
       });
     });
   });

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
@@ -1,0 +1,113 @@
+import { mount, createLocalVue, RouterLinkStub } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+
+import makeStore from '../../makeStore';
+import ReportsLessonResourceLearnerListPage from '../../../src/views/reports/ReportsLessonResourceLearnerListPage';
+
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
+// commonCoach mixin imports kolibri customized router and uses getRoute method
+jest.mock('kolibri.coreVue.router', () => {
+  return {
+    getRoute: (name, params, query) => {
+      return { name, params, query };
+    },
+  };
+});
+
+const ROUTE_NAME = 'FakeReportsLessonResourceLearnerListPage';
+
+const LESSON_ID = 'lesson-id';
+const RESOURCE_ID = 'resource-id';
+
+const ROUTE_ALL_LEARNERS = {
+  name: ROUTE_NAME,
+  params: {
+    lessonId: LESSON_ID,
+    resourceId: RESOURCE_ID,
+  },
+};
+
+const ROUTE_LEARNERS_BY_GROUP = {
+  ...ROUTE_ALL_LEARNERS,
+  query: {
+    groups: 'true',
+  },
+};
+
+const router = new VueRouter({
+  routes: [
+    {
+      path: '/reports/lessons/:lessonId/resources/:resourceId/learners',
+      name: ROUTE_NAME,
+    },
+  ],
+});
+
+const getViewByGroupsCheckbox = wrapper => {
+  return wrapper.find({ name: 'KCheckbox' }).find('input');
+};
+
+const initWrapper = lessonMap => {
+  if (!lessonMap) {
+    lessonMap = {
+      [LESSON_ID]: {
+        groups: [],
+      },
+    };
+  }
+  const contentMap = {
+    [RESOURCE_ID]: {
+      title: 'Boys’ Clothing',
+    },
+  };
+
+  const store = makeStore();
+
+  store.state.classSummary = {
+    ...store.state.classSummary,
+    lessonMap,
+    contentMap,
+  };
+
+  router.push(ROUTE_ALL_LEARNERS);
+
+  const wrapper = mount(ReportsLessonResourceLearnerListPage, {
+    store,
+    localVue,
+    router,
+    stubs: {
+      // avoid auth setup etc. for now since specs are currently dealing mostly with grouping
+      CoreBase: true,
+      RouterLink: RouterLinkStub,
+    },
+  });
+
+  return wrapper;
+};
+
+describe('ReportsLessonResourceLearnerListPage', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = initWrapper();
+  });
+
+  it('renders view by groups checkbox as unchecked when group not in url query', () => {
+    expect(getViewByGroupsCheckbox(wrapper).element.checked).toBe(false);
+  });
+
+  it('renders view by groups checkbox as checked when group in url query', () => {
+    router.push(ROUTE_LEARNERS_BY_GROUP);
+    expect(getViewByGroupsCheckbox(wrapper).element.checked).toBe(true);
+  });
+
+  it('toggles url query on view by groups click', () => {
+    getViewByGroupsCheckbox(wrapper).setChecked(true);
+    expect(wrapper.vm.$route.query.groups).toBe('true');
+
+    getViewByGroupsCheckbox(wrapper).setChecked(false);
+    expect(wrapper.vm.$route.query.groups).toBeUndefined();
+  });
+});

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
@@ -21,6 +21,39 @@ const ROUTE_NAME = 'FakeReportsLessonResourceLearnerListPage';
 const LESSON_ID = 'lesson-id';
 const RESOURCE_ID = 'resource-id';
 
+const LEARNER_1 = {
+  id: 'learner1',
+  name: 'learner1 name',
+};
+
+const LEARNER_2 = {
+  id: 'learner2',
+  name: 'learner2 name',
+};
+
+const LEARNER_3 = {
+  id: 'learner3',
+  name: 'learner3 name',
+};
+
+const GROUP_1 = {
+  id: 'group1',
+  name: 'group1 name',
+  member_ids: [LEARNER_1.id, LEARNER_2.id],
+};
+
+const GROUP_2 = {
+  id: 'group2',
+  name: 'group2 name',
+  member_ids: [LEARNER_2.id],
+};
+
+const GROUP_3 = {
+  id: 'group3',
+  name: 'group3 name',
+  member_ids: [],
+};
+
 const ROUTE_ALL_LEARNERS = {
   name: ROUTE_NAME,
   params: {
@@ -49,6 +82,10 @@ const getViewByGroupsCheckbox = wrapper => {
   return wrapper.find({ name: 'KCheckbox' }).find('input');
 };
 
+const getGroupTitles = wrapper => {
+  return wrapper.findAll('[data-test="group-title"]');
+};
+
 const initWrapper = lessonMap => {
   if (!lessonMap) {
     lessonMap = {
@@ -57,6 +94,19 @@ const initWrapper = lessonMap => {
       },
     };
   }
+
+  const groupMap = {
+    group1: GROUP_1,
+    group2: GROUP_2,
+    group3: GROUP_3,
+  };
+
+  const learnerMap = {
+    learner1: LEARNER_1,
+    learner2: LEARNER_2,
+    learner3: LEARNER_3,
+  };
+
   const contentMap = {
     [RESOURCE_ID]: {
       title: 'Boys’ Clothing',
@@ -68,6 +118,8 @@ const initWrapper = lessonMap => {
   store.state.classSummary = {
     ...store.state.classSummary,
     lessonMap,
+    groupMap,
+    learnerMap,
     contentMap,
   };
 
@@ -109,5 +161,100 @@ describe('ReportsLessonResourceLearnerListPage', () => {
 
     getViewByGroupsCheckbox(wrapper).setChecked(false);
     expect(wrapper.vm.$route.query.groups).toBeUndefined();
+  });
+
+  describe('for an entire class lesson', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders all class learners', () => {
+        expect(wrapper.html()).toContain(LEARNER_1.name);
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+        expect(wrapper.html()).toContain(LEARNER_3.name);
+      });
+    });
+
+    describe('when displaying learners by groups', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+        router.push(ROUTE_LEARNERS_BY_GROUP);
+      });
+
+      it('renders all class learners', () => {
+        expect(wrapper.html()).toContain(LEARNER_1.name);
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+        expect(wrapper.html()).toContain(LEARNER_3.name);
+      });
+
+      it('renders all lesson groups including empty ones and ungrouped learners section', () => {
+        const groupTitles = getGroupTitles(wrapper);
+
+        expect(groupTitles.length).toBe(4);
+
+        expect(groupTitles.at(0).text()).toBe(GROUP_1.name);
+        expect(groupTitles.at(1).text()).toBe(GROUP_2.name);
+        expect(groupTitles.at(2).text()).toBe(GROUP_3.name);
+        expect(groupTitles.at(3).text()).toBe('Ungrouped learners');
+      });
+    });
+  });
+
+  describe('for a lesson restricted to some groups recipents only', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [GROUP_2.id, GROUP_3.id],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders only class learners assigned to a lesson groups', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+      });
+    });
+
+    describe('when displaying learners by groups', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+        router.push(ROUTE_LEARNERS_BY_GROUP);
+      });
+
+      it('renders only class learners assigned to a lesson groups', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+
+        expect(wrapper.html()).toContain(LEARNER_2.name);
+      });
+
+      it('renders only lesson groups including empty ones', () => {
+        const groupTitles = getGroupTitles(wrapper);
+
+        expect(groupTitles.length).toBe(2);
+        expect(groupTitles.at(0).text()).toBe(GROUP_2.name);
+        expect(groupTitles.at(1).text()).toBe(GROUP_3.name);
+      });
+    });
   });
 });

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
@@ -8,7 +8,7 @@ const entries = [
     id: 'd4b',
     name: 'learner1',
     username: 'learner1',
-    groups: ['group1', 'group2'],
+    groups: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
     statusObj: {
       learner_id: 'd4b',
       content_id: 'a97',
@@ -21,7 +21,7 @@ const entries = [
     id: 'a5d',
     name: 'learner2',
     username: 'learner2',
-    groups: ['group2'],
+    groups: [{ id: '23s', name: 'group2' }],
     statusObj: {
       learner_id: 'a5d',
       content_id: 'a97',

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
@@ -1,0 +1,70 @@
+import { shallowMount, mount } from '@vue/test-utils';
+
+import { STATUSES } from '../../../src/modules/classSummary/constants';
+import ReportsResourceLearners from '../../../src/views/reports/ReportsResourceLearners';
+
+const entries = [
+  {
+    id: 'd4b',
+    name: 'learner1',
+    username: 'learner1',
+    groups: ['group1', 'group2'],
+    statusObj: {
+      learner_id: 'd4b',
+      content_id: 'a97',
+      status: STATUSES.completed,
+      last_activity: new Date('2019-05-04T07:00:00Z'),
+      time_spent: 92.5,
+    },
+  },
+  {
+    id: 'a5d',
+    name: 'learner2',
+    username: 'learner2',
+    groups: ['group2'],
+    statusObj: {
+      learner_id: 'a5d',
+      content_id: 'a97',
+      status: STATUSES.started,
+      last_activity: new Date('2019-05-05T08:00:00Z'),
+      time_spent: 17.14,
+    },
+  },
+];
+
+const initWrapper = propsData => {
+  return mount(ReportsResourceLearners, {
+    propsData,
+  });
+};
+
+jest.mock('kolibri.utils.serverClock', () => {
+  return {
+    now: () => new Date('2019-05-05T11:00:00Z'),
+  };
+});
+
+describe('ReportsResourceLearners', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(ReportsResourceLearners);
+
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('renders all entries', () => {
+    const wrapper = initWrapper({
+      entries,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("doesn't render groups information when show groups set to false", () => {
+    const wrapper = initWrapper({
+      entries,
+      showGroupsColumn: false,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsExerciseLearners doesn't render groups information when show groups set to false 1`] = `
+<div class="core-table-container">
+  <table class="core-table">
+    <thead style="border-bottom: 1px solid #e0e0e0; font-size: 12px; color: rgb(97, 97, 97);">
+      <tr>
+        <th>Name</th>
+        <th>Progress</th>
+        <th>Time spent</th>
+        <!---->
+        <th>Last activity</th>
+      </tr>
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed
+  </div></span>
+    <!---->
+</div>
+</td>
+<td><span>92 seconds</span></td>
+<!---->
+<td><span>
+  yesterday
+</span></td>
+</tr>
+<tr data-test="entry">
+  <td>
+    <div>learner2</div>
+  </td>
+  <td>
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    Started
+  </div></span>
+      <!---->
+    </div>
+  </td>
+  <td><span>17 seconds</span></td>
+  <!---->
+  <td><span>
+  3 hours ago
+</span></td>
+</tr></span></table>
+</div>
+`;
+
+exports[`ReportsExerciseLearners renders all entries 1`] = `
+<div class="core-table-container">
+  <table class="core-table">
+    <thead style="border-bottom: 1px solid #e0e0e0; font-size: 12px; color: rgb(97, 97, 97);">
+      <tr>
+        <th>Name</th>
+        <th>Progress</th>
+        <th>Time spent</th>
+        <th>
+          Groups
+        </th>
+        <th>Last activity</th>
+      </tr>
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed
+  </div></span>
+    <!---->
+</div>
+</td>
+<td><span>92 seconds</span></td>
+<td>
+  <div class="items-label"><span>
+    group1, group2
+  </span></div>
+</td>
+<td><span>
+  yesterday
+</span></td>
+</tr>
+<tr data-test="entry">
+  <td>
+    <div>learner2</div>
+  </td>
+  <td>
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    Started
+  </div></span>
+      <!---->
+    </div>
+  </td>
+  <td><span>17 seconds</span></td>
+  <td>
+    <div class="items-label"><span>
+    group2
+  </span></div>
+  </td>
+  <td><span>
+  3 hours ago
+</span></td>
+</tr></span></table>
+</div>
+`;

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders a correct summary tally 1`] = `
+<div class="multi-line" data-test="summary-tally">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed by 1 of 1
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #df4d4f;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 2`] = `
+<div class="single-line">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0 of 0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
+<div class="multi-line" data-test="summary-tally">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed by 1 of 3
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    1 started
+  </div></span>
+    <!---->
+  </div>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #df4d4f;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #df4d4f;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
+<div class="single-line">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0 of 0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders a correct summary tally 1`] = `
+<div class="multi-line" data-test="summary-tally">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed by 1 of 1
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <!---->
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 2`] = `
+<div class="single-line">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0 of 0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
+<div class="multi-line" data-test="summary-tally">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed by 1 of 3
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    1 started
+  </div></span>
+    <!---->
+  </div>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <!---->
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
+<div class="single-line">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    1
+  </div></span>
+    <!---->
+  </div>
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+  <!---->
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
+<div class="single-line">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+    0 of 0
+  </div></span>
+    <!---->
+  </div>
+</div>
+`;

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
@@ -10,6 +10,17 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 </div>
 `;
 
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders correct resources stats 1`] = `
+<table data-test="summary-resources-stats">
+  <tr>
+    <th>
+      Average time spent
+    </th>
+    <td><span>2 minutes</span></td>
+  </tr>
+</table>
+`;
+
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
   <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
@@ -41,6 +52,19 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 </div>
 `;
 
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders correct group resources stats 1`] = `
+<table>
+  <tr>
+    <th>
+      Average time spent
+    </th>
+    <td><span>2 minutes</span></td>
+  </tr>
+</table>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders correct group resources stats 2`] = `undefined`;
+
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
   <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
@@ -56,6 +80,17 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
   <!---->
   <!---->
 </div>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying all learners renders correct resources stats 1`] = `
+<table data-test="summary-resources-stats">
+  <tr>
+    <th>
+      Average time spent
+    </th>
+    <td><span>3 minutes</span></td>
+  </tr>
+</table>
 `;
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
@@ -109,3 +144,27 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
   </div>
 </div>
 `;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders correct group resources stats 1`] = `
+<table>
+  <tr>
+    <th>
+      Average time spent
+    </th>
+    <td><span>3 minutes</span></td>
+  </tr>
+</table>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders correct group resources stats 2`] = `
+<table>
+  <tr>
+    <th>
+      Average time spent
+    </th>
+    <td><span>2 minutes</span></td>
+  </tr>
+</table>
+`;
+
+exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders correct group resources stats 3`] = `undefined`;

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsResourceLearners doesn't render groups information when show groups set to false 1`] = `
+<div class="core-table-container">
+  <table class="core-table">
+    <thead style="border-bottom: 1px solid #e0e0e0; font-size: 12px; color: rgb(97, 97, 97);">
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Time spent</th>
+        <!---->
+        <th>Last activity</th>
+      </tr>
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #3a3a3a;"></mat-svg></div> <div dir="auto" class="label">
+          learner1
+        </div></span></td>
+    <td>
+      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed
+  </div></span>
+        <!---->
+      </div>
+    </td>
+    <td><span>92 seconds</span></td>
+    <!---->
+    <td><span>
+  yesterday
+</span></td>
+    </tr>
+    <tr>
+      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #3a3a3a;"></mat-svg></div> <div dir="auto" class="label">
+          learner2
+        </div></span></td>
+      <td>
+        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    Started
+  </div></span>
+          <!---->
+        </div>
+      </td>
+      <td><span>17 seconds</span></td>
+      <!---->
+      <td><span>
+  3 hours ago
+</span></td>
+    </tr>
+    </span>
+  </table>
+</div>
+`;
+
+exports[`ReportsResourceLearners renders all entries 1`] = `
+<div class="core-table-container">
+  <table class="core-table">
+    <thead style="border-bottom: 1px solid #e0e0e0; font-size: 12px; color: rgb(97, 97, 97);">
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Time spent</th>
+        <th>
+          Groups
+        </th>
+        <th>Last activity</th>
+      </tr>
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #3a3a3a;"></mat-svg></div> <div dir="auto" class="label">
+          learner1
+        </div></span></td>
+    <td>
+      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    Completed
+  </div></span>
+        <!---->
+      </div>
+    </td>
+    <td><span>92 seconds</span></td>
+    <td>
+      <div class="items-label"><span>
+    group1, group2
+  </span></div>
+    </td>
+    <td><span>
+  yesterday
+</span></td>
+    </tr>
+    <tr>
+      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #3a3a3a;"></mat-svg></div> <div dir="auto" class="label">
+          learner2
+        </div></span></td>
+      <td>
+        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #2196f3;"></mat-svg></div> <div dir="auto" class="label">
+    Started
+  </div></span>
+          <!---->
+        </div>
+      </td>
+      <td><span>17 seconds</span></td>
+      <td>
+        <div class="items-label"><span>
+    group2
+  </span></div>
+      </td>
+      <td><span>
+  3 hours ago
+</span></td>
+    </tr>
+    </span>
+  </table>
+</div>
+`;


### PR DESCRIPTION
### Summary

Add "View by groups" feature to exercise learners list reports

#### Screenshots

<img width="734" alt="Screenshot 2019-05-05 at 22 04 32" src="https://user-images.githubusercontent.com/13509191/57199661-e1b96a00-6f81-11e9-807b-b3699c2099fa.png">
<img width="734" alt="Screenshot 2019-05-05 at 22 04 40" src="https://user-images.githubusercontent.com/13509191/57199682-0d3c5480-6f82-11e9-8519-7df4d4900291.png">


#### Design files

- #5403 screens
- https://www.figma.com/file/D5wXhmWNGyt60SpGBgFucwZU/Coach-reports-0.12?node-id=1385%3A4822I'

#### Notes

- We'll need to discuss if/how to visually treat edge cases like empty groups (only non-empty ones are displayed now) and learners without groups (they're ignored now) - I'm going to ask design folks tomorrow on Slack and eventually update the PR/open a follow-up based on the result.
- At first I tried to add a couple of basic `ReportsLessonExerciseLearnerListPage.vue` specs related to the new feature, but got stuck on router mocks for quite a long time - I tried various ways but I always broke something else. Not sure why yet, maybe I overlooked something. After a quite long time, I gave it up for now, but I kept my test scenarios and will add them as soon as I have a look at how to simply test these views (so far it looked that `commonCoach` mixin's dependencies could cause some of those troubles so I would like to have a closer look).
- It was a bit difficult to track all dependencies to store etc. with `commonCoach` mixin when navigating in coach codes. I noticed that it's being used also for smaller components, but tried to avoid that in a new table component. I was thinking about rather splitting the mixin into helpers and smaller pieces in the future (even when it would cost us some duplicates in components/views)? Would it make sense?
- It's my first feature so would like to ask - when will be the right time to add gherkin stories? After the review?

### Reviewer guidance

1. Create a couple of groups and assign learners
2. Create a lesson containing an exercise
3. Login as some learners of groups you created and try to start/finish the exercise or stop in the middle of it
4. Visit Coach -> Reports -> Lessons -> your lesson with an exercise -> Report -> your exercise (`coach/#/<classId>/reports/lessons/<lessonId>/exercises/<exerciseId>/learners`)

- Toggle "View by groups"
- Check groups and their stats
- Check navigation between an exercise learners list and their detail views

### References

Solves first part of #5403

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
