### PR TITLE
Use .exclude instead of .difference when removing nodes from query

### DIFF
--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -57,8 +57,8 @@ def get_nodes_to_transfer(
             pk__in=exclude_node_ids
         ).get_descendants(include_self=True)
 
-        nodes_to_include = nodes_to_include.order_by().difference(
-            nodes_to_exclude.order_by()
+        nodes_to_include = nodes_to_include.order_by().exclude(
+            pk__in=nodes_to_exclude.values("pk")
         )
 
     # By default don't filter node ids by their underlying file importability

--- a/kolibri/plugins/device/test/test_api.py
+++ b/kolibri/plugins/device/test/test_api.py
@@ -299,7 +299,7 @@ class CalculateImportExportSizeViewTestCase(APITestCase):
             },
             format="json",
         )
-        self.assertEqual(response.data["resource_count"], 3)
+        self.assertEqual(response.data["resource_count"], 0)
         self.assertEqual(response.data["file_size"], 0)
 
     def test_all_nodes_present_export(self):


### PR DESCRIPTION
### Summary

Changes a query used in `get_nodes_to_transfer` to use `.exclude` instead of `.difference` to fix a downstream problem.

HT @ralphiee22 for the fix

fixes #6148

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
