### PR TITLE
Postgresql database import speedup

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,50 @@
+name: Postgres Versions Tests
+
+on:
+  schedule:
+    - cron: '0 18 * * 1'
+
+jobs:
+  postgres:
+    name: Python postgres unit tests
+    runs-on: ubuntu-18.04
+    strategy:
+      max-parallel: 5
+      matrix:
+        postgres-version: [9, 10, 11, 12, 13]
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:${{ matrix.postgres-version }}
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6 for Postgres
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: tox env cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/.tox/py3.6
+        key: ${{ runner.os }}-tox-py3.6-${{ hashFiles('requirements/*.txt') }}
+    - name: Test with tox
+      run: tox -e postgres

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -53,7 +53,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:12
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres
@@ -70,11 +70,11 @@ jobs:
           - 5432:5432
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5 for Postgres
+    - name: Set up Python 3.6 for Postgres
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
@@ -84,8 +84,8 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v2
       with:
-        path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
-        key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
+        path: ${{ github.workspace }}/.tox/py3.6
+        key: ${{ runner.os }}-tox-py3.6-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e postgres

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -462,6 +462,16 @@ class NaiveImportTestCase(ContentNodeTestBase, ContentImportTestBase):
         with self.assertRaises(ContentNode.DoesNotExist):
             assert ContentNode.objects.get(pk=obj_id)
 
+    def test_prerequisites_not_duplicated(self):
+        prereqs = ContentNode.has_prerequisite.through.objects.all().count()
+        channel = ChannelMetadata.objects.first()
+        # Decrement current channel version to ensure reimport
+        channel.version -= 1
+        channel.save()
+        self.set_content_fixture()
+        new_prereqs = ContentNode.has_prerequisite.through.objects.all().count()
+        self.assertEqual(prereqs, new_prereqs)
+
     def test_existing_localfiles_are_not_overwritten(self):
 
         with patch(

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -33,6 +33,7 @@ from kolibri.core.content.utils.annotation import (
     set_leaf_node_availability_from_local_file_availability,
 )
 from kolibri.core.content.utils.annotation import update_content_metadata
+from kolibri.core.content.utils.channel_import import BATCH_SIZE
 from kolibri.core.content.utils.channel_import import ChannelImport
 from kolibri.core.content.utils.channel_import import import_channel_from_local_db
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
@@ -211,19 +212,6 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
     Testcase for the base channel import class table import method
     """
 
-    def test_no_models_unflushed_rows_passed_through(
-        self, apps_mock, tree_id_mock, BridgeMock
-    ):
-        channel_import = ChannelImport("test")
-        record_mock = MagicMock(spec=["__table__"])
-        channel_import.destination.get_class.return_value = record_mock
-        self.assertEqual(
-            0,
-            channel_import.table_import(
-                MagicMock(), lambda x, y: None, lambda x: [], 0
-            ),
-        )
-
     def test_no_merge_records_bulk_insert_no_flush(
         self, apps_mock, tree_id_mock, BridgeMock
     ):
@@ -232,9 +220,9 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock.__table__.columns.items.return_value = [("test_attr", MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
         channel_import.table_import(
-            MagicMock(), lambda x, y: "test_val", lambda x: [{}] * 100, 0
+            MagicMock(), lambda x, y: "test_val", lambda x: [{}] * (BATCH_SIZE // 10)
         )
-        channel_import.destination.session.flush.assert_not_called()
+        channel_import.destination.execute.assert_called_once()
 
     def test_no_merge_records_bulk_insert_flush(
         self, apps_mock, tree_id_mock, BridgeMock
@@ -244,43 +232,9 @@ class BaseChannelImportClassTableImportTestCase(TestCase):
         record_mock.__table__.columns.items.return_value = [("test_attr", MagicMock())]
         channel_import.destination.get_class.return_value = record_mock
         channel_import.table_import(
-            MagicMock(), lambda x, y: "test_val", lambda x: [{}] * 10000, 0
+            MagicMock(), lambda x, y: "test_val", lambda x: [{}] * (BATCH_SIZE + 1)
         )
-        channel_import.destination.session.flush.assert_called_once_with()
-
-    @patch("kolibri.core.content.utils.channel_import.merge_models", new=[])
-    def test_merge_records_merge_no_flush(self, apps_mock, tree_id_mock, BridgeMock):
-        from kolibri.core.content.utils.channel_import import merge_models
-
-        channel_import = ChannelImport("test")
-        record_mock = MagicMock(spec=["__table__"])
-        record_mock.__table__.columns.items.return_value = [("test_attr", MagicMock())]
-        channel_import.destination.get_class.return_value = record_mock
-        model_mock = MagicMock()
-        model_mock._meta.pk.name = "test_attr"
-        merge_models.append(model_mock)
-        channel_import.merge_record = Mock()
-        channel_import.table_import(
-            model_mock, lambda x, y: "test_val", lambda x: [{}] * 100, 0
-        )
-        channel_import.destination.session.flush.assert_not_called()
-
-    @patch("kolibri.core.content.utils.channel_import.merge_models", new=[])
-    def test_merge_records_merge_flush(self, apps_mock, tree_id_mock, BridgeMock):
-        from kolibri.core.content.utils.channel_import import merge_models
-
-        channel_import = ChannelImport("test")
-        record_mock = Mock(spec=["__table__"])
-        record_mock.__table__.columns.items.return_value = [("test_attr", MagicMock())]
-        channel_import.destination.get_class.return_value = record_mock
-        model_mock = Mock()
-        model_mock._meta.pk.name = "test_attr"
-        merge_models.append(model_mock)
-        channel_import.merge_record = Mock()
-        channel_import.table_import(
-            model_mock, lambda x, y: "test_val", lambda x: [{}] * 10000, 0
-        )
-        channel_import.destination.session.flush.assert_called_once_with()
+        self.assertEqual(channel_import.destination.execute.call_count, 2)
 
 
 @patch("kolibri.core.content.utils.channel_import.Bridge")
@@ -311,7 +265,6 @@ class BaseChannelImportClassOtherMethodsTestCase(TestCase):
             )
             channel_import.table_import.assert_called_once()
             channel_import.check_and_delete_existing_channel.assert_called_once()
-            channel_import.destination.session.commit.assert_called_once_with()
 
     def test_end(self, apps_mock, tree_id_mock, BridgeMock):
         channel_import = ChannelImport("test")
@@ -325,18 +278,8 @@ class BaseChannelImportClassOtherMethodsTestCase(TestCase):
         channel_import.get_all_destination_tree_ids()
         channel_import.destination.assert_has_calls(
             [
-                call.session.query(class_mock.tree_id),
-                call.session.query().distinct(),
-                call.session.query().distinct().all(),
+                call.execute().fetchall(),
             ]
-        )
-
-    def test_base_table_mapper(self, apps_mock, tree_id_mock, BridgeMock):
-        channel_import = ChannelImport("test")
-        class_mock = Mock()
-        [record for record in channel_import.base_table_mapper(class_mock)]
-        channel_import.destination.assert_has_calls(
-            [call.session.query(class_mock), call.session.query().all()]
         )
 
 
@@ -431,6 +374,7 @@ class ContentImportTestBase(TransactionTestCase):
 
             import_channel_from_local_db("6199dde695db4ee4ab392222d5af1e5c")
             update_content_metadata("6199dde695db4ee4ab392222d5af1e5c")
+        self.content_engine.dispose()
 
     def get_engine(self, connection_string):
         if connection_string == get_default_db_string():

--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -24,6 +24,7 @@ from kolibri.core.content.utils.channels import get_channel_ids_for_content_dirs
 from kolibri.core.content.utils.paths import get_all_content_dir_paths
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.content.utils.sqlalchemybridge import Bridge
+from kolibri.core.content.utils.tree import get_channel_node_depth
 from kolibri.core.upgrade import version_upgrade
 
 
@@ -133,8 +134,6 @@ def update_num_coach_contents():
     """
     bridge = Bridge(app_name=KolibriContentConfig.label)
 
-    ContentNodeClass = bridge.get_class(ContentNode)
-
     ContentNodeTable = bridge.get_table(ContentNode)
 
     connection = bridge.get_connection()
@@ -177,11 +176,7 @@ def update_num_coach_contents():
 
     for channel_id in ChannelMetadata.objects.all().values_list("id", flat=True):
 
-        node_depth = (
-            bridge.session.query(func.max(ContentNodeClass.level))
-            .filter_by(channel_id=channel_id)
-            .scalar()
-        )
+        node_depth = get_channel_node_depth(bridge, channel_id)
 
         # Go from the deepest level to the shallowest
         for level in range(node_depth, 0, -1):
@@ -217,8 +212,6 @@ def update_on_device_resources():
     those that were imported before annotations were performed
     """
     bridge = Bridge(app_name=KolibriContentConfig.label)
-
-    ContentNodeClass = bridge.get_class(ContentNode)
 
     ContentNodeTable = bridge.get_table(ContentNode)
 
@@ -262,11 +255,7 @@ def update_on_device_resources():
 
     for channel_id in ChannelMetadata.objects.all().values_list("id", flat=True):
 
-        node_depth = (
-            bridge.session.query(func.max(ContentNodeClass.level))
-            .filter_by(channel_id=channel_id)
-            .scalar()
-        )
+        node_depth = get_channel_node_depth(bridge, channel_id)
 
         # Go from the deepest level to the shallowest
         for level in range(node_depth, 0, -1):

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -28,6 +28,7 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.sqlalchemybridge import filter_by_checksums
+from kolibri.core.content.utils.tree import get_channel_node_depth
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.utils.lock import db_lock
 
@@ -506,17 +507,11 @@ def set_local_file_availability_from_disk(checksums=None, destination=None):
 def recurse_annotation_up_tree(channel_id):
     bridge = Bridge(app_name=CONTENT_APP_NAME)
 
-    ContentNodeClass = bridge.get_class(ContentNode)
-
     ContentNodeTable = bridge.get_table(ContentNode)
 
     connection = bridge.get_connection()
 
-    node_depth = (
-        bridge.session.query(func.max(ContentNodeClass.level))
-        .filter_by(channel_id=channel_id)
-        .scalar()
-    )
+    node_depth = get_channel_node_depth(bridge, channel_id)
 
     logger.info(
         "Annotating ContentNode objects with children for {levels} levels".format(

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -6,6 +6,7 @@ import time
 from django.apps import apps
 from django.db.models.fields.related import ForeignKey
 from sqlalchemy import or_
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import select
@@ -120,6 +121,9 @@ class StringIteratorIO(io.TextIOBase):
         return "".join(buff)
 
 
+BATCH_SIZE = 1000
+
+
 class ChannelImport(object):
     """
     The ChannelImport class has two functions:
@@ -210,13 +214,13 @@ class ChannelImport(object):
         return None
 
     def get_all_destination_tree_ids(self):
-        ContentNodeRecord = self.destination.get_class(ContentNode)
+        ContentNodeTable = self.destination.get_table(ContentNode)
         return sorted(
             map(
                 lambda x: x[0],
-                self.destination.session.query(ContentNodeRecord.tree_id)
-                .distinct()
-                .all(),
+                self.destination.execute(
+                    select([ContentNodeTable.c.tree_id]).distinct()
+                ).fetchall(),
             )
         )
 
@@ -294,10 +298,10 @@ class ChannelImport(object):
         # Return the mapper function for repeated use
         return mapper
 
-    def base_table_mapper(self, SourceRecord):
-        # If SourceRecord is none, then the source table does not exist in the DB
-        if SourceRecord:
-            return self.source.session.query(SourceRecord).all()
+    def base_table_mapper(self, SourceTable):
+        # If SourceTable is none, then the source table does not exist in the DB
+        if SourceTable is not None:
+            return self.source.execute(select([SourceTable])).fetchall()
         return []
 
     def base_row_mapper(self, record, column):
@@ -315,12 +319,24 @@ class ChannelImport(object):
         # If we got here, there is an invalid table mapping
         raise AttributeError("Table mapping specified but no valid method found")
 
-    def raw_attached_sqlite_table_import(self, model, table_mapper, unflushed_rows):
+    def get_dest_columns(self, DestinationTable):
+        # Filter out columns that are auto-incrementing integer primary keys, as these can cause collisions in the
+        # database. As all of our content database models use UUID primary keys, the only tables using these
+        # primary keys are intermediary tables for ManyToMany fields, and so nothing should be Foreign Keying
+        # to these ids.
+        # By filtering them here, the database should autoset an incremented id.
+        return [
+            (column_name, column_obj)
+            for column_name, column_obj in DestinationTable.columns.items()
+            if column_not_auto_integer_pk(column_obj)
+        ]
+
+    def raw_attached_sqlite_table_import(self, model, table_mapper):
 
         self.check_cancelled()
 
         source_table = self.source.get_table(model)
-        dest_table = self.destination.get_table(model)
+        DestinationTable = self.destination.get_table(model)
 
         # check the schema map and set up any fields to map to constant values
         field_constants = {}
@@ -342,18 +358,9 @@ class ChannelImport(object):
                         )
                     )
 
-        # make sure to ignore any auto-incrementing fields so they're regenerated in the destination table
-        fields_to_ignore = set(
-            [
-                colname
-                for colname, colobj in dest_table.columns.items()
-                if not column_not_auto_integer_pk(colobj)
-            ]
-        )
-
         # enumerate the columns we're going to be writing into, excluding any we're meant to ignore
         dest_columns = [
-            col.name for col in dest_table.c if col.name not in fields_to_ignore
+            col.name for col_name, col in self.get_dest_columns(DestinationTable)
         ]
 
         # build a list of values (constants or source table column references) to be inserted
@@ -380,16 +387,13 @@ class ChannelImport(object):
         # build and execute a raw SQL query to transfer the data in one fell swoop
         query = """{method} INTO {table} ({destcols}) SELECT {sourcevals} FROM sourcedb.{table} AS source""".format(
             method=method,
-            table=dest_table.name,
+            table=DestinationTable.name,
             destcols=", ".join(dest_columns),
             sourcevals=", ".join(source_vals),
         )
-        self.destination.session.execute(text(query))
+        self.destination.execute(text(query))
 
-        # no need to flush/commit as a result of the transfer in this method
-        return 1
-
-    def get_and_set_postgres_column_default(self, column_obj):
+    def get_and_set_column_default(self, column_obj):
         if hasattr(column_obj, "k_memoized_default"):
             default = getattr(column_obj, "k_memoized_default")
         else:
@@ -402,25 +406,16 @@ class ChannelImport(object):
             setattr(column_obj, "k_memoized_default", default)
         return default
 
-    def postgres_table_import(self, model, row_mapper, table_mapper, unflushed_rows):
-        dest_table = self.destination.get_table(model)
+    def postgres_table_import(self, model, row_mapper, table_mapper):
+        DestinationTable = self.destination.get_table(model)
 
         # If the source table does not exist (i.e. this table is undefined in the source database)
         # this will raise an error - as we do not allow custom table mappings for this optimized
         # postgres import, this should never happen.
         source_table = self.source.get_table(model)
 
-        # Filter out columns that are auto-incrementing integer primary keys, as these can cause collisions in the
-        # database. As all of our content database models use UUID primary keys, the only tables using these
-        # primary keys are intermediary tables for ManyToMany fields, and so nothing should be Foreign Keying
-        # to these ids.
-        # By filtering them here, the database should autoset an incremented id.
-        columns = [
-            column_obj
-            for column_name, column_obj in dest_table.columns.items()
-            if column_not_auto_integer_pk(column_obj)
-        ]
-        column_names = [column.name for column in columns]
+        columns = self.get_dest_columns(DestinationTable)
+        column_names = [column.name for col_name, column in columns]
         merge = model in merge_models
         do_not_overwrite = model in models_not_to_overwrite
         self.check_cancelled()
@@ -428,13 +423,11 @@ class ChannelImport(object):
         raw_connection = self.destination.get_raw_connection()
         cursor = raw_connection.cursor()
 
-        results = (
-            self.source.get_connection().execute(select([source_table])).fetchall()
-        )
+        results = self.source.execute(select([source_table])).fetchall()
 
         def generate_data_with_default(record):
             for column_obj in columns:
-                default = self.get_and_set_postgres_column_default(column_obj)
+                default = self.get_and_set_column_default(column_obj)
                 value = row_mapper(record, column_obj.name)
                 yield value if value is not None else default
 
@@ -453,9 +446,10 @@ class ChannelImport(object):
                     for record in results
                 )
             )
+
             cursor.copy_from(
                 data_string_iterator,
-                dest_table.name,
+                DestinationTable.name,
                 sep=separator,
                 columns=column_names,
             )
@@ -463,115 +457,111 @@ class ChannelImport(object):
             # Import here so that we don't need to depend on psycopg2 for Kolibri in general.
             from psycopg2.extras import execute_values
 
-            pk_name = dest_table.primary_key.columns.values()[0].name
-            if do_not_overwrite:
+            pk_name = DestinationTable.primary_key.columns.values()[0].name
 
-                execute_values(
-                    cursor,
-                    "INSERT INTO {table} ({column_names}) VALUES %s ON CONFLICT ({pk_name}) DO NOTHING;".format(
-                        table=dest_table.name,
-                        column_names=", ".join(column_names),
-                        pk_name=pk_name,
-                    ),
-                    (
-                        tuple(datum for datum in generate_data_with_default(record))
-                        for record in results
-                    ),
-                    template="(" + "%s, " * (len(columns) - 1) + "%s)",
-                )
-            else:
-
-                def generate_data(record):
-                    for column_obj in columns:
-                        value = row_mapper(record, column_obj.name)
-                        yield value
-
-                execute_values(
-                    cursor,
-                    # We want to overwrite new values that we are inserting here, so we use an ON CONFLICT DO UPDATE here
-                    # for the resulting SET statement, we generate a statement for each column we are trying to update
-                    "INSERT INTO {table} AS SOURCE ({column_names}) VALUES %s ON CONFLICT ({pk_name}) DO UPDATE SET {set_statement};".format(
-                        table=dest_table.name,
-                        column_names=", ".join(column_names),
-                        pk_name=pk_name,
-                        set_statement=", ".join(
+            for i in range(0, len(results), BATCH_SIZE):
+                results_slice = results[i : i + BATCH_SIZE]
+                insert_statement = insert(DestinationTable)
+                if do_not_overwrite:
+                    self.destination.execute(
+                        insert_statement.values(
                             [
-                                # Here we generate a value assignment for the set statement for
-                                # each column, except for the primary key column, which we leave alone.
-                                # We set the column value to COALESCE (take the first non-null value)
-                                # from either the value we tried to set (EXCLUDED) or the original value
-                                # (SOURCE) - this should have the effect of replacing columns for which
-                                # we have a value to insert, but ignoring columns that we do not.
-                                "{column} = COALESCE(EXCLUDED.{column}, SOURCE.{column})".format(
-                                    column=column_name
+                                tuple(
+                                    datum
+                                    for datum in generate_data_with_default(record)
                                 )
-                                for column_name in column_names
-                                if column_name != pk_name
+                                for record in results_slice
                             ]
-                        ),
-                    ),
-                    (
-                        tuple(datum for datum in generate_data(record))
-                        for record in results
-                    ),
-                    template="(" + "%s, " * (len(columns) - 1) + "%s)",
-                )
-        cursor.close()
-        return unflushed_rows
+                        ).on_conflict_do_nothing(
+                            constraint=DestinationTable.primary_key
+                        )
+                    )
+                else:
 
-    def orm_table_import(self, model, row_mapper, table_mapper, unflushed_rows):
-        DestinationRecord = self.destination.get_class(model)
-        dest_table = self.destination.get_table(model)
+                    def generate_data(record):
+                        for column_obj in columns:
+                            value = row_mapper(record, column_obj.name)
+                            yield value
+
+                    execute_values(
+                        cursor,
+                        # We want to overwrite new values that we are inserting here, so we use an ON CONFLICT DO UPDATE here
+                        # for the resulting SET statement, we generate a statement for each column we are trying to update
+                        "INSERT INTO {table} AS SOURCE ({column_names}) VALUES %s ON CONFLICT ({pk_name}) DO UPDATE SET {set_statement};".format(
+                            table=DestinationTable.name,
+                            column_names=", ".join(column_names),
+                            pk_name=pk_name,
+                            set_statement=", ".join(
+                                [
+                                    # Here we generate a value assignment for the set statement for
+                                    # each column, except for the primary key column, which we leave alone.
+                                    # We set the column value to COALESCE (take the first non-null value)
+                                    # from either the value we tried to set (EXCLUDED) or the original value
+                                    # (SOURCE) - this should have the effect of replacing columns for which
+                                    # we have a value to insert, but ignoring columns that we do not.
+                                    "{column} = COALESCE(EXCLUDED.{column}, SOURCE.{column})".format(
+                                        column=column_name
+                                    )
+                                    for column_name in column_names
+                                    if column_name != pk_name
+                                ]
+                            ),
+                        ),
+                        (
+                            tuple(datum for datum in generate_data(record))
+                            for record in results_slice
+                        ),
+                        template="(" + "%s, " * (len(columns) - 1) + "%s)",
+                    )
+        cursor.close()
+
+    def core_insert_data(
+        self, data_to_insert, DestinationTable, merge, do_not_overwrite
+    ):
+        if merge:
+            data_to_insert = self.merge_records(
+                data_to_insert, DestinationTable, do_not_overwrite
+            )
+        if data_to_insert:
+            self.destination.execute(insert(DestinationTable), data_to_insert)
+
+    def core_table_import(self, model, row_mapper, table_mapper):
+        DestinationTable = self.destination.get_table(model)
 
         # If the source class does not exist (i.e. this table is undefined in the source database)
         # this will raise an error so we set it to None. In this case, a custom table mapper must
         # have been set up to handle the fact that this is None.
         try:
-            SourceRecord = self.source.get_class(model)
+            SourceTable = self.source.get_table(model)
         except ClassNotFoundError:
-            SourceRecord = None
+            SourceTable = None
 
-        # Filter out columns that are auto-incrementing integer primary keys, as these can cause collisions in the
-        # database. As all of our content database models use UUID primary keys, the only tables using these
-        # primary keys are intermediary tables for ManyToMany fields, and so nothing should be Foreign Keying
-        # to these ids.
-        # By filtering them here, the database should autoset an incremented id.
-        columns = [
-            column_name
-            for column_name, column_obj in dest_table.columns.items()
-            if column_not_auto_integer_pk(column_obj)
-        ]
+        columns = self.get_dest_columns(DestinationTable)
         merge = model in merge_models
         do_not_overwrite = model in models_not_to_overwrite
         data_to_insert = []
-        for record in table_mapper(SourceRecord):
+        unflushed_rows = 0
+        for record in table_mapper(SourceTable):
             self.check_cancelled()
-            data = {
-                str(column): row_mapper(record, column)
-                for column in columns
-                if row_mapper(record, column) is not None
-            }
-            if merge:
-                self.merge_record(
-                    data, model, DestinationRecord, do_not_overwrite=do_not_overwrite
-                )
-            else:
-                data_to_insert.append(data)
+            data = {}
+            for column_name, column in columns:
+                value = row_mapper(record, column_name)
+                if value is None and not merge:
+                    value = self.get_and_set_column_default(column)
+                data[column_name] = value
+            data_to_insert.append(data)
             unflushed_rows += 1
-            if unflushed_rows == 10000:
-                if not merge:
-                    self.destination.session.bulk_insert_mappings(
-                        DestinationRecord, data_to_insert
-                    )
-                    data_to_insert = []
-                self.destination.session.flush()
+            if unflushed_rows == BATCH_SIZE:
+                self.core_insert_data(
+                    data_to_insert, DestinationTable, merge, do_not_overwrite
+                )
+                data_to_insert = []
                 unflushed_rows = 0
 
-        if not merge and data_to_insert:
-            self.destination.session.bulk_insert_mappings(
-                DestinationRecord, data_to_insert
+        if data_to_insert:
+            self.core_insert_data(
+                data_to_insert, DestinationTable, merge, do_not_overwrite
             )
-        return unflushed_rows
 
     def is_simple_import(self):
         # Is a simple import in the case that we are
@@ -602,79 +592,100 @@ class ChannelImport(object):
         can_use_attach = can_use_attach and self._sqlite_db_attached
         # Check that the table is in the source database (otherwise we can't use the ATTACH method)
         try:
-            self.source.get_class(model)
+            self.source.get_table(model)
         except ClassNotFoundError:
             return False
 
         return can_use_attach
 
-    def table_import(self, model, row_mapper, table_mapper, unflushed_rows):
+    def table_import(self, model, row_mapper, table_mapper):
 
         # keep track of which model is currently being imported
         self.current_model_being_imported = model
 
         if self.can_use_sqlite_attach_method(model, table_mapper):
-            result = self.raw_attached_sqlite_table_import(
-                model, table_mapper, unflushed_rows
-            )
+            result = self.raw_attached_sqlite_table_import(model, table_mapper)
         elif self.destination.engine.name == "postgresql" and self.is_simple_import():
-            result = self.postgres_table_import(
-                model, row_mapper, table_mapper, unflushed_rows
-            )
+            result = self.postgres_table_import(model, row_mapper, table_mapper)
         else:
-            result = self.orm_table_import(
-                model, row_mapper, table_mapper, unflushed_rows
-            )
+            result = self.core_table_import(model, row_mapper, table_mapper)
 
         self.current_model_being_imported = None
 
         return result
 
-    def merge_record(self, data, model, DestinationRecord, do_not_overwrite=False):
+    def merge_records(self, data, DestinationTable, do_not_overwrite=False):
         # Models that should be merged (see list above) need to be individually merged into the session
         # as SQL Alchemy ORM does not support INSERT ... ON DUPLICATE KEY UPDATE style queries,
         # as not available in SQLite, only MySQL as far as I can tell:
         # http://hackthology.com/how-to-compile-mysqls-on-duplicate-key-update-in-sql-alchemy.html
-        RowEntry = self.destination.session.query(DestinationRecord).get(
-            data[model._meta.pk.name]
-        )
-        if RowEntry:
-            # record already exists, so if we don't want to overwrite, abort here
-            if do_not_overwrite:
-                return
-            for key, value in data.items():
-                setattr(RowEntry, key, value)
+        pk_column = DestinationTable.primary_key.columns.values()[0]
+        columns = self.get_dest_columns(DestinationTable)
+        existing_values = {
+            v[pk_column.name]: v
+            for v in self.destination.execute(
+                select([DestinationTable]).where(
+                    pk_column.in_(d[pk_column.name] for d in data)
+                )
+            ).fetchall()
+        }
+        data_to_return = []
+        if do_not_overwrite:
+            for d in data:
+                if d[pk_column.name] not in existing_values:
+                    for column_name, column in columns:
+                        value = d.get(column_name)
+                        if value is None:
+                            value = self.get_and_set_column_default(column)
+                        d[column_name] = value
+                    data_to_return.append(d)
         else:
-            RowEntry = DestinationRecord(**data)
-        self.destination.session.merge(RowEntry)
+            for d in data:
+                pk = d[pk_column.name]
+                if pk in existing_values:
+                    value = dict(existing_values[pk])
+                    value.update(d)
+                else:
+                    value = d
+                for column_name, column in columns:
+                    if column_name not in value or value[column_name] is None:
+                        value[column_name] = self.get_and_set_column_default(column)
+                data_to_return.append(value)
+        return data_to_return
 
     def check_and_delete_existing_channel(self):
-        ChannelMetadataClass = self.destination.get_class(ChannelMetadata)
-        existing_channel = self.destination.session.query(ChannelMetadataClass).get(
-            self.channel_id
-        )
+        ChannelMetadataTable = self.destination.get_table(ChannelMetadata)
+        existing_channel = self.destination.execute(
+            select([ChannelMetadataTable]).where(
+                ChannelMetadataTable.c.id == self.channel_id
+            )
+        ).fetchone()
 
         if existing_channel:
 
-            if existing_channel.version < self.channel_version:
+            if existing_channel["version"] < self.channel_version:
                 # We have an older version of this channel, so let's clean out the old stuff first
                 logger.info(
                     (
                         "Older version {channel_version} of channel {channel_id} already exists in database; removing old entries "
                         + "so we can upgrade to version {new_channel_version}"
                     ).format(
-                        channel_version=existing_channel.version,
+                        channel_version=existing_channel["version"],
                         channel_id=self.channel_id,
                         new_channel_version=self.channel_version,
                     )
                 )
 
-                root_node = self.destination.session.query(
-                    self.destination.get_class(ContentNode)
-                ).get(existing_channel.root_id)
+                ContentNodeTable = self.destination.get_table(ContentNode)
+
+                root_node = self.destination.execute(
+                    select([ContentNodeTable]).where(
+                        ContentNodeTable.c.id == existing_channel["root_id"]
+                    )
+                ).fetchone()
 
                 if root_node:
-                    self.delete_old_channel_data(root_node.tree_id)
+                    self.delete_old_channel_data(root_node["tree_id"])
             else:
                 # We have previously loaded this channel, with the same or newer version, so our work here is done
                 logger.warn(
@@ -682,7 +693,7 @@ class ChannelImport(object):
                         "Version {channel_version} of channel {channel_id} already exists in database; cancelling import of "
                         + "version {new_channel_version}"
                     ).format(
-                        channel_version=existing_channel.version,
+                        channel_version=existing_channel["version"],
                         channel_id=self.channel_id,
                         new_channel_version=self.channel_version,
                     )
@@ -751,7 +762,7 @@ class ChannelImport(object):
             self.check_cancelled()
 
             # execute the actual query
-            self.destination.session.execute(query)
+            self.destination.execute(query)
 
     def check_cancelled(self):
         if callable(self.cancel_check):
@@ -765,7 +776,7 @@ class ChannelImport(object):
         # attach the external content database to our primary database so we can directly transfer records en masse
         if self.destination.engine.name == "sqlite":
             try:
-                self.destination.session.execute(
+                self.destination.execute(
                     text(
                         "ATTACH '{path}' AS 'sourcedb'".format(path=self.source_db_path)
                     )
@@ -779,7 +790,7 @@ class ChannelImport(object):
         # detach the content database from the primary database so we don't get errors trying to attach it again later
         if self.destination.engine.name == "sqlite":
             try:
-                self.destination.session.execute(text("DETACH 'sourcedb'"))
+                self.destination.execute(text("DETACH 'sourcedb'"))
             except OperationalError:
                 # silently ignore if the database was already detached, as then we're good to go
                 pass
@@ -790,30 +801,25 @@ class ChannelImport(object):
         logger.debug("Beginning channel metadata import")
         start = time.time()
 
-        unflushed_rows = 0
         import_ran = False
 
         try:
             self.try_attaching_sqlite_database()
+            transaction = self.destination.connection.begin()
             if self.check_and_delete_existing_channel():
                 for model in self.content_models:
                     mapping = self.schema_mapping.get(model, {})
                     row_mapper = self.generate_row_mapper(mapping.get("per_row"))
                     table_mapper = self.generate_table_mapper(mapping.get("per_table"))
                     logger.info("Importing {model} data".format(model=model.__name__))
-                    unflushed_rows = self.table_import(
-                        model, row_mapper, table_mapper, unflushed_rows
-                    )
+                    self.table_import(model, row_mapper, table_mapper)
                 import_ran = True
-            self.destination.session.commit()
-            if self.destination.engine.name == "postgresql":
-                self.destination.get_raw_connection().commit()
+
+            transaction.commit()
             self.try_detaching_sqlite_database()
         except (SQLAlchemyError, ImportCancelError) as e:
             # Rollback the transaction if any error occurs during the transaction
-            self.destination.session.rollback()
-            if self.destination.engine.name == "postgresql":
-                self.destination.get_raw_connection().rollback()
+            transaction.rollback()
             self.try_detaching_sqlite_database()
             logger.debug(
                 "Channel metadata import did not complete after {} seconds".format(
@@ -895,11 +901,11 @@ class NoVersionChannelImport(ChannelImport):
     def infer_channel_id_from_source(self, source_object):
         return self.channel_id
 
-    def generate_local_file_from_file(self, SourceRecord):
-        SourceRecord = self.source.get_class(File)
+    def generate_local_file_from_file(self, SourceTable):
+        SourceTable = self.source.get_table(File)
         checksum_record = set()
         # LocalFile objects are unique per checksum
-        for record in self.source.session.query(SourceRecord).all():
+        for record in self.source.execute(select([SourceTable])).fetchall():
             if record.checksum not in checksum_record:
                 checksum_record.add(record.checksum)
                 yield record
@@ -909,24 +915,26 @@ class NoVersionChannelImport(ChannelImport):
     def set_version_to_no_version(self, source_object):
         return NO_VERSION
 
-    def get_license(self, SourceRecord):
-        license_id = SourceRecord.license_id
+    def get_license(self, SourceTable):
+        license_id = SourceTable.license_id
         if not license_id:
             return None
         if license_id not in self.licenses:
-            LicenseRecord = self.source.get_class(License)
-            license = self.source.session.query(LicenseRecord).get(license_id)
+            LicenseTable = self.source.get_table(License)
+            license = self.source.execute(
+                select([LicenseTable]).where(LicenseTable.c.id == license_id)
+            ).fetchone()
             self.licenses[license_id] = license
         return self.licenses[license_id]
 
-    def get_license_name(self, SourceRecord):
-        license = self.get_license(SourceRecord)
+    def get_license_name(self, SourceTable):
+        license = self.get_license(SourceTable)
         if not license:
             return None
         return license.license_name
 
-    def get_license_description(self, SourceRecord):
-        license = self.get_license(SourceRecord)
+    def get_license_description(self, SourceTable):
+        license = self.get_license(SourceTable)
         if not license:
             return None
         return license.license_description
@@ -962,10 +970,9 @@ def initialize_import_manager(
         source or get_content_database_file_path(channel_id)
     )
     # For old versions of content databases, we can only infer the schema version
-    min_version = getattr(
-        channel_metadata,
+    min_version = channel_metadata.get(
         "min_schema_version",
-        getattr(channel_metadata, "inferred_schema_version"),
+        channel_metadata.get("inferred_schema_version"),
     )
 
     try:
@@ -995,7 +1002,7 @@ def initialize_import_manager(
 
     return ImportClass(
         channel_id,
-        channel_version=channel_metadata.version,
+        channel_version=channel_metadata["version"],
         cancel_check=cancel_check,
         source=source,
         destination=destination,

--- a/kolibri/core/content/utils/check_schema_db.py
+++ b/kolibri/core/content/utils/check_schema_db.py
@@ -9,7 +9,7 @@ class DBSchemaError(Exception):
     pass
 
 
-def db_matches_schema(Base, session):
+def db_matches_schema(Base, engine):
     """
     Check whether the current database matches the models declared in model base.
     Currently we check that all tables exist with all columns.
@@ -18,7 +18,6 @@ def db_matches_schema(Base, session):
     :return: True if all declared models have corresponding tables and columns.
     """
 
-    engine = session.get_bind()
     iengine = inspect(engine)
 
     tables = iengine.get_table_names()

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -25,6 +25,7 @@ from kolibri.core.content.utils.sqlalchemybridge import Bridge
 from kolibri.core.content.utils.sqlalchemybridge import coerce_key
 from kolibri.core.content.utils.sqlalchemybridge import filter_by_checksums
 from kolibri.core.content.utils.sqlalchemybridge import filter_by_uuids
+from kolibri.core.content.utils.tree import get_channel_node_depth
 from kolibri.core.utils.cache import process_cache
 
 logger = logging.getLogger(__name__)
@@ -80,13 +81,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):  # noqa
         .values(available=exists(contentnode_statement))
     )
 
-    ContentNodeClass = bridge.get_class(ContentNode)
-
-    node_depth = (
-        bridge.session.query(func.max(ContentNodeClass.level))
-        .filter_by(channel_id=channel_id)
-        .scalar()
-    )
+    node_depth = get_channel_node_depth(bridge, channel_id)
 
     child = ContentNodeTable.alias()
 

--- a/kolibri/core/content/utils/tree.py
+++ b/kolibri/core/content/utils/tree.py
@@ -1,0 +1,20 @@
+from sqlalchemy import func
+from sqlalchemy import select
+
+from kolibri.core.content.models import ContentNode
+
+
+def get_channel_node_depth(bridge, channel_id):
+
+    ContentNodeTable = bridge.get_table(ContentNode)
+
+    node_depth_query = select([func.max(ContentNodeTable.c.level)]).where(
+        ContentNodeTable.c.channel_id == channel_id
+    )
+
+    node_depth = bridge.execute(node_depth_query).fetchone()
+
+    if node_depth is not None:
+        return node_depth[0]
+
+    return 0

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ setenv =
     KOLIBRI_DATABASE_PORT = 5432
     KOLIBRI_RUN_MODE = tox
 basepython =
-    postgres: python3.5
+    postgres: python3.6
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
### Summary
* Speed up channel database import into Postgresql.
* Uses `COPY FROM` in postgres to do quicker importing, while converting the imported SQLite database to a streamed CSV for import
* Produces a roughly 20x speedup over the current import
* Fixes issues in channel metadata deletion
* Updates all Channel metadata import logic to use SQLAlchemy Core, rather than the ORM for more finegrained control over queries

### Reviewer guidance
Would be good to test this in a production environment.

### References
Fixes #5673 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
