### PR TITLE
Force skipping the cache for ExamAttemptsLog fetch

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -158,6 +158,7 @@ export function getExamReport(store, examId, userId, questionNumber = 0, interac
         exam: examId,
         user: userId,
       },
+      force: true,
     });
     const userPromise = FacilityUserResource.fetchModel({ id: userId });
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In response to the issue noted here: https://github.com/learningequality/kolibri/issues/5925

The issue, basically is that the `examattemptslog`, once loaded, would never go back to the API and was using the cache. So - if a Coach was looking at a ReportsQuizLearnerPage / LearnerQuizReport - they would never see an up-to-date quiz status in the details without refreshing the page - _even if they went back to the ReportsQuizLearnerListPage then back to the learner details page_.

*A worthwhile consideration is that* we might do better to use a notification for this so that the LearnerQuizReport updates automatically while the Coach is looking at it. However, for the purposes of the reported issue, this should resolve it.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- As a coach, create a quiz and assign it to a Learner
- In a separate (Incognito) window, sign in as said Learner
- Go to the Reports > Quizzes > Quiz report page as the Coach.
- Answer 1 question as the learner
- As the coach, see that learner's quiz status go from "not started" to "1 of X answered".
- As the coach, drill down to that learner's details for the quiz and see that one question was answered.
- As the coach, go back one page to the list of learners for the quiz.
- As the learner, answer one or more questions.
- As the coach, once again - drill down into the details of that learner's quiz and see that it shows all of the questions the Learner has answered as answered. __This is the issue that is being fixed - previously, it would always show whatever was loaded initially and would not update every time the coach came back to this page_

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5925

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
