### PR TITLE
Various (7) 0.12.6 fixes

### DIFF
--- a/kolibri/core/assets/src/views/AppError/index.vue
+++ b/kolibri/core/assets/src/views/AppError/index.vue
@@ -22,11 +22,11 @@
         :primary="true"
         @click="reloadPage"
       />
-      <KRouterLink
+      <KButton
+        :primary="false"
         appearance="raised-button"
-        :to="{path: '/'}"
         :text="$tr('defaultErrorExitPrompt')"
-        @click.native="clearErrorState"
+        @click="handleClickBackToHome"
       />
     </p>
     <p>
@@ -53,14 +53,12 @@
 
   import { mapActions } from 'vuex';
   import KButton from 'kolibri.coreVue.components.KButton';
-  import KRouterLink from 'kolibri.coreVue.components.KRouterLink';
   import ReportErrorModal from './ReportErrorModal';
 
   export default {
     name: 'AppError',
     components: {
       KButton,
-      KRouterLink,
       ReportErrorModal,
     },
     data() {
@@ -80,8 +78,9 @@
         // reloads without cache
         global.location.reload();
       },
-      clearErrorState() {
+      handleClickBackToHome() {
         this.handleError('');
+        this.$router.push({ path: '/' });
       },
     },
     $trs: {

--- a/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device_management/assets/src/views/DeviceInfoPage.vue
@@ -9,16 +9,15 @@
             {{ $tr('url', { count: deviceInfo.urls.length }) }}
           </th>
           <td>
-            <a
+            <KExternalLink
               v-for="(url, index) in deviceInfo.urls"
               :key="index"
-              dir="auto"
+              :text="url"
               :href="url"
+              :primary="true"
               target="_blank"
-              class="link"
-            >
-              {{ url }}
-            </a>
+              appearance="basic-link"
+            />
           </td>
         </tr>
         <tr>
@@ -61,6 +60,7 @@
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import KButton from 'kolibri.coreVue.components.KButton';
   import TechnicalTextBlock from 'kolibri.coreVue.components.TechnicalTextBlock';
+  import KExternalLink from 'kolibri.coreVue.components.KExternalLink';
 
   export default {
     name: 'DeviceInfoPage',
@@ -72,6 +72,7 @@
     components: {
       AuthMessage,
       KButton,
+      KExternalLink,
       TechnicalTextBlock,
     },
     data() {

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/ChannelListItem.vue
@@ -6,8 +6,12 @@
     :style="[verticalPadding, { borderTop: `1px solid ${$themeColors.palette.grey.v_200}` } ]"
   >
     <template slot="thumbnail">
-      <div class="spec-ref-thumbnail">
-        <img v-if="thumbnailImg" :src="thumbnailImg" class="thumbnail">
+      <div class="thumbnail-container" data-test="thumbnail">
+        <img
+          v-if="thumbnailImg"
+          :src="thumbnailImg"
+          class="thumbnail"
+        >
         <div
           v-else
           class="default-icon"
@@ -220,6 +224,8 @@
 
 <style lang="scss" scoped>
 
+  $thumbnail-side-length: 128px;
+
   .title {
     display: inline;
   }
@@ -228,16 +234,24 @@
     font-size: 0.85em;
   }
 
+  .thumbnail-container {
+    width: $thumbnail-side-length;
+    height: $thumbnail-side-length;
+  }
+
   .thumbnail {
     width: 100%;
   }
 
   .default-icon {
+    width: 100%;
+    height: 100%;
     text-align: center;
     svg {
-      width: 30%;
-      height: 30%;
-      margin: 20px;
+      width: 50%;
+      height: 50%;
+      // Icon scaled to 0.5 of 128px = 64px, so midpoint need to be moved to 128 / 4 = 32 px
+      margin: ($thumbnail-side-length / 2 / 2) 0;
     }
   }
 

--- a/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
+++ b/kolibri/plugins/device_management/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
@@ -83,7 +83,7 @@
       noImportableDrives: 'No drives with Kolibri content are connected to the server',
       noDriveWithSelectedChannelError:
         'No drives with the selected channel are connected to the server',
-      noExportableDrives: 'No drives that can be written to are connected to the server',
+      noExportableDrives: 'Could not find a writable drive connected to the server',
     },
   };
 

--- a/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/channel-list-item.spec.js
@@ -40,7 +40,7 @@ function getElements(wrapper) {
     title: () => wrapper.find('.title').text().trim(),
     version: () => wrapper.find('.version').text().trim(),
     description: () => wrapper.find('.spec-ref-description').text().trim(),
-    thumbnail: () => wrapper.find('.spec-ref-thumbnail'),
+    thumbnail: () => wrapper.find('[data-test="thumbnail"]'),
     addTaskMutation: (task) => wrapper.vm.$store.commit('manageContent/SET_TASK_LIST', [task]),
     dropdownMenu: () => wrapper.find({ name: 'KDropdownMenu' }),
   };

--- a/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/select-drive-modal.spec.js
@@ -155,7 +155,7 @@ describe('selectDriveModal component', () => {
     });
     const wrapper = makeWrapper({ store });
     const driveListText = wrapper.find(UiAlert);
-    const expectedMessage = 'No drives that can be written to are connected to the server';
+    const expectedMessage = 'Could not find a writable drive connected to the server';
     expect(driveListText.text().trim()).toEqual(expectedMessage);
   });
 

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -50,16 +50,16 @@ oriented data synchronization.
           category="action"
           :style="{
             fill: success ? $themeTokens.mastered : $themeColors.palette.grey.v_200,
-            verticalAlign: 0,
+            marginBottom: '-6px',
           }"
         />
         <div class="overall-status-text">
-          <div v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
+          <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
             {{ $tr('completed') }}
-          </div>
-          <div>
+          </span>
+          <span>
             {{ $tr('goal', {count: totalCorrectRequiredM}) }}
-          </div>
+          </span>
         </div>
       </div>
       <div class="table">

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -156,13 +156,8 @@
           let appBarTitle;
           const { searchTerm, last } = this.$route.query;
           if (searchTerm) {
-            immersivePageRoute = this.$router.getRoute(
-              PageNames.SEARCH,
-              {},
-              {
-                searchTerm: searchTerm,
-              }
-            );
+            appBarTitle = this.$tr('searchTitle');
+            immersivePageRoute = this.$router.getRoute(PageNames.SEARCH, {}, this.$route.query);
           } else if (last) {
             // 'last' should only be route names for Recommended Page and its subpages
             immersivePageRoute = this.$router.getRoute(last);

--- a/kolibri/plugins/learn/assets/src/views/PageHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/PageHeader.vue
@@ -58,9 +58,9 @@
   }
 
   .progress-icon {
-    position: relative;
-    top: -2px;
     display: inline-block;
+    float: right;
+    margin-top: -2px;
     margin-left: 16px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/PageHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/PageHeader.vue
@@ -1,14 +1,12 @@
 <template>
 
-  <div dir="auto">
-    <h1 class="title">
-      <KLabeledIcon>
-        <KIcon v-if="contentType" slot="icon" :[iconType]="true" />
-        {{ title }}
-      </KLabeledIcon>
-      <ProgressIcon class="progress-icon" :progress="progress" />
-    </h1>
-  </div>
+  <h1 dir="auto" class="title">
+    <KLabeledIcon>
+      <KIcon v-if="contentType" slot="icon" :[iconType]="true" />
+      {{ title }}
+    </KLabeledIcon>
+    <ProgressIcon class="progress-icon" :progress="progress" />
+  </h1>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -76,23 +76,11 @@
     },
     methods: {
       genContentLink(contentId, contentKind) {
+        const params = { id: contentId };
         if (contentKind === ContentNodeKinds.TOPIC || contentKind === ContentNodeKinds.CHANNEL) {
-          return {
-            name: PageNames.TOPICS_TOPIC,
-            params: {
-              id: contentId,
-            },
-          };
+          return this.$router.getRoute(PageNames.TOPICS_TOPIC, params);
         }
-        return {
-          name: PageNames.TOPICS_CONTENT,
-          params: {
-            id: contentId,
-          },
-          query: {
-            searchTerm: this.searchTerm,
-          },
-        };
+        return this.$router.getRoute(PageNames.TOPICS_CONTENT, params, this.$route.query);
       },
       loadMore() {
         if (!this.loading) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Fixes the position of the progress (clock) icon in RTL mode. (Fixes #5662)

![Screen Shot 2019-06-21 at 1 50 28 PM](https://user-images.githubusercontent.com/10248067/59950696-8f49e500-942b-11e9-9dff-9bf48c50fdc7.png)

1. Changes the implementation of the Device Info Page to use a `KExternalLink` instead of an anchor tag (fixes #5671)
1. Adjusts the vertical alignment of the star at the bottom the exercise viewer (Fixes #5663)

![Screen Shot 2019-06-21 at 1 52 54 PM](https://user-images.githubusercontent.com/10248067/59950800-e64fba00-942b-11e9-9104-d4f21d7d4b36.png)

1. Replaces the button-looking "Back to home" link on the AppError page with an actual button to fix layout issues on Safari: (fixes #5606)

![Screen Shot 2019-06-21 at 1 54 02 PM](https://user-images.githubusercontent.com/10248067/59950859-0d0df080-942c-11e9-87ed-d13d3a52939d.png)

1. Simplifies the "no writable drives" message in the Content export wizard (Fixes #5575)

![Screen Shot 2019-06-21 at 1 55 15 PM](https://user-images.githubusercontent.com/10248067/59950936-39c20800-942c-11e9-8a98-33a07f6215b4.png)

1. In Device > Channel, Match dimensions of the Channel icon placeholder to match real thumbnails (Fixes #5706)

![Screen Shot 2019-06-28 at 10 36 46 AM](https://user-images.githubusercontent.com/10248067/60362634-4e575080-9996-11e9-98f8-e4bd7fc2a533.png)

1. In Search Page, make sure `kind` and `channel_id` query parameters are passed through to make sure the exit-to-results link preserves filters (fixes #5717)

### Reviewer guidance

1. Check to see if clock is positioned correctly in RTL mode wherever ContentPage is used
1. Check link for the 'localhost' URL in DeviceInfo page, try it in a different theme to see if it follows the theme
1. In the exercise viewer, master an exercise; verify the star icon is colored correctly and aligned with the label
1. Check the AppError page in Safari and other browsers to verify that the button is aligned correctly in all browsers and works the same.
1. Check to see that the right "No writable drives" message appears in the wizard
1. Check to see that channel placeholder icons match thumnails in different screen sizes
1. Check to see that exiting a resource found via search preserves the filters you had set earlier (try channel, kind, both, and neither filter).


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
