### PR TITLE
Fix issue with media player not working after loading once

### DIFF
--- a/packages/kolibri-components/src/utils/pluginMediator.js
+++ b/packages/kolibri-components/src/utils/pluginMediator.js
@@ -449,7 +449,7 @@ export default function pluginMediatorFactory({
           reject(`No registered content renderer available for preset: ${preset}`);
         } else if (this._kolibriModuleRegistry[kolibriModuleName]) {
           // There is a named renderer for this preset, and it is already loaded.
-          resolve(this._kolibriModuleRegistry[kolibriModuleName].rendererComponent);
+          resolve(mergeMixin(this._kolibriModuleRegistry[kolibriModuleName].rendererComponent));
         } else {
           // We have a content renderer for this, but it has not been loaded, so load it, and then
           // resolve the promise when it has been loaded.


### PR DESCRIPTION
### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Ensures that the necessary props are defined when passed to a renderer after it's been loaded once. The following error was occurring when loading a video, going back, and then opening another video:
```
vue.runtime.esm.js:1888 TypeError: Cannot read property 'filter' of undefined
    at VueComponent.videoSources (MediaPlayerIndex.vue:105)
    at Watcher.get (vue.runtime.esm.js:4473)
    at Watcher.evaluate (vue.runtime.esm.js:4578)
    at VueComponent.computedGetter [as videoSources] (vue.runtime.esm.js:4830)
    at VueComponent.isVideo (MediaPlayerIndex.vue:118)
    at Watcher.get (vue.runtime.esm.js:4473)
    at Watcher.evaluate (vue.runtime.esm.js:4578)
    at VueComponent.computedGetter [as isVideo] (vue.runtime.esm.js:4830)
    at Object.get (vue.runtime.esm.js:2072)
    at Proxy.render (MediaPlayerIndex.vue?0cd7:48)
```

### Reviewer guidance
1) Have at least 2 videos downloaded in Kolibri
2) Open a video
3) Go back
4) Open another video
5) Does the video load?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://learningequality.slack.com/archives/CB37UM23A/p1572021419178900

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [X] Contributor has fully tested the PR manually

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
