### PR TITLE
Fix briefly flashing checkboxes on CreateExamPage

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -169,7 +169,7 @@ It is recommended to use the ``KIcon`` component when possible, as this will han
 
 .. code-block:: html
 
-  <KIcon forward />
+  <KIcon icon="forward" />
 
 
 If ``KIcon`` does not have the icon you need or is not usable for some reason, we also provide a global CSS class ``rtl-icon`` which will flip the icon. This can be applied conditionally with the ``isRtl`` property, e.g.:

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -4,10 +4,7 @@
     :allLinkText="coachString('viewAllAction')"
     :allLinkRoute="classRoute('ReportsLessonListPage', {})"
   >
-    <KLabeledIcon slot="title">
-      <KIcon slot="icon" lesson />
-      {{ coreString('lessonsLabel') }}
-    </KLabeledIcon>
+    <KLabeledIcon slot="title" icon="lesson" :label="coreString('lessonsLabel')" />
 
     <p v-if="table.length === 0">
       {{ coachString('lessonListEmptyState') }}

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -4,10 +4,7 @@
     :allLinkText="coachString('viewAllAction')"
     :allLinkRoute="classRoute('ReportsQuizListPage', {})"
   >
-    <KLabeledIcon slot="title">
-      <KIcon slot="icon" quiz />
-      {{ coreString('quizzesLabel') }}
-    </KLabeledIcon>
+    <KLabeledIcon slot="title" icon="quiz" :label="coreString('quizzesLabel')" />
 
     <p v-if="table.length === 0">
       {{ coachString('quizListEmptyState') }}

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -193,7 +193,7 @@
       };
     },
     computed: {
-      ...mapState(['pageName', 'toolbarRoute']),
+      ...mapState(['toolbarRoute']),
       ...mapGetters('examCreation', ['numRemainingSearchResults']),
       ...mapState('examCreation', [
         'numberOfQuestions',
@@ -203,6 +203,9 @@
         'searchResults',
         'ancestors',
       ]),
+      pageName() {
+        return this.$route.name;
+      },
       maxQs() {
         return MAX_QUESTIONS;
       },


### PR DESCRIPTION

### Summary

1. Fixes some missing icons on Class Home Page
1. Changes implementation of CreateExamPage to observe the `pageName` through the `$route` object, instead of through vuex state, which can be out of sync with the UI. Fixes #5811 


### Reviewer guidance

1. On the Quiz Creation workflow, verify you don't see the flash any more.

### References

Fixes #5811 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
