### PR TITLE
Lint fix - do not report `mapState` nested array expressions items as unused state

### DIFF
--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -62,7 +62,7 @@ const create = context => {
       }
     */
     {
-      'CallExpression[callee.name=mapState][arguments] ArrayExpression Literal[value]'(node) {
+      'CallExpression[callee.name=mapState][arguments] > ArrayExpression Literal[value]'(node) {
         unusedVuexProperties.push({
           kind: VUEX_STATE,
           name: node.value,

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-unused-vuex-properties.spec.js
@@ -448,6 +448,23 @@ tester.run('vue-no-unused-vuex-properties', rule, {
       `,
     },
 
+    // does not report nested arrays items
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: mapState({
+              channelRootId: state => get(state, ['channel', 'root_id'], '')
+            }),
+            mounted() {
+              alert(this.channelRootId)
+            }
+          };
+        </script>
+      `,
+    },
+
     {
       filename: 'test.vue',
       code: `


### PR DESCRIPTION
### Summary

Fix for an issue reported by @jonboiser regarding nested array items being wrongly reported as an unused state, e.g. `value1` and `value2` in

```
mapState({
  count: state => state.todosCount + f(['value1', 'value2'])
})
``` 

### Reviewer guidance

- Does it work well?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
