### PR TITLE
Fix Hashi behaviour for Proyecto Descartes HTML5 content

### DIFF
--- a/packages/hashi/src/replaceScript.js
+++ b/packages/hashi/src/replaceScript.js
@@ -74,8 +74,12 @@ export function seq(arr, index) {
       const loadEvent = document.createEvent('Event');
       loadEvent.initEvent('load', true, true);
       document.dispatchEvent(DOMContentLoadedEvent);
-      document.dispatchEvent(loadEvent);
-      window.dispatchEvent(loadEvent);
+      if (document.readyState === 'complete') {
+        // Only call this if the document is already fully loaded
+        // and we need to emulate the window load event.
+        document.dispatchEvent(loadEvent);
+        window.dispatchEvent(loadEvent);
+      }
       const elements = document.querySelectorAll(':not(script)');
       Array.prototype.forEach.call(elements, element => {
         element.dispatchEvent(loadEvent);


### PR DESCRIPTION
### Summary
* Previously, Hashi would do a server fetch to get the actual page content after Hashi had been initialized. This led to the window `load` event being called before any on page Javascript for the HTML5 app was around to hear it. To compensate for that, we mocked the window `load` event and fired it again for their benefit.

* Now Hashi loads in a more synchronous manner, so in page Javascript will load before the window `load` event is fired.

* This had the slightly odd side effect of causing Proyecto Descartes HTML5 apps to go into an infinite loop, for reasons that I could not quite discern, but seemed to have to do with writing to the DOM and setting resize listeners within the load event handler.

* To fix this, this PR checks for the `document.readyState` property. The window `load` event is only fired if the property is already set to `'complete'` indicating that the window `load` event has already been fired.

### Reviewer guidance
Import a channel containing Proyecto Descartes content (e.g. `447cedc184ea4345aaedadf2fd6da906`) and import the content node `Habilidades Básicas - ONU Mujeres -> Proyecto Descartes -> Matemáticas -> 10-13 años -> Áreas de polígonos`.

Verify that before this fix viewing the content node will freeze the page and spike CPU to 100%, and that after this fix it runs normally.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
