### PR TITLE
Add estimated content strings.

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -206,6 +206,7 @@
     $trs: {
       selectAll: 'Select all',
       topicHasNoContents: 'This topic has no sub-topics or resources',
+      estimatedCounts: 'Estimated number of resources',
     },
   };
 

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/SelectedResourcesSize.vue
@@ -109,6 +109,8 @@
       availableSpace: 'Drive space available: {space}',
       resourcesSelected:
         'Content selected: {fileSize} ({resources, number, integer} {resources, plural, one {resource} other {resources}})',
+      estimatedResourcesSelected:
+        'Estimated content selected: {fileSize} ({resources, number, integer} {resources, plural, one {resource} other {resources}})',
     },
   };
 


### PR DESCRIPTION
### Summary
String stubbing for content importability annotation work.

### Reviewer guidance
Are these strings? Do they read ok?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
