### PR TITLE
no logging in exit handlers

### DIFF
--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -159,7 +159,6 @@ def register_zeroconf_service(port, id):
 
 
 def unregister_zeroconf_service():
-    logger.info("Unregistering ourselves from zeroconf network...")
     if ZEROCONF_STATE["service"] is not None:
         ZEROCONF_STATE["service"].cleanup()
     ZEROCONF_STATE["service"] = None

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -75,10 +75,10 @@ class NotRunning(Exception):
 
 
 def _cleanup_before_quitting(signum, frame, worker=None):
+    # the IO stack is not thread safe:
+    # make sure not to do any logging in here!
     from kolibri.core.discovery.utils.network.search import unregister_zeroconf_service
     from kolibri.core.tasks.main import scheduler
-
-    logger.info("Cleaning up background services before exiting")
 
     if worker is not None:
         worker.shutdown()


### PR DESCRIPTION
### Summary
According to [this source](https://bugs.python.org/issue24283), it's not safe to do IO stuff in exit signal handlers.

So that means no logging is allowed in `kolibri.utils.server._cleanup_before_quitting` or any of the functions it calls!  (From what I can tell, if it tells other processes/threads to stop and they do some logging, that should be okay...)

Previously we were getting some gnarly looking errors on _ctrl-c_ shutdown.

**FIXES**: https://github.com/learningequality/kolibri/issues/6059

### Reviewer guidance
Start the Kolibri dev server.  Do _ctrl-c_.  Make sure there are no scary looking errors.  Make sure no kolibri processes are running with `ps -A | grep kolibri`.

Do it again, but wait for a while, until webpack is done, before doing _ctrl-c_.

Try it as many times as you'd like.

### References
- https://github.com/learningequality/kolibri/issues/6059
- https://bugs.python.org/issue24283

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
