### PR TITLE
Fix progress bar overlapping with thumbnail

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -193,7 +193,7 @@
 
   .progress-bar-wrapper {
     position: absolute;
-    bottom: 0;
+    bottom: -12px;
     width: 100%;
     height: 5px;
     opacity: 0.9;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

These changes fix overlapping of progress bar with thumbnails.

#### Before

![Screenshot from 2019-05-18 00-29-13](https://user-images.githubusercontent.com/35173644/57950166-1e7f4c80-7904-11e9-8415-0e3913a7722a.png)

#### After

![Screenshot from 2019-05-17 23-30-38](https://user-images.githubusercontent.com/35173644/57947345-49fe3900-78fc-11e9-8f62-376e49b42970.png)

…

### Reviewer guidance

One can go to the device tab and add/import channel and will be able to observe the corresponding progress bar in learn tab. 

…

### References

Fixes #5007 

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
