### PR TITLE
Corrected Progress bar position on Card thumbnail

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -199,7 +199,7 @@
 
   .progress-bar-wrapper {
     position: absolute;
-    bottom: -12px;
+    bottom: 0;
     width: 100%;
     height: 5px;
     opacity: 0.9;

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -163,6 +163,8 @@
     background-repeat: no-repeat;
     background-position: center;
     background-size: contain;
+    // Add an extra border to contain the progress bar and not have it overlap the image
+    border-bottom: solid transparent 5px;
   }
 
   .type-icon {
@@ -199,7 +201,7 @@
 
   .progress-bar-wrapper {
     position: absolute;
-    bottom: 0;
+    bottom: -5px;
     width: 100%;
     height: 5px;
     opacity: 0.9;


### PR DESCRIPTION
### Summary
Changed CSS style for the class `progress-bar-wrapper` and have tested it on Chrome and Mozilla Firefox

…

### Reviewer guidance
Navigate to /learn/channels/

…

### References
This pull request fixes this issue:
![Issue](https://github.com/learningequality/kolibri/issues/5755)

Fixes #5755
…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
