### PR TITLE
Fix router null reference in coach pages

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -19,25 +19,26 @@ class CoachToolsModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
-    router.beforeEach((to, from, next) => {
-      // Clear the snackbar at every navigation to prevent it from re-appearing
-      // when the next page component mounts.
-      if (this.store.state.core.snackbar.isVisible) {
-        this.store.dispatch('clearSnackbar');
-      }
-      this.store.commit('SET_PAGE_NAME', to.name);
-      if (!['CoachClassListPage', 'StatusTestPage'].includes(to.name)) {
-        this.store
-          .dispatch('initClassInfo', to.params.classId)
-          .then(next, error => this.store.dispatch('handleApiError', error));
-      } else {
-        next();
-      }
+    return super.ready().then(() => {
+      router.beforeEach((to, from, next) => {
+        // Clear the snackbar at every navigation to prevent it from re-appearing
+        // when the next page component mounts.
+        if (this.store.state.core.snackbar.isVisible) {
+          this.store.dispatch('clearSnackbar');
+        }
+        this.store.commit('SET_PAGE_NAME', to.name);
+        if (!['CoachClassListPage', 'StatusTestPage'].includes(to.name)) {
+          this.store
+            .dispatch('initClassInfo', to.params.classId)
+            .then(next, error => this.store.dispatch('handleApiError', error));
+        } else {
+          next();
+        }
+      });
+      router.afterEach((toRoute, fromRoute) => {
+        this.store.dispatch('resetModuleState', { toRoute, fromRoute });
+      });
     });
-    router.afterEach((toRoute, fromRoute) => {
-      this.store.dispatch('resetModuleState', { toRoute, fromRoute });
-    });
-    return super.ready();
   }
 }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixes a breakage in the Coach plugin's top-level app.js, that might be caused by a race condition in which the `kolibri.lib.router` is null before the `beforeEach` hook is called on it.

See e31fc608c66a24ecd837c4da2122802084372312

### Reviewer guidance

1. Verify that coach page is not working on develop without this patch.
1. Verify that coach page works 100% of the time with this patch.


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
