### PR TITLE
Use etag to control SPA caching.

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -5,12 +5,17 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import hashlib
 import sys
 
 from django.utils.cache import patch_response_headers
+from django.views.decorators.http import etag
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 from six import string_types
+
+from kolibri import __version__ as kolibri_version
+from kolibri.core.device.models import ContentCacheKey
 
 TRUE_VALUES = ("1", "true")
 FALSE_VALUES = ("0", "false")
@@ -312,6 +317,12 @@ def query_params_required(**kwargs):
     return _params
 
 
+def calculate_spa_etag(*args, **kwargs):
+    return hashlib.md5(
+        kolibri_version.encode("utf-8") + str(ContentCacheKey.get_cache_key()).encode("utf-8")
+    ).hexdigest()
+
+
 def cache_no_user_data(view_func):
     """
     Set appropriate Vary on headers on a view that specify there is
@@ -324,11 +335,12 @@ def cache_no_user_data(view_func):
     on a per user basis.
     """
 
+    @etag(calculate_spa_etag)
     def inner_func(*args, **kwargs):
         request = args[0]
         del request.session
         response = view_func(*args, **kwargs)
-        patch_response_headers(response, cache_timeout=300)
+        patch_response_headers(response, cache_timeout=15)
         response["Vary"] = "accept-encoding, accept"
         return response
 

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -319,7 +319,8 @@ def query_params_required(**kwargs):
 
 def calculate_spa_etag(*args, **kwargs):
     return hashlib.md5(
-        kolibri_version.encode("utf-8") + str(ContentCacheKey.get_cache_key()).encode("utf-8")
+        kolibri_version.encode("utf-8")
+        + str(ContentCacheKey.get_cache_key()).encode("utf-8")
     ).hexdigest()
 
 

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -70,7 +70,7 @@ class ContentCacheKey(models.Model):
         cache_key, created = cls.objects.get_or_create()
         cache_key.key = time.time()
         cache_key.save()
-        cache.delete(CONTENT_CACHE_KEY_CACHE_KEY)
+        cache.set(CONTENT_CACHE_KEY_CACHE_KEY, cache_key.key, 5000)
         return cache_key
 
     @classmethod


### PR DESCRIPTION
### Summary
* Reduces cache time on SPA launch pages to 15 seconds.
* Adds etags to SPA launch pages based on the kolibri version and the current content cache key.

In a siege test this has a minimal impact on performance over current behaviour (both in a no-delay test, and one with delays between requests).

### Reviewer guidance
When you import a new channel in the Device page, does it appear on the Learn page when you navigate there immediately afterwards?

### References
Reports from hack session.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
