### PR TITLE
Ensure apt-get update is not cached by Docker

### DIFF
--- a/docker/build_debian.dockerfile
+++ b/docker/build_debian.dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
 
 RUN adduser --system --shell /bin/bash --home "/kolibribuild" kolibribuild && \
     cd /kolibribuild && \
+    apt-get update && \
     su kolibribuild -c "apt-get -y source kolibri"
 
 # Build an unsigned package


### PR DESCRIPTION
### Summary
When running Docker inside buildkite we are executing
`apt-get update` and `apt-get -y source` in different `RUN` lines
A line with only apt-get update will get cached by the build and won't actually run every time you need to run `apt-get source` so new builds are not using the latest changes in the Debian packaging.


### Reviewer guidance
After running buildkite the new deb package is using the latest Debian package sources.


### Contributor Checklist


PR process:

- [x ] PR has the correct target branch and milestone
- [x ] PR has 'needs review' or 'work-in-progress' label
- [x ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
