### PR TITLE
Fix logging message in P2P network discovery

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -22,7 +22,7 @@ class NetworkClient(object):
         else:
             # normalize the URL and try a number of variations until we find one that's able to connect
             logger.info(
-                "Attempting connections to variations of the URL: {}".format(base_url)
+                "Attempting connections to variations of the URL: {}".format(address)
             )
             self.base_url = self._attempt_connections(
                 get_normalized_url_variations(address)


### PR DESCRIPTION
### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Quick fix to address unhelpful logger message shown in: https://github.com/learningequality/kolibri/issues/5519#issuecomment-494894838

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
