### PR TITLE
Gherkin scenarios for language switching

### DIFF
--- a/integration_testing/features/admin/admin-change-language.feature
+++ b/integration_testing/features/admin/admin-change-language.feature
@@ -4,6 +4,20 @@ Feature: Admin changes user interface language
   Background:
     Given I am signed in to Kolibri as facility admin user
 
+  Scenario: Admin has changed language from |device_language| to |language| prior to logging in
+    When I log in
+    Then Kolibri is in |language|
+    When I log out
+    Then I am redirected to the sign in page and Kolibri is in |language|
+    When I open a new tab and open Kolibri
+    Then Kolibri is shown in |language|
+    When I refresh the page
+    Then Kolibri is shown in |language|
+    When I navigate between and within Coach, Learn, and Facility sections of Kolibri
+    Then Kolibri remains in |language|
+    When I close my browser altogether and go to Kolibri's root server URL
+    Then Kolibri is shown in |device_language|
+
   Scenario: Admin changes language
     When I open the user menu
       And I click *Change language*
@@ -14,5 +28,5 @@ Feature: Admin changes user interface language
       And I see Kolibri UI in <language> language
 
 Examples:
-  | language  |
-  | Kiswahili |
+  | language  | device_language |
+  | Kiswahili | English         |

--- a/integration_testing/features/admin/admin-change-language.feature
+++ b/integration_testing/features/admin/admin-change-language.feature
@@ -4,7 +4,16 @@ Feature: Admin changes user interface language
   Background:
     Given I am signed in to Kolibri as facility admin user
 
-  Scenario: Admin has changed language from <device_language> to <language> prior to logging in
+  Scenario: Admin changes language
+    When I open the user menu
+      And I click *Change language*
+    Then I see the *Change language* modal
+    When I select <language>
+     And I click *Confirm* button
+    Then the modal closes
+      And I see Kolibri UI in <language> language
+
+  Scenario: Admin has changed their own language from <device_language> to <language> prior to logging in
     When I log in
     Then Kolibri is in <language>
     When I log out
@@ -17,15 +26,6 @@ Feature: Admin changes user interface language
     Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
-
-  Scenario: Admin changes language
-    When I open the user menu
-      And I click *Change language*
-    Then I see the *Change language* modal
-    When I select <language>
-     And I click *Confirm* button
-    Then the modal closes
-      And I see Kolibri UI in <language> language
 
 Examples:
   | language  | device_language |

--- a/integration_testing/features/admin/admin-change-language.feature
+++ b/integration_testing/features/admin/admin-change-language.feature
@@ -4,19 +4,19 @@ Feature: Admin changes user interface language
   Background:
     Given I am signed in to Kolibri as facility admin user
 
-  Scenario: Admin has changed language from |device_language| to |language| prior to logging in
+  Scenario: Admin has changed language from <device_language> to <language> prior to logging in
     When I log in
-    Then Kolibri is in |language|
+    Then Kolibri is in <language>
     When I log out
-    Then I am redirected to the sign in page and Kolibri is in |language|
+    Then I am redirected to the sign in page and Kolibri is in <language>
     When I open a new tab and open Kolibri
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I refresh the page
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I navigate between and within Coach, Learn, and Facility sections of Kolibri
-    Then Kolibri remains in |language|
+    Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
-    Then Kolibri is shown in |device_language|
+    Then Kolibri is shown in <device_language>
 
   Scenario: Admin changes language
     When I open the user menu

--- a/integration_testing/features/admin/admin-change-language.feature
+++ b/integration_testing/features/admin/admin-change-language.feature
@@ -24,7 +24,7 @@ Feature: Admin changes user interface language
     Then Kolibri is shown in <language>
     When I navigate between and within Coach, Learn, and Facility sections of Kolibri
     Then Kolibri remains in <language>
-    When I close my browser altogether and go to Kolibri's root server URL
+    When I open a fresh Incognito or Private Browsing window and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
 
 Examples:

--- a/integration_testing/features/coach/coach-change-language.feature
+++ b/integration_testing/features/coach/coach-change-language.feature
@@ -4,7 +4,16 @@ Feature: Coach changes user interface language
   Background:
     Given I am signed in to Kolibri as coach user
 
-  Scenario: Coach has changed language from <device_language> to <language> prior to logging in
+  Scenario: Change language from the user menu
+    When I open the user menu
+      And I click *Change language*
+    Then I see the *Change language* modal
+    When I select <language>
+     And I click *Confirm* button
+    Then the modal closes
+      And I see Kolibri UI in <language> language
+
+  Scenario: Coach has changed their own language from <device_language> to <language> prior to logging in
     When I log in
     Then Kolibri UI is in <language>
     When I log out
@@ -17,15 +26,6 @@ Feature: Coach changes user interface language
     Then Kolibri UI remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
     Then Kolibri UI is shown in <device_language>
-
-  Scenario: Change language from the user menu
-    When I open the user menu
-      And I click *Change language*
-    Then I see the *Change language* modal
-    When I select <language>
-     And I click *Confirm* button
-    Then the modal closes
-      And I see Kolibri UI in <language> language
 
 Examples:
   | language  | device_language |

--- a/integration_testing/features/coach/coach-change-language.feature
+++ b/integration_testing/features/coach/coach-change-language.feature
@@ -4,6 +4,20 @@ Feature: Coach changes user interface language
   Background:
     Given I am signed in to Kolibri as coach user
 
+  Scenario: Coach has changed language from <device_language> to <language> prior to logging in
+    When I log in
+    Then Kolibri UI is in <language>
+    When I log out
+    Then I am redirected to the sign in page and Kolibri UI is in <language>
+    When I open a new tab and open Kolibri
+    Then Kolibri UI is shown in <language>
+    When I refresh the page
+    Then Kolibri UI is shown in <language>
+    When I navigate between and within Coach and Learn sections of Kolibri
+    Then Kolibri UI remains in <language>
+    When I close my browser altogether and go to Kolibri's root server URL
+    Then Kolibri UI is shown in <device_language>
+
   Scenario: Change language from the user menu
     When I open the user menu
       And I click *Change language*
@@ -14,6 +28,5 @@ Feature: Coach changes user interface language
       And I see Kolibri UI in <language> language
 
 Examples:
-  | language  |
-  | Kiswahili |
-  
+  | language  | device_language |
+  | Kiswahili | English         |

--- a/integration_testing/features/coach/coach-change-language.feature
+++ b/integration_testing/features/coach/coach-change-language.feature
@@ -24,7 +24,7 @@ Feature: Coach changes user interface language
     Then Kolibri UI is shown in <language>
     When I navigate between and within Coach and Learn sections of Kolibri
     Then Kolibri UI remains in <language>
-    When I close my browser altogether and go to Kolibri's root server URL
+    When I open a fresh Incognito or Private Browsing window and go to Kolibri's root server URL
     Then Kolibri UI is shown in <device_language>
 
 Examples:

--- a/integration_testing/features/guest/guest-change-language.feature
+++ b/integration_testing/features/guest/guest-change-language.feature
@@ -27,7 +27,7 @@ Feature: Guest changes language
     Then Kolibri UI remains in <language>
     When I return to the sign in page and sign into any account
     Then Kolibri UI is shown in <language>
-    When I close my browser altogether and go to Kolibri's root server URL
+    When I open a fresh Incognito or Private Browsing window and go to Kolibri's root server URL
     Then Kolibri UI is shown in <device_language>
 
   Scenario: Change language from the user menu

--- a/integration_testing/features/guest/guest-change-language.feature
+++ b/integration_testing/features/guest/guest-change-language.feature
@@ -16,7 +16,7 @@ Feature: Guest changes language
     Then the modal closes
       And I see Kolibri UI in <language> language
 
-  Scenario: Guest has changed language from <device_language> to <language> prior to logging in
+  Scenario: Guest has changed their own language from <device_language> to <language> prior to logging in
     When I log in
     Then Kolibri UI is in <language>
     When I open a new tab and open Kolibri

--- a/integration_testing/features/guest/guest-change-language.feature
+++ b/integration_testing/features/guest/guest-change-language.feature
@@ -2,7 +2,7 @@ Feature: Guest changes language
   Guest needs to be able to change language on sign-in page, and from the user drop down menu while browsing content as a guest
 
   Background:
-    Given that Kolibri is available in more than one language    
+    Given that Kolibri is available in more than one language
 
   Scenario: Change language on sign-in page
     Given I am on the Kolibri sign-in page
@@ -16,6 +16,20 @@ Feature: Guest changes language
     Then the modal closes
       And I see Kolibri UI in <language> language
 
+  Scenario: Guest has changed language from <device_language> to <language> prior to logging in
+    When I log in
+    Then Kolibri UI is in <language>
+    When I open a new tab and open Kolibri
+    Then Kolibri UI is shown in <language>
+    When I refresh the page
+    Then Kolibri UI is shown in <language>
+    When I navigate the Kolibri UI
+    Then Kolibri UI remains in <language>
+    When I return to the sign in page and sign into any account
+    Then Kolibri UI is shown in <language>
+    When I close my browser altogether and go to Kolibri's root server URL
+    Then Kolibri UI is shown in <device_language>
+
   Scenario: Change language from the user menu
     Given that I am browsing Kolibri content as a guest
     When I open the user menu
@@ -27,5 +41,5 @@ Feature: Guest changes language
       And I see Kolibri UI in <language> language
 
 Examples:
-  | language  |
-  | Kiswahili |
+  | language  | device_language |
+  | Kiswahili | English         |

--- a/integration_testing/features/learner/learner-change-language.feature
+++ b/integration_testing/features/learner/learner-change-language.feature
@@ -24,7 +24,7 @@ Feature: Learner change language
     Then Kolibri is shown in <language>
     When I navigate the Kolibri UI
     Then Kolibri remains in <language>
-    When I close my browser altogether and go to Kolibri's root server URL
+    When I open a fresh Incognito or Private Browsing window and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
 
 Examples:

--- a/integration_testing/features/learner/learner-change-language.feature
+++ b/integration_testing/features/learner/learner-change-language.feature
@@ -4,19 +4,19 @@ Feature: Learner change language
   Background:
     Given that I am signed in to Kolibri as a learner user
 
-  Scenario: Learner has changed language from |device_language| to |language| prior to logging in
+  Scenario: Learner has changed language from <device_language> to <language> prior to logging in
     When I log in
-    Then Kolibri is in |language|
+    Then Kolibri is in <language>
     When I log out
-    Then I am redirected to the sign in page and Kolibri is in |language|
+    Then I am redirected to the sign in page and Kolibri is in <language>
     When I open a new tab and open Kolibri
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I refresh the page
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I navigate the Kolibri UI
-    Then Kolibri remains in |language|
+    Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
-    Then Kolibri is shown in |device_language|
+    Then Kolibri is shown in <device_language>
 
   Scenario: Change language from the user menu
     When I open the user menu

--- a/integration_testing/features/learner/learner-change-language.feature
+++ b/integration_testing/features/learner/learner-change-language.feature
@@ -1,8 +1,22 @@
 Feature: Learner change language
   Learner needs to be able to change language after login from the user menu
-  
+
   Background:
     Given that I am signed in to Kolibri as a learner user
+
+  Scenario: Learner has changed language from |device_language| to |language| prior to logging in
+    When I log in
+    Then Kolibri is in |language|
+    When I log out
+    Then I am redirected to the sign in page and Kolibri is in |language|
+    When I open a new tab and open Kolibri
+    Then Kolibri is shown in |language|
+    When I refresh the page
+    Then Kolibri is shown in |language|
+    When I navigate the Kolibri UI
+    Then Kolibri remains in |language|
+    When I close my browser altogether and go to Kolibri's root server URL
+    Then Kolibri is shown in |device_language|
 
   Scenario: Change language from the user menu
     When I open the user menu
@@ -16,4 +30,3 @@ Feature: Learner change language
 Examples:
   | language  |
   | Kiswahili |
-  

--- a/integration_testing/features/learner/learner-change-language.feature
+++ b/integration_testing/features/learner/learner-change-language.feature
@@ -4,7 +4,16 @@ Feature: Learner change language
   Background:
     Given that I am signed in to Kolibri as a learner user
 
-  Scenario: Learner has changed language from <device_language> to <language> prior to logging in
+  Scenario: Change language from the user menu
+    When I open the user menu
+      And I click *Change language*
+    Then I see the *Change language* modal
+    When I select <language>
+     And I click *Confirm* button
+    Then the modal closes
+      And I see Kolibri UI in <language> language
+
+  Scenario: Learner has changed their own language from <device_language> to <language> prior to logging in
     When I log in
     Then Kolibri is in <language>
     When I log out
@@ -17,15 +26,6 @@ Feature: Learner change language
     Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
-
-  Scenario: Change language from the user menu
-    When I open the user menu
-      And I click *Change language*
-    Then I see the *Change language* modal
-    When I select <language>
-     And I click *Confirm* button
-    Then the modal closes
-      And I see Kolibri UI in <language> language
 
 Examples:
   | language  |

--- a/integration_testing/features/super-admin/super-admin-change-language.feature
+++ b/integration_testing/features/super-admin/super-admin-change-language.feature
@@ -4,6 +4,20 @@ Feature: Super admin change user interface language
   Background:
     Given I am signed in to Kolibri as super admin user
 
+  Scenario: Super admin has changed language from |device_language| to |language| prior to logging in
+    When I log in
+    Then Kolibri is in |language|
+    When I log out
+    Then I am redirected to the sign in page and Kolibri is in |language|
+    When I open a new tab and open Kolibri
+    Then Kolibri is shown in |language|
+    When I refresh the page
+    Then Kolibri is shown in |language|
+    When I navigate between and within Coach, Learn, Device and Facility sections of Kolibri
+    Then Kolibri remains in |language|
+    When I close my browser altogether and go to Kolibri's root server URL
+    Then Kolibri is shown in |device_language|
+
   Scenario: Super admin changes language
     When I open the user menu
       And I click *Change language*

--- a/integration_testing/features/super-admin/super-admin-change-language.feature
+++ b/integration_testing/features/super-admin/super-admin-change-language.feature
@@ -24,7 +24,7 @@ Feature: Super admin change user interface language
     Then Kolibri is shown in <language>
     When I navigate between and within Coach, Learn, Device and Facility sections of Kolibri
     Then Kolibri remains in <language>
-    When I close my browser altogether and go to Kolibri's root server URL
+    When I open a fresh Incognito or Private Browsing window and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
 
 Examples:

--- a/integration_testing/features/super-admin/super-admin-change-language.feature
+++ b/integration_testing/features/super-admin/super-admin-change-language.feature
@@ -4,19 +4,19 @@ Feature: Super admin change user interface language
   Background:
     Given I am signed in to Kolibri as super admin user
 
-  Scenario: Super admin has changed language from |device_language| to |language| prior to logging in
+  Scenario: Super admin has changed language from <device_language> to <language> prior to logging in
     When I log in
-    Then Kolibri is in |language|
+    Then Kolibri is in <language>
     When I log out
-    Then I am redirected to the sign in page and Kolibri is in |language|
+    Then I am redirected to the sign in page and Kolibri is in <language>
     When I open a new tab and open Kolibri
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I refresh the page
-    Then Kolibri is shown in |language|
+    Then Kolibri is shown in <language>
     When I navigate between and within Coach, Learn, Device and Facility sections of Kolibri
-    Then Kolibri remains in |language|
+    Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
-    Then Kolibri is shown in |device_language|
+    Then Kolibri is shown in <device_language>
 
   Scenario: Super admin changes language
     When I open the user menu

--- a/integration_testing/features/super-admin/super-admin-change-language.feature
+++ b/integration_testing/features/super-admin/super-admin-change-language.feature
@@ -4,7 +4,16 @@ Feature: Super admin change user interface language
   Background:
     Given I am signed in to Kolibri as super admin user
 
-  Scenario: Super admin has changed language from <device_language> to <language> prior to logging in
+  Scenario: Super admin changes language
+    When I open the user menu
+      And I click *Change language*
+    Then I see the *Change language* modal
+    When I select <language>
+     And I click *Confirm* button
+    Then the modal closes
+      And I see Kolibri UI in <language> language
+
+  Scenario: Super admin has changed their own language from <device_language> to <language> prior to logging in
     When I log in
     Then Kolibri is in <language>
     When I log out
@@ -17,15 +26,6 @@ Feature: Super admin change user interface language
     Then Kolibri remains in <language>
     When I close my browser altogether and go to Kolibri's root server URL
     Then Kolibri is shown in <device_language>
-
-  Scenario: Super admin changes language
-    When I open the user menu
-      And I click *Change language*
-    Then I see the *Change language* modal
-    When I select <language>
-     And I click *Confirm* button
-    Then the modal closes
-      And I see Kolibri UI in <language> language
 
 Examples:
   | language  |


### PR DESCRIPTION
### Summary
Adds gherkin scenarios for all user types changing their language prior to signing in.

### Reviewer guidance

[In reference to this Notion page](https://www.notion.so/learningequality/Personal-Dashboard-edc0356e45ee4700ae3b8f349537beea?p=f8c0837f9a254f24bf623a788897bd23) - ensure that all scenarios and stories are covered for all user types so that we are covering all expected user stories.

### References

[Notion Page](https://www.notion.so/learningequality/Personal-Dashboard-edc0356e45ee4700ae3b8f349537beea?p=f8c0837f9a254f24bf623a788897bd23)

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
