### PR TITLE
remove the duplicated step of uploading artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,8 @@ steps:
 
   - wait
 
+  # NOTE: Uploading artifacts should only happen once. Doing so twice during the
+  # release process causes an error, which blocks the execution of the steps.
   - label: Upload artifacts
     command: .buildkite/setup_and_upload_artifact.sh
 
@@ -43,11 +45,6 @@ steps:
   - block: "Create integration testing worksheet?"
   - label: Create integration testing
     command: .buildkite/build_worksheet.sh
-
-  - wait
-
-  - label: Upload new artifacts
-    command: .buildkite/setup_and_upload_artifact.sh
 
   - block: "Build release APK?"
   - label: "Build Release APK"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR removes the duplicated step of uploading artifacts after signing the windows installer.

Previously, this step was added so we can easily find the signed windows installer in the gcs link to the assets. For PR builds, this works well. However, when we have a release, uploading the artifacts means that we also upload them again to the github release page, which would fail and lead to the failure of generating a signed android installer. So removing the second step of uploading artifacts is the way to go.

After removing this step, the signed windows installer can be found in the `Artifact` section in the buildkite build step.



### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check in the buildkite build whether we are able to have a signed android installer

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5661

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
