### PR TITLE
tighten up badge spacing

### DIFF
--- a/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility_management/assets/src/views/UserTable.vue
@@ -224,7 +224,7 @@
 
   .role-badge {
     display: inline-block;
-    padding: 2px;
+    padding: 0;
     padding-right: 8px;
     padding-left: 8px;
     margin-left: 16px;


### PR DESCRIPTION
### Summary

I had noticed that the badges caused the table rows containing them to shift. This meant that a table with many rows containing badges was noticeably taller than one without.

This became especially noticeable when paging through multiple pages

### Reviewer guidance

Try paging through a large number of users with and without the change, and see it makes an improvement in the behavior


### References

follow-up from #5647

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
