### PR TITLE
decouple pypi package description, github readme, and dev docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@
 [![User docs](https://img.shields.io/badge/docs-user-blue.svg)](http://kolibri.readthedocs.org/en/latest/)
 [![Discourse topics](https://img.shields.io/discourse/https/community.learningequality.org/topics.svg?color=blue)](https://community.learningequality.org/)
 
-These docs are for software developers wishing to contribute to Kolibri. If you are looking for help installing, configuring and using Kolibri, please refer to the [User Guide](https://kolibri.readthedocs.io/).
+This repository is for software developers wishing to contribute to Kolibri. If you are looking for help installing, configuring and using Kolibri, please refer to the [User Guide](https://kolibri.readthedocs.io/).
+
 
 ## What is Kolibri?
 
-Kolibri is a Learning Management System / Learning App designed to run on low-power devices, targeting the needs of learners and teachers in contexts with limited infrastructure. A user can install Kolibri and serve the app on a local network, without an internet connection. Kolibri installations can be linked to one another, so that user data and content can be shared. Users can create content for Kolibri and share it when there is network access to another Kolibri installation or the internet.
-
-At its core, Kolibri is about serving educational content. A typical user (called a Learner) will log in to Kolibri to consume educational content (videos, documents, other multimedia) and test their understanding of the content by completing exercises and quizzes, with immediate feedback. A user’s activity will be tracked to offer individualized insight (like "next lesson" recommendations), and to allow user data to be synced across different installations – thus a Kolibri learner can use his or her credentials on any linked Kolibri installation, for instance on different devices at a school.
-
-See [our website](https://learningequality.org/kolibri/) for more information.
+[Kolibri](https://learningequality.org/kolibri/) is the offline learning platform
+from [Learning Equality](https://learningequality.org/).
 
 
 ## How can I use it?
@@ -26,6 +24,13 @@ See [our website](https://learningequality.org/kolibri/) for more information.
 Kolibri is [available for download](https://learningequality.org/download/) from our website.
 
 
+## How do I get help or give feedback?
+
+You can ask questions, make suggestions, and report issues in the [community forums](https://community.learningequality.org/).
+
+If you have found a bug and are comfortable using Github and Markdown, you can create a [Github issue](https://github.com/learningequality/kolibri/issues) following the instructions in the issue template.
+
+
 ## How can I contribute?
 
-Thanks for your interest! Please see the 'contributing' section of our [online developer documentation](http://kolibri-dev.readthedocs.io/).
+Please see the 'contributing' section of our [developer documentation](http://kolibri-dev.readthedocs.io/).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,22 @@
 
-.. mdinclude:: ../README.md
+
+Kolibri Developer Documentation
+===============================
+
+These docs are for software developers wishing to contribute to Kolibri. If you are looking for help installing, configuring and using Kolibri, please refer to the `User Guide <https://kolibri.readthedocs.io/>`__.
+
+
+What is Kolibri?
+----------------
+
+`Kolibri <https://learningequality.org/kolibri/>`__ is the offline learning platform
+from `Learning Equality <https://learningequality.org/>`__. It is `available for download <https://learningequality.org/download/>`__ from our website.
+
+The code is `hosted on Github <https://github.com/learningequality/kolibri/>`__ and MIT-licensed.
+
+You can ask questions, make suggestions, and report issues in the `community forums <https://community.learningequality.org/>`__.
+
+If you have found a bug and are comfortable using Github and Markdown, you can create a `Github issue <https://github.com/learningequality/kolibri/issues>`__ following the instructions in the issue template.
 
 
 Table of contents

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ readme = """
 from `Learning Equality <https://learningequality.org/>`_.
 
 This package can be installed by running ``pip install kolibri``. `See the download
-page <https://learningequality.org/kolibri/>`_ for other methods of installation.
+page <https://learningequality.org/download/>`_ for other methods of installation.
 
 - `View the documentation <https://kolibri.readthedocs.io/>`_ and the `community
   forums <https://community.learningequality.org/>`_ for more guidance on setting up

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import logging
 import os
 import sys
@@ -22,7 +21,22 @@ from kolibri import dist as kolibri_dist
 
 dist_name = "kolibri"
 
-readme = io.open("README.md", mode="r", encoding="utf-8").read()
+# RST-formatted long description.
+# (Markdown will not work until we upgrade build dependencies)
+readme = """
+`Kolibri <https://learningequality.org/kolibri/>`_ is the offline learning platform
+from `Learning Equality <https://learningequality.org/>`_.
+
+This package can be installed by running ``pip install kolibri``. `See the download
+page <https://learningequality.org/kolibri/>`_ for other methods of installation.
+
+- `View the documentation <https://kolibri.readthedocs.io/>`_ and the `community
+  forums <https://community.learningequality.org/>`_ for more guidance on setting up
+  and using Kolibri
+- Visit the `Github project <https://github.com/learningequality/kolibri>`_ and the
+  `developer documentation <https://kolibri-dev.readthedocs.io/>`_ if you would like
+  to contribute to development
+"""
 
 # Default description of the distributed package
 description = """Kolibri - the offline app for universal education"""
@@ -137,7 +151,6 @@ setup(
     version=kolibri.__version__,
     description=description,
     long_description=readme,
-    long_description_content_type="text/markdown",
     author="Learning Equality",
     author_email="info@learningequality.org",
     url="https://github.com/learningequality/kolibri",


### PR DESCRIPTION
### Summary

The pypi package description, github readme, and developer docs all shared common text. This PR separates and contextualizes them.

* use RST rather than markdown in pypi
* customize content for each usage
* simplify language, redirecting to external links rather than risking having outdated copy


### Reviewer guidance

* does it render the links and list correctly?
* any typos or issues with the content?

### References

fixes https://github.com/learningequality/kolibri/issues/5684

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
