### PR TITLE
Add defensive key check in learner API

### DIFF
--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -71,6 +71,7 @@ class LearnerClassroomViewset(ValuesViewset):
                     (
                         progress_map[resource["content_id"]]
                         for resource in lesson["resources"]
+                        if resource["content_id"] in progress_map
                     )
                 ),
                 "total_resources": len(lesson["resources"]),


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixes the following error, when accessing assigned classes as a Learner:
```
ERROR    Internal Server Error: /learn/api/learnerclassroom/
Traceback (most recent call last):
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/rest_framework/viewsets.py", line 116, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/bjester/.local/share/virtualenvs/kolibri-J0Tqdocd/lib/python3.6/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/bjester/Projects/learningequality/kolibri/kolibri/core/api.py", line 109, in list
    return Response(self.serialize(queryset))
  File "/home/bjester/Projects/learningequality/kolibri/kolibri/core/api.py", line 99, in serialize
    list(map(self._map_fields, self._serialize_queryset(queryset) or []))
  File "/home/bjester/Projects/learningequality/kolibri/kolibri/plugins/learn/viewsets.py", line 73, in consolidate
    for resource in lesson["resources"]
  File "/home/bjester/Projects/learningequality/kolibri/kolibri/plugins/learn/viewsets.py", line 73, in <genexpr>
    for resource in lesson["resources"]
KeyError: '57cab9422c62524a820d24405da6f432'
ERROR    "GET /learn/api/learnerclassroom/?1574887027929=1574887027929 HTTP/1.1" 500 34889
```

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/pull/6121
Some 500 errors occurred on this page during bug bash: https://www.notion.so/learningequality/7b9a489fdafd49cd9423ac38288a8d7f?v=c6a9849d2e9746449498c8cea24e612a

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
