### PR TITLE
Cache all infer dataset lookup calls

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -1073,8 +1073,6 @@ class Membership(AbstractFacilityDataModel):
     def infer_dataset(self, *args, **kwargs):
         user_dataset_id = self.cached_related_dataset_lookup("user")
         collection_dataset_id = self.cached_related_dataset_lookup("collection")
-        # user_dataset_id = self.user.dataset_id
-        # collection_dataset_id = self.collection.dataset_id
         if user_dataset_id != collection_dataset_id:
             raise KolibriValidationError(
                 "Collection and user for a Membership object must be in same dataset."

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -124,7 +124,7 @@ class Exam(AbstractFacilityDataModel):
     data_model_version = models.SmallIntegerField(default=2)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.creator.dataset_id
+        return self.cached_related_dataset_lookup("creator")
 
     def calculate_partition(self):
         return self.dataset_id
@@ -160,7 +160,7 @@ class ExamAssignment(AbstractFacilityDataModel):
     )
 
     def infer_dataset(self, *args, **kwargs):
-        return self.assigned_by.dataset_id
+        return self.cached_related_dataset_lookup("assigned_by")
 
     def calculate_source_id(self):
         return "{exam_id}:{collection_id}".format(

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -75,7 +75,7 @@ class Lesson(AbstractFacilityDataModel):
     morango_model_name = "lesson"
 
     def infer_dataset(self, *args, **kwargs):
-        return self.created_by.dataset_id
+        return self.cached_related_dataset_lookup("created_by")
 
     def calculate_partition(self):
         return self.dataset_id
@@ -113,7 +113,7 @@ class LessonAssignment(AbstractFacilityDataModel):
     morango_model_name = "lessonassignment"
 
     def infer_dataset(self, *args, **kwargs):
-        return self.assigned_by.dataset_id
+        return self.cached_related_dataset_lookup("assigned_by")
 
     def calculate_source_id(self):
         return "{lesson_id}:{collection_id}".format(

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -278,7 +278,7 @@ class AttemptLog(BaseAttemptLog):
     sessionlog = models.ForeignKey(ContentSessionLog, related_name="attemptlogs")
 
     def infer_dataset(self, *args, **kwargs):
-        return self.sessionlog.dataset_id
+        return self.cached_related_dataset_lookup("sessionlog")
 
 
 class ExamLog(BaseLogModel):
@@ -321,7 +321,7 @@ class ExamAttemptLog(BaseAttemptLog):
     content_id = UUIDField()
 
     def infer_dataset(self, *args, **kwargs):
-        return self.examlog.dataset_id
+        return self.cached_related_dataset_lookup("examlog")
 
     def calculate_partition(self):
         return self.dataset_id


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Since we call `clean_fields`->`ensure_dataset`->`infer_dataset` on all models during syncing, we need to use the special cache lookup function to catch any `ObjectDoesNotExist` errors when deserializing synced data.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
