### PR TITLE
Update state.currentClass after updating class model

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/__test__/classEditManagementModule.spec.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/__test__/classEditManagementModule.spec.js
@@ -1,0 +1,29 @@
+import makeStore from '../../../../test/makeStore';
+
+describe('classEditManagement module', () => {
+  it('UPDATE_CLASS mutation updates both the class list and the current class', () => {
+    const store = makeStore();
+    store.state.classEditManagement.classes = [
+      { id: 'class_1', name: 'class one' },
+      { id: 'class_2', name: 'class two' },
+    ];
+    store.state.classEditManagement.currentClass = { id: 'class_2', name: 'class two' };
+
+    store.commit('classEditManagement/UPDATE_CLASS', {
+      id: 'class_2',
+      updatedClass: {
+        id: 'class_2',
+        name: 'class two edited',
+      },
+    });
+
+    expect(store.state.classEditManagement.classes).toEqual([
+      { id: 'class_1', name: 'class one' },
+      { id: 'class_2', name: 'class two edited' },
+    ]);
+    expect(store.state.classEditManagement.currentClass).toEqual({
+      id: 'class_2',
+      name: 'class two edited',
+    });
+  });
+});

--- a/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/index.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/classEditManagement/index.js
@@ -32,6 +32,9 @@ export default {
           arr[index] = updatedClass;
         }
       });
+      if (state.currentClass && state.currentClass.id === id) {
+        state.currentClass = updatedClass;
+      }
     },
     DELETE_CLASS_LEARNER(state, id) {
       state.classLearners = state.classLearners.filter(user => user.id !== id);


### PR DESCRIPTION
### Summary

Fixes a bug where renaming a class in Facility > Class Edit Page doesn't immediately update the name of the class.

After fix:

![renaming](https://user-images.githubusercontent.com/10248067/58291111-0c246900-7d71-11e9-8286-26d4da45983a.gif)


### Reviewer guidance

1. Rename a classroom and see that it's name changes after the modal is dismissed.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
