### PR TITLE
Raise validation error when related obj does not exist

### DIFF
--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -1,9 +1,9 @@
 import getpass
-import sys
 
 import requests
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.core.validators import URLValidator
 from django.urls import reverse
 from django.utils.six.moves import input
@@ -44,7 +44,7 @@ class Command(AsyncCommand):
             for idx, f in enumerate(facilities):
                 message += "{}. {}\n".format(idx + 1, f["name"])
             idx = input(message)
-            dataset_id = facilities[int(idx - 1)]["dataset"]
+            dataset_id = facilities[int(idx) - 1]["dataset"]
         elif not dataset_id:
             dataset_id = facilities[0]["dataset"]
         return dataset_id
@@ -55,12 +55,11 @@ class Command(AsyncCommand):
             dataset_id, scope_def_id=FULL_FACILITY
         )
         if not server_certs:
-            print(
+            raise CommandError(
                 "Server does not have any certificates for dataset_id: {}".format(
                     dataset_id
                 )
             )
-            sys.exit(1)
         server_cert = server_certs[0]
 
         # check for the certs we own for the specific facility
@@ -99,7 +98,9 @@ class Command(AsyncCommand):
                     "Please enter username of account that will become the superuser on this device: "
                 )
             if not FacilityUser.objects.filter(username=username).exists():
-                print("User with username {} does not exist".format(username))
+                self.stderr.write(
+                    "User with username {} does not exist".format(username)
+                )
                 username = None
                 continue
 
@@ -122,8 +123,9 @@ class Command(AsyncCommand):
         try:
             URLValidator()((options["base_url"]))
         except ValidationError:
-            print("Base-url is not valid. Please retry command and enter a valid url.")
-            sys.exit(1)
+            raise CommandError(
+                "Base URL is not valid. Please retry command and enter a valid URL."
+            )
 
         # call this in case user directly syncs without migrating database
         if not ScopeDefinition.objects.filter():
@@ -136,22 +138,20 @@ class Command(AsyncCommand):
                     options["base_url"]
                 )
             except ConnectionError:
-                print(
-                    "Can not connect to server with base-url: {}".format(
+                raise CommandError(
+                    "Can not connect to server with base URL: {}".format(
                         options["base_url"]
                     )
                 )
-                sys.exit(1)
 
             # if instance_ids are equal, this means device is trying to sync with itself, which we don't allow
             if (
                 InstanceIDModel.get_or_create_current_instance()[0].id
                 == network_connection.server_info["instance_id"]
             ):
-                print(
-                    "Device can not sync with itself. Please re-check base-url and try again."
+                raise CommandError(
+                    "Device can not sync with itself. Please recheck base URL and try again."
                 )
-                sys.exit(1)
 
             progress_update(1)
 

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -182,7 +182,10 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         )
         dataset_id = cache.get(key)
         if dataset_id is None:
-            dataset_id = getattr(self, related_obj_name).dataset_id
+            try:
+                dataset_id = getattr(self, related_obj_name).dataset_id
+            except ObjectDoesNotExist as e:
+                raise ValidationError(e)
             cache.set(key, dataset_id, 60 * 10)
         return dataset_id
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When deserializing with morango, sometimes the related object does not exist. This should throw a validation error since the `cached_related_dataset_lookup` is called within `clean_fields`. The validation error bubbles up to morango where it is handled appropriately and can safely cascade delete related objects.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Nalanda first reported this issue. They gave me databases they were using for syncing to debug.
The problem was that a user was deleted on device A, but logs for that user were being synced in from device B. Since we were doing foreign key lookups on the logs on device A when deserializing, the user was unable to be found. This raised a `DoesNotExist` error. We now catch that exception and re-raise a `ValidationError`.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
