### PR TITLE
Allow appbar color to be configurable in theme token mapping

### DIFF
--- a/kolibri/core/assets/src/styles/theme.js
+++ b/kolibri/core/assets/src/styles/theme.js
@@ -31,7 +31,10 @@ const staticState = {
       focusOutline: 'brand.secondary.v_200',
       surface: 'white',
       fineLine: '#dedede',
-      appBarPrimary: 'brand.primary.v_400',
+      appBar: 'brand.primary.v_400',
+      appBarDark: 'brand.primary.v_700',
+      appBarFullscreen: 'palette.grey.v_900',
+      appBarFullscreenDark: 'black',
 
       // general semantic colors
       error: 'palette.red.v_700',

--- a/kolibri/core/assets/src/styles/theme.js
+++ b/kolibri/core/assets/src/styles/theme.js
@@ -31,6 +31,7 @@ const staticState = {
       focusOutline: 'brand.secondary.v_200',
       surface: 'white',
       fineLine: '#dedede',
+      appBarPrimary: 'brand.primary.v_400',
 
       // general semantic colors
       error: 'palette.red.v_700',

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div :style="{ backgroundColor: $themeTokens.primary }">
+  <div :style="{ backgroundColor: $themeTokens.appBarPrimary }">
     <UiToolbar
       :title="title"
       type="clear"

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div :style="{ backgroundColor: $themeTokens.appBarPrimary }">
+  <div :style="{ backgroundColor: $themeTokens.appBar }">
     <UiToolbar
       :title="title"
       type="clear"

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -19,7 +19,7 @@
         :appBarTitle="toolbarTitle || appBarTitle"
         :icon="immersivePageIcon"
         :route="immersivePageRoute"
-        :primary="immersivePagePrimary"
+        :isFullscreen="!immersivePagePrimary"
         :height="headerHeight"
         @nav-icon-click="$emit('navIconClick')"
       />

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -7,7 +7,7 @@
     :showIcon="showIcon"
     :style="{
       height: height + 'px',
-      backgroundColor: primary ? $themeTokens.primary : $themeTokens.text,
+      backgroundColor: isFullscreen ? $themeTokens.appBar : $themeTokens.appBarFullscreen,
     }"
     @nav-icon-click="$emit('navIconClick')"
   >
@@ -111,10 +111,9 @@
         required: false,
         validator: validateLinkObject,
       },
-      primary: {
+      isFullscreen: {
         type: Boolean,
-        required: false,
-        default: true,
+        default: false,
       },
     },
     computed: {
@@ -123,12 +122,14 @@
       },
       linkStyle() {
         const hoverAndFocus = {
-          backgroundColor: this.primary
-            ? this.$themeTokens.primaryDark
-            : this.$themeColors.palette.black,
+          backgroundColor: this.isFullscreen
+            ? this.$themeTokens.appBarDark
+            : this.$themeTokens.appBarFullscreenDark,
         };
         return {
-          backgroundColor: this.primary ? this.$themeTokens.primary : this.$themeTokens.text,
+          backgroundColor: this.isFullscreen
+            ? this.$themeTokens.appBar
+            : this.$themeTokens.appBarFullscreen,
           ':hover': hoverAndFocus,
         };
       },

--- a/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
+++ b/kolibri/core/assets/src/views/KNavbar/KNavbarLink.vue
@@ -60,7 +60,7 @@
         return {
           color: this.$themeColors.palette.grey.v_100,
           ':hover': {
-            'background-color': this.$themeTokens.primaryDark,
+            'background-color': this.$themeTokens.appBarDark,
           },
           ':focus': {
             ...this.$coreOutline,

--- a/kolibri/core/assets/src/views/KNavbar/index.vue
+++ b/kolibri/core/assets/src/views/KNavbar/index.vue
@@ -3,7 +3,7 @@
   <div
     class="wrapper"
     :class="wrapperClass"
-    :style="{ backgroundColor: $themeTokens.primary }"
+    :style="{ backgroundColor: $themeTokens.appBar }"
   >
     <nav>
       <button

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -18,7 +18,7 @@
       <ProgressToolbar
         :currentStep="onboardingStep"
         :totalSteps="totalOnboardingSteps"
-        :style="{ backgroundColor: $themeTokens.primary }"
+        :style="{ backgroundColor: $themeTokens.appBar }"
         @backButtonClicked="goToPreviousStep"
       />
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Now able to change color of appBar.

_**SIDE BY SIDE COMPARISON**_
![Screen Shot 2019-10-07 at 5 00 56 PM](https://user-images.githubusercontent.com/6361732/66357516-0e542200-e924-11e9-933c-a2ce3a911826.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Add 
```
theme_hook.TOKEN_MAPPING: {
	"appBarPrimary": "#000000",
},
```
to https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/default_theme/kolibri_plugin.py

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
