### PR TITLE
Add a Sign In link to AuthMessage

### DIFF
--- a/integration_testing/features/common/ORDER.txt
+++ b/integration_testing/features/common/ORDER.txt
@@ -1,3 +1,4 @@
+authorization-message.feature
 view-all-content-types.feature
 appbar-scroll.feature
 appbar-user-type.feature

--- a/integration_testing/features/common/authorization-message.feature
+++ b/integration_testing/features/common/authorization-message.feature
@@ -1,0 +1,23 @@
+Feature: Authorization message
+  Unauthorized users see a message
+
+  Scenario: Seeing message as an anonymous user
+    Given that I am an anonymous user
+    When I attempt to access a restricted page
+    Then I see an Authorization Message
+      And there is a link that says *Sign In to Kolibri*
+
+  Scenario: Seeing message as authenticated but not authorized user
+    Given that I am logged in as an authenticated user
+    When I attempt to access a restricted page
+    Then I see an Authorization Message
+      And there is not a link that says *Sign In to Kolibri*
+
+  Scenario: Getting redirected after signing in
+    Given that I am on a restricted page
+      And I see an Authorization Message
+    When I click the *Sign In to Kolibri* link
+    Then I am taken to the Sign In Page
+    When I provide credentials for an authorized user
+    Then I am taken back to the original restricted page
+      And I do not see an Authorization Message

--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -11,7 +11,7 @@
     </p>
     <p v-if="!isUserLoggedIn">
       <KExternalLink
-        :text="$tr('signInToKolibriAction')"
+        :text="linkText"
         :href="signInLink"
         appearance="basic-link"
       />
@@ -49,12 +49,13 @@
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       detailsText() {
-        if (this.details) {
-          return this.details;
-        } else if (!this.userPluginUrl) {
+        return this.details || this.$tr(this.authorizedRole);
+      },
+      linkText() {
+        if (!this.userPluginUrl) {
           return this.$tr('goBackToHomeAction');
         } else {
-          return this.$tr(this.authorizedRole);
+          return this.$tr('signInToKolibriAction');
         }
       },
       userPluginUrl() {

--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -6,8 +6,15 @@
     </h1>
     <p>
       <slot name="details">
-        {{ details || defaultDetails }}
+        {{ detailsText }}
       </slot>
+    </p>
+    <p v-if="!isUserLoggedIn">
+      <KExternalLink
+        :text="$tr('signInToKolibriAction')"
+        :href="signInLink"
+        appearance="basic-link"
+      />
     </p>
   </div>
 
@@ -15,6 +22,9 @@
 
 
 <script>
+
+  import { mapGetters } from 'vuex';
+  import urls from 'kolibri.urls';
 
   const userRoles = ['admin', 'adminOrCoach', 'learner', 'registeredUser', 'superuser'];
 
@@ -37,8 +47,30 @@
       details: { type: String },
     },
     computed: {
-      defaultDetails() {
-        return this.$tr(this.authorizedRole);
+      ...mapGetters(['isUserLoggedIn']),
+      detailsText() {
+        if (this.details) {
+          return this.details;
+        } else if (!this.userPluginUrl) {
+          return this.$tr('goBackToHomeAction');
+        } else {
+          return this.$tr(this.authorizedRole);
+        }
+      },
+      userPluginUrl() {
+        return urls['kolibri:user:user'];
+      },
+      signInLink() {
+        // Creates a link to the Sign In Page that also has a query parameter that
+        // will redirect back to this page after user logs in with correct credentials.
+        if (!this.userPluginUrl) {
+          // If User plugin is not active, go to the root of whatever plugin you're in.
+          // In practice, this will only happen on select Learn pages.
+          return '/';
+        } else {
+          const currentURL = window.encodeURIComponent(window.location.href);
+          return `${this.userPluginUrl()}#signin?redirect=${currentURL}`;
+        }
       },
     },
     $trs: {
@@ -48,6 +80,8 @@
       registeredUser: 'You must be signed in to view this page',
       superuser: 'You must have super admin permissions to view this page',
       forgetToSignIn: 'Did you forget to sign in?',
+      signInToKolibriAction: 'Sign in to Kolibri',
+      goBackToHomeAction: 'Go to home page',
     },
   };
 

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -1,8 +1,19 @@
+import urls from 'kolibri.urls';
+import Vuex from 'vuex';
 import { shallowMount } from '@vue/test-utils';
 import AuthMessage from '../../src/views/AuthMessage';
 
+jest.mock('urls', () => ({}));
+
 function makeWrapper(options) {
-  return shallowMount(AuthMessage, options);
+  const store = new Vuex.Store({
+    getters: {
+      isUserLoggedIn() {
+        return false;
+      },
+    },
+  });
+  return shallowMount(AuthMessage, { store, ...options });
 }
 
 // prettier-ignore
@@ -56,5 +67,39 @@ describe('auth message component', () => {
     const { headerText, detailsText } = getElements(wrapper);
     expect(headerText()).toEqual('Did you forget to sign in?');
     expect(detailsText()).toEqual('Must be device owner to manage content');
+  });
+
+  it('shows correct link text if there is a user plugin', () => {
+    const userUrl = jest.fn();
+    urls['kolibri:user:user'] = userUrl;
+    userUrl.mockReturnValue('http://localhost:8000/en/user/');
+    const wrapper = makeWrapper();
+    const link = wrapper.find('kexternallink-stub');
+    expect(link.attributes()).toMatchObject({
+      href: 'http://localhost:8000/en/user/#signin?redirect=http%3A%2F%2Fkolibri.time%2F',
+      text: 'Sign in to Kolibri',
+    });
+    delete urls['kolibri:user:user'];
+  });
+
+  it('shows correct link text if there is not a user plugin', () => {
+    const wrapper = makeWrapper();
+    const link = wrapper.find('kexternallink-stub');
+    expect(link.attributes()).toMatchObject({
+      href: '/',
+      text: 'Go to home page',
+    });
+  });
+
+  it('does not show a link if the user is logged in', () => {
+    const store = new Vuex.Store({
+      getters: {
+        isUserLoggedIn() {
+          return true;
+        },
+      },
+    });
+    const wrapper = makeWrapper({ store });
+    expect(wrapper.find('kexternallink-stub').exists()).toBe(false);
   });
 });

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -469,6 +469,9 @@
           };
           if (global.oidcProviderEnabled) {
             sessionPayload['next'] = this.nextParam;
+          } else if (this.$route.query.redirect && !this.nextParam) {
+            // Go to URL in 'redirect' query param, if arriving from AuthMessage
+            sessionPayload['next'] = this.$route.query.redirect;
           }
           this.kolibriLogin(sessionPayload).catch();
         } else {


### PR DESCRIPTION
### Summary

1. Adds a link to the AuthMessage component that goes to the Sign In Page if not logged in. If you are logged in, this link does not appear.
1. The link has a 'redirect' query parameter that is used to bring you back to the page you were looking at when you first saw the AuthMessage

In screen shots, look at the URL on the bottom

**User is not logged in**
<img width="708" alt="Screen Shot 2019-08-22 at 3 26 03 PM" src="https://user-images.githubusercontent.com/10248067/63555287-3a8f1d00-c4f5-11e9-8673-807986c023f8.png">


**User is logged in **
<img width="833" alt="Screen Shot 2019-08-22 at 3 26 41 PM" src="https://user-images.githubusercontent.com/10248067/63555298-3f53d100-c4f5-11e9-91e9-9676c56ea777.png">

### Reviewer guidance
1. Read the Gherkin stories and run through the two main scenarios
1. If willing, try the (undocumented) scenario where the User plugin is disabled

### References

Fixes #5892

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
