### PR TITLE
Update text in "Download Button" dropdown for subtitles and epub files

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -15,7 +15,7 @@ const filePresetStrings = {
   vectorizedVideo: 'Vectorized ({fileSize})',
   // Same 'thumbnail' string is used for video, audio, document, exercise, and topic
   thumbnail: 'Thumbnail ({fileSize})',
-  videoSubtitle: 'Subtitle ({fileSize})',
+  videoSubtitle: 'Subtitles - {langCode} ({fileSize})',
   audio: 'Audio ({fileSize})',
   document: 'Document ({fileSize})',
   exercise: 'Exercise ({fileSize})',
@@ -31,6 +31,12 @@ const filePresetTranslator = createTranslator('FilePresetStrings', filePresetStr
 // translator to return the localized string.
 export function getFilePresetString(file) {
   const { preset, file_size } = file;
+  if (preset === 'Subtitle') {
+    return filePresetTranslator.$tr('videoSubtitle', {
+      langCode: file.lang.lang_code,
+      fileSize: bytesForHumans(file_size),
+    });
+  }
   const trKey = findKey(filePresetStrings, x => x.startsWith(preset));
   if (trKey) {
     return filePresetTranslator.$tr(trKey, { fileSize: bytesForHumans(file_size) });

--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -21,6 +21,7 @@ const filePresetStrings = {
   exercise: 'Exercise ({fileSize})',
   html5Zip: 'HTML5 Zip ({fileSize})',
   html5Thumbnail: 'HTML5 Thumbnail ({fileSize})',
+  epub: 'ePub Document ({fileSize})',
 };
 
 const filePresetTranslator = createTranslator('FilePresetStrings', filePresetStrings);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixes #4806, by appending the short language code to the "subtitles" option

![Screen Shot 2019-07-08 at 12 26 37 PM](https://user-images.githubusercontent.com/10248067/60836978-ebc33900-a17b-11e9-9c8a-20e77a9c0da0.png)

Fixes #5543 by appending the file size to the "ePub Document" option

![Screen Shot 2019-07-08 at 12 29 42 PM](https://user-images.githubusercontent.com/10248067/60837056-17deba00-a17c-11e9-8dee-f724b668f514.png)


### Reviewer guidance

1. For subtitles, view videos in Touchable earth or KA and see that the "Subtitles" option always includes the language code (and the file size).
1. For epubs, check to see that the "ePub Document" option has the file size.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
