### PR TITLE
Give default full name when creating a user with createsuperuser or importusers command

### DIFF
--- a/kolibri/core/auth/management/commands/importusers.py
+++ b/kolibri/core/auth/management/commands/importusers.py
@@ -119,9 +119,10 @@ def create_user(user, default_facility=None):
 
     except FacilityUser.DoesNotExist:
         password = user.get("password", DEFAULT_PASSWORD) or DEFAULT_PASSWORD
+        full_name = user.get("full_name", "") or username
         try:
             new_user = FacilityUser.objects.create_user(
-                full_name=user.get("full_name", ""),
+                full_name=full_name,
                 username=username,
                 facility=facility,
                 password=password,

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -591,7 +591,7 @@ class FacilityUserModelManager(SyncableModelManager, UserManager):
 
         # create the new account in that facility
         superuser = FacilityUser(
-            username=username, password=password, facility=facility
+            full_name=username, username=username, password=password, facility=facility
         )
         superuser.full_clean()
         superuser.set_password(password)

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import csv
 import tempfile
+import os
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -136,77 +137,85 @@ users = [
 ]
 
 
+def test_device_not_setup(self):
+    with self.assertRaisesRegexp(CommandError, "No default facility exists"):
+        csvpath = tempfile.mkstemp(suffix="csv")
+        call_command("importusers", csvpath)
+
+
 class UserImportCommandTestCase(TestCase):
     """
-    Tests for userimport command.
+    Tests for 'kolibri manage importusers' command.
     """
+
+    @classmethod
+    def setUpClass(self):
+        super(UserImportCommandTestCase, self).setUpClass()
+        self.facility, self.superuser = setup_device()
 
     def setUp(self):
         self.csvfile, self.csvpath = tempfile.mkstemp(suffix="csv")
 
-    def test_device_not_setup(self):
-        with self.assertRaisesRegexp(CommandError, "No default facility exists"):
-            call_command("importusers", self.csvpath)
+    def tearDown(self):
+        FacilityUser.objects.exclude(username=self.superuser.username).delete()
+        os.remove(self.csvpath)
 
-    def test_setup_headers_no_username(self):
-        setup_device()
+    def importFromRows(self, *args):
         with open(self.csvpath, "w") as f:
             writer = csv.writer(f)
-            writer.writerow(["class", "facility"])
+            writer.writerows([a for a in args])
+
+        call_command("importusers", self.csvpath)
+
+    def test_setup_headers_no_username(self):
         with self.assertRaisesRegexp(CommandError, "No usernames specified"):
+            self.importFromRows(["class", "facility"])
             call_command("importusers", self.csvpath)
 
     def test_setup_headers_invalid_header(self):
-        setup_device()
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["class", "facility", "dogfood"])
         with self.assertRaisesRegexp(CommandError, "Mix of valid and invalid header"):
+            self.importFromRows(["class", "facility", "dogfood"])
             call_command("importusers", self.csvpath)
 
     def test_setup_headers_make_user(self):
-        setup_device()
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["username"])
-            writer.writerow(["testuser"])
+        self.importFromRows(["username"], ["testuser"])
         call_command("importusers", self.csvpath)
         self.assertTrue(FacilityUser.objects.filter(username="testuser").exists())
 
     def test_setup_no_headers_make_user(self):
-        setup_device()
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["Test user", "testuser"])
-        call_command("importusers", self.csvpath)
+        self.importFromRows(["Test user", "testuser"])
         self.assertTrue(FacilityUser.objects.filter(username="testuser").exists())
 
     def test_setup_no_headers_bad_user_good_user(self):
-        setup_device()
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["Test user", "testuser"])
-            writer.writerow(["Other user", "te$tuser"])
-        call_command("importusers", self.csvpath)
+        self.importFromRows(["Test user", "testuser"], ["Other user", "te$tuser"])
         self.assertTrue(FacilityUser.objects.filter(username="testuser").exists())
         self.assertFalse(FacilityUser.objects.filter(username="te$tuser").exists())
 
+    def test_empty_fullname_defaults_to_username(self):
+        self.importFromRows(["full_name", "username"], ["", "bob123"])
+        self.assertEqual(
+            FacilityUser.objects.get(username="bob123").full_name, "bob123"
+        )
+
+    def test_missing_fullname_defaults_to_username(self):
+        self.importFromRows(["username"], ["bob123"])
+        self.assertEqual(
+            FacilityUser.objects.get(username="bob123").full_name, "bob123"
+        )
+
     def test_update_valid_demographic_info_succeeds(self):
-        facility, superuser = setup_device()
         FacilityUser.objects.create(
             username="alice",
             birth_year="1990",
             gender="FEMALE",
             password="password",
-            facility=facility,
+            facility=self.facility,
         )
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["username", "birth_year", "gender"])
-            writer.writerow(["alice", "", "NOT_SPECIFIED"])
-            writer.writerow(["bob", "1970", "MALE"])
-
-        call_command("importusers", self.csvpath)
+        self.importFromRows(
+            ["username", "birth_year", "gender"],
+            ["alice", "", "NOT_SPECIFIED"],
+            ["bob", "1970", "MALE"],
+        )
         alice = FacilityUser.objects.get(username="alice")
         bob = FacilityUser.objects.get(username="bob")
         self.assertEqual(alice.birth_year, "")
@@ -215,21 +224,19 @@ class UserImportCommandTestCase(TestCase):
         self.assertEqual(bob.gender, "MALE")
 
     def test_update_with_invalid_demographic_info_fails(self):
-        facility, superuser = setup_device()
         FacilityUser.objects.create(
             username="alice",
             birth_year="NOT_SPECIFIED",
             password="password",
-            facility=facility,
+            facility=self.facility,
         )
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(["username", "birth_year", "gender"])
-            writer.writerow(["alice", "BLAH", "FEMALE"])
-            writer.writerow(["bob", "1970", "man"])
+        self.importFromRows(
+            ["username", "birth_year", "gender"],
+            ["alice", "BLAH", "FEMALE"],
+            ["bob", "1970", "man"],
+        )
 
-        call_command("importusers", self.csvpath)
-        # The entire update operation fails
+        # Alice and Bob's demographic data aren't updated
         alice = FacilityUser.objects.get(username="alice")
         bob = FacilityUser.objects.get(username="bob")
         self.assertEqual(alice.birth_year, "NOT_SPECIFIED")
@@ -238,31 +245,26 @@ class UserImportCommandTestCase(TestCase):
         self.assertEqual(bob.gender, "")
 
     def test_update_with_missing_columns(self):
-        facility, superuser = setup_device()
         FacilityUser.objects.create(
             username="alice",
             birth_year="1990",
             gender="FEMALE",
             id_number="ALICE",
             password="password",
-            facility=facility,
+            facility=self.facility,
         )
-        with open(self.csvpath, "w") as f:
-            writer = csv.writer(f)
-            # CSV is missing column for gender, so it should not be updated
-            writer.writerow(["username", "birth_year", "id_number"])
-            writer.writerow(["alice", "2000", ""])
-
-        call_command("importusers", self.csvpath)
+        # CSV is missing column for gender, so it should not be updated
+        self.importFromRows(
+            ["username", "birth_year", "id_number"], ["alice", "2000", ""]
+        )
         alice = FacilityUser.objects.get(username="alice")
         self.assertEqual(alice.gender, "FEMALE")
         self.assertEqual(alice.birth_year, "2000")
         self.assertEqual(alice.id_number, "")
 
     def test_import_from_export_csv(self):
-        facility, superuser = setup_device()
         for user in users:
-            FacilityUser.objects.create(facility=facility, **user)
+            FacilityUser.objects.create(facility=self.facility, **user)
         call_command(
             "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
         )
@@ -275,9 +277,8 @@ class UserImportCommandTestCase(TestCase):
             self.assertEqual(user_model.id_number, "")
 
     def test_import_from_export_missing_headers(self):
-        facility, superuser = setup_device()
         for user in users:
-            FacilityUser.objects.create(facility=facility, **user)
+            FacilityUser.objects.create(facility=self.facility, **user)
         call_command(
             "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
         )
@@ -305,9 +306,8 @@ class UserImportCommandTestCase(TestCase):
             self.assertEqual(user_model.id_number, "")
 
     def test_import_from_export_mixed_headers(self):
-        facility, superuser = setup_device()
         for user in users:
-            FacilityUser.objects.create(facility=facility, **user)
+            FacilityUser.objects.create(facility=self.facility, **user)
         call_command(
             "exportusers", output_file=self.csvpath, overwrite=True, demographic=True
         )

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -137,10 +137,12 @@ users = [
 ]
 
 
-def test_device_not_setup(self):
-    with self.assertRaisesRegexp(CommandError, "No default facility exists"):
-        csvpath = tempfile.mkstemp(suffix="csv")
-        call_command("importusers", csvpath)
+class DeviceNotSetup(TestCase):
+    def test_device_not_setup(self):
+        csvfile, csvpath = tempfile.mkstemp(suffix="csv")
+        with self.assertRaisesRegexp(CommandError, "No default facility exists"):
+            call_command("importusers", csvpath)
+        os.remove(csvpath)
 
 
 class UserImportCommandTestCase(TestCase):


### PR DESCRIPTION
# Summary

1. When using `kolibri manage createsuperuser`, create FacilityUser model with `full_name` equal to username
1. Do the same using `kolibri manage importuser`, when full_name column is either missing or has an empty string
1. Add tests for this feature
1. Refactor tests (noticed that by not calling setup_device() so often, it reduces the run time to 1/3 of original). also added a cleanup to remove tempfiles created by importusers.

### Reviewer guidance

1. Run `createsuperuser` and `importusers` without full names and check that the resulting user accounts have their full name defaulted to username in the app.

### References

Fixes #5923
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
