### PR TITLE
Pin specific version of windows installer before entering the src dir

### DIFF
--- a/docker/build_windows.dockerfile
+++ b/docker/build_windows.dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 # Install wine and related packages
 RUN dpkg --add-architecture i386
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       ca-certificates \
       curl \
       git \
@@ -29,13 +29,14 @@ VOLUME /kolibridist/
 # TODO(cpauya): Verify the checksums of the downloaded Python installers.
 
 CMD git clone https://github.com/learningequality/kolibri-installer-windows.git && \
-    cd kolibri-installer-windows/src && \
-    git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
-    cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
-    export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \
-    make && \
-    curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.msi --output "python-setup/python-3.4.3.msi" && \
-    curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi --output "python-setup/python-3.4.3.amd64.msi" && \
-    wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss && \
-    mv *.exe kolibri-$KOLIBRI_VERSION-unsigned.exe && \
-    cp *.exe /kolibridist/
+      cd kolibri-installer-windows && \
+      git checkout $KOLIBRI_WINDOWS_INSTALLER_VERSION && \
+      cd src && \
+      cp /kolibridist/kolibri-$KOLIBRI_VERSION*.whl . && \
+      export KOLIBRI_BUILD_VERSION=$KOLIBRI_VERSION && \
+      make && \
+      curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.msi --output "python-setup/python-3.4.3.msi" && \
+      curl -sS https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi --output "python-setup/python-3.4.3.amd64.msi" && \
+      wine inno-compiler/ISCC.exe installer-source/KolibriSetupScript.iss && \
+      mv *.exe kolibri-$KOLIBRI_VERSION-unsigned.exe && \
+      cp *.exe /kolibridist/


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that windows installer version was pinned after entering the src directory. The issue led to the failures on buildkite because we changed the name of the directory from `windows` to `src` in v1.3.3.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if the buildkite build succeeds and whether the version is pinned before we enter into the source code directory.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

example failed build: https://buildkite.com/learningequality/kolibri/builds/11998#f6ab76b6-b73b-4974-9f9a-9498a6cf2476

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
