### PR TITLE
Add Html5 option to KIcon

### DIFF
--- a/kolibri/core/assets/src/views/icons/KIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KIcon.vue
@@ -24,6 +24,7 @@
   <mat-svg v-else-if="exercise" name="assignment" category="action" :style="style" />
   <mat-svg v-else-if="topic" name="folder" category="file" :style="style" />
   <mat-svg v-else-if="video" name="ondemand_video" category="notification" :style="style" />
+  <mat-svg v-else-if="html5" name="widgets" category="device" :style="style" />
   <!-- users -->
   <mat-svg v-else-if="classroom" name="business" category="communication" :style="style" />
   <mat-svg v-else-if="group" category="action" name="group_work" :style="style" />
@@ -90,6 +91,7 @@
       exercise: boolean,
       topic: boolean,
       video: boolean,
+      html5: boolean,
       // users
       classroom: boolean,
       group: boolean,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Adds a 'html5' prop to `KIcon`. Since it was missing, HTML5 apps were missing an icon next to their title in the `ContentPage`

### Reviewer guidance

Confirm that when viewing HTML5 apps as a learner, the correct icon appears next to the title.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
