### PR TITLE
Check kolibri user only when running Debian installer

### DIFF
--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -1,6 +1,7 @@
 import getpass
 import os
 import sys
+from shutil import rmtree
 
 from builtins import input
 
@@ -22,7 +23,7 @@ def check_debian_user(noinput=False):
     # Check if Kolibri is installed through the Kolibri Debian package or kolibri-server
     # Debian package
     install_type = installation_type()
-    if install_type not in ["dpkg", "apt"] or not install_type.startswith("kolibri"):
+    if install_type not in ["dpkg", "apt"] and not install_type.startswith("kolibri"):
         return
 
     with open("/etc/kolibri/username", "r") as f:
@@ -61,5 +62,5 @@ def check_debian_user(noinput=False):
     )
     if not cont.strip().lower() == "y":
         # Remove the previously created KOLIBRI_HOME directory
-        os.rmdir(KOLIBRI_HOME)
+        rmtree(KOLIBRI_HOME)
         sys.exit(0)

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -8,8 +8,15 @@ from .conf import KOLIBRI_HOME
 from .server import installation_type
 
 
-def check_debian_user(noninteractive=False):
-    if noninteractive:
+def check_debian_user(noinput=False):
+    """
+    A user account is selected to run the system service during the initial setup
+    of the Debian package installation. This function checks whether the current
+    user who tries to run Kolibri is the user account set in the configuration.
+    Users are free to choose whether they want to continue as the current user even
+    if it is not the user defined in the configuration.
+    """
+    if noinput:
         return
 
     # Check if Kolibri is installed through the Kolibri Debian package or kolibri-server
@@ -53,4 +60,6 @@ def check_debian_user(noninteractive=False):
         "run the command as '{}'? [y/N] ".format(current_user)
     )
     if not cont.strip().lower() == "y":
+        # Remove the previously created KOLIBRI_HOME directory
+        os.rmdir(KOLIBRI_HOME)
         sys.exit(0)

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -4,12 +4,18 @@ import sys
 
 from builtins import input
 
+from .conf import KOLIBRI_HOME
+from .server import installation_type
 
-def check_debian_user():
-    # Check whether the current user is the kolibri user when running kolibri
-    # that is installed from .deb package.
-    # The code is mainly from https://github.com/learningequality/ka-lite/blob/master/bin/kalite#L53
-    if not os.name == "posix" or not os.path.isfile("/etc/kolibri/username"):
+
+def check_debian_user(noninteractive=False):
+    if noninteractive:
+        return
+
+    # Check if Kolibri is installed through the Kolibri Debian package or kolibri-server
+    # Debian package
+    install_type = installation_type()
+    if install_type not in ["dpkg", "apt"] or not install_type.startswith("kolibri"):
         return
 
     with open("/etc/kolibri/username", "r") as f:
@@ -17,11 +23,15 @@ def check_debian_user():
 
     current_user = getpass.getuser()
 
+    # If kolibri user does not exist or is the same as the current user, then do not
+    # prompt the user with the warning.
     if not kolibri_user or kolibri_user == current_user:
         return
 
-    kolibri_home = os.path.expanduser(os.environ.get("KOLIBRI_HOME", "~/.kolibri"))
-    if os.path.exists(kolibri_home) and os.listdir(kolibri_home):
+    # If the database file exists in the KOLIBRI_HOME directory, then kolibri was
+    # started with the current user before. There is no need to prompt the user
+    # with the warning.
+    if os.path.exists(os.path.join(KOLIBRI_HOME, "db.sqlite3")):
         return
 
     sys.stderr.write(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR checks the kolibri user only when user is running the Debian package. 
If the user runs as the user who is not the kolibri user defined in the Debian config, a user prompt will show up in the beginning to ask if the user would like to continue to run as the current user or not.
If the user decides not to run as the current user, KOLIBRI_HOME directory will be deleted (at this time, KOLIBRI_HOME directory should only contain `logs` folder and `kolibri_settings.json` file).

A flag `--no-input` is also added so that users can start kolibri with `kolibri start --no-input`, and the program will start without asking for user input.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Install the Debian package from this PR, configure the kolibri user to be `user A`
2. start kolibri with `user B` -- should be able to see the user prompt
3. start kolibri with `user B` and command `kolibri start --no-input` -- should not see the user prompt
3. get the pex file from this PR, run it with `user B` -- should not see the user prompt


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#5786 

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
