### PR TITLE
Strings for changelog

### DIFF
--- a/kolibri/locale/glossary.tbx
+++ b/kolibri/locale/glossary.tbx
@@ -431,6 +431,7 @@ Mastery measures progress, not performance. For example, a mastery model might s
         <langSet xml:lang="en">
           <tig>
             <term id="82aa4b0af34c2313a562076992e50aa3162-en">network</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A network is a set of computers that can communicate with each other. This is how a Kolibri server installed on one device can communicate with client devices running web browsers</descrip>
           </tig>
         </langSet>
@@ -512,6 +513,7 @@ Mastery measures progress, not performance. For example, a mastery model might s
         <langSet xml:lang="en">
           <tig>
             <term id="6cdd60ea0045eb7a6ec44c54d29ed402184-en">topic</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A collection of resources and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy</descrip>
           </tig>
         </langSet>
@@ -546,6 +548,15 @@ Mastery measures progress, not performance. For example, a mastery model might s
             <term id="58a2fc6ed39fd083f55d4182bf88826d192-en">test</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">test 22222</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="a597e50502f5ff68e3e25b9114205d4a194">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="a597e50502f5ff68e3e25b9114205d4a194-en">unlisted channel</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A channel that is not available publicly through Kolibri Studio. It must be imported using a channel token.</descrip>
           </tig>
         </langSet>
       </termEntry>

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -330,10 +330,22 @@
       documentTitleForLocalImport: "Available Channels on '{driveName}'",
       documentTitleForRemoteImport: 'Available Channels on Kolibri Studio',
       noChannelsAvailable: 'No channels are available on this device',
-      selectEntireChannels: 'Select entire channels instead',
-      selectTopicsAndResources: 'Select topics and resources instead',
-      notEnoughSpaceForChannelsWarning:
-        'Not enough space available on your device. Free up disk space or select fewer resources',
+      selectEntireChannels: {
+        message: 'Select entire channels instead',
+        context:
+          '\nAllow the user to select entire channels instead of individual topics/resources within a channel',
+      },
+      selectTopicsAndResources: {
+        message: 'Select topics and resources instead',
+        context:
+          '\nAllow the user to select individual topics/resources within a channel instead of entire channels',
+      },
+      notEnoughSpaceForChannelsWarning: {
+        message:
+          'Not enough space available on your device. Free up disk space or select fewer resources',
+        context:
+          '\nWarning that appears when there is not enough space on the user’s device for the selected resources',
+      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -162,7 +162,10 @@
     $trs: {
       onYourDevice: 'Resources on device',
       selectResourcesAction: 'Select resources',
-      newLabel: 'New',
+      newLabel: {
+        message: 'New',
+        context: '\nIndicator that channel was recently updated, imported, and unlocked',
+      },
       unlistedChannelTooltip: 'Unlisted channel',
       newVersionMessage: 'New version available',
       moreInformationLabel: 'More information',

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -82,7 +82,10 @@
       },
     },
     $trs: {
-      manageChannelAction: 'Manage',
+      manageChannelAction: {
+        message: 'Manage',
+        context: '\nOperation that can be performed on a channel',
+      },
       deleteChannelAction: 'Delete',
     },
   };

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
@@ -52,8 +52,10 @@
       confirmationQuestion: `Are you sure you want to delete '{channelTitle}' from your device?`,
       confirmationQuestionOneChannel:
         'Are you sure you want to delete this channel from your device?',
-      confirmationQuestionMultipleChannels:
-        'Are you sure you want to delete these channels from your device?',
+      confirmationQuestionMultipleChannels: {
+        message: 'Are you sure you want to delete these channels from your device?',
+        context: '\nA confirmation that appears when a user tries to delete multiple channels',
+      },
       titleSingleChannel: 'Delete channel',
       titleMultipleChannels: 'Delete channels',
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
@@ -4,6 +4,13 @@
     class="new-version-banner"
     :style="{backgroundColor: $themePalette.lightblue.v_100}"
   >
+    <!-- stubs -->
+    <template v-if="false">
+      <UpdateChannelModal />
+      <NewChannelVersionPage />
+      {{ strings }}
+    </template>
+    <!-- end stubs -->
     <span class="version">
       <KIcon
         class="icon"
@@ -27,10 +34,15 @@
 <script>
 
   import channelUpdateStrings from './channelUpdateStrings.js';
+  import UpdateChannelModal from './UpdateChannelModal';
+  import NewChannelVersionPage from './NewChannelVersionPage';
 
   export default {
     name: 'NewChannelVersionBanner',
-    components: {},
+    components: {
+      UpdateChannelModal,
+      NewChannelVersionPage,
+    },
     props: {
       version: {
         type: Number,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
@@ -26,6 +26,8 @@
 
 <script>
 
+  import channelUpdateStrings from './channelUpdateStrings.js';
+
   export default {
     name: 'NewChannelVersionBanner',
     components: {},
@@ -35,8 +37,18 @@
         required: true,
       },
     },
+    computed: {
+      // Stubbed out
+      strings() {
+        return channelUpdateStrings;
+      },
+    },
     $trs: {
-      versionAvailable: 'Version {version} is available',
+      versionAvailable: {
+        message: 'Version {version} is available',
+        context:
+          '\nWhen a new version of the channel is available, this message alerts the user that they can update. ',
+      },
       viewChangesAction: 'View changes',
     },
   };

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -95,7 +95,7 @@
       versionIsAvailable: `Version {nextVersion} of '{channelName}' is available`,
       youAreCurrentlyOnVersion: 'You are currently on version {currentVersion}',
       versionChangesHeader: {
-        message: 'Changes if you choose to update from version {oldVersion} to {newVersion}:',
+        message: 'Changes if you choose to update from version {currentVersion} to {nextVersion}:',
         context:
           'Header above a table that lists what the consequences of updating the channel would be',
       },
@@ -123,7 +123,7 @@
       updateConfirmationQuestion: `Are you sure you want to update '{channelName}' to version {version}?`,
       channelIsIncomplete: {
         message:
-          "This copy of '{channel}' is incomplete. It contains {resourcesInChannel} of {totalResources} resources from the original channel",
+          'This copy of the channel is incomplete. It contains {available} of {total} resources from the original channel',
         context:
           'Warning indicating that the source does not have all content from the original channel',
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -95,7 +95,7 @@
       versionIsAvailable: `Version {nextVersion} of '{channelName}' is available`,
       youAreCurrentlyOnVersion: 'You are currently on version {currentVersion}',
       versionChangesHeader: {
-        message: 'Changes if you choose to update from version {currentVersion} to {nextVersion}:',
+        message: 'Changes if you choose to update from version {currentVersion} to {nextVersion}',
         context:
           'Header above a table that lists what the consequences of updating the channel would be',
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -94,17 +94,39 @@
     $trs: {
       versionIsAvailable: `Version {nextVersion} of '{channelName}' is available`,
       youAreCurrentlyOnVersion: 'You are currently on version {currentVersion}',
-      versionChangesHeader: 'Changes if you update from version {currentVersion} to {nextVersion}',
-      resourcesAvailableForImport: 'New resources available:',
-      resourcesToBeDeleted: 'Resources that will be deleted:',
-      resourcesToBeDeletedTooltip:
-        'When you update this channel, some resources will be deleted. This may affect lessons or quizzes that are using the deleted resources.',
-      resourcesToBeUpdated: 'Resources to be updated:',
+      versionChangesHeader: {
+        message: 'Changes if you choose to update from version {oldVersion} to {newVersion}:',
+        context:
+          'Header above a table that lists what the consequences of updating the channel would be',
+      },
+      resourcesAvailableForImport: {
+        message: 'New resources available',
+        context:
+          'Label associated with the number of resources that would become available for importing if the channel is updated',
+      },
+      resourcesToBeDeleted: {
+        message: 'Resources that will be deleted',
+        context:
+          'Label associated with the number of resources that would be deleted if the channel is updated',
+      },
+      resourcesToBeDeletedTooltip: {
+        message:
+          'When you update this channel, some resources will be deleted. This may affect lessons or quizzes that are using the deleted resources',
+        context: 'Warning about the effects of updating the channel',
+      },
+      resourcesToBeUpdated: {
+        message: 'Resources to be updated',
+        context: 'Label associated with the number of resources would be updated',
+      },
       updateChannelAction: 'Update channel',
       versionNumberHeader: 'Version {version}',
       updateConfirmationQuestion: `Are you sure you want to update '{channelName}' to version {version}?`,
-      channelIsIncomplete:
-        'This channel source is incomplete. It has {available} of {total} resources',
+      channelIsIncomplete: {
+        message:
+          "This copy of '{channel}' is incomplete. It contains {resourcesInChannel} of {totalResources} resources from the original channel",
+        context:
+          'Warning indicating that the source does not have all content from the original channel',
+      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -257,7 +257,11 @@
       noAddressText: 'There are no addresses yet',
       refreshAddressesButtonLabel: 'Refresh addresses',
       peerDeviceName: 'Local Kolibri ({ identifier })',
-      searchingText: 'Searching',
+      searchingText: {
+        message: 'Searching',
+        context:
+          '\nKolibri will search for nearby Kolibri devices every so often. While doing so, this text will be presented to the user',
+      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
@@ -166,8 +166,11 @@
       problemFindingLocalDrives: 'There was a problem finding local drives.',
       selectDrive: 'Select a drive',
       selectExportDestination: 'Select an export destination',
-      notEnoughFreeSpaceWarning:
-        'Not enough space available. Free up space on the drive or select fewer resources',
+      notEnoughFreeSpaceWarning: {
+        message: 'Not enough space available. Free up space on the drive or select fewer resources',
+        context:
+          '\nWarning that appears when a user has selected a drive without enough space for the selected resources',
+      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
@@ -4,42 +4,4 @@ export default createTranslator('ChannelUpdateStrings', {
   notAvailableFromDrives: 'This channel was not found on any attached drives',
   notAvailableFromNetwork: 'This channel was not found on other instances of Kolibri',
   notAvailableFromStudio: 'This channel was not found on Kolibri Studio',
-  newVersionAvailableHeader: "Version {version} of '{channel}' is available",
-  currentVersionLabel: 'You are currently on version {version}',
-  changesHeader: {
-    message: 'Changes if you update from version {oldVersion} to {newVersion}',
-    context:
-      'Header above a table that lists what the consequences of updating the channel would be',
-  },
-  newResourcesAvailableLabel: {
-    message: 'New resources available',
-    context:
-      'Label associated with the number of resources that would become available for importing if the channel is updated',
-  },
-  resourcesDeletedLabel: {
-    message: 'Resources that will be deleted',
-    context:
-      'Label associated with the number of resources that would be deleted if the channel is updated',
-  },
-  resourcesDeletedLabel: {
-    message: 'Resources to be updated',
-    context: 'Label associated with the number of resources would be updated',
-  },
-  updateChannelAction: 'Update channel',
-  channelIncompleteWarning: {
-    message:
-      "This copy of '{channel}' is incomplete. It contains {resourcesInChannel} of {totalResources} resources from the original channel",
-    context:
-      'Warning indicating that the source does not have all content from the original channel',
-  },
-  updateWarning: {
-    message:
-      'When you update this channel, some resources will be deleted. This may affect lessons or quizzes that are using the deleted resources',
-    context: 'Warning about the effects of updating the channel',
-  },
-  updateConfirmationHeader: {
-    message: 'Update channel',
-    context: 'Header for a confirmation of update',
-  },
-  updateConfirmationMessage: "Are you sure you want to update '{channel}' to version {version}?",
 });

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
@@ -1,0 +1,45 @@
+import { createTranslator } from 'kolibri.utils.i18n';
+
+export default createTranslator('ChannelUpdateStrings', {
+  notAvailableFromDrives: 'This channel was not found on any attached drives',
+  notAvailableFromNetwork: 'This channel was not found on other instances of Kolibri',
+  notAvailableFromStudio: 'This channel was not found on Kolibri Studio',
+  newVersionAvailableHeader: "Version {version} of '{channel}' is available",
+  currentVersionLabel: 'You are currently on version {version}',
+  changesHeader: {
+    message: 'Changes if you update from version {oldVersion} to {newVersion}',
+    context:
+      'Header above a table that lists what the consequences of updating the channel would be',
+  },
+  newResourcesAvailableLabel: {
+    message: 'New resources available',
+    context:
+      'Label associated with the number of resources that would become available for importing if the channel is updated',
+  },
+  resourcesDeletedLabel: {
+    message: 'Resources that will be deleted',
+    context:
+      'Label associated with the number of resources that would be deleted if the channel is updated',
+  },
+  resourcesDeletedLabel: {
+    message: 'Resources to be updated',
+    context: 'Label associated with the number of resources would be updated',
+  },
+  updateChannelAction: 'Update channel',
+  channelIncompleteWarning: {
+    message:
+      "This copy of '{channel}' is incomplete. It contains {resourcesInChannel} of {totalResources} resources from the original channel",
+    context:
+      'Warning indicating that the source does not have all content from the original channel',
+  },
+  updateWarning: {
+    message:
+      'When you update this channel, some resources will be deleted. This may affect lessons or quizzes that are using the deleted resources',
+    context: 'Warning about the effects of updating the channel',
+  },
+  updateConfirmationHeader: {
+    message: 'Update channel',
+    context: 'Header for a confirmation of update',
+  },
+  updateConfirmationMessage: "Are you sure you want to update '{channel}' to version {version}?",
+});

--- a/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
@@ -136,8 +136,14 @@
       },
     },
     $trs: {
-      instructions: 'Control the order in which channels will be displayed to learners and coaches',
-      successNotification: 'Channel order saved',
+      instructions: {
+        message: 'Control the order in which channels will be displayed to learners and coaches',
+        context: '\nText explaining how the channel reordering feature works',
+      },
+      successNotification: {
+        message: 'Channel order saved',
+        context: '\nSuccess message shown when the admin re-orders channels',
+      },
       failureNotification: 'There was a problem reordering the channels',
       noChannels: 'There are no channels',
       upLabel: 'Move {name} up one',

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
@@ -59,11 +59,21 @@
         'Are you sure you want to delete this resource from your device?',
       confirmationQuestionMultipleResources:
         'Are you sure you want to delete these resources from your device?',
-      deleteEverywhereLabel: 'Also delete any copies found in other locations and channels',
-      deleteEverywhereExplanationOneResource:
-        'Some copies of this resource may be in other locations on your device',
-      deleteEverywhereExplanationMultipleResources:
-        'Some copies of these resources may be in other locations on your device',
+      deleteEverywhereLabel: {
+        message: 'Also delete any copies found in other locations and channels',
+        context:
+          '\nWhen some of the resources admin selected are present in multiple channels, Kolibri will provide an option for the admin to delete all instances ',
+      },
+      deleteEverywhereExplanationOneResource: {
+        message: 'Some copies of this resource may be in other locations on your device',
+        context:
+          '\nWhen some of the resources admin selected are present in multiple channels, Kolibri will provide an option for the admin to delete all instances ',
+      },
+      deleteEverywhereExplanationMultipleResources: {
+        message: 'Some copies of these resources may be in other locations on your device',
+        context:
+          '\nWhen some of the resources admin selected are present in multiple channels, Kolibri will provide an option for the admin to delete all instances ',
+      },
     },
   };
 


### PR DESCRIPTION
### Summary

* stubs for changelog strings
* adds context which was recently added on crowdin


### Reviewer guidance

are these correct? should they already have existed in the codebase somewhere?

### References

based on:

* https://www.figma.com/file/eJd6xQiNgebzzRWn2XDDS92R/0.13-content-import?node-id=222%3A0
* https://docs.google.com/document/d/1jivSlr5MidAmbBJBkHLps9f3wSR5hLvGmTmCihIkdgI/edit

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
