### PR TITLE
Update Side Nav hover style color to use primary brand

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -98,7 +98,7 @@
         let backgroundColor = '';
         let color = '#000';
         let hover = {
-          backgroundColor: this.$themePalette.grey.v_200,
+          backgroundColor: this.$themeBrand.primary.v_50,
         };
         let fontWeight = 'normal';
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Per feedback from @indirectlylit, this will update the navigation drawer's hover to use the light primary brand color rather than a light gray.

Going from this:
![old-hover](https://user-images.githubusercontent.com/6356129/65330321-2d566400-db6f-11e9-872d-7d837020d748.gif)

To this:
![new-hover](https://user-images.githubusercontent.com/6356129/65330263-0b5ce180-db6f-11e9-8430-8b06f40fefbb.gif)

NOTE - This change affects the hover-effect on the Profile drop-down at the top right.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Run the server, see the new hover works as expected.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/pull/5897

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
