### PR TITLE
Some additions and fixes to the new plugins arquitecture

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -93,6 +93,7 @@ import TextTruncator from '../views/TextTruncator';
 
 import MultiPaneLayout from '../views/MultiPaneLayout';
 import navComponents from '../utils/navComponents';
+import loginComponents from '../utils/loginComponents';
 import coreBannerContent from '../utils/coreBannerContent';
 import CatchErrors from '../utils/CatchErrors';
 import UiIconButton from '../views/KeenUiIconButton.vue';
@@ -191,6 +192,7 @@ export default {
     validators,
     serverClock,
     i18n,
+    loginComponents,
     navComponents,
     coreBannerContent,
     samePageCheckGenerator,

--- a/kolibri/core/assets/src/utils/loginComponents.js
+++ b/kolibri/core/assets/src/utils/loginComponents.js
@@ -1,0 +1,15 @@
+import logger from 'kolibri.lib.logging';
+
+const logging = logger.getLogger(__filename);
+
+const loginComponents = [];
+
+loginComponents.register = component => {
+  if (!loginComponents.includes(component)) {
+    loginComponents.push(component);
+  } else {
+    logging.warn('Component has already been registered');
+  }
+};
+
+export default loginComponents;

--- a/kolibri/plugins/hooks.py
+++ b/kolibri/plugins/hooks.py
@@ -276,6 +276,7 @@ class KolibriHookMeta(SingletonMeta):
                     isabstract(parent)
                     and issubclass(parent, KolibriHook)
                     and parent is not KolibriHook
+                    and hasattr(parent, "_registered_hooks")
                 ):
                     parent.add_hook_to_class_registry(hook)
 

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -125,6 +125,9 @@
                 appearance="flat-button"
               />
             </p>
+            <div slot="options">
+              <component :is="component" v-for="component in loginOptions" :key="component.name" />
+            </div>
             <p
               v-if="showGuestAccess"
               class="guest small-text"
@@ -205,6 +208,7 @@
   import UiAlert from 'keen-ui/src/UiAlert';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import urls from 'kolibri.urls';
+  import loginComponents from 'kolibri.utils.loginComponents';
   import { PageNames } from '../../constants';
   import LanguageSwitcherFooter from '../LanguageSwitcherFooter';
   import getUrlParameter from '../getUrlParameter';
@@ -347,6 +351,10 @@
         }
         // query is before hash
         return getUrlParameter('next');
+      },
+      loginOptions() {
+        // POC, in the future sorting of different login options can be implemented
+        return [...loginComponents];
       },
     },
     watch: {

--- a/kolibri/plugins/utils/settings.py
+++ b/kolibri/plugins/utils/settings.py
@@ -23,7 +23,7 @@ def _validate_settings_module(settings_module):
     return settings_module
 
 
-_tuple_settings = ("INSTALLED_APPS", "TEMPLATE_DIRS", "LOCALE_PATHS")
+_tuple_settings = ("INSTALLED_APPS", "TEMPLATE_DIRS", "LOCALE_PATHS", "AUTHENTICATION_BACKENDS")
 
 
 def _validate_module_setting(

--- a/kolibri/plugins/utils/settings.py
+++ b/kolibri/plugins/utils/settings.py
@@ -23,7 +23,12 @@ def _validate_settings_module(settings_module):
     return settings_module
 
 
-_tuple_settings = ("INSTALLED_APPS", "TEMPLATE_DIRS", "LOCALE_PATHS", "AUTHENTICATION_BACKENDS")
+_tuple_settings = (
+    "INSTALLED_APPS",
+    "TEMPLATE_DIRS",
+    "LOCALE_PATHS",
+    "AUTHENTICATION_BACKENDS",
+)
 
 
 def _validate_module_setting(


### PR DESCRIPTION
### Summary
Added some features to the plugin system plus a fix in the current develop changes.
These changes will allow:
1. Plugins can include new `AUTHENTICATION_BACKENDS` in their settings
2. User plugin has a hook to insert other authentication methods in its frontend part

### Reviewer guidance
1. Creating a plugin adding a new AUTHENTICATION_BACKENDS in its settings.py file should work
2. After creating a plugin with a vue component, the component can be registered using
`loginComponents.register(component);`
and it should appear in the user login screen.
3. Plugins with hooks inhering from `kolibri.plugins.user.hooks.UserSyncHook` should start correctly


### References
Refs #5918 
This work will help to close #5625 moving the OIDC client plugin to become an external plugin to be installed on a Kolibri installation, removing the need of including `mozilla-django-oidc` which depends on `cryptography` in the Kolibri installer.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
