### PR TITLE
Zeroconf-based Kolibri P2P discovery system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 	pip install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
+	rm -rf kolibri/dist/*.egg-info
 	rm -r kolibri/dist/man kolibri/dist/bin || true # remove the two folders introduced by pip 10
 	# Remove unnecessary python2-syntax'ed file
 	# https://github.com/learningequality/kolibri/issues/3152
@@ -145,6 +146,7 @@ staticdeps-cext:
 	pip install -t kolibri/dist/cext -r "requirements/cext_noarch.txt" --no-deps
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -rf kolibri/dist/cext/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
+	rm -rf kolibri/dist/*.egg-info
 	make test-namespaced-packages
 
 writeversion:

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -1,11 +1,21 @@
 from rest_framework import viewsets
+from rest_framework.response import Response
 
 from .models import NetworkLocation
 from .serializers import NetworkLocationSerializer
 from kolibri.core.content.permissions import CanManageContent
+from kolibri.core.device.permissions import UserHasAnyDevicePermissions
+from kolibri.core.discovery.utils.network.search import get_available_instances
 
 
 class NetworkLocationViewSet(viewsets.ModelViewSet):
     permission_classes = (CanManageContent,)
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.all()
+
+
+class NetworkSearchViewSet(viewsets.ViewSet):
+    permission_classes = (UserHasAnyDevicePermissions,)
+
+    def list(self, request):
+        return Response(get_available_instances())

--- a/kolibri/core/discovery/api_urls.py
+++ b/kolibri/core/discovery/api_urls.py
@@ -1,9 +1,11 @@
 from rest_framework import routers
 
 from .api import NetworkLocationViewSet
+from .api import NetworkSearchViewSet
 
 router = routers.SimpleRouter()
 
 router.register(r"networklocation", NetworkLocationViewSet, base_name="networklocation")
+router.register(r"networksearch", NetworkSearchViewSet, base_name="networksearch")
 
 urlpatterns = router.urls

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -115,6 +115,9 @@ class TestNetworkSearch(TestCase):
                 "port": MOCK_PORT,
                 "host": ".".join([MOCK_ID, LOCAL_DOMAIN]),
                 "data": {"facilities": [], "channels": []},
+                "base_url": "http://{ip}:{port}/".format(
+                    ip=MOCK_INTERFACE_IP, port=MOCK_PORT
+                ),
             }
         ]
         register_zeroconf_service(MOCK_PORT, MOCK_ID)

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,23 +1,22 @@
-import mock
 import socket
 
+import mock
 from django.test import TestCase
 from zeroconf import BadTypeInNameException
 from zeroconf import service_type_name
-from zeroconf import Zeroconf
 from zeroconf import ServiceInfo
+from zeroconf import Zeroconf
 
-from .helpers import mock_request
-from ..utils.network.search import SERVICE_TYPE
-from ..utils.network.search import LOCAL_DOMAIN
 from ..utils.network.search import _id_from_name
-from ..utils.network.search import register_zeroconf_service
-from ..utils.network.search import unregister_zeroconf_service
 from ..utils.network.search import get_available_instances
-from ..utils.network.search import ZEROCONF_STATE
 from ..utils.network.search import initialize_zeroconf_listener
 from ..utils.network.search import KolibriZeroconfService
+from ..utils.network.search import LOCAL_DOMAIN
 from ..utils.network.search import NonUniqueNameException
+from ..utils.network.search import register_zeroconf_service
+from ..utils.network.search import SERVICE_TYPE
+from ..utils.network.search import unregister_zeroconf_service
+from ..utils.network.search import ZEROCONF_STATE
 
 MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,0 +1,162 @@
+import mock
+import socket
+
+from django.test import TestCase
+from zeroconf import BadTypeInNameException
+from zeroconf import service_type_name
+from zeroconf import Zeroconf
+from zeroconf import ServiceInfo
+
+from .helpers import mock_request
+from ..utils.network.search import SERVICE_TYPE
+from ..utils.network.search import LOCAL_DOMAIN
+from ..utils.network.search import _id_from_name
+from ..utils.network.search import register_zeroconf_service
+from ..utils.network.search import unregister_zeroconf_service
+from ..utils.network.search import get_available_instances
+from ..utils.network.search import ZEROCONF_STATE
+from ..utils.network.search import initialize_zeroconf_listener
+from ..utils.network.search import KolibriZeroconfService
+from ..utils.network.search import NonUniqueNameException
+
+MOCK_INTERFACE_IP = "111.222.111.222"
+MOCK_PORT = 555
+MOCK_ID = "abba"
+
+
+class MockServiceBrowser(object):
+    def __init__(self, zc, type_, handlers=None, listener=None):
+        assert handlers or listener, "You need to specify at least one handler"
+        if not type_.endswith(service_type_name(type_)):
+            raise BadTypeInNameException
+        self.zc = zc
+        self.type = type_
+
+    def cancel(self):
+        self.zc.remove_listener(self)
+
+
+class MockZeroconf(Zeroconf):
+    def __init__(self, *args, **kwargs):
+        self.browsers = {}
+        self.services = {}
+
+    def get_service_info(self, type_, name, timeout=3000):
+        id = _id_from_name(name)
+        info = ServiceInfo(
+            SERVICE_TYPE,
+            name=".".join([id, SERVICE_TYPE]),
+            server=".".join([id, LOCAL_DOMAIN, ""]),
+            address=socket.inet_aton(MOCK_INTERFACE_IP),
+            port=MOCK_PORT,
+            properties={"facilities": "[]", "channels": "[]"},
+        )
+        return info
+
+    def add_service_listener(self, type_, listener):
+        self.remove_service_listener(listener)
+        self.browsers[listener] = MockServiceBrowser(self, type_, listener)
+        for info in self.services.values():
+            listener.add_service(self, info.type, info.name)
+
+    def register_service(self, info, ttl=60, allow_name_change=False):
+        self.check_service(info, allow_name_change)
+        self.services[info.name.lower()] = info
+        for listener in self.browsers:
+            listener.add_service(self, info.type, info.name)
+
+    def unregister_service(self, info):
+        for listener in self.browsers:
+            listener.remove_service(self, info.type, info.name)
+
+    def check_service(self, info, allow_name_change):
+        service_name = service_type_name(info.name)
+        if not info.type.endswith(service_name):
+            raise BadTypeInNameException
+
+        instance_name = info.name[: -len(service_name) - 1]
+        next_instance_number = 2
+
+        # check for a name conflict
+        while info.name.lower() in self.services:
+
+            if not allow_name_change:
+                raise NonUniqueNameException
+
+            # change the name and look for a conflict
+            info.name = "%s-%s.%s" % (instance_name, next_instance_number, info.type)
+            next_instance_number += 1
+            service_type_name(info.name)
+
+
+@mock.patch(
+    "kolibri.core.discovery.utils.network.search._is_port_open", lambda *a, **kw: True
+)
+@mock.patch("kolibri.core.discovery.utils.network.search.Zeroconf", MockZeroconf)
+@mock.patch(
+    "kolibri.core.discovery.utils.network.search.get_all_addresses",
+    lambda: [MOCK_INTERFACE_IP],
+)
+class TestNetworkSearch(TestCase):
+    def test_initialize_zeroconf_listener(self):
+        assert ZEROCONF_STATE["listener"] is None
+        initialize_zeroconf_listener()
+        assert ZEROCONF_STATE["listener"] is not None
+
+    def test_register_zeroconf_service(self):
+        assert len(get_available_instances()) == 0
+        initialize_zeroconf_listener()
+        register_zeroconf_service(MOCK_PORT, MOCK_ID)
+        assert get_available_instances() == [
+            {
+                "id": MOCK_ID,
+                "ip": MOCK_INTERFACE_IP,
+                "local": True,
+                "self": True,
+                "port": MOCK_PORT,
+                "host": ".".join([MOCK_ID, LOCAL_DOMAIN]),
+                "data": {"facilities": [], "channels": []},
+            }
+        ]
+        register_zeroconf_service(MOCK_PORT, MOCK_ID)
+        unregister_zeroconf_service()
+        assert len(get_available_instances()) == 0
+
+    def test_naming_conflict(self):
+        assert not ZEROCONF_STATE["listener"]
+        service1 = KolibriZeroconfService(id=MOCK_ID, port=MOCK_PORT)
+        service1.register()
+        assert len(get_available_instances()) == 1
+        service2 = KolibriZeroconfService(id=MOCK_ID, port=MOCK_PORT)
+        service2.register()
+        assert len(get_available_instances()) == 2
+        assert service1.id + "-2" == service2.id
+        service1.unregister()
+        service2.unregister()
+
+    def test_irreconcilable_naming_conflict(self):
+        services = [KolibriZeroconfService(id=MOCK_ID, port=MOCK_PORT).register()]
+        for i in range(110):
+            services.append(
+                KolibriZeroconfService(
+                    id="-".join([MOCK_ID, str(i)]), port=MOCK_PORT
+                ).register()
+            )
+        with self.assertRaises(NonUniqueNameException):
+            KolibriZeroconfService(id=MOCK_ID, port=MOCK_PORT).register()
+        for service in services:
+            service.unregister()
+
+    def test_excluding_local(self):
+        initialize_zeroconf_listener()
+        register_zeroconf_service(MOCK_PORT, MOCK_ID)
+        assert len(get_available_instances()) == 1
+        assert len(get_available_instances(include_local=False)) == 0
+        unregister_zeroconf_service()
+
+    def tearDown(self):
+        unregister_zeroconf_service()
+        ZEROCONF_STATE["zeroconf"] = None
+        ZEROCONF_STATE["listener"] = None
+        ZEROCONF_STATE["service"] = None
+        super(TestNetworkSearch, self).tearDown()

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -16,7 +16,7 @@ from kolibri.core.content.models import ChannelMetadata
 
 logger = logging.getLogger(__name__)
 
-SERVICE_TYPE = "_kolibri._http._tcp.local."
+SERVICE_TYPE = "Kolibri._sub._http._tcp.local."
 LOCAL_DOMAIN = "kolibri.local"
 
 ZEROCONF_STATE = {"zeroconf": None, "listener": None, "service": None}

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -113,6 +113,7 @@ class KolibriZeroconfListener(object):
             "port": info.port,
             "host": info.server.strip("."),
             "data": {key: json.loads(val) for (key, val) in info.properties.items()},
+            "base_url": "http://{ip}:{port}/".format(ip=ip, port=info.port),
         }
         logger.info(
             "Kolibri instance '%s' joined zeroconf network; service info: %s\n"

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -1,0 +1,174 @@
+import atexit
+import json
+import logging
+import socket
+import time
+from contextlib import closing
+
+from zeroconf import get_all_addresses
+from zeroconf import NonUniqueNameException
+from zeroconf import ServiceInfo
+from zeroconf import USE_IP_OF_OUTGOING_INTERFACE
+from zeroconf import Zeroconf
+
+from kolibri.core.auth.models import Facility
+from kolibri.core.content.models import ChannelMetadata
+
+logger = logging.getLogger(__name__)
+
+SERVICE_TYPE = "_kolibri._http._tcp.local."
+LOCAL_DOMAIN = "kolibri.local"
+
+ZEROCONF_STATE = {"zeroconf": None, "listener": None, "service": None}
+
+
+def _id_from_name(name):
+    assert name.endswith(SERVICE_TYPE), (
+        "Invalid service name; must end with '%s'" % SERVICE_TYPE
+    )
+    return name.replace(SERVICE_TYPE, "").strip(".")
+
+
+def _is_port_open(host, port, timeout=1):
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex((host, port)) == 0
+
+
+class KolibriZeroconfService(object):
+
+    info = None
+
+    def __init__(self, id, port=8080, data={}):
+        self.id = id
+        self.port = port
+        self.data = {key: json.dumps(val) for (key, val) in data.items()}
+        atexit.register(self.cleanup)
+
+    def register(self):
+
+        if not ZEROCONF_STATE["zeroconf"]:
+            initialize_zeroconf_listener()
+
+        assert self.info is None, "Service is already registered!"
+
+        i = 1
+        id = self.id
+
+        while not self.info:
+
+            # attempt to create an mDNS service and register it on the network
+            try:
+                info = ServiceInfo(
+                    SERVICE_TYPE,
+                    name=".".join([id, SERVICE_TYPE]),
+                    server=".".join([id, LOCAL_DOMAIN, ""]),
+                    address=USE_IP_OF_OUTGOING_INTERFACE,
+                    port=self.port,
+                    properties=self.data,
+                )
+
+                ZEROCONF_STATE["zeroconf"].register_service(info, ttl=60)
+
+                self.info = info
+
+            except NonUniqueNameException:
+                # if there's a name conflict, append incrementing integer until no conflict
+                i += 1
+                id = "%s-%d" % (self.id, i)
+
+            if i > 100:
+                raise NonUniqueNameException()
+
+        self.id = id
+
+        return self
+
+    def unregister(self):
+
+        assert self.info is not None, "Service is not registered!"
+
+        ZEROCONF_STATE["zeroconf"].unregister_service(self.info)
+
+        self.info = None
+
+    def cleanup(self, *args, **kwargs):
+
+        if self.info and ZEROCONF_STATE["zeroconf"]:
+            self.unregister()
+
+
+class KolibriZeroconfListener(object):
+
+    instances = {}
+
+    def add_service(self, zeroconf, type, name):
+        info = zeroconf.get_service_info(type, name)
+        id = _id_from_name(name)
+        ip = socket.inet_ntoa(info.address)
+        self.instances[id] = {
+            "id": id,
+            "ip": ip,
+            "local": ip in get_all_addresses(),
+            "port": info.port,
+            "host": info.server.strip("."),
+            "data": {key: json.loads(val) for (key, val) in info.properties.items()},
+        }
+        logger.info(
+            "Kolibri instance '%s' joined zeroconf network; service info: %s\n"
+            % (id, self.instances[id])
+        )
+
+    def remove_service(self, zeroconf, type, name):
+        id = _id_from_name(name)
+        logger.info("\nKolibri instance '%s' has left the zeroconf network.\n" % (id,))
+        if id in self.instances:
+            del self.instances[id]
+
+
+def get_available_instances(timeout=2, include_local=True):
+    """Retrieve a list of dicts with information about the discovered Kolibri instances on the local network,
+    filtering out those that can't be accessed at the specified port (via attempting to open a socket)."""
+    if not ZEROCONF_STATE["listener"]:
+        initialize_zeroconf_listener()
+        time.sleep(3)
+    instances = []
+    for instance in ZEROCONF_STATE["listener"].instances.values():
+        if instance["local"] and not include_local:
+            continue
+        if not _is_port_open(instance["ip"], instance["port"], timeout=timeout):
+            continue
+        instance["self"] = (
+            ZEROCONF_STATE["service"] and ZEROCONF_STATE["service"].id == instance["id"]
+        )
+        instances.append(instance)
+    return instances
+
+
+def register_zeroconf_service(port, id):
+    if ZEROCONF_STATE["service"] is not None:
+        unregister_zeroconf_service()
+    logger.info("Registering ourselves to zeroconf network with id '%s'..." % id)
+    data = {
+        "facilities": list(Facility.objects.values("id", "dataset_id", "name")),
+        "channels": list(
+            ChannelMetadata.objects.filter(root__available=True).values("id", "name")
+        ),
+    }
+    ZEROCONF_STATE["service"] = KolibriZeroconfService(id=id, port=port, data=data)
+    ZEROCONF_STATE["service"].register()
+
+
+def unregister_zeroconf_service():
+    logger.info("Unregistering ourselves from zeroconf network...")
+    if ZEROCONF_STATE["service"] is not None:
+        ZEROCONF_STATE["service"].cleanup()
+    ZEROCONF_STATE["service"] = None
+
+
+def initialize_zeroconf_listener():
+    ZEROCONF_STATE["zeroconf"] = Zeroconf()
+    ZEROCONF_STATE["listener"] = KolibriZeroconfListener()
+    ZEROCONF_STATE["zeroconf"].add_service_listener(
+        SERVICE_TYPE, ZEROCONF_STATE["listener"]
+    )

--- a/kolibri/plugins/device_management/assets/src/apiResources.js
+++ b/kolibri/plugins/device_management/assets/src/apiResources.js
@@ -3,3 +3,7 @@ import { Resource } from 'kolibri.lib.apiResource';
 export const NetworkLocationResource = new Resource({
   name: 'networklocation',
 });
+
+export const NetworkSearchResource = new Resource({
+  name: 'networksearch',
+});

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SearchAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SearchAddressForm.vue
@@ -20,7 +20,7 @@
             v-model="selectedDeviceId"
             class="radio-button"
             :value="d.id"
-            :label="d.host"
+            :label="formatDeviceName(d)"
             :description="d.base_url"
             :disabled="d.disabled"
           />
@@ -111,6 +111,9 @@
       this.stopPolling();
     },
     methods: {
+      formatDeviceName(device) {
+        return device.host + ' (' + device.data.facilities[0].name + ')';
+      },
       handleSubmit() {
         this.attemptingToConnect = true;
         const device = find(this.devices, { id: this.selectedDeviceId });

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SearchAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SearchAddressForm.vue
@@ -1,0 +1,176 @@
+<template>
+
+  <KModal
+    :title="$tr('header')"
+    :submitText="$tr('submitButtonLabel')"
+    :cancelText="$tr('cancelButtonLabel')"
+    size="medium"
+    :submitDisabled="attemptingToConnect"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    {{ $tr('description') }}
+    <p></p>
+    <div>
+
+      <template v-for="d in devices">
+        <div :key="`div-${d.id}`">
+          <KRadioButton
+            :key="d.id"
+            v-model="selectedDeviceId"
+            class="radio-button"
+            :value="d.id"
+            :label="d.host"
+            :description="d.base_url"
+            :disabled="d.disabled"
+          />
+        </div>
+
+      </template>
+
+      <UiAlert
+        v-if="uiAlertProps"
+        v-show="showUiAlerts"
+        :type="uiAlertProps.type"
+        :dismissible="false"
+      >
+        {{ uiAlertProps.text }}
+      </UiAlert>
+
+      <UiAlert
+        v-if="attemptingToConnect"
+        v-show="showUiAlerts"
+        :dismissible="false"
+      >
+        {{ $tr('tryingToConnect') }}
+      </UiAlert>
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import KModal from 'kolibri.coreVue.components.KModal';
+  import find from 'lodash/find';
+  import KRadioButton from 'kolibri.coreVue.components.KRadioButton';
+  import CatchErrors from 'kolibri.utils.CatchErrors';
+  import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
+  import UiAlert from 'keen-ui/src/UiAlert';
+  import { createAddress, fetchDevices } from './api';
+
+  const Stages = {
+    FETCHING_DEVICES: 'FETCHING_DEVICES',
+    FETCHING_SUCCESSFUL: 'FETCHING_SUCCESSFUL',
+    FETCHING_FAILED: 'FETCHING_FAILED',
+    COULD_NOT_CONNECT: 'COULD_NOT_CONNECT',
+  };
+
+  export default {
+    name: 'SearchAddressForm',
+    components: {
+      KModal,
+      UiAlert,
+      KRadioButton,
+    },
+    props: {},
+    data() {
+      return {
+        selectedDeviceId: '',
+        attemptingToConnect: false,
+        stage: '',
+        devices: [],
+        Stages,
+        showUiAlerts: false,
+      };
+    },
+    computed: {
+      uiAlertProps() {
+        if (this.devices.length === 0) {
+          return {
+            text: this.$tr('noDevicesText'),
+            type: 'info',
+          };
+        }
+        return null;
+      },
+    },
+    beforeMount() {
+      this.refreshDeviceList();
+      this.startPolling();
+    },
+    mounted() {
+      // Wait a little bit of time before showing UI alerts so there is no flash
+      // if data comes back quickly
+      setTimeout(() => {
+        this.showUiAlerts = true;
+      }, 100);
+    },
+    destroyed() {
+      this.stopPolling();
+    },
+    methods: {
+      handleSubmit() {
+        this.attemptingToConnect = true;
+        const device = find(this.devices, { id: this.selectedDeviceId });
+        return createAddress({
+          base_url: device.base_url,
+          device_name: device.host,
+        })
+          .then(address => {
+            this.$emit('submit', address);
+          })
+          .catch(err => {
+            const errorsCaught = CatchErrors(err, [
+              ERROR_CONSTANTS.NETWORK_LOCATION_NOT_FOUND,
+              ERROR_CONSTANTS.INVALID_NETWORK_LOCATION_FORMAT,
+            ]);
+            if (errorsCaught.includes(ERROR_CONSTANTS.NETWORK_LOCATION_NOT_FOUND)) {
+              this.status = Stages.COULD_NOT_CONNECT;
+            } else {
+              this.$store.dispatch('handleApiError', err);
+            }
+          })
+          .then(() => {
+            this.attemptingToConnect = false;
+          });
+      },
+      refreshDeviceList() {
+        this.stage = this.Stages.FETCHING_DEVICES;
+        return fetchDevices(this.isImportingMore ? this.transferredChannel.id : '')
+          .then(devices => {
+            this.stage = this.Stages.FETCHING_SUCCESSFUL;
+            this.devices = devices;
+          })
+          .catch(() => {
+            this.stage = this.Stages.FETCHING_FAILED;
+          });
+      },
+      startPolling() {
+        if (!this.intervalId) {
+          this.intervalId = setInterval(this.refreshDeviceList, 5000);
+        }
+      },
+      stopPolling() {
+        if (this.intervalId) {
+          this.intervalId = clearInterval(this.intervalId);
+        }
+      },
+    },
+    $trs: {
+      description: 'Devices found on the local network (Kolibri 0.13.0+):',
+      noDevicesText: 'No usable devices found. Searching...',
+      addressLabel: 'Full network address',
+      cancelButtonLabel: 'Cancel',
+      errorCouldNotConnect: 'Could not connect to this network address',
+      header: 'Searching for devices',
+      submitButtonLabel: 'Add',
+      tryingToConnect: 'Trying to connect to server…',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -24,13 +24,25 @@
       />
     </UiAlert>
 
-    <KButton
-      v-show="!newAddressButtonDisabled"
-      class="new-address-button"
-      :text="$tr('newAddressButtonLabel')"
-      appearance="basic-link"
-      @click="$emit('click_add_address')"
-    />
+    <template v-show="!newAddressButtonDisabled">
+
+      <KButton
+        class="new-address-button"
+        :text="$tr('newAddressButtonLabel')"
+        appearance="basic-link"
+        @click="$emit('click_add_address')"
+      />
+
+      /
+
+      <KButton
+        class="search-address-button"
+        :text="$tr('searchAddressButtonLabel')"
+        appearance="basic-link"
+        @click="$emit('click_search_address')"
+      />
+
+    </template>
 
     <template v-for="(a, idx) in addresses">
       <div :key="`div-${idx}`">
@@ -204,6 +216,7 @@
       forgetAddressButtonLabel: 'Forget',
       header: 'Select network address',
       newAddressButtonLabel: 'Add new address',
+      searchAddressButtonLabel: 'Search for devices',
       noAddressText: 'There are no addresses yet',
       refreshAddressesButtonLabel: 'Refresh addresses',
       submitButtonLabel: 'Continue',

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectNetworkAddressModal/index.vue
@@ -5,6 +5,7 @@
       v-if="stage === Stages.SELECT_ADDRESS"
       @cancel="resetContentWizardState"
       @click_add_address="goToAddAddress"
+      @click_search_address="goToSearchAddress"
       @removed_address="handleRemovedAddress"
       @submit="handleSelectAddressSubmit"
     />
@@ -12,6 +13,11 @@
       v-if="stage === Stages.ADD_ADDRESS"
       @cancel="goToSelectAddress"
       @added_address="handleAddedAddress"
+    />
+    <SearchAddressForm
+      v-if="stage === Stages.SEARCH_ADDRESS"
+      @cancel="goToSelectAddress"
+      @submit="handleSelectAddressSubmit"
     />
   </div>
 
@@ -24,10 +30,12 @@
   import { availableChannelsPageLink, selectContentPageLink } from '../manageContentLinks';
   import AddAddressForm from './AddAddressForm';
   import SelectAddressForm from './SelectAddressForm';
+  import SearchAddressForm from './SearchAddressForm';
 
   const Stages = {
     ADD_ADDRESS: 'ADD_ADDRESS',
     SELECT_ADDRESS: 'SELECT_ADDRESS',
+    SEARCH_ADDRESS: 'SEARCH_ADDRESS',
   };
 
   export default {
@@ -35,6 +43,7 @@
     components: {
       AddAddressForm,
       SelectAddressForm,
+      SearchAddressForm,
     },
     data() {
       return {
@@ -53,6 +62,9 @@
       }),
       goToAddAddress() {
         this.stage = Stages.ADD_ADDRESS;
+      },
+      goToSearchAddress() {
+        this.stage = Stages.SEARCH_ADDRESS;
       },
       goToSelectAddress() {
         this.stage = Stages.SELECT_ADDRESS;

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -646,6 +646,7 @@ def _get_port(port):
 
 def _cleanup_before_quitting(signum, frame):
     from kolibri.core.discovery.utils.network.search import unregister_zeroconf_service
+
     unregister_zeroconf_service()
     signal.signal(signum, signal.SIG_DFL)
     os.kill(os.getpid(), signum)

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -659,8 +659,12 @@ def main(args=None):  # noqa: max-complexity=13
     to use main() for integration tests in order to test the argument API.
     """
 
-    signal.signal(signal.SIGINT, _cleanup_before_quitting)
-    signal.signal(signal.SIGTERM, _cleanup_before_quitting)
+    try:
+        signal.signal(signal.SIGINT, _cleanup_before_quitting)
+        signal.signal(signal.SIGTERM, _cleanup_before_quitting)
+        logger.info("Added signal handlers for cleaning up on exit...")
+    except ValueError:
+        logger.warn("Error adding signal handlers for cleaning up on exit...")
 
     arguments, django_args = parse_args(args)
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -644,6 +644,13 @@ def _get_port(port):
     return int(port) if port else OPTIONS["Deployment"]["HTTP_PORT"]
 
 
+def _cleanup_before_quitting(signum, frame):
+    from kolibri.core.discovery.utils.network.search import unregister_zeroconf_service
+    unregister_zeroconf_service()
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
 def main(args=None):  # noqa: max-complexity=13
     """
     Kolibri's main function. Parses arguments and calls utility functions.
@@ -651,7 +658,8 @@ def main(args=None):  # noqa: max-complexity=13
     to use main() for integration tests in order to test the argument API.
     """
 
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, _cleanup_before_quitting)
+    signal.signal(signal.SIGTERM, _cleanup_before_quitting)
 
     arguments, django_args = parse_args(args)
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -420,7 +420,7 @@ status.codes = {
 }
 
 
-def services(daemon=True):
+def services(port, daemon=True):
     """
     Start the kolibri background services.
 
@@ -446,7 +446,7 @@ def services(daemon=True):
 
         become_daemon(**kwargs)
 
-    server.services()
+    server.services(port=port)
 
 
 def setup_logging(debug=False):
@@ -657,8 +657,9 @@ def main(args=None):  # noqa: max-complexity=13
 
     debug = arguments["--debug"]
 
+    port = _get_port(arguments["--port"])
+
     if arguments["start"]:
-        port = _get_port(arguments["--port"])
         if OPTIONS["Server"]["CHERRYPY_START"]:
             check_other_kolibri_running(port)
 
@@ -733,7 +734,7 @@ def main(args=None):  # noqa: max-complexity=13
                 "Impossible to create file lock to communicate starting process"
             )
 
-        services(daemon=daemon)
+        services(port=port, daemon=daemon)
         return
 
     if arguments["language"] and arguments["setdefault"]:

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -95,6 +95,7 @@ def run_services(port):
     # Register the Kolibri zeroconf service so it will be discoverable on the network
     from morango.models import InstanceIDModel
     from kolibri.core.discovery.utils.network.search import register_zeroconf_service
+
     instance, _ = InstanceIDModel.get_or_create_current_instance()
     register_zeroconf_service(port=port, id=instance.id[:4])
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -92,6 +92,12 @@ def run_services(port):
 
     initialize_worker()
 
+    # Register the Kolibri zeroconf service so it will be discoverable on the network
+    from morango.models import InstanceIDModel
+    from kolibri.core.discovery.utils.network.search import register_zeroconf_service
+    instance, _ = InstanceIDModel.get_or_create_current_instance()
+    register_zeroconf_service(port=port, id=instance.id[:4])
+
 
 def start(port=8080, run_cherrypy=True):
     """

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -73,7 +73,7 @@ class NotRunning(Exception):
         super(NotRunning, self).__init__()
 
 
-def run_services():
+def run_services(port):
 
     # start the pingback thread
     PingbackThread.start_command()
@@ -100,7 +100,7 @@ def start(port=8080, run_cherrypy=True):
     :param: port: Port number (default: 8080)
     """
 
-    run_services()
+    run_services(port=port)
 
     # Write the new PID
     _write_pid_file(PID_FILE, port=port)
@@ -125,12 +125,12 @@ def start(port=8080, run_cherrypy=True):
         block()
 
 
-def services():
+def services(port):
     """
     Runs the background services.
     """
 
-    run_services()
+    run_services(port=port)
 
     # Write the new PID
     _write_pid_file(PID_FILE)

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -46,17 +46,17 @@ def _posix_pid_exists(pid):
         return True
 
 
-
 def _kill_pid(pid, softkill_signal_number):
     """Kill a PID by sending a signal, starting with a softer one and then escalating as needed"""
-
     try:
         logger.debug("Attempting to soft kill process with pid %d..." % pid)
         os.kill(pid, softkill_signal_number)
         logger.debug("Soft kill signal sent without error.")
     # process does not exist
     except OSError:
-        logger.debug("Soft kill signal could not be sent (OSError); process may not exist?")
+        logger.debug(
+            "Soft kill signal could not be sent (OSError); process may not exist?"
+        )
         return
     # give some time for the process to clean itself up gracefully bfore we force anything
     i = 0
@@ -65,7 +65,10 @@ def _kill_pid(pid, softkill_signal_number):
         i += 1
     # if process didn't exit cleanly, make one last effort to kill it
     if pid_exists(pid):
-        logger.debug("Process wth pid %s still exists after soft kill signal; attempting a SIGKILL." % pid)
+        logger.debug(
+            "Process wth pid %s still exists after soft kill signal; attempting a SIGKILL."
+            % pid
+        )
         os.kill(pid, signal.SIGKILL)
         logger.debug("SIGKILL signal sent without error.")
 

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -16,14 +16,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 import os
+import signal
 import sys
+import time
 
 import six
 from django.db import connections
 
 from .conf import KOLIBRI_HOME
 from kolibri.utils.android import on_android
+
+logger = logging.getLogger(__name__)
 
 
 def _posix_pid_exists(pid):
@@ -41,18 +46,33 @@ def _posix_pid_exists(pid):
         return True
 
 
-def _posix_kill_pid(pid):
-    """Kill a PID by sending a posix signal"""
-    import signal
+
+def _kill_pid(pid, softkill_signal_number):
+    """Kill a PID by sending a signal, starting with a softer one and then escalating as needed"""
 
     try:
-        os.kill(pid, signal.SIGTERM)
+        logger.debug("Attempting to soft kill process with pid %d..." % pid)
+        os.kill(pid, softkill_signal_number)
+        logger.debug("Soft kill signal sent without error.")
     # process does not exist
     except OSError:
+        logger.debug("Soft kill signal could not be sent (OSError); process may not exist?")
         return
-    # process didn't exit cleanly, make one last effort to kill it
+    # give some time for the process to clean itself up gracefully bfore we force anything
+    i = 0
+    while pid_exists(pid) and i < 10:
+        time.sleep(0.5)
+        i += 1
+    # if process didn't exit cleanly, make one last effort to kill it
     if pid_exists(pid):
+        logger.debug("Process wth pid %s still exists after soft kill signal; attempting a SIGKILL." % pid)
         os.kill(pid, signal.SIGKILL)
+        logger.debug("SIGKILL signal sent without error.")
+
+
+def _posix_kill_pid(pid):
+    """Kill a PID by sending a posix-specific soft-kill signal"""
+    _kill_pid(pid, signal.SIGTERM)
 
 
 def _windows_pid_exists(pid):
@@ -70,15 +90,8 @@ def _windows_pid_exists(pid):
 
 
 def _windows_kill_pid(pid):
-    """Kill the proces using pywin32 and pid"""
-    import ctypes
-
-    PROCESS_TERMINATE = 1
-    handle = ctypes.windll.kernel32.OpenProcess(
-        PROCESS_TERMINATE, False, pid
-    )  # @UndefinedVariable
-    ctypes.windll.kernel32.TerminateProcess(handle, -1)  # @UndefinedVariable
-    ctypes.windll.kernel32.CloseHandle(handle)  # @UndefinedVariable
+    """Kill a PID by sending a windows-specific soft-kill signal"""
+    _kill_pid(pid, signal.CTRL_C_EVENT)
 
 
 buffering = int(six.PY3)  # No unbuffered text I/O on Python 3 (#20815).

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,3 +33,4 @@ sentry-sdk==0.7.9
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
+-e git://github.com/learningequality/python-zeroconf.git@8d0e70029a925862e965519c9d42b4016d694d5c#egg=zeroconf

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,4 +33,4 @@ sentry-sdk==0.7.9
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-git+https://github.com/learningequality/python-zeroconf.git@8d0e70029a925862e965519c9d42b4016d694d5c#egg=zeroconf
+zeroconf-py2compat==0.19.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ metafone==0.5
 le-utils==0.1.15
 kolibri_exercise_perseus_plugin==1.1.8
 jsonfield==2.0.2
-morango==0.4.5
+morango==0.4.6
 requests-toolbelt==0.8.0
 clint==0.5.1
 tzlocal==1.5.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,4 +33,4 @@ sentry-sdk==0.7.9
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
--e git://github.com/learningequality/python-zeroconf.git@8d0e70029a925862e965519c9d42b4016d694d5c#egg=zeroconf
+git+https://github.com/learningequality/python-zeroconf.git@8d0e70029a925862e965519c9d42b4016d694d5c#egg=zeroconf


### PR DESCRIPTION
### Summary

We support local network peer connections for content import, and soon, for data syncing. But right now, it's necessary to manually enter the IP and port, which is at best inconvenient, and at worst an insurmountable barrier for many users.

Enter [zeroconf](https://blog.hyperiongray.com/multicast-dns-service-discovery/)! It's specifically designed for this type of situation -- allowing nearby devices on the same network to discover one another and the services they offer.

This PR is a preliminary, but usable, backend implementation of a zeroconf-based "Kolibri service broadcasting and discovery" system. When Kolibri starts up, it will register itself on the local network, and then monitor and track any other instances of Kolibri on the same local network. The frontend code can then call an API endpoint to enumerate the nearby Kolibri instances, including information about what IP/port they're listening on, and what facilities/channels they have loaded on them.

One of the lovely side-effects of using zeroconf (aka mDNS) for this is that it also ends up creating local 
area domain names that can be resolved and used in the browser at least on Linux and OSX:
![image](https://user-images.githubusercontent.com/618416/59385516-633aaf80-8d19-11e9-8d0d-f0a3deb2dbbc.png)

Note: includes some changes I made to https://github.com/learningequality/python-zeroconf

### Reviewer guidance

To test, you'll want to spin up a couple instances of this. To start with, these could be on the same computer, just using different ports and KOLIBRI_HOME directories, e.g.:
```
# run this in one terminal tab
kolibri start

# run this in another tab
KOLIBRI_HOME=~/.kolibri-temp KOLIBRI_LISTEN_PORT=9090 kolibri start
```

Then, login as an admin on each and go to:
http://127.0.0.1:8080/api/discovery/networksearch/
and
http://127.0.0.1:9090/api/discovery/networksearch/

and you should see something like this:

```
[
    {
        "ip": "192.168.1.25",
        "self": true,
        "data": {
            "channels": [
                {
                    "id": "c7eda62c6489554a941058fa883e7c2c",
                    "name": "Better World Ed"
                },
                {
                    "id": "74f36493bb475b62935fa8705ed59fed",
                    "name": "Thoughtful Learning"
                },
                {
                    "id": "f9da12749d995fa197f8b4c0192e7b2c",
                    "name": "PraDigi"
                }
            ],
            "facilities": [
                {
                    "dataset_id": "d265a3809dd02de42570ef5ba5b1bb86",
                    "id": "318aa7335a2ad82434dee8534caf85d9",
                    "name": "a"
                }
            ]
        },
        "port": 8080,
        "host": "b053.kolibri.local",
        "local": true,
        "id": "b053"
    }
]
```

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md

TODO:
- [ ] Add an option in options.ini to disable zeroconf
- [ ] Consider switching service type to `_http._tcp.local` so it's standardized.
- [ ] Rebroadcast service when channels or facilities change