### PR TITLE
Remove unneeded vacuums and close correctly the connection when needed

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -106,6 +106,10 @@ class Command(BaseCommand):
                 logger.warn(
                     "Ping failed ({})! Trying again in {} minutes.".format(e, checkrate)
                 )
+            finally:
+                # if there are db errors, the connection must be closed too
+                connection.close()
+
             if once:
                 break
             time.sleep(checkrate * 60)

--- a/kolibri/core/analytics/test/test_ping.py
+++ b/kolibri/core/analytics/test/test_ping.py
@@ -7,7 +7,7 @@ import zlib
 
 import mock
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TransactionTestCase
 from requests.models import Response
 
 from .test_utils import BaseDeviceSetupMixin
@@ -39,7 +39,7 @@ def mocked_requests_post_wrapper(json_data, status_code):
     return mocked_requests_post
 
 
-class PingCommandTestCase(BaseDeviceSetupMixin, TestCase):
+class PingCommandTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     @mock.patch(
         "requests.post", side_effect=mocked_requests_post_wrapper({"id": 17}, 200)
     )

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -163,6 +163,9 @@ class BaseDeviceSetupMixin(object):
                             content_id=uuid.uuid4().hex,
                         )
 
+    def tearDown(self):
+        pass
+
 
 class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_facility_statistics(self):

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -9,7 +9,7 @@ import os
 import random
 import uuid
 
-from django.test import TestCase
+from django.test import TransactionTestCase
 from le_utils.constants import content_kinds
 
 from kolibri.core.analytics.constants.nutrition_endpoints import PINGBACK
@@ -164,7 +164,7 @@ class BaseDeviceSetupMixin(object):
                         )
 
 
-class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
+class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_facility_statistics(self):
         facility = self.facilities[0]
         actual = extract_facility_statistics(facility)
@@ -230,7 +230,7 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         assert actual["l"] is None
 
 
-class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
+class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_channel_statistics(self):
         actual = extract_channel_statistics(self.channel)
         expected = {
@@ -251,7 +251,7 @@ class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         assert actual == expected
 
 
-class CreateUpdateNotificationsTestCase(TestCase):
+class CreateUpdateNotificationsTestCase(TransactionTestCase):
     def setUp(self):
         self.msg = {
             "i18n": {},

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -163,9 +163,6 @@ class BaseDeviceSetupMixin(object):
                             content_id=uuid.uuid4().hex,
                         )
 
-    def tearDown(self):
-        pass
-
 
 class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_facility_statistics(self):

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -71,3 +71,4 @@ class KolibriCoreConfig(AppConfig):
             # and writes (vs. the default exclusive write lock)
             # at the cost of a slight penalty to all reads.
             cursor.execute(START_PRAGMAS)
+            connection.close()

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -616,9 +616,6 @@ def main(args=None):  # noqa: max-complexity=13
         # Check if the content directory exists when Kolibri runs after the first time.
         check_content_directory_exists_and_writable()
 
-        # Defragment the db
-        call_command("vacuumsqlite")
-
         # Clear old sessions up
         call_command("clearsessions")
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -108,9 +108,6 @@ def start(port=8080, run_cherrypy=True):
     # This should be run every time the server is started for now.
     # Events to trigger it are hard, because of copying a content folder into
     # ~/.kolibri, or deleting a channel DB on disk
-    from kolibri.core.content.utils.annotation import update_channel_metadata
-
-    update_channel_metadata()
 
     def rm_pid_file():
         os.unlink(PID_FILE)


### PR DESCRIPTION
### Summary
When kolibri sqlite database is big (>2 Gb) it takes a long time to start and breaks the `kolibri-server`  [booting checks.](https://github.com/learningequality/kolibri-server/issues/20#issuecomment-523139707)
Also, in 0.12.x branch, the `update_channel_metadata` function leaves the db locked.
This PR:

- removes the `update_channel_metadata` call that was executed everytime kolibri starts, leaving it only when it has to update the db
- removes an unneeded vacuum made in cli.py that was causing duplication of the vacuum process in the cases kolibri was started using the cli.
- Solves a couple of cases where the db was not properly closed and left the db open, thus vacuum does not work correctly and the wal file was kept forever, without a proper clean shutdown of kolibri.


### Reviewer guidance
- Check tests pass

The PR has very few lines, but good to take a look to ensure there are not any typos or stupid  mistakes.


### References
Closes: #5891  
IMPORTANT: The changes this PR adds in the ping.py and core/apps.py file should be ported to develop.


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
