### PR TITLE
Don't serialize collection parent on roles

### DIFF
--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -16,17 +16,9 @@ from kolibri.core import error_constants
 
 
 class RoleSerializer(serializers.ModelSerializer):
-    collection_parent = serializers.SerializerMethodField()
-
     class Meta:
         model = Role
-        fields = ("id", "kind", "collection", "user", "collection_parent")
-
-    def get_collection_parent(self, instance):
-        if instance.collection.parent is not None:
-            return instance.collection.parent.id
-        else:
-            return None
+        fields = ("id", "kind", "collection", "user")
 
 
 class FacilityUserSerializer(serializers.ModelSerializer):

--- a/kolibri/deployment/default/settings/debug_panel.py
+++ b/kolibri/deployment/default/settings/debug_panel.py
@@ -13,3 +13,10 @@ MIDDLEWARE.append("debug_panel.middleware.DebugPanelMiddleware")  # noqa
 INSTALLED_APPS += ["debug_toolbar", "debug_panel"]  # noqa
 
 DEBUG_PANEL_ACTIVE = True
+
+CACHES["debug-panel"] = {  # noqa
+    "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+    "LOCATION": "/var/tmp/debug-panel-cache",
+    "TIMEOUT": 300,
+    "OPTIONS": {"MAX_ENTRIES": 200},
+}

--- a/kolibri/plugins/facility_management/assets/src/modules/userManagement/utils.js
+++ b/kolibri/plugins/facility_management/assets/src/modules/userManagement/utils.js
@@ -1,6 +1,4 @@
 import find from 'lodash/find';
-import map from 'lodash/map';
-import filter from 'lodash/filter';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
 import { RoleResource } from 'kolibri.resources';
 
@@ -42,14 +40,7 @@ export function updateFacilityLevelRoles(facilityUser, newRoleKind) {
 
   // Downgrading Role to LEARNER
   if (newRoleKind === UserKinds.LEARNER) {
-    const roleDeletionPromises = [
-      RoleResource.deleteModel({ id: currentFacilityRole.id }),
-      // Manually have to delete all Roles downstream in Classrooms
-      map(filter(roles, { collection_parent: facility, kind: UserKinds.COACH }), role =>
-        RoleResource.deleteModel({ id: role.id })
-      ),
-    ];
-    return Promise.all(roleDeletionPromises);
+    return RoleResource.deleteCollection({ user: id });
   }
 
   // Changing from one Facility-Level Role to another. Any Classroom-Level Roles


### PR DESCRIPTION
### Summary
Provides a roughly 10x speedup for the classroom API endpoint
Does this by removing the unnecessary `collection_parent` field from the role serializer
The role serializer gets nested inside the FacilityUserSerializer that is used to return the coach data
Removes the only reference to the `collection_parent` field in the frontend, and replaces it with a bulk delete of all roles for that user (which is what the frontend filtering and multiple requests are also trying to achieve).

### Reviewer guidance
Does creating a user with a role still work?
Does editing a user's role from something to a learner still work?

### References
Should provide some relief for #6008 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
