### PR TITLE
Add plugin blacklist for when plugins are disabled.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -74,7 +74,7 @@ INSTALLED_APPS = [
     "django_js_reverse",
     "jsonfield",
     "morango",
-] + conf.config["INSTALLED_APPS"]
+] + conf.config.ACTIVE_PLUGINS
 
 # Add in the external plugins' locale paths. Our frontend messages depends
 # specifically on the value of LOCALE_PATHS to find its catalog files.

--- a/kolibri/plugins/base.py
+++ b/kolibri/plugins/base.py
@@ -60,8 +60,8 @@ class KolibriPluginBase(object):
         """Call this from your enable() method to have the plugin automatically
         added to Kolibri configuration"""
         module_path = cls._module_path()
-        if module_path not in config["INSTALLED_APPS"]:
-            config["INSTALLED_APPS"].append(module_path)
+        if module_path not in config.ACTIVE_PLUGINS:
+            config.enable_plugin(module_path)
         else:
             logger.warning("{} already enabled".format(module_path))
 
@@ -70,8 +70,8 @@ class KolibriPluginBase(object):
         """Call this from your enable() method to have the plugin automatically
         added to Kolibri configuration"""
         module_path = cls._module_path()
-        if module_path in config["INSTALLED_APPS"]:
-            config["INSTALLED_APPS"].remove(module_path)
+        if module_path in config.ACTIVE_PLUGINS:
+            config.disable_plugin(module_path)
         else:
             logger.warning("{} already disabled".format(module_path))
 

--- a/kolibri/plugins/utils.py
+++ b/kolibri/plugins/utils.py
@@ -1,4 +1,29 @@
+import importlib
+import logging
+
+from django.core.exceptions import AppRegistryNotReady
 from django.core.urlresolvers import reverse
+
+from kolibri.plugins.base import KolibriPluginBase
+from kolibri.utils.conf import config
+
+logger = logging.getLogger(__name__)
+
+
+class PluginDoesNotExist(Exception):
+    """
+    This exception is local to the CLI environment in case actions are performed
+    on a plugin that cannot be loaded.
+    """
+
+
+class PluginBaseLoadsApp(Exception):
+    """
+    An exception raised in case a kolibri_plugin.py results in loading of the
+    Django app stack.
+    """
+
+    pass
 
 
 def plugin_url(plugin_class, url_name):
@@ -7,3 +32,81 @@ def plugin_url(plugin_class, url_name):
             namespace=plugin_class().url_namespace(), url_name=url_name
         )
     )
+
+
+def _is_plugin(obj):
+    return (
+        isinstance(obj, type)
+        and obj is not KolibriPluginBase
+        and issubclass(obj, KolibriPluginBase)
+    )
+
+
+def get_kolibri_plugin(plugin_name):
+    """
+    Try to load kolibri_plugin from given plugin module identifier
+
+    :returns: A list of classes inheriting from KolibriPluginBase
+    """
+
+    plugin_classes = []
+
+    try:
+        plugin_module = importlib.import_module(plugin_name + ".kolibri_plugin")
+        for obj in plugin_module.__dict__.values():
+            if _is_plugin(obj):
+                plugin_classes.append(obj)
+    except ImportError as e:
+        # Python 2: message, Python 3: msg
+        exc_message = getattr(e, "message", getattr(e, "msg", None))
+        if exc_message.startswith("No module named"):
+            msg = (
+                "Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?"
+            ).format(plugin_name)
+            raise PluginDoesNotExist(msg)
+        else:
+            raise
+    except AppRegistryNotReady:
+        msg = (
+            "Plugin '{}' loads the Django app registry, which it isn't "
+            "allowed to do while enabling or disabling itself."
+        ).format(plugin_name)
+        raise PluginBaseLoadsApp(msg)
+
+    if not plugin_classes:
+        # There's no clear use case for a plugin without a KolibriPluginBase
+        # inheritor, for now just throw a warning
+        logger.warning(
+            "Plugin '{}' has no KolibriPluginBase defined".format(plugin_name)
+        )
+
+    return plugin_classes
+
+
+def enable_plugin(plugin_name):
+    plugin_classes = get_kolibri_plugin(plugin_name)
+    for klass in plugin_classes:
+        klass.enable()
+
+
+def disable_plugin(plugin_name):
+    try:
+        plugin_classes = get_kolibri_plugin(plugin_name)
+        for klass in plugin_classes:
+            klass.disable()
+    except PluginDoesNotExist as e:
+        logger.error(str(e))
+        logger.warning(
+            "Removing '{}' from configuration in a naive way.".format(plugin_name)
+        )
+        if plugin_name in config["INSTALLED_APPS"]:
+            config["INSTALLED_APPS"].remove(plugin_name)
+            logger.info("Removed '{}' from INSTALLED_APPS".format(plugin_name))
+        else:
+            logger.warning(
+                (
+                    "Could not find any matches for {} in INSTALLED_APPS".format(
+                        plugin_name
+                    )
+                )
+            )

--- a/kolibri/plugins/utils.py
+++ b/kolibri/plugins/utils.py
@@ -36,6 +36,11 @@ def plugin_url(plugin_class, url_name):
 
 def _is_plugin(obj):
     return (
+        # Check that the object is an instance of type
+        # i.e. that it is a class definition, not an
+        # instantiated class.
+        # Failing to do this will result in the call to
+        # issubclass below blowing up.
         isinstance(obj, type)
         and obj is not KolibriPluginBase
         and issubclass(obj, KolibriPluginBase)
@@ -52,7 +57,9 @@ def get_kolibri_plugin(plugin_name):
     plugin_classes = []
 
     try:
+        # Exceptions are expected to be thrown from here.
         plugin_module = importlib.import_module(plugin_name + ".kolibri_plugin")
+        # If no exception is thrown, use this to populate our plugin classes.
         for obj in plugin_module.__dict__.values():
             if _is_plugin(obj):
                 plugin_classes.append(obj)

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import importlib
 import logging
 import os
 import signal
@@ -10,7 +9,6 @@ import sys
 from sqlite3 import DatabaseError as SQLite3DatabaseError
 
 import django
-from django.core.exceptions import AppRegistryNotReady
 from django.core.management import call_command
 from django.db.utils import DatabaseError
 from docopt import docopt
@@ -29,7 +27,11 @@ from .sanity_checks import check_other_kolibri_running  # noqa
 from .sanity_checks import check_log_file_location  # noqa
 from .system import become_daemon  # noqa
 from kolibri.core.deviceadmin.utils import IncompatibleDatabase  # noqa
-from kolibri.utils import conf  # noqa
+from kolibri.plugins.utils import disable_plugin  # noqa
+from kolibri.plugins.utils import enable_plugin  # noqa
+from kolibri.utils.conf import config  # noqa
+from kolibri.utils.conf import KOLIBRI_HOME  # noqa
+from kolibri.utils.conf import OPTIONS  # noqa
 
 
 USAGE = """
@@ -108,29 +110,11 @@ Auto-generated usage instructions from ``kolibri -h``::
 logger = logging.getLogger(__name__)
 
 
-class PluginDoesNotExist(Exception):
-    """
-    This exception is local to the CLI environment in case actions are performed
-    on a plugin that cannot be loaded.
-    """
-
-
-class PluginBaseLoadsApp(Exception):
-    """
-    An exception raised in case a kolibri_plugin.py results in loading of the
-    Django app stack.
-    """
-
-    pass
-
-
 def version_file():
     """
     During test runtime, this path may differ because KOLIBRI_HOME is
     regenerated
     """
-    from .conf import KOLIBRI_HOME
-
     return os.path.join(KOLIBRI_HOME, ".data_version")
 
 
@@ -164,9 +148,8 @@ def initialize(debug=False, skip_update=False):
     else:
         # Do this here so that we can fix any issues with our configuration file before
         # we attempt to set up django.
-        from .conf import autoremove_unavailable_plugins, enable_default_plugins
 
-        autoremove_unavailable_plugins()
+        config.autoremove_unavailable_plugins()
 
         version = open(version_file(), "r").read()
         version = version.strip() if version else ""
@@ -175,7 +158,7 @@ def initialize(debug=False, skip_update=False):
             # Reset the enabled plugins to the defaults
             # This needs to be run before dbbackup because
             # dbbackup relies on settings.INSTALLED_APPS
-            enable_default_plugins()
+            config.enable_default_plugins()
 
         if should_back_up(kolibri.__version__, version):
             # Version changed, make a backup no matter what.
@@ -238,9 +221,7 @@ def _first_run():
     if not SKIP_AUTO_DATABASE_MIGRATION:
         _migrate_databases()
 
-    from .conf import enable_default_plugins
-
-    enable_default_plugins()
+    config.enable_default_plugins()
 
     logger.info("Automatically enabling applications.")
 
@@ -288,7 +269,7 @@ def start(port=None, daemon=True):
     :param: port: Port number (default: 8080)
     :param: daemon: Fork to background process (default: True)
     """
-    run_cherrypy = conf.OPTIONS["Server"]["CHERRYPY_START"]
+    run_cherrypy = OPTIONS["Server"]["CHERRYPY_START"]
 
     # In case some tests run start() function only
     if not isinstance(port, int):
@@ -346,7 +327,7 @@ def stop():
         pid, __, __ = server.get_status()
         server.stop(pid=pid)
         stopped = True
-        if conf.OPTIONS["Server"]["CHERRYPY_START"]:
+        if OPTIONS["Server"]["CHERRYPY_START"]:
             logger.info("Kolibri server has successfully been stopped.")
         else:
             logger.info("Kolibri background services have successfully been stopped.")
@@ -458,7 +439,7 @@ def setup_logging(debug=False):
     fail when debug=False, but if it's true it can fail?
     """
     try:
-        from django.conf.settings import LOGGING
+        from django.settings import LOGGING
     except ImportError:
         from kolibri.deployment.default.settings.base import LOGGING
     if debug:
@@ -488,94 +469,20 @@ def manage(cmd, args=[]):
     execute_from_command_line(argv=argv)
 
 
-def _is_plugin(obj):
-    from kolibri.plugins.base import KolibriPluginBase  # NOQA
-
-    return (
-        isinstance(obj, type)
-        and obj is not KolibriPluginBase
-        and issubclass(obj, KolibriPluginBase)
-    )
-
-
-def get_kolibri_plugin(plugin_name):
-    """
-    Try to load kolibri_plugin from given plugin module identifier
-
-    :returns: A list of classes inheriting from KolibriPluginBase
-    """
-
-    plugin_classes = []
-
-    try:
-        plugin_module = importlib.import_module(plugin_name + ".kolibri_plugin")
-        for obj in plugin_module.__dict__.values():
-            if _is_plugin(obj):
-                plugin_classes.append(obj)
-    except ImportError as e:
-        # Python 2: message, Python 3: msg
-        exc_message = getattr(e, "message", getattr(e, "msg", None))
-        if exc_message.startswith("No module named"):
-            msg = (
-                "Plugin '{}' does not seem to exist. Is it on the PYTHONPATH?"
-            ).format(plugin_name)
-            raise PluginDoesNotExist(msg)
-        else:
-            raise
-    except AppRegistryNotReady:
-        msg = (
-            "Plugin '{}' loads the Django app registry, which it isn't "
-            "allowed to do while enabling or disabling itself."
-        ).format(plugin_name)
-        raise PluginBaseLoadsApp(msg)
-
-    if not plugin_classes:
-        # There's no clear use case for a plugin without a KolibriPluginBase
-        # inheritor, for now just throw a warning
-        logger.warning(
-            "Plugin '{}' has no KolibriPluginBase defined".format(plugin_name)
-        )
-
-    return plugin_classes
-
-
 def plugin(plugin_name, **kwargs):
     """
     Receives a plugin identifier and tries to load its main class. Calls class
     functions.
     """
-    from kolibri.utils import conf
-
     if kwargs.get("enable", False):
         logger.info("Enabling Kolibri plugin {}.".format(plugin_name))
-        plugin_classes = get_kolibri_plugin(plugin_name)
-        for klass in plugin_classes:
-            klass.enable()
+        enable_plugin(plugin_name)
 
     if kwargs.get("disable", False):
-        try:
-            logger.info("Disabling Kolibri plugin {}.".format(plugin_name))
-            plugin_classes = get_kolibri_plugin(plugin_name)
-            for klass in plugin_classes:
-                klass.disable()
-        except PluginDoesNotExist as e:
-            logger.error(str(e))
-            logger.warning(
-                "Removing '{}' from configuration in a naive way.".format(plugin_name)
-            )
-            if plugin_name in conf.config["INSTALLED_APPS"]:
-                conf.config["INSTALLED_APPS"].remove(plugin_name)
-                logger.info("Removed '{}' from INSTALLED_APPS".format(plugin_name))
-            else:
-                logger.warning(
-                    (
-                        "Could not find any matches for {} in INSTALLED_APPS".format(
-                            plugin_name
-                        )
-                    )
-                )
+        logger.info("Disabling Kolibri plugin {}.".format(plugin_name))
+        disable_plugin(plugin_name)
 
-    conf.save()
+    config.save()
 
 
 def set_default_language(lang):
@@ -584,7 +491,6 @@ def set_default_language(lang):
     instance of Kolibri needs to be restarted in order for this change to work.
     """
 
-    from kolibri.utils import conf
     from django.conf import settings
 
     valid_languages = [l[0] for l in settings.LANGUAGES]
@@ -595,8 +501,8 @@ def set_default_language(lang):
                 lang
             )
         )
-        conf.config["LANGUAGE_CODE"] = lang
-        conf.save()
+        config["LANGUAGE_CODE"] = lang
+        config.save()
     else:
         msg = "Invalid language code {langcode}. Must be one of: {validlangs}".format(
             langcode=lang, validlangs=valid_languages

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -108,7 +108,7 @@ class ConfigDict(dict):
                     self.update(json.load(kolibri_conf_file))
                 return
             except json.JSONDecodeError:
-                pass
+                logger.warn("Attempted to load kolibri_settings.json but encountered a file that could not be decoded as valid JSON.")
         logger.info("Initialize kolibri_settings.json..")
         self.save()
 

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -108,7 +108,9 @@ class ConfigDict(dict):
                     self.update(json.load(kolibri_conf_file))
                 return
             except json.JSONDecodeError:
-                logger.warn("Attempted to load kolibri_settings.json but encountered a file that could not be decoded as valid JSON.")
+                logger.warn(
+                    "Attempted to load kolibri_settings.json but encountered a file that could not be decoded as valid JSON."
+                )
         logger.info("Initialize kolibri_settings.json..")
         self.save()
 

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -52,8 +52,6 @@ LOG_ROOT = os.path.join(KOLIBRI_HOME, "logs")
 if not os.path.exists(LOG_ROOT):
     os.mkdir(LOG_ROOT)
 
-#: Set defaults before updating the dict
-config = {}
 
 try:
     # The default list for this is populated from build_tools/default_plugins.txt
@@ -80,92 +78,125 @@ except ImportError:
         "kolibri.plugins.default_theme",
     ]
 
-#: Everything in this list is added to django.conf.settings.INSTALLED_APPS
-config["INSTALLED_APPS"] = DEFAULT_PLUGINS
-
-#: Well-known plugin names that are automatically searched for and enabled on
-#: first-run.
-config["AUTO_SEARCH_PLUGINS"] = []
-
-#: If a config file does not exist, we assume it's the first run
-config["FIRST_RUN"] = True
-
 conf_file = os.path.join(KOLIBRI_HOME, "kolibri_settings.json")
 
 
-def update(new_values):
-    """
-    Updates current configuration with ``new_values``. Does not save to file.
-    """
-    config.update(new_values)
+# These values are encoded on the config dict as sets
+# so they need to be treated specially for serialization
+# and deserialization to/from JSON
+SET_KEYS = ["INSTALLED_APPS", "DISABLED_APPS"]
 
 
-def save(first_run=False):
-    """Saves the current state of the configuration"""
-    config["FIRST_RUN"] = first_run
-    # use default OS encoding
-    with open(conf_file, "w") as kolibri_conf_file:
-        json.dump(config, kolibri_conf_file, indent=2, sort_keys=True)
+class ConfigDict(dict):
+
+    def __init__(self):
+        if os.path.isfile(conf_file):
+            try:
+                # Open up the config file and load settings
+                # use default OS encoding
+                with open(conf_file, "r") as kolibri_conf_file:
+                    self.update(json.load(kolibri_conf_file))
+                return
+            except json.JSONDecodeError:
+                pass
+        # If the settings file does not exist or does not contain
+        # valid JSON then create it
+        logger.info("Initialize kolibri_settings.json..")
+        self.update({
+            #: Everything in this list is added to django.conf.settings.INSTALLED_APPS
+            # except disabled ones below
+            "INSTALLED_APPS": DEFAULT_PLUGINS,
+            #: Everything in this list is removed from the list above
+            "DISABLED_APPS": []
+        })
+        self.save()
+
+    @property
+    def ACTIVE_PLUGINS(self):
+        return list(self["INSTALLED_APPS"] - self["DISABLED_APPS"])
+
+    def update(self, new_values):
+        """
+        Updates current configuration with ``new_values``. Does not save to file.
+        """
+        values_copy = new_values.copy()
+        for key in SET_KEYS:
+            if key in values_copy:
+                values_copy[key] = set(values_copy[key])
+        super(ConfigDict, self).update(values_copy)
+
+    def save(self):
+        # use default OS encoding
+        config_copy = self.copy()
+        for key in SET_KEYS:
+            if key in config_copy:
+                config_copy[key] = list(config_copy[key])
+        with open(conf_file, "w") as kolibri_conf_file:
+            json.dump(config_copy, kolibri_conf_file, indent=2, sort_keys=True)
+
+    def autoremove_unavailable_plugins(self):
+        """
+        Sanitize INSTALLED_APPS - something that should be done separately for all
+        build in plugins, but we should not auto-remove plugins that are actually
+        configured by the user or some other kind of hard dependency that should
+        make execution stop if not loadable.
+        """
+        changed = False
+        # Iterate over a copy of the set so that it is not modified during the loop
+        for module_path in self["INSTALLED_APPS"].copy():
+            if not module_exists(module_path):
+                self["INSTALLED_APPS"].remove(module_path)
+                logger.error(
+                    (
+                        "Plugin {mod} not found and disabled. To re-enable it, run:\n"
+                        "   $ kolibri plugin {mod} enable"
+                    ).format(mod=module_path)
+                )
+                changed = True
+        if changed:
+            self.save()
+
+    def enable_default_plugins(self):
+        """
+        Enable new plugins that have been added between versions
+        This will have the undesired side effect of reactivating
+        default plugins that have been explicitly disabled by a user,
+        in versions prior to the implementation of a plugin blacklist.
+        """
+        changed = False
+        for module_path in DEFAULT_PLUGINS:
+            if module_path not in self["INSTALLED_APPS"]:
+                self["INSTALLED_APPS"].add(module_path)
+                # Can be migrated to upgrade only logic
+                if module_path not in self["DISABLED_APPS"]:
+                    logger.warning(
+                        (
+                            "Default plugin {mod} not found in configuration. To re-disable it, run:\n"
+                            "   $ kolibri plugin {mod} disable"
+                        ).format(mod=module_path)
+                    )
+                changed = True
+
+        if changed:
+            self.save()
+
+    def enable_plugin(self, module_path):
+        self["INSTALLED_APPS"].add(module_path)
+        try:
+            self["DISABLED_APPS"].remove(module_path)
+        except KeyError:
+            pass
+
+    def disable_plugin(self, module_path):
+        self["DISABLED_APPS"].add(module_path)
+        try:
+            self["INSTALLED_APPS"].remove(module_path)
+        except KeyError:
+            pass
 
 
-if not os.path.isfile(conf_file):
-    logger.info("Initialize kolibri_settings.json..")
-    save(True)
-else:
-    # Open up the config file and overwrite defaults
-    # use default OS encoding
-    with open(conf_file, "r") as kolibri_conf_file:
-        config.update(json.load(kolibri_conf_file))
-
-
-def autoremove_unavailable_plugins():
-    """
-    Sanitize INSTALLED_APPS - something that should be done separately for all
-    build in plugins, but we should not auto-remove plugins that are actually
-    configured by the user or some other kind of hard dependency that should
-    make execution stop if not loadable.
-    """
-    global config
-    changed = False
-    # Iterate over a copy of the list so that it is not modified during the loop
-    for module_path in config["INSTALLED_APPS"][:]:
-        if not module_exists(module_path):
-            config["INSTALLED_APPS"].remove(module_path)
-            logger.error(
-                (
-                    "Plugin {mod} not found and disabled. To re-enable it, run:\n"
-                    "   $ kolibri plugin {mod} enable"
-                ).format(mod=module_path)
-            )
-            changed = True
-    if changed:
-        save()
-
-
-def enable_default_plugins():
-    """
-    Enable new plugins that have been added between versions
-    This will have the undesired side effect of reactivating
-    default plugins that have been explicitly disabled by a user.
-    However, until we add disabled plugins to a blacklist, this is
-    unavoidable.
-    """
-    global config
-    changed = False
-    for module_path in DEFAULT_PLUGINS:
-        if module_path not in config["INSTALLED_APPS"]:
-            config["INSTALLED_APPS"].append(module_path)
-            logger.warning(
-                (
-                    "Default plugin {mod} not found in configuration. To re-disable it, run:\n"
-                    "   $ kolibri plugin {mod} disable"
-                ).format(mod=module_path)
-            )
-            changed = True
-
-    if changed:
-        save()
-
+#: Set defaults before updating the dict
+config = ConfigDict()
 
 # read the config file options in here so they can be accessed from a standard location
 OPTIONS = read_options_file(KOLIBRI_HOME)

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -89,18 +89,8 @@ SET_KEYS = ["INSTALLED_APPS", "DISABLED_APPS"]
 
 class ConfigDict(dict):
     def __init__(self):
-        if os.path.isfile(conf_file):
-            try:
-                # Open up the config file and load settings
-                # use default OS encoding
-                with open(conf_file, "r") as kolibri_conf_file:
-                    self.update(json.load(kolibri_conf_file))
-                return
-            except json.JSONDecodeError:
-                pass
         # If the settings file does not exist or does not contain
         # valid JSON then create it
-        logger.info("Initialize kolibri_settings.json..")
         self.update(
             {
                 #: Everything in this list is added to django.conf.settings.INSTALLED_APPS
@@ -110,6 +100,16 @@ class ConfigDict(dict):
                 "DISABLED_APPS": [],
             }
         )
+        if os.path.isfile(conf_file):
+            try:
+                # Open up the config file and load settings
+                # use default OS encoding
+                with open(conf_file, "r") as kolibri_conf_file:
+                    self.update(json.load(kolibri_conf_file))
+                return
+            except json.JSONDecodeError:
+                pass
+        logger.info("Initialize kolibri_settings.json..")
         self.save()
 
     @property

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -88,7 +88,6 @@ SET_KEYS = ["INSTALLED_APPS", "DISABLED_APPS"]
 
 
 class ConfigDict(dict):
-
     def __init__(self):
         if os.path.isfile(conf_file):
             try:
@@ -102,13 +101,15 @@ class ConfigDict(dict):
         # If the settings file does not exist or does not contain
         # valid JSON then create it
         logger.info("Initialize kolibri_settings.json..")
-        self.update({
-            #: Everything in this list is added to django.conf.settings.INSTALLED_APPS
-            # except disabled ones below
-            "INSTALLED_APPS": DEFAULT_PLUGINS,
-            #: Everything in this list is removed from the list above
-            "DISABLED_APPS": []
-        })
+        self.update(
+            {
+                #: Everything in this list is added to django.conf.settings.INSTALLED_APPS
+                # except disabled ones below
+                "INSTALLED_APPS": DEFAULT_PLUGINS,
+                #: Everything in this list is removed from the list above
+                "DISABLED_APPS": [],
+            }
+        )
         self.save()
 
     @property


### PR DESCRIPTION
### Summary
Adds a blacklist for plugins, so that plugins that are deliberately disabled can stay disabled, even on upgrade.

### Reviewer guidance
1) To test, disable a core plugin:
`kolibri plugin kolibri.plugins.learn disable`
2) Start the server.
3) Verify that learn is now not available on the kolibri server.
4) Stop the server.
4) Then enter the shell (`kolibri shell`) and enter the following:
```
from kolibri.utils.conf import config
config.enable_default_plugins()
```
5) Start the server.
6) Verify that learn is still not available on the kolibri server.

### References
Fixes #5633

Will do additional cleanup of some of this logic when rebasing #5494.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
