### PR TITLE
Rearrange the BuildKite pipeline create integration testing step.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,15 +36,15 @@ steps:
 
   - wait
 
+  - block: "Create integration testing worksheet?"
+  - label: Create integration testing
+    command: .buildkite/build_worksheet.sh
+
   - block: "Sign Windows installer?"
   - label: Sign Windows installer
     command: .buildkite/sign_windows_installer.bat
     agents:
       queue: "windows-sign"
-
-  - block: "Create integration testing worksheet?"
-  - label: Create integration testing
-    command: .buildkite/build_worksheet.sh
 
   - block: "Build release APK?"
   - label: "Build Release APK"


### PR DESCRIPTION

### Summary
I rearrange the BuildKite pipeline of `create integration testing` step. (right now, the `sign Windows installer` step is blocking the integration testing spreadsheet to build)


### Reviewer guidance
Check if you can build the BuildKite pipeline of `create integration testing` without building the `sign Windows installer` step.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
