### PR TITLE
import into default db only when upgrading

### DIFF
--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -24,7 +24,7 @@ COPY_METHOD = "copy"
 
 def import_channel_by_id(channel_id, cancel_check):
     try:
-        channel_import.import_channel_from_local_db(
+        return channel_import.import_channel_from_local_db(
             channel_id, cancel_check=cancel_check
         )
     except channel_import.InvalidSchemaVersionError:
@@ -174,8 +174,10 @@ class Command(AsyncCommand):
                                 .exclude(kind=content_kinds.TOPIC)
                                 .values_list("id", flat=True)
                             )
-                            import_channel_by_id(channel_id, self.is_cancelled)
-                            if node_ids:
+                            import_ran = import_channel_by_id(
+                                channel_id, self.is_cancelled
+                            )
+                            if node_ids and import_ran:
                                 # annotate default channel db based on previously annotated leaf nodes
                                 update_content_metadata(channel_id, node_ids=node_ids)
                         except channel_import.ImportCancelError:

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -3,6 +3,7 @@ import os
 from time import sleep
 
 from django.core.management.base import CommandError
+from le_utils.constants import content_kinds
 
 from ...utils import channel_import
 from ...utils import paths
@@ -169,7 +170,9 @@ class Command(AsyncCommand):
                             node_ids = list(
                                 ContentNode.objects.filter(
                                     channel_id=channel_id, available=True
-                                ).values_list("id", flat=True)
+                                )
+                                .exclude(kind=content_kinds.TOPIC)
+                                .values_list("id", flat=True)
                             )
                             import_channel_by_id(channel_id, self.is_cancelled)
                             if node_ids:

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -32,6 +32,7 @@ from kolibri.core.content.utils.annotation import recurse_annotation_up_tree
 from kolibri.core.content.utils.annotation import (
     set_leaf_node_availability_from_local_file_availability,
 )
+from kolibri.core.content.utils.annotation import update_content_metadata
 from kolibri.core.content.utils.channel_import import ChannelImport
 from kolibri.core.content.utils.channel_import import import_channel_from_local_db
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
@@ -339,11 +340,8 @@ class BaseChannelImportClassOtherMethodsTestCase(TestCase):
 
 
 class MaliciousDatabaseTestCase(TestCase):
-    @patch("kolibri.core.content.utils.channel_import.update_content_metadata")
     @patch("kolibri.core.content.utils.channel_import.initialize_import_manager")
-    def test_non_existent_root_node(
-        self, initialize_manager_mock, update_content_metadata_mock
-    ):
+    def test_non_existent_root_node(self, initialize_manager_mock):
         import_mock = MagicMock()
         initialize_manager_mock.return_value = import_mock
         channel_id = "6199dde695db4ee4ab392222d5af1e5c"
@@ -432,6 +430,7 @@ class ContentImportTestBase(TransactionTestCase):
         ):
 
             import_channel_from_local_db("6199dde695db4ee4ab392222d5af1e5c")
+            update_content_metadata("6199dde695db4ee4ab392222d5af1e5c")
 
     def get_engine(self, connection_string):
         if connection_string == get_default_db_string():

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -6,7 +6,6 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import text
 
-from .annotation import update_content_metadata
 from .channels import read_channel_metadata_from_db_file
 from .paths import get_content_database_file_path
 from .sqlalchemybridge import Bridge
@@ -799,8 +798,6 @@ def import_channel_from_local_db(channel_id, cancel_check=None):
     import_manager.import_channel_data()
 
     import_manager.end()
-
-    update_content_metadata(channel_id)
 
     channel = ChannelMetadata.objects.get(id=channel_id)
     channel.last_updated = local_now()

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -35,12 +35,16 @@ def diff_stats(channel_id, method, drive_id=None, baseurl=None):
     try:
         if method == "network":
             call_command(
-                "importchannel", "network", channel_id, baseurl=baseurl, upgrade=True,
+                "importchannel",
+                "network",
+                channel_id,
+                baseurl=baseurl,
+                no_upgrade=True,
             )
         elif method == "disk":
             drive = get_mounted_drive_by_id(drive_id)
             call_command(
-                "importchannel", "disk", channel_id, drive, upgrade=True,
+                "importchannel", "disk", channel_id, drive, no_upgrade=True,
             )
 
         # create all fields/tables at the annotated destination db, based on the current schema version

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -595,6 +595,7 @@ class TasksViewSet(viewsets.ViewSet):
             baseurl=baseurl,
             extra_metadata=job_metadata,
             track_progress=False,
+            cancellable=True,
         )
 
         resp = _job_to_response(queue.fetch_job(job_id))


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In the `importchannel` command, we only annotate a channel (upon importing) if there was a previous channel version in the default database. We do this by checking the available `node_ids` for the previous channel. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Follow the steps outlined in the issue below.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Should resolve https://github.com/learningequality/kolibri/issues/6142.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
