### PR TITLE
Show demo server banner only on Sign In page

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -1,4 +1,4 @@
-const UserKinds = {
+export const UserKinds = {
   ADMIN: 'admin',
   COACH: 'coach',
   LEARNER: 'learner',
@@ -8,12 +8,12 @@ const UserKinds = {
   CAN_MANAGE_CONTENT: 'can manage content',
 };
 
-const CollectionKinds = {
+export const CollectionKinds = {
   CLASSROOM: 'classroom',
   LEARNERGROUP: 'learnergroup',
 };
 
-const ContentNodeKinds = {
+export const ContentNodeKinds = {
   AUDIO: 'audio',
   DOCUMENT: 'document',
   VIDEO: 'video',
@@ -28,9 +28,9 @@ const ContentNodeKinds = {
 };
 
 // used internally on the client as a hack to allow content-icons to display users
-const USER = 'user';
+export const USER = 'user';
 
-const MasteryLoggingMap = {
+export const MasteryLoggingMap = {
   id: 'id',
   summarylog: 'summarylog',
   start_timestamp: 'start_timestamp',
@@ -44,7 +44,7 @@ const MasteryLoggingMap = {
   totalattempts: 'totalattempts',
 };
 
-const AttemptLoggingMap = {
+export const AttemptLoggingMap = {
   id: 'id',
   sessionlog: 'sessionlog',
   item: 'item',
@@ -62,13 +62,13 @@ const AttemptLoggingMap = {
   hinted: 'hinted',
 };
 
-const InteractionTypes = {
+export const InteractionTypes = {
   hint: 'hint',
   answer: 'answer',
   error: 'error',
 };
 
-const MasteryModelGenerators = {
+export const MasteryModelGenerators = {
   do_all: assessmentIds => ({
     m: assessmentIds.length,
     n: assessmentIds.length,
@@ -81,27 +81,27 @@ const MasteryModelGenerators = {
 };
 
 // How many points is a completed content item worth?
-const MaxPointsPerContent = 500;
+export const MaxPointsPerContent = 500;
 
-const LoginErrors = {
+export const LoginErrors = {
   PASSWORD_MISSING: 'PASSWORD_MISSING',
   INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
 };
 
-const PermissionTypes = {
+export const PermissionTypes = {
   SUPERUSER: 'SUPERUSER',
   LIMITED_PERMISSIONS: 'LIMITED_PERMISSIONS',
 };
 
-const SIGNED_OUT_DUE_TO_INACTIVITY = 'SIGNED_OUT_DUE_TO_INACTIVITY';
+export const SIGNED_OUT_DUE_TO_INACTIVITY = 'SIGNED_OUT_DUE_TO_INACTIVITY';
 
-const UPDATE_MODAL_DISMISSED = 'UPDATE_MODAL_DISMISSED';
+export const UPDATE_MODAL_DISMISSED = 'UPDATE_MODAL_DISMISSED';
 
-const NavComponentSections = {
+export const NavComponentSections = {
   ACCOUNT: 'account',
 };
 
-const ERROR_CONSTANTS = {
+export const ERROR_CONSTANTS = {
   // These are an exact copy of the python module kolibri.core.error_constants
   // and should be kept in sync.
   // 400 error based constants
@@ -120,22 +120,4 @@ const ERROR_CONSTANTS = {
   // 403 error constants
   PERMISSION_DENIED: 'PERMISSION_DENIED',
   NOT_AUTHENTICATED: 'NOT_AUTHENTICATED',
-};
-
-export {
-  UserKinds,
-  ContentNodeKinds,
-  MasteryLoggingMap,
-  AttemptLoggingMap,
-  InteractionTypes,
-  USER,
-  MasteryModelGenerators,
-  CollectionKinds,
-  MaxPointsPerContent,
-  LoginErrors,
-  PermissionTypes,
-  SIGNED_OUT_DUE_TO_INACTIVITY,
-  UPDATE_MODAL_DISMISSED,
-  NavComponentSections,
-  ERROR_CONSTANTS,
 };

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -30,6 +30,6 @@ export function pageSessionId(state) {
   return state.pageSessionId;
 }
 
-export function demoBannerVisible(state) {
-  return state.demoBannerVisible;
+export function demoBannerVisible(state, getters, rootState) {
+  return state.demoBannerVisible && rootState.pageName === 'SIGN_IN';
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Updates the `demoBannerVisible` getter to return true only on the Sign IN page.
1. Refactors core/constants.js to use named exports

### Reviewer guidance

1. Confirm that things work normally when the demo server plugin in disabled
1. Enable the demo server plugin with `kolibri plugin kolibri.plugins.demo_server enable`. Confirm that the demo banner only shows on the sign in page, and not on the Create Account page or on the Profile page.

### References

Fixes #5715 
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
