### PR TITLE
Catch KeyError when checking cancel during import.

### DIFF
--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -96,7 +96,7 @@ class AsyncCommand(BaseCommand):
             try:
                 self.check_for_cancel()
                 return False
-            except UserCancelledError:
+            except (UserCancelledError, KeyError):
                 return True
         return False
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/learningequality/kolibri/issues/5535 by handling a thrown KeyError when checking if a job is canceled. If the job doesn't exist, act as if it were canceled anyway.

### Reviewer guidance
I found this issue difficult to replicate - however, given the specificity of the error this should avoid https://github.com/learningequality/kolibri/issues/5535 in the future.

### References
https://github.com/learningequality/kolibri/issues/5535

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
