### PR TITLE
Hide CoachContent annotations from Learners

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -27,7 +27,7 @@
       </p>
       <div class="footer">
         <CoachContentLabel
-          v-if="hasUserPermissions && !isLearner"
+          v-if="userHasPermissions && !isLearner"
           class="coach-content-label"
           :value="numCoachContents"
           :isTopic="isTopic"
@@ -122,7 +122,7 @@
       },
     },
     computed: {
-      ...mapGetters(['isLearner', 'hasUserPermissions']),
+      ...mapGetters(['isLearner', 'userHasPermissions']),
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -27,7 +27,7 @@
       </p>
       <div class="footer">
         <CoachContentLabel
-          v-if="userHasPermissions && !isLearner"
+          v-if="isUserLoggedIn && !isLearner"
           class="coach-content-label"
           :value="numCoachContents"
           :isTopic="isTopic"
@@ -122,7 +122,7 @@
       },
     },
     computed: {
-      ...mapGetters(['isLearner', 'userHasPermissions']),
+      ...mapGetters(['isLearner', 'isUserLoggedIn']),
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -27,7 +27,7 @@
       </p>
       <div class="footer">
         <CoachContentLabel
-          v-if="!isLearner"
+          v-if="hasUserPermissions && !isLearner"
           class="coach-content-label"
           :value="numCoachContents"
           :isTopic="isTopic"
@@ -122,7 +122,7 @@
       },
     },
     computed: {
-      ...mapGetters(['isLearner']),
+      ...mapGetters(['isLearner', 'hasUserPermissions']),
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -27,6 +27,7 @@
       </p>
       <div class="footer">
         <CoachContentLabel
+          v-if="!isLearner"
           class="coach-content-label"
           :value="numCoachContents"
           :isTopic="isTopic"
@@ -47,6 +48,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -120,6 +122,7 @@
       },
     },
     computed: {
+      ...mapGetters(['isLearner']),
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },


### PR DESCRIPTION
### Summary
Fixes issue in https://github.com/learningequality/kolibri/issues/5567 where coach content annotation counts were shown to Learners.

### Reviewer guidance
- Have a channel that includes coach content.
- In release-v0.12.y - log in as a Learner and go to that channel in Learn. See the blue icon with a count.
- Checkout this branch - restart server - see that the icon is hidden from the Learner.
- Log out - then go to the same content as a guest user to see that it is also hidden from non-logged in Guest users.
- As a coach, admin, etc you will still see the annotations.

### References
https://github.com/learningequality/kolibri/issues/5567

----

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
