### PR TITLE
Learner search bar + search page updates

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -5,7 +5,13 @@
     @submit.prevent="search"
     @keydown.esc.prevent="handleEscKey"
   >
-    <div class="search-box-row" :style="{ backgroundColor: $themeTokens.surface }">
+    <div
+      class="search-box-row"
+      :style="{
+        backgroundColor: $themeTokens.surface,
+        borderColor: $themeColors.palette.grey.v_300
+      }"
+    >
       <label class="visuallyhidden" for="searchfield">{{ coachCommon$tr('searchLabel') }}</label>
       <input
         id="searchfield"
@@ -276,6 +282,8 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
+
   .search-box {
     margin-right: 8px;
   }
@@ -288,6 +296,9 @@
     display: table;
     width: 100%;
     max-width: 450px;
+    overflow: hidden;
+    border: solid 1px;
+    border-radius: $radius;
   }
 
   .search-input {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -9,7 +9,8 @@
       class="search-box-row"
       :style="{
         backgroundColor: $themeTokens.surface,
-        borderColor: $themeColors.palette.grey.v_300
+        borderColor: $themeColors.palette.grey.v_300,
+        fontSize: '16px',
       }"
     >
       <label class="visuallyhidden" for="searchfield">{{ coachCommon$tr('searchLabel') }}</label>

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -105,6 +105,7 @@
           :disabled="!channelFilterOptions.length"
           :value="channelFilterSelection"
           class="filter"
+          :style="channelFilterStyle"
           @change="updateFilter"
         />
       </div>
@@ -116,6 +117,7 @@
 
 <script>
 
+  import maxBy from 'lodash/maxBy';
   import { mapGetters, mapState } from 'vuex';
   import themeMixin from 'kolibri.coreVue.mixins.themeMixin';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
@@ -173,6 +175,16 @@
         'kindFilter',
         'channelFilter',
       ]),
+      channelFilterStyle() {
+        const longestChannelName = maxBy(
+          this.channelFilterOptions,
+          channel => channel.label.length
+        );
+        // Adjust the width based on the longest channel name
+        return {
+          width: `${longestChannelName.label.length * 10}px`,
+        };
+      },
       allFilter() {
         return { label: this.$tr('all'), value: ALL_FILTER };
       },

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -31,7 +31,7 @@
           :class="searchQuery === '' ? '' : 'search-clear-button-visible'"
           :style="{ color: $themeTokens.text }"
           :ariaLabel="$tr('clearButtonLabel')"
-          @click="searchQuery = ''"
+          @click="handleClickClear"
         >
           <mat-svg
             name="clear"
@@ -239,6 +239,10 @@
         } else {
           this.searchQuery = '';
         }
+      },
+      handleClickClear() {
+        this.searchQuery = '';
+        this.$refs.searchInput.focus();
       },
       updateFilter() {
         this.search(true);

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -74,6 +74,10 @@
     computed: {
       ...mapState('search', ['contents', 'searchTerm', 'total_results']),
     },
+    beforeDestroy() {
+      // TODO do this clean up in a beforeRouteLeave once SearchPage is rendered in router-link
+      this.$store.commit('search/RESET_STATE');
+    },
     methods: {
       genContentLink(contentId, contentKind) {
         const params = { id: contentId };

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -4,7 +4,7 @@
 
     <h3>{{ $tr('searchPageHeader') }}</h3>
 
-    <SearchBox :filters="true" />
+    <SearchBox ref="searchBox" :filters="contents.length > 0" />
 
     <p v-if="!searchTerm">
       {{ $tr('noSearch') }}
@@ -77,6 +77,15 @@
     beforeDestroy() {
       // TODO do this clean up in a beforeRouteLeave once SearchPage is rendered in router-link
       this.$store.commit('search/RESET_STATE');
+    },
+    mounted() {
+      if (this.$refs.searchBox.$refs.searchInput) {
+        this.$refs.searchBox.$refs.searchInput.focus();
+        // If there are no contents, then select the whole input, so user can try something else
+        if (this.contents.length === 0) {
+          this.$refs.searchBox.$refs.searchInput.select();
+        }
+      }
     },
     methods: {
       genContentLink(contentId, contentKind) {

--- a/kolibri/plugins/learn/assets/src/views/SearchPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchPage.vue
@@ -79,6 +79,8 @@
       this.$store.commit('search/RESET_STATE');
     },
     mounted() {
+      // TODO when beforeRouteEnter is available, focus on filter or text input depending on what
+      // was changed (e.g. if type filter was changed, focus on it after refresh)
       if (this.$refs.searchBox.$refs.searchInput) {
         this.$refs.searchBox.$refs.searchInput.focus();
         // If there are no contents, then select the whole input, so user can try something else


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

**Give the search bar a rounded solid border, and reduce font size on App Bar**

1. Also, re-focus on input after clearing with X button or "ESC"

| Before | After |
|--------|-------|
| ![Screen Shot 2019-07-03 at 12 37 20 PM](https://user-images.githubusercontent.com/10248067/60623102-b6db6e80-9d96-11e9-8635-86840ab63f6c.png)|![Screen Shot 2019-07-03 at 12 37 39 PM](https://user-images.githubusercontent.com/10248067/60623115-bf33a980-9d96-11e9-912c-7a3487f6c2d2.png) |

**Improve behavior when on Search Results Page**

1. Focus on search input automatically
1. Automatically select the search term if there are no results.
1. Hide filters when there are no results
1. Expand the channel select menu to fit the longest channel names
1. Clear out the search term in vuex when leaving the page (without clearing it, the search field would still be filled with previous search term after exiting search results)

| Before | After |
|--------|-------|
| ![Screen Shot 2019-07-03 at 12 38 12 PM](https://user-images.githubusercontent.com/10248067/60623298-2a7d7b80-9d97-11e9-812f-9dbe7ec79a2c.png)    | ![Screen Shot 2019-07-03 at 12 37 58 PM](https://user-images.githubusercontent.com/10248067/60623308-31a48980-9d97-11e9-837a-071ea2677365.png)      |

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Test out  the learner search bar on different browsers
1. Test it out only using keyboard
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
