### PR TITLE
Make sure all kolibri background services die cleanly.

### DIFF
--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -1,4 +1,3 @@
-import atexit
 import os
 
 from sqlalchemy import create_engine
@@ -63,5 +62,4 @@ scheduler = Scheduler(queue=queue, connection=connection)
 
 
 def initialize_worker():
-    worker = Worker(app, connection=connection, num_workers=1)
-    atexit.register(worker.shutdown)
+    return Worker(app, connection=connection, num_workers=1)

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -121,8 +121,8 @@ class Scheduler(StorageMixin):
             self._schedule_checker = self.start_schedule_checker()
 
     def shutdown_scheduler(self):
-        if self._scheduler_checker:
-            self._scheduler_checker.stop()
+        if self._schedule_checker:
+            self._schedule_checker.stop()
 
     def enqueue_at(self, dt, func, *args, **kwargs):
         """

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import threading
 import time
+from functools import partial
 from subprocess import CalledProcessError
 from subprocess import check_output
 
@@ -73,9 +74,15 @@ class NotRunning(Exception):
         super(NotRunning, self).__init__()
 
 
-def _cleanup_before_quitting(signum, frame):
+def _cleanup_before_quitting(signum, frame, worker=None):
     from kolibri.core.discovery.utils.network.search import unregister_zeroconf_service
+    from kolibri.core.tasks.main import scheduler
 
+    logger.info("Cleaning up background services before exiting")
+
+    if worker is not None:
+        worker.shutdown()
+    scheduler.shutdown_scheduler()
     unregister_zeroconf_service()
     signal.signal(signum, signal.SIG_DFL)
     os.kill(os.getpid(), signum)
@@ -107,11 +114,9 @@ def run_services(port):
     # Initialize the iceqube engine to handle queued tasks
     from kolibri.core.tasks.main import initialize_worker
 
-    initialize_worker()
+    worker = initialize_worker()
 
     scheduler.start_scheduler()
-
-    atexit.register(scheduler.shutdown_scheduler)
 
     # Register the Kolibri zeroconf service so it will be discoverable on the network
     from morango.models import InstanceIDModel
@@ -120,12 +125,14 @@ def run_services(port):
     instance, _ = InstanceIDModel.get_or_create_current_instance()
     register_zeroconf_service(port=port, id=instance.id[:4])
 
+    cleanup_func = partial(_cleanup_before_quitting, worker=worker)
+
     try:
-        signal.signal(signal.SIGINT, _cleanup_before_quitting)
-        signal.signal(signal.SIGTERM, _cleanup_before_quitting)
-        logger.info("Added signal handlers for cleaning up on exit...")
+        signal.signal(signal.SIGINT, cleanup_func)
+        signal.signal(signal.SIGTERM, cleanup_func)
+        logger.info("Added signal handlers for cleaning up on exit")
     except ValueError:
-        logger.warn("Error adding signal handlers for cleaning up on exit...")
+        logger.warn("Error adding signal handlers for cleaning up on exit")
 
 
 def _rm_pid_file():

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,6 @@ deps =
     -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/cext.txt
 commands =
-    coverage run -p kolibri start --port=8081
-    coverage run -p kolibri stop
     sh -c 'kolibri manage makemigrations --check'
     # Run the actual tests
     py.test {posargs:--cov=kolibri --cov-report= --cov-append --color=no}


### PR DESCRIPTION
### Summary
Stops using atexit for cleanup logic.
Uses signal handling for all cleanup.
Fixes stupid dumb typo in the scheduler shutdown function.

Stops running `kolibri start` during our test runs, it serves little purpose.

### Reviewer guidance
Run `kolibri services --foreground` and then ctrl break out of it. Check your process manager, is anything still running from kolibri?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
