### PR TITLE
remove all word-break overrides

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/RemoveFromGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/RemoveFromGroupModal.vue
@@ -46,10 +46,4 @@
 </script>
 
 
-<style lang="scss" scoped>
-
-  p {
-    word-break: keep-all;
-  }
-
-</style>
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/UserRemoveConfirmationModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEditPage/UserRemoveConfirmationModal.vue
@@ -56,10 +56,4 @@
 </script>
 
 
-<style lang="scss" scoped>
-
-  p {
-    word-break: keep-all;
-  }
-
-</style>
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -57,10 +57,4 @@
 </script>
 
 
-<style lang="scss" scoped>
-
-  p {
-    word-break: keep-all;
-  }
-
-</style>
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -160,8 +160,6 @@
     display: inline-block;
     width: $thumb-width-desktop;
     text-decoration: none;
-    word-break: break-all; // fallback
-    word-break: break-word;
     vertical-align: top;
     border-radius: 2px;
     transition: box-shadow $core-time ease;


### PR DESCRIPTION

### Summary

* removes breaks in cards to begin addressing #5468
* removes some CJK-related code. We'll need to address that more holistically when the time comes

### Reviewer guidance

make sense?

### References

* https://github.com/learningequality/kolibri/issues/5464
* https://github.com/learningequality/kolibri/issues/5468
* https://github.com/learningequality/kolibri/issues/4419

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
