### PR TITLE
Fixes #5562: Ensure channel gets updated for Safari

### DIFF
--- a/kolibri/plugins/device_management/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device_management/assets/src/modules/manageContent/index.js
@@ -29,6 +29,12 @@ export default {
     SET_TASK_LIST(state, taskList) {
       state.taskList = [...taskList];
     },
+    ADD_TO_CHANNEL_LIST(state, channel) {
+      state.channelList.push(channel);
+    },
+    REMOVE_FROM_CHANNEL_LIST(state, channelId) {
+      state.channelList = state.channelList.filter(channel => channel.id !== channelId);
+    },
   },
   getters: {
     // Channels that are installed & also "available"

--- a/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/handlers.js
@@ -176,9 +176,8 @@ export function showSelectContentPage(store, params) {
   // We let it fail silently, since it is only used to show "on device" files/resources.
   const installedChannelPromise = getChannelWithContentSizes(params.channel_id)
     .then(channel => {
-      if (store.state.manageContent.channelList.length === 0) {
-        store.commit('manageContent/SET_CHANNEL_LIST', [channel]);
-      }
+      store.commit('manageContent/REMOVE_FROM_CHANNEL_LIST', channel.id);
+      store.commit('manageContent/ADD_TO_CHANNEL_LIST', channel);
     })
     .catch(() => {});
 

--- a/kolibri/plugins/device_management/assets/src/routes/wizardTransitionRoutes.js
+++ b/kolibri/plugins/device_management/assets/src/routes/wizardTransitionRoutes.js
@@ -28,10 +28,10 @@ export default [
   {
     name: ContentWizardPages.SELECT_CONTENT,
     path: '/content/channels/:channel_id',
-    handler: ({ query, params }) => {
+    handler: ({ query, params }, from) => {
       // HACK don't refresh state when going from SELECT_CONTENT_TOPIC back to here
-      const cachedChannelPath = store.state.manageContent.wizard.pathCache[params.channel_id];
-      if (cachedChannelPath) {
+      if (from.name === ContentWizardPages.SELECT_CONTENT_TOPIC) {
+        const cachedChannelPath = store.state.manageContent.wizard.pathCache[params.channel_id];
         return updateTreeViewTopic(store, cachedChannelPath[0]);
       }
 

--- a/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/SelectContentPage/index.vue
@@ -268,7 +268,7 @@
           });
       },
       refreshPage() {
-        this.$router.go(this.$router.currentRoute);
+        this.$router.go();
       },
       returnToChannelsList() {
         this.$router.push(manageContentPageLink());


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- `$router.go()` takes a numerical argument, so removed instance where route object was being passed
- Add mutations to state to ensure channel gets updated in state's list

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Ensure you're either running kolibri in production mode or you have the background task worker running
- You may need to remove `.data_version` from the kolibri data directory if running in production mode

Steps:
1) Open Kolibri in Safari-- Browserstack works
1) As device admin, import a channel on Kolibri that you can manipulate on Studio
2) Update the channel's title in Studio
3) Again in Kolibri, use "Import More" action on the channel
4) Click "Update" CTA when it appears
5) Verify that the channel's title is the title updated on studio and the update CTA is no longer visible

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/5562

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
