### PR TITLE
set immersive AppBar for Search in Learn section

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -139,12 +139,12 @@
         }
         if (this.pageName === PageNames.SEARCH) {
           return {
-            appBarTitle: this.$tr('learnTitle'),
+            appBarTitle: this.$tr('searchTitle'),
             immersivePage: true,
             // Default to the Learn root page if there is no lastRoute to return to.
             immersivePageRoute: this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
-            immersivePagePrimary: true,
-            immersivePageIcon: 'arrow_back',
+            immersivePagePrimary: false,
+            immersivePageIcon: 'close',
           };
         }
 
@@ -243,6 +243,7 @@
     $trs: {
       learnTitle: 'Learn',
       examReportTitle: '{examTitle} report',
+      searchTitle: 'Search',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -231,11 +231,13 @@
           return;
         }
 
-        // Destructure the oldRoute into an object with the only four properties.
+        // Destructure the oldRoute into an object with 3 specific properties.
         // Setting this.lastRoute = oldRoute causes issues for some reason.
-        this.lastRoute = (({ name, query, path, params }) => ({ name, query, path, params }))(
-          oldRoute
-        );
+        this.lastRoute = {
+          name: oldRoute.name,
+          query: oldRoute.query,
+          params: oldRoute.params,
+        };
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -83,6 +83,11 @@
       KPageContainer,
     },
     mixins: [responsiveWindow],
+    data() {
+      return {
+        lastRoute: null,
+      };
+    },
     computed: {
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
@@ -136,7 +141,8 @@
           return {
             appBarTitle: this.$tr('learnTitle'),
             immersivePage: true,
-            immersivePageRoute: this.$router.getRoute(PageNames.TOPICS_ROOT),
+            // Default to the Learn root page if there is no lastRoute to return to.
+            immersivePageRoute: this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
             immersivePagePrimary: true,
             immersivePageIcon: 'arrow_back',
           };
@@ -215,6 +221,21 @@
         const isAssessment = content && content.assessment;
         // height of .attempts-container in AssessmentWrapper
         return isAssessment ? BOTTOM_SPACED_RESERVED : 0;
+      },
+    },
+    watch: {
+      $route: function(newRoute, oldRoute) {
+        // Return if the current route is a search path. Otherwise this method creates
+        // an infinite loop.
+        if (newRoute.name === 'SEARCH' && oldRoute.name === 'SEARCH') {
+          return;
+        }
+
+        // Destructure the oldRoute into an object with the only four properties.
+        // Setting this.lastRoute = oldRoute causes issues for some reason.
+        this.lastRoute = (({ name, query, path, params }) => ({ name, query, path, params }))(
+          oldRoute
+        );
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -132,6 +132,15 @@
             };
           }
         }
+        if (this.pageName === PageNames.SEARCH) {
+          return {
+            appBarTitle: this.$tr('learnTitle'),
+            immersivePage: true,
+            immersivePageRoute: this.$router.getRoute(PageNames.TOPICS_ROOT),
+            immersivePagePrimary: true,
+            immersivePageIcon: 'arrow_back',
+          };
+        }
 
         if (this.pageName === PageNames.TOPICS_CONTENT) {
           let immersivePageRoute = {};

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -83,11 +83,6 @@
       KPageContainer,
     },
     mixins: [responsiveWindow],
-    data() {
-      return {
-        lastRoute: null,
-      };
-    },
     computed: {
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
@@ -138,11 +133,13 @@
           }
         }
         if (this.pageName === PageNames.SEARCH) {
+          const encodedJSONRoute = this.$router.history.current.query.returnRoute;
+          const returnRoute = JSON.parse(decodeURI(encodedJSONRoute));
           return {
             appBarTitle: this.$tr('learnTitle'),
             immersivePage: true,
             // Default to the Learn root page if there is no lastRoute to return to.
-            immersivePageRoute: this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
+            immersivePageRoute: returnRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
             immersivePagePrimary: true,
             immersivePageIcon: 'arrow_back',
           };
@@ -221,21 +218,6 @@
         const isAssessment = content && content.assessment;
         // height of .attempts-container in AssessmentWrapper
         return isAssessment ? BOTTOM_SPACED_RESERVED : 0;
-      },
-    },
-    watch: {
-      $route: function(newRoute, oldRoute) {
-        // Return if the current route is a search path. Otherwise this method creates
-        // an infinite loop.
-        if (newRoute.name === 'SEARCH' && oldRoute.name === 'SEARCH') {
-          return;
-        }
-
-        // Destructure the oldRoute into an object with the only four properties.
-        // Setting this.lastRoute = oldRoute causes issues for some reason.
-        this.lastRoute = (({ name, query, path, params }) => ({ name, query, path, params }))(
-          oldRoute
-        );
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -225,8 +225,8 @@
     },
     watch: {
       $route: function(newRoute, oldRoute) {
-        // Return if the current route is a search path. Otherwise this method creates
-        // an infinite loop.
+        // Return if the user is searching another query on the same search results
+        // page. Otherwise, the back arrow will infinitely redirect.
         if (newRoute.name === 'SEARCH' && oldRoute.name === 'SEARCH') {
           return;
         }

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -83,6 +83,11 @@
       KPageContainer,
     },
     mixins: [responsiveWindow],
+    data() {
+      return {
+        lastRoute: null,
+      };
+    },
     computed: {
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
@@ -133,13 +138,11 @@
           }
         }
         if (this.pageName === PageNames.SEARCH) {
-          const encodedJSONRoute = this.$router.history.current.query.returnRoute;
-          const returnRoute = JSON.parse(decodeURI(encodedJSONRoute));
           return {
             appBarTitle: this.$tr('learnTitle'),
             immersivePage: true,
             // Default to the Learn root page if there is no lastRoute to return to.
-            immersivePageRoute: returnRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
+            immersivePageRoute: this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
             immersivePagePrimary: true,
             immersivePageIcon: 'arrow_back',
           };
@@ -218,6 +221,21 @@
         const isAssessment = content && content.assessment;
         // height of .attempts-container in AssessmentWrapper
         return isAssessment ? BOTTOM_SPACED_RESERVED : 0;
+      },
+    },
+    watch: {
+      $route: function(newRoute, oldRoute) {
+        // Return if the current route is a search path. Otherwise this method creates
+        // an infinite loop.
+        if (newRoute.name === 'SEARCH' && oldRoute.name === 'SEARCH') {
+          return;
+        }
+
+        // Destructure the oldRoute into an object with the only four properties.
+        // Setting this.lastRoute = oldRoute causes issues for some reason.
+        this.lastRoute = (({ name, query, path, params }) => ({ name, query, path, params }))(
+          oldRoute
+        );
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -237,7 +237,6 @@
         if (this.searchQuery !== '') {
           const query = {
             searchTerm: this.searchQuery,
-            returnRoute: encodeURI(JSON.stringify(this.$router.history.current)),
           };
           if (filterUpdate === true) {
             if (this.$refs.contentKindFilter.selection.value) {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -237,6 +237,7 @@
         if (this.searchQuery !== '') {
           const query = {
             searchTerm: this.searchQuery,
+            returnRoute: encodeURI(JSON.stringify(this.$router.history.current)),
           };
           if (filterUpdate === true) {
             if (this.$refs.contentKindFilter.selection.value) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This change fixes this issue https://github.com/learningequality/kolibri/issues/5418 by setting the Learn Search page's AppBar to use the Immersive version - clicking the arrow will always return the user to the Learn home page.

Before:
![exit-path-before](https://user-images.githubusercontent.com/6356129/57258335-fee94980-7010-11e9-86d3-928b6fb2a2d1.png)

After:
![exit-path-after](https://user-images.githubusercontent.com/6356129/57258342-01e43a00-7011-11e9-8b28-809d772f07d4.png)



…

### Reviewer guidance
- Checkout develop & enter a search input in the Learn section
- See the hamburger menu
- Checkout this PR's branch, repeat the search
- See the back icon
- Click the icon to return to the Learn home page
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Kolibri Issue: https://github.com/learningequality/kolibri/issues/5418
Clearinghouse Issue: https://github.com/learningequality/clearinghouse/issues/32

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
