### PR TITLE
Extend Job API to allow for progress tracking/cancellable tasks to be defined outside of management commands

### DIFF
--- a/kolibri/core/tasks/test/test_job_running.py
+++ b/kolibri/core/tasks/test/test_job_running.py
@@ -11,6 +11,7 @@ from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.queue import Queue
 from kolibri.core.tasks.storage import Storage
+from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.tasks.utils import import_stringified_func
 from kolibri.core.tasks.utils import stringify_func
 from kolibri.core.tasks.worker import Worker
@@ -55,7 +56,7 @@ def enqueued_job(inmem_queue, simplejob):
     return inmem_queue.storage.get_job(job_id)
 
 
-def cancelable_job(check_for_cancel=None):
+def cancelable_job():
     """
     Test function for checking if a job is cancelable. Meant to be used in a job cancel
     test case.
@@ -66,10 +67,10 @@ def cancelable_job(check_for_cancel=None):
     Calling this function makes the thread check if a cancellation has been requested, and then exits early if true.
     :return: None
     """
-
+    job = get_current_job()
     for _ in range(10):
         time.sleep(0.5)
-        if check_for_cancel():
+        if job.check_for_cancel():
             return
 
 
@@ -147,9 +148,10 @@ def set_flag(threading_flag):
     threading_flag.set()
 
 
-def make_job_updates(flag, update_progress):
+def make_job_updates(flag):
+    job = get_current_job()
     for i in range(3):
-        update_progress(i, 2)
+        job.update_progress(i, 2)
     set_flag(flag)
 
 
@@ -157,7 +159,7 @@ def failing_func():
     raise Exception("Test function failing_func has failed as it's supposed to.")
 
 
-def update_progress_cancelable_job(update_progress, check_for_cancel=None):
+def update_progress_cancelable_job():
     """
     Test function for checking if a job is cancelable when it updates progress.
     Meant to be used in a job cancel with progress update test case.
@@ -169,11 +171,11 @@ def update_progress_cancelable_job(update_progress, check_for_cancel=None):
     Calling this function makes the thread check if a cancellation has been requested, and then exits early if true.
     :return: None
     """
-
+    job = get_current_job()
     for i in range(10):
         time.sleep(0.5)
-        update_progress(i, 9)
-        if check_for_cancel():
+        job.update_progress(i, 9)
+        if job.check_for_cancel():
             return
 
 


### PR DESCRIPTION
### Summary
* Adds progress tracking and cancellation methods to the job instead of passing as extra kwargs to the task function.
* Updates the base async management command to use the job for its logging and reporting.

### Reviewer guidance
Do async tasks still report their progress and are cancellable?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
