### PR TITLE
Add API endpoint for setting channel order.

### DIFF
--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -1,8 +1,16 @@
+import uuid
+
+from django.db.models import Case
+from django.db.models import When
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
+from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from kolibri.core.content.api import ChannelMetadataFilter
 from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.content.serializers import ChannelMetadataSerializer
 
 
@@ -17,3 +25,37 @@ class DeviceChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
             .order_by("-last_updated")
             .select_related("root__lang")
         )
+
+
+def validate_uuid(value):
+    try:
+        uuid.UUID(value, version=4)
+        return True
+    except ValueError:
+        return False
+
+
+class DeviceChannelOrderView(APIView):
+    permission_classes = (CanManageContent,)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            ids = request.data
+            assert isinstance(ids, list)
+            assert all(map(validate_uuid, ids))
+        except AssertionError:
+            raise ParseError("Array of ids not sent in body of request")
+        queryset = ChannelMetadata.objects.filter(root__available=True)
+        total_channels = queryset.count()
+        if len(ids) != total_channels:
+            raise ParseError(
+                "Expected {} ids, but only received {}".format(total_channels, len(ids))
+            )
+        if queryset.filter(id__in=ids).count() != len(ids):
+            raise ParseError(
+                "List of ids does not match the available channels on the server"
+            )
+        queryset.update(
+            order=Case(*(When(id=uuid, then=i + 1) for i, uuid in enumerate(ids)))
+        )
+        return Response({})

--- a/kolibri/plugins/device/api_urls.py
+++ b/kolibri/plugins/device/api_urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from rest_framework import routers
 
 from .api import DeviceChannelMetadataViewSet
+from .api import DeviceChannelOrderView
 
 router = routers.SimpleRouter()
 
@@ -10,4 +11,11 @@ router.register(
     "device_channel", DeviceChannelMetadataViewSet, base_name="device_channel"
 )
 
-urlpatterns = [url(r"^", include(router.urls))]
+urlpatterns = [
+    url(r"^", include(router.urls)),
+    url(
+        r"devicechannelorder",
+        DeviceChannelOrderView.as_view(),
+        name="devicechannelorder",
+    ),
+]

--- a/kolibri/plugins/device/test/test_api.py
+++ b/kolibri/plugins/device/test/test_api.py
@@ -1,0 +1,143 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import setup_device
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentNode
+from kolibri.core.device.models import DevicePermissions
+
+DUMMY_PASSWORD = "password"
+
+
+class ChannelOrderTestCase(APITestCase):
+
+    fixtures = ["content_test.json"]
+    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+
+    def setUp(self):
+        self.facility, self.superuser = setup_device()
+        self.learner = FacilityUser.objects.create(
+            username="learner", facility=self.facility
+        )
+        self.learner.set_password(DUMMY_PASSWORD)
+        self.learner.save()
+        channel = ChannelMetadata.objects.get(id=self.the_channel_id)
+        channel.root.available = True
+        channel.root.save()
+        self.url = reverse("kolibri:kolibri.plugins.device:devicechannelorder")
+
+    def test_learner_cannot_post(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, [], format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_can_manage_content_can_post(self):
+        DevicePermissions.objects.create(user=self.learner, can_manage_content=True)
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, [], format="json")
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_superuser_can_post(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, [], format="json")
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_error_wrong_number_of_uuids(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self.url, [self.the_channel_id, uuid.uuid4().hex], format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_error_invalid_uuid(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, ["test"], format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_error_not_array(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_set_order_one(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        response = self.client.post(self.url, [self.the_channel_id], format="json")
+        channel = ChannelMetadata.objects.get(id=self.the_channel_id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(channel.order, 1)
+
+    def test_set_order_two(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        new_channel_id = uuid.uuid4().hex
+        new_channel = ChannelMetadata.objects.create(
+            id=new_channel_id,
+            name="Test",
+            root=ContentNode.objects.create(
+                title="test",
+                id=uuid.uuid4().hex,
+                channel_id=new_channel_id,
+                content_id=uuid.uuid4().hex,
+                available=True,
+            ),
+        )
+        response = self.client.post(
+            self.url, [self.the_channel_id, new_channel.id], format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        channel = ChannelMetadata.objects.get(id=self.the_channel_id)
+        new_channel.refresh_from_db()
+        self.assertEqual(channel.order, 1)
+        self.assertEqual(new_channel.order, 2)
+
+    def test_set_order_two_one_unavailable(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        new_channel_id = uuid.uuid4().hex
+        new_channel = ChannelMetadata.objects.create(
+            id=new_channel_id,
+            name="Test",
+            root=ContentNode.objects.create(
+                title="test",
+                id=uuid.uuid4().hex,
+                channel_id=new_channel_id,
+                content_id=uuid.uuid4().hex,
+                available=False,
+            ),
+        )
+        response = self.client.post(
+            self.url, [self.the_channel_id, new_channel.id], format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_set_order_two_reorder(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        new_channel_id = uuid.uuid4().hex
+        new_channel = ChannelMetadata.objects.create(
+            id=new_channel_id,
+            name="Test",
+            root=ContentNode.objects.create(
+                title="test",
+                id=uuid.uuid4().hex,
+                channel_id=new_channel_id,
+                content_id=uuid.uuid4().hex,
+                available=True,
+            ),
+            order=1,
+        )
+        channel = ChannelMetadata.objects.get(id=self.the_channel_id)
+        channel.order = 2
+        channel.save()
+        response = self.client.post(
+            self.url, [self.the_channel_id, new_channel.id], format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        new_channel.refresh_from_db()
+        channel.refresh_from_db()
+        self.assertEqual(channel.order, 1)
+        self.assertEqual(new_channel.order, 2)


### PR DESCRIPTION
### Summary
* Adds an API endpoint that accepts an array of all currently available channel ids, and sets the order on them.

### Reviewer guidance
* Do the tests cover all the cases?
* Does it make sense to only order the available channels, given those are the ones that would be shown to the end user in the interface?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
