### PR TITLE
Fixes #5566: Use fullscreen pseudo selector to avoid 0 height in resize event

### DIFF
--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -3,7 +3,7 @@
   <CoreFullscreen
     ref="epubRenderer"
     class="epub-renderer"
-    :class="{small: windowIsSmall, scrolled: scrolled, 'fullscreen-enabled': isInFullscreen}"
+    :class="{small: windowIsSmall, scrolled: scrolled}"
     :style="epubRendererStyle"
     @changeFullscreen="isInFullscreen = $event"
   >
@@ -735,6 +735,7 @@
 
   .epub-renderer {
     position: relative;
+    max-height: 100%;
     padding-top: calc(100% * 8.5 / 11);
     font-size: smaller;
   }
@@ -743,8 +744,8 @@
     padding-top: calc(100% * 11 / 8.5);
   }
 
-  .epub-renderer.fullscreen-mode,
-  .epub-renderer.small.fullscreen-mode {
+  .epub-renderer:fullscreen,
+  .epub-renderer.small:fullscreen {
     padding-top: 0;
   }
 

--- a/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/document_epub_render/assets/src/views/EpubRendererIndex.vue
@@ -3,7 +3,7 @@
   <CoreFullscreen
     ref="epubRenderer"
     class="epub-renderer"
-    :class="{small: windowIsSmall, scrolled: scrolled}"
+    :class="{small: windowIsSmall, scrolled: scrolled, 'fullscreen-enabled': isInFullscreen}"
     :style="epubRendererStyle"
     @changeFullscreen="isInFullscreen = $event"
   >
@@ -743,8 +743,8 @@
     padding-top: calc(100% * 11 / 8.5);
   }
 
-  .epub-renderer.normalize-fullscreen,
-  .epub-renderer.small.normalize-fullscreen {
+  .epub-renderer.fullscreen-mode,
+  .epub-renderer.small.fullscreen-mode {
     padding-top: 0;
   }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Rely on `:fullscreen` which helps with order of operations when toggling between fullscreen, avoiding a computed height of 0 by epub.js which leads to blank document

![screencast-localhost-8000-2019 05 29-12-58-42](https://user-images.githubusercontent.com/819838/58587894-4c716480-8213-11e9-8ecb-2344f9e29599.gif)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Open an EPUB, go fullscreen, and then exit fullscreen. Be sure to not have dev tools open as that can affect the appearance of this bug.
- I tested a bunch of browsers in Browserstack as well.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/5566

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
