### PR TITLE
Fix the devserver

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -195,7 +195,11 @@ program
           if (persistent) {
             childProcess.on('exit', (code, signal) => {
               children.forEach(child => {
-                child.kill(signal);
+                if (signal) {
+                  child.kill(signal);
+                } else {
+                  child.kill();
+                }
               });
               process.exit(code);
             });

--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -65,18 +65,20 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   // The standard strategy (addDevServerEntrypoints) doesn't work for us. See:
   //   https://github.com/webpack/webpack-dev-server/issues/1051#issuecomment-443794959
   if (hot) {
-    // First, turn entry points into an array if it's currently a string:
-    if (typeof bundleConfig.entry[data.name] === 'string') {
-      bundleConfig.entry[data.name] = [bundleConfig.entry[data.name]];
-    } else if (!Array.isArray(bundleConfig.entry[data.name])) {
-      buildLogging.error('Unhandled data type for bundle entries');
-      process.exit(1);
-    }
-    // Next, prepend two hot-reload-related entry points to the config:
-    bundleConfig.entry[data.name].unshift(
-      `webpack-dev-server/client?http://${CONFIG.address}:${port}/`,
-      'webpack/hot/dev-server'
-    );
+    Object.keys(bundleConfig.entry).forEach(key => {
+      // First, turn entry points into an array if it's currently a string:
+      if (typeof bundleConfig.entry[key] === 'string') {
+        bundleConfig.entry[key] = [bundleConfig.entry[key]];
+      } else if (!Array.isArray(bundleConfig.entry[key])) {
+        buildLogging.error('Unhandled data type for bundle entries');
+        process.exit(1);
+      }
+      // Next, prepend two hot-reload-related entry points to the config:
+      bundleConfig.entry[key].unshift(
+        `webpack-dev-server/client?http://${CONFIG.address}:${port}/`,
+        'webpack/hot/dev-server'
+      );
+    });
   }
 
   const compiler = webpack(bundleConfig);


### PR DESCRIPTION
### Summary
After the merging of #5887 - @jonboiser observed that the devserver would fail to properly run in hot mode.
This PR fixes the oversight that led to this issue.

### Reviewer guidance
Does the dev server now run in hot mode?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
