### PR TITLE
For testing: kolibri-installer-windows/pull/108

### DIFF
--- a/docker/env.list
+++ b/docker/env.list
@@ -5,8 +5,8 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.0
-KOLIBRI_WINDOWS_INSTALLER_VERSION="Add-a-setup-logging-and-enhance-the-error-messages"
+# KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.0
+KOLIBRI_WINDOWS_INSTALLER_VERSION=Add-a-setup-logging-and-enhance-the-error-messages
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -6,6 +6,7 @@ KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
 KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.0
+KOLIBRI_WINDOWS_INSTALLER_VERSION="Add-a-setup-logging-and-enhance-the-error-messages"
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"


### PR DESCRIPTION
### Summary

Testing builds with learningequality/kolibri-installer-windows#108

Look-up the BuildKite assets below if there are no errors raised during build.  Look for the installer `.exe/.msi` to use for testing the Kolibri Windows installer.

### Reviewer guidance

DON'T merge

/CC: @mrpau-julius @nucleogenesis @radinamatic 