### PR TITLE
Fixes #5462: Coach Recipients display and group deletion edge case

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/dataHelpers.spec.js
@@ -41,6 +41,62 @@ describe('coach summary data helpers', () => {
       ]);
     });
   });
+  describe('getLearnersForExam', () => {
+    it('returns empty when exam has no assignments', () => {
+      expect(
+        store.getters.getLearnersForExam({
+          assignments: [],
+        })
+      ).toEqual([]);
+    });
+
+    it('passes through to getLearnersForGroups when exam has assignments', () => {
+      const groups = ['group_id_2', 'group_id_3'];
+      const output = store.getters.getLearnersForExam({
+        assignments: groups,
+        groups,
+      });
+      output.sort();
+      expect(output).toEqual([
+        'learner_id_1',
+        'learner_id_11',
+        'learner_id_2',
+        'learner_id_5',
+        'learner_id_6',
+        'learner_id_7',
+        'learner_id_8',
+        'learner_id_9',
+      ]);
+    });
+  });
+  describe('getLearnersForLesson', () => {
+    it('returns empty when lesson has no assignments', () => {
+      expect(
+        store.getters.getLearnersForLesson({
+          assignments: [],
+        })
+      ).toEqual([]);
+    });
+
+    it('passes through to getLearnersForGroups when lesson has assignments', () => {
+      const groups = ['group_id_2', 'group_id_3'];
+      const output = store.getters.getLearnersForLesson({
+        assignments: groups,
+        groups,
+      });
+      output.sort();
+      expect(output).toEqual([
+        'learner_id_1',
+        'learner_id_11',
+        'learner_id_2',
+        'learner_id_5',
+        'learner_id_6',
+        'learner_id_7',
+        'learner_id_8',
+        'learner_id_9',
+      ]);
+    });
+  });
   describe('getContentStatusObjForLearner', () => {
     it('returns a recorded status object given a content ID and learner ID', () => {
       expect(store.getters.getContentStatusObjForLearner('content_Q', 'learner_id_1')).toEqual({

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -63,6 +63,28 @@ export default {
     };
   },
   /*
+   * Return array of learner IDs given an exam
+   */
+  getLearnersForExam() {
+    return function(exam) {
+      if (!exam) {
+        throw new Error('getLearnersForLesson: invalid parameter(s)');
+      }
+      return exam.assignments.length ? this.getLearnersForGroups(exam.groups) : [];
+    };
+  },
+  /*
+   * Return array of learner IDs given a lesson
+   */
+  getLearnersForLesson() {
+    return function(lesson) {
+      if (!lesson) {
+        throw new Error('getLearnersForLesson: invalid parameter(s)');
+      }
+      return lesson.assignments.length ? this.getLearnersForGroups(lesson.groups) : [];
+    };
+  },
+  /*
    * Return a STATUSES constant given a content ID and a learner ID
    */
   getContentStatusObjForLearner(state) {

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -180,6 +180,8 @@ export default {
       'getGroupNames',
       'getGroupNamesForLearner',
       'getLearnersForGroups',
+      'getLearnersForExam',
+      'getLearnersForLesson',
       'getContentStatusObjForLearner',
       'getContentStatusTally',
       'getExamStatusObjForLearner',

--- a/kolibri/plugins/coach/assets/src/views/common/Recipients.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/Recipients.vue
@@ -1,11 +1,14 @@
 <template>
 
   <span>
-    <template v-if="!groupNames.length">
+    <template v-if="groupNames.length">
+      <TruncatedItemList :items="groupNames" />
+    </template>
+    <template v-else-if="hasAssignments">
       {{ $tr('assignmentClass') }}
     </template>
     <template v-else>
-      <TruncatedItemList :items="groupNames" />
+      {{ assignmentNoOne }}
     </template>
   </span>
 
@@ -14,8 +17,12 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import AssignmentSummary from '../plan/assignments/AssignmentSummary';
   import TruncatedItemList from './TruncatedItemList';
   import { coachStringsMixin } from './commonCoachStrings.js';
+
+  const assignmentSummaryStrings = crossComponentTranslator(AssignmentSummary);
 
   export default {
     name: 'Recipients',
@@ -27,6 +34,15 @@
       groupNames: {
         type: Array,
         required: true,
+      },
+      hasAssignments: {
+        type: Boolean,
+        required: true,
+      },
+    },
+    computed: {
+      assignmentNoOne() {
+        return assignmentSummaryStrings.$tr('noOne');
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -10,7 +10,10 @@
 
       <KGridItem size="25" percentage alignment="right">
         <div class="context">
-          <Recipients :groupNames="groupNames" />
+          <Recipients
+            :groupNames="groupNames"
+            :hasAssignments="hasAssignments"
+          />
         </div>
       </KGridItem>
 
@@ -52,6 +55,10 @@
       },
       groupNames: {
         type: Array,
+        required: true,
+      },
+      hasAssignments: {
+        type: Boolean,
         required: true,
       },
       tally: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -57,13 +57,13 @@
       table() {
         const recent = orderBy(this.lessons, this.lastActivity, ['desc']).slice(0, MAX_LESSONS);
         return recent.map(lesson => {
-          const assigned = this.getLearnersForGroups(lesson.groups);
+          const assigned = this.getLearnersForLesson(lesson);
           return {
             key: lesson.id,
             name: lesson.title,
             tally: this.getLessonStatusTally(lesson.id, assigned),
             groups: lesson.groups.map(groupId => this.groupMap[groupId].name),
-            hasAssignments: lesson.assignments.length > 0,
+            hasAssignments: assigned.length > 0,
           };
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -22,6 +22,7 @@
         :name="tableRow.name"
         :tally="tableRow.tally"
         :groupNames="tableRow.groups"
+        :hasAssignments="tableRow.hasAssignments"
         :to="classRoute('ReportsLessonLearnerListPage', { lessonId: tableRow.key })"
       />
     </BlockItem>
@@ -62,6 +63,7 @@
             name: lesson.title,
             tally: this.getLessonStatusTally(lesson.id, assigned),
             groups: lesson.groups.map(groupId => this.groupMap[groupId].name),
+            hasAssignments: lesson.assignments.length > 0,
           };
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -21,6 +21,7 @@
         :name="tableRow.name"
         :tally="tableRow.tally"
         :groupNames="tableRow.groups"
+        :hasAssignments="tableRow.hasAssignments"
         :to="classRoute('ReportsQuizLearnerListPage', { quizId: tableRow.key })"
       />
     </BlockItem>
@@ -60,6 +61,7 @@
             name: exam.title,
             tally: this.getExamStatusTally(exam.id, assigned),
             groups: exam.groups.map(groupId => this.groupMap[groupId].name),
+            hasAssignments: exam.assignments.length > 0,
           };
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -55,13 +55,13 @@
       table() {
         const recent = orderBy(this.exams, this.lastActivity, ['desc']).slice(0, MAX_QUIZZES);
         return recent.map(exam => {
-          const assigned = this.getLearnersForGroups(exam.groups);
+          const assigned = this.getLearnersForExam(exam);
           return {
             key: exam.id,
             name: exam.title,
             tally: this.getExamStatusTally(exam.id, assigned),
             groups: exam.groups.map(groupId => this.groupMap[groupId].name),
-            hasAssignments: exam.assignments.length > 0,
+            hasAssignments: assigned.length > 0,
           };
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -51,7 +51,12 @@
               </KLabeledIcon>
             </td>
 
-            <td> {{ genRecipientsString(exam.groups) }} </td>
+            <td>
+              <Recipients
+                :groupNames="getGroupNames(exam.groups)"
+                :hasAssignments="exam.assignments.length > 0"
+              />
+            </td>
 
             <td>
               <QuizActive :active="exam.active" />
@@ -139,15 +144,6 @@
       },
       newExamRoute() {
         return { name: PageNames.EXAM_CREATION_ROOT };
-      },
-    },
-    methods: {
-      genRecipientsString(groups) {
-        if (!groups.length) {
-          return this.coachStrings.$tr('entireClassLabel');
-        } else {
-          return this.coachStrings.$tr('numberOfGroups', { value: groups.length });
-        }
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
@@ -39,10 +39,10 @@
             </HeaderTableRow>
             <HeaderTableRow :keyText="coachStrings.$tr('recipientsLabel')">
               <template slot="value">
-                <template v-if="currentLesson.lesson_assignments.length === 0">
-                  {{ this.$tr('noOne') }}
-                </template>
-                <Recipients v-else :groupNames="groupNames" />
+                <Recipients
+                  :groupNames="groupNames"
+                  :hasAssignments="currentLesson.lesson_assignments.length > 0"
+                />
               </template>
             </HeaderTableRow>
             <HeaderTableRow

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -50,7 +50,12 @@
               </KLabeledIcon>
             </td>
             <td>{{ coachStrings.$tr('numberOfResources', { value: lesson.resources.length }) }}</td>
-            <td>{{ getLessonVisibility(lesson.lesson_assignments) }}</td>
+            <td>
+              <Recipients
+                :groupNames="getGroupNames(getGroupIds(lesson.lesson_assignments))"
+                :hasAssignments="lesson.lesson_assignments.length > 0"
+              />
+            </td>
             <td>
               <LessonActive :active="lesson.is_active" />
             </td>
@@ -171,17 +176,10 @@
         }
       },
       lessonSummaryLink,
-      getLessonVisibility(assignedGroups) {
-        const numOfAssignments = assignedGroups.length;
-        if (numOfAssignments === 0) {
-          return this.$tr('noOne');
-        } else if (
-          numOfAssignments === 1 &&
-          assignedGroups[0].collection_kind === CollectionKinds.CLASSROOM
-        ) {
-          return this.coachStrings.$tr('entireClassLabel');
-        }
-        return this.coachStrings.$tr('numberOfGroups', { value: numOfAssignments });
+      getGroupIds(assignments) {
+        return assignments
+          .filter(assignment => assignment.collection_kind === CollectionKinds.LEARNERGROUP)
+          .map(assignment => assignment.collection);
       },
       handleDetailsModalContinue(payload) {
         this.detailsModalIsDisabled = true;

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -37,7 +37,11 @@
             <QuizActive slot="value" :active="quiz.active" />
           </HeaderTableRow>
           <HeaderTableRow :keyText="coachStrings.$tr('recipientsLabel')">
-            <Recipients slot="value" :groupNames="learnerGroupNames" />
+            <Recipients
+              slot="value"
+              :groupNames="learnerGroupNames"
+              :hasAssignments="quiz.assignments.length > 0"
+            />
           </HeaderTableRow>
           <HeaderTableRow
             :keyText="coachStrings.$tr('questionOrderLabel')"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
@@ -14,10 +14,10 @@
       </HeaderTableRow>
       <HeaderTableRow :keyText="coachStrings.$tr('recipientsLabel')">
         <template slot="value">
-          <template v-if="!recipients.length">
-            {{ this.$tr('noOne') }}
-          </template>
-          <Recipients v-else :groupNames="groupNames" />
+          <Recipients
+            :groupNames="groupNames"
+            :hasAssignments="recipients.length > 0"
+          />
         </template>
       </HeaderTableRow>
       <HeaderTableRow

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -65,7 +65,7 @@
     },
     computed: {
       entireClassIsSelected() {
-        return isEqual(this.value, [this.classId]) || !this.value.length;
+        return isEqual(this.value, [this.classId]);
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -64,7 +64,7 @@
       },
       table() {
         const sorted = this._.sortBy(this.groupMembers, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const examStatuses = this.examStatuses.filter(status => learner.id === status.learner_id);
           const contentStatuses = this.contentStatuses.filter(
             status => learner.id === status.learner_id
@@ -79,7 +79,6 @@
           Object.assign(augmentedObj, learner);
           return augmentedObj;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -69,7 +69,7 @@
     computed: {
       table() {
         const sorted = this._.sortBy(this.groups, ['name']);
-        const mapped = sorted.map(group => {
+        return sorted.map(group => {
           const groupLessons = this.lessons.filter(
             lesson => lesson.groups.includes(group.id) || !lesson.groups.length
           );
@@ -87,7 +87,6 @@
           Object.assign(tableRow, group);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -82,7 +82,7 @@
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
             statusObj: this.getContentStatusObjForLearner(
@@ -93,7 +93,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -68,12 +68,11 @@
     computed: {
       ...mapGetters('questionList', ['difficultQuestions']),
       table() {
-        const mapped = this.difficultQuestions.map(question => {
+        return this.difficultQuestions.map(question => {
           const tableRow = {};
           Object.assign(tableRow, question);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -103,7 +103,7 @@
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
         const sorted = this._.sortBy(contentArray, ['title']);
-        const mapped = sorted.map(content => {
+        return sorted.map(content => {
           const tableRow = {
             avgTimeSpent: this.getContentAvgTimeSpent(content.content_id, this.recipients),
             tally: this.getContentStatusTally(content.content_id, this.recipients),
@@ -111,7 +111,6 @@
           Object.assign(tableRow, content);
           return tableRow;
         });
-        return mapped;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -104,7 +104,7 @@
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
             statusObj: this.getContentStatusObjForLearner(
@@ -115,7 +115,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -92,7 +92,7 @@
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
             statusObj: this.getExamStatusObjForLearner(this.exam.id, learner.id),
@@ -100,7 +100,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
     },
     beforeMount() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -68,12 +68,11 @@
     computed: {
       ...mapGetters('questionList', ['difficultQuestions']),
       table() {
-        const mapped = this.difficultQuestions.map(question => {
+        return this.difficultQuestions.map(question => {
           const tableRow = {};
           Object.assign(tableRow, question);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -67,7 +67,7 @@
     computed: {
       table() {
         const sorted = this._.sortBy(this.learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const groupNames = this.getGroupNames(
             this._.map(this.groups.filter(group => group.member_ids.includes(learner.id)), 'id')
           );
@@ -86,7 +86,6 @@
           Object.assign(augmentedObj, learner);
           return augmentedObj;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -106,14 +106,13 @@
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
         const sorted = this._.sortBy(contentArray, ['title']);
-        const mapped = sorted.map(content => {
+        return sorted.map(content => {
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
           };
           Object.assign(tableRow, content);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -97,26 +97,24 @@
       lessonsTable() {
         const filtered = this.lessons.filter(lesson => this.isAssigned(lesson.groups));
         const sorted = this._.sortBy(filtered, ['title', 'active']);
-        const mapped = sorted.map(lesson => {
+        return sorted.map(lesson => {
           const tableRow = {
             status: this.getLessonStatusStringForLearner(lesson.id, this.learner.id),
           };
           Object.assign(tableRow, lesson);
           return tableRow;
         });
-        return mapped;
       },
       examsTable() {
         const filtered = this.exams.filter(exam => this.isAssigned(exam.groups));
         const sorted = this._.sortBy(filtered, ['title', 'active']);
-        const mapped = sorted.map(exam => {
+        return sorted.map(exam => {
           const tableRow = {
             statusObj: this.getExamStatusObjForLearner(exam.id, this.learner.id),
           };
           Object.assign(tableRow, exam);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -121,13 +121,13 @@
         return this.groups.filter(group => this.lesson.groups.includes(group.id));
       },
       recipients() {
-        return this.getLearnersForGroups(this.lesson.groups);
+        return this.getLearnersForLesson(this.lesson);
       },
       allEntries() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
 
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getLearnerLessonGroups(learner.id),
             statusObj: this.getContentStatusObjForLearner(
@@ -141,8 +141,6 @@
 
           return tableRow;
         });
-
-        return mapped;
       },
       ungroupedEntries() {
         return this.allEntries.filter(entry => !entry.groups || !entry.groups.length);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -69,12 +69,11 @@
     computed: {
       ...mapGetters('questionList', ['difficultQuestions']),
       table() {
-        const mapped = this.difficultQuestions.map(question => {
+        return this.difficultQuestions.map(question => {
           const tableRow = {};
           Object.assign(tableRow, question);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonHeader.vue
@@ -32,6 +32,7 @@
         <Recipients
           slot="value"
           :groupNames="getGroupNames(lesson.groups)"
+          :hasAssignments="lesson.assignments.length > 0"
         />
       </HeaderTableRow>
       <HeaderTableRow

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -65,12 +65,12 @@
         return this.lessonMap[this.$route.params.lessonId];
       },
       recipients() {
-        return this.getLearnersForGroups(this.lesson.groups);
+        return this.getLearnersForLesson(this.lesson);
       },
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
             status: this.getLessonStatusStringForLearner(this.lesson.id, learner.id),
@@ -78,7 +78,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -82,14 +82,13 @@
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
         const sorted = this._.sortBy(contentArray, ['title']);
-        const mapped = sorted.map(content => {
+        return sorted.map(content => {
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
           };
           Object.assign(tableRow, content);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -45,6 +45,7 @@
             <td>
               <Recipients
                 :groupNames="tableRow.groupNames"
+                :hasAssignments="tableRow.hasAssignments"
               />
             </td>
             <td><LessonActive :active="tableRow.active" /></td>
@@ -124,6 +125,7 @@
             totalLearners: learners.length,
             tally: this.getLessonStatusTally(lesson.id, learners),
             groupNames: this.getGroupNames(lesson.groups),
+            hasAssignments: lesson.assignments.length > 0,
           };
           Object.assign(tableRow, lesson);
           return tableRow;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -119,18 +119,17 @@
           }
         });
         const sorted = this._.sortBy(filtered, ['title', 'active']);
-        const mapped = sorted.map(lesson => {
-          const learners = this.getLearnersForGroups(lesson.groups);
+        return sorted.map(lesson => {
+          const learners = this.getLearnersForLesson(lesson);
           const tableRow = {
             totalLearners: learners.length,
             tally: this.getLessonStatusTally(lesson.id, learners),
             groupNames: this.getGroupNames(lesson.groups),
-            hasAssignments: lesson.assignments.length > 0,
+            hasAssignments: learners.length > 0,
           };
           Object.assign(tableRow, lesson);
           return tableRow;
         });
-        return mapped;
       },
     },
     beforeMount() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -27,7 +27,7 @@
               <KLabeledIcon>
                 <KBasicContentIcon slot="icon" :kind="tableRow.kind" />
                 <KRouterLink
-                  v-if="tableRow.kind === 'exercise'"
+                  v-if="tableRow.kind === 'exercise' && tableRow.hasAssignments"
                   :text="tableRow.title"
                   :to="classRoute(
                     'ReportsLessonExerciseLearnerListPage',
@@ -35,13 +35,16 @@
                   )"
                 />
                 <KRouterLink
-                  v-else
+                  v-else-if="tableRow.hasAssignments"
                   :text="tableRow.title"
                   :to="classRoute(
                     'ReportsLessonResourceLearnerListPage',
                     { resourceId: tableRow.content_id }
                   )"
                 />
+                <template v-else>
+                  {{ tableRow.title }}
+                </template>
               </KLabeledIcon>
             </td>
             <td>
@@ -85,20 +88,21 @@
         return this.lessonMap[this.$route.params.lessonId];
       },
       recipients() {
-        return this.getLearnersForGroups(this.lesson.groups);
+        return this.getLearnersForLesson(this.lesson);
       },
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
         const sorted = this._.sortBy(contentArray, ['title']);
-        const mapped = sorted.map(content => {
+        return sorted.map(content => {
+          const tally = this.getContentStatusTally(content.content_id, this.recipients);
           const tableRow = {
             avgTimeSpent: this.getContentAvgTimeSpent(content.content_id, this.recipients),
-            tally: this.getContentStatusTally(content.content_id, this.recipients),
+            tally,
+            hasAssignments: Object.values(tally).reduce((a, b) => a + b, 0),
           };
           Object.assign(tableRow, content);
           return tableRow;
         });
-        return mapped;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -141,7 +141,7 @@
         return this.contentMap[this.$route.params.resourceId];
       },
       recipients() {
-        return this.getLearnersForGroups(this.lesson.groups);
+        return this.getLearnersForLesson(this.lesson);
       },
       allRecipientsAvgTime() {
         return this.getContentAvgTimeSpent(this.$route.params.resourceId, this.recipients);
@@ -159,7 +159,7 @@
       allEntries() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getLearnerLessonGroups(learner.id),
             statusObj: this.getContentStatusObjForLearner(
@@ -170,7 +170,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
       ungroupedEntries() {
         return this.allEntries.filter(entry => !entry.groups || !entry.groups.length);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
@@ -32,6 +32,7 @@
         <Recipients
           slot="value"
           :groupNames="getGroupNames(exam.groups)"
+          :hasAssignments="exam.assignments.length > 0"
         />
       </HeaderTableRow>
       <HeaderTableRow :keyText="coachStrings.$tr('avgScoreLabel')">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizHeader.vue
@@ -81,7 +81,7 @@
         return this.examMap[this.$route.params.quizId];
       },
       recipients() {
-        return this.getLearnersForGroups(this.exam.groups);
+        return this.getLearnersForExam(this.exam);
       },
       orderDescriptionString() {
         return this.exam.learners_see_fixed_order

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -92,12 +92,12 @@
         return this.examMap[this.$route.params.quizId];
       },
       recipients() {
-        return this.getLearnersForGroups(this.exam.groups);
+        return this.getLearnersForExam(this.exam);
       },
       table() {
         const learners = this.recipients.map(learnerId => this.learnerMap[learnerId]);
         const sorted = this._.sortBy(learners, ['name']);
-        const mapped = sorted.map(learner => {
+        return sorted.map(learner => {
           const tableRow = {
             groups: this.getGroupNamesForLearner(learner.id),
             statusObj: this.getExamStatusObjForLearner(this.exam.id, learner.id),
@@ -105,7 +105,6 @@
           Object.assign(tableRow, learner);
           return tableRow;
         });
-        return mapped;
       },
     },
     beforeMount() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -126,19 +126,18 @@
           }
         });
         const sorted = this._.sortBy(filtered, ['title', 'active']);
-        const mapped = sorted.map(exam => {
-          const learnersForQuiz = this.getLearnersForGroups(exam.groups);
+        return sorted.map(exam => {
+          const learnersForQuiz = this.getLearnersForExam(exam);
           const tableRow = {
             totalLearners: learnersForQuiz.length,
             tally: this.getExamStatusTally(exam.id, learnersForQuiz),
             groupNames: this.getGroupNames(exam.groups),
             avgScore: this.getExamAvgScore(exam.id, learnersForQuiz),
-            hasAssignments: exam.assignments.length > 0,
+            hasAssignments: learnersForQuiz.length > 0,
           };
           Object.assign(tableRow, exam);
           return tableRow;
         });
-        return mapped;
       },
     },
     beforeMount() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -47,7 +47,12 @@
                 :verbose="true"
               />
             </td>
-            <td><Recipients :groupNames="tableRow.groupNames" /></td>
+            <td>
+              <Recipients
+                :groupNames="tableRow.groupNames"
+                :hasAssignments="tableRow.hasAssignments"
+              />
+            </td>
             <td>
               <QuizActive :active="tableRow.active" />
             </td>
@@ -128,6 +133,7 @@
             tally: this.getExamStatusTally(exam.id, learnersForQuiz),
             groupNames: this.getGroupNames(exam.groups),
             avgScore: this.getExamAvgScore(exam.id, learnersForQuiz),
+            hasAssignments: exam.assignments.length > 0,
           };
           Object.assign(tableRow, exam);
           return tableRow;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -68,12 +68,11 @@
     computed: {
       ...mapGetters('questionList', ['difficultQuestions']),
       table() {
-        const mapped = this.difficultQuestions.map(question => {
+        return this.difficultQuestions.map(question => {
           const tableRow = {};
           Object.assign(tableRow, question);
           return tableRow;
         });
-        return mapped;
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsExerciseLearners.spec.js
@@ -9,6 +9,7 @@ const entries = [
     name: 'learner1',
     username: 'learner1',
     groups: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
+    assignments: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
     exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/d4b',
     statusObj: {
       learner_id: 'd4b',
@@ -23,6 +24,7 @@ const entries = [
     name: 'learner2',
     username: 'learner2',
     groups: [{ id: '23s', name: 'group2' }],
+    assignments: [{ id: '23s', name: 'group2' }],
     exerciseLearnerLink: '#/2e3/reports/lessons/79b/exercises/a97/learners/a5d',
     statusObj: {
       learner_id: 'a5d',

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonExerciseLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonExerciseLearnerListPage.spec.js
@@ -35,6 +35,12 @@ const LEARNER_3 = {
   name: 'learner3 name',
 };
 
+const CLASSROOM = {
+  id: 'classroom',
+  name: 'classroom',
+  member_ids: [LEARNER_1.id, LEARNER_2.id, LEARNER_3.id],
+};
+
 const GROUP_1 = {
   id: 'group1',
   name: 'group1 name',
@@ -102,6 +108,7 @@ const initWrapper = lessonMap => {
     lessonMap = {
       [LESSON_ID]: {
         groups: [],
+        assignments: [CLASSROOM],
       },
     };
   }
@@ -202,6 +209,31 @@ describe('ReportsLessonExerciseLearnerListPage', () => {
     expect(wrapper.vm.$route.query.groups).toBeUndefined();
   });
 
+  describe('for a lesson without assignments', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [],
+          assignments: [],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders no class learners', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_2.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+      });
+    });
+  });
+
   describe('for an entire class lesson', () => {
     let lessonMap;
 
@@ -209,6 +241,7 @@ describe('ReportsLessonExerciseLearnerListPage', () => {
       lessonMap = {
         [LESSON_ID]: {
           groups: [],
+          assignments: [CLASSROOM],
         },
       };
     });
@@ -260,13 +293,14 @@ describe('ReportsLessonExerciseLearnerListPage', () => {
     });
   });
 
-  describe('for a lesson restricted to some groups recipents only', () => {
+  describe('for a lesson restricted to some groups recipients only', () => {
     let lessonMap;
 
     beforeEach(() => {
       lessonMap = {
         [LESSON_ID]: {
           groups: [GROUP_2.id, GROUP_3.id],
+          assignments: [GROUP_2.id, GROUP_3.id],
         },
       };
     });

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsLessonResourceLearnerListPage.spec.js
@@ -37,6 +37,12 @@ const LEARNER_3 = {
   name: 'learner3 name',
 };
 
+const CLASSROOM = {
+  id: 'classroom',
+  name: 'classroom',
+  member_ids: [LEARNER_1.id, LEARNER_2.id, LEARNER_3.id],
+};
+
 const GROUP_1 = {
   id: 'group1',
   name: 'group1 name',
@@ -112,6 +118,7 @@ const initWrapper = lessonMap => {
     lessonMap = {
       [LESSON_ID]: {
         groups: [],
+        assignments: [CLASSROOM],
       },
     };
   }
@@ -211,6 +218,31 @@ describe('ReportsLessonResourceLearnerListPage', () => {
     expect(wrapper.vm.$route.query.groups).toBeUndefined();
   });
 
+  describe('for a lesson without assignments', () => {
+    let lessonMap;
+
+    beforeEach(() => {
+      lessonMap = {
+        [LESSON_ID]: {
+          groups: [],
+          assignments: [],
+        },
+      };
+    });
+
+    describe('when displaying all learners', () => {
+      beforeEach(() => {
+        wrapper = initWrapper(lessonMap);
+      });
+
+      it('renders no class learners', () => {
+        expect(wrapper.html()).not.toContain(LEARNER_1.name);
+        expect(wrapper.html()).not.toContain(LEARNER_2.name);
+        expect(wrapper.html()).not.toContain(LEARNER_3.name);
+      });
+    });
+  });
+
   describe('for an entire class lesson', () => {
     let lessonMap;
 
@@ -218,6 +250,7 @@ describe('ReportsLessonResourceLearnerListPage', () => {
       lessonMap = {
         [LESSON_ID]: {
           groups: [],
+          assignments: [CLASSROOM],
         },
       };
     });
@@ -286,6 +319,7 @@ describe('ReportsLessonResourceLearnerListPage', () => {
       lessonMap = {
         [LESSON_ID]: {
           groups: [GROUP_2.id, GROUP_3.id],
+          assignments: [GROUP_2.id, GROUP_3.id],
         },
       };
     });

--- a/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
+++ b/kolibri/plugins/coach/assets/test/views/reports/ReportsResourceLearners.spec.js
@@ -9,6 +9,7 @@ const entries = [
     name: 'learner1',
     username: 'learner1',
     groups: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
+    assignments: [{ id: 'dc2', name: 'group1' }, { id: '23s', name: 'group2' }],
     statusObj: {
       learner_id: 'd4b',
       content_id: 'a97',
@@ -22,6 +23,7 @@ const entries = [
     name: 'learner2',
     username: 'learner2',
     groups: [{ id: '23s', name: 'group2' }],
+    assignments: [{ id: '23s', name: 'group2' }],
     statusObj: {
       learner_id: 'a5d',
       content_id: 'a97',

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders a correct summary tally 1`] = `
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
   <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
     Completed by 1 of 1
@@ -10,7 +10,7 @@ exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some gr
 </div>
 `;
 
-exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
   <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
     1
@@ -35,7 +35,7 @@ exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some gr
 </div>
 `;
 
-exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 2`] = `
+exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
   <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
     0 of 0

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -192,7 +192,15 @@ class LessonSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Lesson
-        fields = ("id", "title", "active", "node_ids", "assignments", "groups", "description")
+        fields = (
+            "id",
+            "title",
+            "active",
+            "node_ids",
+            "assignments",
+            "groups",
+            "description",
+        )
 
     def get_node_ids(self, obj):
         return [resource["contentnode_id"] for resource in obj.resources]

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -183,14 +183,16 @@ class LessonSerializer(serializers.ModelSerializer):
     active = serializers.BooleanField(source="is_active")
     node_ids = serializers.SerializerMethodField()
 
-    # classrooms are in here, and filtered out later
-    groups = LessonAssignmentsField(
+    # classrooms are in here, and filtered out later to create `groups`
+    assignments = LessonAssignmentsField(
         many=True, read_only=True, source="lesson_assignments"
     )
 
+    groups = serializers.ListField(default=[])
+
     class Meta:
         model = Lesson
-        fields = ("id", "title", "active", "node_ids", "groups", "description")
+        fields = ("id", "title", "active", "node_ids", "assignments", "groups", "description")
 
     def get_node_ids(self, obj):
         return [resource["contentnode_id"] for resource in obj.resources]
@@ -210,8 +212,10 @@ class ExamSerializer(serializers.ModelSerializer):
 
     question_sources = ExamQuestionSourcesField(default=[])
 
-    # classes are in here, and filtered out later
-    groups = ExamAssignmentsField(many=True, read_only=True, source="assignments")
+    # classes are in here, and filtered out later to create `groups`
+    assignments = ExamAssignmentsField(many=True, read_only=True)
+
+    groups = serializers.ListField(default=[])
 
     class Meta:
         model = Exam
@@ -220,6 +224,7 @@ class ExamSerializer(serializers.ModelSerializer):
             "title",
             "active",
             "question_sources",
+            "assignments",
             "groups",
             "data_model_version",
             "question_count",
@@ -273,11 +278,11 @@ class ClassSummaryViewSet(viewsets.ViewSet):
 
         # filter classes out of exam assignments
         for exam in exam_data:
-            exam["groups"] = [g for g in exam["groups"] if g != pk]
+            exam["groups"] = [g for g in exam["assignments"] if g != pk]
 
         # filter classes out of lesson assignments
         for lesson in lesson_data:
-            lesson["groups"] = [g for g in lesson["groups"] if g != pk]
+            lesson["groups"] = [g for g in lesson["assignments"] if g != pk]
 
         all_node_ids = set()
         for lesson in lesson_data:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Consolidated Recipients display in Coach module. When a lesson or quiz was assigned to group(s), it would sometimes show the list of group names and sometimes show the quantity of groups. With feedback from @jtamiace states are now:
  - "Entire class"
  - List of group names, truncated if necessary
  - "No one"
- Fixed inability to re-assign lesson or quiz to entire class after deleting the group the lesson or quiz was assigned to 

Before (Coach > Plan):
![group-quantity-before](https://user-images.githubusercontent.com/819838/58117631-de45f580-7bb3-11e9-80bd-ddfc1ff97d0c.png)

After:
![after](https://user-images.githubusercontent.com/819838/58117762-26fdae80-7bb4-11e9-8ee6-a4c7c129afa6.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Follow reproduce steps [here](https://github.com/learningequality/kolibri/issues/5462)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/5462

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
