### PR TITLE
Set stemmed_metaphone to blank on import.

### DIFF
--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -94,6 +94,9 @@ class ChannelImport(object):
             "per_row": {
                 "tree_id": "available_tree_id",
                 "available": "default_to_not_available",
+                # Do this for now because we can't currently delete columns
+                # and properly regenerate our import schema.
+                "stemmed_metaphone": "set_blank_text",
             }
         },
         LocalFile: {"per_row": {"available": "default_to_not_available"}},
@@ -130,6 +133,8 @@ class ChannelImport(object):
         self.available_tree_id = self.find_unique_tree_id()
 
         self.default_to_not_available = 0
+
+        self.set_blank_text = ""
 
     def get_none(self, source_object):
         return None
@@ -618,6 +623,7 @@ class NoVersionChannelImport(ChannelImport):
                 "available": "get_none",
                 "license_name": "get_license_name",
                 "license_description": "get_license_description",
+                "stemmed_metaphone": "set_blank_text",
             }
         },
         File: {


### PR DESCRIPTION
### Summary
* Sets all stemmed_metaphone fields to blank on import.

### Reviewer guidance
* Check that Sikana imports on postgres
* Check that tests pass

### References
Fixes #5885 
Replaces #5902

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
