### PR TITLE
Update the content cache key when reordering channels.

### DIFF
--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -12,6 +12,7 @@ from kolibri.core.content.api import ChannelMetadataFilter
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.content.serializers import ChannelMetadataSerializer
+from kolibri.core.device.models import ContentCacheKey
 
 
 class DeviceChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
@@ -58,4 +59,5 @@ class DeviceChannelOrderView(APIView):
         queryset.update(
             order=Case(*(When(id=uuid, then=i + 1) for i, uuid in enumerate(ids)))
         )
+        ContentCacheKey.update_cache_key()
         return Response({})


### PR DESCRIPTION
### Summary
Update content cache key when channels are reordered.

### Reviewer guidance
Does reordering the channels result in a new order on Learn?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
