### PR TITLE
if username is hash, display full name in app bar

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -52,7 +52,7 @@
             category="social"
             :style="{fill: $themeTokens.textInverted}"
           />
-          <span v-if="isUserLoggedIn" class="username">{{ username }}</span>
+          <span v-if="isUserLoggedIn" class="username">{{ dropdownName }}</span>
           <mat-svg
             name="arrow_drop_down"
             category="navigation"
@@ -149,17 +149,23 @@
     data() {
       return {
         userMenuDropdownIsOpen: false,
+        usernameRegex: /^[a-f0-9]{30}$/,
       };
     },
     computed: {
       ...mapGetters(['isUserLoggedIn', 'getUserKind']),
       ...mapState({
         username: state => state.core.session.username,
+        fullName: state => state.core.session.full_name,
       }),
       menuOptions() {
         return navComponents
           .filter(component => component.section === NavComponentSections.ACCOUNT)
           .filter(this.filterByRole);
+      },
+      // temp hack for the VF plugin
+      dropdownName() {
+        return !this.usernameRegex.test(this.username) ? this.username : this.fullName;
       },
     },
     created() {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -124,6 +124,8 @@
   import navComponentsMixin from '../mixins/nav-components';
   import LogoutSideNavEntry from './LogoutSideNavEntry';
 
+  const hashedValuePattern = /^[a-f0-9]{30}$/;
+
   export default {
     name: 'AppBar',
     components: {
@@ -149,7 +151,6 @@
     data() {
       return {
         userMenuDropdownIsOpen: false,
-        usernameRegex: /^[a-f0-9]{30}$/,
       };
     },
     computed: {
@@ -165,7 +166,7 @@
       },
       // temp hack for the VF plugin
       dropdownName() {
-        return !this.usernameRegex.test(this.username) ? this.username : this.fullName;
+        return !hashedValuePattern.test(this.username) ? this.username : this.fullName;
       },
     },
     created() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

If the username is a 30 bit hash (which it is in all cases for VF plugin), we will display the full name instead in the app bar.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Create user with username `57af8aa04a1145a76ec3af8e24293d`, and watch their full name be displayed in app bar.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
