### PR TITLE
Ensure collectstatic is executed after plugins are enabled

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -666,6 +666,9 @@ def enable(plugin_names, default_plugins):
         exception = click.ClickException("One or more plugins could not be enabled")
         exception.exit_code = 2
         raise exception
+    else:
+        django.setup()
+        call_command("collectstatic", interactive=False, verbosity=1)
 
 
 @plugin.command(help="Disable Kolibri plugins")


### PR DESCRIPTION
### Summary

After enabling an external plugin, collectstatic must be run to ensure its static files are collected.
…

### Reviewer guidance
Install a plugin, enable it , it's static files must appear in KOLIBRI_HOME/static/

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
