### PR TITLE
Revert 5805

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.12.7
+
+- Backed out change related to images in exercises due to regression
+
 ## 0.12.6
 
 ### Changed or Fixed

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -20,13 +20,17 @@ from django.http.response import FileResponse
 from django.http.response import HttpResponseNotModified
 from django.template import loader
 from django.templatetags.static import static
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import etag
 from django.views.generic.base import View
+from le_utils.constants import exercises
+from six.moves.urllib.parse import urlunparse
 
 from .api import cache_forever
 from .decorators import add_security_headers
+from .decorators import get_referrer_url
 from .models import ContentNode
 from .utils.paths import get_content_storage_file_path
 from kolibri import __version__ as kolibri_version
@@ -50,6 +54,19 @@ def get_hashi_filename():
         ) as f:
             HASHI_FILENAME = f.read().strip()
     return HASHI_FILENAME
+
+
+def generate_image_prefix_url(request, zipped_filename):
+    parsed_referrer_url = get_referrer_url(request)
+    # Remove trailing slash
+    zipcontent = reverse(
+        "kolibri:core:zipcontent",
+        kwargs={"zipped_filename": zipped_filename, "embedded_filepath": ""},
+    )[:-1]
+    if parsed_referrer_url:
+        # Reconstruct the parsed URL using a blank scheme and host + port(1)
+        zipcontent = urlunparse(("", parsed_referrer_url[1], zipcontent, "", "", ""))
+    return zipcontent.encode()
 
 
 def calculate_zip_content_etag(request, *args, **kwargs):
@@ -190,7 +207,7 @@ def get_h5p(zf, embedded_filepath):
     return response
 
 
-def get_embedded_file(zf, zipped_filename, embedded_filepath):
+def get_embedded_file(request, zf, zipped_filename, embedded_filepath):
     # if no path, or a directory, is being referenced, look for an index.html file
     if not embedded_filepath or embedded_filepath.endswith("/"):
         embedded_filepath += "index.html"
@@ -217,10 +234,18 @@ def get_embedded_file(zf, zipped_filename, embedded_filepath):
         html = parse_html(content)
         response = HttpResponse(html, content_type=content_type)
         file_size = len(response.content)
-    else:
+    elif not os.path.splitext(embedded_filepath)[1] == ".json":
         # generate a streaming response object, pulling data from within the zip  file
         response = FileResponse(zf.open(info), content_type=content_type)
         file_size = info.file_size
+    else:
+        image_prefix_url = generate_image_prefix_url(request, zipped_filename)
+        # load the stream from json file into memory, replace the path_place_holder.
+        content = zf.open(info).read()
+        str_to_be_replaced = ("$" + exercises.IMG_PLACEHOLDER).encode()
+        content_with_path = content.replace(str_to_be_replaced, image_prefix_url)
+        response = HttpResponse(content_with_path, content_type=content_type)
+        file_size = len(response.content)
 
     # set the content-length header to the size of the embedded file
     if file_size:
@@ -259,7 +284,9 @@ class ZipContentView(View):
             ):
                 response = get_h5p(zf, embedded_filepath)
             else:
-                response = get_embedded_file(zf, zipped_filename, embedded_filepath)
+                response = get_embedded_file(
+                    request, zf, zipped_filename, embedded_filepath
+                )
 
         # ensure the browser knows not to try byte-range requests, as we don't support them here
         response["Accept-Ranges"] = "none"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.15
-kolibri_exercise_perseus_plugin==1.1.10
+kolibri_exercise_perseus_plugin==1.1.8
 jsonfield==2.0.2
 morango==0.4.9
 requests-toolbelt==0.8.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.15
-kolibri_exercise_perseus_plugin==1.1.8
+kolibri_exercise_perseus_plugin==1.1.9
 jsonfield==2.0.2
 morango==0.4.9
 requests-toolbelt==0.8.0


### PR DESCRIPTION

### Summary

* revert changes in https://github.com/learningequality/kolibri/pull/5805
* update version to `(0, 12, 7, "beta", 0)`
* set perseus to version `1.1.9`

### Reviewer guidance

attempts to address apparent regression found during release of 0.12.6

### References

https://github.com/learningequality/kolibri/pull/5805#issuecomment-515635656

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
