### PR TITLE
Bump morango to release 0.4.7 w/o python 2.7-only stmt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ metafone==0.5
 le-utils==0.1.15
 kolibri_exercise_perseus_plugin==1.1.8
 jsonfield==2.0.2
-morango==0.4.6
+morango==0.4.7
 requests-toolbelt==0.8.0
 clint==0.5.1
 tzlocal==1.5.1


### PR DESCRIPTION
### Summary

CC: @ralphiee22 @indirectlylit 

Not sure if we are planning another 0.12 release, but given that it's the currently supported series, it'd be great to get this in.

### Reviewer guidance

@ralphiee22 

### References

https://github.com/learningequality/morango/compare/v0.4.6...v0.4.7

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
