### PR TITLE
Add current group membership summary to group enrollment

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -32,7 +32,12 @@
           :selectAllLabel="$tr('selectAllOnPage')"
           :userCheckboxLabel="$tr('selectUser')"
           :emptyMessage="emptyMessage"
-        />
+          :infoDescriptor="$tr('learnerGroups')"
+        >
+          <template slot="info" slot-scope="userRow">
+            <TruncatedItemList :items="getGroupsForLearner(userRow.user.id)" />
+          </template>
+        </UserTable>
 
         <nav>
           <span>
@@ -99,7 +104,7 @@
 
 <script>
 
-  import { mapActions, mapState } from 'vuex';
+  import { mapActions, mapGetters, mapState } from 'vuex';
   import differenceWith from 'lodash/differenceWith';
   import responsiveWindow from 'kolibri.coreVue.mixins.responsiveWindow';
   import KButton from 'kolibri.coreVue.components.KButton';
@@ -136,6 +141,7 @@
     },
     computed: {
       ...mapState('groups', ['groups', 'classUsers']),
+      ...mapGetters('classSummary', ['getGroupNamesForLearner']),
       pageTitle() {
         return this.$tr('pageHeader', { className: this.currentGroup.name });
       },
@@ -208,6 +214,9 @@
       goToPage(page) {
         this.pageNum = page;
       },
+      getGroupsForLearner(learnerId) {
+        return this.getGroupNamesForLearner(learnerId);
+      },
     },
     $trs: {
       pageHeader: "Enroll learners into '{className}'",
@@ -223,6 +232,7 @@
       selectUser: 'Select user',
       pagination:
         '{ visibleStartRange, number } - { visibleEndRange, number } of { numFilteredUsers, number }',
+      learnerGroups: 'Current groups',
     },
   };
 

--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -30,6 +30,9 @@
             </span>
           </th>
           <th>{{ $tr('username') }}</th>
+          <th v-if="$scopedSlots.info">
+            {{ infoDescriptor }}
+          </th>
           <th v-if="$scopedSlots.action" class="user-action-button">
             <span class="visuallyhidden">
               {{ $tr('userActionsColumnHeader') }}
@@ -80,6 +83,9 @@
             <span dir="auto">
               {{ user.username }}
             </span>
+          </td>
+          <td v-if="$scopedSlots.info">
+            <slot name="info" :user="user"></slot>
           </td>
           <td v-if="$scopedSlots.action" class="core-table-button-col">
             <slot name="action" :user="user"></slot>
@@ -148,6 +154,10 @@
       isCoach: {
         type: Boolean,
         default: false,
+      },
+      infoDescriptor: {
+        type: String,
+        default: '',
       },
     },
     computed: {


### PR DESCRIPTION
### Summary
Adds a truncated item list of current group membership to each user row in the group enrollment page.
Does this to address feedback that it was difficult to know which users were already enrolled in groups, when attempting to construct mutually exclusive groups.

### Reviewer guidance
Does this change look ok? Anything wrong with the strings?

### References
Address this feedback:
> If the teacher wants to create mutually exclusive groups, then he/she always needs to select from the complete list of students. Its overhead for a teacher, to always keep the name of students in mind who are already added to the earlier group.

Before
![image](https://user-images.githubusercontent.com/1680573/57420671-78259f80-71bd-11e9-9fd3-e802d4678de1.png)

After
![image](https://user-images.githubusercontent.com/1680573/57420655-5debc180-71bd-11e9-958c-8d37303cf8dc.png)

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
