### PR TITLE
OIDC Provider Authorize template changes

### DIFF
--- a/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
+++ b/kolibri/plugins/oidc_provider_plugin/kolibri_plugin.py
@@ -9,6 +9,7 @@ from kolibri.plugins.base import KolibriPluginBase
 class OIDCProvider(KolibriPluginBase):
     root_view_urls = "root_urls"
     django_settings = "settings"
+    kolibri_options = "options"
 
     def url_slug(self):
         return "^oidc_provider/"

--- a/kolibri/plugins/oidc_provider_plugin/options.py
+++ b/kolibri/plugins/oidc_provider_plugin/options.py
@@ -1,0 +1,9 @@
+option_spec = {
+    "OIDCProvider": {
+        "REQUIRE_CONSENT": {
+            "type": "boolean",
+            "default": True,
+            "envvars": ("KOLIBRI_OIDC_PROVIDER_REQUEST_CONSENT",),
+        }
+    }
+}

--- a/kolibri/plugins/oidc_provider_plugin/settings.py
+++ b/kolibri/plugins/oidc_provider_plugin/settings.py
@@ -1,3 +1,17 @@
+from kolibri.utils.conf import OPTIONS
+
 INSTALLED_APPS = ["oidc_provider"]
 OIDC_LOGIN_URL = "/user/#/signin/"
 OIDC_USERINFO = "kolibri.plugins.oidc_provider_plugin.kolibri_userinfo"
+
+# for some special purposes, let's break rules and let's not ask for consent:
+if OPTIONS["OIDCProvider"]["REQUIRE_CONSENT"]:
+    OIDC_TEMPLATES = {
+        "authorize": "oidc_provider/authorize.html",
+        "error": "oidc_provider/error.html",
+    }
+else:
+    OIDC_TEMPLATES = {
+        "authorize": "oidc_provider/authorize_without_consent.html",
+        "error": "oidc_provider/error.html",
+    }

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html
@@ -1,12 +1,20 @@
 {% load i18n staticfiles %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% trans 'OpenID Provider Authorization' %}</title>
+</head>
 
+<body>
 {% block content %}
 
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
         <h2>{% trans 'Request for Permission' %}</h2>
         <p class="lead">Client <i>{{ client.name }}</i> would like to access this information of you.</p>
-        <form method="post" action="{% url 'kolibri:oidcprovider:oidc_provider:authorize' %}">
+        <form method="post" action="{% url 'oidc_provider:authorize' %}">
             {% csrf_token %}
             {{ hidden_inputs }}
             <ul>
@@ -22,3 +30,5 @@
 </div>
 
 {% endblock %}
+</body>
+</html>

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize_without_consent.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize_without_consent.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+    <title>authorizing...</title>
+</head>
 
 <body style="display:none">
-    <div class="row">
-        <div class="col-md-6 col-md-offset-3">
+    <div>
+        <div>
         <form method="post" action="{% url 'oidc_provider:authorize' %}" id="auth_form">
             {% csrf_token %}
             {{ hidden_inputs }}

--- a/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize_without_consent.html
+++ b/kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize_without_consent.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<body style="display:none">
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+        <form method="post" action="{% url 'oidc_provider:authorize' %}" id="auth_form">
+            {% csrf_token %}
+            {{ hidden_inputs }}
+        </form>
+    </div>
+</div>
+
+
+<script type="text/javascript">
+    const form = document.getElementById("auth_form")
+    const allowInput = document.createElement("input");
+    allowInput.type = "hidden";
+    allowInput.name = "allow";
+    form.appendChild(allowInput);
+    allowInput.value = "Authorize"
+    form.submit()
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
### Summary
This PR:
* Fix an url resolving after https://github.com/learningequality/kolibri/pull/5722/commits/faf67e2eb1d92b7c15caa098c7c8499f1927ea53 changes
* Adds a new option to kolibri, when the `oidc_provider_plugin`is enabled that allows the OIDC Provider break the rules and authorize automatically any logged user.


### Reviewer guidance
`KOLIBRI_OIDC_PROVIDER_REQUEST_CONSENT=false kolibri start`
or starting kolibri after having set in options.ini:
```
[OIDCProvider] 
REQUIRE_CONSENT=false
```
should make any oidc client work, skipping the authorization web page allowance after the user logins (or login automatically if the user is already logged in kolibri)

In  [this repository](https://github.com/jredrejo/oidc_test_client) a simple example client application can be found to test the OIDC provider.

### References
 Relates: #5722

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
