### PR TITLE
Adding gherking stories to test kolibri-server package

### DIFF
--- a/integration_testing/features/ORDER.txt
+++ b/integration_testing/features/ORDER.txt
@@ -4,3 +4,4 @@ coach
 learner
 guest
 common
+debian

--- a/integration_testing/features/debian/ORDER.txt
+++ b/integration_testing/features/debian/ORDER.txt
@@ -1,0 +1,5 @@
+kolibri-server-uninstall.feature
+kolibri-server-stop.feature
+kolibri-server-change-port.feature
+kolibri-server-handle-multiple-args-in-url.feature
+kolibri-server-show-file-streams.feature

--- a/integration_testing/features/debian/kolibri-server-change-port.feature
+++ b/integration_testing/features/debian/kolibri-server-change-port.feature
@@ -1,0 +1,11 @@
+Feature: kolibri-server manages ports correctly
+  If the user changes the port after installing kolibri-server, those changes must be applied upon restart. This test should be done in Debian Buster and Ubuntu bionic.
+
+  Background:
+    Given that the kolibri-server is installed and running
+
+  Scenario: Change Kolibri port
+    When I edit the file '~/.kolibri/options.ini' to change the HTTP_PORT option to one of the allowed options: 80, 8008 or 8080
+      And I restart kolibri-server
+      And I reload the browser with the new port
+    Then I see Kolibri running with the new port

--- a/integration_testing/features/debian/kolibri-server-handle-multiple-args-in-url.feature
+++ b/integration_testing/features/debian/kolibri-server-handle-multiple-args-in-url.feature
@@ -1,0 +1,15 @@
+Feature: kolibri-server handles urls with more than 50 args
+  If the url contains many (>50 args) in the url, they should not be limited
+
+  Background:
+    Given that the kolibri-server is installed and running
+        And channel with token 'nakav-mafak' is installed
+
+  Scenario: Lesson with multiple args
+    Given I am signed in to Kolibri as a coach or super-admin
+    When I create a new class <class> and a new lesson <lesson> in <class>
+      And I add more than 50 resources to <lesson>
+      And I activate <lesson>
+      And I go to *Learn > Classes* and select <class>
+      And I open <lesson>
+    Then I can view and interact correctly with the content

--- a/integration_testing/features/debian/kolibri-server-show-file-streams.feature
+++ b/integration_testing/features/debian/kolibri-server-show-file-streams.feature
@@ -1,0 +1,10 @@
+Feature: kolibri-server handles correctly content provided under file streams
+  Some of the kolibri contents are not actual files but streams, they must be correctly handled
+  Background:
+    Given that the kolibri-server is installed and running
+      And channel with token 'nakav-mafak' is installed
+
+  Scenario: Interact with PLIX HTML5 app
+    Given I am signed in to Kolibri
+    When I open the PLIX HTML5 app in the browser
+    Then I can view and interact correctly with the content

--- a/integration_testing/features/debian/kolibri-server-stop.feature
+++ b/integration_testing/features/debian/kolibri-server-stop.feature
@@ -1,0 +1,10 @@
+Feature: Stopping kolibri-server service stops kolibri too
+  After kolibri-server service is stopped, there should not be any kolibri instances running either. This test should be done in Debian Buster and Ubuntu bionic.
+
+  Background:
+    Given that the kolibri-server is installed and running
+
+  Scenario: Stop kolibri-server
+    When I run the 'sudo service kolibri-service stop' command in the Terminal
+      And I run 'sudo service kolibri status'
+    Then I see the '...Stopped LSB: kolibri daemon...' text in the last line of the output

--- a/integration_testing/features/debian/kolibri-server-uninstall.feature
+++ b/integration_testing/features/debian/kolibri-server-uninstall.feature
@@ -1,0 +1,12 @@
+Feature: Clean uninstall of kolibri-server
+  Kolibri needs to continue running after kolibri-server has been uninstalled. This test should be done in Debian Buster and Ubuntu bionic.
+
+  Background:
+    Given that kolibri-server is installed and running
+
+  Scenario: Uninstall kolibri-server
+    When I run the 'apt remove kolibri-server' command in the Terminal
+	  And the command prompt appears again
+    Then I still can access Kolibri in the browser
+      And the file /etc/nginx/conf.d/kolibri.conf does not exist
+      And the folder /etc/kolibri/nginx.d does not exist


### PR DESCRIPTION
### Summary
These integration tests have been created to test the `kolibri-server` package before adding it to the main ppa repository
The cover the differences between a normal kolibri installation and the use of kolibri-server plus add some regression tests to cover know issues that were fixed in the past.

### Reviewer guidance
Read through them to be sure they are understable and follow kolibri gherkin stories policy.

### References
Included regression tests for:
- https://github.com/learningequality/kolibri-server/issues/11
- https://github.com/learningequality/kolibri-server/issues/20
- https://github.com/learningequality/kolibri-server/issues/24
- https://github.com/learningequality/kolibri-server/issues/29



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
