### PR TITLE
Add svg slot for KCheckbox

### DIFF
--- a/packages/kolibri-components/src/KCheckbox.vue
+++ b/packages/kolibri-components/src/KCheckbox.vue
@@ -43,12 +43,10 @@
 
       </div>
 
-      <div v-if="$slots.svg" class="k-checkbox-icon">
-        <slot name="svg"></slot>
-      </div>
+      <slot v-if="$slots.default"></slot>
 
       <label
-        v-if="label"
+        v-else-if="label && !$slots.default"
         dir="auto"
         class="k-checkbox-label"
         :for="id"
@@ -78,7 +76,7 @@
        */
       label: {
         type: String,
-        required: true,
+        required: false,
       },
       /**
        * Whether to show label
@@ -212,14 +210,6 @@
     transform: translate(-50%, -50%);
   }
 
-  .k-checkbox-icon {
-    display: table-cell;
-    padding-left: 8px;
-    line-height: 24px;
-    vertical-align: middle;
-    cursor: pointer;
-  }
-
   .k-checkbox-label {
     display: table-cell;
     padding-left: 8px;
@@ -231,8 +221,7 @@
   .k-checkbox-disabled {
     .k-checkbox,
     .k-checkbox-input,
-    .k-checkbox-label,
-    .k-checkbox-icon {
+    .k-checkbox-label {
       cursor: default;
     }
   }

--- a/packages/kolibri-components/src/KCheckbox.vue
+++ b/packages/kolibri-components/src/KCheckbox.vue
@@ -43,7 +43,12 @@
 
       </div>
 
-      <slot v-if="$slots.default"></slot>
+      <div
+        v-if="!label && $slots.default"
+        class="k-checkbox-label"
+      >
+        <slot></slot>
+      </div>
 
       <label
         v-else-if="label && !$slots.default"

--- a/packages/kolibri-components/src/KCheckbox.vue
+++ b/packages/kolibri-components/src/KCheckbox.vue
@@ -43,6 +43,10 @@
 
       </div>
 
+      <div v-if="$slots.svg" class="k-checkbox-icon">
+        <slot name="svg"></slot>
+      </div>
+
       <label
         v-if="label"
         dir="auto"
@@ -208,6 +212,14 @@
     transform: translate(-50%, -50%);
   }
 
+  .k-checkbox-icon {
+    display: table-cell;
+    padding-left: 8px;
+    line-height: 24px;
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
   .k-checkbox-label {
     display: table-cell;
     padding-left: 8px;
@@ -219,7 +231,8 @@
   .k-checkbox-disabled {
     .k-checkbox,
     .k-checkbox-input,
-    .k-checkbox-label {
+    .k-checkbox-label,
+    .k-checkbox-icon {
       cursor: default;
     }
   }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Need to be able to add an svg icon for KDP, so added an optional slot to the `KCheckbox` component. Either use the slot or the label, but not both.

**_Before:_**
![Screen Shot 2019-10-29 at 4 06 14 PM](https://user-images.githubusercontent.com/6361732/67816087-11938700-fa66-11e9-8ca5-842e0edb81b0.png)

**_After:_**
![Screen Shot 2019-10-29 at 4 01 30 PM](https://user-images.githubusercontent.com/6361732/67815956-a649b500-fa65-11e9-9256-9460caf28888.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Add within any `KCheckbox` and remove `label` attribute.
```
              <mat-svg
                class="svg"
                category="communication"
                name="business"
              />
              <span class="text">some text
              </span>
``` 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
