### PR TITLE
RTL behavior updates: grids, headers, labeled icons

### DIFF
--- a/kolibri/core/assets/src/views/KGrid/KGridItem.vue
+++ b/kolibri/core/assets/src/views/KGrid/KGridItem.vue
@@ -169,7 +169,10 @@
           paddingLeft: padding,
           paddingRight: padding,
         };
-        const isRtl = this.gridMetrics && this.gridMetrics.direction === 'rtl';
+        let isRtl = this.isRtl;
+        if (this.gridMetrics && this.gridMetrics.direction) {
+          isRtl = this.gridMetrics.direction === 'rtl';
+        }
         if (this.currentAlignment) {
           // TODO: rename the alignment inputs to 'start' and 'end'
           if (isRtl && this.currentAlignment === 'left') {

--- a/kolibri/core/assets/src/views/KGrid/index.vue
+++ b/kolibri/core/assets/src/views/KGrid/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div style="direction: inherit;">
     <div class="pure-g" :style="style">
       <slot></slot>
     </div>
@@ -123,7 +123,7 @@
       });
       Object.defineProperty(gridMetrics, 'direction', {
         enumerable: true,
-        get: () => (this.$el ? getComputedStyle(this.$el).direction : 'ltr'),
+        get: () => (this.$el ? getComputedStyle(this.$el).direction : undefined),
       });
       Object.defineProperty(gridMetrics, 'debug', {
         enumerable: true,

--- a/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
@@ -4,7 +4,7 @@
     <div class="icon">
       <slot name="icon"></slot>
     </div>
-    <div class="label" dir="auto">
+    <div class="label">
       <slot></slot>
     </div>
   </span>

--- a/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
+++ b/kolibri/core/assets/src/views/icons/KLabeledIcon.vue
@@ -5,7 +5,10 @@
       <slot name="icon"></slot>
     </div>
     <div class="label">
-      <slot></slot>
+      <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
+      <span dir="auto">
+        <slot></slot>
+      </span>
     </div>
   </span>
 

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -11,7 +11,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
         <!---->
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed
   </div></span>
     <!---->
@@ -28,7 +28,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
     <div>learner2</div>
   </td>
   <td>
-    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     Started
   </div></span>
       <!---->
@@ -56,7 +56,7 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
         </th>
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed
   </div></span>
     <!---->
@@ -77,7 +77,7 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
     <div>learner2</div>
   </td>
   <td>
-    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     Started
   </div></span>
       <!---->

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -11,10 +11,11 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
         <!---->
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed
-  </div></span>
-    <!---->
+  </span>
+</div></span>
+<!---->
 </div>
 </td>
 <td><span>92 seconds</span></td>
@@ -28,10 +29,10 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
     <div>learner2</div>
   </td>
   <td>
-    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started
-  </div></span>
-      <!---->
+  </span></div></span>
+    <!---->
     </div>
   </td>
   <td><span>17 seconds</span></td>
@@ -56,10 +57,11 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
         </th>
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+    </thead><span tag="tbody" name="list"><tr data-test="entry"><td><div>learner1</div></td> <td><div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed
-  </div></span>
-    <!---->
+  </span>
+</div></span>
+<!---->
 </div>
 </td>
 <td><span>92 seconds</span></td>
@@ -77,10 +79,10 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
     <div>learner2</div>
   </td>
   <td>
-    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started
-  </div></span>
-      <!---->
+  </span></div></span>
+    <!---->
     </div>
   </td>
   <td><span>17 seconds</span></td>

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed by 1 of 1
   </div></span>
     <!---->
@@ -12,22 +12,22 @@ exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -37,7 +37,7 @@ exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0 of 0
   </div></span>
     <!---->
@@ -47,12 +47,12 @@ exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed by 1 of 3
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     1 started
   </div></span>
     <!---->
@@ -64,22 +64,22 @@ exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -89,22 +89,22 @@ exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -114,7 +114,7 @@ exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0 of 0
   </div></span>
     <!---->

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonExerciseLearnerListPage.spec.js.snap
@@ -2,122 +2,122 @@
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed by 1 of 1
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+  </span></div></span>
+  <!---->
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for a lesson restricted to some groups recipients only when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0 of 0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed by 1 of 3
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+  </span></div></span>
+  <!---->
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     1 started
-  </div></span>
-    <!---->
-  </div>
-  <!---->
-  <!---->
+  </span></div></span>
+<!---->
+</div>
+<!---->
+<!---->
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+  </span></div></span>
+  <!---->
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+  </span></div></span>
+  <!---->
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; has some needing help" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="error" category="alert" style="fill: #c62828;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  </span></div></span>
+<!---->
+</div>
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonExerciseLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0 of 0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed by 1 of 1
   </div></span>
     <!---->
@@ -23,18 +23,18 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -44,7 +44,7 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0 of 0
   </div></span>
     <!---->
@@ -67,12 +67,12 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed by 1 of 3
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     1 started
   </div></span>
     <!---->
@@ -95,18 +95,18 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -116,18 +116,18 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     1
   </div></span>
     <!---->
   </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
   </div>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0
   </div></span>
     <!---->
@@ -137,7 +137,7 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div dir="auto" class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
     0 of 0
   </div></span>
     <!---->

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsLessonResourceLearnerListPage.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="everyone finished" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed by 1 of 1
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;
 
@@ -23,32 +23,32 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
-    0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
+<!---->
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
+    0
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some groups recipents only when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0 of 0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;
 
@@ -67,18 +67,18 @@ exports[`ReportsLessonResourceLearnerListPage for a lesson restricted to some gr
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying all learners renders a correct summary tally 1`] = `
 <div class="multi-line" data-test="summary-tally">
-  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div showratiointooltip="" debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed by 1 of 3
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+  </span></div></span>
+  <!---->
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     1 started
-  </div></span>
-    <!---->
-  </div>
-  <!---->
-  <!---->
+  </span></div></span>
+<!---->
+</div>
+<!---->
+<!---->
 </div>
 `;
 
@@ -95,53 +95,53 @@ exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when di
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 1`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
-    1
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
+    1
+  </span></div></span>
+<!---->
+</div>
+<!---->
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 2`] = `
 <div class="single-line">
-  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+  <div debug="ratio; has some completed" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     1
-  </div></span>
-    <!---->
-  </div>
-  <div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
-    0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
   <!---->
-  <div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+</div>
+<div debug="ratio; has some started" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+<!---->
+</div>
+<!---->
+<div debug="ratio; not verbose" class="item" style="color: rgb(224, 224, 224);"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
+    0
+  </span></div></span>
+<!---->
+</div>
 </div>
 `;
 
 exports[`ReportsLessonResourceLearnerListPage for an entire class lesson when displaying learners by groups renders a correct group tally 3`] = `
 <div class="single-line">
-  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label">
+  <div debug="no learners" class="item"><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="brightness_1" category="image" style="fill: #e0e0e0;"></mat-svg></div> <div class="label"><span dir="auto">
     0 of 0
-  </div></span>
-    <!---->
-  </div>
+  </span></div></span>
+  <!---->
+</div>
 </div>
 `;
 

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
@@ -11,11 +11,11 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
         <!---->
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div dir="auto" class="label">
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
           learner1
         </div></span></td>
     <td>
-      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed
   </div></span>
         <!---->
@@ -28,11 +28,11 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
 </span></td>
     </tr>
     <tr>
-      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div dir="auto" class="label">
+      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
           learner2
         </div></span></td>
       <td>
-        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     Started
   </div></span>
           <!---->
@@ -62,11 +62,11 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
         </th>
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div dir="auto" class="label">
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
           learner1
         </div></span></td>
     <td>
-      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div dir="auto" class="label">
+      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
     Completed
   </div></span>
         <!---->
@@ -83,11 +83,11 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
 </span></td>
     </tr>
     <tr>
-      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div dir="auto" class="label">
+      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
           learner2
         </div></span></td>
       <td>
-        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div dir="auto" class="label">
+        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
     Started
   </div></span>
           <!---->

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
@@ -11,41 +11,40 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
         <!---->
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
           learner1
-        </div></span></td>
-    <td>
-      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+        </span>
+</div></span></td>
+<td>
+  <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed
-  </div></span>
-        <!---->
-      </div>
-    </td>
-    <td><span>92 seconds</span></td>
-    <!---->
-    <td><span>
+  </span></div></span>
+  <!---->
+  </div>
+</td>
+<td><span>92 seconds</span></td>
+<!---->
+<td><span>
   yesterday
 </span></td>
-    </tr>
-    <tr>
-      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
+</tr>
+<tr>
+  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
           learner2
-        </div></span></td>
-      <td>
-        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+        </span></div></span></td>
+  <td>
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started
-  </div></span>
-          <!---->
-        </div>
-      </td>
-      <td><span>17 seconds</span></td>
-      <!---->
-      <td><span>
+  </span></div></span>
+    <!---->
+    </div>
+  </td>
+  <td><span>17 seconds</span></td>
+  <!---->
+  <td><span>
   3 hours ago
 </span></td>
-    </tr>
-    </span>
-  </table>
+</tr></span></table>
 </div>
 `;
 
@@ -62,48 +61,47 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
         </th>
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
           learner1
-        </div></span></td>
-    <td>
-      <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label">
+        </span>
+</div></span></td>
+<td>
+  <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
     Completed
-  </div></span>
-        <!---->
-      </div>
-    </td>
-    <td><span>92 seconds</span></td>
-    <td>
-      <div class="items-label"><span>
+  </span></div></span>
+  <!---->
+  </div>
+</td>
+<td><span>92 seconds</span></td>
+<td>
+  <div class="items-label"><span>
     group1, group2
   </span></div>
-    </td>
-    <td><span>
+</td>
+<td><span>
   yesterday
 </span></td>
-    </tr>
-    <tr>
-      <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label">
+</tr>
+<tr>
+  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
           learner2
-        </div></span></td>
-      <td>
-        <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label">
+        </span></div></span></td>
+  <td>
+    <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started
-  </div></span>
-          <!---->
-        </div>
-      </td>
-      <td><span>17 seconds</span></td>
-      <td>
-        <div class="items-label"><span>
+  </span></div></span>
+    <!---->
+    </div>
+  </td>
+  <td><span>17 seconds</span></td>
+  <td>
+    <div class="items-label"><span>
     group2
   </span></div>
-      </td>
-      <td><span>
+  </td>
+  <td><span>
   3 hours ago
 </span></td>
-    </tr>
-    </span>
-  </table>
+</tr></span></table>
 </div>
 `;

--- a/kolibri/plugins/learn/assets/src/views/PageHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/PageHeader.vue
@@ -1,12 +1,18 @@
 <template>
 
-  <h1 dir="auto" class="title">
-    <KLabeledIcon>
-      <KIcon v-if="contentType" slot="icon" :[iconType]="true" />
-      {{ title }}
-    </KLabeledIcon>
-    <ProgressIcon class="progress-icon" :progress="progress" />
-  </h1>
+  <KGrid>
+    <KGridItem sizes="3, 7, 11">
+      <h1>
+        <KLabeledIcon>
+          <KIcon v-if="contentType" slot="icon" :[iconType]="true" />
+          {{ title }}
+        </KLabeledIcon>
+      </h1>
+    </KGridItem>
+    <KGridItem sizes="1, 1, 1" alignment="right">
+      <ProgressIcon class="progress-icon" :progress="progress" />
+    </KGridItem>
+  </KGrid>
 
 </template>
 
@@ -16,10 +22,14 @@
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import KIcon from 'kolibri.coreVue.components.KIcon';
   import KLabeledIcon from 'kolibri.coreVue.components.KLabeledIcon';
+  import KGrid from 'kolibri.coreVue.components.KGrid';
+  import KGridItem from 'kolibri.coreVue.components.KGridItem';
 
   export default {
     name: 'PageHeader',
     components: {
+      KGridItem,
+      KGrid,
       KIcon,
       KLabeledIcon,
       ProgressIcon,
@@ -51,15 +61,9 @@
 
 <style lang="scss" scoped>
 
-  .title {
-    display: inline-block;
-  }
-
   .progress-icon {
-    display: inline-block;
-    float: right;
-    margin-top: -2px;
-    margin-left: 16px;
+    position: relative;
+    top: 20px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h1 dir="auto" class="classroom-name">
+    <h1 class="classroom-name">
       <KLabeledIcon>
         <KIcon slot="icon" classroom />
         {{ classroomName }}


### PR DESCRIPTION
### Summary

* Removes `dir="auto"` from labeled icons so that text is aligned with the associated icon
* Use grids in headers instead of floats, and align progress icon to the right for consistency with cards
* Fix issue in grids which defaulted to `ltr` when context couldn't be found. Instead, default to global direction. (ref: #4686 cc @rtibbles). Also adds a `direction: inherit;` to top level element which seemed important in some cases.

### Reviewer guidance

Here are a few cases I tested:


| app dir | before | after |
|--|--|--|
| ltr | ![image](https://user-images.githubusercontent.com/2367265/60378011-16b9ca00-99d1-11e9-8014-f2620d3f1042.png) | ![image](https://user-images.githubusercontent.com/2367265/60377924-1e2ca380-99d0-11e9-8aa2-61451217be6a.png) |
| rtl | ![image](https://user-images.githubusercontent.com/2367265/60378024-26d1a980-99d1-11e9-9843-a7b27ebeaf27.png) | ![image](https://user-images.githubusercontent.com/2367265/60377928-2ab0fc00-99d0-11e9-9d28-a50188bb23c5.png) |
| ltr | ![image](https://user-images.githubusercontent.com/2367265/60378031-49fc5900-99d1-11e9-9ba1-cffa9759339e.png) | ![image](https://user-images.githubusercontent.com/2367265/60377935-40bebc80-99d0-11e9-8b4d-b13b6e5e00bf.png) |
| rtl | ![image](https://user-images.githubusercontent.com/2367265/60378030-3b15a680-99d1-11e9-9ec7-54019026ff51.png) | ![image](https://user-images.githubusercontent.com/2367265/60377932-33a1cd80-99d0-11e9-8ffd-847c99c3c4c7.png) |
| ltr | ![image](https://user-images.githubusercontent.com/2367265/60378002-fb4ebf00-99d0-11e9-8adc-edc14ee42acc.png) | ![image](https://user-images.githubusercontent.com/2367265/60377940-4fa56f00-99d0-11e9-96a2-75f388e28535.png) |
| rtl | ![image](https://user-images.githubusercontent.com/2367265/60377997-ec680c80-99d0-11e9-9650-cd13e48bd32f.png) | ![image](https://user-images.githubusercontent.com/2367265/60377944-5cc25e00-99d0-11e9-884f-b4ca60970048.png) |




### References

This relates to #5662 and #4686. It builds on work done by @jonboiser in #5699


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
