### PR TITLE
Allow a hook to define custom theming.

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -23,6 +23,7 @@
     <script src="{% url 'api-docs:schema-js' %}"></script>
   {% endif %}
   {% kolibri_language_globals %}
+  {% kolibri_theme %}
   {% kolibri_set_urls %}
   {% webpack_asset 'user_agent' %}
 </head>

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -31,6 +31,7 @@ from six import iteritems
 import kolibri
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.hooks import NavigationHook
+from kolibri.core.hooks import ThemeHook
 from kolibri.core.webpack.utils import webpack_asset_render
 from kolibri.utils import conf
 from kolibri.utils import i18n
@@ -119,6 +120,20 @@ def kolibri_navigation_actions():
     :return: An html string
     """
     return webpack_asset_render(NavigationHook)
+
+
+@register.simple_tag()
+def kolibri_theme():
+    """
+    A tag to include a theme configuration object to add custom theming to Kolibri.
+    :return: An html string
+    """
+    template = """
+    <script>
+      var customTheme = JSON.parse('{theme}');
+    </script>
+    """
+    return mark_safe(template.format(theme=json.dumps(ThemeHook().theme)))
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
### Summary
Adds a custom theme hook to allow a plugin to customize theming of Kolibri.

### Reviewer guidance
Does it work? Does it load a customTheme global var?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
