### PR TITLE
Set our path prefix option on all Django cookie path settings.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -271,6 +271,11 @@ CSRF_COOKIE_PATH = path_prefix
 # cookies set by other Django apps served from the same domain.
 LANGUAGE_COOKIE_PATH = path_prefix
 
+# https://docs.djangoproject.com/en/1.11/ref/settings/#session-cookie-path
+# Ensure that our session cookie does not collidge with other session cookies
+# set by other Django apps served from the same domain.
+SESSION_COOKIE_PATH = path_prefix
+
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
 # https://docs.djangoproject.com/en/1.9/topics/logging/
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -261,6 +261,11 @@ if path_prefix != '/':
 STATIC_URL = urljoin(path_prefix, 'static/')
 STATIC_ROOT = os.path.join(conf.KOLIBRI_HOME, "static")
 
+# https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-path
+# Ensure that our CSRF cookie does not collide with other CSRF cookies
+# set by other Django apps served from the same domain.
+CSRF_COOKIE_PATH = path_prefix
+
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
 # https://docs.djangoproject.com/en/1.9/topics/logging/
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -266,6 +266,11 @@ STATIC_ROOT = os.path.join(conf.KOLIBRI_HOME, "static")
 # set by other Django apps served from the same domain.
 CSRF_COOKIE_PATH = path_prefix
 
+# https://docs.djangoproject.com/en/1.11/ref/settings/#language-cookie-path
+# Ensure that our language cookie does not collide with other language
+# cookies set by other Django apps served from the same domain.
+LANGUAGE_COOKIE_PATH = path_prefix
+
 # https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
 # https://docs.djangoproject.com/en/1.9/topics/logging/
 


### PR DESCRIPTION
### Summary
Sets our path prefix setting on all cookie paths set by the backend.

### Reviewer guidance
Can you still:
* Login?
* Change language?

### References
Fixes #5478 and precautionarily fixes it for other cookie types also.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
