### PR TITLE
Added strings for downloadable coach reports

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -3,10 +3,12 @@ import { createTranslator } from 'kolibri.utils.i18n';
 const coachStrings = createTranslator('CommonCoachStrings', {
   // actions
   copyAction: 'Copy',
+  exportCSVAction: 'Export as CSV', // TODO: stubbed for downloadable reports
   manageResourcesAction: 'Manage resources',
   newLessonAction: 'New lesson',
   newQuizAction: 'New quiz',
   previewAction: 'Preview',
+  printReportAction: 'Print report', // TODO: stubbed for downloadable reports
   renameAction: 'Rename',
   viewAllAction: 'View all',
   showMoreAction: 'Show more',
@@ -20,6 +22,7 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   avgTimeSpentLabel: 'Average time spent',
   avgQuizScoreLabel: 'Average quiz score',
   backToLessonLabel: "Back to '{lesson}'",
+  classLabel: 'Class', // TODO: stubbed for downloadable reports
   classesLabel: 'Classes', // Kept for use in common.js
   coachLabel: 'Coach', // Kept here for use in common.js
   descriptionLabel: 'Description',
@@ -35,6 +38,7 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   lastActivityLabel: 'Last activity',
   inactiveLabel: 'Inactive',
   learnersLabel: 'Learners', // Kept here for use in common.js
+  lessonLabel: 'Lesson', // TODO: stubbed for downloadable reports
   lessonsLabel: 'Lessons', // Kept here for use in common.js
   lessonsAssignedLabel: 'Lessons assigned',
   masteryModelLabel: 'Completion requirement',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Added strings for the downloadable coach reports feature yet to come. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Spelling errors?
- Missing any strings? 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Notion project: https://www.notion.so/learningequality/Downloadable-printable-coach-reports-9f6d1d4ed2e543afbcac3edf7fb1f999

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
