### PR TITLE
Default to zero-width without slot or label

### DIFF
--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
@@ -11,9 +11,7 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
         <!---->
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
-        learner1
-      </span>
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">learner1</span>
 </div></span></td>
 <td>
   <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
@@ -29,9 +27,7 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
 </span></td>
 </tr>
 <tr>
-  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
-        learner2
-      </span></div></span></td>
+  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">learner2</span></div></span></td>
   <td>
     <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started
@@ -61,9 +57,7 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
         </th>
         <th>Last activity</th>
       </tr>
-    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
-        learner1
-      </span>
+    </thead><span tag="tbody" name="list"><tr><td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">learner1</span>
 </div></span></td>
 <td>
   <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="stars" category="action" style="fill: #ffc107;"></mat-svg></div> <div class="label"><span dir="auto">
@@ -83,9 +77,7 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
 </span></td>
 </tr>
 <tr>
-  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">
-        learner2
-      </span></div></span></td>
+  <td><span class="labeled-icon-wrapper"><div class="icon"><mat-svg name="person" category="social" style="fill: #212121;"></mat-svg></div> <div class="label"><span dir="auto">learner2</span></div></span></td>
   <td>
     <div><span class="labeled-icon-wrapper" nowrap="nowrap"><div class="icon"><mat-svg name="access_time" category="device" style="fill: #03a9f4;"></mat-svg></div> <div class="label"><span dir="auto">
     Started

--- a/packages/kolibri-components/src/KLabeledIcon.vue
+++ b/packages/kolibri-components/src/KLabeledIcon.vue
@@ -9,9 +9,9 @@
     <div class="label">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto">
-        <slot>
-          {{ label }}
-        </slot>
+        <!-- Use zero-width space when empty -->
+        <slot v-if="!labelEmpty">{{ label }}</slot>
+        <template v-else>&#8203;</template>
       </span>
     </div>
   </span>
@@ -38,6 +38,16 @@
       label: {
         type: String,
         required: false,
+      },
+    },
+    computed: {
+      labelEmpty() {
+        const defaultSlot =
+          'default' in this.$slots && this.$slots.default.length
+            ? this.$slots.default[0].text
+            : null;
+
+        return !defaultSlot && !this.label;
       },
     },
   };

--- a/packages/kolibri-components/src/KLabeledIcon.vue
+++ b/packages/kolibri-components/src/KLabeledIcon.vue
@@ -42,12 +42,20 @@
     },
     computed: {
       labelEmpty() {
-        const defaultSlot =
-          'default' in this.$slots && this.$slots.default.length
-            ? this.$slots.default[0].text
-            : null;
+        if (this.label) {
+          return false;
+        }
 
-        return !defaultSlot && !this.label;
+        if (!('default' in this.$slots) || !this.$slots.default.length) {
+          return true;
+        }
+
+        const defaultSlot = this.$slots.default[0];
+        return !(
+          defaultSlot.text ||
+          defaultSlot.tag ||
+          (defaultSlot.children && defaultSlot.children.length)
+        );
       },
     },
   };


### PR DESCRIPTION
### Summary
The `KLabeledIcon` component has been updated to default to the zero-width character `&#8203;` when the label would be otherwise empty. This seems to fix the rendering of the HTML tag such that its height is consistent with its height when it has text.

#### Before
![screenshot-localhost-8080-2019 09 04-10-05-01](https://user-images.githubusercontent.com/819838/64282187-b895ef80-cf09-11e9-8db9-098c7344f003.png)

#### After
![screenshot-localhost-8080-2019 09 04-10-07-19](https://user-images.githubusercontent.com/819838/64282198-bfbcfd80-cf09-11e9-95fb-0410c8bc7b87.png)


### Reviewer guidance
The easiest way to reproduce and test this is to use the [user CSV import functionality](https://kolibri.readthedocs.io/en/latest/advanced.html#import-users-from-a-csv-file), importing a user with an empty name.

### References
https://github.com/learningequality/kolibri/issues/5678

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [X] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
