### PR TITLE
Import related bug fixes

### DIFF
--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -797,3 +797,5 @@ def import_channel_from_local_db(channel_id, cancel_check=None):
             id=node_id, title=channel.name, content_id=node_id, channel_id=channel_id
         )
     channel.save()
+
+    logger.info("Channel {} successfully imported into the database".format(channel_id))

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import wizard from '../wizard';
-import { TaskStatuses, taskIsClearable } from '../../constants';
+import { TaskTypes, TaskStatuses, taskIsClearable } from '../../constants';
 import actions from './actions';
 
 function defaultState() {
@@ -53,7 +53,10 @@ export default {
     },
     channelIsBeingDeleted(state) {
       return function beingDeleted(channelId) {
-        const match = find(state.taskList, { type: 'DELETECHANNEL', channel_id: channelId });
+        const match = find(state.taskList, {
+          type: TaskTypes.DELETECHANNEL,
+          channel_id: channelId,
+        });
         if (match) {
           return !taskIsClearable(match);
         }
@@ -79,6 +82,12 @@ export default {
     activeTaskList(state) {
       return state.taskList.filter(
         task => task.status !== TaskStatuses.CANCELING && task.status !== TaskStatuses.CANCELED
+      );
+    },
+    managedTasks(state) {
+      // Tasks that we want to show in the task manager - ignore channel metadata tasks here.
+      return state.taskList.filter(
+        task => ![TaskTypes.REMOTECHANNELIMPORT, TaskTypes.DISKCHANNELIMPORT].includes(task.type)
       );
     },
   },

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -253,7 +253,6 @@ export function showSelectContentPage(store, params) {
         transferType,
         transferredChannel,
       });
-      store.commit('CORE_SET_PAGE_LOADING', false);
 
       const isSamePage = samePageCheckGenerator(store);
       return loadChannelMetadata(store).then(() => {

--- a/kolibri/plugins/device/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/utils.js
@@ -45,6 +45,7 @@ export function downloadChannelMetadata(store = coreStore) {
   } else {
     return Error('Channel Metadata is only downloaded when importing');
   }
+  store.commit('CORE_SET_PAGE_LOADING', false);
   promise = promise.catch(() => Promise.reject({ errorType: ErrorTypes.CONTENT_DB_LOADING_ERROR }));
 
   return promise

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/BottomBar/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/BottomBar/TasksBar.vue
@@ -29,7 +29,7 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import countBy from 'lodash/countBy';
   import sumBy from 'lodash/sumBy';
@@ -47,18 +47,18 @@
       return {};
     },
     computed: {
-      ...mapState('manageContent', ['taskList']),
+      ...mapGetters('manageContent', ['managedTasks']),
       totalTasks() {
-        return this.taskList.length;
+        return this.managedTasks.length;
       },
       taskCounts() {
-        return countBy(this.taskList, 'status');
+        return countBy(this.managedTasks, 'status');
       },
       doneTasks() {
         return this.taskCounts.COMPLETED || 0;
       },
       progress() {
-        const inProgressTasks = this.taskList.filter(t => t.status !== 'COMPLETED');
+        const inProgressTasks = this.managedTasks.filter(t => t.status !== 'COMPLETED');
         return (this.doneTasks + sumBy(inProgressTasks, 'percentage') / this.totalTasks) * 100;
       },
       tasksString() {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -12,7 +12,7 @@
         <a href="#">{{ $tr('backToChannelsAction') }}</a>
       </p>
     </template>
-    <p v-if="!loading && taskList.length === 0">
+    <p v-if="!loading && managedTasks.length === 0">
       {{ $tr('emptyTasksMessage') }}
     </p>
 
@@ -39,7 +39,7 @@
 
   import reverse from 'lodash/fp/reverse';
   import some from 'lodash/some';
-  import { mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
   import { TaskResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { taskIsClearable } from '../../constants';
@@ -63,16 +63,16 @@
       };
     },
     computed: {
-      ...mapState('manageContent', ['taskList']),
+      ...mapGetters('manageContent', ['managedTasks']),
       sortedTaskList() {
-        return reverse(this.taskList);
+        return reverse(this.managedTasks);
       },
       showClearCompletedButton() {
-        return some(this.taskList, taskIsClearable);
+        return some(this.managedTasks, taskIsClearable);
       },
     },
     watch: {
-      taskList(val) {
+      managedTasks(val) {
         if (val.length > 0) {
           this.loading = false;
         }
@@ -80,7 +80,7 @@
     },
     mounted() {
       // Wait some time for first poll from Tasks API
-      if (this.taskList.length === 0) {
+      if (this.managedTasks.length === 0) {
         setTimeout(() => {
           this.loading = false;
         }, 2000);


### PR DESCRIPTION
### Summary
* Various bug fixes related to import/export
* Hides an unnecessary loaded state when channel metadata is not being downloaded
* Hides channel metadata tasks from the task manager
* Adds an INFO logging message to channel import
* Catches an uncaught error when trying to update job status

### Reviewer guidance
* Import a channel, check that the metadata shows on the page, and not in the task bar.
* Import from the same channel again, and check that the loading state does not turn off and on again

### References
Fixes #6041
Fixes #5672
Fixes #6070
Fixes #5537

![unnecessary_loaded_state](https://user-images.githubusercontent.com/1680573/68996107-498c2e00-089e-11ea-8b5a-550d0e55a47c.gif)

![stop_unnecessary_loaded_state](https://user-images.githubusercontent.com/1680573/68996106-498c2e00-089e-11ea-9719-5c107fd7cccf.gif)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
