### PR TITLE
Remove erroneous warning about plugin initialization

### DIFF
--- a/kolibri/plugins/base.py
+++ b/kolibri/plugins/base.py
@@ -7,10 +7,8 @@ from __future__ import unicode_literals
 
 import logging
 import sys
-import warnings
 from importlib import import_module
 
-from django.conf import settings
 from django.utils.module_loading import module_has_submodule
 
 from kolibri.utils.conf import config
@@ -78,15 +76,6 @@ class KolibriPluginBase(object):
 
     # : Suggested property, not yet in use
     collect_static_on_enable = False
-
-    def __init__(self):
-        if settings.configured:
-            # Check to see if a plugin is being initialized after Django
-            warnings.warn(
-                "{module} exposes a KolibriPluginBase derived object but is initialized after Django - enable as a plugin to use this properly".format(
-                    module=self._module_path()
-                )
-            )
 
     @classmethod
     def _module_path(cls):


### PR DESCRIPTION
### Summary
Removes an erroneous warning about plugin initialization.
Any actual error will trigger worse results.

### Reviewer guidance
Make sure the error doesn't appear when using the pex file.

### References
Fixes #5788

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
