### PR TITLE
Update the Windows installer to 1.3.3

### DIFF
--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -22,7 +22,7 @@ VOLUME /kolibridist/
 # TODO(cpauya): Verify the checksums of the downloaded Python installers.
 
 CMD git clone https://github.com/learningequality/kolibri-installer-windows.git && \
-    cd kolibri-installer-windows/windows && \
+    cd kolibri-installer-windows/src && \
     git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
     cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
     export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.2
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.3.3
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"


### PR DESCRIPTION
# Summary
I updated the Windows installer to released v1.3.3

Details of the updates can be found on this [milestone](https://github.com/learningequality/kolibri-installer-windows/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A1.3.3)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
