### PR TITLE
update dev docs based on feedback

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -102,6 +102,25 @@ Now, any commands run with will target your virtual environment rather than the 
 .. warning::
   Never install project dependencies using ``sudo pip install ...``
 
+
+.. _EnvVars:
+
+
+Environment variables
+~~~~~~~~~~~~~~~~~~~~~
+
+Environment variables can be set in many ways, including:
+
+* adding them to a ``~/.bash_profile`` file (for Bash) or a similar file in your shell of choice
+* using a ``.env`` file for this project, `loaded with Pipenv <https://docs.pipenv.org/en/latest/advanced/#automatic-loading-of-env>`_
+* setting them temporarily in the current Bash session using ``EXPORT`` or similar (not recommended except for testing)
+
+There are two environment variables you should plan to set:
+
+* ``KOLIBRI_RUN_MODE`` (required): This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_, and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. (There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing gherkin stories.)
+* ``KOLIBRI_HOME`` (optional): This variable determines where Kolibri will store its content and databases. It is useful to set if you want to have multiple versions of Kolibri running simultaneously.
+
+
 Install Python dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -308,8 +308,8 @@ This will output a JSON blob like:
 
 You can `redirect this output to a file <https://askubuntu.com/questions/420981/how-do-i-save-terminal-output-to-a-file>`_ (Bash) or `pipe it to the clipboard <https://stackoverflow.com/questions/1753110/>`_ (Mac)
 
-Set Kolibri's ``RUN_MODE`` to ``staged-msgs`` to receive staged messages. Test that all languages are displayed correctly.
+Set Kolibri's ``KOLIBRI_RUN_MODE`` to ``staged-msgs-ver-0.0.1`` to receive staged messages, as described in :ref:`EnvVars`. Test that all languages are displayed correctly.
 
-Next, emulate different versions and ensure that the semver conditional logic is being processed correctly. Set ``RUN_MODE`` to something like ``staged-msgs-ver-0.12.3`` to emulate version 0.12.3, for example.
+Next, emulate different versions and ensure that the semver conditional logic is being processed correctly. Set ``KOLIBRI_RUN_MODE`` to something like ``staged-msgs-ver-0.12.3`` to emulate version 0.12.3, for example. For more information, take a look at `the function for parsing these strings <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L129-L149>`_.
 
 Once testing has confirmed that the message works as expected, set the message to active to enable it.


### PR DESCRIPTION

### Summary

* add notes about setting environment vars to the 'getting started' docs
* clarify usage of `KOLIBRI_RUN_MODE` for sending test messages

### Reviewer guidance

make sense?

### References

based on comments:
* https://github.com/learningequality/kolibri/pull/5686#pullrequestreview-253720283
* https://github.com/learningequality/kolibri/pull/5686#pullrequestreview-253721653

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
