### PR TITLE
Fix windows log file error when upgrading version

### DIFF
--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import sys
 
 import portend
@@ -93,4 +94,4 @@ def check_log_file_location():
         old_log_path = os.path.join(home, log)
         if os.path.exists(old_log_path):
             new_log_path = os.path.join(home, "logs", log_location_update[log])
-            os.rename(old_log_path, new_log_path)
+            shutil.move(old_log_path, new_log_path)

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -43,12 +43,12 @@ class SanityCheckTestCase(TestCase):
             logging_mock.assert_called()
 
     @patch("kolibri.utils.cli.initialize")
-    @patch("kolibri.utils.sanity_checks.os.rename")
+    @patch("kolibri.utils.sanity_checks.shutil.move")
     @patch(
         "kolibri.utils.sanity_checks.os.path.exists", side_effect=[False, True, True]
     )
-    def test_old_log_file_exists(self, path_exists_mock, rename_mock, initialize_mock):
+    def test_old_log_file_exists(self, path_exists_mock, move_mock, initialize_mock):
         cli.main(["language", "setdefault", "en"])
-        # Check if the number of calls to os.rename equals to the number of times
+        # Check if the number of calls to shutil.move equals to the number of times
         # os.path.exists returns True
-        self.assertEqual(rename_mock.call_count, 2)
+        self.assertEqual(move_mock.call_count, 2)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The PR fixes the issue that kolibri cannot start during version upgrade due to an OSError from `os.rename` on Windows. The issue is because `os.rename` [cannot handle the case when the destination file exists on Windows](https://docs.python.org/2/library/os.html#os.rename). 
The solution is to instead use `shutil.move` so that when the destination file exists, the source file will be copied over to the destination and deleted afterwards.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please see if the error has been fixed on windows. (I tested this on my Windows VM)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5597

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
