### PR TITLE
Check if Kolibri is running before running any updates.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -334,6 +334,20 @@ def update(old_version, new_version):
 
     logger.info("Running update routines for new version...")
 
+    try:
+        # Check if there are other kolibri instances running
+        # If there are, then we need to stop users from starting kolibri again.
+        server.get_status()
+        logger.error(
+            "There is a Kolibri server running."
+            "Running updates now could cause a database error."
+            "Please use `kolibri stop` and try again."
+        )
+        sys.exit(1)
+
+    except server.NotRunning:
+        pass
+
     # Need to do this here, before we run any Django management commands that
     # import settings. Otherwise the updated configuration will not be used
     # during this runtime.

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -229,6 +229,20 @@ def test_update(update, get_version):
 
 
 @pytest.mark.django_db
+@patch("kolibri.utils.cli.get_version", return_value="0.0.1")
+def test_update_exits_if_running(get_version):
+    """
+    Tests that update() function performs as expected
+    """
+    with patch("kolibri.utils.cli.server.get_status"):
+        try:
+            cli.initialize()
+            pytest.fail("Update did not exit when Kolibri was already running")
+        except SystemExit:
+            pass
+
+
+@pytest.mark.django_db
 def test_version_updated():
     """
     Tests our db backup logic: version_updated gets any change, backup gets only non-dev changes


### PR DESCRIPTION
### Summary
Prevent updates from running if Kolibri is running.
Does this slightly differently to the sanity check as multiple things might trigger updates apart from start.

### References
Fixes #5906

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
