### PR TITLE
Invoke black directly and add size of artifacts to buildkite report

### DIFF
--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -118,7 +118,7 @@ def create_status_report_html(artifacts):
             if artifact["category"] != current_heading:
                 current_heading = artifact["category"]
                 html += "<h2>{heading}</h2>\n".format(heading=current_heading)
-            html += "<p>{description}: <a href='{media_url}'>{name}</a></p>\n".format(
+            html += "<p>{description}: <a href='{media_url}'>{name}</a> ({size_mb} MB)</p>\n".format(
                 **artifact
             )
     html += "</body>\n</html>"
@@ -203,7 +203,12 @@ def upload_artifacts():
             )
         blob.upload_from_filename(filename=file_data.get("file_location"))
         blob.make_public()
-        file_data.update({"media_url": blob.media_link})
+        file_data.update(
+            {
+                "size_mb": os.path.getsize(file_data.get("file_location")) / 1048576.0,
+                "media_url": blob.media_link,
+            }
+        )
 
     html = create_status_report_html(artifacts)
 

--- a/tox.ini
+++ b/tox.ini
@@ -120,10 +120,12 @@ commands =
     flake8 kolibri
 
 [testenv:pythonblack]
+# black is unpinned because they have no useful version semantics,
+# so better to break immediately and decide from there
+deps =
+    black
 commands =
-    yarn
-    npm rebuild node-sass
-    yarn run fmt-backend:check
+    black --check --diff --exclude '/(\.git|\.tox|\.venv|build|static|dist|node_modules)/' .
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
### Summary

 * Spreading some general awareness of our file size footprint. It's also nice to know when starting a download.
 * Added `--diff` to tox.ini such that Travis CI will show the error in code formatting. Replaced the black-fmt wrapper in tox.ini because it doesn't support `--diff` and I don't see why our CI should use a wrapper in its already isolated `pythonblack` tox env, when this is faster? CC: @ralphiee22 

### Reviewer guidance

Waiting for build to pass. Not related to any critical code.

### References

This was just me trying to grab an artifact on a slow connection, and felt like the size was missing.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
