### PR TITLE
Prevent a race condition when starting and stopping kolibri rapidly

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -123,10 +123,11 @@ def start(port=8080, run_cherrypy=True):
     :param: port: Port number (default: 8080)
     """
 
-    run_services(port=port)
-
     # Write the new PID
+    # Note: to prevent a race condition on some setups, this needs to happen first
     _write_pid_file(PID_FILE, port=port)
+
+    run_services(port=port)
 
     atexit.register(_rm_pid_file)
 
@@ -143,10 +144,11 @@ def services(port=8080):
     Runs the background services.
     """
 
-    run_services(port=port)
-
     # Write the new PID
+    # Note: to prevent a race condition on some setups, this needs to happen first
     _write_pid_file(PID_FILE)
+
+    run_services(port=port)
 
     atexit.register(_rm_pid_file)
 


### PR DESCRIPTION
## Summary
In short, the CI pipeline is blocked and this should unblock it!

The recently merged zeroconf branch prolonged the startup time long enough to trigger a latent race condition (:checkered_flag: :racehorse: :snake: :running_man:).  This caused the tox python 2.7 environment to fail ~ 80% of the time.

The crux of the issue was that the shutdown process got initiated before the startup process had managed to create the PID file.  The shutdown process relied on PID file being there in order to make sense of what was going on, and got confused when it wasn't there yet.

The PID file is now created before starting any services.

### Reviewer guidance

If Travis finishes successfully, there's a very good chance this fix is working.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
