### PR TITLE
Ensure proper language code after redirect

### DIFF
--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -20,7 +20,7 @@ from kolibri.core.device.translation import get_settings_language
 class KolibriTagNavigationTestCase(APITestCase):
     def test_redirect_to_setup_wizard(self):
         with patch("kolibri.core.views.is_provisioned", return_value=False):
-            response = self.client.get("/")
+            response = self.client.get(reverse("kolibri:core:root_redirect"))
             self.assertEqual(response.status_code, 302)
             self.assertEqual(
                 response.get("location"),
@@ -29,7 +29,7 @@ class KolibriTagNavigationTestCase(APITestCase):
 
     def test_redirect_root_to_user_if_not_logged_in(self):
         provision_device()
-        response = self.client.get("/")
+        response = self.client.get(reverse("kolibri:core:root_redirect"))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.get("location"), reverse("kolibri:user:user"))
 
@@ -38,7 +38,7 @@ class KolibriTagNavigationTestCase(APITestCase):
         do = create_superuser(facility)
         provision_device()
         self.client.login(username=do.username, password=DUMMY_PASSWORD)
-        response = self.client.get("/")
+        response = self.client.get(reverse("kolibri:core:root_redirect"))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.get("location"), reverse("kolibri:learn:learn"))
 

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -14,6 +14,7 @@ from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.auth.test.test_api import FacilityUserFactory
 from kolibri.deployment.default.urls import urlpatterns
+from kolibri.core.device.translation import get_settings_language
 
 
 class KolibriTagNavigationTestCase(APITestCase):
@@ -154,3 +155,46 @@ class AllUrlsTest(APITestCase):
         self.check_responses(
             credentials={"username": user.username, "password": DUMMY_PASSWORD}
         )
+
+
+class LogoutLanguagePersistenceTest(APITestCase):
+    def setUp(self):
+        provision_device()
+        facility = FacilityFactory.create()
+        user = create_superuser(facility)
+        self.credentials = {"username": user.username, "password": DUMMY_PASSWORD}
+
+    def test_persistent_language_on_namespaced_logout(self):
+        # Test that namespaced /{lang_code}/logout persists that namespace.
+        # Test a few language codes
+        for lang_code in ["sw-tz", "fr-fr", "es-es"]:
+            self.client.login(**self.credentials)
+            response = self.client.post("/{}/logout".format(lang_code))
+            self.assertTrue(lang_code in response.url)
+
+    def test_default_language_without_namespaced_logout(self):
+        # Test /logout without any in-path language code. Expect default language setting.
+        self.client.login(**self.credentials)
+        response = self.client.get("/logout")
+        self.assertTrue(get_settings_language() in response.url)
+
+    def test_persistent_cookie_language_setting_on_logout(self):
+        # Test when set on a cookie.
+        from django.http.cookie import SimpleCookie
+        from django.conf import settings
+
+        self.client.login(**self.credentials)
+        self.client.cookies = SimpleCookie({settings.LANGUAGE_COOKIE_NAME: "fr-fr"})
+        response = self.client.post("/logout")
+        self.assertTrue("fr-fr" in response.url)
+
+    def test_persistent_session_language_setting_on_logout(self):
+        # Test when set on a session.
+        from django.utils.translation import LANGUAGE_SESSION_KEY
+
+        self.client.login(**self.credentials)
+        session = self.client.session
+        session[LANGUAGE_SESSION_KEY] = "sw-tz"
+        session.save()
+        response = self.client.post("/logout")
+        self.assertTrue("sw-tz" in response.url)

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -53,6 +53,7 @@ app_name = "kolibri"
 # Patterns that we want to prefix because they need access to the current language
 lang_prefixed_patterns = [
     url(r"^i18n/setlang/$", set_language, name="set_language"),
+    url(r"^logout/$", logout_view, name="logout"),
     url(r"^redirectuser/$", RootURLRedirectView.as_view(), name="redirect_user"),
     url(r"^guestaccess/$", GuestRedirectView.as_view(), name="guest"),
     url(r"^unsupported/$", UnsupportedBrowserView.as_view(), name="unsupported"),
@@ -60,7 +61,6 @@ lang_prefixed_patterns = [
 
 core_urlpatterns = [
     url(r"^$", RootURLRedirectView.as_view(), name="root_redirect"),
-    url(r"^logout/$", logout_view, name="logout"),
     url(r"^api/", include("kolibri.core.api_urls")),
     url(r"", include(i18n_patterns(lang_prefixed_patterns))),
     url(r"", include("kolibri.core.content.urls")),

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -57,10 +57,10 @@ lang_prefixed_patterns = [
     url(r"^redirectuser/$", RootURLRedirectView.as_view(), name="redirect_user"),
     url(r"^guestaccess/$", GuestRedirectView.as_view(), name="guest"),
     url(r"^unsupported/$", UnsupportedBrowserView.as_view(), name="unsupported"),
+    url(r"^$", RootURLRedirectView.as_view(), name="root_redirect"),
 ]
 
 core_urlpatterns = [
-    url(r"^$", RootURLRedirectView.as_view(), name="root_redirect"),
     url(r"^api/", include("kolibri.core.api_urls")),
     url(r"", include(i18n_patterns(lang_prefixed_patterns))),
     url(r"", include("kolibri.core.content.urls")),


### PR DESCRIPTION
### Summary
Addressing https://github.com/learningequality/kolibri/issues/5727.

This PR will maintain the user's selected language for the duration of their session - even through opening new tabs and through the logout process.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Set the default language of a server to English
- Log in as a different user
- Set your language to French
- Log out. See that the login page is in French
- Open the root path (ie, `localhost:8000/`) and see that it redirects to the French login page
- Log in. See it is still in French.
- Log out again, clear browser cookies and cache, go to server root URL (ie, http://localhost:8000) which has no language code, see that the site redirects to the English version (ie, http://localhost:8000/en/...)

### References
https://github.com/learningequality/kolibri/issues/5727

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
