### PR TITLE
Add theme option to disable scrim from background image

### DIFF
--- a/kolibri/core/theme_hook.py
+++ b/kolibri/core/theme_hook.py
@@ -37,7 +37,7 @@ SIGN_IN = "signIn"
 SIDE_NAV = "sideNav"
 APP_BAR = "appBar"
 BACKGROUND = "background"
-DISABLE_SCRIM = "disableScrim"
+SCRIM_OPACITY = "scrimOpacity"
 TITLE = "title"
 TITLE_STYLE = "titleStyle"
 TOP_LOGO = "topLogo"
@@ -102,6 +102,17 @@ def _validateBrandColors(theme):
                 logger.error("{} '{}' not defined by theme".format(color, name))
 
 
+def _validateScrimOpacity(theme):
+    if SCRIM_OPACITY in theme[SIGN_IN]:
+        opacity = theme[SIGN_IN][SCRIM_OPACITY]
+        if opacity is not None:
+            if opacity < 0 or opacity > 1:
+                logger.error(
+                    "scrim opacity should be a value in the closed interval [0,1]"
+                )
+                return
+
+
 def _initFields(theme):
     """
     set up top-level dicts if they don't exist
@@ -144,6 +155,7 @@ class ThemeHook(hooks.KolibriHook):
         _initFields(theme)
         _validateMetadata(theme)
         _validateBrandColors(theme)
+        _validateScrimOpacity(theme)
 
         # set up cache busting
         bust = "?" + self.cacheKey

--- a/kolibri/core/theme_hook.py
+++ b/kolibri/core/theme_hook.py
@@ -3,12 +3,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-
-from kolibri.plugins import hooks
-import kolibri
-from django.utils.six.moves.urllib import parse
-from django.conf import settings
 import os
+
+from django.conf import settings
+from django.utils.six.moves.urllib import parse
+
+import kolibri
+from kolibri.plugins import hooks
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ SIGN_IN = "signIn"
 SIDE_NAV = "sideNav"
 APP_BAR = "appBar"
 BACKGROUND = "background"
+DISABLE_SCRIM = "disableScrim"
 TITLE = "title"
 TITLE_STYLE = "titleStyle"
 TOP_LOGO = "topLogo"

--- a/kolibri/plugins/default_theme/kolibri_plugin.py
+++ b/kolibri/plugins/default_theme/kolibri_plugin.py
@@ -49,7 +49,7 @@ class DefaultThemeHook(theme_hook.ThemeHook):
             # sign-in page config
             theme_hook.SIGN_IN: {
                 theme_hook.BACKGROUND: static("background.jpg"),
-                theme_hook.DISABLE_SCRIM: False,
+                theme_hook.SCRIM_OPACITY: None,  # use default: 0.7,
                 theme_hook.TITLE: None,  # use default: "Kolibri"
                 theme_hook.TOP_LOGO: {
                     theme_hook.IMG_SRC: None,  # use default Kolibri bird

--- a/kolibri/plugins/default_theme/kolibri_plugin.py
+++ b/kolibri/plugins/default_theme/kolibri_plugin.py
@@ -4,9 +4,8 @@ from __future__ import unicode_literals
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
-from kolibri.plugins.base import KolibriPluginBase
-
 from kolibri.core import theme_hook
+from kolibri.plugins.base import KolibriPluginBase
 
 
 class DefaultThemePlugin(KolibriPluginBase):
@@ -50,6 +49,7 @@ class DefaultThemeHook(theme_hook.ThemeHook):
             # sign-in page config
             theme_hook.SIGN_IN: {
                 theme_hook.BACKGROUND: static("background.jpg"),
+                theme_hook.DISABLE_SCRIM: False,
                 theme_hook.TITLE: None,  # use default: "Kolibri"
                 theme_hook.TOP_LOGO: {
                     theme_hook.IMG_SRC: None,  # use default Kolibri bird

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -338,9 +338,11 @@
         if (this.$theme.signIn.background) {
           return {
             backgroundColor: this.$themeTokens.primary,
-            backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(${
-              this.$theme.signIn.background
-            })`,
+            backgroundImage: this.$theme.signIn.disableScrim
+              ? `url(${this.$theme.signIn.background})`
+              : `linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(${
+                  this.$theme.signIn.background
+                })`,
           };
         }
         return { backgroundColor: this.$themeColors.brand.primary.v_900 };

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -336,13 +336,13 @@
       },
       backgroundImageStyle() {
         if (this.$theme.signIn.background) {
+          const scrimOpacity =
+            this.$theme.signIn.scrimOpacity !== null ? this.$theme.signIn.scrimOpacity : 0.7;
           return {
             backgroundColor: this.$themeTokens.primary,
-            backgroundImage: this.$theme.signIn.disableScrim
-              ? `url(${this.$theme.signIn.background})`
-              : `linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(${
-                  this.$theme.signIn.background
-                })`,
+            backgroundImage: `linear-gradient(rgba(0, 0, 0, ${scrimOpacity}), rgba(0, 0, 0, ${scrimOpacity})), url(${
+              this.$theme.signIn.background
+            })`,
           };
         }
         return { backgroundColor: this.$themeColors.brand.primary.v_900 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

_**BEFORE**_
![Screen Shot 2019-10-07 at 3 53 25 PM](https://user-images.githubusercontent.com/6361732/66355094-c4ffd480-e91b-11e9-8b27-ec2a54d21c20.png)

_**AFTER**_
![Screen Shot 2019-10-07 at 3 52 56 PM](https://user-images.githubusercontent.com/6361732/66355101-c7fac500-e91b-11e9-9a6b-918bf0ada716.png)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Set `DISABLE_SCRIM` option to `True`.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

As requested by partners for this option cc: @indirectlylit 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
