### PR TITLE
Automatic Mac Builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,8 @@ steps:
     label: ":mac:"
     build:
       message: "${BUILDKITE_MESSAGE}"
+      meta_data: 
+        triggered_from_job_id: "${BUILDKITE_JOB_ID}"
     
     # Android build only requires whl file
   - label: Build Android APK

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,11 @@ steps:
 
   - wait
 
+  - trigger: "wip-kolibri-macos"
+    label: ":mac:"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+    
     # Android build only requires whl file
   - label: Build Android APK
     env:

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -37,6 +37,7 @@ buildkite-agent artifact download 'dist/*.whl' dist/
 buildkite-agent artifact download 'dist/*.tar.gz' dist/
 buildkite-agent artifact download 'dist/*.deb' dist/
 buildkite-agent artifact download 'dist/*.exe' dist/
+buildkite-agent artifact download 'dist/*.dmg' dist/
 
 {
     buildkite-agent artifact download '*.exe' dist/ --step "Sign Windows installer"

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -100,6 +100,7 @@ file_manifest = {
 
 file_order = [
     "deb",
+    "dmg",
     "unsigned-exe",
     "signed-exe",
     # 'apk',

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -54,6 +54,12 @@ file_manifest = {
         "category": INSTALLER_CAT,
         "content_type": "application/vnd.debian.binary-package",
     },
+    "dmg": {
+        "extension": "dmg",
+        "description": "Mac Package",
+        "category": INSTALLER_CAT,
+        "content_type": "application/x-apple-diskimage",
+    },
     "unsigned-exe": {
         "extension": "exe",
         "description": "Unsigned Windows installer",


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Pulled this out of some of my pipeline refactor work to get it in on time. Some hacks (one pipeline uploading to another) was necessary to get the artifacts to go to the appropriate places and show up on the right page. That's likely to be redone later.

Why WIP? Installer isn't signed yet. Not guaranteed to be in, but working on it until EOD on Friday November 14th, 2019.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Monitor buildkite progress
- Check and see if a mac installer shows up on the generated HTML page under details
- Log into buildkite and see if the MacOS pipeline was triggered properly
- Download the macos installer for this PR and test it

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- #1 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
