### PR TITLE
Ensure cached value of ContentNodeSlim/popular is never None

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -565,48 +565,50 @@ class ContentNodeSlimViewset(viewsets.ReadOnlyModelViewSet):
                 cache_key = "popular_content_coach"
                 coach_content = True
 
+        if cache.get(cache_key) is not None:
+            return Response(cache.get(cache_key))
+
         queryset = self.get_queryset(prefetch=True)
 
-        if not cache.get(cache_key):
-            if ContentSessionLog.objects.count() < 50:
-                # return 25 random content nodes if not enough session logs
-                pks = queryset.values_list("pk", flat=True).exclude(
-                    kind=content_kinds.TOPIC
+        if ContentSessionLog.objects.count() < 50:
+            # return 25 random content nodes if not enough session logs
+            pks = queryset.values_list("pk", flat=True).exclude(
+                kind=content_kinds.TOPIC
+            )
+            # .count scales with table size, so can get slow on larger channels
+            count_cache_key = "content_count_for_popular"
+            count = cache.get(count_cache_key) or min(pks.count(), 25)
+            queryset = queryset.filter(pk__in=sample(list(pks), count))
+            if not coach_content:
+                queryset = queryset.exclude(coach_content=True)
+        else:
+            # get the most accessed content nodes
+            # search for content nodes that currently exist in the database
+            content_nodes = models.ContentNode.objects.filter(available=True)
+            if not coach_content:
+                content_nodes = content_nodes.exclude(coach_content=True)
+            content_counts_sorted = (
+                ContentSessionLog.objects.filter(
+                    content_id__in=content_nodes.values_list(
+                        "content_id", flat=True
+                    ).distinct()
                 )
-                # .count scales with table size, so can get slow on larger channels
-                count_cache_key = "content_count_for_popular"
-                count = cache.get(count_cache_key) or min(pks.count(), 25)
-                queryset = queryset.filter(pk__in=sample(list(pks), count))
-                if not coach_content:
-                    queryset = queryset.exclude(coach_content=True)
-            else:
-                # get the most accessed content nodes
-                # search for content nodes that currently exist in the database
-                content_nodes = models.ContentNode.objects.filter(available=True)
-                if not coach_content:
-                    content_nodes = content_nodes.exclude(coach_content=True)
-                content_counts_sorted = (
-                    ContentSessionLog.objects.filter(
-                        content_id__in=content_nodes.values_list(
-                            "content_id", flat=True
-                        ).distinct()
-                    )
-                    .values_list("content_id", flat=True)
-                    .annotate(Count("content_id"))
-                    .order_by("-content_id__count")
-                )
+                .values_list("content_id", flat=True)
+                .annotate(Count("content_id"))
+                .order_by("-content_id__count")
+            )
 
-                most_popular = queryset.filter(
-                    content_id__in=list(content_counts_sorted[:20])
-                )
-                queryset = most_popular.dedupe_by_content_id()
+            most_popular = queryset.filter(
+                content_id__in=list(content_counts_sorted[:20])
+            )
+            queryset = most_popular.dedupe_by_content_id()
 
-            serializer = self.get_serializer(queryset, many=True)
+        serializer = self.get_serializer(queryset, many=True)
 
-            # cache the popular results queryset for 10 minutes, for efficiency
-            cache.set(cache_key, serializer.data, 60 * 10)
+        # cache the popular results queryset for 10 minutes, for efficiency
+        cache.set(cache_key, serializer.data, 60 * 10)
 
-        return Response(cache.get(cache_key))
+        return Response(serializer.data)
 
     @detail_route(methods=["get"])
     def resume(self, request, **kwargs):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Modifies ContentNodeSlim/popular functional view to make sure it doesn't return None, especially when working locally (see #5456), by using the same short-circuit-and-return-with-cached-value technique used in the other views (like "ancestors").

### Reviewer guidance

1. Go to the recommended page as an (un)authenticated user. The "popular" section should appear fine.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #5456 
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
