### PR TITLE
Update Time Spent & Last Activity columns from notifications in Coach Lesson Reports

### DIFF
--- a/integration_testing/features/coach/coach-class-reports-lessons.feature
+++ b/integration_testing/features/coach/coach-class-reports-lessons.feature
@@ -58,6 +58,11 @@ Feature: Lessons subtab
     When a learner has not started <resource> or <exercise>
     Then the learner's *Progress* column states *Not started*
 
+  Scenario: Learner has submitted an answer to a resource
+    When a learner has answered a question on a <resource> or <exercise>
+    Then the *Time Spent* column automatically updates the time value
+      And the *Last Activity* column automatically updates the time value
+
   Scenario: Learner has started a resource
     When a learner has started an <resource> or <exercise>
     Then the learner's *Progress* column states *Started*

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -169,6 +169,29 @@ def check_and_created_completed_lesson(lesson, user_id, timestamp):
     return notification
 
 
+def check_and_created_answered_lesson(lesson, user_id, contentnode_id, timestamp):
+    notification = None
+    # Check if the notification has been previously saved:
+    if not LearnerProgressNotification.objects.filter(
+        user_id=user_id,
+        notification_object=NotificationObjectType.Resource,
+        notification_event=NotificationEventType.Answered,
+        lesson_id=lesson.id,
+        classroom_id=lesson.group_or_classroom,
+        timestamp=timestamp,
+    ).exists():
+        # Let's create an Lesson Completion notification
+        notification = create_notification(
+            NotificationObjectType.Resource,
+            NotificationEventType.Answered,
+            user_id,
+            lesson.group_or_classroom,
+            lesson_id=lesson.id,
+            timestamp=timestamp,
+        )
+    return notification
+
+
 def check_and_created_started(lesson, user_id, contentnode_id, timestamp):
     # If the Resource started notification exists, nothing to do here:
     if LearnerProgressNotification.objects.filter(
@@ -179,7 +202,6 @@ def check_and_created_started(lesson, user_id, contentnode_id, timestamp):
         contentnode_id=contentnode_id,
     ).exists():
         return []
-
     notifications = []
     # Let's create an Resource Started notification
     notifications.append(
@@ -425,10 +447,17 @@ def parse_attemptslog(attemptlog):
                     timestamp=attemptlog.end_timestamp,
                 )
                 notifications.append(notification)
+
         notifications_started = check_and_created_started(
             lesson, attemptlog.user_id, contentnode_id, attemptlog.start_timestamp
         )
-
         notifications += notifications_started
+
+        notifications_answered = check_and_created_answered_lesson(
+            lesson, attemptlog.user_id, contentnode_id, attemptlog.end_timestamp
+        )
+        if notifications_answered:
+            notifications.append(notifications_answered)
+
     if notifications:
         save_notifications(notifications)

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -453,11 +453,14 @@ def parse_attemptslog(attemptlog):
         )
         notifications += notifications_started
 
-        notifications_answered = check_and_created_answered_lesson(
-            lesson, attemptlog.user_id, contentnode_id, attemptlog.end_timestamp
-        )
-        if notifications_answered:
-            notifications.append(notifications_answered)
+        # If the timestamps don't match, then it isn't a "started" event and
+        # should be an answer attempt
+        if attemptlog.start_timestamp != attemptlog.end_timestamp:
+            notifications_answered = check_and_created_answered_lesson(
+                lesson, attemptlog.user_id, contentnode_id, attemptlog.end_timestamp
+            )
+            if notifications_answered:
+                notifications.append(notifications_answered)
 
     if notifications:
         save_notifications(notifications)

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -39,10 +39,6 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
 
     const { object, type, event } = firstEvent;
 
-    if (type === 'QuizAnswered') {
-      continue; // Skip QuizAnswered notifications
-    }
-
     // Set details about Lesson or Quiz
     let assignment;
 

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -55,9 +55,14 @@
     computed: {
       ...mapGetters('coachNotifications', ['summarizedNotifications']),
       notifications() {
-        return orderBy(this.summarizedNotifications, ({ lastId }) => Number(lastId), [
-          'desc',
-        ]).slice(0, MAX_NOTIFICATIONS);
+        // Filter out "Answered" notifications to avoid flooding the list
+        const filteredNotifications = this.summarizedNotifications.filter(
+          n => n.event !== 'Answered'
+        );
+        return orderBy(filteredNotifications, ({ lastId }) => Number(lastId), ['desc']).slice(
+          0,
+          MAX_NOTIFICATIONS
+        );
       },
     },
     methods: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Makes 'Time Spent' column update automatically on a Coach Lesson Report Detail page - issue reported: https://github.com/learningequality/kolibri/issues/5496

This PR makes use of work that I did in https://github.com/learningequality/kolibri/pull/5595 implementing the `NotificationEventType.Answered` to send a `ResourceAnswered` notification. 

This allows the `end_timestamp` time to be the timestamp for the Resource - so it will update live now.

One change that I did in the last commit is that I basically nullified my work on https://github.com/learningequality/kolibri/pull/5936/files where I filtered out `QuizAnswered` notifications in the getter.

Instead, I've now updated the `ActivityBlock` to filter out any notification where `event.type === "Answered"`. Handling this on the component feels better to me - the data we get from the backend is now accurately reflected in the Vuex state, but the components consuming that state decide what they want to do with it - which is to not show "Answered" events.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Have a Lesson created with an exercise added.
2. Login to two browsers (one anonymous). In one browser, be a coach viewing the lesson details page under reports. In the other, be a learner who can work through that lesson.
3. As the learner, answer questions. Expect to see the status change from "Not Started" -> "Started" and the "Time Spent" and "Last Activity" columns update as questions are answered.
4. Ensure also that the "Status" changes properly - to "Completed" when you finish, or to "Needs Help" when you answer 3 wrongly.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5496
https://github.com/learningequality/kolibri/pull/5595
https://github.com/learningequality/kolibri/pull/5936/files

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
