### PR TITLE
Update windows installer to v1.3.1

### DIFF
--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -22,6 +22,7 @@ CMD git clone https://github.com/learningequality/kolibri-installer-windows.git 
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
     export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \
+    make all && \
     wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss && \
     mv *.exe kolibri-$KOLIBRI_VERSION-unsigned.exe && \
     cp *.exe /kolibridist/

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -5,6 +5,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       ca-certificates \
+      curl \
       git \
       git-lfs \
       sudo \
@@ -17,11 +18,16 @@ RUN git lfs install
 
 VOLUME /kolibridist/
 
+
+# TODO(cpauya): Verify the checksums of the downloaded Python installers.
+
 CMD git clone https://github.com/learningequality/kolibri-installer-windows.git && \
     cd kolibri-installer-windows/windows && \
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
     export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \
+    curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.msi --output "python-setup/python-3.4.3.msi" && \
+    curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi --output "python-setup/python-3.4.3.amd64.msi" && \
     wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss && \
     mv *.exe kolibri-$KOLIBRI_VERSION-unsigned.exe && \
     cp *.exe /kolibridist/

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -22,7 +22,6 @@ CMD git clone https://github.com/learningequality/kolibri-installer-windows.git 
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
     export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \
-    make all && \
     wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss && \
     mv *.exe kolibri-$KOLIBRI_VERSION-unsigned.exe && \
     cp *.exe /kolibridist/

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=for-testing-milestone-1-3-1
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha0
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.2.1
+KOLIBRI_WINDOWS_INSTALLER_VERSION=for-testing-milestone-1-3-1
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha2
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha1
+KOLIBRI_WINDOWS_INSTALLER_VERSION=for-testing-milestone-1-3-1
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,7 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha0
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha1
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,8 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-# KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.2.1
-KOLIBRI_WINDOWS_INSTALLER_VERSION=for-testing-milestone-1-3-1
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1-alpha2
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -5,6 +5,7 @@ EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
+# KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.2.1
 KOLIBRI_WINDOWS_INSTALLER_VERSION=for-testing-milestone-1-3-1
 
 # Make sure we don't record these docker runs in pingbacks


### PR DESCRIPTION
### Summary

**NOTE:** Contains important fixes to include Python installers when building the Windows installer via BuildKite.

This is to test features and/or fixes for [milestone v1.3.1](https://github.com/learningequality/kolibri-installer-windows/milestone/7) in the released [`v1.3.1-alpha1`](https://github.com/learningequality/kolibri-installer-windows/releases/tag/v1.3.1-alpha1).

Look-up the BuildKite assets below if there are no errors raised during build. Look for the installer .exe/.msi to use for testing the Kolibri Windows installer.

The `docker/env.list/KOLIBRI_WINDOWS_INSTALLER_VERSION` env var value will eventually be set to the (soon-to-be-released) `v1.3.1` value once testing is verified.

### Reviewer guidance

**Merge only when all of these are checked!**

- [x] Code changes at the released [v1.3.1-alpha2](https://github.com/learningequality/kolibri-installer-windows/releases/tag/v1.3.1-alpha2) are tested
- [x] The `env.list/KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.1` is already used and tested

/CC: @mrpau-julius @mrpau-richard @radinamatic 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md