### PR TITLE
Fix 'no selectable nodes' logic when importing from a local drive

### DIFF
--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -103,13 +103,15 @@
       },
       noSelectableNodes() {
         // If importing from an external drive, disable select-all if every child node is
-        // 1) a leaf node and 2) already on the server or not available on the drive
+        // 1) a leaf node AND
+        // 2a) not importable from the drive OR
+        // 2b) already on the server
         // TODO check to see if this logic is valid for PEER_IMPORT as well.
         if (this.transferType === TransferTypes.LOCALIMPORT) {
           return every(this.annotatedChildNodes, node => {
             return (
               node.kind !== ContentNodeKinds.TOPIC &&
-              (!node.available || node.on_device_resources > 0)
+              (!node.importable || node.on_device_resources > 0)
             );
           });
         } else {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Fixes the logic of ContentTreeViewer.noSelectableNodes, when importing from a local drive. This means that, effectively, the "Select All" checkbox will be disabled when every leaf-level resources on the drive, at a given topic, is already on the Kolibri Server (when a resource is not on the drive i.e. not "importable", it is not shown on the list in the Import workflow).



### Reviewer guidance

Check to see that this fixes the specific 'select-all' disabling issue in #5548. We will wait to see what happens in #5490 	to fix other bugs you might notice like the overestimating-of-imported-resources-when-selecting-topics bug.

Some scenarios to look into

1. All/some/no resources in the topic already on server
1. All/some/no resource in the topic on the USB drive


Fixes #5548 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
