### PR TITLE
Externalize sentry plugin

### DIFF
--- a/docs/manual_testing.rst
+++ b/docs/manual_testing.rst
@@ -107,13 +107,13 @@ Collecting client and server errors using Sentry
 
 `Sentry <https://docs.sentry.io/>`__ clients are available for both backend and frontend error reporting. This can be particularly useful to have running on beta and demo servers in order to catch errors "in the wild".
 
-The Sentry SDK Python package is not distributed with Kolibri. In order to use Sentry, you must install it to your system Python packages and make the SDK available to Kolibri. To install, run
+This behaviour is activated by installing the `Kolibri Sentry Plugin <https://github.com/learningequality/kolibri-sentry-plugin>`__. Once installed, the options below become available for configuration.
 
 .. code-block:: bash
 
-    pip install sentry-sdk  # might need to run with sudo
+    pip install kolibri-sentry-plugin  # might need to run with sudo
 
-If you're running Kolibri using a pex file, you'll need to make sure that the pex inherits a Python path with `sentry_sdk` available. To do this without inheriting the full system path, run the pex from an active virtual environment with `PEX_INHERIT_PATH=1 python kolibri.pex`.
+If you're running Kolibri using a pex file, you'll need to make sure that the pex inherits a Python path with `kolibri_sentry_plugin` available. To do this without inheriting the full system path, run the pex from an active virtual environment with `PEX_INHERIT_PATH=1 python kolibri.pex`.
 
 To set up error reporting, you'll need a `Sentry DSN <https://docs.sentry.io/error-reporting/quickstart>`__. These are available from your project settings at ``https://sentry.io/settings/[org_name]/[project_name]/keys/``
 

--- a/kolibri/core/assets/src/core-app/constructor.js
+++ b/kolibri/core/assets/src/core-app/constructor.js
@@ -66,5 +66,6 @@ export default class CoreApp {
     publicMethods.forEach(method => {
       this[method] = mediator[method].bind(mediator);
     });
+    this.version = __version;
   }
 }

--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -28,33 +28,6 @@ const logging = require('kolibri.lib.logging').default;
 
 logging.setDefaultLevel(process.env.NODE_ENV === 'production' ? 2 : 0);
 
-// optionally set up client-side Sentry error reporting
-if (global.sentryDSN) {
-  require.ensure(['@sentry/browser'], function(require) {
-    const Sentry = require('@sentry/browser');
-    const SentryIntegrations = require('@sentry/integrations');
-    const Vue = require('./kolibriVue');
-
-    Sentry.init({
-      dsn: global.sentryDSN,
-      environment: global.sentryEnv,
-      release: __version,
-      integrations: [new SentryIntegrations.Vue({ Vue: Vue.default })],
-      beforeSend: (event, hint) => {
-        logging.error('Sending error to Sentry:');
-        logging.error(event);
-        logging.error(hint);
-        return event;
-      },
-    });
-    Sentry.configureScope(scope => {
-      scope.setTag('lang', global.languageCode);
-      scope.setTag('host', window.location.hostname);
-    });
-    logging.warn('Sentry error logging is enabled - this makes console errors less readable');
-  });
-}
-
 // Create an instance of the global app object.
 // This is exported by webpack as the kolibriGlobal object, due to the 'output.library' flag
 // which exports the coreApp at the bottom of this file as a named global variable:

--- a/kolibri/core/assets/src/kolibri_module.js
+++ b/kolibri/core/assets/src/kolibri_module.js
@@ -28,7 +28,7 @@ export default class KolibriModule {
   constructor(options, ...args) {
     /* eslint-disable no-undef */
     // __kolibriModuleName is replaced during webpack compilation with the name derived from
-    // the Python module name and the name of the class that defines the frontend kolibriModule.
+    // the unique_slug that is defined on the class that defines the frontend kolibriModule.
     this.name = __kolibriModuleName;
     /* eslint-enable no-undef */
     const safeOptions = {};

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -164,14 +164,6 @@ export function handleError(store, errorString) {
   logging.debug(errorString);
   store.commit('CORE_SET_ERROR', errorString);
   store.commit('CORE_SET_PAGE_LOADING', false);
-
-  // optionally log to sentry
-  if (global.sentryDSN) {
-    require.ensure(['@sentry/browser'], function(require) {
-      const Sentry = require('@sentry/browser');
-      Sentry.captureException(errorString);
-    });
-  }
 }
 
 export function clearError(store) {
@@ -212,24 +204,6 @@ export function setSession(store, { session, clientNow }) {
   }
   session = pick(session, Object.keys(baseSessionState));
   store.commit('CORE_SET_SESSION', session);
-  // optionally set user context info
-  if (global.sentryDSN) {
-    // hack - delay this to give time for logging to be set up
-    setTimeout(() => {
-      require.ensure(['@sentry/browser'], function(require) {
-        const Sentry = require('@sentry/browser');
-        Sentry.configureScope(scope => {
-          scope.setUser({
-            id: session.user_id,
-            full_name: session.full_name,
-            username: session.username,
-            facility_id: session.facility_id,
-            type: JSON.stringify(session.kind),
-          });
-        });
-      });
-    }, 500);
-  }
 }
 
 /**

--- a/kolibri/core/assets/src/utils/getPluginData.js
+++ b/kolibri/core/assets/src/utils/getPluginData.js
@@ -1,0 +1,3 @@
+export default function getPluginData() {
+  return (global[__kolibriPluginDataName] || {})[__kolibriModuleName] || {};
+}

--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -19,7 +19,7 @@ from le_utils.constants import content_kinds
 
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.plugins.hooks import KolibriHook
-from kolibri.utils import conf
+from kolibri.utils.js_names import KOLIBRI_CORE_JS_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ class ContentRendererHook(WebpackBundleHook):
         urls = [chunk["url"] for chunk in self.bundle]
         tags = self.frontend_message_tag() + [
             '<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {content_types});</script>'.format(
-                kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
+                kolibri_name=KOLIBRI_CORE_JS_NAME,
                 bundle=self.bundle_id,
                 urls='","'.join(urls),
                 content_types=json.dumps(self.content_types),

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -4,8 +4,6 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
-    "@sentry/browser": "^5.0.5",
-    "@sentry/integrations": "^5.0.5",
     "@shopify/draggable": "^1.0.0-beta.8",
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "array-includes": "^3.0.3",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -38,7 +38,7 @@
     "vuex": "^3.1.0"
   },
   "devDependencies": {
-    "kolibri-tools": "0.13.0-dev.3",
+    "kolibri-tools": "0.13.0-dev.5",
     "responselike": "^1.0.2"
   }
 }

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -33,7 +33,6 @@
   {% include "kolibri/loading_snippet.html" %}
 </rootvue>
 {% block frontend_assets %}
-{% kolibri_sentry_error_reporting %}
 {% kolibri_content_cache_key %}
 {% webpack_asset 'default_frontend' %}
 {% kolibri_navigation_actions %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -34,8 +34,8 @@ from kolibri.core.hooks import NavigationHook
 from kolibri.core.oidc_provider_hook import OIDCProviderHook
 from kolibri.core.theme_hook import ThemeHook
 from kolibri.core.webpack.utils import webpack_asset_render
-from kolibri.utils import conf
 from kolibri.utils import i18n
+from kolibri.utils.js_names import KOLIBRI_CORE_JS_NAME
 
 register = template.Library()
 
@@ -200,7 +200,7 @@ def kolibri_bootstrap_model(context, base_name, api_resource, **kwargs):
         "var model = {0}.resources.{1}.createModel(JSON.parse({2}));"
         "model.synced = true;"
         "</script>".format(
-            conf.KOLIBRI_CORE_JS_NAME,
+            KOLIBRI_CORE_JS_NAME,
             api_resource,
             json.dumps(JSONRenderer().render(response.data).decode("utf-8")),
         )
@@ -218,7 +218,7 @@ def kolibri_bootstrap_collection(context, base_name, api_resource, **kwargs):
         "var collection = {0}.resources.{1}.createCollection({2}, JSON.parse({3}));"
         "collection.synced = true;"
         "</script>".format(
-            conf.KOLIBRI_CORE_JS_NAME,
+            KOLIBRI_CORE_JS_NAME,
             api_resource,
             json.dumps(kwargs),
             json.dumps(JSONRenderer().render(response.data).decode("utf-8")),

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -31,8 +31,8 @@ from six import iteritems
 import kolibri
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.hooks import NavigationHook
-from kolibri.core.theme_hook import ThemeHook
 from kolibri.core.oidc_provider_hook import OIDCProviderHook
+from kolibri.core.theme_hook import ThemeHook
 from kolibri.core.webpack.utils import webpack_asset_render
 from kolibri.utils import conf
 from kolibri.utils import i18n
@@ -254,23 +254,3 @@ def _kolibri_bootstrap_helper(context, base_name, api_resource, route, **kwargs)
     response = view(request, **view_kwargs)
     _replace_dict_values(str(""), None, kwargs)
     return response, kwargs
-
-
-@register.simple_tag()
-def kolibri_sentry_error_reporting():
-
-    if not conf.OPTIONS["Debug"]["SENTRY_FRONTEND_DSN"]:
-        return ""
-
-    template = """
-      <script>
-        var sentryDSN = '{dsn}';
-        var sentryEnv = '{env}';
-      </script>
-    """
-    return mark_safe(
-        template.format(
-            dsn=conf.OPTIONS["Debug"]["SENTRY_FRONTEND_DSN"],
-            env=conf.OPTIONS["Debug"]["SENTRY_ENVIRONMENT"],
-        )
-    )

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -32,7 +32,8 @@ from pkg_resources import resource_filename
 from six import text_type
 
 from kolibri.plugins import hooks
-from kolibri.utils import conf
+from kolibri.utils.js_names import KOLIBRI_CORE_JS_NAME
+from kolibri.utils.js_names import KOLIBRI_JS_PLUGIN_DATA_NAME
 
 # Use the cache specifically for built files
 # Only reference the specific cache inside methods
@@ -78,9 +79,9 @@ class WebpackBundleHook(hooks.KolibriHook):
     inline = False
 
     # : A mapping of key to JSON serializable value.
-    # : This context will be bootstrapped into the window object
-    # : with a key of the unique_slug as a Javascript object
-    context = {}
+    # : This plugin_data will be bootstrapped into a global object on window
+    # : with a key of the bundle_id as a Javascript object
+    plugin_data = {}
 
     def __init__(self, *args, **kwargs):
         super(WebpackBundleHook, self).__init__(*args, **kwargs)
@@ -268,7 +269,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         if self.frontend_messages():
             return [
                 '<script>{kolibri_name}.registerLanguageAssets("{bundle}", "{lang_code}", {messages});</script>'.format(
-                    kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
+                    kolibri_name=KOLIBRI_CORE_JS_NAME,
                     bundle=self.bundle_id,
                     lang_code=get_language(),
                     messages=self.frontend_messages(),
@@ -277,11 +278,18 @@ class WebpackBundleHook(hooks.KolibriHook):
         else:
             return []
 
-    def context_tag(self):
-        if self.context:
+    def plugin_data_tag(self):
+        if self.plugin_data:
             return [
-                '<script>window.{bundle} = JSON.parse("{context}");</script>'.format(
-                    bundle=self.unique_slug, context=json.dumps(self.context)
+                """
+                <script>
+                    window["{name}"] = window["{name}"] || {{}};
+                    window["{name}"]["{bundle}"] = JSON.parse('{plugin_data}');
+                </script>
+                """.format(
+                    name=KOLIBRI_JS_PLUGIN_DATA_NAME,
+                    bundle=self.bundle_id,
+                    plugin_data=json.dumps(self.plugin_data),
                 )
             ]
         else:
@@ -360,7 +368,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         :return: HTML of script tags for insertion into a page.
         """
         tags = (
-            self.context_tag()
+            self.plugin_data_tag()
             + self.frontend_message_tag()
             + list(self.js_and_css_tags())
         )
@@ -384,11 +392,11 @@ class WebpackBundleHook(hooks.KolibriHook):
         """
         urls = [chunk["url"] for chunk in self.sorted_chunks()]
         tags = (
-            self.context_tag()
+            self.plugin_data_tag()
             + self.frontend_message_tag()
             + [
                 '<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"]);</script>'.format(
-                    kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
+                    kolibri_name=KOLIBRI_CORE_JS_NAME,
                     bundle=self.bundle_id,
                     urls='","'.join(urls),
                 )

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -281,8 +281,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         if self.context:
             return [
                 '<script>window.{bundle} = JSON.parse("{context}");</script>'.format(
-                    bundle=self.unique_slug,
-                    context=json.dumps(self.context),
+                    bundle=self.unique_slug, context=json.dumps(self.context)
                 )
             ]
         else:
@@ -360,7 +359,11 @@ class WebpackBundleHook(hooks.KolibriHook):
         :param bundle_data: The data returned from
         :return: HTML of script tags for insertion into a page.
         """
-        tags = self.context_tag() + self.frontend_message_tag() + list(self.js_and_css_tags())
+        tags = (
+            self.context_tag()
+            + self.frontend_message_tag()
+            + list(self.js_and_css_tags())
+        )
 
         return mark_safe("\n".join(tags))
 
@@ -380,13 +383,17 @@ class WebpackBundleHook(hooks.KolibriHook):
         :returns: HTML of a script tag to insert into a page.
         """
         urls = [chunk["url"] for chunk in self.sorted_chunks()]
-        tags = self.context_tag() + self.frontend_message_tag() + [
-            '<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"]);</script>'.format(
-                kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
-                bundle=self.bundle_id,
-                urls='","'.join(urls),
-            )
-        ]
+        tags = (
+            self.context_tag()
+            + self.frontend_message_tag()
+            + [
+                '<script>{kolibri_name}.registerKolibriModuleAsync("{bundle}", ["{urls}"]);</script>'.format(
+                    kolibri_name=conf.KOLIBRI_CORE_JS_NAME,
+                    bundle=self.bundle_id,
+                    urls='","'.join(urls),
+                )
+            ]
+        )
         return mark_safe("\n".join(tags))
 
     class Meta:

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -326,23 +326,4 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 1200
 
 
-if conf.OPTIONS["Debug"]["SENTRY_BACKEND_DSN"]:
-    import sentry_sdk
-    from kolibri.utils.server import installation_type
-    from sentry_sdk.integrations.django import DjangoIntegration
-
-    sentry_sdk.init(
-        dsn=conf.OPTIONS["Debug"]["SENTRY_BACKEND_DSN"],
-        environment=conf.OPTIONS["Debug"]["SENTRY_ENVIRONMENT"],
-        integrations=[DjangoIntegration()],
-        release=kolibri.__version__,
-    )
-
-    with sentry_sdk.configure_scope() as scope:
-        scope.set_tag("mode", conf.OPTIONS["Deployment"]["RUN_MODE"])
-        scope.set_tag("installer", installation_type())
-
-    print("Sentry backend error logging is enabled")
-
-
 apply_settings(sys.modules[__name__])

--- a/kolibri/utils/KOLIBRI_CORE_JS_NAME
+++ b/kolibri/utils/KOLIBRI_CORE_JS_NAME
@@ -1,1 +1,0 @@
-kolibriGlobal

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -29,10 +29,6 @@ from .compat import module_exists
 
 logger = logging.getLogger(__name__)
 
-# use default OS encoding
-with open(os.path.join(os.path.dirname(__file__), "KOLIBRI_CORE_JS_NAME")) as f:
-    KOLIBRI_CORE_JS_NAME = f.read().strip()
-
 #: Absolute path of the main user data directory.
 #: Will be created automatically if it doesn't exist.
 KOLIBRI_HOME = os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))

--- a/kolibri/utils/js_names.py
+++ b/kolibri/utils/js_names.py
@@ -1,0 +1,20 @@
+"""
+A module that reads names used to describe Javascript global variables
+that we use for bootstrapping data into templates.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import io
+import json
+import os
+
+with io.open(
+    os.path.join(os.path.dirname(__file__), "kolibri_js_names.json"),
+    mode="r",
+    encoding="utf-8",
+) as f:
+    names = json.load(f)
+    KOLIBRI_CORE_JS_NAME = names["KOLIBRI_CORE_JS_NAME"]
+    KOLIBRI_JS_PLUGIN_DATA_NAME = names["KOLIBRI_JS_PLUGIN_DATA_NAME"]

--- a/kolibri/utils/kolibri_js_names.json
+++ b/kolibri/utils/kolibri_js_names.json
@@ -1,0 +1,4 @@
+{
+    "KOLIBRI_CORE_JS_NAME": "kolibriGlobal",
+    "KOLIBRI_JS_PLUGIN_DATA_NAME": "__kolibriPluginData"
+}

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -162,20 +162,6 @@ base_option_spec = {
             "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
     },
-    "Debug": {
-        "SENTRY_BACKEND_DSN": {
-            "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_BACKEND_DSN",),
-        },
-        "SENTRY_FRONTEND_DSN": {
-            "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_FRONTEND_DSN",),
-        },
-        "SENTRY_ENVIRONMENT": {
-            "type": "string",
-            "envvars": ("KOLIBRI_DEBUG_SENTRY_ENVIRONMENT",),
-        },
-    },
 }
 
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "black-fmt": "https://github.com/learningequality/black-fmt#v0.1.3",
-    "kolibri-tools": "0.13.0-dev.3",
+    "kolibri-tools": "0.13.0-dev.5",
     "yarn-run-all": "^3.1.1"
   },
   "optionalDependencies": {

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.13.0-dev.3",
+  "version": "0.13.0-dev.5",
   "description": "Custom rules.",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri",
-  "version": "0.13.0-dev.3",
+  "version": "0.13.0-dev.5",
   "description": "The Kolibri core API",
   "repository": "github.com/learningequality/kolibri",
   "author": "Learning Equality",
@@ -8,6 +8,6 @@
   "private": false,
   "dependencies": {},
   "devDependencies": {
-    "kolibri-tools": "0.13.0-dev.3"
+    "kolibri-tools": "0.13.0-dev.5"
   }
 }

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
     __filename: true,
     __copyrightYear: true,
     __kolibriModuleName: true,
+    __kolibriPluginDataName: true,
   },
   extends: [
     'eslint:recommended',

--- a/packages/kolibri-tools/lib/apiSpecExportTools.js
+++ b/packages/kolibri-tools/lib/apiSpecExportTools.js
@@ -121,6 +121,12 @@ const baseAliasSourcePaths = {
     __dirname,
     '../../../kolibri/core/assets/src/content_renderer_module'
   ),
+  'kolibri.utils.getPluginData': path.resolve(
+    __dirname,
+    '../../../kolibri/core/assets/src/utils/getPluginData'
+  ),
+  // To clean up - once we allow for core API elements to be defined as either bundled or not bundled
+  // into the default frontend code bundle, we should amalgamate all of these into the main API spec.
 };
 
 const baseAliasDistPath = path.resolve(__dirname, '../dist');
@@ -129,6 +135,7 @@ const baseAliasDistPaths = {
   kolibri_module: path.resolve(baseAliasDistPath, 'kolibri_module'),
   kolibri_app: path.resolve(baseAliasDistPath, 'kolibri_app'),
   content_renderer_module: path.resolve(baseAliasDistPath, 'content_renderer_module'),
+  'kolibri.utils.getPluginData': path.resolve(baseAliasDistPath, 'kolibri.utils.getPluginData'),
 };
 
 // Assume if kolibri_module is not available on the source path, then we need to use the dist

--- a/packages/kolibri-tools/lib/kolibriName.js
+++ b/packages/kolibri-tools/lib/kolibriName.js
@@ -2,16 +2,19 @@ const fs = require('fs');
 const path = require('path');
 const ensureDist = require('./ensureDist');
 
-let kolibriName;
+const sourcePath = path.resolve(__dirname, '../../../kolibri/utils/kolibri_js_names.json');
+const distPath = path.resolve(__dirname, '../dist/kolibri_js_names.json');
 
-const sourcePath = path.resolve(__dirname, '../../../kolibri/utils/KOLIBRI_CORE_JS_NAME');
-const distPath = path.resolve(__dirname, '../dist/KOLIBRI_CORE_JS_NAME');
+let names;
 
 try {
-  kolibriName = fs.readFileSync(sourcePath, 'utf-8').trim();
+  names = require(sourcePath);
 } catch (e) {
-  kolibriName = fs.readFileSync(distPath, 'utf-8').trim();
+  names = require(distPath);
 }
+
+const kolibriName = names['KOLIBRI_CORE_JS_NAME'];
+const kolibriPluginDataName = names['KOLIBRI_JS_PLUGIN_DATA_NAME'];
 
 function __buildKolibriName() {
   if (!fs.existsSync(sourcePath)) {
@@ -19,12 +22,13 @@ function __buildKolibriName() {
       'Attempting to build the kolibriName file from outside the Kolibri source repo'
     );
   }
-  const name = fs.readFileSync(sourcePath, 'utf-8').trim();
+  const nameFile = fs.readFileSync(sourcePath, 'utf-8').trim();
   ensureDist();
-  fs.writeFileSync(distPath, name, { encoding: 'utf-8' });
+  fs.writeFileSync(distPath, nameFile, { encoding: 'utf-8' });
 }
 
 module.exports = {
   kolibriName,
+  kolibriPluginDataName,
   __buildKolibriName,
 };

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -20,7 +20,7 @@ const ExtractStrings = require('./ExtractStrings');
 const logging = require('./logging');
 const coreExternals = require('./apiSpecExportTools').coreExternals();
 const coreAliases = require('./apiSpecExportTools').coreAliases();
-const { kolibriName } = require('./kolibriName');
+const { kolibriName, kolibriPluginDataName } = require('./kolibriName');
 const WebpackMessages = require('./webpackMessages');
 
 /**
@@ -247,6 +247,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
       // the kolibri version).
       // Also add the copyright year for auto updated copyright footers.
       new webpack.DefinePlugin({
+        __kolibriPluginDataName: JSON.stringify(kolibriPluginDataName),
         __kolibriModuleName: JSON.stringify(data.name),
         __version: JSON.stringify(data.version),
         __copyrightYear: new Date().getFullYear(),

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.13.0-dev.3",
+  "version": "0.13.0-dev.5",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": "github.com/learningequality/kolibri",
@@ -32,7 +32,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.1",
-    "eslint-plugin-kolibri": "0.13.0-dev.3",
+    "eslint-plugin-kolibri": "0.13.0-dev.5",
     "eslint-plugin-vue": "^5.2.2",
     "espree": "^5.0.1",
     "esquery": "^1.0.1",
@@ -93,6 +93,6 @@
     "readline-sync": "^1.4.9"
   },
   "optionalDependencies": {
-    "kolibri": "0.13.0-dev.3"
+    "kolibri": "0.13.0-dev.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,67 +357,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@^5.0.5":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.5.0.tgz#ec99ea6897d23affc46d58e6ada32016b27721b5"
-  integrity sha512-QZw4EXK47Qp9Q+vNpL5H4P4tYyfAN8qpWWeLIM0RDiNLlOugTVUdkfkeNTEJZ9VlqJ5RLx/2G/PITG4R6pwh/A==
-  dependencies:
-    "@sentry/core" "5.5.0"
-    "@sentry/types" "5.5.0"
-    "@sentry/utils" "5.5.0"
-    tslib "^1.9.3"
-
-"@sentry/core@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.5.0.tgz#574fdc9228c8b4a909c0140eb0d8b098175c0f47"
-  integrity sha512-xOcBud0t5mfhFdyd2tQQti4uuWSrLiJihpXzxeRpdCfk2ic+xmpeQs3G4UqnluvQDc48ug/Igt7LXfSBRBx4eg==
-  dependencies:
-    "@sentry/hub" "5.5.0"
-    "@sentry/minimal" "5.5.0"
-    "@sentry/types" "5.5.0"
-    "@sentry/utils" "5.5.0"
-    tslib "^1.9.3"
-
-"@sentry/hub@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.5.0.tgz#6b8eecf769fa693260d45e771f4bca15bdbc6f4b"
-  integrity sha512-+jKh5U1nv8ufoquGciWoZPOmKuEjFPH5m0VifCs6t3NcEbAq2qnfF26KUGqhUNznlUN/PkbWB4qMfKn14uNE2Q==
-  dependencies:
-    "@sentry/types" "5.5.0"
-    "@sentry/utils" "5.5.0"
-    tslib "^1.9.3"
-
-"@sentry/integrations@^5.0.5":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.5.0.tgz#4d36adb607c007cab30c2fd83af0e905f0b62a88"
-  integrity sha512-27B2CZEER50h5BIA7z32Cg80oD4UsVrreKglqpHLrhKhJ7KpoY3VhlEIEsoGclUyNuLXs1KtI0Op33EsgUpCxA==
-  dependencies:
-    "@sentry/types" "5.5.0"
-    "@sentry/utils" "5.5.0"
-    tslib "^1.9.3"
-
-"@sentry/minimal@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.5.0.tgz#ea7939b8efe307d25775b23227a3f85dfb46b274"
-  integrity sha512-o6O30+/pNrO7fTgwKxgZynHB7cMScJlw9HXgnNXgLXS6LBiqjYCQfVnWAgV//SyyG0uUlcjH3P6PnV6TsJOmVQ==
-  dependencies:
-    "@sentry/hub" "5.5.0"
-    "@sentry/types" "5.5.0"
-    tslib "^1.9.3"
-
-"@sentry/types@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.5.0.tgz#0e7d8e8359c7af685258d92b23831072bb79f46a"
-  integrity sha512-3otF/miVDth91o+iign00x0o31McUPeyIFbMjLbgeTRRW9rXpu2jGrcRrvHfofECtoqCf5Y734hwvvlBvFZeIw==
-
-"@sentry/utils@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.5.0.tgz#5c516be0568f4d462ad550c723b78e3ad7776c4e"
-  integrity sha512-gO8Bs/QcKDn7ncc2f2fIOTPx2AiZKrGj4us1Yxu6mBU8JZqMQRl9XjDMFAUECJQvquBAta+TFJyYj71ZedeQUQ==
-  dependencies:
-    "@sentry/types" "5.5.0"
-    tslib "^1.9.3"
-
 "@shopify/draggable@^1.0.0-beta.8":
   version "1.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.8.tgz#2eb3c2f72298ce3e53fe16f34ab124cc495cd4fc"
@@ -12683,7 +12622,7 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
### Summary
* Removes sentry integration
* Adds code to allow external plugin of sentry - currently WIP at: https://github.com/learningequality/kolibri-sentry-plugin
* Optimistically updates docs to point at the above repo (installation instructions to follow in the readme there).

### Reviewer guidance
Main thing to note is the new 'context' API for WebpackBundleHooks to allow frontend assets to load Django context into `window[<__moduleName>]` where `__moduleName` is the `bundle_id` property defined on the instance and used to generate the name of the module in all built JS assets.

### References
https://github.com/learningequality/kolibri-sentry-plugin

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
