### PR TITLE
Fixes #5565: Revise EPUB renderer z-indices

### DIFF
--- a/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
@@ -96,7 +96,6 @@
   @import './EpubStyles';
 
   .bottom-bar {
-    z-index: 0;
     height: 54px;
     padding: 8px 8px 0;
     overflow: hidden;

--- a/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/BottomBar.vue
@@ -96,7 +96,7 @@
   @import './EpubStyles';
 
   .bottom-bar {
-    z-index: 8;
+    z-index: 0;
     height: 54px;
     padding: 8px 8px 0;
     overflow: hidden;

--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -793,7 +793,7 @@
   .search-button {
     position: absolute;
     top: 0;
-    z-index: 6;
+    z-index: 2;
   }
   .settings-button {
     right: 72px;

--- a/kolibri/plugins/document_epub_render/assets/src/views/LoadingError.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/LoadingError.vue
@@ -49,13 +49,13 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 24;
+    z-index: 3;
   }
 
   .epub-renderer-error.loaded {
     top: 36px;
     bottom: auto;
-    z-index: 4;
+    z-index: 0;
     background: transparent;
   }
 

--- a/kolibri/plugins/document_epub_render/assets/src/views/LoadingScreen.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/LoadingScreen.vue
@@ -47,7 +47,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 24;
+    z-index: 3;
   }
 
   .loading-status {

--- a/kolibri/plugins/document_epub_render/assets/src/views/SideBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/SideBar.vue
@@ -24,7 +24,7 @@
   @import './EpubStyles';
 
   .side-bar {
-    z-index: 8;
+    z-index: 3;
     width: 250px;
     padding: 16px;
     overflow-y: auto;

--- a/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/TopBar.vue
@@ -128,7 +128,7 @@
   @import './EpubStyles';
 
   .top-bar {
-    z-index: 4;
+    z-index: 1;
     box-shadow: $epub-box-shadow;
   }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updated all z-index values to be within 0 and 4
![epub-zindex](https://user-images.githubusercontent.com/819838/58577544-90586f80-81fb-11e9-9261-729b109f113b.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Open an EPUB
- Decrease page height until app top bar disappears on scroll
- Verify no EPUB renderer components appear above (Z axis) the app top bar
- Verify EPUB toolbar buttons properly toggle sidebars

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/5565

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
