### PR TITLE
Export users command

### DIFF
--- a/kolibri/core/auth/constants/demographics.py
+++ b/kolibri/core/auth/constants/demographics.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+MALE = "MALE"
+FEMALE = "FEMALE"
+NOT_SPECIFIED = "NOT_SPECIFIED"
+DEFERRED = "DEFERRED"
+
+
+choices = (
+    (MALE, "Male"),
+    (FEMALE, "Female"),
+    (NOT_SPECIFIED, "Not specified"),
+    (DEFERRED, "Defers for later"),
+)
+
+DEMO_FIELDS = ("gender", "birth_year", "id_number")

--- a/kolibri/core/auth/csv_utils.py
+++ b/kolibri/core/auth/csv_utils.py
@@ -212,11 +212,11 @@ def csv_file_generator(facility, filepath, overwrite=True, demographic=False):
                 )
             )
             .prefetch_related("memberships__collection")
-            .values(*columns)
             .filter(
                 Q(memberships__collection__kind=CLASSROOM)
                 | Q(memberships__collection__isnull=True)
             )
+            .values(*columns)
         ):
             if item["username"] not in usernames:
                 writer.writerow(map_output(item))

--- a/kolibri/core/auth/csv_utils.py
+++ b/kolibri/core/auth/csv_utils.py
@@ -1,0 +1,127 @@
+from __future__ import unicode_literals
+
+import csv
+import io
+import logging
+import os
+import sys
+from collections import OrderedDict
+from functools import partial
+
+from kolibri.core.auth.constants.demographics import choices
+from kolibri.core.auth.constants.demographics import DEMO_FIELDS
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+
+
+logger = logging.getLogger(__name__)
+
+
+def infer_facility(facility_id):
+    if facility_id is not None:
+        try:
+            # Try lookup by id first, then name
+            facility = Facility.objects.get(pk=facility_id)
+        except (Facility.DoesNotExist, ValueError):
+            try:
+                facility = Facility.objects.get(name=facility_id)
+            except Facility.DoesNotExist:
+                raise ValueError(
+                    "Facility matching identifier {facility} was not found".format(
+                        facility=facility_id
+                    )
+                )
+    else:
+        facility = Facility.get_default_facility()
+        if facility:
+            logger.info(
+                "No facility specified, using the default facility {}".format(
+                    facility.name
+                )
+            )
+        else:
+            raise ValueError(
+                "No default facility exists, please make sure to provision this device before running this command"
+            )
+    return facility
+
+
+choices_dict = dict(choices)
+
+
+def transform_choices(field, obj):
+    return choices_dict.get(obj[field], obj[field])
+
+
+mappings = {
+    "gender": partial(transform_choices, "gender"),
+    "birth_year": partial(transform_choices, "birth_year"),
+}
+
+labels = OrderedDict(
+    (
+        ("facility__name", "Facility name"),
+        ("facility__id", "Facility id"),
+        ("memberships__collection__name", "Class name"),
+        ("memberships__collection__id", "Class id"),
+        ("full_name", "Full name"),
+        ("gender", "Gender"),
+        ("birth_year", "Birth year"),
+        ("id_number", "ID number"),
+        ("username", "Username"),
+    )
+)
+
+
+def map_object(obj):
+    mapped_obj = {}
+    for header, label in labels.items():
+        if header in mappings and header in obj:
+            mapped_obj[label] = mappings[header](obj)
+        elif header in obj:
+            mapped_obj[label] = obj[header]
+    return mapped_obj
+
+
+db_columns = (
+    "facility__name",
+    "facility__id",
+    "memberships__collection__name",
+    "memberships__collection__id",
+    "full_name",
+    "username",
+    "gender",
+    "birth_year",
+    "id_number",
+)
+
+
+def csv_file_generator(facility, filepath, overwrite=True, demographic=False):
+    if not overwrite and os.path.exists(filepath):
+        raise ValueError("{} already exists".format(filepath))
+    queryset = FacilityUser.objects.filter(facility=facility)
+
+    header_labels = tuple(
+        label
+        for field, label in labels.items()
+        if demographic or field not in DEMO_FIELDS
+    )
+
+    columns = tuple(
+        column for column in db_columns if demographic or column not in DEMO_FIELDS
+    )
+
+    if sys.version_info[0] < 3:
+        csv_file = io.open(filepath, "wb")
+    else:
+        csv_file = io.open(filepath, "w", newline="")
+
+    with csv_file as f:
+        writer = csv.DictWriter(f, header_labels)
+        logger.info("Creating csv file {filename}".format(filename=filepath))
+        writer.writeheader()
+        for item in queryset.select_related(
+            "facility", "memberships__collection"
+        ).values(*columns):
+            writer.writerow(map_object(item))
+            yield

--- a/kolibri/core/auth/management/commands/exportusers.py
+++ b/kolibri/core/auth/management/commands/exportusers.py
@@ -1,0 +1,75 @@
+import logging
+import os
+import sys
+
+from django.core.management.base import CommandError
+
+from kolibri.core.auth.csv_utils import csv_file_generator
+from kolibri.core.auth.csv_utils import infer_facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.tasks.management.commands.base import AsyncCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(AsyncCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-O",
+            "--output-file",
+            action="store",
+            dest="output_file",
+            default=None,
+            type=str,
+            help="The generated file will be saved with this name",
+        )
+        parser.add_argument(
+            "--facility",
+            action="store",
+            type=str,
+            help="Facility id or name to export the users from",
+        )
+        parser.add_argument(
+            "-w",
+            "--overwrite",
+            action="store_true",
+            dest="overwrite",
+            default=True,
+            help="Allows overwritten of the exported file in case it exists",
+        )
+        parser.add_argument(
+            "-d",
+            "--demographic-data",
+            action="store_true",
+            dest="demographic",
+            default=False,
+            help="Include demographic data in exported CSV",
+        )
+
+    def handle_async(self, *args, **options):
+        try:
+            facility = infer_facility(options["facility"])
+        except ValueError as e:
+            raise CommandError(str(e))
+
+        if options["output_file"] is None:
+            filename = "exported_users_{}.csv".format(facility.id)
+        else:
+            filename = options["output_file"]
+
+        filepath = os.path.join(os.getcwd(), filename)
+
+        total_rows = FacilityUser.objects.filter(facility=facility).count()
+
+        with self.start_progress(total=total_rows) as progress_update:
+            try:
+                for row in csv_file_generator(
+                    facility,
+                    filepath,
+                    overwrite=options["overwrite"],
+                    demographic=options["demographic"],
+                ):
+                    progress_update(1)
+            except (ValueError, IOError) as e:
+                logger.error("Error trying to write csv file: {}".format(e))
+                sys.exit(1)

--- a/kolibri/core/auth/management/commands/importusers.py
+++ b/kolibri/core/auth/management/commands/importusers.py
@@ -89,14 +89,18 @@ def create_user(user, default_facility=None):
     facility = infer_facility(user.get("facility", None), facility=default_facility)
     classroom = infer_and_create_class(user.get("class", None), facility)
     username = user["username"]
+    password = user.get("password", "")
     try:
         user_obj = FacilityUser.objects.get(username=username, facility=facility)
+        if password:
+            user_obj.set_password(password)
+            user_obj.save()
         update_user_demographics(user, user_obj)
 
         if classroom and not user_obj.is_member_of(classroom):
             classroom.add_member(user_obj)
             logger.info(
-                'Exiting user "{username}" was added to a classroom "{classroom}"'.format(
+                'Existing user "{username}" was added to a classroom "{classroom}"'.format(
                     username=username, classroom=classroom.name
                 )
             )
@@ -202,7 +206,7 @@ class Command(BaseCommand):
             if has_header:
                 reader = csv.DictReader(f, strict=True)
             else:
-                reader = csv.reader(f, strict=True)
+                reader = csv.DictReader(f, fieldnames=input_fields, strict=True)
             with transaction.atomic():
                 total = 0
                 for row in reader:

--- a/kolibri/core/auth/management/commands/importusers.py
+++ b/kolibri/core/auth/management/commands/importusers.py
@@ -83,10 +83,20 @@ def update_user_demographics(user_dict, user_model):
         )
 
 
+def get_facility(user, default_facility):
+    try:
+        return infer_facility(user.get("facility", None), facility=default_facility)
+    except ValueError:
+        raise CommandError(
+            "Facility name/id not found. Please make sure that the facility name/id {} in the CSV file exists on the device.".format(
+                user.get("facility", None)
+            )
+        )
+
+
 def create_user(user, default_facility=None):
     validate_username(user)
-
-    facility = infer_facility(user.get("facility", None), facility=default_facility)
+    facility = get_facility(user, default_facility)
     classroom = infer_and_create_class(user.get("class", None), facility)
     username = user["username"]
     password = user.get("password", "")

--- a/kolibri/core/auth/management/commands/importusers.py
+++ b/kolibri/core/auth/management/commands/importusers.py
@@ -1,7 +1,5 @@
 import csv
 import logging
-from functools import partial
-from itertools import starmap
 
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
@@ -9,6 +7,11 @@ from django.core.management.base import CommandError
 from django.db import transaction
 
 from kolibri.core.auth.constants.demographics import DEMO_FIELDS
+from kolibri.core.auth.csv_utils import infer_facility
+from kolibri.core.auth.csv_utils import input_fields
+from kolibri.core.auth.csv_utils import labels
+from kolibri.core.auth.csv_utils import map_input
+from kolibri.core.auth.csv_utils import transform_inputs
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -23,24 +26,6 @@ def validate_username(user):
     # Check if username is specified, if not, throw an error
     if "username" not in user or user["username"] is None:
         raise CommandError("No usernames specified, this is required for user creation")
-
-
-def infer_facility(user, default_facility):
-    if "facility" in user and user["facility"]:
-        try:
-            # Try lookup by id first, then name
-            return Facility.objects.get(pk=user["facility"])
-        except (Facility.DoesNotExist, ValueError):
-            try:
-                return Facility.objects.get(name=user["facility"])
-            except Facility.DoesNotExist:
-                raise CommandError(
-                    "Facility matching identifier {facility} was not found".format(
-                        facility=user["facility"]
-                    )
-                )
-    else:
-        return default_facility
 
 
 def infer_and_create_class(class_id, facility):
@@ -63,23 +48,32 @@ def update_user_demographics(user_dict, user_model):
     if not user_updated:
         return
 
+    user_updated = False
+
     if user_dict.get("gender", None) is not None:
-        user_model.gender = user_dict["gender"]
+        value = transform_inputs("gender", user_dict)
+        user_updated = user_updated or value != user_model.gender
+        user_model.gender = value
 
     if user_dict.get("birth_year", None) is not None:
-        user_model.birth_year = user_dict["birth_year"]
+        value = transform_inputs("birth_year", user_dict)
+        user_updated = user_updated or value != user_model.birth_year
+        user_model.birth_year = value
 
     if user_dict.get("id_number", None) is not None:
-        user_model.id_number = user_dict["id_number"]
+        value = user_dict["id_number"]
+        user_updated = user_updated or value != user_model.id_number
+        user_model.id_number = value
 
     try:
-        user_model.full_clean()
-        user_model.save()
-        logger.info(
-            'User "{username}" was updated with demographic info'.format(
-                username=username
+        if user_updated:
+            user_model.full_clean()
+            user_model.save()
+            logger.info(
+                'User "{username}" was updated with demographic info'.format(
+                    username=username
+                )
             )
-        )
 
     except ValidationError as e:
         logger.error(
@@ -89,23 +83,17 @@ def update_user_demographics(user_dict, user_model):
         )
 
 
-def create_user(i, user):
+def create_user(user, default_facility=None):
     validate_username(user)
 
-    if i == 0 and all(key == val or val is None for key, val in user.items()):
-        # Check whether the first row is a header row or not
-        # Either each key will be equal to the value
-        # Or the header is not included in the CSV, so it is None
-        return False
-
-    facility = infer_facility(user.get("facility", None))
+    facility = infer_facility(user.get("facility", None), facility=default_facility)
     classroom = infer_and_create_class(user.get("class", None), facility)
     username = user["username"]
     try:
         user_obj = FacilityUser.objects.get(username=username, facility=facility)
         update_user_demographics(user, user_obj)
 
-        if classroom:
+        if classroom and not user_obj.is_member_of(classroom):
             classroom.add_member(user_obj)
             logger.info(
                 'Exiting user "{username}" was added to a classroom "{classroom}"'.format(
@@ -191,22 +179,14 @@ class Command(BaseCommand):
                 "No default facility exists, please make sure to provision this device before running this command"
             )
 
-        fieldnames = [
-            "full_name",
-            "username",
-            "password",
-            "facility",
-            "class",
-            "gender",
-            "birth_year",
-            "id_number",
-        ]
+        fieldnames = input_fields + tuple(val for val in labels.values())
+
         # open using default OS encoding
         with open(options["filepath"]) as f:
             header = next(csv.reader(f, strict=True))
             if all(col in fieldnames for col in header):
                 # Every item in the first row matches an item in the fieldnames, it is a header row
-                if "username" not in header:
+                if "username" not in header and str(labels["username"]) not in header:
                     raise CommandError(
                         "No usernames specified, this is required for user creation"
                     )
@@ -216,12 +196,18 @@ class Command(BaseCommand):
                     "Mix of valid and invalid header labels found in first row"
                 )
             else:
-                ordered_fieldnames = fieldnames
+                ordered_fieldnames = input_fields
 
         # open using default OS encoding
         with open(options["filepath"]) as f:
             reader = csv.DictReader(f, fieldnames=ordered_fieldnames, strict=True)
             with transaction.atomic():
-                create_func = partial(create_user, default_facility=default_facility)
-                total = sum(starmap(create_func, enumerate(reader)))
+                total = 0
+                for row in reader:
+                    if not all(col in row.values() for col in ordered_fieldnames):
+                        total += int(
+                            create_user(
+                                map_input(row), default_facility=default_facility
+                            )
+                        )
                 logger.info("{total} users created".format(total=total))

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -66,6 +66,7 @@ from .permissions.general import IsAdminForOwnFacility
 from .permissions.general import IsFromSameFacility
 from .permissions.general import IsOwn
 from .permissions.general import IsSelf
+from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
 from kolibri.core.auth.constants.morango_scope_definitions import FULL_FACILITY
 from kolibri.core.auth.constants.morango_scope_definitions import SINGLE_USER
 from kolibri.core.errors import KolibriValidationError
@@ -656,14 +657,6 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
     facility = models.ForeignKey("Facility")
 
     is_facility_user = True
-
-    # Demographic information
-    GENDER_CHOICES = [
-        ("MALE", "Male"),
-        ("FEMALE", "Female"),
-        ("NOT_SPECIFIED", "Not specified"),
-        ("DEFERRED", "Defers for later"),
-    ]
 
     gender = models.CharField(
         max_length=16, choices=GENDER_CHOICES, default="", blank=True

--- a/kolibri/core/auth/test/test_user_export.py
+++ b/kolibri/core/auth/test/test_user_export.py
@@ -1,0 +1,100 @@
+"""
+Tests that ensure the correct items are returned from api calls.
+Also tests whether the users with permissions can create logs.
+"""
+import csv
+import sys
+import tempfile
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from .helpers import setup_device
+from kolibri.core.auth.constants.demographics import DEFERRED
+from kolibri.core.auth.constants.demographics import DEMO_FIELDS
+from kolibri.core.auth.constants.demographics import FEMALE
+from kolibri.core.auth.constants.demographics import MALE
+from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
+from kolibri.core.auth.csv_utils import labels
+from kolibri.core.auth.csv_utils import transform_choices
+from kolibri.core.auth.models import FacilityUser
+
+
+users = [
+    {
+        "username": "alice",
+        "birth_year": "1990",
+        "gender": FEMALE,
+        "password": "password",
+    },
+    {"username": "bob", "birth_year": "1914", "gender": MALE, "password": "password"},
+    {
+        "username": "clara",
+        "birth_year": "1900",
+        "gender": NOT_SPECIFIED,
+        "password": "password",
+    },
+    {
+        "username": "devone",
+        "birth_year": "2100",
+        "gender": DEFERRED,
+        "password": "password",
+    },
+]
+
+
+class ContentSummaryLogCSVExportTestCase(TestCase):
+    def test_csv_export_with_demographics(self):
+        facility, superuser = setup_device()
+        for user in users:
+            FacilityUser.objects.create(facility=facility, **user)
+        expected_count = FacilityUser.objects.count()
+        _, filepath = tempfile.mkstemp(suffix=".csv")
+        call_command(
+            "exportusers", output_file=filepath, overwrite=True, demographic=True
+        )
+        if sys.version_info[0] < 3:
+            csv_file = open(filepath, "rb")
+        else:
+            csv_file = open(filepath, "r", newline="")
+        with csv_file as f:
+            results = list(row for row in csv.DictReader(f))
+
+        for row in results:
+            user = filter(lambda x: x["username"] == row[labels["username"]], users)
+            if user:
+                user = user[0]
+                self.assertEqual(row[labels["birth_year"]], user["birth_year"])
+                self.assertEqual(
+                    row[labels["gender"]], transform_choices("gender", user)
+                )
+                self.assertEqual(row[labels["facility__name"]], facility.name)
+                self.assertEqual(row[labels["facility__id"]], facility.id)
+                self.assertEqual(row[labels["memberships__collection__name"]], "")
+                self.assertEqual(row[labels["memberships__collection__id"]], "")
+
+        self.assertEqual(len(results), expected_count)
+        for demo_field in DEMO_FIELDS:
+            label = labels[demo_field]
+            self.assertTrue(label in results[0])
+
+    def test_csv_export_no_demographics(self):
+        facility, superuser = setup_device()
+        for user in users:
+            FacilityUser.objects.create(facility=facility, **user)
+        expected_count = FacilityUser.objects.count()
+        _, filepath = tempfile.mkstemp(suffix=".csv")
+        call_command(
+            "exportusers", output_file=filepath, overwrite=True, demographic=False
+        )
+        if sys.version_info[0] < 3:
+            csv_file = open(filepath, "rb")
+        else:
+            csv_file = open(filepath, "r", newline="")
+        with csv_file as f:
+            results = list(row for row in csv.DictReader(f))
+
+        self.assertEqual(len(results), expected_count)
+        for demo_field in DEMO_FIELDS:
+            label = labels[demo_field]
+            self.assertFalse(label in results[0])

--- a/kolibri/core/auth/test/test_user_export.py
+++ b/kolibri/core/auth/test/test_user_export.py
@@ -8,6 +8,7 @@ import tempfile
 
 from django.core.management import call_command
 from django.test import TestCase
+from six.moves import filter
 
 from .helpers import setup_device
 from kolibri.core.auth.constants.demographics import DEFERRED

--- a/kolibri/core/auth/test/test_user_export.py
+++ b/kolibri/core/auth/test/test_user_export.py
@@ -63,9 +63,10 @@ class UserCSVExportTestCase(TestCase):
             results = list(row for row in csv.DictReader(f))
 
         for row in results:
-            user = filter(lambda x: x["username"] == row[labels["username"]], users)
+            user = next(
+                filter(lambda x: x["username"] == row[labels["username"]], users), None
+            )
             if user:
-                user = user[0]
                 self.assertEqual(row[labels["birth_year"]], user["birth_year"])
                 self.assertEqual(
                     row[labels["gender"]], transform_choices("gender", user)
@@ -144,9 +145,10 @@ class UserCSVExportTestCase(TestCase):
         self.assertEqual(len(results), 2)
 
         for row in results:
-            user = filter(lambda x: x["username"] == row[labels["username"]], users)
+            user = next(
+                filter(lambda x: x["username"] == row[labels["username"]], users), None
+            )
             if user:
-                user = user[0]
                 self.assertEqual(
                     row[labels["memberships__collection__name"]], classroom.name
                 )

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -9,13 +9,18 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
+from ..csv_utils import infer_facility
 from ..management.commands.importusers import create_user
 from ..management.commands.importusers import infer_and_create_class
-from ..management.commands.importusers import infer_facility
 from ..management.commands.importusers import validate_username
 from ..models import Classroom
 from ..models import FacilityUser
 from .helpers import setup_device
+from kolibri.core.auth.constants.demographics import DEFERRED
+from kolibri.core.auth.constants.demographics import FEMALE
+from kolibri.core.auth.constants.demographics import MALE
+from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
+from kolibri.core.auth.csv_utils import labels
 
 
 class UserImportTestCase(TestCase):
@@ -34,81 +39,65 @@ class UserImportTestCase(TestCase):
         with self.assertRaises(CommandError):
             validate_username({"username": None})
 
-    def test_infer_facility_not_specified(self):
-        default = {}
-        user = {}
-        self.assertEqual(infer_facility(user, default), default)
-
     def test_infer_facility_none(self):
         default = {}
-        user = {"facility": None}
-        self.assertEqual(infer_facility(user, default), default)
+        self.assertEqual(infer_facility(None, default), default)
 
     def test_infer_facility_by_id(self):
         default = {}
-        user = {"facility": self.facility.id}
-        self.assertEqual(infer_facility(user, default), self.facility)
+        self.assertEqual(infer_facility(self.facility.id, default), self.facility)
 
     def test_infer_facility_by_name(self):
         default = {}
-        user = {"facility": self.facility.name}
-        self.assertEqual(infer_facility(user, default), self.facility)
+        self.assertEqual(infer_facility(self.facility.name, default), self.facility)
 
     def test_infer_facility_fail(self):
         default = {}
-        user = {"facility": "garbage"}
-        with self.assertRaises(CommandError):
-            infer_facility(user, default)
+        with self.assertRaises(ValueError):
+            infer_facility("garbage", default)
 
     def test_infer_class_no_class_no_effect(self):
-        user = {}
-        infer_and_create_class(user, self.facility)
+        infer_and_create_class(None, self.facility)
         self.assertEqual(Classroom.objects.count(), 0)
 
     def test_infer_class_falsy_class_no_effect(self):
-        user = {"class": ""}
-        infer_and_create_class(user, self.facility)
+        infer_and_create_class("", self.facility)
         self.assertEqual(Classroom.objects.count(), 0)
 
     def test_infer_class_by_id(self):
         classroom = Classroom.objects.create(name="testclass", parent=self.facility)
-        user = {"class": classroom.id}
-        self.assertEqual(infer_and_create_class(user, self.facility), classroom)
+        self.assertEqual(infer_and_create_class(classroom.id, self.facility), classroom)
 
     def test_infer_class_by_name(self):
         classroom = Classroom.objects.create(name="testclass", parent=self.facility)
-        user = {"class": classroom.name}
-        self.assertEqual(infer_and_create_class(user, self.facility), classroom)
+        self.assertEqual(
+            infer_and_create_class(classroom.name, self.facility), classroom
+        )
 
     def test_infer_class_create(self):
-        user = {"class": "testclass"}
         self.assertEqual(
-            infer_and_create_class(user, self.facility),
+            infer_and_create_class("testclass", self.facility),
             Classroom.objects.get(name="testclass"),
         )
 
-    def test_create_user_test_header_row(self):
-        user = {"class": "class", "facility": "facility", "username": "username"}
-        self.assertFalse(create_user(0, user))
-
     def test_create_user_exists(self):
         user = {"username": self.superuser.username}
-        self.assertFalse(create_user(1, user, default_facility=self.facility))
+        self.assertFalse(create_user(user, default_facility=self.facility))
 
     def test_create_user_exists_add_classroom(self):
         user = {"username": self.superuser.username, "class": "testclass"}
-        create_user(1, user, default_facility=self.facility)
+        create_user(user, default_facility=self.facility)
         self.assertTrue(
             self.superuser.is_member_of(Classroom.objects.get(name="testclass"))
         )
 
     def test_create_user_not_exist(self):
         user = {"username": "testuser"}
-        self.assertTrue(create_user(1, user, default_facility=self.facility))
+        self.assertTrue(create_user(user, default_facility=self.facility))
 
     def test_create_user_not_exist_add_classroom(self):
         user = {"username": "testuser", "class": "testclass"}
-        create_user(1, user, default_facility=self.facility)
+        create_user(user, default_facility=self.facility)
         self.assertTrue(
             FacilityUser.objects.get(username="testuser").is_member_of(
                 Classroom.objects.get(name="testclass")
@@ -117,7 +106,30 @@ class UserImportTestCase(TestCase):
 
     def test_create_user_not_exist_bad_username(self):
         user = {"username": "test$user"}
-        self.assertFalse(create_user(1, user, default_facility=self.facility))
+        self.assertFalse(create_user(user, default_facility=self.facility))
+
+
+users = [
+    {
+        "username": "alice",
+        "birth_year": "1990",
+        "gender": FEMALE,
+        "password": "password",
+    },
+    {"username": "bob", "birth_year": "1914", "gender": MALE, "password": "password"},
+    {
+        "username": "clara",
+        "birth_year": "1900",
+        "gender": NOT_SPECIFIED,
+        "password": "password",
+    },
+    {
+        "username": "devone",
+        "birth_year": "2100",
+        "gender": DEFERRED,
+        "password": "password",
+    },
+]
 
 
 class UserImportCommandTestCase(TestCase):
@@ -242,3 +254,80 @@ class UserImportCommandTestCase(TestCase):
         self.assertEqual(alice.gender, "FEMALE")
         self.assertEqual(alice.birth_year, "2000")
         self.assertEqual(alice.id_number, "")
+
+    def test_import_from_export_csv(self):
+        facility, superuser = setup_device()
+        for user in users:
+            FacilityUser.objects.create(facility=facility, **user)
+        call_command(
+            "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
+        )
+        FacilityUser.objects.all().delete()
+        call_command("importusers", self.csvpath)
+        for user in users:
+            user_model = FacilityUser.objects.get(username=user["username"])
+            self.assertEqual(user_model.gender, user["gender"])
+            self.assertEqual(user_model.birth_year, user["birth_year"])
+            self.assertEqual(user_model.id_number, "")
+
+    def test_import_from_export_missing_headers(self):
+        facility, superuser = setup_device()
+        for user in users:
+            FacilityUser.objects.create(facility=facility, **user)
+        call_command(
+            "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
+        )
+        cols_to_remove = ["Facility id", "Gender"]
+        with open(self.csvpath, "r") as source:
+            reader = csv.DictReader(source)
+            rows = list(row for row in reader)
+        with open(self.csvpath, "w") as result:
+            writer = csv.DictWriter(
+                result,
+                tuple(
+                    label for label in labels.values() if label not in cols_to_remove
+                ),
+            )
+            writer.writeheader()
+            for row in rows:
+                for col in cols_to_remove:
+                    del row[col]
+                writer.writerow(row)
+        FacilityUser.objects.all().delete()
+        call_command("importusers", self.csvpath)
+        for user in users:
+            user_model = FacilityUser.objects.get(username=user["username"])
+            self.assertEqual(user_model.birth_year, user["birth_year"])
+            self.assertEqual(user_model.id_number, "")
+
+    def test_import_from_export_mixed_headers(self):
+        facility, superuser = setup_device()
+        for user in users:
+            FacilityUser.objects.create(facility=facility, **user)
+        call_command(
+            "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
+        )
+        cols_to_replace = {"Facility id": "facility", "Gender": "gender"}
+        with open(self.csvpath, "r") as source:
+            reader = csv.DictReader(source)
+            rows = list(row for row in reader)
+        with open(self.csvpath, "w") as result:
+            writer = csv.DictWriter(
+                result,
+                tuple(
+                    cols_to_replace[label] if label in cols_to_replace else label
+                    for label in labels.values()
+                ),
+            )
+            writer.writeheader()
+            for row in rows:
+                for col in cols_to_replace:
+                    row[cols_to_replace[col]] = row[col]
+                    del row[col]
+                writer.writerow(row)
+        FacilityUser.objects.all().delete()
+        call_command("importusers", self.csvpath)
+        for user in users:
+            user_model = FacilityUser.objects.get(username=user["username"])
+            self.assertEqual(user_model.birth_year, user["birth_year"])
+            self.assertEqual(user_model.id_number, "")

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -43,6 +43,10 @@ class UserImportTestCase(TestCase):
         default = {}
         self.assertEqual(infer_facility(None, default), default)
 
+    def test_infer_facility_empty_string(self):
+        default = {}
+        self.assertEqual(infer_facility("", default), default)
+
     def test_infer_facility_by_id(self):
         default = {}
         self.assertEqual(infer_facility(self.facility.id, default), self.facility)


### PR DESCRIPTION
### Summary
* Adds `exportusers` management command
* Has optional `-d/--demographic-data` flag to toggle exporting of demographic data, defaults to `False`
* Updates `importusers` command to be able to import data directly from an edited form of the `exportusers` command

### Reviewer guidance
1) Export some user data
2) Update some demographic information
3) Import the csv using import users
4) Profit

Repeat and delete entire columns that are optional - like the facility id (as long as you have the name), and any other user information except the username.

Uses human readable column names, but does not currently implement any internationalization.
This could be extended to do so using the default device language (or potentially adding a language flag to the commands).

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
