### PR TITLE
Don't pass notifications in summarizedNotifications

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -39,6 +39,10 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
 
     const { object, type, event } = firstEvent;
 
+    if (type === 'QuizAnswered') {
+      continue; // Skip QuizAnswered notifications
+    }
+
     // Set details about Lesson or Quiz
     let assignment;
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Addresses a regression from https://github.com/learningequality/kolibri/pull/5595 that caused "QuizAnswered" events to show in the Coach ActivityBlock. There is no need to show those notifications - a class of students taking a quiz would flood the summarized notifications for the coach to review.

This is also noted in https://github.com/learningequality/kolibri/issues/5921 - which is an unrelated issue, but the issue was originally noted there in this comment: https://github.com/learningequality/kolibri/issues/5921#issuecomment-528895111

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Create a quiz for a class of students as a coach and assign it to the class, enable it, etc.
- View the Coach > Reports > Quiz Report for that quiz
- In a Private Browsing / Incognito window, sign in as one of the learners assigned to the quiz
- Answer a few questions. As a coach, note that that learner's status for the quiz goes to `x of y answered`
- After answering a few of them - go to the Class overview page. See that you see none of what is shown in this image: https://github.com/learningequality/kolibri/issues/5921#issuecomment-528895111
- Complete the quiz then you ought to see the proper "Learner completed quiz" notification. You should also see the "Learner started quiz" and other normal notifications.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5921#issuecomment-528895111
https://github.com/learningequality/kolibri/pull/5595

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
