### PR TITLE
Add two strings previously forgotten

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -186,6 +186,8 @@
         context:
           'A label for a checkbox that allows the Coach to assign the quiz to individual learners who may not be in a selected group.',
       },
+      /* TODO Remove this disabling of the rule when the component is put into use */
+      /* eslint-disable kolibri/vue-no-unused-translations */
       numHiddenLearnersLabel: {
         message:
           '{ numLearners, number } { numLearners, plural, one {learner} other {learners} } hidden',

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -186,6 +186,17 @@
         context:
           'A label for a checkbox that allows the Coach to assign the quiz to individual learners who may not be in a selected group.',
       },
+      numHiddenLearnersLabel: {
+        message:
+          '{ numLearners, number } { numLearners, plural, one {learner} other {learners} } hidden',
+        context:
+          'A label indicating the number of learners who are hidden due to being part of a group that is already selected.',
+      },
+      hiddenGroupsTooltipLabel: {
+        message: 'Not showing learners selected from',
+        context:
+          'A label in a tooltip that explains which groups of learners are not being displayed in the table used to select individual learners.',
+      },
       searchPlaceholder: 'Search for a user…',
       noUsersMatch: 'No users match',
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I forgot to add these strings in the PR I made previously that added this component with strings.

This PR does nothing but add strings.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See that the strings are added...

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
