### PR TITLE
update Changelog and bump to 0.12.6 beta 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ List of the most important changes for each release.
 
 ## 0.12.5
 
-### Changed or fixed
-
 - Upgraded Morango to 0.4.6, fixing startup errors for some users.
 
 View all [0.12.5 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ List of the most important changes for each release.
 
 - Upgraded Morango to 0.4.6, fixing startup errors for some users.
 
-View all [0.12.5 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.5)
+([0.12.5 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.5))
 
 ## 0.12.4
 
@@ -25,7 +25,7 @@ View all [0.12.5 changes on Github](https://github.com/learningequality/kolibri/
 - Added a new theming system for customizing various colors that appear in Kolibri.
 
 
-View all [0.12.4 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.4)
+([0.12.4 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.4))
 
 ## 0.12.3
 
@@ -37,7 +37,7 @@ View all [0.12.4 changes on Github](https://github.com/learningequality/kolibri/
 - Improved PostgreSQL support
 - Added fixes related to coach tools
 
-View all [0.12.3 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.3)
+([0.12.3 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.3))
 
 
 ## 0.12.2
@@ -71,7 +71,7 @@ View all [0.12.3 changes on Github](https://github.com/learningequality/kolibri/
 - Added Gujarati
 - Fixed missing translations in coach group management
 
-View all [0.12.2 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.2)
+([0.12.2 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.2))
 
 
 ## 0.12.1
@@ -91,7 +91,7 @@ View all [0.12.2 changes on Github](https://github.com/learningequality/kolibri/
 
 - Added Burmese
 
-View all [0.12.1 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.1)
+([0.12.1 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.1))
 
 
 ## 0.12.0
@@ -129,7 +129,7 @@ View all [0.12.1 changes on Github](https://github.com/learningequality/kolibri/
 
 - Languages: English, Arabic, Bengali, Bulgarian, Chinyanja, Farsi, French, Fulfulde Mbororoore, Hindi, Marathi, Portuguese (Brazilian), Spanish, Swahili, Telugu, Urdu, Vietnamese, and Yoruba
 
-View all [0.12.0 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.0)
+([0.12.0 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.12.0))
 
 
 ## 0.11.1
@@ -154,7 +154,7 @@ View all [0.12.0 changes on Github](https://github.com/learningequality/kolibri/
 
 - Added Fufulde Mboroore
 
-View all [0.11.1 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.1)
+([0.11.1 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.1))
 
 ## 0.11.0
 
@@ -187,7 +187,7 @@ View all [0.11.1 changes on Github](https://github.com/learningequality/kolibri/
 - Many fixes to translation and localization
 - Consistent font rendering across all languages
 
-View all [0.11.0 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0)
+([0.11.0 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.11.0))
 
 
 ## 0.10.3
@@ -202,14 +202,14 @@ View all [0.11.0 changes on Github](https://github.com/learningequality/kolibri/
 - Channel import listing of USB devices when non-US locale
 - Counts for coach-specific content would in some cases be wrongly displayed
 
-View all [0.10.3 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.3)
+([0.10.3 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.3))
 
 ## 0.10.2
 
 - Performance improvements and bug fixes for content import
 - Exam creation optimizations
 
-View all [0.10.2 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.2)
+([0.10.2 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.2))
 
 ## 0.10.1
 
@@ -218,7 +218,7 @@ View all [0.10.2 changes on Github](https://github.com/learningequality/kolibri/
 - Fixes for SSL issues on low-spec devices / unstable connectivity
 - Compatibility fixes for older system libraries
 
-View all [0.10.1 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.1)
+([0.10.1 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.1))
 
 ## 0.10.0
 
@@ -235,7 +235,7 @@ View all [0.10.1 changes on Github](https://github.com/learningequality/kolibri/
 - Command to migrate content directory location
 - Languages: English, Arabic, Bengali, Chinyanja, Farsi, French, Hindi, Kannada, Marathi, Burmese, Portuguese (Brazilian), Spanish, Swahili, Tamil, Telugu, Urdu, Yoruba, and Zulu
 
-View all [0.10.0 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.0)
+([0.10.0 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.10.0))
 
 0.9.3
 -----
@@ -243,7 +243,7 @@ View all [0.10.0 changes on Github](https://github.com/learningequality/kolibri/
 - Compressed database upload
 - Various bug fixes
 
-View all [0.9.3 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.3)
+([0.9.3 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.3))
 
 0.9.2
 -----
@@ -251,7 +251,7 @@ View all [0.9.3 changes on Github](https://github.com/learningequality/kolibri/i
 - Various bug fixes
 - Languages: English, Arabic, Bengali, Chinyanja, Farsi, French, Hindi, Marathi, Portuguese (Brazilian), Spanish, Swahili, Tamil, Telugu, Urdu, Yoruba, and Zulu
 
-View all [0.9.2 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.2)
+([0.9.2 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.2))
 
 0.9.1
 -----
@@ -265,7 +265,7 @@ View all [0.9.2 changes on Github](https://github.com/learningequality/kolibri/i
 - Various other fixes
 - Languages: English, Arabic, Chinyanja, Farsi, French, Hindi, Marathi, Portuguese (Brazilian), Spanish, Swahili, Tamil, Telugu, and Urdu
 
-View all [0.9.1 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.1)
+([0.9.1 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.1))
 
 0.9.0
 -----
@@ -283,7 +283,7 @@ View all [0.9.1 changes on Github](https://github.com/learningequality/kolibri/i
 - Added icon next to language-switching functionality
 - Languages: English, Arabic, Farsi, French, Hindi, Spanish, Swahili, and Urdu
 
-View all [0.9.0 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.0)
+([0.9.0 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.9.0))
 
 0.8.0
 -----
@@ -295,7 +295,7 @@ View all [0.9.0 changes on Github](https://github.com/learningequality/kolibri/i
 - Languages: English, Spanish, Arabic, Farsi, Urdu, French, Haitian Creole, and Burmese
 - Various bug fixes
 
-View all [0.8.0 changes on Github](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.8.0)
+([0.8.0 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.8.0))
 
 0.7.2
 -----


### PR DESCRIPTION
### Summary

Re-words links from 

> View all [0.A.B changes on Github](#)

to

> ([0.A.B Github milestone](#))

Because it more accurately reflects the link destination, ~is one less place to edit when updating the changelog~, and looks a little cleaner.

### Reviewer guidance

This make sense?




### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
