### PR TITLE
Gracefully handle failure of ifcfg due to multiple IP bindings.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -480,9 +480,12 @@ def get_urls(listen_port=None):
             __, __, port = get_status()
         urls = []
         if port:
-            interfaces = ifcfg.interfaces()
-            for interface in filter(lambda i: i["inet"], interfaces.values()):
-                urls.append("http://{}:{}/".format(interface["inet"], port))
+            try:
+                interfaces = ifcfg.interfaces()
+                for interface in filter(lambda i: i["inet"], interfaces.values()):
+                    urls.append("http://{}:{}/".format(interface["inet"], port))
+            except RuntimeError:
+                logger.error("Error retrieving network interface list!")
         return STATUS_RUNNING, urls
     except NotRunning as e:
         return e.status_code, []


### PR DESCRIPTION
### Summary

When an interface has multiple IPs bound to it, the following issue surfaces: https://github.com/ftao/python-ifcfg/issues/34

This prevents Kolibri from starting at all.

After this PR, this situation is handled somewhat gracefully:

```
INFO     Running Kolibri with the following settings: kolibri.deployment.default.settings.base
INFO     Sqlite database Vacuum finished.
INFO     Running 'kolibri start' as daemon (system service)
ERROR    Error retrieving network interface list!
ERROR    Could not detect an IP address that Kolibri binds to, but try opening up the following addresses:

        http://localhost:8080
        http://127.0.0.1:8080

INFO     Going to daemon mode, logging to /home/user/.kolibri/logs/kolibri.txt
```

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Wasn't able to force a replication locally, but tested the fix on the remote server where the issue was being observed, and it worked.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Sidesteps issue caused by https://github.com/ftao/python-ifcfg/issues/34

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
