### PR TITLE
Update kolibri-tools for external plugin building.

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -40,7 +40,7 @@
     "vuex": "^3.1.0"
   },
   "devDependencies": {
-    "kolibri-tools": "0.12.0-beta.3.2",
+    "kolibri-tools": "0.13.0-dev.3",
     "responselike": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "black-fmt": "https://github.com/learningequality/black-fmt#v0.1.3",
-    "kolibri-tools": "0.12.0-beta.3.2",
+    "kolibri-tools": "0.13.0-dev.3",
     "yarn-run-all": "^3.1.1"
   },
   "optionalDependencies": {

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.12.0-beta.3.2",
+  "version": "0.13.0-dev.3",
   "description": "Custom rules.",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri",
-  "version": "0.12.0-beta.3.2",
+  "version": "0.13.0-dev.3",
   "description": "The Kolibri core API",
   "repository": "github.com/learningequality/kolibri",
   "author": "Learning Equality",
@@ -8,6 +8,6 @@
   "private": false,
   "dependencies": {},
   "devDependencies": {
-    "kolibri-tools": "0.12.0-beta.3.2"
+    "kolibri-tools": "0.13.0-dev.3"
   }
 }

--- a/packages/kolibri-tools/.npmignore
+++ b/packages/kolibri-tools/.npmignore
@@ -1,1 +1,1 @@
-build.js
+build_kolibri_tools.js

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -38,7 +38,7 @@ const WebpackMessages = require('./webpackMessages');
 module.exports = (data, { mode = 'development', hot = false } = {}) => {
   if (
     typeof data.name === 'undefined' ||
-    typeof data.config === 'undefined' ||
+    typeof data.config_path === 'undefined' ||
     typeof data.static_dir === 'undefined' ||
     typeof data.stats_file === 'undefined' ||
     typeof data.locale_data_folder === 'undefined' ||
@@ -48,7 +48,32 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
     logging.error(data.name + ' plugin is misconfigured, missing parameter(s)');
     return;
   }
-
+  const configData = require(data.config_path);
+  let webpackConfig;
+  if (data.index !== null) {
+    webpackConfig = configData[data.index].webpack_config;
+  } else {
+    webpackConfig = configData.webpack_config;
+  }
+  if (typeof webpackConfig.entry === 'string') {
+    webpackConfig.entry = {
+      [data.name]: path.join(data.plugin_path, webpackConfig.entry),
+    };
+  } else {
+    Object.keys(webpackConfig.entry).forEach(key => {
+      function makePathAbsolute(entryPath) {
+        if (entryPath.startsWith('./') || entryPath.startsWith('../')) {
+          return path.join(data.plugin_path, entryPath);
+        }
+        return entryPath;
+      }
+      if (Array.isArray(webpackConfig.entry[key])) {
+        webpackConfig.entry[key] = webpackConfig.entry[key].map(makePathAbsolute);
+      } else {
+        webpackConfig.entry[key] = makePathAbsolute(webpackConfig.entry[key]);
+      }
+    });
+  }
   const production = mode === 'production';
 
   const cssInsertionLoader = hot ? 'style-loader' : MiniCssExtractPlugin.loader;
@@ -82,7 +107,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
 
   let externals;
 
-  if (!data.config.output || data.config.output.library !== kolibriName) {
+  if (!webpackConfig.output || webpackConfig.output.library !== kolibriName) {
     // If this is not the core bundle, then we need to add the external library mappings.
     externals = coreExternals;
   } else {
@@ -236,7 +261,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
     stats: 'minimal',
   };
 
-  bundle = merge.smart(bundle, data.config);
+  bundle = merge.smart(bundle, webpackConfig);
 
   return bundle;
 };

--- a/packages/kolibri-tools/lib/webpack_json.py
+++ b/packages/kolibri-tools/lib/webpack_json.py
@@ -15,6 +15,9 @@ from pkg_resources import resource_listdir
 
 logger = logging.getLogger("webpack_json")
 logger.setLevel(level=logging.INFO)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
 
 BUILD_CONFIG = "buildConfig.js"
 

--- a/packages/kolibri-tools/lib/webpack_json.py
+++ b/packages/kolibri-tools/lib/webpack_json.py
@@ -15,9 +15,9 @@ from pkg_resources import resource_listdir
 
 logger = logging.getLogger("webpack_json")
 logger.setLevel(level=logging.INFO)
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
-logger.addHandler(ch)
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+logger.addHandler(handler)
 
 BUILD_CONFIG = "buildConfig.js"
 

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.12.0-beta.3.2",
+  "version": "0.13.0-dev.3",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": "github.com/learningequality/kolibri",
@@ -32,7 +32,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.1",
-    "eslint-plugin-kolibri": "0.12.0-beta.3.2",
+    "eslint-plugin-kolibri": "0.13.0-dev.3",
     "eslint-plugin-vue": "^5.2.2",
     "espree": "^5.0.1",
     "esquery": "^1.0.1",
@@ -93,6 +93,6 @@
     "readline-sync": "^1.4.9"
   },
   "optionalDependencies": {
-    "kolibri": "0.12.0-beta.3.2"
+    "kolibri": "0.13.0-dev.3"
   }
 }

--- a/packages/kolibri-tools/test/test_webpack.config.base.spec.js
+++ b/packages/kolibri-tools/test/test_webpack.config.base.spec.js
@@ -16,6 +16,16 @@ jest.mock('../lib/logging', () => ({
   },
 }));
 
+jest.mock(
+  'test',
+  () => ({
+    webpack_config: {
+      entry: 'test',
+    },
+  }),
+  { virtual: true }
+);
+
 const baseData = {
   name: 'kolibri.plugin.test.test_plugin',
   stats_file: 'output.json',
@@ -24,11 +34,8 @@ const baseData = {
   locale_data_folder: 'kolibri/locale/test',
   version: 'test',
   plugin_path: 'kolibri/plugin',
-  config: {
-    entry: {
-      test_plugin: 'src/file.js',
-    },
-  },
+  config_path: 'test',
+  index: null,
 };
 
 describe('webpackConfigBase', function() {
@@ -86,9 +93,9 @@ describe('webpackConfigBase', function() {
       expectParsedDataIsUndefined(data);
     });
   });
-  describe('input is missing config, bundles output', function() {
+  describe('input is missing config_path, bundles output', function() {
     it('should be undefined', function() {
-      delete data.config;
+      delete data.config_path;
       expectParsedDataIsUndefined(data);
     });
   });

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ porter2stemmer==1.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.17
-kolibri_exercise_perseus_plugin==1.2.0
+kolibri_exercise_perseus_plugin==1.2.1
 jsonfield==2.0.2
 morango==0.4.9
 requests-toolbelt==0.8.0


### PR DESCRIPTION
### Summary
Small tweaks to plugin building.
Upgrade perseus renderer with new build configuration.

### Reviewer Guidance
Does the devserver run and load pages without errors.

### References
Fixes #5865 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
