### PR TITLE
Fix key error

### DIFF
--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -351,12 +351,11 @@ def parse_attemptslog(attemptlog):
     failed_interactions = []
     attempts = AttemptLog.objects.filter(masterylog_id=attemptlog.masterylog_id)
 
-    # NOTE: saw at elast one error here where failed['correct'] raised a key error
     failed_interactions = [
         failed
         for attempt in attempts
         for failed in attempt.interaction_history
-        if failed["correct"] == 0
+        if failed.get("correct", 0) == 0
     ]
 
     # More than 3 errors in this mastery log:


### PR DESCRIPTION
### Summary
* Exercise notifications would trigger an error in case a hint or an error occurred, because the interaction history item was checked for a non-existent 'correct' key.
* Make get correct not trigger an error in case a hint was taken or error occurred.


This was observed during development, and has also been observed in user logs.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
