### PR TITLE
Remove sentry-sdk dependency

### DIFF
--- a/docs/manual_testing.rst
+++ b/docs/manual_testing.rst
@@ -113,7 +113,7 @@ The Sentry SDK Python package is not distributed with Kolibri. In order to use S
 
     pip install sentry-sdk  # might need to run with sudo
 
-If you're running Kolibri using a pex file, you'll need to make sure that the pex inherits the Python path. To do this, ensure that an environment variable ``PEX_INHERIT_PATH`` is set to ``1``.
+If you're running Kolibri using a pex file, you'll need to make sure that the pex inherits a Python path with `sentry_sdk` available. To do this without inheriting the full system path, run the pex from an active virtual environment with `PEX_INHERIT_PATH=1 python kolibri.pex`.
 
 To set up error reporting, you'll need a `Sentry DSN <https://docs.sentry.io/error-reporting/quickstart>`__. These are available from your project settings at ``https://sentry.io/settings/[org_name]/[project_name]/keys/``
 

--- a/docs/manual_testing.rst
+++ b/docs/manual_testing.rst
@@ -107,6 +107,14 @@ Collecting client and server errors using Sentry
 
 `Sentry <https://docs.sentry.io/>`__ clients are available for both backend and frontend error reporting. This can be particularly useful to have running on beta and demo servers in order to catch errors "in the wild".
 
+The Sentry SDK Python package is not distributed with Kolibri. In order to use Sentry, you must install it to your system Python packages and make the SDK available to Kolibri. To install, run
+
+.. code-block:: bash
+
+    pip install sentry-sdk  # might need to run with sudo
+
+If you're running Kolibri using a pex file, you'll need to make sure that the pex inherits the Python path. To do this, ensure that an environment variable ``PEX_INHERIT_PATH`` is set to ``1``.
+
 To set up error reporting, you'll need a `Sentry DSN <https://docs.sentry.io/error-reporting/quickstart>`__. These are available from your project settings at ``https://sentry.io/settings/[org_name]/[project_name]/keys/``
 
 You can set these either in options.ini or as environment variables.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,6 @@ python-dateutil==2.7.5
 ifcfg==0.18
 sqlalchemy==1.2.10
 semver==2.8.1
-sentry-sdk==0.7.9
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1


### PR DESCRIPTION
# Summary

Removes the Sentry integration.

### Reviewer guidance

We are not using the sentry-sdk plugin for end-users, and it causes issues because of bytecode precompilation on incompatible systems.

### References

#5652
#5646

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
