### PR TITLE
Annotate num coach contents at startup

### DIFF
--- a/kolibri/core/content/test/test_enumerate_channel.py
+++ b/kolibri/core/content/test/test_enumerate_channel.py
@@ -36,8 +36,11 @@ class EnumerateChannelTestCase(TestCase):
             f.write("test corrupted database file")
         return db_file
 
+    @patch("kolibri.core.content.utils.annotation.update_num_coach_contents")
     @patch("kolibri.core.content.utils.annotation.logger.warning")
-    def test_corrupted_database_file_server_start(self, logger_mock):
+    def test_corrupted_database_file_server_start(
+        self, logger_mock, coach_contents_mock
+    ):
         db_file = self.create_corrupted_database_file(get_content_database_dir_path())
         update_channel_metadata()
         message_list = [message[0][0] for message in logger_mock.call_args_list]

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -161,11 +161,10 @@ def update_num_coach_contents():
         ContentNodeTable.update()
         .where(
             # That are not topics
-            ContentNodeTable.c.kind != content_kinds.TOPIC,
+            ContentNodeTable.c.kind
+            != content_kinds.TOPIC
         )
-        .values(
-            num_coach_contents=cast(ContentNodeTable.c.coach_content, Integer())
-        )
+        .values(num_coach_contents=cast(ContentNodeTable.c.coach_content, Integer()))
     )
 
     # Expression to capture all available child nodes of a contentnode

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -137,8 +137,8 @@ def fix_multiple_trees_with_id_one():
 
 def update_num_coach_contents():
     """
-    Function to set num_coach_content on topic trees that were imported before
-    the annotation would have been run.
+    Function to set num_coach_content on all topic trees to account for
+    those that were imported before annotations were performed
     """
     bridge = Bridge(app_name=CONTENT_APP_NAME)
 

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -291,7 +291,7 @@ def recurse_annotation_up_tree(channel_id):
 
     connection = bridge.get_connection()
 
-    node_depth = bridge.session.query(func.max(ContentNodeClass.level)).scalar()
+    node_depth = bridge.session.query(func.max(ContentNodeClass.level)).filter_by(channel_id=channel_id).scalar()
 
     logger.info(
         "Annotating ContentNode objects with children for {levels} levels".format(

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -150,17 +150,19 @@ def update_num_coach_contents():
 
     child = ContentNodeTable.alias()
 
-    logger.info(
-        "Updating num_coach_content on existing channels"
-    )
+    logger.info("Updating num_coach_content on existing channels")
 
     # start a transaction
 
     trans = connection.begin()
 
-    for channel_id in ChannelMetadata.objects.all().values_list('id', flat=True):
+    for channel_id in ChannelMetadata.objects.all().values_list("id", flat=True):
 
-        node_depth = bridge.session.query(func.max(ContentNodeClass.level)).filter_by(channel_id=channel_id).scalar()
+        node_depth = (
+            bridge.session.query(func.max(ContentNodeClass.level))
+            .filter_by(channel_id=channel_id)
+            .scalar()
+        )
 
         # Update all leaf ContentNodes to have num_coach_content to 1 or 0
         connection.execute(
@@ -173,7 +175,9 @@ def update_num_coach_contents():
                     ContentNodeTable.c.kind != content_kinds.TOPIC,
                 )
             )
-            .values(num_coach_contents=cast(ContentNodeTable.c.coach_content, Integer()))
+            .values(
+                num_coach_contents=cast(ContentNodeTable.c.coach_content, Integer())
+            )
         )
 
         # Go from the deepest level to the shallowest
@@ -209,9 +213,7 @@ def update_num_coach_contents():
                 # Because we have set availability to False on all topics as a starting point
                 # we only need to make updates to topics with available children.
                 .where(exists(available_nodes))
-                .values(
-                    num_coach_contents=coach_content_num,
-                )
+                .values(num_coach_contents=coach_content_num)
             )
 
     # commit the transaction
@@ -377,7 +379,11 @@ def recurse_annotation_up_tree(channel_id):
 
     connection = bridge.get_connection()
 
-    node_depth = bridge.session.query(func.max(ContentNodeClass.level)).filter_by(channel_id=channel_id).scalar()
+    node_depth = (
+        bridge.session.query(func.max(ContentNodeClass.level))
+        .filter_by(channel_id=channel_id)
+        .scalar()
+    )
 
     logger.info(
         "Annotating ContentNode objects with children for {levels} levels".format(

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -252,6 +252,10 @@ class Bridge(object):
         return get_class(DjangoModel, self.Base)
 
     def get_table(self, DjangoModel):
+        """
+        Return the SQLAlchemy Table object associated with this Django Model
+        https://docs.sqlalchemy.org/en/13/orm/extensions/declarative/table_config.html#using-a-hybrid-approach-with-table
+        """
         return self.get_class(DjangoModel).__table__
 
     def get_connection(self):

--- a/kolibri/utils/tests/test_handler.py
+++ b/kolibri/utils/tests/test_handler.py
@@ -15,9 +15,9 @@ class KolibriTimedRotatingFileHandlerTestCase(TestCase):
         # Temporarily set the rotation time of the log file to be every second
         settings.LOGGING["handlers"]["file"]["when"] = "s"
         # make sure that kolibri will be running for more than one second
-        cli.main(["language", "setdefault", "en"])
+        cli.main(["--skipupdate", "manage", "help"])
         sleep(1)
-        cli.main(["language", "setdefault", "en"])
+        cli.main(["--skipupdate", "manage", "help"])
         # change back to the original rotation time
         settings.LOGGING["handlers"]["file"]["when"] = orig_value
 


### PR DESCRIPTION
### Summary
Annotates num_coach_contents at startup to ensure it is properly annotated after being added as an explicit field.

### Reviewer guidance
Does server startup take drastically longer? Do previously imported channels show the correct number of coach contents?

### References
Fixes #5511 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
