### PR TITLE
Use the specific kolibri host for access control origin header.

### DIFF
--- a/kolibri/core/content/decorators.py
+++ b/kolibri/core/content/decorators.py
@@ -1,9 +1,3 @@
-from six.moves.urllib.parse import urlparse
-from six.moves.urllib.parse import urlunparse
-
-from kolibri.utils.conf import OPTIONS
-
-
 def add_security_headers(some_func):
     """
     Decorator for adding security headers to zipcontent endpoints
@@ -29,7 +23,7 @@ def add_security_headers(some_func):
 
 
 def _add_access_control_headers(request, response):
-    response["Access-Control-Allow-Origin"] = "*"
+    response["Access-Control-Allow-Origin"] = get_host(request)
     response["Access-Control-Allow-Methods"] = "GET, OPTIONS"
     requested_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "")
     if requested_headers:
@@ -46,18 +40,4 @@ def _add_content_security_policy_header(request, response):
 
 
 def get_host(request):
-    parsed_referrer_url = get_referrer_url(request)
-    if parsed_referrer_url:
-        host = urlunparse(
-            (parsed_referrer_url[0], parsed_referrer_url[1], "", "", "", "")
-        )
-    else:
-        host = request.build_absolute_uri(OPTIONS["Deployment"]["URL_PATH_PREFIX"])
-    return host.strip("/")
-
-
-def get_referrer_url(request):
-    if request.META.get("HTTP_REFERER"):
-        # If available use HTTP_REFERER to infer the host as that will give us more
-        # information if Kolibri is behind a proxy.
-        return urlparse(request.META.get("HTTP_REFERER"))
+    return request.build_absolute_uri("/").strip("/")


### PR DESCRIPTION
### Summary
Due to a bug in Microsoft Edge, resource loading inside some HTML5 apps is currently broken because of the way that we set `Access-Control-Allow-Origin` headers to a wild card. It appears that this bug is still extant after several years: https://thisinterestsme.com/microsoft-edge-cors-bug/

This PR fixes this issue by setting a specific `Access-Control-Allow-Origin` header - to that of the current Kolibri host. This is good because HTML5 apps should only be loading things from Kolibri host anyway!

### Reviewer guidance
Do Funza apps work in Microsoft Edge?
Do HTML5 apps work properly with this and Kolibri-server?

I have manually tested this behind an nginx proxy and it worked fine, I have tested it on Microsoft Edge, but not specifically with Funza.

### References
cc @jamalex and @jredrejo as this has implications for our nginx configs - in fact, it makes the explicit overwriting of `Access-Control-Allow-Origin` headers in our nginx configs unnecessary, as I am now properly generating the host name from the request.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
