### PR TITLE
rename all the log files and add log rotation to kolibri.txt

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -29,7 +29,7 @@ Implications and real-world consequences for learners, coaches, admins, and othe
 <!--
 Relevant logs from:
  * the command line
- * ~/.kolibri/kolibri.log
+ * ~/.kolibri/logs/kolibri.txt
  * the browser console
 
 Please wrap errors in triple backticks for clean formatting like this:

--- a/kolibri/core/logger/test/test_handler.py
+++ b/kolibri/core/logger/test/test_handler.py
@@ -1,0 +1,24 @@
+import os
+from time import sleep
+
+from django.conf import settings
+from django.test import TestCase
+
+from kolibri.utils import cli
+
+
+class KolibriTimedRotatingFileHandlerTestCase(TestCase):
+    def test_do_rollover(self):
+        archive_dir = os.path.join(os.environ["KOLIBRI_HOME"], "logs", "archive")
+        orig_value = settings.LOGGING["handlers"]["file"]["when"]
+
+        # Temporarily set the rotation time of the log file to be every second
+        settings.LOGGING["handlers"]["file"]["when"] = "s"
+        # make sure that kolibri will be running for more than one second
+        cli.main(["language", "setdefault", "en"])
+        sleep(1)
+        cli.main(["language", "setdefault", "en"])
+        # change back to the original rotation time
+        settings.LOGGING["handlers"]["file"]["when"] = orig_value
+
+        self.assertNotEqual(os.listdir(archive_dir), [])

--- a/kolibri/core/logger/utils/formatter.py
+++ b/kolibri/core/logger/utils/formatter.py
@@ -1,0 +1,18 @@
+import re
+from logging import Formatter
+
+
+class KolibriLogFileFormatter(Formatter):
+    """
+    A custom Formatter to change the format string of Cherrypy logging messages.
+    """
+
+    def format(self, record):
+        if "cherrypy" in record.name:
+            # Remove the timestamp from Cherrypy logging so that the message only contains one timestamp.
+            record.msg = re.sub(r"\[[^)]*\]\s", "", record.msg)
+            # Change the format string for Cherrypy logging messages from %module(_cplogging) to %name.
+            record.module = record.name
+
+        message = super(KolibriLogFileFormatter, self).format(record)
+        return message

--- a/kolibri/core/logger/utils/handler.py
+++ b/kolibri/core/logger/utils/handler.py
@@ -1,0 +1,88 @@
+import os
+from logging.handlers import TimedRotatingFileHandler
+
+GET_FILES_TO_DELETE = "getFilesToDelete"
+DO_ROLLOVER = "doRollover"
+
+
+class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """
+    A custom TimedRotatingFileHandler that overrides two methods, getFilesToDelete
+    and doRollover, to rename the rotation files from KOLIBRI_HOME/logs/kolibri.txt.YYYY-MM-DD
+    to KOLIBRI_HOME/logs/archive/KOLIBRI-YYYY-MM-DD.txt.
+    The original code is here: https://github.com/python/cpython/blob/2.7/Lib/logging/handlers.py#L162
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(KolibriTimedRotatingFileHandler, self).__init__(*args, **kwargs)
+        dirname, basename = os.path.split(self.baseFilename)
+        archive_dir = os.path.join(dirname, "archive")
+
+        # Define attributes for this custom handler class
+        self.dirname = dirname
+        self.basename = basename
+        self.archive_dir = archive_dir
+
+    def getFilesToDelete(self):
+        """
+        Overriding the original getFilesToDelete method because the names of
+        rotation files have been changed in doRollover method.
+        """
+        # If the archive directory does not exist, it means that there are no
+        # rotation files
+        if not os.path.exists(self.archive_dir):
+            return []
+
+        filenames = os.listdir(self.archive_dir)
+        prefix = self.basename.split(".")[0] + "-"
+
+        # Find all the rotation files in the KOLIBRI_HOME/logs/archive directory
+        result = self._rotation_files(filenames, prefix, GET_FILES_TO_DELETE)
+        result.sort()
+
+        if len(result) < self.backupCount:
+            result = []
+        else:
+            result = result[: len(result) - self.backupCount]
+        return result
+
+    def doRollover(self):
+        """
+        Overriding the original doRollover method so that the rotation files will
+        be renamed from KOLIBRI_HOME/logs/kolibri.txt.YYYY-MM-DD to
+        KOLIBRI_HOME/logs/archive/KOLIBRI-YYYY-MM-DD.txt.
+        """
+        super(KolibriTimedRotatingFileHandler, self).doRollover()
+        filenames = os.listdir(self.dirname)
+        prefix = self.basename + "."
+
+        # Find all the rotation files in the KOLIBRI_HOME/logs directory and rename
+        # them.
+        if not os.path.exists(self.archive_dir):
+            os.mkdir(self.archive_dir)
+        self._rotation_files(filenames, prefix)
+
+    def _rotation_files(self, filenames, prefix, func=DO_ROLLOVER):
+        result = []
+        plen = len(prefix)
+
+        for filename in filenames:
+            if filename[:plen] != prefix:
+                continue
+
+            rollover_time = filename[plen:].split(".")[0]
+            if not self.extMatch.match(rollover_time):
+                continue
+
+            if func == GET_FILES_TO_DELETE:
+                # Get the set of rotation files if the method is called from getFilesToDelete().
+                result.append(os.path.join(self.archive_dir, filename))
+            else:
+                # Rename the rotation files if the method is called from doRollover().
+                logname, ext = self.basename.split(".")
+                new_name = logname + "-" + rollover_time + "." + ext
+                destination_filename = os.path.join(self.archive_dir, new_name)
+                source_filename = os.path.join(self.dirname, filename)
+                os.rename(source_filename, destination_filename)
+
+        return result

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -268,6 +268,10 @@ LOGGING = {
         },
         "simple": {"format": "%(levelname)s %(message)s"},
         "simple_date": {"format": "%(levelname)s %(asctime)s %(module)s %(message)s"},
+        "simple_date_file": {
+            "()": "kolibri.core.logger.utils.formatter.KolibriLogFileFormatter",
+            "format": "%(levelname)s %(asctime)s %(module)s %(message)s",
+        },
         "color": {
             "()": "colorlog.ColoredFormatter",
             "format": "%(log_color)s%(levelname)-8s %(message)s",
@@ -305,15 +309,17 @@ LOGGING = {
             "level": "DEBUG",
             "filters": ["require_debug_true"],
             "class": "logging.FileHandler",
-            "filename": os.path.join(conf.KOLIBRI_HOME, "debug.log"),
+            "filename": os.path.join(conf.LOG_ROOT, "debug.txt"),
             "formatter": "simple_date",
         },
         "file": {
             "level": "INFO",
             "filters": [],
-            "class": "logging.FileHandler",
-            "filename": os.path.join(conf.KOLIBRI_HOME, "kolibri.log"),
-            "formatter": "simple_date",
+            "class": "kolibri.core.logger.utils.handler.KolibriTimedRotatingFileHandler",
+            "filename": os.path.join(conf.LOG_ROOT, "kolibri.txt"),
+            "formatter": "simple_date_file",
+            "when": "midnight",
+            "backupCount": 30,
         },
     },
     "loggers": {
@@ -338,6 +344,8 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        "cherrypy.access": {"handlers": ["file"], "level": "INFO", "propagate": False},
+        "cherrypy.error": {"handlers": ["file"], "level": "INFO", "propagate": False},
     },
 }
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -344,8 +344,16 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
-        "cherrypy.access": {"handlers": ["file"], "level": "INFO", "propagate": False},
-        "cherrypy.error": {"handlers": ["file"], "level": "INFO", "propagate": False},
+        "cherrypy.access": {
+            "handlers": ["file", "console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "cherrypy.error": {
+            "handlers": ["file", "console"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -316,7 +316,10 @@ def start(port=None, daemon=True):
     # Daemonize at this point, no more user output is needed
     if daemon:
 
-        logger.info("Going to daemon mode, logging to {0}".format(server.KOLIBRI_LOG))
+        from django.conf import settings
+
+        kolibri_log = settings.LOGGING["handlers"]["file"]["filename"]
+        logger.info("Going to daemon mode, logging to {0}".format(kolibri_log))
 
         kwargs = {}
         # Truncate the file
@@ -424,7 +427,10 @@ def services(daemon=True):
     # Daemonize at this point, no more user output is needed
     if daemon:
 
-        logger.info("Going to daemon mode, logging to {0}".format(server.KOLIBRI_LOG))
+        from django.conf import settings
+
+        kolibri_log = settings.LOGGING["handlers"]["file"]["filename"]
+        logger.info("Going to daemon mode, logging to {0}".format(kolibri_log))
 
         kwargs = {}
         # Truncate the file

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -26,6 +26,7 @@ from . import server  # noqa
 from .conf import OPTIONS  # noqa
 from .sanity_checks import check_content_directory_exists_and_writable  # noqa
 from .sanity_checks import check_other_kolibri_running  # noqa
+from .sanity_checks import check_log_file_location  # noqa
 from .system import become_daemon  # noqa
 from kolibri.core.deviceadmin.utils import IncompatibleDatabase  # noqa
 from kolibri.utils import conf  # noqa
@@ -315,11 +316,12 @@ def start(port=None, daemon=True):
     # Daemonize at this point, no more user output is needed
     if daemon:
 
+        logger.info("Going to daemon mode, logging to {0}".format(server.KOLIBRI_LOG))
+
         kwargs = {}
         # Truncate the file
         if os.path.isfile(server.DAEMON_LOG):
             open(server.DAEMON_LOG, "w").truncate()
-        logger.info("Going to daemon mode, logging to {0}".format(server.DAEMON_LOG))
         kwargs["out_log"] = server.DAEMON_LOG
         kwargs["err_log"] = server.DAEMON_LOG
 
@@ -422,11 +424,12 @@ def services(daemon=True):
     # Daemonize at this point, no more user output is needed
     if daemon:
 
+        logger.info("Going to daemon mode, logging to {0}".format(server.KOLIBRI_LOG))
+
         kwargs = {}
         # Truncate the file
         if os.path.isfile(server.DAEMON_LOG):
             open(server.DAEMON_LOG, "w").truncate()
-        logger.info("Going to daemon mode, logging to {0}".format(server.DAEMON_LOG))
         kwargs["out_log"] = server.DAEMON_LOG
         kwargs["err_log"] = server.DAEMON_LOG
 
@@ -470,6 +473,7 @@ def manage(cmd, args=[]):
     from django.core.management import execute_from_command_line
 
     argv = ["kolibri manage", cmd] + args
+    logger.info("Invoking command '{}'.".format(" ".join(argv)))
     execute_from_command_line(argv=argv)
 
 
@@ -532,12 +536,14 @@ def plugin(plugin_name, **kwargs):
     from kolibri.utils import conf
 
     if kwargs.get("enable", False):
+        logger.info("Enabling Kolibri plugin {}.".format(plugin_name))
         plugin_classes = get_kolibri_plugin(plugin_name)
         for klass in plugin_classes:
             klass.enable()
 
     if kwargs.get("disable", False):
         try:
+            logger.info("Disabling Kolibri plugin {}.".format(plugin_name))
             plugin_classes = get_kolibri_plugin(plugin_name)
             for klass in plugin_classes:
                 klass.disable()
@@ -573,6 +579,11 @@ def set_default_language(lang):
     valid_languages = [l[0] for l in settings.LANGUAGES]
 
     if lang in valid_languages:
+        logger.info(
+            "Setting the default language code to {} for this installation of Kolibri.".format(
+                lang
+            )
+        )
         conf.config["LANGUAGE_CODE"] = lang
         conf.save()
     else:
@@ -580,7 +591,7 @@ def set_default_language(lang):
             langcode=lang, validlangs=valid_languages
         )
 
-        logging.warning(msg)
+        logger.warning(msg)
 
 
 def parse_args(args=None):
@@ -639,6 +650,8 @@ def main(args=None):  # noqa: max-complexity=13
         port = _get_port(arguments["--port"])
         if OPTIONS["Server"]["CHERRYPY_START"]:
             check_other_kolibri_running(port)
+
+    check_log_file_location()
 
     try:
         initialize(debug=debug, skip_update=arguments["--skipupdate"])

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -47,6 +47,11 @@ if not os.path.exists(KOLIBRI_HOME):
         )
     os.mkdir(KOLIBRI_HOME)
 
+# Create a folder named logs inside KOLIBRI_HOME to store all the log files.
+LOG_ROOT = os.path.join(KOLIBRI_HOME, "logs")
+if not os.path.exists(LOG_ROOT):
+    os.mkdir(LOG_ROOT)
+
 #: Set defaults before updating the dict
 config = {}
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -182,8 +182,9 @@ def get_logger(KOLIBRI_HOME):
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "simple_date": {
-                "format": "%(levelname)s %(asctime)s %(module)s %(message)s"
+            "simple_date_file": {
+                "()": "kolibri.core.logger.utils.formatter.KolibriLogFileFormatter",
+                "format": "%(levelname)s %(asctime)s %(module)s %(message)s",
             },
             "color": {
                 "()": "colorlog.ColoredFormatter",
@@ -198,9 +199,11 @@ def get_logger(KOLIBRI_HOME):
             },
             "file": {
                 "level": "INFO",
-                "class": "logging.FileHandler",
-                "filename": os.path.join(KOLIBRI_HOME, "kolibri.log"),
-                "formatter": "simple_date",
+                "class": "kolibri.core.logger.utils.handler.KolibriTimedRotatingFileHandler",
+                "filename": os.path.join(KOLIBRI_HOME, "logs", "kolibri.txt"),
+                "formatter": "simple_date_file",
+                "when": "midnight",
+                "backupCount": 30,
             },
         },
         "loggers": {

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -16,7 +16,7 @@ PORT_AVAILABILITY_CHECK_TIMEOUT = 2
 
 def check_other_kolibri_running(port):
     """
-    Make sure there are no other Kolibri instances running before starting the kolibri.
+    Make sure there are no other Kolibri instances running before starting the server.
     """
     try:
         # Check if there are other kolibri instances running

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -15,6 +15,9 @@ PORT_AVAILABILITY_CHECK_TIMEOUT = 2
 
 
 def check_other_kolibri_running(port):
+    """
+    Make sure there are no other Kolibri instances running before starting the kolibri.
+    """
     try:
         # Check if there are other kolibri instances running
         # If there are, then we need to stop users from starting kolibri again.
@@ -32,6 +35,9 @@ def check_other_kolibri_running(port):
 
 
 def check_port_availability(host, port):
+    """
+    Make sure the port is available for the server to start.
+    """
     try:
         portend.free(host, port, timeout=PORT_AVAILABILITY_CHECK_TIMEOUT)
     except portend.Timeout:
@@ -45,6 +51,9 @@ def check_port_availability(host, port):
 
 
 def check_content_directory_exists_and_writable():
+    """
+    Make sure the content directory of Kolibri exists and is writable.
+    """
     content_directory = OPTIONS["Paths"]["CONTENT_DIR"]
 
     # Check if the content directory exists
@@ -60,3 +69,28 @@ def check_content_directory_exists_and_writable():
             "The content directory {} is not writable.".format(content_directory)
         )
         sys.exit(1)
+
+
+def check_log_file_location():
+    """
+    Starting from Kolibri v0.12.4, log files are going to be renamed and moved
+    from KOLIBRI_HOME directory to KOLIBRI_HOME/logs directory.
+    """
+    home = os.environ["KOLIBRI_HOME"]
+    log_location_update = {}
+
+    # Old log file names
+    old_daemon_log = "server.log"
+    old_kolibri_log = "kolibri.log"
+    old_debug_log = "debug.log"
+
+    # New log file names
+    log_location_update[old_daemon_log] = "daemon.txt"
+    log_location_update[old_kolibri_log] = "kolibri.txt"
+    log_location_update[old_debug_log] = "debug.txt"
+
+    for log in log_location_update:
+        old_log_path = os.path.join(home, log)
+        if os.path.exists(old_log_path):
+            new_log_path = os.path.join(home, "logs", log_location_update[log])
+            os.rename(old_log_path, new_log_path)

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -54,8 +54,6 @@ PROFILE_LOCK = os.path.join(conf.KOLIBRI_HOME, "server_profile.lock")
 # might not have made it to the log file!
 DAEMON_LOG = os.path.join(conf.LOG_ROOT, "daemon.txt")
 
-KOLIBRI_LOG = settings.LOGGING["handlers"]["file"]["filename"]
-
 # Currently non-configurable until we know how to properly handle this
 LISTEN_ADDRESS = "0.0.0.0"
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -52,7 +52,9 @@ PROFILE_LOCK = os.path.join(conf.KOLIBRI_HOME, "server_profile.lock")
 
 # This is a special file with daemon activity. It logs ALL stderr output, some
 # might not have made it to the log file!
-DAEMON_LOG = os.path.join(conf.KOLIBRI_HOME, "server.log")
+DAEMON_LOG = os.path.join(conf.LOG_ROOT, "daemon.txt")
+
+KOLIBRI_LOG = settings.LOGGING["handlers"]["file"]["filename"]
 
 # Currently non-configurable until we know how to properly handle this
 LISTEN_ADDRESS = "0.0.0.0"
@@ -263,8 +265,12 @@ def run_server(port):
             "tools.caching.on": True,
             "tools.caching.maxobj_size": 2000000,
             "tools.caching.maxsize": calculate_cache_size(),
+            "log.screen": False,
+            "log.access_file": "",
+            "log.error_file": "",
         }
     )
+    cherrypy.engine.unsubscribe("graceful", cherrypy.log.reopen_files)
 
     # Mount static files
     static_files_handler = cherrypy.tools.staticdir.handler(

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -196,6 +196,9 @@ def test_path_expansion():
     Checks that options under [Path] have "~" expanded, and are relativized to the KOLIBRI_HOME directory.
     """
     KOLIBRI_HOME_TEMP = tempfile.mkdtemp()
+    logs_dir = os.path.join(KOLIBRI_HOME_TEMP, "logs")
+    if not os.path.exists(logs_dir):
+        os.mkdir(logs_dir)
 
     _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
 

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -1,9 +1,12 @@
+import tempfile
+
 import portend
 from django.test import TestCase
 from mock import patch
 
 from kolibri.utils import cli
 from kolibri.utils.server import NotRunning
+from kolibri.utils.tests.helpers import override_option
 
 
 class SanityCheckTestCase(TestCase):
@@ -11,7 +14,7 @@ class SanityCheckTestCase(TestCase):
     @patch("kolibri.utils.sanity_checks.get_status", return_value={1, 2, 3})
     def test_other_kolibri_running(self, status_mock, logging_mock):
         with self.assertRaises(SystemExit):
-            cli.main({"start": True})
+            cli.main(["start"])
             logging_mock.assert_called()
 
     @patch("kolibri.utils.sanity_checks.logging.error")
@@ -21,20 +24,31 @@ class SanityCheckTestCase(TestCase):
         status_mock.side_effect = NotRunning("Kolibri not running")
         portend_mock.side_effect = portend.Timeout
         with self.assertRaises(SystemExit):
-            cli.main({"start": True})
+            cli.main(["start"])
             logging_mock.assert_called()
 
     @patch("kolibri.utils.sanity_checks.logging.error")
-    @patch("kolibri.utils.sanity_checks.os.path.exists", return_value=False)
-    def test_content_dir_dne(self, path_mock, logging_mock):
+    @override_option("Paths", "CONTENT_DIR", "/dir_dne")
+    def test_content_dir_dne(self, logging_mock):
         with self.assertRaises(SystemExit):
             cli.main({"start": True})
             logging_mock.assert_called()
 
     @patch("kolibri.utils.sanity_checks.logging.error")
     @patch("kolibri.utils.sanity_checks.os.access", return_value=False)
-    @patch("kolibri.utils.sanity_checks.os.path.exists", return_value=True)
-    def test_content_dir_writable(self, path_exists_mock, access_mock, logging_mock):
+    @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
+    def test_content_dir_not_writable(self, access_mock, logging_mock):
         with self.assertRaises(SystemExit):
-            cli.main({"start": True})
-            logging_mock.assert_called
+            cli.main(["start"])
+            logging_mock.assert_called()
+
+    @patch("kolibri.utils.cli.initialize")
+    @patch("kolibri.utils.sanity_checks.os.rename")
+    @patch(
+        "kolibri.utils.sanity_checks.os.path.exists", side_effect=[False, True, True]
+    )
+    def test_old_log_file_exists(self, path_exists_mock, rename_mock, initialize_mock):
+        cli.main(["language", "setdefault", "en"])
+        # Check if the number of calls to os.rename equals to the number of times
+        # os.path.exists returns True
+        self.assertEqual(rename_mock.call_count, 2)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to
1. rename the log files:
   -  server.log --> logs/daemon.txt
   - debug.log --> logs/debug.txt
   - kolibri.log --> logs/kolibri.txt  

2. put the logging messages from server.log and kolibri.log into kolibri.txt
3. add daily rotation to kolibri.txt and the rotation files are named as logs/archive/kolibri-YYYY-MM-DD.txt
4. add a check before the server starts to move the previous log files to the correct location
5. add more logs in cli.py so that the log files can capture what commands users have invoked for developers to better debug the issues

-----
The custom handler KolibriTimedRotatingFileHandler is to change the default rotation filename from logs/kolibri.txt.YYYY-MM-DD to logs/archive/kolibri-YYYY-MM-DD.txt


The custom formatter KolibriLogFileFormatter is to change the logging information of cherrypy.
For example, **without** the formatter, the logging of cherrypy would look like this:
```
INFO:_cplogging:[21/May/2019:15:59:02] ENGINE Bus STARTING
```
**with** the formatter, the logging looks like this:
```
INFO:cherrypy.error: ENGINE Bus STARTING
```
----
I have tested the following situations:
1. log rotation on windows
2. log rotation on macosx
3. log rotation on ubuntu
4. when there are existing log files with the old name conventions, they will be moved to the new location

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check if the code makes sense, and the new logging works. Thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/2512
https://github.com/learningequality/kolibri/issues/4652

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
