### PR TITLE
Set all task file size and resource size task metadata on the backend.

### DIFF
--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -36,8 +36,6 @@ export default new Resource({
    * @param {string} [params.baseurl] - URL of remote source (defaults to Kolibri Studio)
    * @param {Array<string>} [params.node_ids] -
    * @param {Array<string>} [params.exclude_node_ids] -
-   * @param {Number} [params.file_size] - Total file size for the transfer
-   * @param {Number} [params.total_resources] - Total resource count for the transfer
    * @returns {Promise}
    *
    */
@@ -64,8 +62,6 @@ export default new Resource({
    * @param {string} params.drive_id -
    * @param {Array<string>} [params.node_ids] -
    * @param {Array<string>} [params.exclude_node_ids] -
-   * @param {Number} [file_size] - Total file size for the transfer
-   * @param {Number} [resource_count] - Total resource count for the transfer
    * @returns {Promise}
    *
    */

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -179,7 +179,7 @@ class ImportChannelTestCase(TestCase):
 
 
 @patch(
-    "kolibri.core.content.management.commands.importcontent.import_export_content.get_files_to_transfer",
+    "kolibri.core.content.management.commands.importcontent.calculate_files_to_transfer",
 )
 @patch("kolibri.core.content.management.commands.importcontent.annotation")
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
@@ -267,7 +267,7 @@ class ImportContentTestCase(TestCase):
         annotation_mock.recurse_annotation_up_tree.assert_not_called()
 
     @patch(
-        "kolibri.core.content.management.commands.importcontent.import_export_content.compare_checksums",
+        "kolibri.core.content.management.commands.importcontent.compare_checksums",
         return_value=True,
     )
     @patch(

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -50,18 +50,10 @@ def validate_content_task(request, task_description, require_channel=False):
     try:
         channel = ChannelMetadata.objects.get(id=channel_id)
         channel_name = channel.name
-        file_size = channel.published_size
-        total_resources = channel.total_resource_count
     except ChannelMetadata.DoesNotExist:
         if require_channel:
             raise serializers.ValidationError("This channel does not exist")
         channel_name = ""
-        file_size = None
-        total_resources = None
-
-    file_size = task_description.get("file_size", file_size)
-
-    total_resources = task_description.get("total_resources", total_resources)
 
     node_ids = task_description.get("node_ids", None)
     exclude_node_ids = task_description.get("exclude_node_ids", None)
@@ -75,8 +67,6 @@ def validate_content_task(request, task_description, require_channel=False):
     return {
         "channel_id": channel_id,
         "channel_name": channel_name,
-        "file_size": file_size,
-        "total_resources": total_resources,
         "exclude_node_ids": exclude_node_ids,
         "node_ids": node_ids,
         "started_by": request.user.pk,

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/api.js
@@ -1,14 +1,12 @@
 import { TaskResource } from 'kolibri.resources';
 
 export function startImportTask(params) {
-  const { importSource, channelId, included, excluded, fileSize, totalResources } = params;
+  const { importSource, channelId, included, excluded } = params;
 
   const taskParams = {
     channel_id: channelId,
     node_ids: included,
     exclude_node_ids: excluded,
-    file_size: fileSize,
-    total_resources: totalResources,
   };
 
   if (importSource.type === 'peer' || importSource.type === 'studio') {


### PR DESCRIPTION
### Summary
* Sets all task file size and resource size metadata on the backend
* Sets completed totals for file size and resource size after task completion for content import

### Reviewer guidance
My main concern is that duplication may throw off the totals here for the resource counts, and it could look like not everything has imported when it actually has.

Result from a cancelled task:
![Screenshot from 2019-11-23 18-43-59](https://user-images.githubusercontent.com/1680573/69488697-dea0a100-0e21-11ea-89da-a8ed60286e86.png)

### References
FIxes #6100
Refs #6098

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
