### PR TITLE
fix descenders

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -196,7 +196,9 @@
 
   .username {
     max-width: 200px;
-    overflow: hidden;
+    // overflow-x hidden seems to affect overflow-y also, so include a fixed height
+    height: 16px;
+    overflow-x: hidden;
     text-overflow: ellipsis;
   }
 

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -962,7 +962,10 @@
   }
 
   .ui-select-display-value {
+    position: relative;
+    top: 2px;
     flex-grow: 1;
+    height: 22px; // height and top help prevent descender clipping
     overflow: hidden;
     text-overflow: ellipsis;
 


### PR DESCRIPTION
### Summary

Adds height to a couple items which had `overflow: hidden` and `text-overflow: ellipsis`.

### Reviewer guidance

I would have expected to fix this by switching from `overflow` to `overflow-x`, but that didn't work. Not sure why.

This change feels like a hack but I couldn't figure out an alternative.

### References

* fixes #5538 
* fixes #5553

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
