### PR TITLE
Add more strings for printable coach reports

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -210,6 +210,10 @@ export default {
         filter,
       };
     },
+    isPrint() {
+      // TODO: stubbed for downloadable/printable reports project
+      return false;
+    },
   },
   methods: {
     classRoute(name, params = {}, query = {}) {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -10,7 +10,7 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <ReportsHeader />
+      <ReportsHeader :title="isPrint ? $tr('printLabel', {className}) : null" />
       <CoreTable :emptyMessage="coachString('groupListEmptyState')">
         <thead slot="thead">
           <tr>
@@ -111,6 +111,9 @@
 
         return statuses.length ? this.maxLastActivity(statuses) : null;
       },
+    },
+    $trs: {
+      printLabel: '{className} Groups',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -8,7 +8,7 @@
         :text="$tr('home')"
       />
     </p>
-    <h1>{{ coachString('reportsLabel') }}</h1>
+    <h1>{{ reportTitle }}</h1>
     <p>{{ $tr('description') }}</p>
     <HeaderTabs>
 
@@ -44,8 +44,17 @@
     name: 'ReportsHeader',
     components: {},
     mixins: [commonCoach, commonCoreStrings],
+    props: {
+      title: {
+        type: String,
+        required: false,
+      },
+    },
     computed: {
       ...mapGetters(['classListPageEnabled']),
+      reportTitle() {
+        return this.title || this.coachString('reportsLabel');
+      },
     },
     $trs: {
       home: 'Class Home',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -10,7 +10,7 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <ReportsHeader />
+      <ReportsHeader :title="isPrint ? $tr('printLabel', {className}) : null" />
       <!-- TODO COACH
       <KCheckbox :label="coachString('viewByGroupsLabel')" />
       <h2>{{ coachString('overallLabel') }}</h2>
@@ -119,6 +119,9 @@
         );
         return statuses.length;
       },
+    },
+    $trs: {
+      printLabel: '{className} Learners',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -9,7 +9,7 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <ReportsHeader />
+      <ReportsHeader :title="isPrint ? $tr('printLabel', {className}) : null" />
       <KSelect
         v-model="filter"
         :label="coreString('showAction')"
@@ -170,6 +170,7 @@
         context:
           'Column header for table of lessons which will include a toggle switch the user can use to set the visibility status of a lesson.',
       },
+      printLabel: '{className} Lessons',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -10,7 +10,7 @@
     <TopNavbar slot="sub-nav" />
 
     <KPageContainer>
-      <ReportsHeader />
+      <ReportsHeader :title="isPrint ? $tr('printLabel', {className}) : null" />
       <KSelect
         v-model="filter"
         :label="coreString('showAction')"
@@ -236,6 +236,7 @@
     $trs: {
       noActiveExams: 'No active quizzes',
       noInactiveExams: 'No inactive quizzes',
+      printLabel: '{className} Quizzes',
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Added strings for the titles of individual report list tables in print view.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- The header in a class's reports view still says `Reports`
- No spelling errors in new strings

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Other added strings: https://github.com/learningequality/kolibri/pull/6054


----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
