### PR TITLE
Don't translate in import scope!

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -212,8 +212,6 @@
   import getUrlParameter from '../getUrlParameter';
   import FacilityModal from './FacilityModal';
 
-  const closeString = crossComponentTranslator(FacilityModal).$tr('close');
-
   export default {
     name: 'SignInPage',
     metaInfo() {
@@ -359,7 +357,7 @@
         return getUrlParameter('next');
       },
       closeString() {
-        return closeString;
+        return crossComponentTranslator(FacilityModal).$tr('close');
       },
     },
     watch: {


### PR DESCRIPTION
### Summary
* Removes module scope invocation of translation function which causes translation machinery to be invoked before it is ready in the case where the `Intl` polyfill is being lazily loaded.

### Reviewer guidance
Does it fix Kolibri in Safari 9.1 or earlier?

### References
Plus ca change: #5254
Fixes #6001 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
