### PR TITLE
update all references to 'content' to instead refer to 'resources'

### DIFF
--- a/integration_testing/features/admin/admin-manage-content.feature
+++ b/integration_testing/features/admin/admin-manage-content.feature
@@ -1,5 +1,5 @@
 Feature: Facility admin device management
-  Facility admins with device permissions need to see the *Device* dashboard to be able to manage content
+  Facility admins with device permissions need to see the *Device* dashboard to be able to manage resources
 
   Background:
     Given I am signed into Kolibri as a facility admin user with device permissions for content import
@@ -15,4 +15,3 @@ Feature: Facility admin device management
       And I can select one of the options
 
       # Continue testing content management by using the scenarios for super admins
-      

--- a/integration_testing/features/super-admin/super-admin-downgrade-from-super-content-import-permission.feature
+++ b/integration_testing/features/super-admin/super-admin-downgrade-from-super-content-import-permission.feature
@@ -10,7 +10,7 @@ Background:
       And I uncheck the *Make super admin* checkbox
     Then I see that all checkboxes are unchecked and active
       And I see that the *Save changes* button is active
-    When I check the *Can manage content on this device* checkbox under *Device permissions*
+    When I check the *Can manage resources on this device* checkbox under *Device permissions*
       And I see that *Save changes* is still active
     When I click *Save changes*
     Then I remain on this page

--- a/integration_testing/features/super-admin/super-admin-grant-content-import-permissions.feature
+++ b/integration_testing/features/super-admin/super-admin-grant-content-import-permissions.feature
@@ -8,7 +8,7 @@ Feature: Super admin grants and revokes the content import permissions
   Scenario: Grant import content device permissions
     When I click on *Edit permissions* button for <username> user
     Then I see <full_name> user permissions page
-    When I check the *Can manage content on this device* checkbox
+    When I check the *Can manage resources on this device* checkbox
     Then I see the *Save changes* button is active
     When I click *Save changes* button
     Then I see the *Changes saved* notification
@@ -21,7 +21,7 @@ Feature: Super admin grants and revokes the content import permissions
     Given that <username> user has import content device permissions
     When I click on *Edit permissions* button for <username> user
     Then I see <username> permissions page
-    When I uncheck the *Can manage content on this device* checkbox
+    When I uncheck the *Can manage resources on this device* checkbox
     Then I see the *Save changes* button is active
     When I click *Save changes* button
     Then I see the *Changes saved* notification

--- a/kolibri/core/assets/src/utils/licenseTranslations.js
+++ b/kolibri/core/assets/src/utils/licenseTranslations.js
@@ -99,55 +99,55 @@ const licenseDescriptionConsumerStrings = {
     message:
       'You may distribute, adapt, and build upon this resource – even commercially – as long as you give credit to the author.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
   },
   'CC BY-SA': {
     message:
       'You may adapt and build upon this resource – even commercially – as long as you credit the author and license your new resources under identical terms. All new resources based on yours must also carry the same license.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
   },
   'CC BY-ND': {
     message:
       'You may reuse the resource for any purpose, including commercially. However it cannot be adapted, and credit must be provided to the author.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
   },
   'CC BY-NC': {
     message:
       'You may adapt and build upon this resource non-commercially. Your new resources must credit the author and also be non-commercial.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
   },
   'CC BY-NC-SA': {
     message:
       'You may adapt, and build upon this resource non-commercially, as long as you give credit to the author and license your new resources under identical terms.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
   },
   'CC BY-NC-ND': {
     message:
       'You may download this resource and share it with others as long as you give credit to the author. You may not adapt it in any way or use it commercially.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sd/2.0/',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://creativecommons.org/licenses/by-nc-sd/2.0/',
   },
   'All Rights Reserved': {
     message:
       'You may not distribute, adapt, or build upon this resource without permission from the copyright owner.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
   },
   'Public Domain': {
     message:
       'This resource is free of known restrictions under copyright law. You may distribute, adapt, and build upon this resource, even commercially.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
+      'License details from the perspective of the resource consumer or end-user.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
   },
   'Special Permissions': {
     message:
       'This resource has a special license. Contact the owner of this license for a description of what you are allowed to do with it.',
     context:
-      'License details from the perspective of the content consumer or end-user.\nA special licensing arrangement was reached with the copyright owner',
+      'License details from the perspective of the resource consumer or end-user.\nA special licensing arrangement was reached with the copyright owner',
   },
 };
 
@@ -156,54 +156,54 @@ const licenseDescriptionCreatorStrings = {
     message:
       'This license lets others distribute, adapt, and build upon your resource – even commercially – as long as they credit you for the original creation. This is the most accommodating of the Creative Commons licenses. Recommended for maximum dissemination and use of licensed materials.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by/2.0/',
   },
   'CC BY-SA': {
     message:
-      'This license lets others adapt and build upon your resource – even commercially – as long as they credit you and license their new resources under identical terms. This license is often compared to “copyleft” free and open source software licenses. All new resources based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
+      'This license lets others adapt and build upon your resource – even commercially – as long as they credit you and license their new resources under identical terms. This license is often compared to “copyleft” free and open source software licenses. All new resources based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating resource from Wikipedia and similarly licensed projects.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-sa/2.0/',
   },
   'CC BY-ND': {
     message:
       'This license lets others reuse the resource for any purpose, including commercially. However it cannot be shared with others in adapted form, and credit must be provided to you.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nd/2.0/',
   },
   'CC BY-NC': {
     message:
       'This license lets others adapt and build upon your resource non-commercially. Although their new derivative resources must credit you and be non-commercial, they don’t have to be licensed under the same terms.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc/2.0/',
   },
   'CC BY-NC-SA': {
     message:
       'This license lets others adapt and build upon your resource non-commercially, as long as they credit you and license their new resources under the identical terms.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-sa/2.0/',
   },
   'CC BY-NC-ND': {
     message:
       'This license is the most restrictive of the six main Creative Commons licenses. It only allows others to download your resources and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://creativecommons.org/licenses/by-nc-nd/2.0/',
   },
   'All Rights Reserved': {
     message:
       'You reserve all the rights provided by copyright law, and others may not legally distribute, adapt, or build upon this resource without your permission.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/All_rights_reserved',
   },
   'Public Domain': {
     message: 'This resource is free of known restrictions under copyright law.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nFor more info, see https://en.wikipedia.org/wiki/Public_domain',
   },
   'Special Permissions': {
     message:
       'This is a custom license to use when the other options do not apply. You are responsible for creating a description of what this license entails and communicating it with users.',
     context:
-      'License details from the perspective of the content creator, author, or copyright owner.\nA special licensing arrangement was reached with the copyright owner',
+      'License details from the perspective of the resource creator, author, or copyright owner.\nA special licensing arrangement was reached with the copyright owner',
   },
 };
 

--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -91,7 +91,7 @@
       signInToKolibriAction: 'Sign in to Kolibri',
       goBackToHomeAction: 'Go to home page',
       contentManager:
-        'You must be signed in as a superuser or have content management permissions to view this page',
+        'You must be signed in as a superuser or have resource management permissions to view this page',
     },
   };
 

--- a/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
@@ -17,7 +17,7 @@
       UiAlert,
     },
     $trs: {
-      rendererNotAvailable: 'Kolibri is unable to render this content',
+      rendererNotAvailable: 'Kolibri is unable to render this resource',
     },
   };
 

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -34,7 +34,7 @@
         window.open(file.url, '_blank');
       },
     },
-    $trs: { downloadContent: 'Download content' },
+    $trs: { downloadContent: 'Download resource' },
   };
 
 </script>

--- a/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
+++ b/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
@@ -10,7 +10,7 @@
         <h1 class="title">
           <KLabeledIcon icon="person" :label="userName" />
         </h1>
-        <KLabeledIcon icon="quiz" :label="$tr('title', { name: contentName })" />
+        <KLabeledIcon icon="quiz" :label="contentName" />
       </div>
 
       <table class="scores">
@@ -106,7 +106,6 @@
       },
     },
     $trs: {
-      title: `'{name}' performance`,
       overallScore: 'Overall score',
       questionsCorrectLabel: 'Questions correct',
       questionsCorrectValue: '{correct, number} out of {total, number}',

--- a/kolibri/core/assets/src/views/PrivacyInfoModal.vue
+++ b/kolibri/core/assets/src/views/PrivacyInfoModal.vue
@@ -96,9 +96,9 @@
       kolibriUsersL4:
         'Intentionally interfere with or damage the operation of Kolibri or any user’s enjoyment of it, by any means',
       kolibriUsersP5:
-        'When you use Kolibri as a logged-in user, information such as your name, username, age, birth year, identification number, the content that you view, and your performance on assessments may be made available to administrators and coaches in your facility. Your information may also be used by the developers of Kolibri and shared with content creators to help improve the software and content for different learner types and needs.',
+        'When you use Kolibri as a logged-in user, information such as your name, username, age, birth year, identification number, the resources that you view, and your performance on assessments may be made available to administrators and coaches in your facility. Your information may also be used by the developers of Kolibri and shared with content creators to help improve the software and resources for different learner types and needs.',
       kolibriUsersP6:
-        'When you use Kolibri as a guest, aggregate information about the content you and other guest users view may be available to administrators and certain coaches.',
+        'When you use Kolibri as a guest, aggregate information about the resources you and other guest users view may be available to administrators and certain coaches.',
       kolibriOwnersTitle: 'Administrators',
       kolibriOwnersP1:
         'You should run Kolibri as a service in compliance with all applicable laws. If you are the owner of the device that Kolibri is installed on, please be aware that you are ultimately responsible for the safety and protection of the user data that gets stored in Kolibri.',
@@ -118,7 +118,7 @@
       kolibriAboutP4:
         'It is also possible for administrators to sync Kolibri data to the cloud-based Kolibri Data Portal service. If this occurs, all facility data will be accessible to organization admins on Kolibri Data Portal. It will be uploaded to cloud servers operated by Learning Equality, who will also have access to this data.',
       kolibriAboutP5:
-        'In order to improve the quality of Kolibri and the content on it, Learning Equality collects anonymized usage information when Kolibri has access to the internet. This includes IP addresses associated with the server, and device details such as the operating system and time zone. We also collect aggregate statistics including: number of users and facilities, birth year and gender distribution, and content popularity. We make every effort to avoid collecting personally identifying information about Kolibri users.',
+        'In order to improve the quality of Kolibri and the resources on it, Learning Equality collects anonymized usage information when Kolibri has access to the internet. This includes IP addresses associated with the server, and device details such as the operating system and time zone. We also collect aggregate statistics including: number of users and facilities, birth year and gender distribution, and resource popularity. We make every effort to avoid collecting personally identifying information about Kolibri users.',
       openIdH1: 'Signing in to third-party applications using Kolibri',
       openIdP1:
         'It is possible to use Kolibri to register or sign in to third-party applications. If you do this, the other application will have access to your Kolibri username, unique user ID, and full name.',

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -95,7 +95,7 @@
       upgradeMessageImportant:
         'We have released an important update with fixes to this version of Kolibri.',
       upgradeMessage0130:
-        'Kolibri version 0.13.0 is available! It contains major improvements to content management, coach tools, and much more.',
+        'Kolibri version 0.13.0 is available! It contains major improvements to resource management, coach tools, and much more.',
       upgradeDownload: 'Download it here',
       upgradeLearnAndDownload: 'Learn more and download it here',
       /* eslint-enable kolibri/vue-no-unused-translations */

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -61,12 +61,12 @@ describe('auth message component', () => {
   it('shows correct text when one text manually provided as prop', () => {
     const wrapper = makeWrapper({
       propsData: {
-        details: 'Must be device owner to manage content',
+        details: 'Must be device owner to manage resources',
       },
     });
     const { headerText, detailsText } = getElements(wrapper);
     expect(headerText()).toEqual('Did you forget to sign in?');
-    expect(detailsText()).toEqual('Must be device owner to manage content');
+    expect(detailsText()).toEqual('Must be device owner to manage resources');
   });
 
   it('shows correct link text if there is a user plugin', () => {

--- a/kolibri/locale/glossary.tbx
+++ b/kolibri/locale/glossary.tbx
@@ -32,7 +32,7 @@
         <langSet xml:lang="en">
           <tig>
             <term id="642e92efb79421734881b53e1e1b18b648-en">license</term>
-            <descrip type="definition">A legal mechanism which defines the terms under which the content resources can be shared, reused, and modified. The license is chosen by the copyright holder</descrip>
+            <descrip type="definition">A legal mechanism which defines the terms under which the resources can be shared, reused, and modified. The license is chosen by the copyright holder</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
@@ -46,7 +46,7 @@
           <tig>
             <term id="f457c545a9ded88f18ecee47145a72c049-en">copyright holder</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Person or organization who has legal ownership over a content resource</descrip>
+            <descrip type="definition">Person or organization who has legal ownership over a resource</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
@@ -103,7 +103,7 @@
         <langSet xml:lang="en">
           <tig>
             <term id="ea5d2f1c4608232e07d3aa3d998e513564-en">learner</term>
-            <descrip type="definition">An account type that has limited permissions. Learners can be enrolled in classes, get assigned content through lessons and quizzes, and navigate channels directly. We intentionally did not use the term "student" to be more inclusive of non-formal educational contexts.</descrip>
+            <descrip type="definition">An account type that has limited permissions. Learners can be enrolled in classes, get assigned resources through lessons and quizzes, and navigate channels directly. We intentionally did not use the term "student" to be more inclusive of non-formal educational contexts.</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
@@ -193,7 +193,7 @@
           <tig>
             <term id="f0935e4cd5920aa6c7c996a5ee53a70f106-en">channel</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A set of content resources that can be imported to and exported from Kolibri. It is often curated in order to achieve certain pre-defined learning objectives. Channels are originally created within Kolibri Studio</descrip>
+            <descrip type="definition">A set of resources that can be imported to and exported from Kolibri. It is often curated in order to achieve certain pre-defined learning objectives. Channels are originally created within Kolibri Studio</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="fv">
@@ -208,10 +208,9 @@
           <tig>
             <term id="a3c65c2974270fd093ee8a9bf8ae7d0b108-en">assign</term>
             <termNote type="partOfSpeech">verb</termNote>
-            <descrip type="definition">1. to assign a coach to a class
-An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user may have a coach account, but that user can also be an admin or super admin
-2. to assign a quiz or a lesson to learners
-A coach can assign content to learners in their classes</descrip>
+            <descrip type="definition">1. to assign a coach to a class. An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user may have a coach account, but that user can also be an admin or super admin
+
+2. to assign a quiz or a lesson to learners. A coach can assign resources to learners in their classes</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -220,7 +219,7 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="5f93f983524def3dca464469d2cf9f3e110-en">account</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A set of data associated with a particular user, including their name, username, password, and logs of their interactions with content. Most users will have an account in order to track their progress as a learner, manage Kolibri as an admin, or manage their classes as a coach.</descrip>
+            <descrip type="definition">A set of data associated with a particular user, including their name, username, password, and logs of their interactions with resources. Most users will have an account in order to track their progress as a learner, manage Kolibri as an admin, or manage their classes as a coach.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -238,7 +237,7 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="c45147dee729311ef5b5c3003946c48f116-en">app</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">In Kolibri, an app is a certain kind of content resource. Specifically, apps are generally self-contained, interactive HTML and Javascript applications.</descrip>
+            <descrip type="definition">In Kolibri, an app is a certain kind of resource. Specifically, apps are generally self-contained, interactive HTML and Javascript applications.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -265,7 +264,7 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="a0a080f42e6f13b3a2df133f073095dd122-en">assign (a quiz or a lesson to learners)</term>
             <termNote type="partOfSpeech">verb</termNote>
-            <descrip type="definition">A coach can assign content to learners in their classes</descrip>
+            <descrip type="definition">A coach can assign a resource to learners in their classes</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -298,18 +297,9 @@ A coach can assign content to learners in their classes</descrip>
       <termEntry id="9b8619251a19057cff70779273e95aa6130">
         <langSet xml:lang="en">
           <tig>
-            <term id="9b8619251a19057cff70779273e95aa6130-en">coach content, coach resource</term>
+            <term id="9b8619251a19057cff70779273e95aa6130-en">coach resource</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Content that is only visible to accounts with type coach, facility coach, admin, or super admin. Coach content might be answer keys, teacher training, or other similar materials</descrip>
-          </tig>
-        </langSet>
-      </termEntry>
-      <termEntry id="65ded5353c5ee48d0b7d48c591b8f430132">
-        <langSet xml:lang="en">
-          <tig>
-            <term id="65ded5353c5ee48d0b7d48c591b8f430132-en">content</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Content is a general term for the videos, exercises, apps, and other materials available in the learning platform. It is used synonymously with resources. Note: in English, the word “content” is an uncountable collective singular noun: "Import the content". Therefore when a singular or countable word is needed, we use the word “resource”, e.g. "Import 3 resources" or "Remove resource".</descrip>
+            <descrip type="definition">A resource that is only visible to accounts with type coach, facility coach, admin, or super admin. Coach resources might be answer keys, teacher training, or other similar materials</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -318,7 +308,7 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="02522a2b2726fb0a03bb19f2d8d9524d134-en">data</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Refers to information associated with users' accounts contained in their profile, which classes and facilities they are in, and the logs showing how they have interacted with content. Data does not contain content, but may contain references to it.</descrip>
+            <descrip type="definition">Refers to information associated with users' accounts contained in their profile, which classes and facilities they are in, and the logs showing how they have interacted with resources. Data does not contain resources, but may contain references to them.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -327,7 +317,7 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="42a0e188f5033bc65bf8d78622277c4e136-en">demo site</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">An online "demonstration" version of Kolibri that can be accessed publicly. All data and content on the demo site is liable to be deleted or changed periodically</descrip>
+            <descrip type="definition">An online "demonstration" version of Kolibri that can be accessed publicly. All data and resources on the demo site is liable to be deleted or changed periodically</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -407,7 +397,7 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="1d7f7abc18fcb43975065399b0d1e48e154-en">lesson</term>
-            <descrip type="definition">A lesson is a linear learning pathway defined by a coach. The coach can select content from any channel, add it to the lesson, define the ordering, and assign it to learners in their class</descrip>
+            <descrip type="definition">A lesson is a linear learning pathway defined by a coach. The coach can select resources from any channel, add them to the lesson, define the ordering, and assign the lesson to learners in their class</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -415,7 +405,7 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="1c9ac0159c94d8d0cbedc973445af2da156-en">logs</term>
-            <descrip type="definition">A subset of data stored on the device which contains information about the way that users have interacted with content, especially their progress and performance</descrip>
+            <descrip type="definition">A subset of data stored on the device which contains information about the way that users have interacted with resources, especially their progress and performance</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -423,7 +413,9 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="06409663226af2f3114485aa4e0a23b4158-en">mastery, mastery model</term>
-            <descrip type="definition">When a learner has sufficiently internalized and understood some material, they are said to have at least temporarily achieved mastery. Content curators on Kolibri Studio assign a mastery model- the number of correct answers considered to communicate mastery- across either entire content sources or individual content nodes. Mastery measures progress, not performance. For example, a mastery model might say that the learner must correctly answer 3 questions in a row before they can move on, or perhaps that they must get 7 out of the last 10 questions correct on the first attempt before moving on.</descrip>
+            <descrip type="definition">When a learner has sufficiently internalized and understood some material, they are said to have at least temporarily achieved mastery. Educational resource curators on Kolibri Studio assign a mastery model- the number of correct answers considered to communicate mastery- across either entire channels or individual resources.
+
+Mastery measures progress, not performance. For example, a mastery model might say that the learner must correctly answer 3 questions in a row before they can move on, or perhaps that they must get 7 out of the last 10 questions correct on the first attempt before moving on.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -463,7 +455,7 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="006f52e9102a8d3be2fe5614f42ba989168-en">points</term>
-            <descrip type="definition">Points are an abstract reward given to learners as they make progress through content resources</descrip>
+            <descrip type="definition">Points are an abstract reward given to learners as they make progress through resources</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -479,7 +471,7 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="1ff8a7b5dc7a7d1f0ed65aaa29c04b1e172-en">progress</term>
-            <descrip type="definition">This is a rough measure of how much a learner has engaged with content, quizzes, and lessons. Progress is approximated differently depending on the type of content. For example, documents factor in how many pages the document has and how long the learner has had the document open in the browser. For exercises, progress is directly related to the mastery model.</descrip>
+            <descrip type="definition">This is a rough measure of how much a learner has engaged with resources, quizzes, and lessons. Progress is approximated differently depending on the type of resource. For example, documents factor in how many pages the document has and how long the learner has had the document open in the browser. For exercises, progress is directly related to the mastery model.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -495,7 +487,8 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="38af86134b65d0f10fe33d30dd76442e176-en">resource</term>
-            <descrip type="definition">Resources, or content resources, are synonymous with the term content</descrip>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A resource is a general term for the videos, exercises, apps, and other materials available in the learning platform.</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -519,7 +512,7 @@ A coach can assign content to learners in their classes</descrip>
         <langSet xml:lang="en">
           <tig>
             <term id="6cdd60ea0045eb7a6ec44c54d29ed402184-en">topic</term>
-            <descrip type="definition">A collection of content and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy</descrip>
+            <descrip type="definition">A collection of resources and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy</descrip>
           </tig>
         </langSet>
       </termEntry>
@@ -544,6 +537,15 @@ A coach can assign content to learners in their classes</descrip>
           <tig>
             <term id="cfecdb276f634854f3ef915e2e980c31190-en">username</term>
             <descrip type="definition">A name that uniquely identifies an account within a facility.</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="58a2fc6ed39fd083f55d4182bf88826d192">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="58a2fc6ed39fd083f55d4182bf88826d192-en">test</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">test 22222</descrip>
           </tig>
         </langSet>
       </termEntry>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -155,12 +155,12 @@
       saveSuccessNotification: 'Settings have been updated',
       selectedLanguageLabel: 'Default language',
       facilitySettings: 'You can also configure facility settings',
-      allowGuestAccess: 'Allow users to access content without signing in',
+      allowGuestAccess: 'Allow users to access resources without signing in',
       landingPageLabel: 'Landing page',
       signInPageChoice: 'Sign-in page',
       learnerAppPageChoice: 'Learn page',
       unlistedChannels: 'Allow other computers on this network to import my unlisted channels',
-      lockedContent: 'Learners should only see content assigned to them in classes',
+      lockedContent: 'Learners should only see resources assigned to them in classes',
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/DriveList.vue
@@ -78,7 +78,7 @@
     },
     $trs: {
       drivesFound: 'Drives found',
-      noImportableDrives: 'No drives with Kolibri content are connected to the server',
+      noImportableDrives: 'No drives with Kolibri resources are connected to the server',
       noDriveWithSelectedChannelError:
         'No drives with the selected channel are connected to the server',
       noExportableDrives: 'Could not find a writable drive connected to the server',

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -111,11 +111,11 @@
       selectLocalRemoteSourceTitle: 'Select a source',
       loadingMessage: 'Loading connections…',
       studioDescription:
-        "Import content channels from Learning Equality's library if you are connected to the internet",
+        "Import resources from Learning Equality's library if you are connected to the internet",
       networkDescription:
-        'Import content channels from Kolibri running on another device, either in the same local network or on the internet',
+        'Import resources from another instance of Kolibri running on another device, either in the same local network or on the internet',
       localDescription:
-        'Import content channels from a drive. Channels must first be exported onto the drive from another Kolibri device with existing content',
+        'Import resources from a drive. Channels must have first been exported onto the drive from another instance of Kolibri',
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TaskProgress.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TaskProgress.vue
@@ -182,8 +182,8 @@
       },
     },
     $trs: {
-      importingContent: 'Importing content…',
-      exportingContent: 'Exporting content…',
+      importingContent: 'Importing resources…',
+      exportingContent: 'Exporting resources…',
       finished: 'Finished! Click "Close" button to see changes.',
       preparingTask: 'Preparing…',
       taskHasFailed: 'Transfer failed. Please try again.',

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -136,7 +136,7 @@
         }
       },
       childNodes() {
-        // Guard against when state is reset going back to manage content page
+        // Guard against when state is reset going back to manage resources page
         return this.currentTopicNode.children || [];
       },
       noSelectableNodes() {

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentWizardUiAlert.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentWizardUiAlert.vue
@@ -57,7 +57,7 @@
       networkLocationDoesNotExist: 'The device with this ID does not exist',
       networkLocationUnavailable:
         'The Kolibri server on the selected device is not available at the moment',
-      transferInProgressError: 'A content transfer is currently in progress',
+      transferInProgressError: 'A transfer is currently in progress',
       kolibriStudioUnavailable: 'Kolibri Studio is unavailable',
       networkLocationDoesNotHaveChannel:
         'The device with this ID does not have the desired channel',

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -325,7 +325,7 @@
       pageLoadError: 'There was a problem loading this page…',
       problemFetchingChannel: 'There was a problem getting the contents of this channel',
       problemTransferringContents: 'There was a problem transferring the selected contents',
-      selectContent: "Select content from '{channelName}'",
+      selectContent: "Select resources from '{channelName}'",
       kolibriStudioLabel: 'Kolibri Studio',
       importingFromDrive: `Importing from drive '{driveName}'`,
       importingFromPeer: `Importing from '{deviceName}' ({url})`,

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -215,7 +215,7 @@
       UserType,
     },
     $trs: {
-      devicePermissionsDetails: 'Can manage content on this device',
+      devicePermissionsDetails: 'Can manage resources on this device',
       documentTitle: "{ name }'s Device Permissions",
       makeSuperAdmin: 'Make super admin',
       permissionChangeConfirmation: 'Changes saved',

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -25,7 +25,7 @@
     $trs: {
       welcomeModalHeader: 'Welcome to Kolibri!',
       welcomeModalContentDescription:
-        'The first thing you should do is import some content from the Channel tab.',
+        'The first thing you should do is import some resources from the Channel tab.',
       welcomeModalPermissionsDescription:
         'The super admin account you created during setup has special permissions to do this. Learn more in the Permissions tab later.',
       welcomeButtonDismissText: 'OK',

--- a/kolibri/plugins/device/assets/test/views/SelectDriveModal.spec.js
+++ b/kolibri/plugins/device/assets/test/views/SelectDriveModal.spec.js
@@ -144,7 +144,7 @@ describe('selectDriveModal component', () => {
     });
     const wrapper = makeWrapper({ store });
     const driveListText = wrapper.find(UiAlert);
-    const expectedMessage = 'No drives with Kolibri content are connected to the server';
+    const expectedMessage = 'No drives with Kolibri resources are connected to the server';
     expect(driveListText.text().trim()).toEqual(expectedMessage);
   });
 

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -179,13 +179,13 @@
     $trs: {
       pageHeading: 'Export usage data',
       pageSubHeading:
-        'Download CSV (comma-separated value) files containing information about users and their interactions with the content on this device',
+        'Download CSV (comma-separated value) files containing information about users and their interactions with the resources on this device',
       detailsHeading: 'Session logs',
       detailsSubHeading: 'Individual visits to each resource',
       summaryHeading: 'Summary logs',
       summarySubHeading: 'Total time/progress for each resource',
       detailsInfo:
-        'When a user views content, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific resource. This includes anonymous usage, when no user is signed in.',
+        'When a user views a resource, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific resource. This includes anonymous usage, when no user is signed in.',
       summaryInfo:
         'A user may visit the same resource multiple times. This file records the total time and progress each user has achieved for each resource, summarized across possibly more than one visit. Anonymous usage is not included.',
       generateLog: 'Generate log file',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -163,8 +163,8 @@
       learnerCanEditUsername: 'Allow learners and coaches to edit their username',
       learnerCanSignUp: 'Allow learners to create accounts',
       learnerCanLoginWithNoPassword: 'Allow learners to sign in with no password',
-      showDownloadButtonInLearn: "Show 'download' button with content",
-      allowGuestAccess: 'Allow users to access content without signing in',
+      showDownloadButtonInLearn: "Show 'download' button with resources",
+      allowGuestAccess: 'Allow users to access resources without signing in',
       /* eslint-enable kolibri/vue-no-unused-translations */
       pageDescription: 'Configure facility settings here.',
       deviceSettings: 'You can also configure device settings',

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -45,8 +45,8 @@ describe('facility config page view', () => {
       'Allow learners and coaches to edit their full name',
       'Allow learners to create accounts',
       'Allow learners to sign in with no password',
-      "Show 'download' button with content",
-      'Allow users to access content without signing in',
+      "Show 'download' button with resources",
+      'Allow users to access resources without signing in',
     ];
     labels.forEach((label, idx) => {
       expect(checkboxes.at(idx).props().label).toEqual(label);

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -100,7 +100,7 @@
     },
     $trs: {
       documentTitle: '{ examTitle } report',
-      missingContent: 'This quiz cannot be displayed because some content was deleted',
+      missingContent: 'This quiz cannot be displayed because some resources were deleted',
     },
   };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
@@ -47,9 +47,9 @@
     },
     $trs: {
       description:
-        'This allows anyone to view content on Kolibri without needing to make an account',
+        'This allows anyone to view resources on Kolibri without needing to make an account',
       header: 'Enable guest access?',
-      noOptionLabel: 'No. Users must have an account to view content on Kolibri',
+      noOptionLabel: 'No. Users must have an account to view resources on Kolibri',
     },
   };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -132,7 +132,7 @@
     $trs: {
       adminAccountCreationHeader: 'Create super admin account',
       adminAccountCreationDescription:
-        'This account allows you to manage the facility, content, and user accounts on this device',
+        'This account allows you to manage the facility, resources, and user accounts on this device',
       rememberThisAccountInformation:
         'Important: please remember this account information. Write it down if needed',
     },

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -327,7 +327,7 @@
       },
       demographicInfoExplanation: {
         message:
-          'It will be visible to administrators. It will also be used to help improve the software and content for different learner types and needs.',
+          'It will be visible to administrators. It will also be used to help improve the software and resources for different learner types and needs.',
         context:
           'Text explaining to the user how demographic information requested in a visible form will be utilized.',
       },


### PR DESCRIPTION
### Summary

* changes references to 'content' to instead refer to 'a resource' or 'resources'
* removes one incorrect reference to 'performance'
* also updates the glossary


### References

fixes https://github.com/learningequality/kolibri/issues/5965

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
