### PR TITLE
To test the Greek language display properly

### DIFF
--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -28,7 +28,7 @@ VOLUME /kolibridist/
 
 # TODO(cpauya): Verify the checksums of the downloaded Python installers.
 
-CMD git clone https://github.com/learningequality/kolibri-installer-windows.git && \
+CMD git clone https://github.com/mrpau/kolibri.git && \
     cd kolibri-installer-windows/windows && \
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -28,7 +28,7 @@ VOLUME /kolibridist/
 
 # TODO(cpauya): Verify the checksums of the downloaded Python installers.
 
-CMD git clone https://github.com/mrpau/kolibri.git && \
+CMD git clone https://github.com/mrpau/kolibri-installer-windows && \
     cd kolibri-installer-windows/windows && \
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \

--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -28,7 +28,7 @@ VOLUME /kolibridist/
 
 # TODO(cpauya): Verify the checksums of the downloaded Python installers.
 
-CMD git clone https://github.com/mrpau/kolibri-installer-windows && \
+CMD git clone https://github.com/mrpau/kolibri-installer-windows.git && \
     cd kolibri-installer-windows/windows && \
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.2
+KOLIBRI_WINDOWS_INSTALLER_VERSION=feature/test-Greek-language
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=feature/test-Greek-language
+KOLIBRI_WINDOWS_INSTALLER_VERSION=feature/131-Greek-language-corrupted
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR use to test the Greek language that I restore. To see that the Greek language can display properly/correctly.

Note:
WIP - Don't merge

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Issue: https://github.com/learningequality/kolibri-installer-windows/issues/131
PR: https://github.com/learningequality/kolibri-installer-windows/pull/134

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
