### PR TITLE
kolibri cli returns exit code 1 if not parameter is passed

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -335,15 +335,20 @@ You can also run: kolibri COMMAND --help
 """
 
 
-@click.group(help=main_help)
+@click.group(invoke_without_command=True, help=main_help)
+@click.pass_context
 @click.version_option(version=kolibri.__version__)
-def main():
+def main(ctx):
     """
     Kolibri's main function.
 
     Utility functions should be callable for unit testing purposes, but remember
     to use main() for integration tests in order to test the argument API.
     """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(1)
+
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 


### PR DESCRIPTION
### Summary
When `kolibri` cli is run without any options it retuns the help system and exit code `1`


### Reviewer guidance
1. Run `kolibri`without any option
2. It should return kolibri help
3. Executing `echo $?` should return `1` 

1. Run `kolibri` with any valid option (ex. `kolibri stop`)
2. Executing `echo $?` should return `0` 


### References
Closes: #5930 



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
