### PR TITLE
[WIP] upgrade multiple dependencies to use Markdown for PyPi project description

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -36,6 +36,7 @@ VOLUME /docker/mnt
 
 # do the time-consuming base install commands
 RUN cd /kolibri \
+    && pip install -U pip \
     && pip install -r requirements/dev.txt \
     && pip install -r requirements/build.txt \
     && pip install -r requirements/test.txt \

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -40,3 +40,5 @@ RUN cd /kolibri \
     && pip install -r requirements/build.txt \
     && pip install -r requirements/test.txt \
     && yarn install
+
+RUN apt-get remove -y python-setuptools python-wheel

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -36,10 +36,8 @@ VOLUME /docker/mnt
 
 # do the time-consuming base install commands
 RUN cd /kolibri \
-    && pip install -U pip \
+    && pip install -U pip==9.0.2 \
     && pip install -r requirements/dev.txt \
     && pip install -r requirements/build.txt \
     && pip install -r requirements/test.txt \
     && yarn install
-
-RUN apt-get remove -y python-setuptools python-wheel

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -37,6 +37,8 @@ RUN echo '--- Installing Python dependencies' && \
     pip install -r requirements/dev.txt && \
     pip install -r requirements/build.txt
 
+RUN apt-get remove -y python-setuptools python-wheel
+
 # Set yarn cache folder for easy binding during runtime
 RUN yarn config set cache-folder /yarn_cache
 

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -34,6 +34,7 @@ WORKDIR /kolibri
 # Python dependencies
 COPY requirements/ requirements/
 RUN echo '--- Installing Python dependencies' && \
+    pip install -U pip && \
     pip install -r requirements/dev.txt && \
     pip install -r requirements/build.txt
 
@@ -47,8 +48,8 @@ COPY . .
 
 CMD echo '--- Installing JS dependencies' && \
     yarn install --pure-lockfile && \
-    echo `--- Making whl` && \
+    echo '--- Making whl' && \
     make dist && \
-    echo `--- Making pex` && \
+    echo '--- Making pex' && \
     make pex && \
     cp /kolibri/dist/* /kolibridist/

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -34,11 +34,9 @@ WORKDIR /kolibri
 # Python dependencies
 COPY requirements/ requirements/
 RUN echo '--- Installing Python dependencies' && \
-    pip install -U pip && \
+    pip install -U pip==9.0.2 && \
     pip install -r requirements/dev.txt && \
     pip install -r requirements/build.txt
-
-RUN apt-get remove -y python-setuptools python-wheel
 
 # Set yarn cache folder for easy binding during runtime
 RUN yarn config set cache-folder /yarn_cache

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -9,3 +9,4 @@ pex<1.6
 setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.7.1
 requests==2.21.0
+wheel>=0.31.0

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,7 +5,7 @@ sphinx
 sphinx-intl
 sphinx-rtd-theme
 sphinx-autobuild
-pex<1.6
+pex
 setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.7.1
 requests==2.21.0

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,7 +6,7 @@ sphinx-intl
 sphinx-rtd-theme
 sphinx-autobuild
 pex
-setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
+setuptools==41.0.1
 beautifulsoup4==4.7.1
 requests==2.21.0
 wheel>=0.31.0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
**note: I would like to test on pypi test server (https://test.pypi.org/) to make sure this PR fix the issue before merging**
**note2: this PR doesn't work 😅**

According to the [PyPi documentation](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata), we need to meet these requirements to use Markdown for the project description:

```
setuptools >= 38.6.0
wheel >= 0.31.0
twine >= 1.11.0
```
1. wheel
The wheel package version in the base Docker image was `0.30.0`, so we need to pin a version newer than that.

2. pex
We pinned pex because of [this issue](https://github.com/learningequality/kolibri/issues/1710). Since this issue has been confirmed as resolved, I think we can unpin it. Also `pex<1.6` breaks the build.

3. setuptools
We previously pinned the setuptools due to pex requirements. But pex now vendors setuptools and wheel, so we don't need to worry about that now.

4. pip
after satisfying all the requirements above, the package we got from the build was still wrong. I notice that the pip version in the Docker image is 9.0.1. Since `setuptools` version needs to be >=38.6.0, I checked that `setuptools` was released on Mar 15, 2018, so I assume we need a pip released after that, which is pip 9.0.2. I tried upgraded pip to latest version 19.1.1, but that broke the installation of packages.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

two ways to check if we have fixed the issue:
Download the whl file from the PR
1. run the following commands
```
pip install twine
twine check <.whl>
```
2. running `python setup.py bdist_wheel --static` does not generate the warning 
```
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'long_description_content_type'
```



### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#5684 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
