### PR TITLE
Hotfix: Handle case in which server is started in subthread (e.g. on Android)

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -651,7 +651,10 @@ def main(args=None):  # noqa: max-complexity=13
     to use main() for integration tests in order to test the argument API.
     """
 
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+    except ValueError:
+        logger.warn("Error adding signal handler for SIGINT...")
 
     arguments, django_args = parse_args(args)
 


### PR DESCRIPTION
Quick fix for Android issue that leads to `ValueError: signal only works in main thread`.