### PR TITLE
Translations for content license descriptions and names

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -53,6 +53,7 @@ import * as validators from '../validators';
 import * as serverClock from '../serverClock';
 import * as resources from '../api-resources';
 import * as i18n from '../utils/i18n';
+import * as licenseTranslations from '../utils/licenseTranslations';
 import * as browser from '../utils/browser';
 import bytesForHumans from '../utils/bytesForHumans';
 import UserType from '../utils/UserType';
@@ -192,6 +193,7 @@ export default {
     validators,
     serverClock,
     i18n,
+    licenseTranslations,
     loginComponents,
     navComponents,
     coreBannerContent,

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -12,7 +12,6 @@ export {
   languageValidator,
   getContentLangDir,
 } from 'kolibri-components/src/utils/i18n';
-export { licenseTranslations } from './licenseTranslations';
 
 const logging = logger.getLogger(__filename);
 

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -18,7 +18,12 @@ const logging = logger.getLogger(__filename);
 
 const languageGlobals = plugin_data['languageGlobals'] || {};
 
+let _i18nReady = false;
+
 function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
+  if (!_i18nReady) {
+    throw 'Translator used before i18n is ready';
+  }
   if (args) {
     if (!Array.isArray(args) && typeof args !== 'object') {
       logging.error(`The $tr functions take either an array of positional
@@ -188,6 +193,8 @@ function _setUpVueIntl() {
     vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);
   }
   importVueIntlLocaleData().forEach(localeData => VueIntl.addLocaleData(localeData));
+
+  _i18nReady = true;
 }
 
 function _loadDefaultFonts() {

--- a/kolibri/core/assets/src/utils/licenseTranslations.js
+++ b/kolibri/core/assets/src/utils/licenseTranslations.js
@@ -1,5 +1,5 @@
 /*
-  Look up translations based on LE Utils license names
+  Define translations using LE Utils license names as keys
 */
 
 import { createTranslator } from 'kolibri.utils.i18n';
@@ -97,55 +97,55 @@ const licenseLongNameStrings = {
 const licenseDescriptionConsumerStrings = {
   'CC BY': {
     message:
-      'You may distribute, remix, tweak, and build upon this work, even commercially, as long as you give credit to the creator.',
+      'You may distribute, adapt, and build upon this resource – even commercially – as long as you give credit to the author.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
   },
   'CC BY-SA': {
     message:
-      'You may remix, tweak, and build upon this work, even for commercial purposes, as long as you give credit and license your new creations under identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use.',
+      'You may adapt and build upon this resource – even commercially – as long as you credit the author and license your new resources under identical terms. All new resources based on yours must also carry the same license.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
   },
   'CC BY-ND': {
     message:
-      'You may reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to the creator.',
+      'You may reuse the resource for any purpose, including commercially. However it cannot be adapted, and credit must be provided to the author.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
   },
   'CC BY-NC': {
     message:
-      'You may remix, tweak, and build upon this work non-commercially. Although your new works must also acknowledge the creator and be non-commercial, they don’t have to license their derivative works on the same terms.',
+      'You may adapt and build upon this resource non-commercially. Your new resources must credit the author and also be non-commercial.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
   },
   'CC BY-NC-SA': {
     message:
-      'You may remix, tweak, and build upon this work non-commercially, as long as you give credit to the creator and license your new creations under the identical terms.',
+      'You may adapt, and build upon this resource non-commercially, as long as you give credit to the author and license your new resources under identical terms.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
   },
   'CC BY-NC-ND': {
     message:
-      'You may download this work and share it with others as long as you give credit to the creator. You may not change it in any way or use it commercially.',
+      'You may download this resource and share it with others as long as you give credit to the author. You may not adapt it in any way or use it commercially.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sd/2.0/',
   },
   'All Rights Reserved': {
     message:
-      'The copyright holder reserves, or holds for their own use, all the rights provided by copyright law. You may not distribute, remix, tweak, or build upon this work without permission from the copyright owner.',
+      'You may not distribute, adapt, or build upon this resource without permission from the copyright owner.',
     context:
       'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
   },
   'Public Domain': {
     message:
-      'This work is free of known restrictions under copyright law, including all related and neighboring rights. You may distribute, remix, tweak, and build upon this work, even commercially',
+      'This resource is free of known restrictions under copyright law. You may distribute, adapt, and build upon this resource, even commercially.',
     context:
       'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
   },
   'Special Permissions': {
     message:
-      'This content has a special license. Contact the owner of this license for a description of what this license entails.',
+      'This resource has a special license. Contact the owner of this license for a description of what you are allowed to do with it.',
     context:
       'License details from the perspective of the content consumer or end-user.\nA special licensing arrangement was reached with the copyright owner',
   },
@@ -154,54 +154,54 @@ const licenseDescriptionConsumerStrings = {
 const licenseDescriptionCreatorStrings = {
   'CC BY': {
     message:
-      'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of the Creative Commons licenses. Recommended for maximum dissemination and use of licensed materials.',
+      'This license lets others distribute, adapt, and build upon your resource – even commercially – as long as they credit you for the original creation. This is the most accommodating of the Creative Commons licenses. Recommended for maximum dissemination and use of licensed materials.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
   },
   'CC BY-SA': {
     message:
-      'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
+      'This license lets others adapt and build upon your resource – even commercially – as long as they credit you and license their new resources under identical terms. This license is often compared to “copyleft” free and open source software licenses. All new resources based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
   },
   'CC BY-ND': {
     message:
-      'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+      'This license lets others reuse the resource for any purpose, including commercially. However it cannot be shared with others in adapted form, and credit must be provided to you.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
   },
   'CC BY-NC': {
     message:
-      'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
+      'This license lets others adapt and build upon your resource non-commercially. Although their new derivative resources must credit you and be non-commercial, they don’t have to be licensed under the same terms.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
   },
   'CC BY-NC-SA': {
     message:
-      'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
+      'This license lets others adapt and build upon your resource non-commercially, as long as they credit you and license their new resources under the identical terms.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
   },
   'CC BY-NC-ND': {
     message:
-      'This license is the most restrictive of the six main Creative Commons licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
+      'This license is the most restrictive of the six main Creative Commons licenses. It only allows others to download your resources and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
   },
   'All Rights Reserved': {
-    message: 'You reserve, or holds for your own use, all the rights provided by copyright law.',
+    message:
+      'You reserve all the rights provided by copyright law, and others may not legally distribute, adapt, or build upon this resource without your permission.',
     context:
       'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
   },
   'Public Domain': {
-    message:
-      'This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights.',
+    message: 'This resource is free of known restrictions under copyright law.',
     context:
       'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
   },
   'Special Permissions': {
     message:
-      'Special Permissions is a custom license to use when the current licenses do not apply to the content. You are responsible for creating a description of what this license entails.',
+      'This is a custom license to use when the other options do not apply. You are responsible for creating a description of what this license entails and communicating it with users.',
     context:
       'License details from the perspective of the content creator, author, or copyright owner.\nA special licensing arrangement was reached with the copyright owner',
   },

--- a/kolibri/core/assets/src/utils/licenseTranslations.js
+++ b/kolibri/core/assets/src/utils/licenseTranslations.js
@@ -1,166 +1,251 @@
-// except where specified, these are from
-// https://creativecommons.org/licenses/?lang=ar
+/*
+  Look up translations based on LE Utils license names
+*/
 
-export const licenseTranslations = {
-  ar: {
-    'CC BY': {
-      name: 'نَسب المُصنَّف',
-      description:
-        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك، سواء أكان ذلك لأغراض تجارية أو غير تجارية، طالما ينسبون العمل الأصلي لك. هذه هي الرخصة الأكثر تسامحاً في مجموعة الرخص المعروضة. وهي الأنسب لضمان أكبر انتشار واستخدام ممكن للمواد المرخَّصة.',
-    },
-    'CC BY-SA': {
-      name: 'نَسب المُصنَّف - الترخيص بالمثل',
-      description:
-        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك، سواء أكان ذلك لأغراض تجارية أو غير تجارية، طالما ينسبون العمل الأصلي لك ويرخصون أعمالهم المشتقة تحت نفس الشروط. وهذه الرخصة غالباً تضاهي رخص "الحقوق المتروكة" للبرمجيات الحرة والمفتوحة المصدر. كل الأعمال المشتقة من عملك ستحمل نفس الرخصة، بالتالي جميع الأعمال المشتقة تسمح بالاستخدام التجاري. هذه الرخصة هي المستخدمة من قبل ويكيبيديا، وننصح بها للمواد التي قد تستفيد من الاشتقاق من ويكيبيديا والمشاريع المماثلة في الترخيص.',
-    },
-    'CC BY-ND': {
-      name: 'نسب المصنف - منع الاشتقاق',
-      // unofficial translation:
-      description:
-        'َهذه الرخصة تسمح بإعادة التوزیع، الاستخدام التجاري وغیر التجاري، بشرط عدم التعدیل، ون',
-    },
-    'CC BY-NC': {
-      name: 'نسب المصنف - غير تجاري',
-      description:
-        'هذه الرخصة تتيح للآخرين حرية إعادة التوزيع، التعديل، التغيير، والاشتقاق من عملك في غير الأغراض التجارية، وبالرغم من أن الأعمال المشتقة يجب أن تنسب العمل الأصلي إليك وأن تكون غير تجارية، فإنه لا يلزم أن يتم ترخيصها بنفس الشروط.',
-    },
-    'CC BY-NC-SA': {
-      name: 'نَسب المُصنَّف - غير تجاري - الترخيص بالمثل',
-      description:
-        'هذه الرخصة تتيح للآخرين التعديل، التحسين، وبناء نسخ مشتقة من المُصنَّف ولكن في غير الأغراض التجارية، بشرط نَسب العمل الأصلي إليك وترخيص الأعمال الجديدة بنفس الرخصة.',
-    },
-    'CC BY-NC-ND': {
-      name: 'نَسب المُصنَّف - غير تجاري - منع الاشتقاق',
-      description:
-        'هذه الرخصة هي الأكثر قيوداً في رخصنا الستة الأساسية، إنها تتيح فقط للآخرين تحميل أعمالك ومشاركتها مع الآخرين بشرط نَسب العمل الأصلي إليك، ودون القيام بأي تعديل أو استخدامها لأغراض تجارية.',
-    },
+import { createTranslator } from 'kolibri.utils.i18n';
+
+const licenseShortNameStrings = {
+  'CC BY': {
+    message: 'CC BY',
+    context:
+      'Abbreviated name of the Creative Commons "BY" license.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
   },
-  en: {
-    'CC BY': {
-      name: 'Attribution',
-      description:
-        'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.',
-    },
-    'CC BY-SA': {
-      name: 'Attribution-ShareAlike',
-      description:
-        'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
-    },
-    'CC BY-ND': {
-      name: 'Attribution-NoDerivs',
-      description:
-        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
-    },
-    'CC BY-NC': {
-      name: 'Attribution-NonCommercial',
-      description:
-        'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
-    },
-    'CC BY-NC-SA': {
-      name: 'Attribution-NonCommercial-ShareAlike',
-      description:
-        'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
-    },
-    'CC BY-NC-ND': {
-      name: 'Attribution-NonCommercial-NoDerivs',
-      description:
-        'This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
-    },
+  'CC BY-SA': {
+    message: 'CC BY-SA',
+    context:
+      'Abbreviated name of the Creative Commons "BY-SA" license.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
   },
-  'fr-fr': {
-    'CC BY': {
-      name: 'Attribution',
-      description:
-        'Cette licence permet aux autres de distribuer, remixer, arranger, et adapter votre œuvre, même à des fins commerciales, tant qu’on vous accorde le mérite de la création originale en citant votre nom. C’est le contrat le plus souple proposé. Recommandé pour la diffusion et l’utilisation maximales d’œuvres licenciées sous CC.',
-    },
-    'CC BY-SA': {
-      name: 'Attribution - Partage dans les Mêmes Conditions',
-      description:
-        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre, même à des fins commerciales, tant qu’on vous accorde le mérite en citant votre nom et qu’on diffuse les nouvelles créations selon des conditions identiques. Cette licence est souvent comparée aux licences de logiciels libres, “open source” ou “copyleft”. Toutes les nouvelles œuvres basées sur les vôtres auront la même licence, et toute œuvre dérivée pourra être utilisée même à des fins commerciales. C’est la licence utilisée par Wikipédia ; elle est recommandée pour des œuvres qui pourraient bénéficier de l’incorporation de contenu depuis Wikipédia et d’autres projets sous licence similaire.',
-    },
-    'CC BY-ND': {
-      name: 'Attribution - Pas de Modification',
-      description:
-        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
-    },
-    'CC BY-NC': {
-      name: 'Attribution - Pas d’Utilisation Commerciale',
-      description:
-        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre à des fins non commerciales et, bien que les nouvelles œuvres doivent vous créditer en citant votre nom et ne pas constituer une utilisation commerciale, elles n’ont pas à être diffusées selon les mêmes conditions.',
-    },
-    'CC BY-NC-SA': {
-      name: 'Attribution - Pas d’Utilisation Commerciale - Partage dans les Mêmes Conditions',
-      description:
-        'Cette licence permet aux autres de remixer, arranger, et adapter votre œuvre à des fins non commerciales tant qu’on vous crédite en citant votre nom et que les nouvelles œuvres sont diffusées selon les mêmes conditions.',
-    },
-    'CC BY-NC-ND': {
-      name: 'Attribution - Pas d’Utilisation Commerciale - Pas de Modification',
-      description:
-        'Cette licence est la plus restrictive de nos six licences principales, n’autorisant les autres qu’à télécharger vos œuvres et à les partager tant qu’on vous crédite en citant votre nom, mais on ne peut les modifier de quelque façon que ce soit ni les utiliser à des fins commerciales.',
-    },
+  'CC BY-ND': {
+    message: 'CC BY-ND',
+    context:
+      'Abbreviated name of the Creative Commons "BY-ND" license.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
   },
-  'es-es': {
-    'CC BY': {
-      name: 'Atribución',
-      description:
-        'Esta licencia permite a otras distribuir, remezclar, retocar, y crear a partir de su obra, incluso con fines comerciales, siempre y cuando den crédito por la creación original. Esta es la más flexible de las licencias ofrecidas. Se recomienda para la máxima difusión y utilización de los materiales licenciados.',
-    },
-    'CC BY-SA': {
-      name: 'Atribución-CompartirIgual',
-      description:
-        'Esta licencia permite a otras remezclar, retocar, y crear a partir de su obra, incluso con fines comerciales, siempre y cuando den crédito y licencien sus nuevas creaciones bajo los mismos términos. Esta licencia suele ser comparada con las licencias «copyleft» de software libre y de código abierto. Todas las nuevas obras basadas en la suya portarán la misma licencia, así que cualesquiera obras derivadas permitirán también uso comercial. Esta es la licencia que usa Wikipedia, y se recomienda para materiales que se beneficiarían de incorporar contenido de Wikipedia y proyectos con licencias similares.',
-    },
-    'CC BY-ND': {
-      name: 'Atribución-SinDerivadas',
-      description:
-        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
-    },
-    'CC BY-NC': {
-      name: 'Atribución-NoComercial',
-      description:
-        'Esta licencia permite a otras distribuir, remezclar, retocar, y crear a partir de su obra de forma no comercial y, a pesar de que sus nuevas obras deben siempre mencionarle y ser no comerciales, no están obligadas a licenciar sus obras derivadas bajo los mismos términos.',
-    },
-    'CC BY-NC-SA': {
-      name: 'Atribución-NoComercial-CompartirIgual',
-      description:
-        'Esta licencia permite a otras remezclar, retocar, y crear a partir de su obra de forma no comercial, siempre y cuando den crédito y licencien sus nuevas creaciones bajo los mismos términos.',
-    },
-    'CC BY-NC-ND': {
-      name: 'Atribución-NoComercial-SinDerivadas',
-      description:
-        'Esta licencia es la más restrictiva de nuestras seis licencias principales, permitiendo a otras sólo descargar sus obras y compartirlas con otras siempre y cuando den crédito, pero no pueden cambiarlas de forma alguna ni usarlas de forma comercial.',
-    },
+  'CC BY-NC': {
+    message: 'CC BY-NC',
+    context:
+      'Abbreviated name of the Creative Commons "BY-NC" license.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
   },
-  'pt-br': {
-    'CC BY': {
-      name: 'Atribuição',
-      description:
-        'Esta licença permite que outros distribuam, remixem, adaptem e criem a partir do seu trabalho, mesmo para fins comerciais, desde que lhe atribuam o devido crédito pela criação original. É a licença mais flexível de todas as licenças disponíveis. É recomendada para maximizar a disseminação e uso dos materiais licenciados.',
-    },
-    'CC BY-SA': {
-      name: 'Atribuição-CompartilhaIgual',
-      description:
-        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho, mesmo para fins comerciais, desde que lhe atribuam o devido crédito e que licenciem as novas criações sob termos idênticos. Esta licença costuma ser comparada com as licenças de software livre e de código aberto "copyleft". Todos os trabalhos novos baseados no seu terão a mesma licença, portanto quaisquer trabalhos derivados também permitirão o uso comercial. Esta é a licença usada pela Wikipédia e é recomendada para materiais que seriam beneficiados com a incorporação de conteúdos da Wikipédia e de outros projetos com licenciamento semelhante.',
-    },
-    'CC BY-ND': {
-      name: 'Atribuição-SemDerivações',
-      description:
-        'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
-    },
-    'CC BY-NC': {
-      name: 'Atribuição-NãoComercial',
-      description:
-        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho para fins não comerciais, e embora os novos trabalhos tenham de lhe atribuir o devido crédito e não possam ser usados para fins comerciais, os usuários não têm de licenciar esses trabalhos derivados sob os mesmos termos.',
-    },
-    'CC BY-NC-SA': {
-      name: 'Atribuição-NãoComercial-CompartilhaIgual',
-      description:
-        'Esta licença permite que outros remixem, adaptem e criem a partir do seu trabalho para fins não comerciais, desde que atribuam a você o devido crédito e que licenciem as novas criações sob termos idênticos.',
-    },
-    'CC BY-NC-ND': {
-      name: 'Atribuição-SemDerivações-SemDerivados',
-      description:
-        'Esta é a mais restritiva das nossas seis licenças principais, só permitindo que outros façam download dos seus trabalhos e os compartilhem desde que atribuam crédito a você, mas sem que possam alterá-los de nenhuma forma ou utilizá-los para fins comerciais.',
-    },
+  'CC BY-NC-SA': {
+    message: 'CC BY-NC-SA',
+    context:
+      'Abbreviated name of the Creative Commons "BY-NC-SA" license.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+  },
+  'CC BY-NC-ND': {
+    message: 'CC BY-NC-ND',
+    context:
+      'Abbreviated name of the Creative Commons "BY-NC-ND" license.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+  },
+  'All Rights Reserved': {
+    message: 'All rights reserved',
+    context: 'For more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'Public Domain': {
+    message: 'Public domain',
+    context: 'For more info, see https://en.wikipedia.org/wiki/Public_domain',
+  },
+  'Special Permissions': {
+    message: 'Special permissions',
+    context: 'A special licensing arrangement was reached with the copyright owner',
   },
 };
+
+const licenseLongNameStrings = {
+  'CC BY': {
+    message: 'Creative Commons: attribution',
+    context:
+      'Long-form name of the Creative Commons "BY" license.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
+  },
+  'CC BY-SA': {
+    message: 'Creative Commons: attribution, share-alike',
+    context:
+      'Long-form name of the Creative Commons "BY-SA" license.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+  },
+  'CC BY-ND': {
+    message: 'Creative Commons: attribution, no derivatives',
+    context:
+      'Long-form name of the Creative Commons "BY-ND" license.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+  },
+  'CC BY-NC': {
+    message: 'Creative Commons: attribution, non-commercial',
+    context:
+      'Long-form name of the Creative Commons "BY-NC" license.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+  },
+  'CC BY-NC-SA': {
+    message: 'Creative Commons: attribution, non-commercial, share-alike',
+    context:
+      'Long-form name of the Creative Commons "BY-NC-SA" license.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+  },
+  'CC BY-NC-ND': {
+    message: 'Creative Commons: attribution, non-commercial, no derivatives',
+    context:
+      'Long-form name of the Creative Commons "BY-NC-ND" license.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+  },
+  'All Rights Reserved': {
+    message: 'All rights reserved',
+    context: 'For more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'Public Domain': {
+    message: 'Public domain',
+    context: 'For more info, see https://en.wikipedia.org/wiki/Public_domain',
+  },
+  'Special Permissions': {
+    message: 'Special permissions',
+    context: 'A special licensing arrangement was reached with the copyright owner',
+  },
+};
+
+const licenseDescriptionConsumerStrings = {
+  'CC BY': {
+    message:
+      'You may distribute, remix, tweak, and build upon this work, even commercially, as long as you give credit to the creator.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+  },
+  'CC BY-SA': {
+    message:
+      'You may remix, tweak, and build upon this work, even for commercial purposes, as long as you give credit and license your new creations under identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+  },
+  'CC BY-ND': {
+    message:
+      'You may reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to the creator.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+  },
+  'CC BY-NC': {
+    message:
+      'You may remix, tweak, and build upon this work non-commercially. Although your new works must also acknowledge the creator and be non-commercial, they don’t have to license their derivative works on the same terms.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+  },
+  'CC BY-NC-SA': {
+    message:
+      'You may remix, tweak, and build upon this work non-commercially, as long as you give credit to the creator and license your new creations under the identical terms.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+  },
+  'CC BY-NC-ND': {
+    message:
+      'You may download this work and share it with others as long as you give credit to the creator. You may not change it in any way or use it commercially.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'All Rights Reserved': {
+    message:
+      'The copyright holder reserves, or holds for their own use, all the rights provided by copyright law. You may not distribute, remix, tweak, or build upon this work without permission from the copyright owner.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'Public Domain': {
+    message:
+      'This work is free of known restrictions under copyright law, including all related and neighboring rights. You may distribute, remix, tweak, and build upon this work, even commercially',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
+  },
+  'Special Permissions': {
+    message:
+      'This content has a special license. Contact the owner of this license for a description of what this license entails.',
+    context:
+      'License details from the perspective of the content consumer or end-user.\nA special licensing arrangement was reached with the copyright owner',
+  },
+};
+
+const licenseDescriptionCreatorStrings = {
+  'CC BY': {
+    message:
+      'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of the Creative Commons licenses. Recommended for maximum dissemination and use of licensed materials.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+  },
+  'CC BY-SA': {
+    message:
+      'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+  },
+  'CC BY-ND': {
+    message:
+      'This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+  },
+  'CC BY-NC': {
+    message:
+      'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+  },
+  'CC BY-NC-SA': {
+    message:
+      'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+  },
+  'CC BY-NC-ND': {
+    message:
+      'This license is the most restrictive of the six main Creative Commons licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'All Rights Reserved': {
+    message: 'You reserve, or holds for your own use, all the rights provided by copyright law.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+  },
+  'Public Domain': {
+    message:
+      'This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
+  },
+  'Special Permissions': {
+    message:
+      'Special Permissions is a custom license to use when the current licenses do not apply to the content. You are responsible for creating a description of what this license entails.',
+    context:
+      'License details from the perspective of the content creator, author, or copyright owner.\nA special licensing arrangement was reached with the copyright owner',
+  },
+};
+
+const shortNameTranslator = createTranslator('ShortLicenseNames', licenseShortNameStrings);
+const longNameTranslator = createTranslator('LongLicenseNames', licenseLongNameStrings);
+const creatorDescriptionTranslator = createTranslator(
+  'LicenseDescriptionsForCreators',
+  licenseDescriptionCreatorStrings
+);
+const consumerDescriptionTranslator = createTranslator(
+  'LicenseDescriptionsForConsumers',
+  licenseDescriptionConsumerStrings
+);
+
+// Translated short-form license names
+export function licenseShortName(leUtilsLicenseName) {
+  if (licenseShortNameStrings[leUtilsLicenseName]) {
+    return shortNameTranslator.$tr(leUtilsLicenseName);
+  }
+  return leUtilsLicenseName;
+}
+
+// Translated long-form license names
+export function licenseLongName(leUtilsLicenseName) {
+  if (licenseLongNameStrings[leUtilsLicenseName]) {
+    return longNameTranslator.$tr(leUtilsLicenseName);
+  }
+  return leUtilsLicenseName;
+}
+
+// Translated license descriptions, aimed at creators of the content
+export function licenseDescriptionForCreator(leUtilsLicenseName, leUtilsLicenseDescription) {
+  if (licenseDescriptionCreatorStrings[leUtilsLicenseName]) {
+    return creatorDescriptionTranslator.$tr(leUtilsLicenseName);
+  }
+  return leUtilsLicenseDescription;
+}
+
+// Translated license descriptions, aimed at users and consumers of the content
+export function licenseDescriptionForConsumer(leUtilsLicenseName, leUtilsLicenseDescription) {
+  if (licenseDescriptionConsumerStrings[leUtilsLicenseName]) {
+    return consumerDescriptionTranslator.$tr(leUtilsLicenseName);
+  }
+  return leUtilsLicenseDescription;
+}

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -36,13 +36,13 @@
           {{ $tr('authorDataHeader') }}:
           {{ content.author }}
         </li>
-        <li v-if="content.license_name">
+        <li v-if="licenseName">
           {{ $tr('licenseDataHeader') }}:
-          {{ content.license_name }}
+          {{ licenseName }}
           <InfoIcon
-            v-if="content.license_description"
-            :tooltipText="licenseHelpText"
-            :iconAriaLabel="content.license_description"
+            v-if="licenseDescription"
+            :tooltipText="licenseDescription"
+            :iconAriaLabel="licenseDescription"
           />
         </li>
         <li v-if="content.license_owner">
@@ -80,7 +80,10 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import InfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { currentLanguage, licenseTranslations } from 'kolibri.utils.i18n';
+  import {
+    licenseLongName,
+    licenseDescriptionForConsumer,
+  } from 'kolibri.utils.licenseTranslations';
   import markdownIt from 'markdown-it';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
@@ -160,20 +163,14 @@
       content() {
         return this.currentContentNode;
       },
-      translatedLicense() {
-        if (
-          licenseTranslations[currentLanguage] &&
-          licenseTranslations[currentLanguage][this.content.license_name]
-        ) {
-          return licenseTranslations[currentLanguage][this.content.license_name];
-        }
-        return null;
+      licenseName() {
+        return licenseLongName(this.content.license_name);
       },
-      licenseHelpText() {
-        if (this.translatedLicense) {
-          return `${this.translatedLicense.name} – ${this.translatedLicense.description}`;
-        }
-        return this.content.license_description;
+      licenseDescription() {
+        return licenseDescriptionForConsumer(
+          this.content.license_name,
+          this.content.license_description
+        );
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -61,10 +61,10 @@
       <p v-if="content.author">
         {{ $tr('author', {author: content.author}) }}
       </p>
-      <p v-if="content.license_name">
-        {{ $tr('license', {license: content.license_name}) }}
+      <p v-if="licenseShortName">
+        {{ $tr('license', {license: licenseShortName}) }}
 
-        <template v-if="content.license_description">
+        <template v-if="licenseDescription">
           <UiIconButton
             :ariaLabel="$tr('toggleLicenseDescription')"
             size="small"
@@ -75,15 +75,10 @@
             <mat-svg v-else name="expand_more" category="navigation" />
           </UiIconButton>
           <div v-if="licenceDescriptionIsVisible" dir="auto" class="license-details">
-            <template v-if="translatedLicense">
-              <p class="license-details-name">
-                {{ licenseName }}
-              </p>
-              <p>{{ licenseDescription }}</p>
-            </template>
-            <p v-else>
-              {{ content.license_description }}
+            <p class="license-details-name">
+              {{ licenseLongName }}
             </p>
+            <p>{{ licenseDescription }}</p>
           </div>
         </template>
       </p>
@@ -138,7 +133,11 @@
   import { isAndroidWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
-  import { currentLanguage, licenseTranslations } from 'kolibri.utils.i18n';
+  import {
+    licenseShortName,
+    licenseLongName,
+    licenseDescriptionForConsumer,
+  } from 'kolibri.utils.licenseTranslations';
   import { PageNames, PageModes, ClassesPageNames } from '../constants';
   import { updateContentNodeProgress } from '../modules/coreLearn/utils';
   import PageHeader from './PageHeader';
@@ -248,26 +247,17 @@
           params: { id: this.content.next_content.id },
         };
       },
-      translatedLicense() {
-        if (
-          licenseTranslations[currentLanguage] &&
-          licenseTranslations[currentLanguage][this.content.license_name]
-        ) {
-          return licenseTranslations[currentLanguage][this.content.license_name];
-        }
-        return null;
+      licenseShortName() {
+        return licenseShortName(this.content.license_name);
       },
-      licenseName() {
-        if (this.translatedLicense) {
-          return this.translatedLicense.name;
-        }
-        return this.content.license_name;
+      licenseLongName() {
+        return licenseLongName(this.content.license_name);
       },
       licenseDescription() {
-        if (this.translatedLicense) {
-          return this.translatedLicense.description;
-        }
-        return this.content.license_description;
+        return licenseDescriptionForConsumer(
+          this.content.license_name,
+          this.content.license_description
+        );
       },
     },
     created() {


### PR DESCRIPTION

### Summary

* Adds license names and descriptions as actual translated strings
* Removes all references to user-facing strings in LE-utils. License names are only used as IDs now
* Raise error if translation machinery is run before ready

We now have four sets of strings:

* Short license names
* Long license names (sometimes the same as short)
* License descriptions, from the perspective of a content consumer
* License descriptions, from the perspective of a content creator (unused)


### Reviewer guidance

See any issues?

### References

* fixes https://github.com/learningequality/kolibri/issues/2371
* fixes https://github.com/learningequality/kolibri/issues/5569
* fixes #6003
* refs https://github.com/learningequality/kolibri/pull/5205

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
