### PR TITLE
explicitly set liveReload on webpack devserver

### DIFF
--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -55,7 +55,7 @@ function webpackConfig(pluginData, hot) {
 function buildWebpack(data, index, startCallback, doneCallback, options) {
   const port = options.port + index;
   const publicPath = genPublicPath(CONFIG.address, port, CONFIG.basePath);
-  const hot = options.hot;
+  const hot = Boolean(options.hot);
 
   // webpack config for this bundle
   const bundleConfig = webpackConfig(data, hot);
@@ -82,6 +82,7 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   const compiler = webpack(bundleConfig);
   const devServerOptions = {
     hot,
+    liveReload: !hot,
     host: CONFIG.host,
     port,
     watchOptions: {


### PR DESCRIPTION
### Summary

* In 2daa429a1ecf426c1ab37d38c00cd7b12c776b28 we upgraded the webpack devserver to 3.7.2
* In [webpack devserver 3.4.0](https://github.com/webpack/webpack-dev-server/releases/tag/v3.4.0) they added a new `liveReload` option which defaults to `true`
* In #5867 I mistakenly thought hot reload was enabled, but it was actually the new live reloading

### Reviewer guidance

This PR explicitly toggles between live reloading and hot reloading. One of them is always active. Live reloading is mainly useful for testing RTL.

### References

* fixes #5867
* https://webpack.js.org/configuration/dev-server/

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
