### PR TITLE
content -> resource (develop branch)

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -152,7 +152,7 @@ class ContentNodeFilter(IdFilter):
     resume = CharFilter(method="filter_resume")
     kind = ChoiceFilter(
         method="filter_kind",
-        choices=(content_kinds.choices + (("content", _("Content")),)),
+        choices=(content_kinds.choices + (("content", _("Resource")),)),
     )
     user_kind = ChoiceFilter(method="filter_user_kind", choices=user_kinds.choices)
     in_lesson = CharFilter(method="filter_in_lesson")

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -319,8 +319,8 @@
     $trs: {
       channelUpToDate: 'Channel up-to-date',
       pageLoadError: 'There was a problem loading this page…',
-      problemFetchingChannel: 'There was a problem getting the contents of this channel',
-      problemTransferringContents: 'There was a problem transferring the selected contents',
+      problemFetchingChannel: 'There was a problem getting the list of resources from this channel',
+      problemTransferringContents: 'There was a problem transferring the selected resources',
       selectContent: "Select resources from '{channelName}'",
       kolibriStudioLabel: 'Kolibri Studio',
       importingFromDrive: `Importing from drive '{driveName}'`,

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -38,7 +38,7 @@
       header: 'No resources available',
       adminLink: 'As an administrator you can import channels',
       learnerText: 'Please ask your coach or administrator for assistance',
-      documentTitle: 'Content Unavailable',
+      documentTitle: 'Resource unavailable',
     },
   };
 


### PR DESCRIPTION

### Summary

follow-up from note in https://crowdin.com/translate/kolibri/3312/en-bn#229030

### Reviewer guidance

previously we changed all instances of 'content' to 'resource' but missed this one in the python source

### References

b2a9621ecf0d43ff4a6e89be5343c7a0079091be

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
