### PR TITLE
further updates to grid layout of channel filters

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -1,32 +1,30 @@
 <template>
 
   <div :class="{'fclc-sm': !windowIsLarge}">
+    <slot name="header"></slot>
     <KGrid class="top-panel">
-      <KGridItem :layout12="{span: 4}">
-        <slot name="header"></slot>
+      <template v-if="channels.length > 0">
+        <KGridItem :layout12="{span: 4}">
+          <KSelect
+            v-model="languageFilter"
+            class="filter-lang"
+            :options="languageFilterOptions"
+            :label="$tr('languageFilterLabel')"
+            :inline="true"
+          />
+        </KGridItem>
+        <KGridItem :layout12="{span: 5}" class="filter-title">
+          <FilterTextbox
+            v-model="titleFilter"
+            :placeholder="$tr('titleFilterPlaceholder')"
+            :throttleInput="500"
+          />
+        </KGridItem>
+      </template>
+      <KGridItem :layout12="{span: 3}">
         <p class="count-msg" data-test="available">
           {{ channelsCountMsg }}
         </p>
-      </KGridItem>
-      <KGridItem v-if="channels.length > 0" :layout12="{span: 8}" class="filters">
-        <KGrid>
-          <KGridItem :layout12="{span: 6}">
-            <KSelect
-              v-model="languageFilter"
-              class="filter-lang"
-              :options="languageFilterOptions"
-              :label="$tr('languageFilterLabel')"
-              :inline="true"
-            />
-          </KGridItem>
-          <KGridItem :layout12="{span: 6}" class="filter-title">
-            <FilterTextbox
-              v-model="titleFilter"
-              :placeholder="$tr('titleFilterPlaceholder')"
-              :throttleInput="500"
-            />
-          </KGridItem>
-        </KGrid>
       </KGridItem>
     </KGrid>
 
@@ -202,16 +200,10 @@
     }
   }
 
-  .filters {
-    margin: auto;
-
-    .fclc-sm & {
-      margin-left: 0;
-    }
-  }
-
   .filter-lang {
+    width: 100%;
     min-width: 240px;
+    max-width: 300px;
   }
 
   .filter-title {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -1,7 +1,11 @@
 <template>
 
   <div :class="{'fclc-sm': !windowIsLarge}">
+
     <slot name="header"></slot>
+
+    <slot name="abovechannels"></slot>
+
     <KGrid class="top-panel">
       <template v-if="channels.length > 0">
         <KGridItem :layout12="{span: 4}">
@@ -27,8 +31,6 @@
         </p>
       </KGridItem>
     </KGrid>
-
-    <slot name="abovechannels"></slot>
 
     <template v-if="selectAllCheckbox">
       <KCheckbox


### PR DESCRIPTION
### Summary

* removed extra layer of nesting in grid code
* made title full-width of screen
* moved toggle link closer to header
* moved filters closer to thing being filtered

Motivations:

* more space for page title
* move toggle navigation next to page title so that the two pair together: "This is the current page; here you can toggle to other page"
* move filters closer to table of items being filtered
* the count shown is the number of channels _after_ filtering, not before

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/69159752-6ac76700-0ab6-11ea-8b29-2143665bb51b.png) | ![image](https://user-images.githubusercontent.com/2367265/69159603-2b991600-0ab6-11ea-91ac-1f9e7459c929.png)|
| ![image](https://user-images.githubusercontent.com/2367265/69160247-428c3800-0ab7-11ea-9230-cd826fab6bb2.png) | ![image](https://user-images.githubusercontent.com/2367265/69160367-72d3d680-0ab7-11ea-82b3-0799cad0ae4b.png)|




### Reviewer guidance

make sense?



### References

follow-up from:

* https://github.com/learningequality/kolibri/pull/6088
* https://github.com/learningequality/kolibri/issues/6022
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
