### PR TITLE
fixed trailing white space in front of links (coach plugin)

### DIFF
--- a/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
+++ b/kolibri/core/assets/src/views/buttons-and-links/buttons.scss
@@ -41,7 +41,7 @@ a.button {
 }
 
 .link {
-  display: inline;
+  display: inline-block;
   padding: 0;
   text-align: left;
   text-decoration: underline;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
 I changed the class `link`'s display attribute from inline to inline-block. This fixed the trailing white space in front of links within the coach plugin.

# Before
![Screenshot from 2019-07-24 18-09-58](https://user-images.githubusercontent.com/7971405/61838896-44632900-ae40-11e9-8eaa-8b1f47f20922.png)
![Screenshot from 2019-07-24 18-10-30](https://user-images.githubusercontent.com/7971405/61838905-4f1dbe00-ae40-11e9-8faf-596d7b3d652a.png)

# After

![Screenshot from 2019-07-24 18-11-26](https://user-images.githubusercontent.com/7971405/61838913-547b0880-ae40-11e9-809b-b4b62e740ccd.png)
![Screenshot from 2019-07-24 18-11-38](https://user-images.githubusercontent.com/7971405/61838929-71174080-ae40-11e9-9262-3de44d7ca8e6.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
You must be in coach's dashboard and then simply alternate from inline and inline-block to see the changes.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
This will fix this issue: [#5779](https://github.com/learningequality/kolibri/issues/5779)

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ x] Contributor has fully tested the PR manually
- [x ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
