### PR TITLE
Clean up 'always on' hasIcons prop.

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -11,7 +11,6 @@
       <div
         v-if="$slots.header"
         class="ui-menu-header"
-        :class="{'ui-menu-header-lp': hasIcons}"
         :style="{ color: $coreTextDefault }"
       >
         <slot name="header"></slot>
@@ -122,12 +121,9 @@
 
   .ui-menu-header {
     padding: 1rem;
+    padding-left: 50px; // TODO make a variable?
     font-size: $ui-dropdown-item-font-size;
     border-bottom: solid 1px rgba(black, 0.08);
-  }
-
-  .ui-menu-header-lp {
-    padding-left: 50px; // TODO make a variable?
   }
 
   /* stylelint-enable */

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -47,7 +47,6 @@
           <CoreMenu
             role="navigation"
             :style="{ backgroundColor: $coreBgLight }"
-            :hasIcons="true"
             :aria-label="$tr('navigationLabel')"
           >
             <template slot="options">


### PR DESCRIPTION
### Summary
#5423 removed the `hasIcons` prop from the CoreMenu, because both our instances of the CoreMenu had icons.
However, I failed to clean up all references, so it was throwing nasty vue warnings.
This cleans up the remaining references.

### Reviewer guidance
Icons still display properly in the side nav and user drop down.

### References
Clean up from #5423 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
