### PR TITLE
work on integrating OIDC provider workflow as a built-in plugin

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -243,8 +243,14 @@ export function kolibriLogin(store, sessionPayload) {
   Lockr.set(UPDATE_MODAL_DISMISSED, false);
   return SessionResource.saveModel({ data: sessionPayload })
     .then(() => {
-      // Redirect on login
-      redirectBrowser();
+      // OIDC redirect
+      if (sessionPayload.next) {
+        redirectBrowser(sessionPayload.next);
+      }
+      // Normal redirect on login
+      else {
+        redirectBrowser();
+      }
     })
     .catch(error => {
       store.commit('CORE_SET_SIGN_IN_BUSY', false);

--- a/kolibri/core/oidc_provider_hook.py
+++ b/kolibri/core/oidc_provider_hook.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from kolibri.plugins import hooks
+
+
+class OIDCProviderHook(hooks.KolibriHook):
+    """
+    A hook to enable the OIDC provider
+    """
+
+    class Meta:
+        abstract = True
+
+    @property
+    def is_enabled(self):
+        return len(list(self.registered_hooks)) == 1

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -23,6 +23,7 @@
     <script src="{% url 'api-docs:schema-js' %}"></script>
   {% endif %}
   {% kolibri_language_globals %}
+  {% enable_oidc_provider %}
   {% kolibri_theme %}
   {% kolibri_set_urls %}
   {% webpack_asset 'user_agent' %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -32,6 +32,7 @@ import kolibri
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.theme_hook import ThemeHook
+from kolibri.core.oidc_provider_hook import OIDCProviderHook
 from kolibri.core.webpack.utils import webpack_asset_render
 from kolibri.utils import conf
 from kolibri.utils import i18n
@@ -120,6 +121,21 @@ def kolibri_navigation_actions():
     :return: An html string
     """
     return webpack_asset_render(NavigationHook)
+
+
+@register.simple_tag()
+def enable_oidc_provider():
+    """
+    Specify whether or not the oidc_provider plugin is enabled
+    """
+    template = """
+    <script>
+      var oidcProvider = {};
+    </script>
+    """
+    return mark_safe(
+        template.format("true" if OIDCProviderHook().is_enabled else "false")
+    )
 
 
 @register.simple_tag()

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -130,7 +130,7 @@ def enable_oidc_provider():
     """
     template = """
     <script>
-      var oidcProvider = {};
+      var oidcProviderEnabled = {};
     </script>
     """
     return mark_safe(

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from .base import *  # noqa isort:skip @UnusedWildImport
 
-INSTALLED_APPS += ["rest_framework_swagger"]  # noqa
+INSTALLED_APPS = list(INSTALLED_APPS) + ["rest_framework_swagger"]  # noqa F405
 
 INTERNAL_IPS = ["127.0.0.1"]
 

--- a/kolibri/plugins/base.py
+++ b/kolibri/plugins/base.py
@@ -49,6 +49,11 @@ class KolibriPluginBase(object):
     # with a language prefixs
     translated_view_urls = None
 
+    # Name of a local module that contains url_patterns that define
+    # URLs for views that should be attached to the domain root.
+    # Use with caution! The lack of namespacing is dangerous.
+    root_view_urls = None
+
     # Name of a local module that contains additional settings to augment
     # Django settings.
     # For settings that take a tuple or list, these will be appended to the value from
@@ -177,6 +182,31 @@ class KolibriPluginBase(object):
                 logging.warn(
                     "{plugin} defined {urls} untranslated view urls but the module was not found".format(
                         plugin=self._module_path(), urls=self.untranslated_view_urls
+                    )
+                )
+            return module
+
+    def root_url_module(self):
+        """
+        Return a url module, containing ``urlpatterns = [...]``, a conventional
+        Django application url module.
+
+        Do this separately for endpoints that need to be attached at the root.
+
+        URLs are by default accessed through Django's reverse lookups like
+        this::
+
+            reverse('kolibri:url_name')
+
+        By default this will be discovered based on the root_view_urls
+        property.
+        """
+        if self.root_view_urls:
+            module = self._return_module(self.root_view_urls)
+            if module is None:
+                logging.warn(
+                    "{plugin} defined {urls} root view urls but the module was not found".format(
+                        plugin=self._module_path(), urls=self.root_view_urls
                     )
                 )
             return module

--- a/kolibri/plugins/oidc_provider_plugin/__init__.py
+++ b/kolibri/plugins/oidc_provider_plugin/__init__.py
@@ -1,0 +1,6 @@
+def kolibri_userinfo(claims, user):
+    """
+    Fill claims with the information available in the Kolibri database
+    """
+    claims["name"] = user.full_name
+    return claims

--- a/kolibri/plugins/oidc_provider_plugin/api_urls.py
+++ b/kolibri/plugins/oidc_provider_plugin/api_urls.py
@@ -1,0 +1,17 @@
+from django.conf.urls import include
+from django.conf.urls import url
+from rest_framework import routers
+
+from .views import ProviderInfoView
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(
+        r"^\.well-known/openid-configuration/?$",
+        ProviderInfoView.as_view(),
+        name="provider-info",
+    ),
+    url(r"^", include("oidc_provider.urls", namespace="oidc_provider")),
+]
+urlpatterns += router.urls

--- a/kolibri/plugins/oidc_provider_plugin/api_urls.py
+++ b/kolibri/plugins/oidc_provider_plugin/api_urls.py
@@ -2,16 +2,7 @@ from django.conf.urls import include
 from django.conf.urls import url
 from rest_framework import routers
 
-from .views import ProviderInfoView
-
 router = routers.SimpleRouter()
 
-urlpatterns = [
-    url(
-        r"^\.well-known/openid-configuration/?$",
-        ProviderInfoView.as_view(),
-        name="provider-info",
-    ),
-    url(r"^", include("oidc_provider.urls", namespace="oidc_provider")),
-]
+urlpatterns = [url(r"^", include("oidc_provider.urls", namespace="oidc_provider"))]
 urlpatterns += router.urls

--- a/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
+++ b/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
@@ -4,9 +4,13 @@ from kolibri.plugins.base import KolibriPluginBase
 from kolibri.core.oidc_provider_hook import OIDCProviderHook
 
 
-class OIDCProviderPlugin(KolibriPluginBase):
+class OIDCProvider(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
+    root_view_urls = "root_urls"
     django_settings = "settings"
+
+    def url_slug(self):
+        return "^oidc_provider/"
 
     # IMPORTANT: This should be added in case we want to have this feature:
     # https://django-oidc-provider.readthedocs.io/en/latest/sections/sessionmanagement.html#sessionmanagement

--- a/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
+++ b/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from kolibri.plugins.base import KolibriPluginBase
+
+from kolibri.core.oidc_provider_hook import OIDCProviderHook
+
+
+class OIDCProviderPlugin(KolibriPluginBase):
+    untranslated_view_urls = "api_urls"
+    django_settings = "settings"
+
+    # IMPORTANT: This should be added in case we want to have this feature:
+    # https://django-oidc-provider.readthedocs.io/en/latest/sections/sessionmanagement.html#sessionmanagement
+    # def __init__(self):
+    #     MIDDLEWARE += ["oidc_provider.middleware.SessionManagementMiddleware"]
+    #     setattr(settings, 'MIDDLEWARE', MIDDLEWARE)
+
+
+class EnableOIDC(OIDCProviderHook):
+    pass

--- a/kolibri/plugins/oidc_provider_plugin/management/commands/oidccreateclient.py
+++ b/kolibri/plugins/oidc_provider_plugin/management/commands/oidccreateclient.py
@@ -1,0 +1,77 @@
+import binascii
+import logging
+import os
+
+from django.core.management.base import BaseCommand
+from oidc_provider.models import Client
+from oidc_provider.models import ResponseType
+
+logger = logging.getLogger(__name__)
+
+"""
+Usage example:
+kolibri manage oidccreateclient  --name="hooooo" --redirect-uri="http://otro/callback"
+"""
+
+
+class Command(BaseCommand):
+    help = (
+        "Command to add new clients applications that will use kolibri as an OpenID Connect provider"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--name",
+            action="store",
+            dest="name",
+            required=True,
+            help="Specifies the name to identify the client. It is an informative value.",
+        )
+        parser.add_argument(
+            "--clientid",
+            action="store",
+            dest="client_id",
+            help="OpenID Connect client ID to be used. If it's not provided it will be the same as the name",
+        )
+        parser.add_argument(
+            "--redirect-uri",
+            action="store",
+            dest="redirect_uri",
+            required=True,
+            help="Path to redirect to on successful login",
+        )
+
+    def handle(self, *args, **options):
+        client_id = (
+            options["name"] if not options["client_id"] else options["client_id"]
+        )
+        client_secret = binascii.hexlify(os.urandom(16))
+        allowed_responses = ("code", "id_token", "id_token token")
+        response_codes = ResponseType.objects.filter(value__in=allowed_responses)
+
+        try:
+            new_client = Client.objects.create(
+                name=options["name"],
+                client_type="public",
+                client_id=client_id,
+                client_secret=client_secret,
+                jwt_alg="RS256",
+                reuse_consent=True,
+                require_consent=False,
+                _redirect_uris=options["redirect_uri"],
+                _scope="openid profile",
+            )
+            new_client.save()
+            new_client.response_types = response_codes
+
+            logger.warn(
+                "Client {id} created with client secret {secret}".format(
+                    id=client_id, secret=client_secret
+                )
+            )
+        except Exception as e:
+            logger.error(
+                "Client {id} could not be created. There was an error {error}".format(
+                    id=client_id, error=e.message
+                )
+            )

--- a/kolibri/plugins/oidc_provider_plugin/root_urls.py
+++ b/kolibri/plugins/oidc_provider_plugin/root_urls.py
@@ -1,0 +1,15 @@
+from django.conf.urls import url
+from rest_framework import routers
+
+from .views import ProviderInfoView
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(
+        r"^\.well-known/openid-configuration/?$",
+        ProviderInfoView.as_view(),
+        name="provider-info",
+    )
+]
+urlpatterns += router.urls

--- a/kolibri/plugins/oidc_provider_plugin/settings.py
+++ b/kolibri/plugins/oidc_provider_plugin/settings.py
@@ -1,1 +1,2 @@
 INSTALLED_APPS = ["oidc_provider"]
+OIDC_LOGIN_URL = "/user/#/signin"

--- a/kolibri/plugins/oidc_provider_plugin/settings.py
+++ b/kolibri/plugins/oidc_provider_plugin/settings.py
@@ -1,2 +1,4 @@
 INSTALLED_APPS = ["oidc_provider"]
 OIDC_LOGIN_URL = "/user/#/signin"
+LOGIN_URL = "/user/#/signin"
+OIDC_USERINFO = "kolibri.plugins.oidc_provider_plugin.kolibri_userinfo"

--- a/kolibri/plugins/oidc_provider_plugin/settings.py
+++ b/kolibri/plugins/oidc_provider_plugin/settings.py
@@ -1,0 +1,1 @@
+INSTALLED_APPS = ["oidc_provider"]

--- a/kolibri/plugins/oidc_provider_plugin/settings.py
+++ b/kolibri/plugins/oidc_provider_plugin/settings.py
@@ -1,4 +1,3 @@
 INSTALLED_APPS = ["oidc_provider"]
-OIDC_LOGIN_URL = "/user/#/signin"
-LOGIN_URL = "/user/#/signin"
+OIDC_LOGIN_URL = "/user/#/signin/"
 OIDC_USERINFO = "kolibri.plugins.oidc_provider_plugin.kolibri_userinfo"

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
@@ -1,0 +1,25 @@
+{% load i18n staticfiles %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <h2>{% trans 'Request for Permission' %}</h2>
+        <p class="lead">Client <i>{{ client.name }}</i> would like to access this information of you.</p>
+        <form method="post" action="{% url 'kolibri:unwomen:oidc_provider:authorize' %}">
+            {% csrf_token %}
+            {{ hidden_inputs }}
+            <ul>
+                {% for scope in scopes %}
+                <li><strong>{{ scope.name }}</strong> <br><i class="text-muted">{{ scope.description }}</i></li>
+                {% endfor %}
+            </ul>
+            <br>
+            <input type="submit" class="btn btn-primary btn-block btn-lg" name="allow"  value="Authorize" />
+            <input type="submit" class="btn btn-secondary btn-block" value="Decline" />
+        </form>
+    </div>
+</div>
+
+{% endblock %}
+

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
@@ -6,7 +6,7 @@
     <div class="col-md-6 col-md-offset-3">
         <h2>{% trans 'Request for Permission' %}</h2>
         <p class="lead">Client <i>{{ client.name }}</i> would like to access this information of you.</p>
-        <form method="post" action="{% url 'kolibri:unwomen:oidc_provider:authorize' %}">
+        <form method="post" action="{% url 'kolibri:oidcprovider:oidc_provider:authorize' %}">
             {% csrf_token %}
             {{ hidden_inputs }}
             <ul>
@@ -22,4 +22,3 @@
 </div>
 
 {% endblock %}
-

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/error.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/error.html
@@ -1,0 +1,11 @@
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <h2>{{ error }}</h2>
+        <p class="lead">{{ description }}</p>
+    </div>
+</div>
+
+{% endblock %}

--- a/kolibri/plugins/oidc_provider_plugin/views.py
+++ b/kolibri/plugins/oidc_provider_plugin/views.py
@@ -1,0 +1,60 @@
+from django.core.urlresolvers import reverse
+from django.http import JsonResponse
+from django.views.generic import View
+from oidc_provider import settings as oidc_settings
+from oidc_provider.lib.utils.common import get_site_url
+from oidc_provider.models import ResponseType
+
+
+class ProviderInfoView(View):
+    def get(self, request, *args, **kwargs):
+        dic = dict()
+        site_url = get_site_url(request=request)
+        dic["issuer"] = (
+            site_url
+            + reverse("kolibri:unwomen:provider-info").split(
+                "/.well-known/openid-configuration"
+            )[0]
+        )
+        dic["authorization_endpoint"] = site_url + reverse(
+            "kolibri:unwomen:oidc_provider:authorize"
+        )
+        dic["token_endpoint"] = site_url + reverse(
+            "kolibri:unwomen:oidc_provider:token"
+        )
+        dic["userinfo_endpoint"] = site_url + reverse(
+            "kolibri:unwomen:oidc_provider:userinfo"
+        )
+        dic["end_session_endpoint"] = site_url + reverse(
+            "kolibri:unwomen:oidc_provider:end-session"
+        )
+        dic["introspection_endpoint"] = site_url + reverse(
+            "kolibri:unwomen:oidc_provider:token-introspection"
+        )
+
+        types_supported = [
+            response_type.value for response_type in ResponseType.objects.all()
+        ]
+        dic["response_types_supported"] = types_supported
+
+        dic["jwks_uri"] = site_url + reverse("kolibri:unwomen:oidc_provider:jwks")
+
+        dic["id_token_signing_alg_values_supported"] = ["HS256", "RS256"]
+
+        # See: http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
+        dic["subject_types_supported"] = ["public"]
+
+        dic["token_endpoint_auth_methods_supported"] = [
+            "client_secret_post",
+            "client_secret_basic",
+        ]
+
+        if oidc_settings.get("OIDC_SESSION_MANAGEMENT_ENABLE"):
+            dic["check_session_iframe"] = site_url + reverse(
+                "kolibri:unwomen:oidc_provider:check-session-iframe"
+            )
+
+        response = JsonResponse(dic)
+        response["Access-Control-Allow-Origin"] = "*"
+
+        return response

--- a/kolibri/plugins/oidc_provider_plugin/views.py
+++ b/kolibri/plugins/oidc_provider_plugin/views.py
@@ -6,55 +6,49 @@ from oidc_provider.lib.utils.common import get_site_url
 from oidc_provider.models import ResponseType
 
 
+def gen_url(base, key):
+    return base + reverse(key)
+
+
 class ProviderInfoView(View):
     def get(self, request, *args, **kwargs):
-        dic = dict()
-        site_url = get_site_url(request=request)
-        dic["issuer"] = (
-            site_url
-            + reverse("kolibri:unwomen:provider-info").split(
-                "/.well-known/openid-configuration"
-            )[0]
+        base = get_site_url(request=request)
+        response_dict = dict()
+        response_dict["issuer"] = gen_url(
+            base, "kolibri:oidcprovider:provider-info"
+        ).split("/.well-known/openid-configuration")[0]
+        response_dict["authorization_endpoint"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:authorize"
         )
-        dic["authorization_endpoint"] = site_url + reverse(
-            "kolibri:unwomen:oidc_provider:authorize"
+        response_dict["token_endpoint"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:token"
         )
-        dic["token_endpoint"] = site_url + reverse(
-            "kolibri:unwomen:oidc_provider:token"
+        response_dict["userinfo_endpoint"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:userinfo"
         )
-        dic["userinfo_endpoint"] = site_url + reverse(
-            "kolibri:unwomen:oidc_provider:userinfo"
+        response_dict["end_session_endpoint"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:end-session"
         )
-        dic["end_session_endpoint"] = site_url + reverse(
-            "kolibri:unwomen:oidc_provider:end-session"
+        response_dict["introspection_endpoint"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:token-introspection"
         )
-        dic["introspection_endpoint"] = site_url + reverse(
-            "kolibri:unwomen:oidc_provider:token-introspection"
-        )
-
-        types_supported = [
+        response_dict["response_types_supported"] = [
             response_type.value for response_type in ResponseType.objects.all()
         ]
-        dic["response_types_supported"] = types_supported
-
-        dic["jwks_uri"] = site_url + reverse("kolibri:unwomen:oidc_provider:jwks")
-
-        dic["id_token_signing_alg_values_supported"] = ["HS256", "RS256"]
-
+        response_dict["jwks_uri"] = gen_url(
+            base, "kolibri:oidcprovider:oidc_provider:jwks"
+        )
+        response_dict["id_token_signing_alg_values_supported"] = ["HS256", "RS256"]
         # See: http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
-        dic["subject_types_supported"] = ["public"]
-
-        dic["token_endpoint_auth_methods_supported"] = [
+        response_dict["subject_types_supported"] = ["public"]
+        response_dict["token_endpoint_auth_methods_supported"] = [
             "client_secret_post",
             "client_secret_basic",
         ]
-
         if oidc_settings.get("OIDC_SESSION_MANAGEMENT_ENABLE"):
-            dic["check_session_iframe"] = site_url + reverse(
-                "kolibri:unwomen:oidc_provider:check-session-iframe"
+            response_dict["check_session_iframe"] = gen_url(
+                base, "kolibri:oidcprovider:oidc_provider:check-session-iframe"
             )
-
-        response = JsonResponse(dic)
+        response = JsonResponse(response_dict, json_dumps_params={"indent": 2})
         response["Access-Control-Allow-Origin"] = "*"
-
         return response

--- a/kolibri/plugins/oidc_provider_plugin/views.py
+++ b/kolibri/plugins/oidc_provider_plugin/views.py
@@ -1,6 +1,14 @@
 import oidc_provider.lib.utils.token
+import oidc_provider.views
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 from django.http import JsonResponse
+from django.http import QueryDict
+from django.shortcuts import resolve_url
+from django.utils.six.moves.urllib.parse import urlparse
+from django.utils.six.moves.urllib.parse import urlunparse
 from django.views.generic import View
 from oidc_provider import settings as oidc_settings
 from oidc_provider.lib.utils.common import get_site_url
@@ -35,6 +43,28 @@ def get_issuer(site_url=None, request=None):
     issuer = site_url + path
 
     return str(issuer)
+
+
+# This is needed to avoid redirect_to_login moving '#/signin?' to the end of the url:
+@monkeypatch_method(oidc_provider.views)
+def redirect_to_login(next, login_url=None,
+                      redirect_field_name=REDIRECT_FIELD_NAME):
+    """
+    Redirects the user to the login page, passing the given 'next' page
+    """
+    resolved_url = resolve_url(login_url or settings.LOGIN_URL)
+
+    login_url_parts = list(urlparse(resolved_url))
+    if redirect_field_name:
+        querystring = QueryDict(login_url_parts[4], mutable=True)
+        querystring[redirect_field_name] = next
+        redirect_url = '{root}?{redirection}'.format(
+            root=resolved_url,
+            redirection=querystring.urlencode(safe='/'))
+    else:
+        redirect_url = urlunparse(login_url_parts)
+
+    return HttpResponseRedirect(redirect_url)
 
 
 class ProviderInfoView(View):

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -104,9 +104,11 @@
                 appearance="flat-button"
               />
             </p>
-            <p class="guest small-text">
+            <p
+              v-if="showGuestAccess"
+              class="guest small-text"
+            >
               <KExternalLink
-                v-if="allowGuestAccess"
                 :text="$tr('accessAsGuest')"
                 :href="guestURL"
                 :primary="true"
@@ -272,8 +274,8 @@
       needPasswordField() {
         return !this.simpleSignIn || this.hasServerError;
       },
-      allowGuestAccess() {
-        return this.facilityConfig.allow_guest_access;
+      showGuestAccess() {
+        return this.facilityConfig.allow_guest_access && !this.oidcProviderFlow;
       },
       logoText() {
         return this.$theme.signIn.title ? this.$theme.signIn.title : this.$tr('kolibri');
@@ -291,6 +293,9 @@
           };
         }
         return { backgroundColor: this.$themeColors.brand.primary.v_900 };
+      },
+      oidcProviderFlow() {
+        return global.oidcProviderEnabled && this.$route.query.next;
       },
     },
     watch: {
@@ -405,11 +410,15 @@
       signIn() {
         this.formSubmitted = true;
         if (this.formIsValid) {
-          this.kolibriLogin({
+          const sessionPayload = {
             username: this.username,
             password: this.password,
             facility: this.facilityId,
-          }).catch();
+          };
+          if (global.oidcProviderEnabled) {
+            sessionPayload['next'] = this.$route.query.next;
+          }
+          this.kolibriLogin(sessionPayload).catch();
         } else {
           this.focusOnInvalidField();
         }

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -168,6 +168,14 @@
   import LanguageSwitcherFooter from '../LanguageSwitcherFooter';
   import FacilityModal from './FacilityModal';
 
+  // https://davidwalsh.name/query-string-javascript
+  function getUrlParameter(name) {
+    name = name.replace(/[[]/, '[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    var results = regex.exec(location.search);
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  }
+
   export default {
     name: 'SignInPage',
     metaInfo() {
@@ -295,7 +303,15 @@
         return { backgroundColor: this.$themeColors.brand.primary.v_900 };
       },
       oidcProviderFlow() {
-        return global.oidcProviderEnabled && this.$route.query.next;
+        return global.oidcProviderEnabled && this.nextParam;
+      },
+      nextParam() {
+        // query is after hash
+        if (this.$route.query.next) {
+          return this.$route.query.next;
+        }
+        // query is before hash
+        return getUrlParameter('next');
       },
     },
     watch: {
@@ -416,7 +432,7 @@
             facility: this.facilityId,
           };
           if (global.oidcProviderEnabled) {
-            sessionPayload['next'] = this.$route.query.next;
+            sessionPayload['next'] = this.nextParam;
           }
           this.kolibriLogin(sessionPayload).catch();
         } else {

--- a/kolibri/plugins/utils/urls.py
+++ b/kolibri/plugins/utils/urls.py
@@ -10,6 +10,7 @@ def get_urls():
     for plugin_instance in registered_plugins:
         url_module = plugin_instance.url_module()
         api_url_module = plugin_instance.api_url_module()
+        root_url_module = plugin_instance.root_url_module()
         instance_patterns = []
         # Normalize slug
         slug = plugin_instance.url_slug().lstrip("^").rstrip("/") + "/"
@@ -17,6 +18,8 @@ def get_urls():
             instance_patterns += i18n_patterns(url_module.urlpatterns, prefix=slug)
         if api_url_module:
             instance_patterns.append(url(slug + "api/", include(api_url_module)))
+        if root_url_module:
+            instance_patterns.append(url("", include(root_url_module)))
         if instance_patterns:
             urlpatterns.append(
                 url(

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -77,6 +77,7 @@ except ImportError:
         "kolibri.plugins.style_guide",
         "kolibri.plugins.document_epub_render",
         "kolibri.plugins.default_theme",
+        "kolibri.plugins.oidc_provider_plugin",
     ]
 
 conf_file = os.path.join(KOLIBRI_HOME, "kolibri_settings.json")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,3 +33,4 @@ sentry-sdk==0.7.9
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
+django-oidc-provider==0.7.0


### PR DESCRIPTION

### Summary

Builds off of @jredrejo's work in https://github.com/learningequality/kolibri-un-women-online-plugin/pull/7/

### Reviewer guidance

* Attempts to use the standard sign in page for OIDC sign-in
* Can be activated by running `kolibri plugin kolibri.plugins.oidc_provider_plugin enable`
* Mounts `openid-configuration` at the domain root

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
