### PR TITLE
Correct export sizes

### DIFF
--- a/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentTreeViewerActions.js
+++ b/kolibri/plugins/device_management/assets/src/modules/wizard/actions/contentTreeViewerActions.js
@@ -18,7 +18,7 @@ function isDescendantOrSelf(testNode, selfNode) {
  *
  */
 export function getContentNodeFileSize(node) {
-  return ContentNodeFileSizeResource.fetchModel({ id: node.id });
+  return ContentNodeFileSizeResource.fetchModel({ id: node.id, force: true });
 }
 
 /**


### PR DESCRIPTION
### Summary
Forces fetch of content node file size endpoint to prevent caching.

### Reviewer guidance
Does it fix #5620 ?

### References
Fixes #5620

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
