### PR TITLE
For testing: kolibri-installer-windows/pull/110

### DIFF
--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,8 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.0
+# KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.0
+KOLIBRI_WINDOWS_INSTALLER_VERSION=Display-the-Kolibri-link-address-to-the-system-tray-message
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"


### PR DESCRIPTION
### Summary

Testing builds with learningequality/kolibri-installer-windows#110

Look-up the BuildKite assets below if there are no errors raised during build. Look for the installer .exe/.msi to use for testing the Kolibri Windows installer.

Supposed to address: https://github.com/learningequality/kolibri-installer-windows/issues/104

### Reviewer guidance

DON'T merge

/CC: @mrpau-julius @radinamatic