### PR TITLE
Ensure needs_help are mapped properly in classsummary

### DIFF
--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -35,7 +35,7 @@ def content_status_serializer(lesson_data, learners_data, classroom):
     for lesson in lesson_data:
         lesson_node_ids |= set(lesson.get("node_ids"))
 
-    # Now create a map of node_id to content_id so that we can map between lessons, and notifications
+    # Now create a map of content_id to node_id so that we can map between lessons, and notifications
     # which use the node id, and summary logs, which use content_id. Note that many node_ids may map
     # to the same content_id.
     content_map = {

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -35,12 +35,13 @@ def content_status_serializer(lesson_data, learners_data, classroom):
     for lesson in lesson_data:
         lesson_node_ids |= set(lesson.get("node_ids"))
 
-    # Now create a map of content_id to node_id so that we can map between lessons, and notifications
-    # which use the node id, and summary logs, which use content_id
+    # Now create a map of node_id to content_id so that we can map between lessons, and notifications
+    # which use the node id, and summary logs, which use content_id. Note that many node_ids may map
+    # to the same content_id.
     content_map = {
         n[0]: n[1]
         for n in ContentNode.objects.filter(id__in=lesson_node_ids).values_list(
-            "content_id", "id"
+            "id", "content_id"
         )
     }
 
@@ -48,7 +49,7 @@ def content_status_serializer(lesson_data, learners_data, classroom):
     # relevant content items.
     content_log_values = (
         logger_models.ContentSummaryLog.objects.filter(
-            content_id__in=set(content_map.keys()),
+            content_id__in=set(content_map.values()),
             user__in=[learner["id"] for learner in learners_data],
         )
         .annotate(attempts=Count("masterylogs__attemptlogs"))
@@ -96,17 +97,19 @@ def content_status_serializer(lesson_data, learners_data, classroom):
         current progress.
         """
         content_id = log["content_id"]
-        if content_id in content_map:
+        if content_id in content_map.values():
             # Don't try to lookup anything if we don't know the content_id
             # node_id mapping - might happen if a channel has since been deleted
-            key = lookup_key.format(
-                user_id=log["user_id"], node_id=content_map[content_id]
-            )
-            if key in needs_help:
-                # Now check if we have not already registered completion of the content node
-                # or if we have and the timestamp is earlier than that on the needs_help event
-                if key not in completed or completed[key] < needs_help[key]:
-                    return HELP_NEEDED
+            content_ids = [
+                key for key, value in content_map.items() if value == content_id
+            ]
+            for c_id in content_ids:
+                key = lookup_key.format(user_id=log["user_id"], node_id=c_id)
+                if key in needs_help:
+                    # Now check if we have not already registered completion of the content node
+                    # or if we have and the timestamp is earlier than that on the needs_help event
+                    if key not in completed or completed[key] < needs_help[key]:
+                        return HELP_NEEDED
         if log["progress"] == 1:
             return COMPLETED
         if log["kind"] == content_kinds.EXERCISE:

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -28,7 +28,7 @@ HELP_NEEDED = "HelpNeeded"
 COMPLETED = "Completed"
 
 
-def content_status_serializer(lesson_data, learners_data, classroom):
+def content_status_serializer(lesson_data, learners_data, classroom):  # noqa C901
 
     # First generate a unique set of content node ids from all the lessons
     lesson_node_ids = set()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Resolves issue with Needs Help not being properly received in Class Summary API. 

The issue was that we mapped a dict of `content_id`s to `node_id`s. However, the same `content_id` can be shared by many `node_id`s. The previous implementation would define the `content_id` as a dict key - which meant that if there were many `node_id`s - only one would ultimately be mapped which made it possible to miss `node_ids` that needed to be accounted for.

Now we map `content_id` to `node_id` because `node_id` is unique and update the code to account for this change.

Noted by @radinamatic in  this Issue: https://github.com/learningequality/kolibri/issues/5881

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

*On Old Branch*
- As a Coach, have a Lesson created and assigned.
- As a Learner, in separate (Incognito) browser, go answer wrongly 3 times so that the learner "Needs Help"
- Note on the Coach "Class Home" for that class that there is a Notification about the Learner who needs help.  

*On This PR Branch*
- Reload the Coach "Class Home" page and see that the "Needs Help" status is accurately reflected in the "Lessons" block.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5881

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
