### PR TITLE
Implement permalinking scheme for content.

### DIFF
--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -18,6 +18,7 @@ from django.utils.safestring import mark_safe
 from le_utils.constants import content_kinds
 
 from kolibri.core.webpack.hooks import WebpackBundleHook
+from kolibri.plugins.hooks import KolibriHook
 from kolibri.utils import conf
 
 logger = logging.getLogger(__name__)
@@ -108,3 +109,17 @@ class ContentRendererHook(WebpackBundleHook):
             )
         ]
         return mark_safe("\n".join(tags))
+
+
+class ContentNodeDisplayHook(KolibriHook):
+    """
+    A hook that registers a capability of a plugin to provide a user interface
+    for a content node. When subclassed, this hook should expose a method that
+    accepts a ContentNode instance as an argument, and returns a URL where the
+    interface to interacting with that node for the user is exposed.
+    If this plugin cannot produce an interface for this particular content node
+    then it may return None.
+    """
+
+    def node_url(self, content_node):
+        raise NotImplementedError("This must be overridden by a subclass")

--- a/kolibri/core/content/test/test_redirectcontent.py
+++ b/kolibri/core/content/test/test_redirectcontent.py
@@ -1,0 +1,100 @@
+import uuid
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from mock import patch
+from six.moves.urllib.parse import urlencode
+
+from kolibri.core.content.models import ContentNode
+
+
+class RedirectContentTestCase(TestCase):
+    """
+    Testcase for viewcontent endpoint
+    """
+
+    fixtures = ["content_test.json"]
+    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+
+    def _get_url(self, **kwargs):
+        url = reverse("kolibri:core:contentpermalink")
+        if any(kwargs.values()):
+            url += "?"
+            url += urlencode({k: v for k, v in kwargs.items() if v is not None})
+        return url
+
+    def test_no_params_404(self):
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 404)
+
+    def test_node_id_only_valid(self):
+        node_id = ContentNode.objects.first().id
+        response = self.client.get(self._get_url(node_id=node_id))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        self.assertTrue(node_id in response.url)
+
+    def test_node_id_only_invalid(self):
+        response = self.client.get(self._get_url(node_id="rubbish"))
+        self.assertEqual(response.status_code, 404)
+
+    def test_node_id_and_content_id_valid(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id=node.id, content_id=node.content_id))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_and_content_id_and_channel_id_valid(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id=node.id, content_id=node.content_id, channel_id=node.channel_id))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_missing_and_content_id_and_channel_id_valid(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=node.content_id, channel_id=node.channel_id))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        # Can make this assertion because this node is unique
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_missing_and_content_id_valid_and_channel_id_missing(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=node.content_id, channel_id=uuid.uuid4().hex))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        # Can make this assertion because this node is unique
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_missing_and_content_id_missing_and_channel_id_missing(self):
+        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex))
+        self.assertEqual(response.status_code, 404)
+
+    def test_node_id_invalid_and_content_id_and_channel_id_valid(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id="rubbish", content_id=node.content_id, channel_id=node.channel_id))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        # Can make this assertion because this node is unique
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_invalid_and_content_id_valid_and_channel_id_invalid(self):
+        node = ContentNode.objects.first()
+        response = self.client.get(self._get_url(node_id="rubbish", content_id=node.content_id, channel_id="rubbish"))
+        self.assertEqual(response.status_code, 302)
+        # This is true for our default learn urls for now.
+        # Can make this assertion because this node is unique
+        self.assertTrue(node.id in response.url)
+
+    def test_node_id_invalid_and_content_id_invalid_and_channel_id_invalid(self):
+        response = self.client.get(self._get_url(node_id="rubbish", content_id="rubbish", channel_id="rubbish"))
+        self.assertEqual(response.status_code, 404)
+
+    def test_node_id_only_valid_no_hooks_404(self):
+        node_id = ContentNode.objects.first().id
+        with patch("kolibri.core.content.views.ContentNodeDisplayHook") as hook_mock:
+            hook_mock.registered_hooks.return_value = []
+            response = self.client.get(self._get_url(node_id=node_id))
+            self.assertEqual(response.status_code, 404)

--- a/kolibri/core/content/test/test_redirectcontent.py
+++ b/kolibri/core/content/test/test_redirectcontent.py
@@ -40,21 +40,33 @@ class RedirectContentTestCase(TestCase):
 
     def test_node_id_and_content_id_valid(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id=node.id, content_id=node.content_id))
+        response = self.client.get(
+            self._get_url(node_id=node.id, content_id=node.content_id)
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         self.assertTrue(node.id in response.url)
 
     def test_node_id_and_content_id_and_channel_id_valid(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id=node.id, content_id=node.content_id, channel_id=node.channel_id))
+        response = self.client.get(
+            self._get_url(
+                node_id=node.id, content_id=node.content_id, channel_id=node.channel_id
+            )
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         self.assertTrue(node.id in response.url)
 
     def test_node_id_missing_and_content_id_and_channel_id_valid(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=node.content_id, channel_id=node.channel_id))
+        response = self.client.get(
+            self._get_url(
+                node_id=uuid.uuid4().hex,
+                content_id=node.content_id,
+                channel_id=node.channel_id,
+            )
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
@@ -62,19 +74,37 @@ class RedirectContentTestCase(TestCase):
 
     def test_node_id_missing_and_content_id_valid_and_channel_id_missing(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=node.content_id, channel_id=uuid.uuid4().hex))
+        response = self.client.get(
+            self._get_url(
+                node_id=uuid.uuid4().hex,
+                content_id=node.content_id,
+                channel_id=uuid.uuid4().hex,
+            )
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
         self.assertTrue(node.id in response.url)
 
     def test_node_id_missing_and_content_id_missing_and_channel_id_missing(self):
-        response = self.client.get(self._get_url(node_id=uuid.uuid4().hex, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex))
+        response = self.client.get(
+            self._get_url(
+                node_id=uuid.uuid4().hex,
+                content_id=uuid.uuid4().hex,
+                channel_id=uuid.uuid4().hex,
+            )
+        )
         self.assertEqual(response.status_code, 404)
 
     def test_node_id_invalid_and_content_id_and_channel_id_valid(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id="rubbish", content_id=node.content_id, channel_id=node.channel_id))
+        response = self.client.get(
+            self._get_url(
+                node_id="rubbish",
+                content_id=node.content_id,
+                channel_id=node.channel_id,
+            )
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
@@ -82,14 +112,20 @@ class RedirectContentTestCase(TestCase):
 
     def test_node_id_invalid_and_content_id_valid_and_channel_id_invalid(self):
         node = ContentNode.objects.first()
-        response = self.client.get(self._get_url(node_id="rubbish", content_id=node.content_id, channel_id="rubbish"))
+        response = self.client.get(
+            self._get_url(
+                node_id="rubbish", content_id=node.content_id, channel_id="rubbish"
+            )
+        )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
         self.assertTrue(node.id in response.url)
 
     def test_node_id_invalid_and_content_id_invalid_and_channel_id_invalid(self):
-        response = self.client.get(self._get_url(node_id="rubbish", content_id="rubbish", channel_id="rubbish"))
+        response = self.client.get(
+            self._get_url(node_id="rubbish", content_id="rubbish", channel_id="rubbish")
+        )
         self.assertEqual(response.status_code, 404)
 
     def test_node_id_only_valid_no_hooks_404(self):

--- a/kolibri/core/content/urls.py
+++ b/kolibri/core/content/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 
+from .views import ContentPermalinkRedirect
 from .views import DownloadContentView
 from .views import ZipContentView
 
@@ -16,4 +17,5 @@ urlpatterns = [
         {},
         "downloadcontent",
     ),
+    url(r"^viewcontent$", ContentPermalinkRedirect.as_view(), name="contentpermalink"),
 ]

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.http import Http404
 from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 from django.http.response import FileResponse
 from django.http.response import HttpResponseNotModified
 from django.template import loader
@@ -30,9 +31,11 @@ from six.moves.urllib.parse import urlunparse
 from .api import cache_forever
 from .decorators import add_security_headers
 from .decorators import get_referrer_url
+from .models import ContentNode
 from .utils.paths import get_content_storage_file_path
 from kolibri import __version__ as kolibri_version
 from kolibri.core.content.errors import InvalidStorageFilenameError
+from kolibri.core.content.hooks import ContentNodeDisplayHook
 
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
 # https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
@@ -319,3 +322,33 @@ class DownloadContentView(View):
         response["Content-Length"] = os.path.getsize(path)
 
         return response
+
+
+class ContentPermalinkRedirect(View):
+    def get(self, request, *args, **kwargs):
+
+        # extract the GET parameters
+        channel_id = request.GET.get("channel_id")
+        node_id = request.GET.get("node_id")
+        content_id = request.GET.get("content_id")
+
+        try:  # first, try to get the node by the unique node_id
+            node = ContentNode.objects.get(id=node_id)
+        except ContentNode.DoesNotExist:  # if it isn't found, fall back to looking for the content_id in the channel
+            node = ContentNode.objects.filter(
+                channel_id=channel_id, content_id=content_id
+            ).first()
+            if (
+                not node
+            ):  # if it's still not found, see if we can find anything with the content_id across any channel
+                node = ContentNode.objects.filter(content_id=content_id).first()
+
+        # build up the target topic/content page URL
+        if node:
+            url = None
+            for hook in ContentNodeDisplayHook().registered_hooks:
+                url = hook.node_url(node)
+            if url:
+                return HttpResponseRedirect(url)
+
+        raise Http404

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -2,8 +2,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.urls import reverse
+
 from . import hooks
 from kolibri.core.auth.constants.user_kinds import LEARNER
+from kolibri.core.content.hooks import ContentNodeDisplayHook
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack import hooks as webpack_hooks
@@ -34,3 +37,16 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 
 class LearnInclusionHook(hooks.LearnSyncHook):
     bundle_class = LearnAsset
+
+
+class LearnContentNodeHook(ContentNodeDisplayHook):
+    def node_url(self, node):
+        kind_slug = None
+        if not node.parent:
+            kind_slug = ""
+        elif node.kind == "topic":
+            kind_slug = "t/"
+        else:
+            kind_slug = "c/"
+        if kind_slug is not None:
+            return reverse("kolibri:learn:learn") + "#/topics/" + kind_slug + node.id


### PR DESCRIPTION
### Summary
Implements a permalinking scheme for content.
Sets up a hook for the learn plugin to redirect based on permalinks.

### Reviewer guidance
These links will be permanent, so we don't want to change them. How does this look?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
