### PR TITLE
refactorize search splitting it

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -675,12 +675,16 @@ def union(queries):
 
 @query_params_required(search=str, max_results=int, max_results__default=30)
 class ContentNodeSearchViewset(ContentNodeSlimViewset):
-    def search(self, value, max_results):
+    def search(self, value, max_results, filter=True):
         """
         Implement various filtering strategies in order to get a wide range of search results.
+        When filter is used, this object must have a request attribute having
+        a 'query_params' QueryDict containing the filters to be applied
         """
-        queryset = self.filter_queryset(self.get_queryset())
-
+        if filter:
+            queryset = self.filter_queryset(self.get_queryset())
+        else:
+            queryset = self.get_queryset()
         # all words with punctuation removed
         all_words = [w for w in re.split('[?.,!";: ]', value) if w]
         # words in all_words that are not stopwords

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -769,7 +769,9 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
     def list(self, request, **kwargs):
         value = self.kwargs["search"]
         max_results = self.kwargs["max_results"]
-        results, channel_ids, content_kinds, total_results = self.search(value, max_results)
+        results, channel_ids, content_kinds, total_results = self.search(
+            value, max_results
+        )
         serializer = self.get_serializer(results, many=True)
         return Response(
             {


### PR DESCRIPTION
### Summary
Currently all the code to search resources in Kolibri is inside one function, where the search itself and its data representation are tighten.

This PR refactorizes it so the search section can be reused by some other parts of the application (thought for the opensearch plugin), and the representation of the search results is separate to a different function.

### Reviewer guidance
Searching resources in kolibri should work after this PR is applied

### References
None, it solves a need for the OpenSearch plugin


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
