### PR TITLE
Changes to demographic info collection when creating a user

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/PrivacyLinkAndModal.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PrivacyLinkAndModal.vue
@@ -3,7 +3,7 @@
   <div>
 
     <KButton
-      :text="coreString('usageAndPrivacyLabel')"
+      :text="text || coreString('usageAndPrivacyLabel')"
       appearance="basic-link"
       @click="privacyModalVisible = true"
     />
@@ -30,6 +30,10 @@
     },
     mixins: [commonCoreStrings],
     props: {
+      text: {
+        type: String,
+        required: false,
+      },
       modalProps: {
         type: Object,
         required: false,

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -103,7 +103,7 @@
 
   import every from 'lodash/every';
   import { mapState, mapGetters } from 'vuex';
-  import { UserKinds, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
+  import { UserKinds, ERROR_CONSTANTS, DemographicConstants } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import GenderSelect from 'kolibri.coreVue.components.GenderSelect';
   import BirthYearSelect from 'kolibri.coreVue.components.BirthYearSelect';
@@ -112,6 +112,8 @@
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import IdentifierTextbox from './IdentifierTextbox';
+
+  const { NOT_SPECIFIED } = DemographicConstants;
 
   export default {
     name: 'UserCreatePage',
@@ -137,8 +139,8 @@
         usernameValid: false,
         password: '',
         passwordValid: false,
-        gender: '',
-        birthYear: '',
+        gender: NOT_SPECIFIED,
+        birthYear: NOT_SPECIFIED,
         idNumber: '',
         kind: {
           label: this.coreString('learnerLabel'),

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -1,6 +1,9 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import { currentLanguage } from 'kolibri.utils.i18n';
+import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
+
+const { NOT_SPECIFIED } = DemographicConstants;
 
 export default {
   state: {
@@ -28,8 +31,8 @@ export default {
         full_name: '',
         username: '',
         password: '',
-        gender: '',
-        birthYear: '',
+        gender: NOT_SPECIFIED,
+        birth_year: NOT_SPECIFIED,
       },
     },
     loading: false,
@@ -66,6 +69,7 @@ export default {
     },
     SET_SU(state, payload) {
       state.onboardingData.superuser = {
+        ...state.onboardingData.superuser,
         ...payload,
       };
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -31,16 +31,6 @@
       autocomplete="new-password"
     />
 
-    <GenderSelect
-      :value.sync="gender"
-      class="select"
-    />
-
-    <BirthYearSelect
-      :value.sync="birthYear"
-      class="select"
-    />
-
     <PrivacyLinkAndModal />
 
     <div slot="footer" class="reminder">
@@ -63,14 +53,9 @@
   import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
-  import BirthYearSelect from 'kolibri.coreVue.components.BirthYearSelect';
-  import GenderSelect from 'kolibri.coreVue.components.GenderSelect';
   import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
   import OnboardingForm from './OnboardingForm';
-
-  const { DEFERRED } = DemographicConstants;
 
   export default {
     name: 'SuperuserCredentialsForm',
@@ -79,8 +64,6 @@
       FullNameTextbox,
       UsernameTextbox,
       PasswordTextbox,
-      BirthYearSelect,
-      GenderSelect,
       PrivacyLinkAndModal,
     },
     mixins: [commonCoreStrings],
@@ -99,8 +82,6 @@
         usernameValid: false,
         password: superuser.password,
         passwordValid: false,
-        birthYear: superuser.birth_year,
-        gender: superuser.gender,
         formSubmitted: false,
       };
     },
@@ -122,8 +103,6 @@
           full_name: this.fullName,
           username: this.username,
           password: this.password,
-          birth_year: this.birthYear || DEFERRED,
-          gender: this.gender || DEFERRED,
         });
       },
       submitForm() {

--- a/kolibri/plugins/setup_wizard/assets/test/views/SetupWizardIndex.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/SetupWizardIndex.spec.js
@@ -100,6 +100,8 @@ describe('SetupWizardIndex', () => {
         full_name: 'Fred Rogers',
         username: 'mr_rogers',
         password: 'password',
+        gender: 'NOT_SPECIFIED',
+        birth_year: 'NOT_SPECIFIED',
       },
       settings: {
         allow_guest_access: true,

--- a/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
@@ -26,8 +26,6 @@ describe('SuperuserCredentialsForm', () => {
       usernameValid: true,
       password: 'password',
       passwordValid: true,
-      birthYear: '1901',
-      gender: 'NOT_SPECIFIED',
     });
     actions.simulateSubmit();
     await wrapper.vm.$nextTick();
@@ -35,7 +33,7 @@ describe('SuperuserCredentialsForm', () => {
       full_name: 'Schoolhouse Rock',
       username: 'schoolhouse_rock',
       password: 'password',
-      birth_year: '1901',
+      birth_year: 'NOT_SPECIFIED',
       gender: 'NOT_SPECIFIED',
     });
     expect(wrapper.vm.$emit).toHaveBeenCalledWith('submit');

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -332,7 +332,7 @@
           'Text explaining to the user how demographic information requested in a visible form will be utilized.',
       },
       privacyLinkText: {
-        message: 'Learn more about usage and privacy.',
+        message: 'Learn more about usage and privacy',
         context:
           'Text shown in a link to open the Kolibri usage and privacy modal. This is shown alongside other text describing collection of demographic user information.',
       },

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -48,11 +48,26 @@
               {{ currentFacility.label }}
             </p>
           </template>
+
+          <PrivacyLinkAndModal
+            class="privacy-link"
+            :modalProps="{ hideOwnersSection: true }"
+          />
         </div>
 
         <div v-show="!atFirstStep">
           <p>
+            {{ $tr('demographicInfoOptional') }}
+          </p>
+          <p>
             {{ $tr('demographicInfoExplanation') }}
+          </p>
+          <p>
+            <PrivacyLinkAndModal
+              class="privacy-link"
+              :text="$tr('privacyLinkText')"
+              :modalProps="{ hideOwnersSection: true }"
+            />
           </p>
           <GenderSelect
             class="select"
@@ -65,11 +80,6 @@
             :disabled="busy"
           />
         </div>
-
-        <PrivacyLinkAndModal
-          class="privacy-link"
-          :modalProps="{ hideOwnersSection: true }"
-        />
 
         <p>
           <KButton
@@ -310,8 +320,22 @@
     $trs: {
       createAccount: 'Create an account',
       documentTitle: 'Create account',
-      demographicInfoExplanation:
-        'This information is optional. It is used to help with user administration.',
+      demographicInfoOptional: {
+        message: 'Providing this information is optional.',
+        context:
+          'Text informing the user that form fields requesting demographic information are optional.',
+      },
+      demographicInfoExplanation: {
+        message:
+          'It will be visible to administrators. It will also be used to help improve the software and content for different learner types and needs.',
+        context:
+          'Text explaining to the user how demographic information requested in a visible form will be utilized.',
+      },
+      privacyLinkText: {
+        message: 'Learn more about usage and privacy.',
+        context:
+          'Text shown in a link to open the Kolibri usage and privacy modal. This is shown alongside other text describing collection of demographic user information.',
+      },
     },
   };
 
@@ -319,9 +343,6 @@
 
 
 <style lang="scss" scoped>
-
-  $iphone-5-width: 320px;
-  $vertical-page-margin: 100px;
 
   .narrow-container {
     max-width: 600px;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Removed demographic collection from user creation in setup wizard to eliminate the need for clarity regarding how that information is used
- In setup wizard and facility new user creation, gender and birth year default to "Not specified"
- In user sign up flow, new copy explains how demographic data is used

#### Setup Wizard
| Before | After |
| --- | --- |
| ![screenshot-localhost-8000-2019 11 12-11-30-07](https://user-images.githubusercontent.com/819838/68718859-61427a00-055f-11ea-8738-dd7c4e77ec1f.png) | ![screenshot-localhost-8000-2019 11 12-15-09-35](https://user-images.githubusercontent.com/819838/68718878-6dc6d280-055f-11ea-8cf3-bf4323a44ef0.png) |

#### New user creation
| Before | After |
| --- | --- |
| ![screenshot-localhost-8000-2019 11 12-15-13-09](https://user-images.githubusercontent.com/819838/68718912-833bfc80-055f-11ea-8685-ee7ec11346bb.png) | ![screenshot-localhost-8000-2019 11 12-15-13-33](https://user-images.githubusercontent.com/819838/68718932-8d5dfb00-055f-11ea-9f68-ccfcd01da90e.png) |

#### User sign up
| Before | After |
| --- | --- |
| ![screenshot-localhost-8000-2019 11 13-10-41-13](https://user-images.githubusercontent.com/819838/68800632-50514180-060f-11ea-876a-f09d67366b57.png) | ![screenshot-localhost-8000-2019 11 13-12-12-31](https://user-images.githubusercontent.com/819838/68800646-5810e600-060f-11ea-82a2-ed4bc1d20326.png) |


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Verify Kolibri setup functions correctly, doesn't ask for demographic data, and sets gender and birth year to "Not specified"
- Verify new user creation defaults to "Not specified" for gender and birth year in Facility new user creation
- Verify new copy exists in Sign up flow

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/6013

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
