### PR TITLE
don't use zeroconf to send channel/facility info

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -21,6 +21,7 @@ from ..utils.network.search import ZEROCONF_STATE
 MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555
 MOCK_ID = "abba"
+MOCK_PROPERTIES = {b"version": '[0, 13, 0, "alpha", 0]'}
 
 
 class MockServiceBrowser(object):
@@ -48,8 +49,9 @@ class MockZeroconf(Zeroconf):
             server=".".join([id, LOCAL_DOMAIN, ""]),
             address=socket.inet_aton(MOCK_INTERFACE_IP),
             port=MOCK_PORT,
-            properties={"facilities": "[]", "channels": "[]"},
+            properties=MOCK_PROPERTIES,
         )
+
         return info
 
     def add_service_listener(self, type_, listener):
@@ -114,7 +116,7 @@ class TestNetworkSearch(TestCase):
                 "self": True,
                 "port": MOCK_PORT,
                 "host": ".".join([MOCK_ID, LOCAL_DOMAIN]),
-                "data": {"facilities": [], "channels": []},
+                "data": {"version": [0, 13, 0, "alpha", 0]},
                 "base_url": "http://{ip}:{port}/".format(
                     ip=MOCK_INTERFACE_IP, port=MOCK_PORT
                 ),

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -11,8 +11,7 @@ from zeroconf import ServiceInfo
 from zeroconf import USE_IP_OF_OUTGOING_INTERFACE
 from zeroconf import Zeroconf
 
-from kolibri.core.auth.models import Facility
-from kolibri.core.content.models import ChannelMetadata
+import kolibri
 
 logger = logging.getLogger(__name__)
 
@@ -106,13 +105,17 @@ class KolibriZeroconfListener(object):
         info = zeroconf.get_service_info(type, name)
         id = _id_from_name(name)
         ip = socket.inet_ntoa(info.address)
+
         self.instances[id] = {
             "id": id,
             "ip": ip,
             "local": ip in get_all_addresses(),
             "port": info.port,
             "host": info.server.strip("."),
-            "data": {key: json.loads(val) for (key, val) in info.properties.items()},
+            "data": {
+                bytes.decode(key): json.loads(val)
+                for (key, val) in info.properties.items()
+            },
             "base_url": "http://{ip}:{port}/".format(ip=ip, port=info.port),
         }
         logger.info(
@@ -150,12 +153,7 @@ def register_zeroconf_service(port, id):
     if ZEROCONF_STATE["service"] is not None:
         unregister_zeroconf_service()
     logger.info("Registering ourselves to zeroconf network with id '%s'..." % id)
-    data = {
-        "facilities": list(Facility.objects.values("id", "dataset_id", "name")),
-        "channels": list(
-            ChannelMetadata.objects.filter(root__available=True).values("id", "name")
-        ),
-    }
+    data = {"version": kolibri.VERSION}
     ZEROCONF_STATE["service"] = KolibriZeroconfService(id=id, port=port, data=data)
     ZEROCONF_STATE["service"].register()
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -68,7 +68,7 @@
       </div>
     </template>
 
-    <template>
+    <template v-if="false">
       {{ $tr('searchingText') }}
     </template>
 


### PR DESCRIPTION
### Summary
This change fixes #6080. 

Zeroconf limits the amount of data that can be sent between peers.  The prototype peer discovery implementation used zeroconf to communicate information about available channels and facilities, but for Kolibri instances with long channel names, this caused Kolibri to crash on startup.

Going forward, zeroconf will only be used for discovery.  Right now, the only device info it sends is the version info.  Once peer instances of Kolibri discover each other they'll talk directly with the API (coming soon!)

### Reviewer guidance
Try starting Kolibri.  If it starts, we should be okay.

If you want to be really thorough, you can go and try starting an instance of Kolibri that has a channel with a very long name.  But I don't think this is necessary.  You can see in the code that zeroconf is no longer being passed channels or facilities.

### References
#6080 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
