### PR TITLE
Add version number to wsgi start

### DIFF
--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -13,6 +13,8 @@ import time
 from django.core.wsgi import get_wsgi_application
 from django.db.utils import OperationalError
 
+import kolibri
+
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
 )
@@ -23,7 +25,7 @@ tries_remaining = 6
 interval = 10
 while not application and tries_remaining:
     try:
-        logger.info("Starting Kolibri")
+        logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
         application = get_wsgi_application()
     except OperationalError:
         # an OperationalError happens when sqlite vacuum is being executed. the db is locked

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -6,32 +6,26 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
-import logging
 import os
 import time
 
 from django.core.wsgi import get_wsgi_application
 from django.db.utils import OperationalError
 
-import kolibri
-
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
 )
-logger = logging.getLogger(__name__)
 
 application = None
 tries_remaining = 6
 interval = 10
 while not application and tries_remaining:
     try:
-        logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
         application = get_wsgi_application()
     except OperationalError:
         # an OperationalError happens when sqlite vacuum is being executed. the db is locked
-        logger.info("DB busy. Trying again in {}s".format(interval))
         tries_remaining -= 1
         time.sleep(interval)
         application = get_wsgi_application()  # try again one last time
 if not application:
-    logger.error("Could not start Kolibri")
+    print("Could not start Kolibri")

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -13,6 +13,7 @@ import requests
 from django.conf import settings
 from django.core.management import call_command
 
+import kolibri
 from .system import kill_pid
 from .system import pid_exists
 from kolibri.core.content.utils import paths
@@ -115,6 +116,8 @@ def start(port=8080, run_cherrypy=True):
         os.unlink(PID_FILE)
 
     atexit.register(rm_pid_file)
+
+    logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
 
     if run_cherrypy:
         run_server(port=port)


### PR DESCRIPTION
### Summary
We currently log that Kolibri is starting, but not what version number it is. This can make debugging difficult when looking at logs.

This change adds the version number to the logs to help with debugging in the future.

### Reviewer guidance
Does the server still start?

### References
Cherry picked from #5494

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
