### PR TITLE
Focus on username/full name fields after dismissing FacilityModal

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -389,6 +389,9 @@
       ...mapActions(['kolibriLogin']),
       closeFacilityModal() {
         this.facilityModalVisible = false;
+        this.$nextTick().then(() => {
+          this.$refs.username.focus();
+        });
       },
       setSuggestionTerm(newVal) {
         if (newVal !== null && typeof newVal !== 'undefined') {

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -247,7 +247,9 @@
       }),
       closeFacilityModal() {
         this.facilityModalVisible = false;
-        this.$refs.name.focus();
+        this.$nextTick().then(() => {
+          this.$refs.name.focus();
+        });
       },
       signUp() {
         this.formSubmitted = true;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Focuses the username (on SignInPage) or full name (on SignUpPage) fields after dismissing the FacilityModal (following changes in #5861).

Makes things a little better for keyboard-only navigation

### Reviewer guidance

In a multi-facility server, check that the forms get autofocused after dismissing the FacilityModal.

### References

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
