### PR TITLE
Fix infinite loop between search and viewing searched content.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -225,9 +225,10 @@
     },
     watch: {
       $route: function(newRoute, oldRoute) {
-        // Return if the user is searching another query on the same search results
-        // page. Otherwise, the back arrow will infinitely redirect.
-        if (newRoute.name === 'SEARCH' && oldRoute.name === 'SEARCH') {
+        // Return if the user is leaving or entering the Search page.
+        // This ensures we never set this.lastRoute to be any kind of
+        // SEARCH route and avoids infinite loops.
+        if (newRoute.name === 'SEARCH' || oldRoute.name === 'SEARCH') {
           return;
         }
 


### PR DESCRIPTION
### Summary
After it was merged, @bjester found an infinite loop in this PR: https://github.com/learningequality/kolibri/pull/5459 where a user who searches content and then clicks to view some of that content is put into an infinite loop where they cannot leave either the content or the search.

### Reviewer guidance

#### On Develop
1. Go to Learn
2. Drill a level or two into some Topic nodes
3. Search something that will find existing content.
4. Click to view that content (specifically, a piece of content, not a topic)
5. Click the arrow back to Search
6. Click the X to leave Search
7. You are returned to the content you were just viewing.

#### On this PR
- Repeat steps 1-6 above
- Get returned to the place you drilled down to in step 2.

### References
https://github.com/learningequality/kolibri/pull/5459
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
