### PR TITLE
Fix missing images in Khan Academy Perseus exercises

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -6,7 +6,6 @@ import zipfile
 from bs4 import BeautifulSoup
 from django.test import Client
 from django.test import TestCase
-from le_utils.constants import exercises
 from mock import patch
 
 from ..models import LocalFile
@@ -43,10 +42,6 @@ class ZipContentTestCase(TestCase):
     test_str_1 = "This is a test!"
     test_name_2 = "testfile2.txt"
     test_str_2 = "And another test..."
-    test_name_3 = "testfile3.json"
-    test_str_3 = "A test of image placeholder replacement ${placeholder}".format(
-        placeholder=exercises.IMG_PLACEHOLDER
-    )
 
     def setUp(self):
 
@@ -71,7 +66,6 @@ class ZipContentTestCase(TestCase):
             zf.writestr(self.empty_html_name, self.empty_html_str)
             zf.writestr(self.test_name_1, self.test_str_1)
             zf.writestr(self.test_name_2, self.test_str_2)
-            zf.writestr(self.test_name_3, self.test_str_3)
 
         self.zip_file_obj = LocalFile(
             id=self.hash, extension=self.extension, available=True
@@ -165,30 +159,6 @@ class ZipContentTestCase(TestCase):
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS=headerval,
         )
         self.assertEqual(response.get("Access-Control-Allow-Headers", ""), headerval)
-
-    def test_json_image_replacement_http_referer_header(self, filename_patch):
-        server_name = "http://testserver"
-        response = self.client.get(
-            self.zip_file_base_url + self.test_name_3, HTTP_REFERER=server_name
-        )
-        self.assertEqual(
-            response.content.decode("utf-8"),
-            self.test_str_3.replace(
-                "$" + exercises.IMG_PLACEHOLDER,
-                (server_name.replace("http:", "") + self.zip_file_base_url),
-            ).strip("/"),
-        )
-
-    def test_json_image_replacement_no_http_referer_header(self, filename_patch):
-        server_name = "http://testserver"
-        response = self.client.get(self.zip_file_base_url + self.test_name_3)
-        self.assertEqual(
-            response.content.decode("utf-8"),
-            self.test_str_3.replace(
-                "$" + exercises.IMG_PLACEHOLDER,
-                (server_name.replace("http:", "") + self.zip_file_base_url),
-            ).strip("/"),
-        )
 
     def test_request_for_html_no_head_return_hashi_modified_html(self, filename_patch):
         response = self.client.get(self.zip_file_base_url)

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -20,16 +20,13 @@ from django.http.response import FileResponse
 from django.http.response import HttpResponseNotModified
 from django.template import loader
 from django.templatetags.static import static
-from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import etag
 from django.views.generic.base import View
-from six.moves.urllib.parse import urlunparse
 
 from .api import cache_forever
 from .decorators import add_security_headers
-from .decorators import get_referrer_url
 from .models import ContentNode
 from .utils.paths import get_content_storage_file_path
 from kolibri import __version__ as kolibri_version
@@ -53,19 +50,6 @@ def get_hashi_filename():
         ) as f:
             HASHI_FILENAME = f.read().strip()
     return HASHI_FILENAME
-
-
-def generate_image_prefix_url(request, zipped_filename):
-    parsed_referrer_url = get_referrer_url(request)
-    # Remove trailing slash
-    zipcontent = reverse(
-        "kolibri:core:zipcontent",
-        kwargs={"zipped_filename": zipped_filename, "embedded_filepath": ""},
-    )[:-1]
-    if parsed_referrer_url:
-        # Reconstruct the parsed URL using a blank scheme and host + port(1)
-        zipcontent = urlunparse(("", parsed_referrer_url[1], zipcontent, "", "", ""))
-    return zipcontent.encode()
 
 
 def calculate_zip_content_etag(request, *args, **kwargs):

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -25,7 +25,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import etag
 from django.views.generic.base import View
-from le_utils.constants import exercises
 from six.moves.urllib.parse import urlunparse
 
 from .api import cache_forever
@@ -234,18 +233,10 @@ def get_embedded_file(request, zf, zipped_filename, embedded_filepath):
         html = parse_html(content)
         response = HttpResponse(html, content_type=content_type)
         file_size = len(response.content)
-    elif not os.path.splitext(embedded_filepath)[1] == ".json":
+    else:
         # generate a streaming response object, pulling data from within the zip  file
         response = FileResponse(zf.open(info), content_type=content_type)
         file_size = info.file_size
-    else:
-        image_prefix_url = generate_image_prefix_url(request, zipped_filename)
-        # load the stream from json file into memory, replace the path_place_holder.
-        content = zf.open(info).read()
-        str_to_be_replaced = ("$" + exercises.IMG_PLACEHOLDER).encode()
-        content_with_path = content.replace(str_to_be_replaced, image_prefix_url)
-        response = HttpResponse(content_with_path, content_type=content_type)
-        file_size = len(response.content)
 
     # set the content-length header to the size of the embedded file
     if file_size:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.15
-kolibri_exercise_perseus_plugin==1.1.9
+kolibri_exercise_perseus_plugin==1.1.11
 jsonfield==2.0.2
 morango==0.4.9
 requests-toolbelt==0.8.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.15
-kolibri_exercise_perseus_plugin==1.1.11
+kolibri_exercise_perseus_plugin==1.1.12
 jsonfield==2.0.2
 morango==0.4.9
 requests-toolbelt==0.8.0


### PR DESCRIPTION
### Summary
Fixes #5702 - this time without causing a horrendous regression.
Does this by remembering to include a `g` in the regex, in order to ensure global replacement.

### Reviewer guidance
Test creating a quiz with questions from the following exercise:
Khan Academy (Español) ->  Matemáticas -> Matemáticas elementales -> Contar -> Contar -> Cuenta con números pequeños

Confirm that the images all display.

### References
https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v1.1.10...v1.1.11

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
