### PR TITLE
Propagate corrupt database handling to scanforcontent command.

### DIFF
--- a/kolibri/core/content/management/commands/scanforcontent.py
+++ b/kolibri/core/content/management/commands/scanforcontent.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.core.management.base import BaseCommand
+from sqlalchemy.exc import DatabaseError
 
 from ...utils.annotation import annotate_content
 from ...utils.channel_import import FutureSchemaError
@@ -38,6 +39,12 @@ class Command(BaseCommand):
                 except (InvalidSchemaVersionError, FutureSchemaError):
                     logger.warning(
                         "Tried to import channel {channel_id}, but database file was incompatible".format(
+                            channel_id=channel_id
+                        )
+                    )
+                except DatabaseError:
+                    logger.warning(
+                        "Tried to import channel {channel_id}, but database file was corrupted.".format(
                             channel_id=channel_id
                         )
                     )


### PR DESCRIPTION
### Summary
Copies handling of corrupt databases in the channel metadata scanning function to the `scanforcontent` management command

### Reviewer guidance
Make sense?

### References
#5419

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
