### PR TITLE
Add pycompile in Travis matrix for Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,11 +110,10 @@ before_script:
 # command to run tests
 script:
   # Get static deps in order to try and compile them all for Python 3
-  - make staticdeps
+  - SKIP_PY_CHECK=1 make staticdeps
   # Ensures that we can compile all source code files in this Python 3+ version
   # This behavior is disabled in the 'include' matrix above for Python 2.7
-  - python -m compileall -x py2only kolibri -q
-  - python --version
+  - make staticdeps-compileall
   - tox -e $TOX_ENV
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,8 @@ script:
   # Ensures that we can compile all source code files in this Python 3+ version
   # This behavior is disabled in the 'include' matrix above for Python 2.7
   - make staticdeps-compileall
+  # Remove staticdeps again, so they are not part of tox
+  - make clean-staticdeps
   - tox -e $TOX_ENV
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ before_script:
 
 # command to run tests
 script:
+  # Get static deps in order to try and compile them all for Python 3
+  - make staticdeps
   # Ensures that we can compile all source code files in this Python 3+ version
   # This behavior is disabled in the 'include' matrix above for Python 2.7
   - python -m compileall -x py2only kolibri -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
     - python: "3.5"
       env:
         - TOX_ENV=docs
+      script:
+       - tox -e $TOX_ENV
     - python: "3.4"
       env:
         - TOX_ENV=py3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint2
+      script:
+       - tox -e $TOX_ENV
     - python: "3.6"
       env:
         - TOX_ENV=pythonlint3
@@ -32,9 +34,13 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=licenses
+      script:
+       - tox -e $TOX_ENV
     - python: "2.7"
       env:
         - TOX_ENV=py2.7
+      script:
+       - tox -e $TOX_ENV
     - python: "3.5"
       env:
         - TOX_ENV=docs
@@ -55,12 +61,16 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=node10.x
+      script:
+       - tox -e $TOX_ENV
     - python: "3.5"
       env:
         - TOX_ENV=postgres
     - python: "2.7"
       env:
         - TOX_ENV=frontendlint
+      script:
+       - tox -e $TOX_ENV
     - python: "2.7"
       env:
         - TOX_ENV=nocext
@@ -99,6 +109,10 @@ before_script:
 
 # command to run tests
 script:
+  # Ensures that we can compile all source code files in this Python 3+ version
+  # This behavior is disabled in the 'include' matrix above for Python 2.7
+  - python -m compileall -x py2only kolibri -q
+  - python --version
   - tox -e $TOX_ENV
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help:
 	@echo "i18n-install-font name=<noto-font>: Downloads and installs a new or updated font"
 
 
-clean: clean-build clean-pyc clean-assets
+clean: clean-build clean-pyc clean-assets clean-staticdeps
 
 clean-assets:
 	yarn run clean
@@ -127,10 +127,12 @@ test-namespaced-packages:
 	# https://github.com/learningequality/kolibri/pull/2972
 	! find kolibri/dist -mindepth 1 -maxdepth 1 -type d -not -name __pycache__ -not -name cext -not -name py2only -exec ls {}/__init__.py \; 2>&1 | grep  "No such file"
 
-staticdeps:
-	test "${SKIP_PY_CHECK}" = "1" || python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
+clean-staticdeps:
 	rm -rf kolibri/dist/* || true # remove everything
 	git checkout -- kolibri/dist # restore __init__.py
+
+staticdeps: clean-staticdeps
+	test "${SKIP_PY_CHECK}" = "1" || python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
 	pip2 install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -r kolibri/dist/man kolibri/dist/bin || true # remove the two folders introduced by pip 10

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ staticdeps:
 	test "${SKIP_PY_CHECK}" = "1" || python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
 	rm -rf kolibri/dist/* || true # remove everything
 	git checkout -- kolibri/dist # restore __init__.py
-	pip install -t kolibri/dist -r "requirements.txt"
+	pip2 install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -r kolibri/dist/man kolibri/dist/bin || true # remove the two folders introduced by pip 10
 	# Remove unnecessary python2-syntax'ed file
@@ -147,6 +147,11 @@ staticdeps-cext:
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -rf kolibri/dist/cext/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	make test-namespaced-packages
+
+staticdeps-compileall:
+	bash -c 'python --version'
+	# Seems like the compileall module does not return a non-zero exit code when failing
+	bash -c 'if ( python -m compileall -x py2only kolibri -q | grep SyntaxError ) ; then echo "Failed to compile kolibri/dist/" ; exit 1 ; else exit 0 ; fi'
 
 writeversion:
 	python -c "import kolibri; print(kolibri.__version__)" > kolibri/VERSION


### PR DESCRIPTION
### Summary

Try to add better upfront guarantees about ability to compile.

This was due to `async` keywords included in some bundled dependencies that broke on Python 3.4.

See:

https://docs.python.org/3/library/compileall.html

### Reviewer guidance

n/a

### References

https://github.com/learningequality/kolibri/issues/5646

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
