### PR TITLE
rename data to pluginData in webpackConfig in i18n.js

### DIFF
--- a/packages/kolibri-tools/lib/i18n.js
+++ b/packages/kolibri-tools/lib/i18n.js
@@ -13,7 +13,7 @@ function webpackConfig(pluginData) {
   const pluginBundle = webpackBaseConfig(pluginData);
 
   pluginBundle.output.path = os.tmpdir();
-  pluginBundle.plugins.push(new ProfileStrings(data.locale_data_folder, data.name));
+  pluginBundle.plugins.push(new ProfileStrings(pluginData.locale_data_folder, pluginData.name));
 
   return pluginBundle;
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

This PR makes a small change to the i18n.js Webpack file that ensures that the proper data is used when instantiating the strings profiler.

I have had trouble replicating this. @radinamatic had the issue initially and the change in this PR fixed it on her end and works as expected locally.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Ensure that `yarn makemessages` works as expected.


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
