### PR TITLE
Add pagination to Facility Users table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 List of the most important changes for each release.
 
+## 0.12.6
+
+### Changed or Fixed
+
+- Facility user table is now paginated to improve performance for facilities with large numbers of users.
+
 ## 0.12.4
 
 ### Changed or fixed

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
@@ -21,7 +21,7 @@
     />
 
     <nav>
-      <span>
+      <span dir="auto" class="pagination-label">
         {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredUsers }) }}
       </span>
       <UiIconButton
@@ -29,6 +29,8 @@
         :ariaLabel="$tr('previousResults')"
         :disabled="pageNum === 1"
         size="small"
+        :dir="isRtl ? 'rtl' : 'ltr'"
+        class="pagination-button"
         @click="goToPage(pageNum - 1)"
       >
         <mat-svg
@@ -47,6 +49,8 @@
         :ariaLabel="$tr('nextResults')"
         :disabled="pageNum === 0 || pageNum === numPages"
         size="small"
+        :dir="isRtl ? 'rtl' : 'ltr'"
+        class="pagination-button"
         @click="goToPage(pageNum + 1)"
       >
         <mat-svg
@@ -194,7 +198,13 @@
   .actions-header,
   .footer,
   nav {
-    text-align: right;
+    text-align: end;
+  }
+  .pagination-button[dir='ltr'] {
+    margin-left: 8px;
+  }
+  .pagination-button[dir='rtl'] {
+    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/ClassEnrollForm.vue
@@ -29,40 +29,20 @@
         :ariaLabel="$tr('previousResults')"
         :disabled="pageNum === 1"
         size="small"
-        :dir="isRtl ? 'rtl' : 'ltr'"
         class="pagination-button"
         @click="goToPage(pageNum - 1)"
       >
-        <mat-svg
-          v-if="isRtl"
-          name="chevron_right"
-          category="navigation"
-        />
-        <mat-svg
-          v-else
-          name="chevron_left"
-          category="navigation"
-        />
+        <KIcon back style="position: relative; top: -1px;" />
       </UiIconButton>
       <UiIconButton
         type="primary"
         :ariaLabel="$tr('nextResults')"
         :disabled="pageNum === 0 || pageNum === numPages"
         size="small"
-        :dir="isRtl ? 'rtl' : 'ltr'"
         class="pagination-button"
         @click="goToPage(pageNum + 1)"
       >
-        <mat-svg
-          v-if="isRtl"
-          name="chevron_left"
-          category="navigation"
-        />
-        <mat-svg
-          v-else
-          name="chevron_right"
-          category="navigation"
-        />
+        <KIcon forward style="position: relative; top: -1px;" />
       </UiIconButton>
     </nav>
 
@@ -87,6 +67,7 @@
   import KButton from 'kolibri.coreVue.components.KButton';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import KFilterTextbox from 'kolibri.coreVue.components.KFilterTextbox';
+  import KIcon from 'kolibri.coreVue.components.KIcon';
   import { userMatchesFilter, filterAndSortUsers } from '../userSearchUtils';
   import UserTable from './UserTable';
 
@@ -94,6 +75,7 @@
     name: 'ClassEnrollForm',
     components: {
       KButton,
+      KIcon,
       UiIconButton,
       KFilterTextbox,
       UserTable,
@@ -200,11 +182,8 @@
   nav {
     text-align: end;
   }
-  .pagination-button[dir='ltr'] {
+  .pagination-button {
     margin-left: 8px;
-  }
-  .pagination-button[dir='rtl'] {
-    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -241,6 +241,13 @@
         return this.isSuperuser || !user.is_superuser;
       },
     },
+    watch: {
+      searchFilter() {
+        // Reset the pageNum to the first page when searchFilter changes
+        // to avoid showing an empty page.
+        this.pageNum = 1;
+      },
+    },
     $trs: {
       filterUserType: 'User type',
       searchText: 'Search for a user…',

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -196,6 +196,13 @@
         return this.sortedFilteredUsers.length;
       },
     },
+    watch: {
+      searchFilter() {
+        // Reset the pageNum to the first page when searchFilter changes
+        // to avoid showing an empty page.
+        this.pageNum = 1;
+      },
+    },
     beforeMount() {
       this.roleFilter = this.userKinds[0];
     },
@@ -239,13 +246,6 @@
         // If logged-in user is a superuser, then they can edit anybody (including other SUs).
         // Otherwise, only non-SUs can be edited.
         return this.isSuperuser || !user.is_superuser;
-      },
-    },
-    watch: {
-      searchFilter() {
-        // Reset the pageNum to the first page when searchFilter changes
-        // to avoid showing an empty page.
-        this.pageNum = 1;
       },
     },
     $trs: {
@@ -302,7 +302,7 @@
   .actions-header,
   .footer,
   nav {
-    text-align: right;
+    text-align: end;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -44,12 +44,16 @@
     </UserTable>
 
     <nav>
-      <span>{{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredUsers }) }}</span>
+      <span dir="auto">
+        {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredUsers }) }}
+      </span>
       <UiIconButton
         type="primary"
         :ariaLabel="$tr('previousResults')"
         :disabled="pageNum === 1"
         size="small"
+        class="pagination-button"
+        :dir="isRtl ? 'rtl' : 'ltr'"
         @click="goToPage(pageNum - 1)"
       >
         <mat-svg v-if="isRtl" name="chevron_right" category="navigation" />
@@ -60,6 +64,8 @@
         :ariaLabel="$tr('nextResults')"
         :disabled="pageNum === 0 || pageNum === numPages"
         size="small"
+        class="pagination-button"
+        :dir="isRtl ? 'rtl' : 'ltr'"
         @click="goToPage(pageNum + 1)"
       >
         <mat-svg v-if="isRtl" name="chevron_left" category="navigation" />
@@ -303,6 +309,12 @@
   .footer,
   nav {
     text-align: end;
+  }
+  .pagination-button[dir='ltr'] {
+    margin-left: 8px;
+  }
+  .pagination-button[dir='rtl'] {
+    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -53,11 +53,9 @@
         :disabled="pageNum === 1"
         size="small"
         class="pagination-button"
-        :dir="isRtl ? 'rtl' : 'ltr'"
         @click="goToPage(pageNum - 1)"
       >
-        <mat-svg v-if="isRtl" name="chevron_right" category="navigation" />
-        <mat-svg v-else name="chevron_left" category="navigation" />
+        <KIcon back style="position: relative; top: -1px;" />
       </UiIconButton>
       <UiIconButton
         type="primary"
@@ -65,11 +63,9 @@
         :disabled="pageNum === 0 || pageNum === numPages"
         size="small"
         class="pagination-button"
-        :dir="isRtl ? 'rtl' : 'ltr'"
         @click="goToPage(pageNum + 1)"
       >
-        <mat-svg v-if="isRtl" name="chevron_left" category="navigation" />
-        <mat-svg v-else name="chevron_right" category="navigation" />
+        <KIcon forward style="position: relative; top: -1px;" />
       </UiIconButton>
     </nav>
 
@@ -113,6 +109,7 @@
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import KIcon from 'kolibri.coreVue.components.KIcon';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import UserTable from '../UserTable';
   import { Modals } from '../../constants';
@@ -139,6 +136,7 @@
       KButton,
       KFilterTextbox,
       KDropdownMenu,
+      KIcon,
       KSelect,
       KGrid,
       KGridItem,
@@ -310,11 +308,8 @@
   nav {
     text-align: end;
   }
-  .pagination-button[dir='ltr'] {
+  .pagination-button {
     margin-left: 8px;
-  }
-  .pagination-button[dir='rtl'] {
-    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserPage/index.vue
@@ -1,7 +1,6 @@
 <template>
 
   <div>
-
     <KGrid>
       <KGridItem sizes="100, 50, 50" percentage>
         <h1>{{ $tr('users') }}</h1>
@@ -32,11 +31,7 @@
       </KGridItem>
     </KGrid>
 
-    <UserTable
-      class="user-roster move-down"
-      :users="visibleUsers"
-      :emptyMessage="emptyMessage"
-    >
+    <UserTable class="user-roster move-down" :users="visibleUsers" :emptyMessage="emptyMessage">
       <template slot="action" slot-scope="userRow">
         <KDropdownMenu
           :text="$tr('optionsButtonLabel')"
@@ -48,11 +43,32 @@
       </template>
     </UserTable>
 
+    <nav>
+      <span>{{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredUsers }) }}</span>
+      <UiIconButton
+        type="primary"
+        :ariaLabel="$tr('previousResults')"
+        :disabled="pageNum === 1"
+        size="small"
+        @click="goToPage(pageNum - 1)"
+      >
+        <mat-svg v-if="isRtl" name="chevron_right" category="navigation" />
+        <mat-svg v-else name="chevron_left" category="navigation" />
+      </UiIconButton>
+      <UiIconButton
+        type="primary"
+        :ariaLabel="$tr('nextResults')"
+        :disabled="pageNum === 0 || pageNum === numPages"
+        size="small"
+        @click="goToPage(pageNum + 1)"
+      >
+        <mat-svg v-if="isRtl" name="chevron_left" category="navigation" />
+        <mat-svg v-else name="chevron_right" category="navigation" />
+      </UiIconButton>
+    </nav>
+
     <!-- Modals -->
-    <UserCreateModal
-      v-if="modalShown===Modals.CREATE_USER"
-      @cancel="closeModal"
-    />
+    <UserCreateModal v-if="modalShown===Modals.CREATE_USER" @cancel="closeModal" />
 
     <EditUserModal
       v-if="modalShown===Modals.EDIT_USER"
@@ -76,7 +92,6 @@
       :username="selectedUser.username"
       @cancel="closeModal"
     />
-
   </div>
 
 </template>
@@ -92,6 +107,7 @@
   import KSelect from 'kolibri.coreVue.components.KSelect';
   import KGrid from 'kolibri.coreVue.components.KGrid';
   import KGridItem from 'kolibri.coreVue.components.KGridItem';
+  import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import UserTable from '../UserTable';
   import { Modals } from '../../constants';
   import { userMatchesFilter, filterAndSortUsers } from '../../userSearchUtils';
@@ -121,12 +137,15 @@
       KGrid,
       KGridItem,
       UserTable,
+      UiIconButton,
     },
     data() {
       return {
         searchFilter: '',
         roleFilter: null,
         selectedUser: null,
+        perPage: 10,
+        pageNum: 1,
       };
     },
     computed: {
@@ -141,11 +160,14 @@
           { label: this.$tr('admins'), value: UserKinds.ADMIN },
         ];
       },
-      visibleUsers() {
+      sortedFilteredUsers() {
         return filterAndSortUsers(
           this.facilityUsers,
           user => userMatchesFilter(user, this.searchFilter) && this.userMatchesRole(user)
         );
+      },
+      visibleUsers() {
+        return this.sortedFilteredUsers.slice(this.startRange, this.endRange);
       },
       emptyMessage() {
         if (this.facilityUsers.length === 0) {
@@ -154,6 +176,24 @@
           return this.$tr('allUsersFilteredOut');
         }
         return '';
+      },
+      numPages() {
+        return Math.ceil(this.numFilteredUsers / this.perPage);
+      },
+      startRange() {
+        return (this.pageNum - 1) * this.perPage;
+      },
+      visibleStartRange() {
+        return Math.min(this.startRange + 1, this.numFilteredUsers);
+      },
+      endRange() {
+        return this.pageNum * this.perPage;
+      },
+      visibleEndRange() {
+        return Math.min(this.endRange, this.numFilteredUsers);
+      },
+      numFilteredUsers() {
+        return this.sortedFilteredUsers.length;
       },
     },
     beforeMount() {
@@ -188,6 +228,9 @@
           },
         ];
       },
+      goToPage(page) {
+        this.pageNum = page;
+      },
       handleManageUserSelection(selection, user) {
         this.selectedUser = user;
         this.displayModal(selection.value);
@@ -220,6 +263,10 @@
       deleteUser: 'Delete',
       userActions: 'User management actions',
       userPageTitle: 'Users',
+      pagination:
+        '{ visibleStartRange, number } - { visibleEndRange, number } of { numFilteredUsers, number }',
+      previousResults: 'Previous results',
+      nextResults: 'Next results',
     },
   };
 
@@ -244,6 +291,11 @@
 
   .user-roster {
     overflow-x: auto;
+  }
+  .actions-header,
+  .footer,
+  nav {
+    text-align: right;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Added pagination to the Facility > Users page to improve performance with a large number of users. See https://github.com/learningequality/kolibri/issues/5563 for some background.

**Before**
![pagination-before](https://user-images.githubusercontent.com/6356129/59232242-80944000-8b98-11e9-95cd-5dc5d3c0ff1c.png)

**After**
![pagination-after](https://user-images.githubusercontent.com/6356129/59232248-8722b780-8b98-11e9-9e37-8c1f275e6858.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Add a bunch of users to your installation. I did it in the kolibri shell - import `kolibri.core.auth.models` and add a bunch of FacilityUsers.
2. On the target branch, log in and go to Facility > Users and see the table take a long time to load. 
3. Try filtering - see the time it takes to re-render.

Now, checkout this branch... see the pagination. See how the page loads much more quickly. There may still be a smidge of delay between typing and seeing the filtered results.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Ref: https://github.com/learningequality/kolibri/issues/5563

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
