### PR TITLE
update ifcfg to 0.19

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ clint==0.5.1
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5
-ifcfg==0.17
+ifcfg==0.19
 sqlalchemy==1.2.10
 semver==2.8.1
 sentry-sdk==0.7.9


### PR DESCRIPTION
Any reason that upgrading to ifcfg 0.19 for kolibri 0.12.9 would be risky?

https://github.com/ftao/python-ifcfg/releases