### PR TITLE
dynamically add env vars for custom installer build into docker env

### DIFF
--- a/build_tools/__init__.py
+++ b/build_tools/__init__.py
@@ -3,7 +3,10 @@ This module is intended to allow easier build time configuration of Kolibri.
 This is currently implemented by allowing additional build configuration options to be configured
 through environment variables.
 In order for these environment variables to propagate through to our docker build environment
-we explicitly list them in the env.list file in the root of the repository.
+we dynamically add them to the env.list file in the root of the repository.
+All the environment variables should be prefixed with KOLIBRI_BUILD_ in the current environment,
+and will be passed into the docker environment without the prefix by running the
+customize_docker_envlist.py script.
 The following environment variables are supported:
 
 BUILD_TIME_PLUGINS, a txt file containing an explicit list of all Kolibri plugins that should
@@ -32,4 +35,6 @@ This environment variable is used in the customize_requirements.py script.
 For BUILD_TIME_PLUGINS, RUN_TIME_PLUGINS, and EXTRA_REQUIREMENTS if the environment variable
 specifies a URL, the scripts will attempt to download a text file from that URL and then use
 that file.
+
+BACKGROUND_IMAGE, an image to display on the Kolibri login page.
 """

--- a/build_tools/__init__.py
+++ b/build_tools/__init__.py
@@ -35,6 +35,4 @@ This environment variable is used in the customize_requirements.py script.
 For BUILD_TIME_PLUGINS, RUN_TIME_PLUGINS, and EXTRA_REQUIREMENTS if the environment variable
 specifies a URL, the scripts will attempt to download a text file from that URL and then use
 that file.
-
-BACKGROUND_IMAGE, an image to display on the Kolibri login page.
 """

--- a/build_tools/customize_docker_envlist.py
+++ b/build_tools/customize_docker_envlist.py
@@ -22,7 +22,7 @@ def add_env_var_to_docker():
             # removing the prefix.
             if env.startswith(BUILD_ENV_PREFIX):
                 key = env.replace(BUILD_ENV_PREFIX, "")
-                f.write("{key}={value}\n".format(key=key, value=envs[env]))
+                f.write("\n{key}={value}".format(key=key, value=envs[env]))
                 print(
                     "Writing value of environment variable {} to Docker env.list\n".format(
                         key

--- a/build_tools/customize_docker_envlist.py
+++ b/build_tools/customize_docker_envlist.py
@@ -1,0 +1,34 @@
+"""
+This module defines a function for customizing the environment variables used
+at Kolibri build time to pass into the docker build environment.
+
+For more detail see the documentation in __init__.py
+"""
+import os
+
+BUILD_ENV_PREFIX = "KOLIBRI_BUILD_"
+ENVLIST_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.dirname(__file__)), "docker", "env.list")
+)
+
+
+def add_env_var_to_docker():
+    envs = os.environ
+
+    with open(ENVLIST_FILE, "a") as f:
+        for env in envs:
+            # Find all the environment variables prefixed with KOLIBRI_BUILD_
+            # and add them to env.list to pass into docker environment after
+            # removing the prefix.
+            if env.startswith(BUILD_ENV_PREFIX):
+                key = env.replace(BUILD_ENV_PREFIX, "")
+                f.write("{key}={value}\n".format(key=key, value=envs[env]))
+                print(
+                    "Writing value of environment variable {} to Docker env.list\n".format(
+                        key
+                    )
+                )
+
+
+if __name__ == "__main__":
+    add_env_var_to_docker()

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -5,14 +5,14 @@ ENV NODE_VERSION=10.14.1
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      curl \
-      software-properties-common \
-      gettext \
-      git \
-      git-lfs \
-      python2.7 \
-      python-pip \
-      python-sphinx
+    curl \
+    software-properties-common \
+    gettext \
+    git \
+    git-lfs \
+    python2.7 \
+    python-pip \
+    python-sphinx
 
 # add yarn ppa
 RUN (curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -) && \
@@ -45,8 +45,8 @@ COPY . .
 
 CMD echo '--- Installing JS dependencies' && \
     yarn install --pure-lockfile && \
-    echo `--- Making whl` && \
+    echo '--- Making whl' && \
     make dist && \
-    echo `--- Making pex` && \
+    echo '--- Making pex' && \
     make pex && \
     cp /kolibri/dist/* /kolibridist/

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,3 @@
-BUILD_TIME_PLUGINS
-RUN_TIME_PLUGINS
-DEFAULT_SETTINGS_MODULE
-EXTRA_REQUIREMENTS
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
@@ -29,5 +25,3 @@ KOLIBRI_RUN_MODE="docker"
 # DOCKERMNT_PEX_PATH=
 # Specify path to a .pex file in the /docker/mnt volume, e.g.
 # DOCKERMNT_PEX_PATH=/docker/mnt/kolibri-0.11.0a1.dev_git-37-gb15b923.pex
-
-BACKGROUND_IMAGE


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to add a script to dynamically add env vars prefixed with KOLIBRI_BUILD_ into docker environment for building the UN Women custom installers.
The script `build_tools/customize_docker_envlist.py` will parse through all the environment variables in the current environment, find all the variables prefixed with `KOLIBRI_BUILD_`, remove the prefix and pass the result name and corresponding value to `env.list` so that docker can read from this file.
The env.list will be restored after running docker container so that the dynamic env vars will not be committed to the repo.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

testing buildkite pipeline:
1. `export KOLIBRI_BUILD_XXX=a`
2. run `make docker-whl` 
3. run `docker exec -it <kolibri_container>` to see if the environment variable `XXX` exists

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#5769 

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
