### PR TITLE
Move zeroconf exit handling to server.py

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -380,14 +380,6 @@ def update(old_version, new_version):
     cache.clear()
 
 
-def _cleanup_before_quitting(signum, frame):
-    from kolibri.core.discovery.utils.network.search import unregister_zeroconf_service
-
-    unregister_zeroconf_service()
-    signal.signal(signum, signal.SIG_DFL)
-    os.kill(os.getpid(), signum)
-
-
 main_help = """Kolibri management commands
 
 For more information, see:
@@ -410,13 +402,7 @@ def main(ctx):
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
         ctx.exit(1)
-
-    try:
-        signal.signal(signal.SIGINT, _cleanup_before_quitting)
-        signal.signal(signal.SIGTERM, _cleanup_before_quitting)
-        logger.info("Added signal handlers for cleaning up on exit...")
-    except ValueError:
-        logger.warn("Error adding signal handlers for cleaning up on exit...")
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 def create_startup_lock(port):


### PR DESCRIPTION
### Summary
Did this to see if I could sort out #6080 - it didn't fix it, but I think it needed to be done anyway!

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
