### PR TITLE
Always pass get params in requests

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -137,11 +137,11 @@ export class Model {
             if (!this.new || exists) {
               // If this Model is not new, then can do a PATCH against the Model
               url = this.url;
-              clientObj = { path: url, method: 'PATCH', entity: payload };
+              clientObj = { path: url, method: 'PATCH', entity: payload, params: this.getParams };
             } else {
               // Otherwise, must POST to the Collection endpoint to create the Model
               url = this.resource.collectionUrl();
-              clientObj = { path: url, entity: payload };
+              clientObj = { path: url, entity: payload, params: this.getParams };
             }
             // Do a save on the URL.
             this.resource.client(clientObj).then(
@@ -195,7 +195,7 @@ export class Model {
             reject('Can not delete model that we do not have an id for');
           } else {
             // Otherwise, DELETE the Model
-            const clientObj = { path: this.url, method: 'DELETE' };
+            const clientObj = { path: this.url, method: 'DELETE', params: this.getParams };
             this.resource.client(clientObj).then(
               () => {
                 // delete this instance


### PR DESCRIPTION
### Summary
Small bug fix for the API resource layer, only came to light because of data portal work.

### Reviewer guidance

This shouldn't affect anything in Kolibri, but a quick check around in the app would be helpful.

### References
https://github.com/learningequality/kolibri-data-portal/pull/39

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
