### PR TITLE
Hide 'answered' notifications in ActivityList

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -189,7 +189,11 @@
             this.notifications = [
               ...this.notifications,
               ...data.results.map(this.reshapeNotification).filter(Boolean),
-            ];
+            ].filter(n => {
+              // 'Answered' event types should not show up in the notifications
+              // because it would add a ton of meaningless events.
+              return n.event !== 'Answered';
+            });
             this.moreResults = data.next !== null;
             this.nextPage = this.nextPage + 1;
             this.loading = false;

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/ActivityList.vue
@@ -188,12 +188,15 @@
           .then(data => {
             this.notifications = [
               ...this.notifications,
-              ...data.results.map(this.reshapeNotification).filter(Boolean),
-            ].filter(n => {
-              // 'Answered' event types should not show up in the notifications
-              // because it would add a ton of meaningless events.
-              return n.event !== 'Answered';
-            });
+              ...data.results
+                .filter(n => {
+                  // 'Answered' event types should not show up in the notifications
+                  // because it would add a ton of meaningless events.
+                  return n.event !== 'Answered';
+                })
+                .map(this.reshapeNotification)
+                .filter(Boolean),
+            ];
             this.moreResults = data.next !== null;
             this.nextPage = this.nextPage + 1;
             this.loading = false;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Noted here: https://github.com/learningequality/kolibri/pull/5936

That PR removed the 'Answered' type notifications from the Class Home summary of notifications, but I failed to also note that they'd show up in the List view of those notifications.

This PR fixes that.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Create a quiz for a class of students as a coach and assign it to the class, enable it, etc.
- View the Coach > Reports > Quiz Report for that quiz
- In a Private Browsing / Incognito window, sign in as one of the learners assigned to the quiz
- After answering a few of them - go to the Class overview page. See that you see none of what is shown in this image: https://github.com/learningequality/kolibri/issues/5921#issuecomment-528895111
- Click to "View All" notifications and also see that there are not any notifications of the same kind as seen in the image linked in the last step.
- Complete the quiz then you ought to see the proper "Learner completed quiz" notification. You should also see the "Learner started quiz" and other normal notifications.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/pull/5936
https://github.com/learningequality/kolibri/issues/5921#issuecomment-528895111

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
