### PR TITLE
Remote and disk file availability utilities

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -16,6 +16,7 @@ from django.http.request import HttpRequest
 from django.utils.cache import patch_response_headers
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
+from django.views.decorators.http import etag
 from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import ChoiceFilter
@@ -42,6 +43,7 @@ from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.paths import get_info_url
 from kolibri.core.content.utils.stopwords import stopwords_set
 from kolibri.core.decorators import query_params_required
+from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 
@@ -783,6 +785,11 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
         )
 
 
+def get_cache_key(*args, **kwargs):
+    return str(ContentCacheKey.get_cache_key())
+
+
+@method_decorator(etag(get_cache_key), name="retrieve")
 class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.ContentNodeGranularSerializer
 

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -1,5 +1,3 @@
-import os
-
 from django.core.cache import cache
 from django.db.models import Manager
 from django.db.models import Sum
@@ -7,19 +5,24 @@ from django.db.models.query import RawQuerySet
 from le_utils.constants import content_kinds
 from rest_framework import serializers
 
-from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
-from kolibri.core.content.utils.channels import get_mounted_drives_with_channel_info
+from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.content_types_tools import (
     renderable_contentnodes_without_topics_q_filter,
 )
+from kolibri.core.content.utils.file_availability import (
+    get_available_checksums_from_disk,
+)
+from kolibri.core.content.utils.file_availability import (
+    get_available_checksums_from_remote,
+)
 from kolibri.core.content.utils.import_export_content import get_num_coach_contents
-from kolibri.core.content.utils.paths import get_content_storage_file_path
+from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.fields import create_timezonestamp
 
 
@@ -574,51 +577,73 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
         for_export = self.context["request"].query_params.get("for_export", None)
         return get_num_coach_contents(instance, filter_available=for_export)
 
+    def checksums_from_drive_id(self, drive_id, instance):
+        try:
+            datafolder = get_mounted_drive_by_id(drive_id)
+        except KeyError:
+            raise serializers.ValidationError(
+                "The external drive with given drive id {} does not exist.".format(
+                    drive_id
+                )
+            )
+
+        return get_available_checksums_from_disk(instance.channel_id, datafolder)
+
+    def checksums_from_peer_id(self, peer_id, instance):
+        try:
+            network_location = NetworkLocation.objects.values("base_url").get(
+                id=peer_id
+            )
+            base_url = network_location["base_url"]
+        except NetworkLocation.DoesNotExist:
+            raise serializers.ValidationError(
+                "The network location with the id {} does not exist".format(peer_id)
+            )
+
+        return get_available_checksums_from_remote(instance.channel_id, base_url)
+
     def get_importable(self, instance):
         drive_id = self.context["request"].query_params.get(
             "importing_from_drive_id", None
         )
+        peer_id = self.context["request"].query_params.get(
+            "importing_from_peer_id", None
+        )
 
-        # If node is from a remote source, assume it is importable.
-        # Topics are annotated as importable by default, but client may disable importing
-        # of the topic if it determines that the entire topic sub-tree is already on the device.
-        if drive_id is None or instance.kind == content_kinds.TOPIC:
+        # If import is from Studio, assume it is importable.
+        if drive_id is None and peer_id is None:
             return True
 
-        # If non-topic ContentNode has no files, then it is not importable.
-        content_files = instance.files.all()
-        if not content_files.exists():
+        if drive_id is not None and peer_id is not None:
+            raise serializers.ValidationError(
+                "Must specify at most one of importing_from_drive_id and importing_from_peer_id"
+            )
+        if drive_id is not None:
+            channel_checksums = self.checksums_from_drive_id(drive_id, instance)
+
+        elif peer_id is not None:
+            channel_checksums = self.checksums_from_peer_id(peer_id, instance)
+
+        if instance.kind == content_kinds.TOPIC:
+            descendants = instance.get_descendants().exclude(kind=content_kinds.TOPIC)
+            content_files = File.objects.filter(
+                supplementary=False, contentnode__in=descendants
+            )
+            file_requirement_operator = any
+        else:
+            content_files = instance.files.filter(supplementary=False)
+            file_requirement_operator = all
+        content_files = list(
+            content_files.values_list("local_file_id", flat=True).distinct()
+        )
+
+        # If ContentNode has no files, then it is not importable.
+        if not content_files:
             return False
 
-        # Inspecting the external drive's files
-        datafolder = cache.get(drive_id, None)
-
-        if datafolder is None:
-            drive_ids = get_mounted_drives_with_channel_info()
-            if drive_id in drive_ids:
-                datafolder = drive_ids[drive_id].datafolder
-                cache.set(drive_id, datafolder, 60)  # cache the datafolder for 1 minute
-            else:
-                raise serializers.ValidationError(
-                    "The external drive with given drive id {} does not exist.".format(
-                        drive_id
-                    )
-                )
-
-        importable = True
-        for f in content_files:
-            # Node is importable only if all of its Files are on the external drive
-            try:
-                file_path = get_content_storage_file_path(
-                    f.local_file.get_filename(), datafolder
-                )
-                importable = importable and os.path.exists(file_path)
-            except InvalidStorageFilenameError:
-                importable = False
-            if not importable:
-                break
-
-        return importable
+        return file_requirement_operator(
+            checksum in channel_checksums for checksum in content_files
+        )
 
 
 class ContentNodeProgressListSerializer(serializers.ListSerializer):

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -596,7 +596,7 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
 
     def checksums_from_drive_id(self, drive_id, instance):
         try:
-            datafolder = get_mounted_drive_by_id(drive_id)
+            datafolder = get_mounted_drive_by_id(drive_id).datafolder
         except KeyError:
             raise serializers.ValidationError(
                 "The external drive with given drive id {} does not exist.".format(

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -641,6 +641,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
         elif peer_id is not None:
             channel_checksums = self.checksums_from_peer_id(peer_id, instance)
 
+        if channel_checksums is None:
+            # This happens if channel_checksums was not inferrable for some reason
+            # either because the remote peer does not have the endpoint required
+            # or because there was an error in fetching.
+            # Just assume importability in this case as we have no information.
+            return True
+
         if instance.kind == content_kinds.TOPIC:
             descendants = (
                 instance.get_descendants()

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -23,6 +23,7 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content import models as content
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
+from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 
@@ -264,21 +265,88 @@ class ContentNodeAPITestCase(APITestCase):
             },
         )
 
-    @mock.patch("kolibri.core.content.serializers.get_mounted_drives_with_channel_info")
-    def test_contentnode_granular_local_import(self, drive_mock):
+    @mock.patch("kolibri.core.content.serializers.get_available_checksums_from_disk")
+    @mock.patch("kolibri.core.content.serializers.get_mounted_drive_by_id")
+    def test_contentnode_granular_local_import(self, drive_mock, checksums_mock):
         DriveData = namedtuple("DriveData", ["id", "datafolder"])
-        drive_mock.return_value = {"123": DriveData(id="123", datafolder="test/")}
-
+        drive_mock.return_value = DriveData(id="123", datafolder="test/")
         content.LocalFile.objects.update(available=False)
         content.ContentNode.objects.update(available=False)
 
         c1_id = content.ContentNode.objects.get(title="root").id
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
+        checksums = content.File.objects.filter(
+            contentnode__in=content.ContentNode.objects.get(id=c3_id).get_descendants(),
+            supplementary=False,
+        ).values_list("local_file_id", flat=True)
+        checksums_mock.return_value = set(checksums)
 
         response = self.client.get(
             reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1_id}),
             {"importing_from_drive_id": "123"},
+        )
+        self.assertEqual(
+            response.data,
+            {
+                "id": c1_id,
+                "title": "root",
+                "kind": "topic",
+                "available": False,
+                "total_resources": 2,
+                "on_device_resources": 0,
+                "importable": True,
+                "coach_content": False,
+                "num_coach_contents": 0,
+                "children": [
+                    {
+                        "id": c2_id,
+                        "title": "c1",
+                        "kind": "video",
+                        "available": False,
+                        "total_resources": 1,
+                        "on_device_resources": 0,
+                        "importable": False,
+                        "coach_content": False,
+                        "num_coach_contents": 0,
+                    },
+                    {
+                        "id": c3_id,
+                        "title": "c2",
+                        "kind": "topic",
+                        "available": False,
+                        "total_resources": 1,
+                        "on_device_resources": 0,
+                        "importable": True,
+                        "coach_content": False,
+                        "num_coach_contents": 0,
+                    },
+                ],
+            },
+        )
+
+    @mock.patch("kolibri.core.content.serializers.get_available_checksums_from_remote")
+    @mock.patch("kolibri.core.content.serializers.get_mounted_drive_by_id")
+    def test_contentnode_granular_remote_import(self, drive_mock, checksums_mock):
+        DriveData = namedtuple("DriveData", ["id", "datafolder"])
+        drive_mock.return_value = DriveData(id="123", datafolder="test/")
+        content.LocalFile.objects.update(available=False)
+        content.ContentNode.objects.update(available=False)
+
+        c1_id = content.ContentNode.objects.get(title="root").id
+        c2_id = content.ContentNode.objects.get(title="c1").id
+        c3_id = content.ContentNode.objects.get(title="c2").id
+        checksums = content.File.objects.filter(
+            contentnode__in=content.ContentNode.objects.get(id=c3_id).get_descendants(),
+            supplementary=False,
+        ).values_list("local_file_id", flat=True)
+        checksums_mock.return_value = set(checksums)
+
+        location = NetworkLocation.objects.create(base_url="test", instance_id="123")
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1_id}),
+            {"importing_from_peer_id": location.id},
         )
         self.assertEqual(
             response.data,

--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -55,14 +55,14 @@ class LocalFileByDisk(TransactionTestCase):
         checksums = get_available_checksums_from_disk(
             test_channel_id, self.mock_home_dir
         )
-        self.assertEqual(checksums, [file_id_1])
+        self.assertEqual(checksums, set([file_id_1]))
 
     def test_set_one_file_not_in_channel(self):
         self.createmock_content_file(uuid.uuid4().hex)
         checksums = get_available_checksums_from_disk(
             test_channel_id, self.mock_home_dir
         )
-        self.assertEqual(checksums, [])
+        self.assertEqual(checksums, set())
 
     def test_set_two_files_in_channel(self):
         self.createmock_content_file1()
@@ -70,7 +70,7 @@ class LocalFileByDisk(TransactionTestCase):
         checksums = get_available_checksums_from_disk(
             test_channel_id, self.mock_home_dir
         )
-        self.assertEqual(set(checksums), set([file_id_1, file_id_2]))
+        self.assertEqual(checksums, set([file_id_1, file_id_2]))
 
     def test_set_two_files_one_in_channel(self):
         self.createmock_content_file1()
@@ -78,7 +78,7 @@ class LocalFileByDisk(TransactionTestCase):
         checksums = get_available_checksums_from_disk(
             test_channel_id, self.mock_home_dir
         )
-        self.assertEqual(checksums, [file_id_1])
+        self.assertEqual(checksums, set([file_id_1]))
 
     def test_set_two_files_none_in_channel(self):
         self.createmock_content_file(uuid.uuid4().hex)
@@ -86,11 +86,20 @@ class LocalFileByDisk(TransactionTestCase):
         checksums = get_available_checksums_from_disk(
             test_channel_id, self.mock_home_dir
         )
-        self.assertEqual(checksums, [])
+        self.assertEqual(checksums, set())
 
     def tearDown(self):
         shutil.rmtree(self.mock_home_dir)
         super(LocalFileByDisk, self).tearDown()
+
+
+local_file_qs = (
+    LocalFile.objects.filter(
+        files__contentnode__channel_id=test_channel_id, files__supplementary=False
+    )
+    .values_list("id", flat=True)
+    .distinct()
+)
 
 
 @patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
@@ -100,28 +109,35 @@ class LocalFileRemote(TransactionTestCase):
 
     @patch("kolibri.core.content.utils.file_availability.requests")
     def test_set_one_file(self, requests_mock):
-        LocalFile.objects.all().update(available=True)
-        LocalFile.objects.filter(id=file_id_1).update(available=False)
+        id_1 = local_file_qs[0]
         requests_mock.post.return_value.status_code = 200
         requests_mock.post.return_value.content = "1"
         checksums = get_available_checksums_from_remote(test_channel_id, "test")
-        self.assertEqual(checksums, [file_id_1])
+        self.assertEqual(checksums, set([id_1]))
 
     @patch("kolibri.core.content.utils.file_availability.requests")
     def test_set_two_files_in_channel(self, requests_mock):
-        LocalFile.objects.all().update(available=True)
-        LocalFile.objects.filter(id__in=[file_id_1, file_id_2]).update(available=False)
+        local_file_qs = (
+            LocalFile.objects.filter(
+                files__contentnode__channel_id=test_channel_id,
+                files__supplementary=False,
+            )
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        id_1 = local_file_qs[0]
+        id_2 = local_file_qs[1]
         requests_mock.post.return_value.status_code = 200
         requests_mock.post.return_value.content = "3"
         checksums = get_available_checksums_from_remote(test_channel_id, "test")
-        self.assertEqual(set(checksums), set([file_id_1, file_id_2]))
+        self.assertEqual(checksums, set([id_1, id_2]))
 
     @patch("kolibri.core.content.utils.file_availability.requests")
     def test_set_two_files_none_in_channel(self, requests_mock):
         requests_mock.post.return_value.status_code = 200
         requests_mock.post.return_value.content = "0"
         checksums = get_available_checksums_from_remote(test_channel_id, "test")
-        self.assertEqual(checksums, [])
+        self.assertEqual(checksums, set())
 
     @patch("kolibri.core.content.utils.file_availability.requests")
     def test_404_remote_checksum_response(self, requests_mock):

--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -1,0 +1,162 @@
+import json
+import os
+import shutil
+import tempfile
+import uuid
+
+from django.test import TransactionTestCase
+from mock import patch
+
+from .sqlalchemytesting import django_connection_engine
+from kolibri.core.content.utils.file_availability import (
+    get_available_checksums_from_disk,
+)
+from kolibri.core.content.utils.file_availability import (
+    get_available_checksums_from_remote,
+)
+
+
+def get_engine(connection_string):
+    return django_connection_engine()
+
+
+test_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+file_id_1 = "6bdfea4a01830fdd4a585181c0b8068c"
+file_id_2 = "e00699f859624e0f875ac6fe1e13d648"
+
+
+@patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
+class LocalFileByDisk(TransactionTestCase):
+
+    fixtures = ["content_test.json"]
+
+    def setUp(self):
+        super(LocalFileByDisk, self).setUp()
+        self.mock_home_dir = tempfile.mkdtemp()
+        self.mock_storage_dir = os.path.join(self.mock_home_dir, "content", "storage")
+        os.makedirs(self.mock_storage_dir)
+
+    def createmock_content_file(self, prefix, suffix="mp4"):
+        second_dir = os.path.join(self.mock_storage_dir, prefix[0], prefix[1])
+        try:
+            os.makedirs(second_dir)
+        except OSError:
+            pass
+        open(os.path.join(second_dir, prefix + "." + suffix), "w+b")
+
+    def createmock_content_file1(self):
+        self.createmock_content_file(file_id_1, suffix="mp4")
+
+    def createmock_content_file2(self):
+        self.createmock_content_file(file_id_2, suffix="epub")
+
+    def test_set_one_file_in_channel(self):
+        self.createmock_content_file1()
+        checksums = get_available_checksums_from_disk(
+            test_channel_id, self.mock_home_dir
+        )
+        self.assertEqual(checksums, [file_id_1])
+
+    def test_set_one_file_not_in_channel(self):
+        self.createmock_content_file(uuid.uuid4().hex)
+        checksums = get_available_checksums_from_disk(
+            test_channel_id, self.mock_home_dir
+        )
+        self.assertEqual(checksums, [])
+
+    def test_set_two_files_in_channel(self):
+        self.createmock_content_file1()
+        self.createmock_content_file2()
+        checksums = get_available_checksums_from_disk(
+            test_channel_id, self.mock_home_dir
+        )
+        self.assertEqual(set(checksums), set([file_id_1, file_id_2]))
+
+    def test_set_two_files_one_in_channel(self):
+        self.createmock_content_file1()
+        self.createmock_content_file(uuid.uuid4().hex)
+        checksums = get_available_checksums_from_disk(
+            test_channel_id, self.mock_home_dir
+        )
+        self.assertEqual(checksums, [file_id_1])
+
+    def test_set_two_files_none_in_channel(self):
+        self.createmock_content_file(uuid.uuid4().hex)
+        self.createmock_content_file(uuid.uuid4().hex)
+        checksums = get_available_checksums_from_disk(
+            test_channel_id, self.mock_home_dir
+        )
+        self.assertEqual(checksums, [])
+
+    def tearDown(self):
+        shutil.rmtree(self.mock_home_dir)
+        super(LocalFileByDisk, self).tearDown()
+
+
+@patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
+class LocalFileRemote(TransactionTestCase):
+
+    fixtures = ["content_test.json"]
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_set_one_file_in_channel(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps([file_id_1])
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(checksums, [file_id_1])
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_set_one_file_not_in_channel(self, requests_mock):
+        # This shouldn't happen unless something weird is happening on the other
+        # end of the request, but make sure we behave anyway
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps([uuid.uuid4().hex])
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(checksums, [])
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_set_two_files_in_channel(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps([file_id_1, file_id_2])
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(set(checksums), set([file_id_1, file_id_2]))
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_set_two_files_one_in_channel(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps(
+            [file_id_1, uuid.uuid4().hex]
+        )
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(checksums, [file_id_1])
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_set_two_files_none_in_channel(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps(
+            [uuid.uuid4().hex, uuid.uuid4().hex]
+        )
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(checksums, [])
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_404_remote_checksum_response(self, requests_mock):
+        requests_mock.get.return_value.status_code = 404
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertIsNone(checksums)
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_invalid_json_remote_checksum_response(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = "I am not a json, I am a free man!"
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertIsNone(checksums)
+
+    @patch("kolibri.core.content.utils.file_availability.requests")
+    def test_invalid_checksums_remote_checksum_response(self, requests_mock):
+        requests_mock.get.return_value.status_code = 200
+        requests_mock.get.return_value.content = json.dumps(
+            ["I am not a checksum, I am a free man!", file_id_1 + ".mp4"]
+        )
+        checksums = get_available_checksums_from_remote(test_channel_id, "test")
+        self.assertEqual(checksums, [])

--- a/kolibri/core/content/utils/content_types_tools.py
+++ b/kolibri/core/content/utils/content_types_tools.py
@@ -6,6 +6,7 @@ from kolibri.core.content.hooks import ContentRendererHook
 # Start with an empty Q object, as we'll be using OR to add conditions
 renderable_contentnodes_without_topics_q_filter = Q()
 
+renderable_files_q_filter = Q()
 
 # loop through all the registered content renderer hooks
 for hook in ContentRendererHook.registered_hooks:
@@ -13,6 +14,7 @@ for hook in ContentRendererHook.registered_hooks:
         # iterate through each of the content presets that each hook can handle
         # Extend the q filter by ORing with a q filter for this preset
         renderable_contentnodes_without_topics_q_filter |= Q(files__preset=preset)
+        renderable_files_q_filter |= Q(preset=preset)
 
 # Regardless of which renderers are installed, we can render topics!
 renderable_contentnodes_q_filter = (

--- a/kolibri/core/content/utils/file_availability.py
+++ b/kolibri/core/content/utils/file_availability.py
@@ -4,6 +4,8 @@ import re
 
 import requests
 from django.core.cache import cache
+from morango.constants.capabilities import GZIP_BUFFER_POST
+from morango.utils import CAPABILITIES
 
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.paths import get_content_storage_dir_path
@@ -35,7 +37,15 @@ def get_available_checksums_from_remote(channel_id, baseurl):
         baseurl=baseurl, channel_id=channel_id
     )
     if CACHE_KEY not in cache:
-        response = requests.get(get_file_checksums_url(channel_id, baseurl))
+        # By default requests adds gzip accept encoding, regardless of whether the system
+        # can actually decode gzip
+        if GZIP_BUFFER_POST not in CAPABILITIES:
+            response = requests.get(
+                get_file_checksums_url(channel_id, baseurl),
+                headers={"accept-encoding": ""},
+            )
+        else:
+            response = requests.get(get_file_checksums_url(channel_id, baseurl))
 
         checksums = None
 

--- a/kolibri/core/content/utils/file_availability.py
+++ b/kolibri/core/content/utils/file_availability.py
@@ -25,7 +25,7 @@ def generate_checksum_integer_mask(checksums, available_checksums):
 def _generate_mask_from_integer(integer_mask):
     while integer_mask:
         yield bool(integer_mask % 2)
-        integer_mask /= 2
+        integer_mask //= 2
 
 
 def get_available_checksums_from_remote(channel_id, baseurl):

--- a/kolibri/core/content/utils/file_availability.py
+++ b/kolibri/core/content/utils/file_availability.py
@@ -1,0 +1,73 @@
+import json
+import os
+import re
+
+import requests
+from django.core.cache import cache
+
+from kolibri.core.content.models import LocalFile
+from kolibri.core.content.utils.paths import get_content_storage_dir_path
+from kolibri.core.content.utils.paths import get_file_checksums_url
+
+
+checksum_regex = re.compile("^([a-f0-9]{32})$")
+
+
+def get_available_checksums_from_remote(channel_id, baseurl):
+    CACHE_KEY = "PEER_AVAILABLE_CHECKSUMS_{baseurl}_{channel_id}".format(
+        baseurl=baseurl, channel_id=channel_id
+    )
+    if CACHE_KEY not in cache:
+        response = requests.get(get_file_checksums_url(channel_id, baseurl))
+
+        checksums = None
+
+        # Do something if we got a successful return
+        if response.status_code == 200:
+            try:
+                checksums = json.loads(response.content)
+                # Filter to avoid passing in bad checksums
+                checksums = [
+                    checksum for checksum in checksums if checksum_regex.match(checksum)
+                ]
+                cache.set(CACHE_KEY, checksums, 3600)
+            except (ValueError, TypeError):
+                # Bad JSON parsing will throw ValueError
+                # If the result of the json.loads is not iterable, a TypeError will be thrown
+                # If we end up here, just set checksums to None to allow us to cleanly continue
+                pass
+    return cache.get(CACHE_KEY)
+
+
+def get_available_checksums_from_disk(channel_id, basepath):
+    PER_DISK_CACHE_KEY = "DISK_AVAILABLE_CHECKSUMS_{basepath}".format(basepath=basepath)
+    PER_DISK_PER_CHANNEL_CACHE_KEY = "DISK_AVAILABLE_CHECKSUMS_{basepath}_{channel_id}".format(
+        basepath=basepath, channel_id=channel_id
+    )
+    if PER_DISK_PER_CHANNEL_CACHE_KEY not in cache:
+        if PER_DISK_CACHE_KEY not in cache:
+            content_dir = get_content_storage_dir_path(datafolder=basepath)
+
+            disk_checksums = []
+
+            for _, _, files in os.walk(content_dir):
+                for name in files:
+                    checksum = os.path.splitext(name)[0]
+                    # Only add valid checksums formatted according to our standard filename
+                    if checksum_regex.match(checksum):
+                        disk_checksums.append(checksum)
+            # Cache is per device, so a relatively long lived one should
+            # be fine.
+            cache.set(PER_DISK_CACHE_KEY, disk_checksums, 3600)
+        disk_checksums = set(cache.get(PER_DISK_CACHE_KEY))
+        channel_checksums = set(
+            LocalFile.objects.filter(
+                files__contentnode__channel_id=channel_id
+            ).values_list("id", flat=True)
+        )
+        cache.set(
+            PER_DISK_PER_CHANNEL_CACHE_KEY,
+            channel_checksums.intersection(disk_checksums),
+            3600,
+        )
+    return cache.get(PER_DISK_PER_CHANNEL_CACHE_KEY)

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -1,7 +1,6 @@
 import hashlib
 
 from django.db.models import Sum
-from le_utils.constants import content_kinds
 from requests.exceptions import ChunkedEncodingError
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -81,26 +80,6 @@ def _get_node_ids(node_ids):
         .get_descendants(include_self=True)
         .values_list("id", flat=True)
     )
-
-
-def get_num_coach_contents(contentnode, filter_available=True):
-    """
-    Given a ContentNode model, return the number of Coach Contents underneath it
-    """
-    if contentnode.coach_content:
-        if contentnode.kind == content_kinds.TOPIC:
-            queryset = contentnode.get_descendants().filter(coach_content=True)
-
-            if filter_available:
-                queryset = queryset.filter(available=True)
-
-            return queryset.exclude(kind=content_kinds.TOPIC).distinct().count()
-        else:
-            # if the content kind is not a topic but it is marked as coach content the total
-            # coach content count has to be 1 since this is the last node in the tree
-            return 1
-    else:
-        return 1 if contentnode.coach_content else 0
 
 
 def retry_import(e, **kwargs):

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -10,7 +10,7 @@ from kolibri.utils import conf
 
 
 # valid storage filenames consist of 32-char hex plus a file extension
-VALID_STORAGE_FILENAME = re.compile("[0-9a-f]{32}(-data)?\\.[0-9a-z]+")
+VALID_STORAGE_FILENAME = re.compile(r"[0-9a-f]{32}(-data)?\.[0-9a-z]+")
 
 # set of file extensions that should be considered zip files and allow access to internal files
 POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".perseus", ".zip", ".h5p"])
@@ -125,6 +125,16 @@ def get_channel_lookup_url(
     content_server_path += urlencode(query_params)
 
     return get_content_server_url(content_server_path, baseurl=baseurl)
+
+
+def get_file_checksums_url(channel_id, baseurl, version="1"):
+    # This endpoint does not exist on Studio, so a baseurl is required.
+    return get_content_server_url(
+        "/api/public/v{version}/file_checksums/{channel_id}".format(
+            version=version, channel_id=channel_id
+        ),
+        baseurl=baseurl,
+    )
 
 
 def get_content_storage_file_url(filename, baseurl=None):

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -149,11 +149,11 @@ def get_public_file_checksums(request, version, channel_id):
                 .values_list("id", flat=True)
                 .distinct()
             )
-            return HttpResponse(
-                json.dumps(list(checksums)), content_type="application/json"
-            )
         except ChannelMetadata.DoesNotExist:
-            pass
+            checksums = []
+        return HttpResponse(
+            json.dumps(list(checksums)), content_type="application/json"
+        )
     return HttpResponseNotFound(
         json.dumps({"id": error_constants.NOT_FOUND, "metadata": {"view": ""}}),
         content_type="application/json",

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -20,6 +20,7 @@ from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.serializers import PublicChannelSerializer
+from kolibri.core.content.utils.file_availability import generate_checksum_integer_mask
 
 
 class InfoViewSet(viewsets.ViewSet):
@@ -144,10 +145,7 @@ def get_public_file_checksums(request, version):
             .distinct()
         )
         return HttpResponse(
-            sum(
-                int(checksum in available_checksums) << i
-                for i, checksum in enumerate(checksums)
-            ),
+            generate_checksum_integer_mask(checksums, available_checksums),
             content_type="application/octet-stream",
         )
     return HttpResponseNotFound(

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -22,6 +22,7 @@ from rest_framework import routers
 from ..auth.api import PublicFacilityViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
+from .api import get_public_file_checksums
 from .api import InfoViewSet
 
 router = routers.SimpleRouter()
@@ -41,5 +42,10 @@ urlpatterns = [
         r"(?P<version>[^/]+)/channels",
         get_public_channel_list,
         name="get_public_channel_list",
+    ),
+    url(
+        r"(?P<version>[^/]+)/file_checksums/(?P<channel_id>[^/]+)",
+        get_public_file_checksums,
+        name="get_public_file_checksums",
     ),
 ]

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
         name="get_public_channel_list",
     ),
     url(
-        r"(?P<version>[^/]+)/file_checksums/(?P<channel_id>[^/]+)",
+        r"(?P<version>[^/]+)/file_checksums/",
         get_public_file_checksums,
         name="get_public_file_checksums",
     ),

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -184,7 +184,7 @@ class PublicAPITestCase(APITestCase):
             data=[],
             format="json",
         )
-        self.assertEqual(response.content, "0")
+        self.assertEqual(int(response.content), 0)
 
     def test_public_checksum_lookup_not_available(self):
         LocalFile.objects.all().update(available=True)
@@ -196,7 +196,7 @@ class PublicAPITestCase(APITestCase):
             data=[test.id],
             format="json",
         )
-        self.assertEqual(response.content, "0")
+        self.assertEqual(int(response.content), 0)
 
     def test_public_checksum_lookup_two_available(self):
         LocalFile.objects.all().update(available=True)
@@ -206,7 +206,7 @@ class PublicAPITestCase(APITestCase):
             data=ids,
             format="json",
         )
-        self.assertEqual(response.content, "3")
+        self.assertEqual(int(response.content), 3)
 
     def test_public_checksum_lookup_one_available(self):
         LocalFile.objects.all().update(available=True)
@@ -219,4 +219,4 @@ class PublicAPITestCase(APITestCase):
             data=ids,
             format="json",
         )
-        self.assertEqual(response.content, "2")
+        self.assertEqual(int(response.content), 2)

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -178,12 +178,45 @@ class PublicAPITestCase(APITestCase):
         response = self.client.get(get_channel_lookup_url(identifier=uuid.uuid4().hex))
         self.assertEqual(response.status_code, 404)
 
-    def test_public_checksum_lookup_no_channel(self):
-        channel_id = uuid.uuid4().hex
-        response = self.client.get(
-            reverse(
-                "kolibri:core:get_public_file_checksums",
-                kwargs={"version": "v1", "channel_id": channel_id},
-            )
+    def test_public_checksum_lookup_no_checksums(self):
+        response = self.client.post(
+            reverse("kolibri:core:get_public_file_checksums", kwargs={"version": "v1"}),
+            data=[],
+            format="json",
         )
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.content, "0")
+
+    def test_public_checksum_lookup_not_available(self):
+        LocalFile.objects.all().update(available=True)
+        test = LocalFile.objects.all().first()
+        test.available = False
+        test.save()
+        response = self.client.post(
+            reverse("kolibri:core:get_public_file_checksums", kwargs={"version": "v1"}),
+            data=[test.id],
+            format="json",
+        )
+        self.assertEqual(response.content, "0")
+
+    def test_public_checksum_lookup_two_available(self):
+        LocalFile.objects.all().update(available=True)
+        ids = LocalFile.objects.all()[:2].values_list("id", flat=True)
+        response = self.client.post(
+            reverse("kolibri:core:get_public_file_checksums", kwargs={"version": "v1"}),
+            data=ids,
+            format="json",
+        )
+        self.assertEqual(response.content, "3")
+
+    def test_public_checksum_lookup_one_available(self):
+        LocalFile.objects.all().update(available=True)
+        ids = LocalFile.objects.all()[:2].values_list("id", flat=True)
+        test = LocalFile.objects.all().first()
+        test.available = False
+        test.save()
+        response = self.client.post(
+            reverse("kolibri:core:get_public_file_checksums", kwargs={"version": "v1"}),
+            data=ids,
+            format="json",
+        )
+        self.assertEqual(response.content, "2")

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -177,3 +177,13 @@ class PublicAPITestCase(APITestCase):
     def test_public_channel_lookup_no_channel(self):
         response = self.client.get(get_channel_lookup_url(identifier=uuid.uuid4().hex))
         self.assertEqual(response.status_code, 404)
+
+    def test_public_checksum_lookup_no_channel(self):
+        channel_id = uuid.uuid4().hex
+        response = self.client.get(
+            reverse(
+                "kolibri:core:get_public_file_checksums",
+                kwargs={"version": "v1", "channel_id": channel_id},
+            )
+        )
+        self.assertEqual(response.json(), [])

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -210,8 +210,8 @@ class PublicAPITestCase(APITestCase):
 
     def test_public_checksum_lookup_one_available(self):
         LocalFile.objects.all().update(available=True)
-        ids = LocalFile.objects.all()[:2].values_list("id", flat=True)
-        test = LocalFile.objects.all().first()
+        ids = LocalFile.objects.all().order_by("id")[:2].values_list("id", flat=True)
+        test = LocalFile.objects.all().order_by("id")[0]
         test.available = False
         test.save()
         response = self.client.post(

--- a/kolibri/deployment/default/settings/test.py
+++ b/kolibri/deployment/default/settings/test.py
@@ -12,3 +12,9 @@ if "KOLIBRI_HOME" not in os.environ:
 
 
 from .base import *  # noqa isort:skip @UnusedWildImport
+
+# Create a dummy cache for each cache
+CACHES = {
+    key: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}
+    for key in CACHES.keys()  # noqa F405
+}

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -281,6 +281,10 @@ export function updateTreeViewTopic(store, topic) {
   if (store.getters['manageContent/wizard/inExportMode']) {
     fetchArgs.for_export = 'true';
   }
+  if (store.getters['manageContent/wizard/inPeerImportMode']) {
+    const { selectedPeer } = store.state.manageContent.wizard;
+    fetchArgs.importing_from_peer_id = selectedPeer.id;
+  }
   store.commit('CORE_SET_PAGE_LOADING', true);
   return ContentNodeGranularResource.fetchModel({
     id: topic.id,


### PR DESCRIPTION
### Summary
Adds:
* Public endpoint for querying the checksums of files available for a particular channel
* Utility function for generating the path to a public endpoint for checksums available
* Utility function for querying this endpoint and returning the checksums that can be imported for a particular channel
* Utility function for reading a drive location and returning all the files available there for a particular channel
* Tests for the latter two functions
* Integrates this into the importability annotation used in the ContentNodeGranular endpoint

Notes:
* Caches the latter two functions to prevent repeated requests and disk scans.

### Reviewer guidance
Do the tests describe the behaviour of these functions sufficiently?

### References
This is a necessary prerequisite of any functionality that seeks to show the user which files are able to be imported either from a P2P import or a local disk import.

https://www.notion.so/learningequality/Post-import-content-management-c1bba77a25ce438692ed6bc9b9f0d30c?p=fd7369c799c645e0bbaf5c74f5d297bb

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
