### PR TITLE
Update skipupdate references to skip-update.

### DIFF
--- a/kolibri/utils/tests/test_handler.py
+++ b/kolibri/utils/tests/test_handler.py
@@ -16,12 +16,12 @@ class KolibriTimedRotatingFileHandlerTestCase(TestCase):
         settings.LOGGING["handlers"]["file"]["when"] = "s"
         # make sure that kolibri will be running for more than one second
         try:
-            cli.main(["manage", "--skipupdate", "help"])
+            cli.main(["manage", "--skip-update", "help"])
         except SystemExit:
             pass
         sleep(1)
         try:
-            cli.main(["manage", "--skipupdate", "help"])
+            cli.main(["manage", "--skip-update", "help"])
         except SystemExit:
             pass
         # change back to the original rotation time

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watch": "kolibri-tools build dev --file ./build_tools/build_plugins.txt",
     "watch-hot": "yarn run watch --hot",
     "django-devserver": "kolibri manage --debug runserver --settings=kolibri.deployment.default.settings.dev \"0.0.0.0:8000\" ",
-    "services": "kolibri services --foreground --skipupdate",
+    "services": "kolibri services --foreground --skip-update",
     "devserver": "npm-run-all --parallel django-devserver lint-frontend:watch:format hashi-dev watch services",
     "devserver-warn": "npm-run-all --parallel django-devserver lint-frontend:watch hashi-dev watch services",
     "devserver-hot": "npm-run-all --parallel django-devserver lint-frontend:watch:format hashi-dev watch-hot services",


### PR DESCRIPTION
### Summary
* In #5494 the `skipupdate` flag was changed to `skip-update`
* This PR migrates three references that were not updated.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
