### PR TITLE
Perseus CSVs with Crowdin

### DIFF
--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -75,7 +75,9 @@ CROWDIN_PROJECT = "kolibri"  # crowdin project name
 CROWDIN_API_KEY = os.environ["CROWDIN_API_KEY"]
 CROWDIN_API_URL = "https://api.crowdin.com/api/project/{proj}/{cmd}?key={key}{params}"
 
-PERSEUS_CSV = "kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.csv"
+PERSEUS_CSV = (
+    "kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.csv"
+)
 GLOSSARY_XML_FILE = "glossary.tbx"
 
 DETAILS_URL = CROWDIN_API_URL.format(
@@ -301,7 +303,6 @@ def _csv_to_json():
             else:
                 csv_path = os.path.join(csv_locale_dir_path, file_name)
 
-
             # Account for csv reading differences in Pythons 2 and 3
             try:
                 if sys.version_info[0] < 3:
@@ -393,7 +394,9 @@ def download_translations(branch):
         z.extractall(target)
 
         # hack for perseus
-        perseus_target = os.path.join(utils.local_perseus_locale_csv_path(), lang_object["crowdin_code"])
+        perseus_target = os.path.join(
+            utils.local_perseus_locale_csv_path(), lang_object["crowdin_code"]
+        )
         ## TODO - Update this to work with perseus properly - likely to need to update
         ## the kolibri-exercise-perseus-plugin repo directly to produce a CSV for its
         ## translations.

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -75,8 +75,7 @@ CROWDIN_PROJECT = "kolibri"  # crowdin project name
 CROWDIN_API_KEY = os.environ["CROWDIN_API_KEY"]
 CROWDIN_API_URL = "https://api.crowdin.com/api/project/{proj}/{cmd}?key={key}{params}"
 
-PERSEUS_FILE = "exercise_perseus_render_module-messages.json"
-PERSEUS_CSV = "exercise_perseus_render_module-messages.csv"
+PERSEUS_CSV = "kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.csv"
 GLOSSARY_XML_FILE = "glossary.tbx"
 
 DETAILS_URL = CROWDIN_API_URL.format(
@@ -208,7 +207,7 @@ UPLOAD_TRANSLATION_URL = CROWDIN_API_URL.format(
 
 
 def _translation_upload_ref(file_name, lang_object):
-    if file_name == PERSEUS_FILE:  # hack for perseus, assumes the same file name
+    if file_name == PERSEUS_CSV:  # hack for perseus, assumes the same file name
         source_path = utils.local_perseus_locale_path(lang_object)
     else:
         source_path = utils.local_locale_path(lang_object)
@@ -283,36 +282,49 @@ def _csv_to_json():
         csv_locale_dir_path = os.path.join(
             utils.local_locale_csv_path(), lang_object["crowdin_code"]
         )
-        for file_name in os.listdir(csv_locale_dir_path):
-            if file_name.endswith("json"):
-                # Then it is a Perseus JSON file - just copy it.
-                source = os.path.join(csv_locale_dir_path, file_name)
-                target = os.path.join(perseus_path, file_name)
-                try:
-                    os.makedirs(perseus_path)
-                except:
-                    pass
-                shutil.copyfile(source, target)
-                continue
-            elif not file_name.endswith("csv"):
+        perseus_locale_dir_path = os.path.join(
+            utils.local_perseus_locale_csv_path(), lang_object["crowdin_code"]
+        )
+
+        # Make sure that the Perseus directory for CSV_FILES/{lang_code} exists
+        if not os.path.exists(perseus_locale_dir_path):
+            os.makedirs(perseus_locale_dir_path)
+
+        csv_dirs = os.listdir(csv_locale_dir_path) + os.listdir(perseus_locale_dir_path)
+
+        for file_name in csv_dirs:
+            if "csv" not in file_name:
                 continue
 
-            csv_path = os.path.join(csv_locale_dir_path, file_name)
+            if file_name is PERSEUS_CSV:
+                csv_path = os.path.join(perseus_locale_dir_path, file_name)
+            else:
+                csv_path = os.path.join(csv_locale_dir_path, file_name)
+
 
             # Account for csv reading differences in Pythons 2 and 3
-            if sys.version_info[0] < 3:
-                csv_file = open(csv_path, "rb")
-            else:
-                csv_file = open(csv_path, "r", newline="")
+            try:
+                if sys.version_info[0] < 3:
+                    csv_file = open(csv_path, "rb")
+                else:
+                    csv_file = open(csv_path, "r", newline="")
+            except FileNotFoundError as e:
+                logging.info("Failed to find CSV file in: {}".format(csv_path))
+                continue
 
             with csv_file as f:
                 csv_data = list(row for row in csv.DictReader(f))
 
             data = _locale_data_from_csv(csv_data)
 
-            utils.json_dump_formatted(
-                data, locale_path, file_name.replace("csv", "json")
-            )
+            if file_name in PERSEUS_CSV:
+                utils.json_dump_formatted(
+                    data, perseus_path, file_name.replace("csv", "json")
+                )
+            else:
+                utils.json_dump_formatted(
+                    data, locale_path, file_name.replace("csv", "json")
+                )
 
 
 def _locale_data_from_csv(file_data):
@@ -381,7 +393,7 @@ def download_translations(branch):
         z.extractall(target)
 
         # hack for perseus
-        perseus_target = utils.local_perseus_locale_csv_path()
+        perseus_target = os.path.join(utils.local_perseus_locale_csv_path(), lang_object["crowdin_code"])
         ## TODO - Update this to work with perseus properly - likely to need to update
         ## the kolibri-exercise-perseus-plugin repo directly to produce a CSV for its
         ## translations.
@@ -389,7 +401,7 @@ def download_translations(branch):
             os.makedirs(perseus_target)
         try:
             shutil.move(
-                os.path.join(target, PERSEUS_CSV),
+                os.path.join(target, lang_object["crowdin_code"], PERSEUS_CSV),
                 os.path.join(perseus_target, PERSEUS_CSV),
             )
         except:
@@ -469,7 +481,7 @@ UPDATE_SOURCE_URL = CROWDIN_API_URL.format(
 
 
 def _source_upload_ref(file_name):
-    if file_name == PERSEUS_FILE:  # hack for perseus, assumes the same file name
+    if file_name == PERSEUS_CSV:  # hack for perseus, assumes the same file name
         file_pointer = open(os.path.join(utils.PERSEUS_SOURCE_PATH, file_name), "rb")
     else:
         file_pointer = open(os.path.join(utils.SOURCE_PATH, file_name), "rb")
@@ -519,7 +531,7 @@ def upload_sources(branch):
     )
 
     # hack for perseus
-    source_files.add(PERSEUS_FILE)
+    source_files.add(PERSEUS_CSV)
 
     current_files = crowdin_files(branch, details)
     to_add = source_files.difference(current_files)

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -318,7 +318,7 @@ def _csv_to_json():
 
             data = _locale_data_from_csv(csv_data)
 
-            if file_name in PERSEUS_CSV:
+            if file_name is PERSEUS_CSV:
                 utils.json_dump_formatted(
                     data, perseus_path, file_name.replace("csv", "json")
                 )

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -14,7 +14,7 @@
     "js-cookie": "^2.1.2",
     "keen-ui": "https://github.com/learningequality/Keen-UI/",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-components": "0.13.0-dev.8",
+    "kolibri-components": "0.13.0-dev.10",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",
@@ -31,7 +31,7 @@
     "vuex": "^3.1.0"
   },
   "devDependencies": {
-    "kolibri-tools": "0.13.0-dev.9",
+    "kolibri-tools": "0.13.0-dev.10",
     "responselike": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.12",
     "black-fmt": "https://github.com/learningequality/black-fmt#v0.1.3",
-    "kolibri-tools": "0.13.0-dev.9",
+    "kolibri-tools": "0.13.0-dev.10",
     "yarn-run-all": "^3.1.1"
   },
   "optionalDependencies": {

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.13.0-dev.9",
+  "version": "0.13.0-dev.10",
   "description": "Custom rules.",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-components/package.json
+++ b/packages/kolibri-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-components",
-  "version": "0.13.0-dev.8",
+  "version": "0.13.0-dev.10",
   "description": "Front-end components and utilities supporting the Kolibri Design System",
   "author": "Learning Equality",
   "license": "MIT",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri",
-  "version": "0.13.0-dev.9",
+  "version": "0.13.0-dev.10",
   "description": "The Kolibri core API",
   "repository": "github.com/learningequality/kolibri",
   "author": "Learning Equality",
@@ -12,12 +12,12 @@
     "core-js": "^3.2.1",
     "date-fns": "^1.28.2",
     "fontfaceobserver": "^2.0.13",
-    "frame-throttle": "^2.0.1",
+    "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "js-cookie": "^2.1.2",
     "keen-ui": "https://github.com/learningequality/Keen-UI/",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-components": "0.13.0-dev.8",
+    "kolibri-components": "0.13.0-dev.10",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",
@@ -34,6 +34,6 @@
     "vuex": "^3.1.0"
   },
   "devDependencies": {
-    "kolibri-tools": "0.13.0-dev.9"
+    "kolibri-tools": "0.13.0-dev.10"
   }
 }

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.13.0-dev.9",
+  "version": "0.13.0-dev.10",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": "github.com/learningequality/kolibri",
@@ -34,7 +34,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.1",
-    "eslint-plugin-kolibri": "0.13.0-dev.9",
+    "eslint-plugin-kolibri": "0.13.0-dev.10",
     "eslint-plugin-vue": "^5.2.2",
     "espree": "^5.0.1",
     "esquery": "^1.0.1",
@@ -96,6 +96,6 @@
     "readline-sync": "^1.4.9"
   },
   "optionalDependencies": {
-    "kolibri": "0.13.0-dev.9"
+    "kolibri": "0.13.0-dev.10"
   }
 }


### PR DESCRIPTION
### Summary

Perseus will now use the same CSV workflow as Kolibri through Crowdin. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Prepare yourself and your repo:

- You'll need to have your Perseus repo pointing to the latest version. These instructions assume you have cloned https://github.com/learningequality/kolibri-exercise-perseus-plugin/ somewhere on your system. So do that if you haven't already.

```
cd ../path/to/perseus/repo
git fetch --all
git checkout develop
cd kolibri_exercise_perseus_plugin
yarn install
cd ..
make dist
cd ../to/kolibri/base/repo
pip install -e /path/to/perseus/repo
```

- Now - fake going through the translation process:

```
make i18n-upload branch=your-test-branch
make i18n-pretranslate-approve-all branch=your-test-branch
make i18n-download branch=your-test-branch
```

- Now - make sure that the `locale` path in your Perseus repo has the following:

> `CSV_FILES` directory with CSV files in it
>
> Translations for all languages in `locale/{lang}/LC_MESSAGES` and that the files are all JSON files and that they have translations, generally. Soime translations missing is fine because we've just used the auto-approval method for now.

**Known Issue**

The ACH (Crowdin's made up placeholder language?) file doesn't download for the Perseus file - so it won't be found and a message is logged. It is inconsequential for the translation process as far as I can tell.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri-exercise-perseus-plugin/pull/206

https://www.notion.so/learningequality/Adjust-Perseus-plugin-to-work-accordingly-41cc2c967819479e9503307d83c67ce9

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
