### PR TITLE
Lint: Check assignment to built-in variables

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 -r base.txt
 flake8==3.5.0
+flake8-builtins==1.4.1
 pre-commit==1.15.1
 tox==3.1.3
 django-debug-panel==0.8.3


### PR DESCRIPTION
### Summary

Unfortunately, this check is not part of default flake8. Hence, we have 49 occurrences where we assign to built-in references.

Adding a flake8 plugin to test this. Tests should now fail :tada: 

Black will not detect these mistakes. Actually, Black is quite limited compared to what Flake8 provides, and I just want to flag that it doesn't seem like a mature replacement.

![image](https://user-images.githubusercontent.com/374612/59925957-7ea06b80-9439-11e9-9b5d-f7596bacf9e8.png)



### Reviewer guidance

Should I go ahead and fix these?

```
kolibri/core/tasks/api.py:54:5: A003 "list" is a python builtin, consider renaming the class attribute
kolibri/core/exams/serializers.py:171:13: A001 "id" is a python builtin and is being shadowed, consider renaming the variable
kolibri/core/content/api.py:678:5: A003 "list" is a python builtin, consider renaming the class attribute
kolibri/core/content/api.py:898:5: A003 "list" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:153:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:201:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:265:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:284:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:364:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:404:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/models.py:425:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/serializers.py:198:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/content/utils/channel_import.py:680:13: A001 "license" is a python builtin and is being shadowed, consider renaming the variable
kolibri/core/content/utils/channel_import.py:685:9: A001 "license" is a python builtin and is being shadowed, consider renaming the variable
kolibri/core/content/utils/channel_import.py:691:9: A001 "license" is a python builtin and is being shadowed, consider renaming the variable
kolibri/core/content/utils/transfer.py:87:5: A003 "next" is a python builtin, consider renaming the class attribute
kolibri/core/content/utils/transfer.py:177:5: A003 "next" is a python builtin, consider renaming the class attribute
kolibri/core/content/management/commands/scanforcontent.py:24:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/analytics/models.py:14:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/analytics/management/commands/profile.py:43:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/analytics/management/commands/ping.py:38:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/analytics/management/commands/benchmark.py:74:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/deviceadmin/management/commands/dbrestore.py:27:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/deviceadmin/management/commands/dbbackup.py:21:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/deviceadmin/management/commands/vacuumsqlite.py:16:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/lessons/serializers.py:146:13: A001 "id" is a python builtin and is being shadowed, consider renaming the variable
kolibri/core/notifications/models.py:107:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/notifications/models.py:138:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/templatetags/kolibri_tags.py:214:42: A002 "dict" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/core/logger/utils/formatter.py:10:5: A003 "format" is a python builtin, consider renaming the class attribute
kolibri/core/logger/management/commands/generateuserdata.py:24:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/device/api.py:50:5: A003 "list" is a python builtin, consider renaming the class attribute
kolibri/core/device/api.py:66:28: A002 "format" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/core/device/management/commands/provisiondevice.py:115:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/registerfacility.py:16:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/syncdata.py:27:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/sync.py:19:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/deleteuser.py:9:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/deprovision.py:53:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/importusers.py:111:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/auth/management/commands/user_info.py:18:5: A003 "help" is a python builtin, consider renaming the class attribute
kolibri/core/public/api.py:26:5: A003 "list" is a python builtin, consider renaming the class attribute
kolibri/core/public/test/test_api.py:26:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/core/public/test/test_api.py:37:5: A003 "id" is a python builtin, consider renaming the class attribute
kolibri/utils/lru_cache.py:32:9: A002 "sorted" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/utils/lru_cache.py:33:9: A002 "tuple" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/utils/lru_cache.py:34:9: A002 "type" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/utils/lru_cache.py:35:9: A002 "len" is used as an argument and thus shadows a python builtin, consider renaming the argument
kolibri/plugins/coach/api.py:183:5: A003 "list" is a python builtin, consider renaming the class attribute

```

### References

n/a

@rtibbles @jamalex - sorry for the times where I mentioned assigning to built-ins.. I thought this was an integral part of code checks because my Liclipse does this.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
