### PR TITLE
Change morango imports according to project restructure

### DIFF
--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -2,8 +2,8 @@ import logging
 import sys
 
 from django.db.models.signals import post_delete
-from morango.certificates import Certificate
 from morango.models import Buffer
+from morango.models import Certificate
 from morango.models import DatabaseIDModel
 from morango.models import DeletedModels
 from morango.models import Store

--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -7,11 +7,11 @@ from django.core.management.base import CommandError
 from django.core.validators import URLValidator
 from django.urls import reverse
 from django.utils.six.moves import input
-from morango.certificates import Certificate
-from morango.certificates import Filter
-from morango.certificates import ScopeDefinition
-from morango.controller import MorangoProfileController
+from morango.models import Certificate
+from morango.models import Filter
 from morango.models import InstanceIDModel
+from morango.models import ScopeDefinition
+from morango.sync.controller import MorangoProfileController
 from requests.exceptions import ConnectionError
 from six.moves.urllib.parse import urljoin
 

--- a/kolibri/core/auth/management/commands/registerfacility.py
+++ b/kolibri/core/auth/management/commands/registerfacility.py
@@ -3,7 +3,7 @@ import sys
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
-from morango.certificates import Certificate
+from morango.models import Certificate
 from requests import exceptions
 
 from kolibri.core import error_constants

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -3,8 +3,8 @@ import sys
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from morango.certificates import Filter
-from morango.controller import MorangoProfileController
+from morango.models import Filter
+from morango.sync.controller import MorangoProfileController
 from requests.exceptions import ConnectionError
 
 from kolibri.core.auth.constants.morango_scope_definitions import FULL_FACILITY

--- a/kolibri/core/auth/migrations/0001_initial.py
+++ b/kolibri/core/auth/migrations/0001_initial.py
@@ -7,7 +7,7 @@ import uuid
 import django.core.validators
 import django.db.models.deletion
 import django.utils.timezone
-import morango.utils.uuids
+import morango.models
 import mptt.fields
 from django.db import migrations
 from django.db import models
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         default=uuid.uuid4,
                         editable=False,
                         primary_key=True,
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -112,7 +112,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -147,7 +147,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -202,7 +202,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -243,7 +243,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -36,11 +36,11 @@ from django.db import models
 from django.db.models.query import F
 from django.db.utils import IntegrityError
 from django.utils.encoding import python_2_unicode_compatible
-from morango.certificates import Certificate
-from morango.manager import SyncableModelManager
+from morango.models import Certificate
+from morango.models import MorangoMPTTModel
+from morango.models import MorangoMPTTTreeManager
 from morango.models import SyncableModel
-from morango.utils.morango_mptt import MorangoMPTTModel
-from morango.utils.morango_mptt import MorangoMPTTTreeManager
+from morango.models import SyncableModelManager
 from mptt.models import TreeForeignKey
 
 from .constants import collection_kinds

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -8,10 +8,10 @@ import uuid
 
 import requests
 from django.test import TestCase
-from morango.controller import MorangoProfileController
 from morango.models import InstanceIDModel
 from morango.models import Store
-from morango.utils.register_models import _profile_models
+from morango.models import syncable_models
+from morango.sync.controller import MorangoProfileController
 from rest_framework import status
 from six.moves.urllib.parse import urljoin
 
@@ -127,16 +127,16 @@ class EcosystemTestCase(TestCase):
         return resp
 
     def assertServerQuerysetEqual(self, s1, s2, dataset_id):
-        syncable_models = list(_profile_models["facilitydata"].values())
-        syncable_models.pop(
+        models = syncable_models.get_models("facilitydata")
+        models.pop(
             0
         )  # remove FacilityDataset because __str__() does not point to correct db alias
-        for klass in syncable_models:
+        for model in models:
             self.assertQuerysetEqual(
-                klass.objects.using(s1.db_alias).filter(dataset_id=dataset_id),
+                model.objects.using(s1.db_alias).filter(dataset_id=dataset_id),
                 [
                     repr(u)
-                    for u in klass.objects.using(s2.db_alias).filter(
+                    for u in model.objects.using(s2.db_alias).filter(
                         dataset_id=dataset_id
                     )
                 ],

--- a/kolibri/core/auth/test/test_register_facility.py
+++ b/kolibri/core/auth/test/test_register_facility.py
@@ -4,7 +4,7 @@ import mock
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
-from morango.certificates import Certificate
+from morango.models import Certificate
 
 from kolibri.core.auth.test.test_api import FacilityFactory
 

--- a/kolibri/core/exams/migrations/0001_initial.py
+++ b/kolibri/core/exams/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import django.db.models.deletion
 import jsonfield.fields
-import morango.utils.uuids
+import morango.models
 from django.db import migrations
 from django.db import models
 
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),

--- a/kolibri/core/lessons/migrations/0001_initial.py
+++ b/kolibri/core/lessons/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import django.db.models.deletion
 import jsonfield.fields
-import morango.utils.uuids
+import morango.models
 from django.conf import settings
 from django.db import migrations
 from django.db import models
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -74,7 +74,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),

--- a/kolibri/core/logger/migrations/0001_initial.py
+++ b/kolibri/core/logger/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import django.core.validators
 import django.db.models.deletion
 import jsonfield.fields
-import morango.utils.uuids
+import morango.models
 from django.db import migrations
 from django.db import models
 
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -84,7 +84,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -202,7 +202,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -264,7 +264,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -309,7 +309,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),
@@ -366,7 +366,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    morango.utils.uuids.UUIDField(
+                    morango.models.UUIDField(
                         editable=False, primary_key=True, serialize=False
                     ),
                 ),

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -21,7 +21,7 @@ from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils import timezone
 from jsonfield import JSONField
-from morango.query import SyncableModelQuerySet
+from morango.models import SyncableModelQuerySet
 
 from .permissions import AnyoneCanWriteAnonymousLogs
 from kolibri.core.auth.constants import role_kinds

--- a/kolibri/core/utils/portal.py
+++ b/kolibri/core/utils/portal.py
@@ -2,8 +2,8 @@ import json
 
 import requests
 from morango.api.serializers import CertificateSerializer
-from morango.certificates import Certificate
 from morango.constants.api_urls import NONCE
+from morango.models import Certificate
 from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.constants.morango_scope_definitions import FULL_FACILITY

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ metafone==0.5
 le-utils==0.1.15
 kolibri_exercise_perseus_plugin==1.1.8
 jsonfield==2.0.2
-morango==0.4.7
+morango==0.4.9
 requests-toolbelt==0.8.0
 clint==0.5.1
 tzlocal==1.5.1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The morango project structure was refactored so imports needed to be updated in kolibri.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/morango/compare/v0.4.7...v0.4.9
Refer to https://github.com/learningequality/morango/releases/tag/v0.4.8 and https://github.com/learningequality/morango/releases/tag/v0.4.9 for changelog notes.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
