### PR TITLE
Importability files fix

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -397,7 +397,15 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(pk="211523265f53825b82f70ba19218a02e").update(
             file_size=336974
         )
-        files_to_transfer_mock.return_value = (LocalFile.objects.all(), 10)
+        files_to_transfer_mock.return_value = (
+            LocalFile.objects.filter(
+                pk__in=[
+                    "6bdfea4a01830fdd4a585181c0b8068c",
+                    "211523265f53825b82f70ba19218a02e",
+                ]
+            ),
+            10,
+        )
         call_command(
             "importcontent",
             "network",
@@ -536,7 +544,15 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(pk="211523265f53825b82f70ba19218a02e").update(
             file_size=336974
         )
-        files_to_transfer_mock.return_value = (LocalFile.objects.all(), 10)
+        files_to_transfer_mock.return_value = (
+            LocalFile.objects.filter(
+                pk__in=[
+                    "6bdfea4a01830fdd4a585181c0b8068c",
+                    "211523265f53825b82f70ba19218a02e",
+                ]
+            ),
+            10,
+        )
         call_command(
             "importcontent",
             "network",
@@ -628,7 +644,12 @@ class ImportContentTestCase(TestCase):
             files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
         ).update(file_size=1)
         path_mock.side_effect = [local_dest_path, local_src_path]
-        files_to_transfer_mock.return_value = (LocalFile.objects.all(), 10)
+        files_to_transfer_mock.return_value = (
+            LocalFile.objects.filter(
+                files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
+            ),
+            10,
+        )
         call_command(
             "importcontent",
             "disk",

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -91,8 +91,8 @@ def get_files_to_transfer(
         channel_id,
         node_ids,
         exclude_node_ids,
-        renderable_only,
         available,
+        renderable_only=renderable_only,
         drive_id=drive_id,
         peer_id=peer_id,
     )

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -20,9 +20,13 @@ class CrossProcessCache(object):
     def get(self, key, default=None, version=None):
         if key in caches["default"] or cache_options["CACHE_BACKEND"] == "redis":
             return caches["default"].get(key, default=default, version=version)
-        item = caches["process_cache"].get(key, default=None, version=None)
-        caches["default"].set(key, item, timeout=self.default_timeout, version=version)
-        return item
+        if key in caches["process_cache"]:
+            item = caches["process_cache"].get(key, default=None, version=None)
+            caches["default"].set(
+                key, item, timeout=self.default_timeout, version=version
+            )
+            return item
+        return default
 
     def set(self, key, value, timeout=None, version=None):
         caches["default"].set(


### PR DESCRIPTION
### Summary
* During #6049 a bug was introduced that caused all files to be filtered if renderable_only was set to True.
* Fixes the error and adds a regression test.

### Reviewer guidance
Does importing work now?

### References
Fixes #6096 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
