### PR TITLE
hide 'view all' link when no items exist

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -3,6 +3,7 @@
   <Block
     :allLinkText="coachString('viewAllAction')"
     :allLinkRoute="$router.getRoute('HomeActivityPage')"
+    :showAllLink="notifications.length"
   >
     <template slot="title">
       {{ $tr('classActivityLabel') }}

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/Block.vue
@@ -3,17 +3,18 @@
   <KPageContainer class="block">
     <KGrid>
       <KGridItem
-        :layout8="{ span: 4 }"
-        :layout12="{ span: 6 }"
+        :layout8="{ span: showAllLink ? 5 : 8 }"
+        :layout12="{ span: showAllLink ? 8 : 12 }"
       >
         <h2>
           <slot name="title"></slot>
         </h2>
       </KGridItem>
       <KGridItem
+        v-if="showAllLink"
         :layout="{ alignment: 'right' }"
-        :layout8="{ span: 4 }"
-        :layout12="{ span: 6 }"
+        :layout8="{ span: 3 }"
+        :layout12="{ span: 4 }"
       >
         <KRouterLink
           appearance="flat-button"
@@ -44,6 +45,10 @@
       allLinkRoute: {
         type: Object,
         required: true,
+      },
+      showAllLink: {
+        type: Boolean,
+        default: true,
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -3,6 +3,7 @@
   <Block
     :allLinkText="coachString('viewAllAction')"
     :allLinkRoute="classRoute('ReportsLessonListPage', {})"
+    :showAllLink="table.length"
   >
     <KLabeledIcon slot="title" icon="lesson" :label="coreString('lessonsLabel')" />
 

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -3,6 +3,7 @@
   <Block
     :allLinkText="coachString('viewAllAction')"
     :allLinkRoute="classRoute('ReportsQuizListPage', {})"
+    :showAllLink="table.length"
   >
     <KLabeledIcon slot="title" icon="quiz" :label="coreString('quizzesLabel')" />
 


### PR DESCRIPTION

### Summary

* Minor update to hide the 'view all' links in the coach dashboard when no items exist
* Also tweaks the internal layout column sizes to allot more to the title than the button

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/65187463-cb87e400-da20-11e9-8d0c-fdace9ae607f.png) | ![image](https://user-images.githubusercontent.com/2367265/65187447-c165e580-da20-11e9-8358-55cfbcf3c93b.png) |

### Reviewer guidance

does it work and make sense

### References

N/A

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
