### PR TITLE
Customizable anonymous users

### DIFF
--- a/kolibri/core/auth/middleware.py
+++ b/kolibri/core/auth/middleware.py
@@ -1,8 +1,41 @@
+from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import SimpleLazyObject
 
-from .models import KolibriAnonymousUser
+
+def get_anonymous_user_model():
+    """
+    Return the Anonymous User model that is active in this project.
+    """
+    try:
+        app_name = settings.AUTH_ANONYMOUS_USER_MODEL.split(".")[0]
+    except AttributeError:
+        raise ImproperlyConfigured("AUTH_ANONYMOUS_USER_MODEL is not a string")
+    try:
+        model_name = settings.AUTH_ANONYMOUS_USER_MODEL.split(".")[1]
+        app = apps.get_app_config(app_name)
+        models_module = app.models_module
+    except IndexError:
+        raise ImproperlyConfigured(
+            "AUTH_ANONYMOUS_USER_MODEL must be of the form 'app_label.model_name'"
+        )
+    except LookupError:
+        raise ImproperlyConfigured(
+            "AUTH_ANONYMOUS_USER_MODEL refers to an app '{}' that has not been installed".format(
+                app_name
+            )
+        )
+    try:
+        return getattr(models_module, model_name)
+    except AttributeError:
+        raise ImproperlyConfigured(
+            "AUTH_ANONYMOUS_USER_MODEL refers to a model '{}' that does not exist in the app '{}'".format(
+                model_name, app_name
+            )
+        )
 
 
 def _get_user(request):
@@ -10,7 +43,8 @@ def _get_user(request):
     if not hasattr(request, "_cached_user"):
         user = get_user(request)
         if user.is_anonymous():
-            user = KolibriAnonymousUser()
+            AnonymousUser = get_anonymous_user_model()
+            user = AnonymousUser()
         request._cached_user = user
 
     return request._cached_user

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -46,6 +46,7 @@ from mptt.models import TreeForeignKey
 from .constants import collection_kinds
 from .constants import facility_presets
 from .constants import role_kinds
+from .constants import user_kinds
 from .errors import InvalidRoleKind
 from .errors import UserDoesNotHaveRoleError
 from .errors import UserHasRoleOnlyIndirectlyThroughHierarchyError
@@ -285,6 +286,15 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
     def get_short_name(self):
         return self.full_name.split(" ", 1)[0]
 
+    @property
+    def session_data(self):
+        """
+        Data that is added to the session data at login and during session updates.
+        """
+        raise NotImplementedError(
+            "Subclasses of KolibriAbstractBaseUser must override the `session_data` property."
+        )
+
     def is_member_of(self, coll):
         """
         Determine whether this user is a member of the specified ``Collection``.
@@ -485,6 +495,16 @@ class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
     class Meta:
         abstract = True
 
+    @property
+    def session_data(self):
+        return {
+            "username": "",
+            "full_name": "",
+            "user_id": None,
+            "facility_id": getattr(Facility.get_default_facility(), "id", None),
+            "kind": [user_kinds.ANONYMOUS],
+        }
+
     def is_member_of(self, coll):
         return False
 
@@ -650,6 +670,25 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
                 return True
             return False
         return False
+
+    @property
+    def session_data(self):
+        roles = list(self.roles.values_list("kind", flat=True).distinct())
+
+        if self.is_superuser:
+            roles.insert(0, user_kinds.SUPERUSER)
+
+        if not roles:
+            roles = [user_kinds.LEARNER]
+
+        return {
+            "username": self.username,
+            "full_name": self.full_name,
+            "user_id": self.id,
+            "kind": roles,
+            "can_manage_content": self.can_manage_content,
+            "facility_id": self.facility_id,
+        }
 
     @property
     def can_manage_content(self):

--- a/kolibri/core/auth/test/test_middleware.py
+++ b/kolibri/core/auth/test/test_middleware.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.test import TestCase
 
 from ..middleware import _get_user
 from ..middleware import CustomAuthenticationMiddleware
+from ..middleware import get_anonymous_user_model
 from ..models import KolibriAnonymousUser
 
 
@@ -28,3 +31,32 @@ class AuthMiddlewareTestCase(TestCase):
         self.assertIsInstance(user, KolibriAnonymousUser)
         user = _get_user(request)
         self.assertIsInstance(user, KolibriAnonymousUser)
+
+    @override_settings(AUTH_ANONYMOUS_USER_MODEL=None)
+    def test_custom_anonymous_user_customization_invalid_setting(self):
+        with self.assertRaisesRegexp(ImproperlyConfigured, "not a string"):
+            get_anonymous_user_model()
+
+    @override_settings(AUTH_ANONYMOUS_USER_MODEL="kolibriauth")
+    def test_custom_anonymous_user_customization_only_app_name(self):
+        with self.assertRaisesRegexp(
+            ImproperlyConfigured,
+            "AUTH_ANONYMOUS_USER_MODEL must be of the form 'app_label.model_name'",
+        ):
+            get_anonymous_user_model()
+
+    @override_settings(
+        AUTH_ANONYMOUS_USER_MODEL="not_a_real_app_name.KolibriAnonymousUser"
+    )
+    def test_custom_anonymous_user_customization_invalid_app_name(self):
+        with self.assertRaisesRegexp(ImproperlyConfigured, "has not been installed"):
+            get_anonymous_user_model()
+
+    @override_settings(
+        AUTH_ANONYMOUS_USER_MODEL="kolibriauth.NotTheKolibriAnonymousUser"
+    )
+    def test_custom_anonymous_user_customization_invalid_model_name(self):
+        with self.assertRaisesRegexp(
+            ImproperlyConfigured, "that does not exist in the app"
+        ):
+            get_anonymous_user_model()

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -376,6 +376,10 @@ LOGGING = {
 
 AUTH_USER_MODEL = "kolibriauth.FacilityUser"
 
+# Our own custom setting to override the anonymous user model
+
+AUTH_ANONYMOUS_USER_MODEL = "kolibriauth.KolibriAnonymousUser"
+
 AUTHENTICATION_BACKENDS = ["kolibri.core.auth.backends.FacilityUserBackend"]
 
 


### PR DESCRIPTION
### Summary
* Adds a setting that allows the anonymous user model that we use in our authentication middleware customizable.
* Sets that setting to the `KolibriAnonymousUser` by default.
* Changes the way that the user specific session data is generated, by delegating to a `session_data` property on the user model.
* Implements `session_data` property on the `FacilityUser` and the `KolibriAnonymousUser`.

### Reviewer guidance
Check that the tests satisfactorily cover the changes. No changes were made to the session login/logout tests, so the overall API of that endpoint should be unchanged.

### References
In support of https://github.com/learningequality/kolibri-data-portal/pull/38

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
