### PR TITLE
Add extra logic to ensure H5P doesn't initialize before ready [donotmerge]

### DIFF
--- a/kolibri/core/content/static/assets/h5p-standalone-dist/js/finished-loading.js
+++ b/kolibri/core/content/static/assets/h5p-standalone-dist/js/finished-loading.js
@@ -1,0 +1,1 @@
+window.hashiFinishedLoading = true;

--- a/kolibri/core/content/static/assets/h5p-standalone-dist/js/h5p-standalone-frame.min.js
+++ b/kolibri/core/content/static/assets/h5p-standalone-dist/js/h5p-standalone-frame.min.js
@@ -1,1 +1,4030 @@
-var H5P;!function(h,w){var t,n,v=typeof w,g=h.document,e=h.location,r=h.jQuery,i=h.$,o={},d=[],a="1.9.1",y=d.concat,s=d.push,u=d.slice,c=d.indexOf,l=o.toString,m=o.hasOwnProperty,f=a.trim,ve=function(e,t){return new ve.fn.init(e,t,n)},p=/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,C=/\S+/g,b=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,x=/^(?:(<[\w\W]+>)[^>]*|#([\w-]*))$/,P=/^<(\w+)\s*\/?>(?:<\/\1>|)$/,H=/^[\],:{}\s]*$/,T=/(?:^|:|,)(?:\s*\[)+/g,S=/\\(?:["\\\/bfnrt]|u[\da-fA-F]{4})/g,E=/"[^"\\\r\n]*"|true|false|null|-?(?:\d+\.|)\d+(?:[eE][+-]?\d+|)/g,N=/^-ms-/,k=/-([\da-z])/gi,A=function(e,t){return t.toUpperCase()},D=function(e){(g.addEventListener||"load"===e.type||"complete"===g.readyState)&&(I(),ve.ready())},I=function(){g.addEventListener?(g.removeEventListener("DOMContentLoaded",D,!1),h.removeEventListener("load",D,!1)):(g.detachEvent("onreadystatechange",D),h.detachEvent("onload",D))};function j(e){var t=e.length,n=ve.type(e);return!ve.isWindow(e)&&(!(1!==e.nodeType||!t)||("array"===n||"function"!==n&&(0===t||"number"==typeof t&&0<t&&t-1 in e)))}ve.fn=ve.prototype={jquery:a,constructor:ve,init:function(e,t,n){var r,i;if(!e)return this;if("string"==typeof e){if(!(r="<"===e.charAt(0)&&">"===e.charAt(e.length-1)&&3<=e.length?[null,e,null]:x.exec(e))||!r[1]&&t)return!t||t.jquery?(t||n).find(e):this.constructor(t).find(e);if(r[1]){if(t=t instanceof ve?t[0]:t,ve.merge(this,ve.parseHTML(r[1],t&&t.nodeType?t.ownerDocument||t:g,!0)),P.test(r[1])&&ve.isPlainObject(t))for(r in t)ve.isFunction(this[r])?this[r](t[r]):this.attr(r,t[r]);return this}if((i=g.getElementById(r[2]))&&i.parentNode){if(i.id!==r[2])return n.find(e);this.length=1,this[0]=i}return this.context=g,this.selector=e,this}return e.nodeType?(this.context=this[0]=e,this.length=1,this):ve.isFunction(e)?n.ready(e):(e.selector!==w&&(this.selector=e.selector,this.context=e.context),ve.makeArray(e,this))},selector:"",length:0,size:function(){return this.length},toArray:function(){return u.call(this)},get:function(e){return null==e?this.toArray():e<0?this[this.length+e]:this[e]},pushStack:function(e){var t=ve.merge(this.constructor(),e);return t.prevObject=this,t.context=this.context,t},each:function(e,t){return ve.each(this,e,t)},ready:function(e){return ve.ready.promise().done(e),this},slice:function(){return this.pushStack(u.apply(this,arguments))},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},eq:function(e){var t=this.length,n=+e+(e<0?t:0);return this.pushStack(0<=n&&n<t?[this[n]]:[])},map:function(n){return this.pushStack(ve.map(this,function(e,t){return n.call(e,t,e)}))},end:function(){return this.prevObject||this.constructor(null)},push:s,sort:[].sort,splice:[].splice},ve.fn.init.prototype=ve.fn,ve.extend=ve.fn.extend=function(){var e,t,n,r,i,o,a=arguments[0]||{},s=1,c=arguments.length,l=!1;for("boolean"==typeof a&&(l=a,a=arguments[1]||{},s=2),"object"==typeof a||ve.isFunction(a)||(a={}),c===s&&(a=this,--s);s<c;s++)if(null!=(i=arguments[s]))for(r in i)e=a[r],a!==(n=i[r])&&(l&&n&&(ve.isPlainObject(n)||(t=ve.isArray(n)))?(t?(t=!1,o=e&&ve.isArray(e)?e:[]):o=e&&ve.isPlainObject(e)?e:{},a[r]=ve.extend(l,o,n)):n!==w&&(a[r]=n));return a},ve.extend({noConflict:function(e){return h.$===ve&&(h.$=i),e&&h.jQuery===ve&&(h.jQuery=r),ve},isReady:!1,readyWait:1,holdReady:function(e){e?ve.readyWait++:ve.ready(!0)},ready:function(e){if(!0===e?!--ve.readyWait:!ve.isReady){if(!g.body)return setTimeout(ve.ready);(ve.isReady=!0)!==e&&0<--ve.readyWait||(t.resolveWith(g,[ve]),ve.fn.trigger&&ve(g).trigger("ready").off("ready"))}},isFunction:function(e){return"function"===ve.type(e)},isArray:Array.isArray||function(e){return"array"===ve.type(e)},isWindow:function(e){return null!=e&&e==e.window},isNumeric:function(e){return!isNaN(parseFloat(e))&&isFinite(e)},type:function(e){return null==e?String(e):"object"==typeof e||"function"==typeof e?o[l.call(e)]||"object":typeof e},isPlainObject:function(e){if(!e||"object"!==ve.type(e)||e.nodeType||ve.isWindow(e))return!1;try{if(e.constructor&&!m.call(e,"constructor")&&!m.call(e.constructor.prototype,"isPrototypeOf"))return!1}catch(e){return!1}var t;for(t in e);return t===w||m.call(e,t)},isEmptyObject:function(e){var t;for(t in e)return!1;return!0},error:function(e){throw new Error(e)},parseHTML:function(e,t,n){if(!e||"string"!=typeof e)return null;"boolean"==typeof t&&(n=t,t=!1),t=t||g;var r=P.exec(e),i=!n&&[];return r?[t.createElement(r[1])]:(r=ve.buildFragment([e],t,i),i&&ve(i).remove(),ve.merge([],r.childNodes))},parseJSON:function(e){return h.JSON&&h.JSON.parse?h.JSON.parse(e):null===e?e:"string"==typeof e&&(e=ve.trim(e))&&H.test(e.replace(S,"@").replace(E,"]").replace(T,""))?new Function("return "+e)():void ve.error("Invalid JSON: "+e)},parseXML:function(e){var t;if(!e||"string"!=typeof e)return null;try{h.DOMParser?t=(new DOMParser).parseFromString(e,"text/xml"):((t=new ActiveXObject("Microsoft.XMLDOM")).async="false",t.loadXML(e))}catch(e){t=w}return t&&t.documentElement&&!t.getElementsByTagName("parsererror").length||ve.error("Invalid XML: "+e),t},noop:function(){},globalEval:function(e){e&&ve.trim(e)&&(h.execScript||function(e){h.eval.call(h,e)})(e)},camelCase:function(e){return e.replace(N,"ms-").replace(k,A)},nodeName:function(e,t){return e.nodeName&&e.nodeName.toLowerCase()===t.toLowerCase()},each:function(e,t,n){var r=0,i=e.length,o=j(e);if(n){if(o)for(;r<i&&!1!==t.apply(e[r],n);r++);else for(r in e)if(!1===t.apply(e[r],n))break}else if(o)for(;r<i&&!1!==t.call(e[r],r,e[r]);r++);else for(r in e)if(!1===t.call(e[r],r,e[r]))break;return e},trim:f&&!f.call("\ufeff ")?function(e){return null==e?"":f.call(e)}:function(e){return null==e?"":(e+"").replace(b,"")},makeArray:function(e,t){var n=t||[];return null!=e&&(j(Object(e))?ve.merge(n,"string"==typeof e?[e]:e):s.call(n,e)),n},inArray:function(e,t,n){var r;if(t){if(c)return c.call(t,e,n);for(r=t.length,n=n?n<0?Math.max(0,r+n):n:0;n<r;n++)if(n in t&&t[n]===e)return n}return-1},merge:function(e,t){var n=t.length,r=e.length,i=0;if("number"==typeof n)for(;i<n;i++)e[r++]=t[i];else for(;t[i]!==w;)e[r++]=t[i++];return e.length=r,e},grep:function(e,t,n){var r=[],i=0,o=e.length;for(n=!!n;i<o;i++)n!==!!t(e[i],i)&&r.push(e[i]);return r},map:function(e,t,n){var r,i=0,o=e.length,a=[];if(j(e))for(;i<o;i++)null!=(r=t(e[i],i,n))&&(a[a.length]=r);else for(i in e)null!=(r=t(e[i],i,n))&&(a[a.length]=r);return y.apply([],a)},guid:1,proxy:function(e,t){var n,r,i;return"string"==typeof t&&(i=e[t],t=e,e=i),ve.isFunction(e)?(n=u.call(arguments,2),(r=function(){return e.apply(t||this,n.concat(u.call(arguments)))}).guid=e.guid=e.guid||ve.guid++,r):w},access:function(e,t,n,r,i,o,a){var s=0,c=e.length,l=null==n;if("object"===ve.type(n))for(s in i=!0,n)ve.access(e,t,s,n[s],!0,o,a);else if(r!==w&&(i=!0,ve.isFunction(r)||(a=!0),l&&(a?(t.call(e,r),t=null):(l=t,t=function(e,t,n){return l.call(ve(e),n)})),t))for(;s<c;s++)t(e[s],n,a?r:r.call(e[s],s,t(e[s],n)));return i?e:l?t.call(e):c?t(e[0],n):o},now:function(){return(new Date).getTime()}}),ve.ready.promise=function(e){if(!t)if(t=ve.Deferred(),"complete"===g.readyState)setTimeout(ve.ready);else if(g.addEventListener)g.addEventListener("DOMContentLoaded",D,!1),h.addEventListener("load",D,!1);else{g.attachEvent("onreadystatechange",D),h.attachEvent("onload",D);var n=!1;try{n=null==h.frameElement&&g.documentElement}catch(e){}n&&n.doScroll&&function t(){if(!ve.isReady){try{n.doScroll("left")}catch(e){return setTimeout(t,50)}I(),ve.ready()}}()}return t.promise(e)},ve.each("Boolean Number String Function Array Date RegExp Object Error".split(" "),function(e,t){o["[object "+t+"]"]=t.toLowerCase()}),n=ve(g);var L={};ve.Callbacks=function(i){var e,n;i="string"==typeof i?L[i]||(n=L[e=i]={},ve.each(e.match(C)||[],function(e,t){n[t]=!0}),n):ve.extend({},i);var r,t,o,a,s,c,l=[],u=!i.once&&[],d=function(e){for(t=i.memory&&e,o=!0,s=c||0,c=0,a=l.length,r=!0;l&&s<a;s++)if(!1===l[s].apply(e[0],e[1])&&i.stopOnFalse){t=!1;break}r=!1,l&&(u?u.length&&d(u.shift()):t?l=[]:f.disable())},f={add:function(){if(l){var e=l.length;!function r(e){ve.each(e,function(e,t){var n=ve.type(t);"function"===n?i.unique&&f.has(t)||l.push(t):t&&t.length&&"string"!==n&&r(t)})}(arguments),r?a=l.length:t&&(c=e,d(t))}return this},remove:function(){return l&&ve.each(arguments,function(e,t){for(var n;-1<(n=ve.inArray(t,l,n));)l.splice(n,1),r&&(n<=a&&a--,n<=s&&s--)}),this},has:function(e){return e?-1<ve.inArray(e,l):!(!l||!l.length)},empty:function(){return l=[],this},disable:function(){return l=u=t=w,this},disabled:function(){return!l},lock:function(){return u=w,t||f.disable(),this},locked:function(){return!u},fireWith:function(e,t){return t=[e,(t=t||[]).slice?t.slice():t],!l||o&&!u||(r?u.push(t):d(t)),this},fire:function(){return f.fireWith(this,arguments),this},fired:function(){return!!o}};return f},ve.extend({Deferred:function(e){var a=[["resolve","done",ve.Callbacks("once memory"),"resolved"],["reject","fail",ve.Callbacks("once memory"),"rejected"],["notify","progress",ve.Callbacks("memory")]],i="pending",s={state:function(){return i},always:function(){return c.done(arguments).fail(arguments),this},then:function(){var o=arguments;return ve.Deferred(function(i){ve.each(a,function(e,t){var n=t[0],r=ve.isFunction(o[e])&&o[e];c[t[1]](function(){var e=r&&r.apply(this,arguments);e&&ve.isFunction(e.promise)?e.promise().done(i.resolve).fail(i.reject).progress(i.notify):i[n+"With"](this===s?i.promise():this,r?[e]:arguments)})}),o=null}).promise()},promise:function(e){return null!=e?ve.extend(e,s):s}},c={};return s.pipe=s.then,ve.each(a,function(e,t){var n=t[2],r=t[3];s[t[1]]=n.add,r&&n.add(function(){i=r},a[1^e][2].disable,a[2][2].lock),c[t[0]]=function(){return c[t[0]+"With"](this===c?s:this,arguments),this},c[t[0]+"With"]=n.fireWith}),s.promise(c),e&&e.call(c,c),c},when:function(e){var i,t,n,r=0,o=u.call(arguments),a=o.length,s=1!==a||e&&ve.isFunction(e.promise)?a:0,c=1===s?e:ve.Deferred(),l=function(t,n,r){return function(e){n[t]=this,r[t]=1<arguments.length?u.call(arguments):e,r===i?c.notifyWith(n,r):--s||c.resolveWith(n,r)}};if(1<a)for(i=new Array(a),t=new Array(a),n=new Array(a);r<a;r++)o[r]&&ve.isFunction(o[r].promise)?o[r].promise().done(l(r,n,o)).fail(c.reject).progress(l(r,t,i)):--s;return s||c.resolveWith(n,o),c.promise()}}),ve.support=function(){var o,e,t,n,r,i,a,s,c,l,u=g.createElement("div");if(u.setAttribute("className","t"),u.innerHTML="  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>",e=u.getElementsByTagName("*"),t=u.getElementsByTagName("a")[0],!e||!t||!e.length)return{};a=(r=g.createElement("select")).appendChild(g.createElement("option")),n=u.getElementsByTagName("input")[0],t.style.cssText="top:1px;float:left;opacity:.5",o={getSetAttribute:"t"!==u.className,leadingWhitespace:3===u.firstChild.nodeType,tbody:!u.getElementsByTagName("tbody").length,htmlSerialize:!!u.getElementsByTagName("link").length,style:/top/.test(t.getAttribute("style")),hrefNormalized:"/a"===t.getAttribute("href"),opacity:/^0.5/.test(t.style.opacity),cssFloat:!!t.style.cssFloat,checkOn:!!n.value,optSelected:a.selected,enctype:!!g.createElement("form").enctype,html5Clone:"<:nav></:nav>"!==g.createElement("nav").cloneNode(!0).outerHTML,boxModel:"CSS1Compat"===g.compatMode,deleteExpando:!0,noCloneEvent:!0,inlineBlockNeedsLayout:!1,shrinkWrapBlocks:!1,reliableMarginRight:!0,boxSizingReliable:!0,pixelPosition:!1},n.checked=!0,o.noCloneChecked=n.cloneNode(!0).checked,r.disabled=!0,o.optDisabled=!a.disabled;try{delete u.test}catch(e){o.deleteExpando=!1}for(l in(n=g.createElement("input")).setAttribute("value",""),o.input=""===n.getAttribute("value"),n.value="t",n.setAttribute("type","radio"),o.radioValue="t"===n.value,n.setAttribute("checked","t"),n.setAttribute("name","t"),(i=g.createDocumentFragment()).appendChild(n),o.appendChecked=n.checked,o.checkClone=i.cloneNode(!0).cloneNode(!0).lastChild.checked,u.attachEvent&&(u.attachEvent("onclick",function(){o.noCloneEvent=!1}),u.cloneNode(!0).click()),{submit:!0,change:!0,focusin:!0})u.setAttribute(s="on"+l,"t"),o[l+"Bubbles"]=s in h||!1===u.attributes[s].expando;return u.style.backgroundClip="content-box",u.cloneNode(!0).style.backgroundClip="",o.clearCloneStyle="content-box"===u.style.backgroundClip,ve(function(){var e,t,n,r="padding:0;margin:0;border:0;display:block;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;",i=g.getElementsByTagName("body")[0];i&&((e=g.createElement("div")).style.cssText="border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px",i.appendChild(e).appendChild(u),u.innerHTML="<table><tr><td></td><td>t</td></tr></table>",(n=u.getElementsByTagName("td"))[0].style.cssText="padding:0;margin:0;border:0;display:none",c=0===n[0].offsetHeight,n[0].style.display="",n[1].style.display="none",o.reliableHiddenOffsets=c&&0===n[0].offsetHeight,u.innerHTML="",u.style.cssText="box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%;",o.boxSizing=4===u.offsetWidth,o.doesNotIncludeMarginInBodyOffset=1!==i.offsetTop,h.getComputedStyle&&(o.pixelPosition="1%"!==(h.getComputedStyle(u,null)||{}).top,o.boxSizingReliable="4px"===(h.getComputedStyle(u,null)||{width:"4px"}).width,(t=u.appendChild(g.createElement("div"))).style.cssText=u.style.cssText=r,t.style.marginRight=t.style.width="0",u.style.width="1px",o.reliableMarginRight=!parseFloat((h.getComputedStyle(t,null)||{}).marginRight)),typeof u.style.zoom!==v&&(u.innerHTML="",u.style.cssText=r+"width:1px;padding:1px;display:inline;zoom:1",o.inlineBlockNeedsLayout=3===u.offsetWidth,u.style.display="block",u.innerHTML="<div></div>",u.firstChild.style.width="5px",o.shrinkWrapBlocks=3!==u.offsetWidth,o.inlineBlockNeedsLayout&&(i.style.zoom=1)),i.removeChild(e),e=u=n=t=null)}),e=r=i=a=t=n=null,o}();var F=/(?:\{[\s\S]*\}|\[[\s\S]*\])$/,M=/([A-Z])/g;function B(e,t,n,r){if(ve.acceptData(e)){var i,o,a=ve.expando,s="string"==typeof t,c=e.nodeType,l=c?ve.cache:e,u=c?e[a]:e[a]&&a;if(u&&l[u]&&(r||l[u].data)||!s||n!==w)return u||(c?e[a]=u=d.pop()||ve.guid++:u=a),l[u]||(l[u]={},c||(l[u].toJSON=ve.noop)),"object"!=typeof t&&"function"!=typeof t||(r?l[u]=ve.extend(l[u],t):l[u].data=ve.extend(l[u].data,t)),i=l[u],r||(i.data||(i.data={}),i=i.data),n!==w&&(i[ve.camelCase(t)]=n),s?null==(o=i[t])&&(o=i[ve.camelCase(t)]):o=i,o}}function O(e,t,n){if(ve.acceptData(e)){var r,i,o,a=e.nodeType,s=a?ve.cache:e,c=a?e[ve.expando]:ve.expando;if(s[c]){if(t&&(o=n?s[c]:s[c].data)){for((r=0,i=(t=ve.isArray(t)?t.concat(ve.map(t,ve.camelCase)):t in o?[t]:(t=ve.camelCase(t))in o?[t]:t.split(" ")).length);r<i;r++)delete o[t[r]];if(!(n?_:ve.isEmptyObject)(o))return}(n||(delete s[c].data,_(s[c])))&&(a?ve.cleanData([e],!0):ve.support.deleteExpando||s!=s.window?delete s[c]:s[c]=null)}}}function q(e,t,n){if(n===w&&1===e.nodeType){var r="data-"+t.replace(M,"-$1").toLowerCase();if("string"==typeof(n=e.getAttribute(r))){try{n="true"===n||"false"!==n&&("null"===n?null:+n+""===n?+n:F.test(n)?ve.parseJSON(n):n)}catch(e){}ve.data(e,t,n)}else n=w}return n}function _(e){var t;for(t in e)if(("data"!==t||!ve.isEmptyObject(e[t]))&&"toJSON"!==t)return!1;return!0}ve.extend({cache:{},expando:"jQuery"+(a+Math.random()).replace(/\D/g,""),noData:{embed:!0,object:"clsid:D27CDB6E-AE6D-11cf-96B8-444553540000",applet:!0},hasData:function(e){return!!(e=e.nodeType?ve.cache[e[ve.expando]]:e[ve.expando])&&!_(e)},data:function(e,t,n){return B(e,t,n)},removeData:function(e,t){return O(e,t)},_data:function(e,t,n){return B(e,t,n,!0)},_removeData:function(e,t){return O(e,t,!0)},acceptData:function(e){if(e.nodeType&&1!==e.nodeType&&9!==e.nodeType)return!1;var t=e.nodeName&&ve.noData[e.nodeName.toLowerCase()];return!t||!0!==t&&e.getAttribute("classid")===t}}),ve.fn.extend({data:function(t,e){var n,r,i=this[0],o=0,a=null;if(t===w){if(this.length&&(a=ve.data(i),1===i.nodeType&&!ve._data(i,"parsedAttrs"))){for(n=i.attributes;o<n.length;o++)(r=n[o].name).indexOf("data-")||(r=ve.camelCase(r.slice(5)),q(i,r,a[r]));ve._data(i,"parsedAttrs",!0)}return a}return"object"==typeof t?this.each(function(){ve.data(this,t)}):ve.access(this,function(e){if(e===w)return i?q(i,t,ve.data(i,t)):null;this.each(function(){ve.data(this,t,e)})},null,e,1<arguments.length,null,!0)},removeData:function(e){return this.each(function(){ve.removeData(this,e)})}}),ve.extend({queue:function(e,t,n){var r;if(e)return t=(t||"fx")+"queue",r=ve._data(e,t),n&&(!r||ve.isArray(n)?r=ve._data(e,t,ve.makeArray(n)):r.push(n)),r||[]},dequeue:function(e,t){t=t||"fx";var n=ve.queue(e,t),r=n.length,i=n.shift(),o=ve._queueHooks(e,t);"inprogress"===i&&(i=n.shift(),r--),(o.cur=i)&&("fx"===t&&n.unshift("inprogress"),delete o.stop,i.call(e,function(){ve.dequeue(e,t)},o)),!r&&o&&o.empty.fire()},_queueHooks:function(e,t){var n=t+"queueHooks";return ve._data(e,n)||ve._data(e,n,{empty:ve.Callbacks("once memory").add(function(){ve._removeData(e,t+"queue"),ve._removeData(e,n)})})}}),ve.fn.extend({queue:function(t,n){var e=2;return"string"!=typeof t&&(n=t,t="fx",e--),arguments.length<e?ve.queue(this[0],t):n===w?this:this.each(function(){var e=ve.queue(this,t,n);ve._queueHooks(this,t),"fx"===t&&"inprogress"!==e[0]&&ve.dequeue(this,t)})},dequeue:function(e){return this.each(function(){ve.dequeue(this,e)})},delay:function(r,e){return r=ve.fx&&ve.fx.speeds[r]||r,e=e||"fx",this.queue(e,function(e,t){var n=setTimeout(e,r);t.stop=function(){clearTimeout(n)}})},clearQueue:function(e){return this.queue(e||"fx",[])},promise:function(e,t){var n,r=1,i=ve.Deferred(),o=this,a=this.length,s=function(){--r||i.resolveWith(o,[o])};for("string"!=typeof e&&(t=e,e=w),e=e||"fx";a--;)(n=ve._data(o[a],e+"queueHooks"))&&n.empty&&(r++,n.empty.add(s));return s(),i.promise(t)}});var $,R,z=/[\t\r\n]/g,X=/\r/g,W=/^(?:input|select|textarea|button|object)$/i,U=/^(?:a|area)$/i,V=/^(?:checked|selected|autofocus|autoplay|async|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped)$/i,Q=/^(?:checked|selected)$/i,Y=ve.support.getSetAttribute,J=ve.support.input;ve.fn.extend({attr:function(e,t){return ve.access(this,ve.attr,e,t,1<arguments.length)},removeAttr:function(e){return this.each(function(){ve.removeAttr(this,e)})},prop:function(e,t){return ve.access(this,ve.prop,e,t,1<arguments.length)},removeProp:function(e){return e=ve.propFix[e]||e,this.each(function(){try{this[e]=w,delete this[e]}catch(e){}})},addClass:function(t){var e,n,r,i,o,a=0,s=this.length,c="string"==typeof t&&t;if(ve.isFunction(t))return this.each(function(e){ve(this).addClass(t.call(this,e,this.className))});if(c)for(e=(t||"").match(C)||[];a<s;a++)if(r=1===(n=this[a]).nodeType&&(n.className?(" "+n.className+" ").replace(z," "):" ")){for(o=0;i=e[o++];)r.indexOf(" "+i+" ")<0&&(r+=i+" ");n.className=ve.trim(r)}return this},removeClass:function(t){var e,n,r,i,o,a=0,s=this.length,c=0===arguments.length||"string"==typeof t&&t;if(ve.isFunction(t))return this.each(function(e){ve(this).removeClass(t.call(this,e,this.className))});if(c)for(e=(t||"").match(C)||[];a<s;a++)if(r=1===(n=this[a]).nodeType&&(n.className?(" "+n.className+" ").replace(z," "):"")){for(o=0;i=e[o++];)for(;0<=r.indexOf(" "+i+" ");)r=r.replace(" "+i+" "," ");n.className=t?ve.trim(r):""}return this},toggleClass:function(o,a){var s=typeof o,c="boolean"==typeof a;return ve.isFunction(o)?this.each(function(e){ve(this).toggleClass(o.call(this,e,this.className,a),a)}):this.each(function(){if("string"===s)for(var e,t=0,n=ve(this),r=a,i=o.match(C)||[];e=i[t++];)n[(r=c?r:!n.hasClass(e))?"addClass":"removeClass"](e);else s!==v&&"boolean"!==s||(this.className&&ve._data(this,"__className__",this.className),this.className=this.className||!1===o?"":ve._data(this,"__className__")||"")})},hasClass:function(e){for(var t=" "+e+" ",n=0,r=this.length;n<r;n++)if(1===this[n].nodeType&&0<=(" "+this[n].className+" ").replace(z," ").indexOf(t))return!0;return!1},val:function(r){var e,i,o,t=this[0];return arguments.length?(o=ve.isFunction(r),this.each(function(e){var t,n=ve(this);1===this.nodeType&&(null==(t=o?r.call(this,e,n.val()):r)?t="":"number"==typeof t?t+="":ve.isArray(t)&&(t=ve.map(t,function(e){return null==e?"":e+""})),(i=ve.valHooks[this.type]||ve.valHooks[this.nodeName.toLowerCase()])&&"set"in i&&i.set(this,t,"value")!==w||(this.value=t))})):t?(i=ve.valHooks[t.type]||ve.valHooks[t.nodeName.toLowerCase()])&&"get"in i&&(e=i.get(t,"value"))!==w?e:"string"==typeof(e=t.value)?e.replace(X,""):null==e?"":e:void 0}}),ve.extend({valHooks:{option:{get:function(e){var t=e.attributes.value;return!t||t.specified?e.value:e.text}},select:{get:function(e){for(var t,n,r=e.options,i=e.selectedIndex,o="select-one"===e.type||i<0,a=o?null:[],s=o?i+1:r.length,c=i<0?s:o?i:0;c<s;c++)if(((n=r[c]).selected||c===i)&&(ve.support.optDisabled?!n.disabled:null===n.getAttribute("disabled"))&&(!n.parentNode.disabled||!ve.nodeName(n.parentNode,"optgroup"))){if(t=ve(n).val(),o)return t;a.push(t)}return a},set:function(e,t){var n=ve.makeArray(t);return ve(e).find("option").each(function(){this.selected=0<=ve.inArray(ve(this).val(),n)}),n.length||(e.selectedIndex=-1),n}}},attr:function(e,t,n){var r,i,o,a=e.nodeType;if(e&&3!==a&&8!==a&&2!==a)return typeof e.getAttribute===v?ve.prop(e,t,n):((i=1!==a||!ve.isXMLDoc(e))&&(t=t.toLowerCase(),r=ve.attrHooks[t]||(V.test(t)?R:$)),n===w?r&&i&&"get"in r&&null!==(o=r.get(e,t))?o:(typeof e.getAttribute!==v&&(o=e.getAttribute(t)),null==o?w:o):null!==n?r&&i&&"set"in r&&(o=r.set(e,n,t))!==w?o:(e.setAttribute(t,n+""),n):void ve.removeAttr(e,t))},removeAttr:function(e,t){var n,r,i=0,o=t&&t.match(C);if(o&&1===e.nodeType)for(;n=o[i++];)r=ve.propFix[n]||n,V.test(n)?!Y&&Q.test(n)?e[ve.camelCase("default-"+n)]=e[r]=!1:e[r]=!1:ve.attr(e,n,""),e.removeAttribute(Y?n:r)},attrHooks:{type:{set:function(e,t){if(!ve.support.radioValue&&"radio"===t&&ve.nodeName(e,"input")){var n=e.value;return e.setAttribute("type",t),n&&(e.value=n),t}}}},propFix:{tabindex:"tabIndex",readonly:"readOnly",for:"htmlFor",class:"className",maxlength:"maxLength",cellspacing:"cellSpacing",cellpadding:"cellPadding",rowspan:"rowSpan",colspan:"colSpan",usemap:"useMap",frameborder:"frameBorder",contenteditable:"contentEditable"},prop:function(e,t,n){var r,i,o=e.nodeType;if(e&&3!==o&&8!==o&&2!==o)return(1!==o||!ve.isXMLDoc(e))&&(t=ve.propFix[t]||t,i=ve.propHooks[t]),n!==w?i&&"set"in i&&(r=i.set(e,n,t))!==w?r:e[t]=n:i&&"get"in i&&null!==(r=i.get(e,t))?r:e[t]},propHooks:{tabIndex:{get:function(e){var t=e.getAttributeNode("tabindex");return t&&t.specified?parseInt(t.value,10):W.test(e.nodeName)||U.test(e.nodeName)&&e.href?0:w}}}}),R={get:function(e,t){var n=ve.prop(e,t),r="boolean"==typeof n&&e.getAttribute(t),i="boolean"==typeof n?J&&Y?null!=r:Q.test(t)?e[ve.camelCase("default-"+t)]:!!r:e.getAttributeNode(t);return i&&!1!==i.value?t.toLowerCase():w},set:function(e,t,n){return!1===t?ve.removeAttr(e,n):J&&Y||!Q.test(n)?e.setAttribute(!Y&&ve.propFix[n]||n,n):e[ve.camelCase("default-"+n)]=e[n]=!0,n}},J&&Y||(ve.attrHooks.value={get:function(e,t){var n=e.getAttributeNode(t);return ve.nodeName(e,"input")?e.defaultValue:n&&n.specified?n.value:w},set:function(e,t,n){if(!ve.nodeName(e,"input"))return $&&$.set(e,t,n);e.defaultValue=t}}),Y||($=ve.valHooks.button={get:function(e,t){var n=e.getAttributeNode(t);return n&&("id"===t||"name"===t||"coords"===t?""!==n.value:n.specified)?n.value:w},set:function(e,t,n){var r=e.getAttributeNode(n);return r||e.setAttributeNode(r=e.ownerDocument.createAttribute(n)),r.value=t+="","value"===n||t===e.getAttribute(n)?t:w}},ve.attrHooks.contenteditable={get:$.get,set:function(e,t,n){$.set(e,""!==t&&t,n)}},ve.each(["width","height"],function(e,n){ve.attrHooks[n]=ve.extend(ve.attrHooks[n],{set:function(e,t){if(""===t)return e.setAttribute(n,"auto"),t}})})),ve.support.hrefNormalized||(ve.each(["href","src","width","height"],function(e,n){ve.attrHooks[n]=ve.extend(ve.attrHooks[n],{get:function(e){var t=e.getAttribute(n,2);return null==t?w:t}})}),ve.each(["href","src"],function(e,t){ve.propHooks[t]={get:function(e){return e.getAttribute(t,4)}}})),ve.support.style||(ve.attrHooks.style={get:function(e){return e.style.cssText||w},set:function(e,t){return e.style.cssText=t+""}}),ve.support.optSelected||(ve.propHooks.selected=ve.extend(ve.propHooks.selected,{get:function(e){var t=e.parentNode;return t&&(t.selectedIndex,t.parentNode&&t.parentNode.selectedIndex),null}})),ve.support.enctype||(ve.propFix.enctype="encoding"),ve.support.checkOn||ve.each(["radio","checkbox"],function(){ve.valHooks[this]={get:function(e){return null===e.getAttribute("value")?"on":e.value}}}),ve.each(["radio","checkbox"],function(){ve.valHooks[this]=ve.extend(ve.valHooks[this],{set:function(e,t){if(ve.isArray(t))return e.checked=0<=ve.inArray(ve(e).val(),t)}})});var G=/^(?:input|select|textarea)$/i,K=/^key/,Z=/^(?:mouse|contextmenu)|click/,ee=/^(?:focusinfocus|focusoutblur)$/,te=/^([^.]*)(?:\.(.+)|)$/;function ne(){return!0}function re(){return!1}ve.event={global:{},add:function(e,t,n,r,i){var o,a,s,c,l,u,d,f,p,h,g,m=ve._data(e);if(m){for(n.handler&&(n=(c=n).handler,i=c.selector),n.guid||(n.guid=ve.guid++),(a=m.events)||(a=m.events={}),(u=m.handle)||((u=m.handle=function(e){return typeof ve===v||e&&ve.event.triggered===e.type?w:ve.event.dispatch.apply(u.elem,arguments)}).elem=e),s=(t=(t||"").match(C)||[""]).length;s--;)p=g=(o=te.exec(t[s])||[])[1],h=(o[2]||"").split(".").sort(),l=ve.event.special[p]||{},p=(i?l.delegateType:l.bindType)||p,l=ve.event.special[p]||{},d=ve.extend({type:p,origType:g,data:r,handler:n,guid:n.guid,selector:i,needsContext:i&&ve.expr.match.needsContext.test(i),namespace:h.join(".")},c),(f=a[p])||((f=a[p]=[]).delegateCount=0,l.setup&&!1!==l.setup.call(e,r,h,u)||(e.addEventListener?e.addEventListener(p,u,!1):e.attachEvent&&e.attachEvent("on"+p,u))),l.add&&(l.add.call(e,d),d.handler.guid||(d.handler.guid=n.guid)),i?f.splice(f.delegateCount++,0,d):f.push(d),ve.event.global[p]=!0;e=null}},remove:function(e,t,n,r,i){var o,a,s,c,l,u,d,f,p,h,g,m=ve.hasData(e)&&ve._data(e);if(m&&(u=m.events)){for(l=(t=(t||"").match(C)||[""]).length;l--;)if(p=g=(s=te.exec(t[l])||[])[1],h=(s[2]||"").split(".").sort(),p){for(d=ve.event.special[p]||{},f=u[p=(r?d.delegateType:d.bindType)||p]||[],s=s[2]&&new RegExp("(^|\\.)"+h.join("\\.(?:.*\\.|)")+"(\\.|$)"),c=o=f.length;o--;)a=f[o],!i&&g!==a.origType||n&&n.guid!==a.guid||s&&!s.test(a.namespace)||r&&r!==a.selector&&("**"!==r||!a.selector)||(f.splice(o,1),a.selector&&f.delegateCount--,d.remove&&d.remove.call(e,a));c&&!f.length&&(d.teardown&&!1!==d.teardown.call(e,h,m.handle)||ve.removeEvent(e,p,m.handle),delete u[p])}else for(p in u)ve.event.remove(e,p+t[l],n,r,!0);ve.isEmptyObject(u)&&(delete m.handle,ve._removeData(e,"events"))}},trigger:function(e,t,n,r){var i,o,a,s,c,l,u,d=[n||g],f=m.call(e,"type")?e.type:e,p=m.call(e,"namespace")?e.namespace.split("."):[];if(a=l=n=n||g,3!==n.nodeType&&8!==n.nodeType&&!ee.test(f+ve.event.triggered)&&(0<=f.indexOf(".")&&(f=(p=f.split(".")).shift(),p.sort()),o=f.indexOf(":")<0&&"on"+f,(e=e[ve.expando]?e:new ve.Event(f,"object"==typeof e&&e)).isTrigger=!0,e.namespace=p.join("."),e.namespace_re=e.namespace?new RegExp("(^|\\.)"+p.join("\\.(?:.*\\.|)")+"(\\.|$)"):null,e.result=w,e.target||(e.target=n),t=null==t?[e]:ve.makeArray(t,[e]),c=ve.event.special[f]||{},r||!c.trigger||!1!==c.trigger.apply(n,t))){if(!r&&!c.noBubble&&!ve.isWindow(n)){for(s=c.delegateType||f,ee.test(s+f)||(a=a.parentNode);a;a=a.parentNode)d.push(a),l=a;l===(n.ownerDocument||g)&&d.push(l.defaultView||l.parentWindow||h)}for(u=0;(a=d[u++])&&!e.isPropagationStopped();)e.type=1<u?s:c.bindType||f,(i=(ve._data(a,"events")||{})[e.type]&&ve._data(a,"handle"))&&i.apply(a,t),(i=o&&a[o])&&ve.acceptData(a)&&i.apply&&!1===i.apply(a,t)&&e.preventDefault();if(e.type=f,!r&&!e.isDefaultPrevented()&&(!c._default||!1===c._default.apply(n.ownerDocument,t))&&("click"!==f||!ve.nodeName(n,"a"))&&ve.acceptData(n)&&o&&n[f]&&!ve.isWindow(n)){(l=n[o])&&(n[o]=null),ve.event.triggered=f;try{n[f]()}catch(e){}ve.event.triggered=w,l&&(n[o]=l)}return e.result}},dispatch:function(e){e=ve.event.fix(e);var t,n,r,i,o,a,s=u.call(arguments),c=(ve._data(this,"events")||{})[e.type]||[],l=ve.event.special[e.type]||{};if((s[0]=e).delegateTarget=this,!l.preDispatch||!1!==l.preDispatch.call(this,e)){for(a=ve.event.handlers.call(this,e,c),t=0;(i=a[t++])&&!e.isPropagationStopped();)for(e.currentTarget=i.elem,o=0;(r=i.handlers[o++])&&!e.isImmediatePropagationStopped();)e.namespace_re&&!e.namespace_re.test(r.namespace)||(e.handleObj=r,e.data=r.data,(n=((ve.event.special[r.origType]||{}).handle||r.handler).apply(i.elem,s))!==w&&!1===(e.result=n)&&(e.preventDefault(),e.stopPropagation()));return l.postDispatch&&l.postDispatch.call(this,e),e.result}},handlers:function(e,t){var n,r,i,o,a=[],s=t.delegateCount,c=e.target;if(s&&c.nodeType&&(!e.button||"click"!==e.type))for(;c!=this;c=c.parentNode||this)if(1===c.nodeType&&(!0!==c.disabled||"click"!==e.type)){for(i=[],o=0;o<s;o++)i[n=(r=t[o]).selector+" "]===w&&(i[n]=r.needsContext?0<=ve(n,this).index(c):ve.find(n,this,null,[c]).length),i[n]&&i.push(r);i.length&&a.push({elem:c,handlers:i})}return s<t.length&&a.push({elem:this,handlers:t.slice(s)}),a},fix:function(e){if(e[ve.expando])return e;var t,n,r,i=e.type,o=e,a=this.fixHooks[i];for(a||(this.fixHooks[i]=a=Z.test(i)?this.mouseHooks:K.test(i)?this.keyHooks:{}),r=a.props?this.props.concat(a.props):this.props,e=new ve.Event(o),t=r.length;t--;)e[n=r[t]]=o[n];return e.target||(e.target=o.srcElement||g),3===e.target.nodeType&&(e.target=e.target.parentNode),e.metaKey=!!e.metaKey,a.filter?a.filter(e,o):e},props:"altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),fixHooks:{},keyHooks:{props:"char charCode key keyCode".split(" "),filter:function(e,t){return null==e.which&&(e.which=null!=t.charCode?t.charCode:t.keyCode),e}},mouseHooks:{props:"button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement".split(" "),filter:function(e,t){var n,r,i,o=t.button,a=t.fromElement;return null==e.pageX&&null!=t.clientX&&(i=(r=e.target.ownerDocument||g).documentElement,n=r.body,e.pageX=t.clientX+(i&&i.scrollLeft||n&&n.scrollLeft||0)-(i&&i.clientLeft||n&&n.clientLeft||0),e.pageY=t.clientY+(i&&i.scrollTop||n&&n.scrollTop||0)-(i&&i.clientTop||n&&n.clientTop||0)),!e.relatedTarget&&a&&(e.relatedTarget=a===e.target?t.toElement:a),e.which||o===w||(e.which=1&o?1:2&o?3:4&o?2:0),e}},special:{load:{noBubble:!0},click:{trigger:function(){if(ve.nodeName(this,"input")&&"checkbox"===this.type&&this.click)return this.click(),!1}},focus:{trigger:function(){if(this!==g.activeElement&&this.focus)try{return this.focus(),!1}catch(e){}},delegateType:"focusin"},blur:{trigger:function(){if(this===g.activeElement&&this.blur)return this.blur(),!1},delegateType:"focusout"},beforeunload:{postDispatch:function(e){e.result!==w&&(e.originalEvent.returnValue=e.result)}}},simulate:function(e,t,n,r){var i=ve.extend(new ve.Event,n,{type:e,isSimulated:!0,originalEvent:{}});r?ve.event.trigger(i,null,t):ve.event.dispatch.call(t,i),i.isDefaultPrevented()&&n.preventDefault()}},ve.removeEvent=g.removeEventListener?function(e,t,n){e.removeEventListener&&e.removeEventListener(t,n,!1)}:function(e,t,n){var r="on"+t;e.detachEvent&&(typeof e[r]===v&&(e[r]=null),e.detachEvent(r,n))},ve.Event=function(e,t){if(!(this instanceof ve.Event))return new ve.Event(e,t);e&&e.type?(this.originalEvent=e,this.type=e.type,this.isDefaultPrevented=e.defaultPrevented||!1===e.returnValue||e.getPreventDefault&&e.getPreventDefault()?ne:re):this.type=e,t&&ve.extend(this,t),this.timeStamp=e&&e.timeStamp||ve.now(),this[ve.expando]=!0},ve.Event.prototype={isDefaultPrevented:re,isPropagationStopped:re,isImmediatePropagationStopped:re,preventDefault:function(){var e=this.originalEvent;this.isDefaultPrevented=ne,e&&(e.preventDefault?e.preventDefault():e.returnValue=!1)},stopPropagation:function(){var e=this.originalEvent;this.isPropagationStopped=ne,e&&(e.stopPropagation&&e.stopPropagation(),e.cancelBubble=!0)},stopImmediatePropagation:function(){this.isImmediatePropagationStopped=ne,this.stopPropagation()}},ve.each({mouseenter:"mouseover",mouseleave:"mouseout"},function(e,i){ve.event.special[e]={delegateType:i,bindType:i,handle:function(e){var t,n=e.relatedTarget,r=e.handleObj;return n&&(n===this||ve.contains(this,n))||(e.type=r.origType,t=r.handler.apply(this,arguments),e.type=i),t}}}),ve.support.submitBubbles||(ve.event.special.submit={setup:function(){if(ve.nodeName(this,"form"))return!1;ve.event.add(this,"click._submit keypress._submit",function(e){var t=e.target,n=ve.nodeName(t,"input")||ve.nodeName(t,"button")?t.form:w;n&&!ve._data(n,"submitBubbles")&&(ve.event.add(n,"submit._submit",function(e){e._submit_bubble=!0}),ve._data(n,"submitBubbles",!0))})},postDispatch:function(e){e._submit_bubble&&(delete e._submit_bubble,this.parentNode&&!e.isTrigger&&ve.event.simulate("submit",this.parentNode,e,!0))},teardown:function(){if(ve.nodeName(this,"form"))return!1;ve.event.remove(this,"._submit")}}),ve.support.changeBubbles||(ve.event.special.change={setup:function(){if(G.test(this.nodeName))return"checkbox"!==this.type&&"radio"!==this.type||(ve.event.add(this,"propertychange._change",function(e){"checked"===e.originalEvent.propertyName&&(this._just_changed=!0)}),ve.event.add(this,"click._change",function(e){this._just_changed&&!e.isTrigger&&(this._just_changed=!1),ve.event.simulate("change",this,e,!0)})),!1;ve.event.add(this,"beforeactivate._change",function(e){var t=e.target;G.test(t.nodeName)&&!ve._data(t,"changeBubbles")&&(ve.event.add(t,"change._change",function(e){!this.parentNode||e.isSimulated||e.isTrigger||ve.event.simulate("change",this.parentNode,e,!0)}),ve._data(t,"changeBubbles",!0))})},handle:function(e){var t=e.target;if(this!==t||e.isSimulated||e.isTrigger||"radio"!==t.type&&"checkbox"!==t.type)return e.handleObj.handler.apply(this,arguments)},teardown:function(){return ve.event.remove(this,"._change"),!G.test(this.nodeName)}}),ve.support.focusinBubbles||ve.each({focus:"focusin",blur:"focusout"},function(e,t){var n=0,r=function(e){ve.event.simulate(t,e.target,ve.event.fix(e),!0)};ve.event.special[t]={setup:function(){0==n++&&g.addEventListener(e,r,!0)},teardown:function(){0==--n&&g.removeEventListener(e,r,!0)}}}),ve.fn.extend({on:function(e,t,n,r,i){var o,a;if("object"==typeof e){for(o in"string"!=typeof t&&(n=n||t,t=w),e)this.on(o,t,n,e[o],i);return this}if(null==n&&null==r?(r=t,n=t=w):null==r&&("string"==typeof t?(r=n,n=w):(r=n,n=t,t=w)),!1===r)r=re;else if(!r)return this;return 1===i&&(a=r,(r=function(e){return ve().off(e),a.apply(this,arguments)}).guid=a.guid||(a.guid=ve.guid++)),this.each(function(){ve.event.add(this,e,r,n,t)})},one:function(e,t,n,r){return this.on(e,t,n,r,1)},off:function(e,t,n){var r,i;if(e&&e.preventDefault&&e.handleObj)return r=e.handleObj,ve(e.delegateTarget).off(r.namespace?r.origType+"."+r.namespace:r.origType,r.selector,r.handler),this;if("object"==typeof e){for(i in e)this.off(i,t,e[i]);return this}return!1!==t&&"function"!=typeof t||(n=t,t=w),!1===n&&(n=re),this.each(function(){ve.event.remove(this,e,n,t)})},bind:function(e,t,n){return this.on(e,null,t,n)},unbind:function(e,t){return this.off(e,null,t)},delegate:function(e,t,n,r){return this.on(t,e,n,r)},undelegate:function(e,t,n){return 1===arguments.length?this.off(e,"**"):this.off(t,e||"**",n)},trigger:function(e,t){return this.each(function(){ve.event.trigger(e,t,this)})},triggerHandler:function(e,t){var n=this[0];if(n)return ve.event.trigger(e,t,n,!0)}}),function(n,e){var t,P,H,o,r,h,l,w,g,C,i,m,v,a,s,y,u,T="sizzle"+-new Date,b=n.document,x={},S=0,d=0,c=te(),f=te(),p=te(),E="undefined",N=1<<31,k=[],A=k.pop,D=k.push,I=k.slice,j=k.indexOf||function(e){for(var t=0,n=this.length;t<n;t++)if(this[t]===e)return t;return-1},L="[\\x20\\t\\r\\n\\f]",F="(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",M=F.replace("w","w#"),B="\\["+L+"*("+F+")"+L+"*(?:([*^$|!~]?=)"+L+"*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|("+M+")|)|)"+L+"*\\]",O=":("+F+")(?:\\(((['\"])((?:\\\\.|[^\\\\])*?)\\3|((?:\\\\.|[^\\\\()[\\]]|"+B.replace(3,8)+")*)|.*)\\)|)",q=new RegExp("^"+L+"+|((?:^|[^\\\\])(?:\\\\.)*)"+L+"+$","g"),_=new RegExp("^"+L+"*,"+L+"*"),$=new RegExp("^"+L+"*([\\x20\\t\\r\\n\\f>+~])"+L+"*"),R=new RegExp(O),z=new RegExp("^"+M+"$"),X={ID:new RegExp("^#("+F+")"),CLASS:new RegExp("^\\.("+F+")"),NAME:new RegExp("^\\[name=['\"]?("+F+")['\"]?\\]"),TAG:new RegExp("^("+F.replace("w","w*")+")"),ATTR:new RegExp("^"+B),PSEUDO:new RegExp("^"+O),CHILD:new RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\("+L+"*(even|odd|(([+-]|)(\\d*)n|)"+L+"*(?:([+-]|)"+L+"*(\\d+)|))"+L+"*\\)|)","i"),needsContext:new RegExp("^"+L+"*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\("+L+"*((?:-\\d)?\\d*)"+L+"*\\)|)(?=[^-]|$)","i")},W=/[\x20\t\r\n\f]*[+~]/,U=/^[^{]+\{\s*\[native code/,V=/^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,Q=/^(?:input|select|textarea|button)$/i,Y=/^h\d$/i,J=/'|\\/g,G=/\=[\x20\t\r\n\f]*([^'"\]]*)[\x20\t\r\n\f]*\]/g,K=/\\([\da-fA-F]{1,6}[\x20\t\r\n\f]?|.)/g,Z=function(e,t){var n="0x"+t-65536;return n!=n?t:n<0?String.fromCharCode(n+65536):String.fromCharCode(n>>10|55296,1023&n|56320)};try{I.call(b.documentElement.childNodes,0)[0].nodeType}catch(e){I=function(e){for(var t,n=[];t=this[e++];)n.push(t);return n}}function ee(e){return U.test(e+"")}function te(){var n,r=[];return n=function(e,t){return r.push(e+=" ")>H.cacheLength&&delete n[r.shift()],n[e]=t}}function ne(e){return e[T]=!0,e}function re(e){var t=C.createElement("div");try{return e(t)}catch(e){return!1}finally{t=null}}function ie(e,t,n,r){var i,o,a,s,c,l,u,d,f,p;if((t?t.ownerDocument||t:b)!==C&&g(t),n=n||[],!e||"string"!=typeof e)return n;if(1!==(s=(t=t||C).nodeType)&&9!==s)return[];if(!m&&!r){if(i=V.exec(e))if(a=i[1]){if(9===s){if(!(o=t.getElementById(a))||!o.parentNode)return n;if(o.id===a)return n.push(o),n}else if(t.ownerDocument&&(o=t.ownerDocument.getElementById(a))&&y(t,o)&&o.id===a)return n.push(o),n}else{if(i[2])return D.apply(n,I.call(t.getElementsByTagName(e),0)),n;if((a=i[3])&&x.getByClassName&&t.getElementsByClassName)return D.apply(n,I.call(t.getElementsByClassName(a),0)),n}if(x.qsa&&!v.test(e)){if(u=!0,d=T,f=t,p=9===s&&e,1===s&&"object"!==t.nodeName.toLowerCase()){for(l=le(e),(u=t.getAttribute("id"))?d=u.replace(J,"\\$&"):t.setAttribute("id",d),d="[id='"+d+"'] ",c=l.length;c--;)l[c]=d+ue(l[c]);f=W.test(e)&&t.parentNode||t,p=l.join(",")}if(p)try{return D.apply(n,I.call(f.querySelectorAll(p),0)),n}catch(e){}finally{u||t.removeAttribute("id")}}}return function(e,t,n,r){var i,o,a,s,c,l=le(e);if(!r&&1===l.length){if(2<(o=l[0]=l[0].slice(0)).length&&"ID"===(a=o[0]).type&&9===t.nodeType&&!m&&H.relative[o[1].type]){if(!(t=H.find.ID(a.matches[0].replace(K,Z),t)[0]))return n;e=e.slice(o.shift().value.length)}for(i=X.needsContext.test(e)?0:o.length;i--&&(a=o[i],!H.relative[s=a.type]);)if((c=H.find[s])&&(r=c(a.matches[0].replace(K,Z),W.test(o[0].type)&&t.parentNode||t))){if(o.splice(i,1),!(e=r.length&&ue(o)))return D.apply(n,I.call(r,0)),n;break}}return h(e,l)(r,t,m,n,W.test(e)),n}(e.replace(q,"$1"),t,n,r)}function oe(e,t){var n=t&&e,r=n&&(~t.sourceIndex||N)-(~e.sourceIndex||N);if(r)return r;if(n)for(;n=n.nextSibling;)if(n===t)return-1;return e?1:-1}function ae(t){return function(e){return"input"===e.nodeName.toLowerCase()&&e.type===t}}function se(n){return function(e){var t=e.nodeName.toLowerCase();return("input"===t||"button"===t)&&e.type===n}}function ce(a){return ne(function(o){return o=+o,ne(function(e,t){for(var n,r=a([],e.length,o),i=r.length;i--;)e[n=r[i]]&&(e[n]=!(t[n]=e[n]))})})}for(t in r=ie.isXML=function(e){var t=e&&(e.ownerDocument||e).documentElement;return!!t&&"HTML"!==t.nodeName},g=ie.setDocument=function(e){var c=e?e.ownerDocument||e:b;return c!==C&&9===c.nodeType&&c.documentElement&&(i=(C=c).documentElement,m=r(c),x.tagNameNoComments=re(function(e){return e.appendChild(c.createComment("")),!e.getElementsByTagName("*").length}),x.attributes=re(function(e){e.innerHTML="<select></select>";var t=typeof e.lastChild.getAttribute("multiple");return"boolean"!==t&&"string"!==t}),x.getByClassName=re(function(e){return e.innerHTML="<div class='hidden e'></div><div class='hidden'></div>",!(!e.getElementsByClassName||!e.getElementsByClassName("e").length)&&(e.lastChild.className="e",2===e.getElementsByClassName("e").length)}),x.getByName=re(function(e){e.id=T+0,e.innerHTML="<a name='"+T+"'></a><div name='"+T+"'></div>",i.insertBefore(e,i.firstChild);var t=c.getElementsByName&&c.getElementsByName(T).length===2+c.getElementsByName(T+0).length;return x.getIdNotName=!c.getElementById(T),i.removeChild(e),t}),H.attrHandle=re(function(e){return e.innerHTML="<a href='#'></a>",e.firstChild&&typeof e.firstChild.getAttribute!==E&&"#"===e.firstChild.getAttribute("href")})?{}:{href:function(e){return e.getAttribute("href",2)},type:function(e){return e.getAttribute("type")}},x.getIdNotName?(H.find.ID=function(e,t){if(typeof t.getElementById!==E&&!m){var n=t.getElementById(e);return n&&n.parentNode?[n]:[]}},H.filter.ID=function(e){var t=e.replace(K,Z);return function(e){return e.getAttribute("id")===t}}):(H.find.ID=function(e,t){if(typeof t.getElementById!==E&&!m){var n=t.getElementById(e);return n?n.id===e||typeof n.getAttributeNode!==E&&n.getAttributeNode("id").value===e?[n]:void 0:[]}},H.filter.ID=function(e){var n=e.replace(K,Z);return function(e){var t=typeof e.getAttributeNode!==E&&e.getAttributeNode("id");return t&&t.value===n}}),H.find.TAG=x.tagNameNoComments?function(e,t){if(typeof t.getElementsByTagName!==E)return t.getElementsByTagName(e)}:function(e,t){var n,r=[],i=0,o=t.getElementsByTagName(e);if("*"===e){for(;n=o[i++];)1===n.nodeType&&r.push(n);return r}return o},H.find.NAME=x.getByName&&function(e,t){if(typeof t.getElementsByName!==E)return t.getElementsByName(name)},H.find.CLASS=x.getByClassName&&function(e,t){if(typeof t.getElementsByClassName!==E&&!m)return t.getElementsByClassName(e)},a=[],v=[":focus"],(x.qsa=ee(c.querySelectorAll))&&(re(function(e){e.innerHTML="<select><option selected=''></option></select>",e.querySelectorAll("[selected]").length||v.push("\\["+L+"*(?:checked|disabled|ismap|multiple|readonly|selected|value)"),e.querySelectorAll(":checked").length||v.push(":checked")}),re(function(e){e.innerHTML="<input type='hidden' i=''/>",e.querySelectorAll("[i^='']").length&&v.push("[*^$]="+L+"*(?:\"\"|'')"),e.querySelectorAll(":enabled").length||v.push(":enabled",":disabled"),e.querySelectorAll("*,:x"),v.push(",.*:")})),(x.matchesSelector=ee(s=i.matchesSelector||i.mozMatchesSelector||i.webkitMatchesSelector||i.oMatchesSelector||i.msMatchesSelector))&&re(function(e){x.disconnectedMatch=s.call(e,"div"),s.call(e,"[s!='']:x"),a.push("!=",O)}),v=new RegExp(v.join("|")),a=new RegExp(a.join("|")),y=ee(i.contains)||i.compareDocumentPosition?function(e,t){var n=9===e.nodeType?e.documentElement:e,r=t&&t.parentNode;return e===r||!(!r||1!==r.nodeType||!(n.contains?n.contains(r):e.compareDocumentPosition&&16&e.compareDocumentPosition(r)))}:function(e,t){if(t)for(;t=t.parentNode;)if(t===e)return!0;return!1},u=i.compareDocumentPosition?function(e,t){var n;return e===t?(l=!0,0):(n=t.compareDocumentPosition&&e.compareDocumentPosition&&e.compareDocumentPosition(t))?1&n||e.parentNode&&11===e.parentNode.nodeType?e===c||y(b,e)?-1:t===c||y(b,t)?1:0:4&n?-1:1:e.compareDocumentPosition?-1:1}:function(e,t){var n,r=0,i=e.parentNode,o=t.parentNode,a=[e],s=[t];if(e===t)return l=!0,0;if(!i||!o)return e===c?-1:t===c?1:i?-1:o?1:0;if(i===o)return oe(e,t);for(n=e;n=n.parentNode;)a.unshift(n);for(n=t;n=n.parentNode;)s.unshift(n);for(;a[r]===s[r];)r++;return r?oe(a[r],s[r]):a[r]===b?-1:s[r]===b?1:0},l=!1,[0,0].sort(u),x.detectDuplicates=l),C},ie.matches=function(e,t){return ie(e,null,null,t)},ie.matchesSelector=function(e,t){if((e.ownerDocument||e)!==C&&g(e),t=t.replace(G,"='$1']"),x.matchesSelector&&!m&&(!a||!a.test(t))&&!v.test(t))try{var n=s.call(e,t);if(n||x.disconnectedMatch||e.document&&11!==e.document.nodeType)return n}catch(e){}return 0<ie(t,C,null,[e]).length},ie.contains=function(e,t){return(e.ownerDocument||e)!==C&&g(e),y(e,t)},ie.attr=function(e,t){var n;return(e.ownerDocument||e)!==C&&g(e),m||(t=t.toLowerCase()),(n=H.attrHandle[t])?n(e):m||x.attributes?e.getAttribute(t):((n=e.getAttributeNode(t))||e.getAttribute(t))&&!0===e[t]?t:n&&n.specified?n.value:null},ie.error=function(e){throw new Error("Syntax error, unrecognized expression: "+e)},ie.uniqueSort=function(e){var t,n=[],r=1,i=0;if(l=!x.detectDuplicates,e.sort(u),l){for(;t=e[r];r++)t===e[r-1]&&(i=n.push(r));for(;i--;)e.splice(n[i],1)}return e},o=ie.getText=function(e){var t,n="",r=0,i=e.nodeType;if(i){if(1===i||9===i||11===i){if("string"==typeof e.textContent)return e.textContent;for(e=e.firstChild;e;e=e.nextSibling)n+=o(e)}else if(3===i||4===i)return e.nodeValue}else for(;t=e[r];r++)n+=o(t);return n},H=ie.selectors={cacheLength:50,createPseudo:ne,match:X,find:{},relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{ATTR:function(e){return e[1]=e[1].replace(K,Z),e[3]=(e[4]||e[5]||"").replace(K,Z),"~="===e[2]&&(e[3]=" "+e[3]+" "),e.slice(0,4)},CHILD:function(e){return e[1]=e[1].toLowerCase(),"nth"===e[1].slice(0,3)?(e[3]||ie.error(e[0]),e[4]=+(e[4]?e[5]+(e[6]||1):2*("even"===e[3]||"odd"===e[3])),e[5]=+(e[7]+e[8]||"odd"===e[3])):e[3]&&ie.error(e[0]),e},PSEUDO:function(e){var t,n=!e[5]&&e[2];return X.CHILD.test(e[0])?null:(e[4]?e[2]=e[4]:n&&R.test(n)&&(t=le(n,!0))&&(t=n.indexOf(")",n.length-t)-n.length)&&(e[0]=e[0].slice(0,t),e[2]=n.slice(0,t)),e.slice(0,3))}},filter:{TAG:function(t){return"*"===t?function(){return!0}:(t=t.replace(K,Z).toLowerCase(),function(e){return e.nodeName&&e.nodeName.toLowerCase()===t})},CLASS:function(e){var t=c[e+" "];return t||(t=new RegExp("(^|"+L+")"+e+"("+L+"|$)"))&&c(e,function(e){return t.test(e.className||typeof e.getAttribute!==E&&e.getAttribute("class")||"")})},ATTR:function(n,r,i){return function(e){var t=ie.attr(e,n);return null==t?"!="===r:!r||(t+="","="===r?t===i:"!="===r?t!==i:"^="===r?i&&0===t.indexOf(i):"*="===r?i&&-1<t.indexOf(i):"$="===r?i&&t.slice(-i.length)===i:"~="===r?-1<(" "+t+" ").indexOf(i):"|="===r&&(t===i||t.slice(0,i.length+1)===i+"-"))}},CHILD:function(p,e,t,h,g){var m="nth"!==p.slice(0,3),v="last"!==p.slice(-4),y="of-type"===e;return 1===h&&0===g?function(e){return!!e.parentNode}:function(e,t,n){var r,i,o,a,s,c,l=m!==v?"nextSibling":"previousSibling",u=e.parentNode,d=y&&e.nodeName.toLowerCase(),f=!n&&!y;if(u){if(m){for(;l;){for(o=e;o=o[l];)if(y?o.nodeName.toLowerCase()===d:1===o.nodeType)return!1;c=l="only"===p&&!c&&"nextSibling"}return!0}if(c=[v?u.firstChild:u.lastChild],v&&f){for(s=(r=(i=u[T]||(u[T]={}))[p]||[])[0]===S&&r[1],a=r[0]===S&&r[2],o=s&&u.childNodes[s];o=++s&&o&&o[l]||(a=s=0)||c.pop();)if(1===o.nodeType&&++a&&o===e){i[p]=[S,s,a];break}}else if(f&&(r=(e[T]||(e[T]={}))[p])&&r[0]===S)a=r[1];else for(;(o=++s&&o&&o[l]||(a=s=0)||c.pop())&&((y?o.nodeName.toLowerCase()!==d:1!==o.nodeType)||!++a||(f&&((o[T]||(o[T]={}))[p]=[S,a]),o!==e)););return(a-=g)===h||a%h==0&&0<=a/h}}},PSEUDO:function(e,o){var t,a=H.pseudos[e]||H.setFilters[e.toLowerCase()]||ie.error("unsupported pseudo: "+e);return a[T]?a(o):1<a.length?(t=[e,e,"",o],H.setFilters.hasOwnProperty(e.toLowerCase())?ne(function(e,t){for(var n,r=a(e,o),i=r.length;i--;)e[n=j.call(e,r[i])]=!(t[n]=r[i])}):function(e){return a(e,0,t)}):a}},pseudos:{not:ne(function(e){var r=[],i=[],s=h(e.replace(q,"$1"));return s[T]?ne(function(e,t,n,r){for(var i,o=s(e,null,r,[]),a=e.length;a--;)(i=o[a])&&(e[a]=!(t[a]=i))}):function(e,t,n){return r[0]=e,s(r,null,n,i),!i.pop()}}),has:ne(function(t){return function(e){return 0<ie(t,e).length}}),contains:ne(function(t){return function(e){return-1<(e.textContent||e.innerText||o(e)).indexOf(t)}}),lang:ne(function(n){return z.test(n||"")||ie.error("unsupported lang: "+n),n=n.replace(K,Z).toLowerCase(),function(e){var t;do{if(t=m?e.getAttribute("xml:lang")||e.getAttribute("lang"):e.lang)return(t=t.toLowerCase())===n||0===t.indexOf(n+"-")}while((e=e.parentNode)&&1===e.nodeType);return!1}}),target:function(e){var t=n.location&&n.location.hash;return t&&t.slice(1)===e.id},root:function(e){return e===i},focus:function(e){return e===C.activeElement&&(!C.hasFocus||C.hasFocus())&&!!(e.type||e.href||~e.tabIndex)},enabled:function(e){return!1===e.disabled},disabled:function(e){return!0===e.disabled},checked:function(e){var t=e.nodeName.toLowerCase();return"input"===t&&!!e.checked||"option"===t&&!!e.selected},selected:function(e){return e.parentNode&&e.parentNode.selectedIndex,!0===e.selected},empty:function(e){for(e=e.firstChild;e;e=e.nextSibling)if("@"<e.nodeName||3===e.nodeType||4===e.nodeType)return!1;return!0},parent:function(e){return!H.pseudos.empty(e)},header:function(e){return Y.test(e.nodeName)},input:function(e){return Q.test(e.nodeName)},button:function(e){var t=e.nodeName.toLowerCase();return"input"===t&&"button"===e.type||"button"===t},text:function(e){var t;return"input"===e.nodeName.toLowerCase()&&"text"===e.type&&(null==(t=e.getAttribute("type"))||t.toLowerCase()===e.type)},first:ce(function(){return[0]}),last:ce(function(e,t){return[t-1]}),eq:ce(function(e,t,n){return[n<0?n+t:n]}),even:ce(function(e,t){for(var n=0;n<t;n+=2)e.push(n);return e}),odd:ce(function(e,t){for(var n=1;n<t;n+=2)e.push(n);return e}),lt:ce(function(e,t,n){for(var r=n<0?n+t:n;0<=--r;)e.push(r);return e}),gt:ce(function(e,t,n){for(var r=n<0?n+t:n;++r<t;)e.push(r);return e})}},{radio:!0,checkbox:!0,file:!0,password:!0,image:!0})H.pseudos[t]=ae(t);for(t in{submit:!0,reset:!0})H.pseudos[t]=se(t);function le(e,t){var n,r,i,o,a,s,c,l=f[e+" "];if(l)return t?0:l.slice(0);for(a=e,s=[],c=H.preFilter;a;){for(o in n&&!(r=_.exec(a))||(r&&(a=a.slice(r[0].length)||a),s.push(i=[])),n=!1,(r=$.exec(a))&&(n=r.shift(),i.push({value:n,type:r[0].replace(q," ")}),a=a.slice(n.length)),H.filter)!(r=X[o].exec(a))||c[o]&&!(r=c[o](r))||(n=r.shift(),i.push({value:n,type:o,matches:r}),a=a.slice(n.length));if(!n)break}return t?a.length:a?ie.error(e):f(e,s).slice(0)}function ue(e){for(var t=0,n=e.length,r="";t<n;t++)r+=e[t].value;return r}function de(s,e,t){var c=e.dir,l=t&&"parentNode"===c,u=d++;return e.first?function(e,t,n){for(;e=e[c];)if(1===e.nodeType||l)return s(e,t,n)}:function(e,t,n){var r,i,o,a=S+" "+u;if(n){for(;e=e[c];)if((1===e.nodeType||l)&&s(e,t,n))return!0}else for(;e=e[c];)if(1===e.nodeType||l)if((i=(o=e[T]||(e[T]={}))[c])&&i[0]===a){if(!0===(r=i[1])||r===P)return!0===r}else if((i=o[c]=[a])[1]=s(e,t,n)||P,!0===i[1])return!0}}function fe(i){return 1<i.length?function(e,t,n){for(var r=i.length;r--;)if(!i[r](e,t,n))return!1;return!0}:i[0]}function pe(e,t,n,r,i){for(var o,a=[],s=0,c=e.length,l=null!=t;s<c;s++)(o=e[s])&&(n&&!n(o,r,i)||(a.push(o),l&&t.push(s)));return a}function he(p,h,g,m,v,e){return m&&!m[T]&&(m=he(m)),v&&!v[T]&&(v=he(v,e)),ne(function(e,t,n,r){var i,o,a,s=[],c=[],l=t.length,u=e||function(e,t,n){for(var r=0,i=t.length;r<i;r++)ie(e,t[r],n);return n}(h||"*",n.nodeType?[n]:n,[]),d=!p||!e&&h?u:pe(u,s,p,n,r),f=g?v||(e?p:l||m)?[]:t:d;if(g&&g(d,f,n,r),m)for(i=pe(f,c),m(i,[],n,r),o=i.length;o--;)(a=i[o])&&(f[c[o]]=!(d[c[o]]=a));if(e){if(v||p){if(v){for(i=[],o=f.length;o--;)(a=f[o])&&i.push(d[o]=a);v(null,f=[],i,r)}for(o=f.length;o--;)(a=f[o])&&-1<(i=v?j.call(e,a):s[o])&&(e[i]=!(t[i]=a))}}else f=pe(f===t?f.splice(l,f.length):f),v?v(null,t,f,r):D.apply(t,f)})}function ge(e){for(var r,t,n,i=e.length,o=H.relative[e[0].type],a=o||H.relative[" "],s=o?1:0,c=de(function(e){return e===r},a,!0),l=de(function(e){return-1<j.call(r,e)},a,!0),u=[function(e,t,n){return!o&&(n||t!==w)||((r=t).nodeType?c(e,t,n):l(e,t,n))}];s<i;s++)if(t=H.relative[e[s].type])u=[de(fe(u),t)];else{if((t=H.filter[e[s].type].apply(null,e[s].matches))[T]){for(n=++s;n<i&&!H.relative[e[n].type];n++);return he(1<s&&fe(u),1<s&&ue(e.slice(0,s-1)).replace(q,"$1"),t,s<n&&ge(e.slice(s,n)),n<i&&ge(e=e.slice(n)),n<i&&ue(e))}u.push(t)}return fe(u)}function me(){}h=ie.compile=function(e,t){var n,m,v,y,b,x,r,i=[],o=[],a=p[e+" "];if(!a){for(t||(t=le(e)),n=t.length;n--;)(a=ge(t[n]))[T]?i.push(a):o.push(a);a=p(e,(m=o,b=(y=0)<(v=i).length,x=0<m.length,r=function(e,t,n,r,i){var o,a,s,c=[],l=0,u="0",d=e&&[],f=null!=i,p=w,h=e||x&&H.find.TAG("*",i&&t.parentNode||t),g=S+=null==p?1:Math.random()||.1;for(f&&(w=t!==C&&t,P=y);null!=(o=h[u]);u++){if(x&&o){for(a=0;s=m[a++];)if(s(o,t,n)){r.push(o);break}f&&(S=g,P=++y)}b&&((o=!s&&o)&&l--,e&&d.push(o))}if(l+=u,b&&u!==l){for(a=0;s=v[a++];)s(d,c,t,n);if(e){if(0<l)for(;u--;)d[u]||c[u]||(c[u]=A.call(r));c=pe(c)}D.apply(r,c),f&&!e&&0<c.length&&1<l+v.length&&ie.uniqueSort(r)}return f&&(S=g,w=p),d},b?ne(r):r))}return a},H.pseudos.nth=H.pseudos.eq,H.filters=me.prototype=H.pseudos,H.setFilters=new me,g(),ie.attr=ve.attr,ve.find=ie,ve.expr=ie.selectors,ve.expr[":"]=ve.expr.pseudos,ve.unique=ie.uniqueSort,ve.text=ie.getText,ve.isXMLDoc=ie.isXML,ve.contains=ie.contains}(h);var ie=/Until$/,oe=/^(?:parents|prev(?:Until|All))/,ae=/^.[^:#\[\.,]*$/,se=ve.expr.match.needsContext,ce={children:!0,contents:!0,next:!0,prev:!0};function le(e,t){for(;(e=e[t])&&1!==e.nodeType;);return e}function ue(e,n,r){if(n=n||0,ve.isFunction(n))return ve.grep(e,function(e,t){return!!n.call(e,t,e)===r});if(n.nodeType)return ve.grep(e,function(e){return e===n===r});if("string"==typeof n){var t=ve.grep(e,function(e){return 1===e.nodeType});if(ae.test(n))return ve.filter(n,t,!r);n=ve.filter(n,t)}return ve.grep(e,function(e){return 0<=ve.inArray(e,n)===r})}function de(e){var t=fe.split("|"),n=e.createDocumentFragment();if(n.createElement)for(;t.length;)n.createElement(t.pop());return n}ve.fn.extend({find:function(e){var t,n,r,i=this.length;if("string"!=typeof e)return(r=this).pushStack(ve(e).filter(function(){for(t=0;t<i;t++)if(ve.contains(r[t],this))return!0}));for(n=[],t=0;t<i;t++)ve.find(e,this[t],n);return(n=this.pushStack(1<i?ve.unique(n):n)).selector=(this.selector?this.selector+" ":"")+e,n},has:function(e){var t,n=ve(e,this),r=n.length;return this.filter(function(){for(t=0;t<r;t++)if(ve.contains(this,n[t]))return!0})},not:function(e){return this.pushStack(ue(this,e,!1))},filter:function(e){return this.pushStack(ue(this,e,!0))},is:function(e){return!!e&&("string"==typeof e?se.test(e)?0<=ve(e,this.context).index(this[0]):0<ve.filter(e,this).length:0<this.filter(e).length)},closest:function(e,t){for(var n,r=0,i=this.length,o=[],a=se.test(e)||"string"!=typeof e?ve(e,t||this.context):0;r<i;r++)for(n=this[r];n&&n.ownerDocument&&n!==t&&11!==n.nodeType;){if(a?-1<a.index(n):ve.find.matchesSelector(n,e)){o.push(n);break}n=n.parentNode}return this.pushStack(1<o.length?ve.unique(o):o)},index:function(e){return e?"string"==typeof e?ve.inArray(this[0],ve(e)):ve.inArray(e.jquery?e[0]:e,this):this[0]&&this[0].parentNode?this.first().prevAll().length:-1},add:function(e,t){var n="string"==typeof e?ve(e,t):ve.makeArray(e&&e.nodeType?[e]:e),r=ve.merge(this.get(),n);return this.pushStack(ve.unique(r))},addBack:function(e){return this.add(null==e?this.prevObject:this.prevObject.filter(e))}}),ve.fn.andSelf=ve.fn.addBack,ve.each({parent:function(e){var t=e.parentNode;return t&&11!==t.nodeType?t:null},parents:function(e){return ve.dir(e,"parentNode")},parentsUntil:function(e,t,n){return ve.dir(e,"parentNode",n)},next:function(e){return le(e,"nextSibling")},prev:function(e){return le(e,"previousSibling")},nextAll:function(e){return ve.dir(e,"nextSibling")},prevAll:function(e){return ve.dir(e,"previousSibling")},nextUntil:function(e,t,n){return ve.dir(e,"nextSibling",n)},prevUntil:function(e,t,n){return ve.dir(e,"previousSibling",n)},siblings:function(e){return ve.sibling((e.parentNode||{}).firstChild,e)},children:function(e){return ve.sibling(e.firstChild)},contents:function(e){return ve.nodeName(e,"iframe")?e.contentDocument||e.contentWindow.document:ve.merge([],e.childNodes)}},function(r,i){ve.fn[r]=function(e,t){var n=ve.map(this,i,e);return ie.test(r)||(t=e),t&&"string"==typeof t&&(n=ve.filter(t,n)),n=1<this.length&&!ce[r]?ve.unique(n):n,1<this.length&&oe.test(r)&&(n=n.reverse()),this.pushStack(n)}}),ve.extend({filter:function(e,t,n){return n&&(e=":not("+e+")"),1===t.length?ve.find.matchesSelector(t[0],e)?[t[0]]:[]:ve.find.matches(e,t)},dir:function(e,t,n){for(var r=[],i=e[t];i&&9!==i.nodeType&&(n===w||1!==i.nodeType||!ve(i).is(n));)1===i.nodeType&&r.push(i),i=i[t];return r},sibling:function(e,t){for(var n=[];e;e=e.nextSibling)1===e.nodeType&&e!==t&&n.push(e);return n}});var fe="abbr|article|aside|audio|bdi|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video",pe=/ jQuery\d+="(?:null|\d+)"/g,he=new RegExp("<(?:"+fe+")[\\s/>]","i"),ge=/^\s+/,me=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,ye=/<([\w:]+)/,be=/<tbody/i,xe=/<|&#?\w+;/,Pe=/<(?:script|style|link)/i,He=/^(?:checkbox|radio)$/i,we=/checked\s*(?:[^=]|=\s*.checked.)/i,Ce=/^$|\/(?:java|ecma)script/i,Te=/^true\/(.*)/,Se=/^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,Ee={option:[1,"<select multiple='multiple'>","</select>"],legend:[1,"<fieldset>","</fieldset>"],area:[1,"<map>","</map>"],param:[1,"<object>","</object>"],thead:[1,"<table>","</table>"],tr:[2,"<table><tbody>","</tbody></table>"],col:[2,"<table><tbody></tbody><colgroup>","</colgroup></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],_default:ve.support.htmlSerialize?[0,"",""]:[1,"X<div>","</div>"]},Ne=de(g).appendChild(g.createElement("div"));function ke(e){var t=e.getAttributeNode("type");return e.type=(t&&t.specified)+"/"+e.type,e}function Ae(e){var t=Te.exec(e.type);return t?e.type=t[1]:e.removeAttribute("type"),e}function De(e,t){for(var n,r=0;null!=(n=e[r]);r++)ve._data(n,"globalEval",!t||ve._data(t[r],"globalEval"))}function Ie(e,t){if(1===t.nodeType&&ve.hasData(e)){var n,r,i,o=ve._data(e),a=ve._data(t,o),s=o.events;if(s)for(n in delete a.handle,a.events={},s)for(r=0,i=s[n].length;r<i;r++)ve.event.add(t,n,s[n][r]);a.data&&(a.data=ve.extend({},a.data))}}function je(e,t){var n,r,i;if(1===t.nodeType){if(n=t.nodeName.toLowerCase(),!ve.support.noCloneEvent&&t[ve.expando]){for(r in(i=ve._data(t)).events)ve.removeEvent(t,r,i.handle);t.removeAttribute(ve.expando)}"script"===n&&t.text!==e.text?(ke(t).text=e.text,Ae(t)):"object"===n?(t.parentNode&&(t.outerHTML=e.outerHTML),ve.support.html5Clone&&e.innerHTML&&!ve.trim(t.innerHTML)&&(t.innerHTML=e.innerHTML)):"input"===n&&He.test(e.type)?(t.defaultChecked=t.checked=e.checked,t.value!==e.value&&(t.value=e.value)):"option"===n?t.defaultSelected=t.selected=e.defaultSelected:"input"!==n&&"textarea"!==n||(t.defaultValue=e.defaultValue)}}function Le(e,t){var n,r,i=0,o=typeof e.getElementsByTagName!==v?e.getElementsByTagName(t||"*"):typeof e.querySelectorAll!==v?e.querySelectorAll(t||"*"):w;if(!o)for(o=[],n=e.childNodes||e;null!=(r=n[i]);i++)!t||ve.nodeName(r,t)?o.push(r):ve.merge(o,Le(r,t));return t===w||t&&ve.nodeName(e,t)?ve.merge([e],o):o}function Fe(e){He.test(e.type)&&(e.defaultChecked=e.checked)}Ee.optgroup=Ee.option,Ee.tbody=Ee.tfoot=Ee.colgroup=Ee.caption=Ee.thead,Ee.th=Ee.td,ve.fn.extend({text:function(e){return ve.access(this,function(e){return e===w?ve.text(this):this.empty().append((this[0]&&this[0].ownerDocument||g).createTextNode(e))},null,e,arguments.length)},wrapAll:function(t){if(ve.isFunction(t))return this.each(function(e){ve(this).wrapAll(t.call(this,e))});if(this[0]){var e=ve(t,this[0].ownerDocument).eq(0).clone(!0);this[0].parentNode&&e.insertBefore(this[0]),e.map(function(){for(var e=this;e.firstChild&&1===e.firstChild.nodeType;)e=e.firstChild;return e}).append(this)}return this},wrapInner:function(n){return ve.isFunction(n)?this.each(function(e){ve(this).wrapInner(n.call(this,e))}):this.each(function(){var e=ve(this),t=e.contents();t.length?t.wrapAll(n):e.append(n)})},wrap:function(t){var n=ve.isFunction(t);return this.each(function(e){ve(this).wrapAll(n?t.call(this,e):t)})},unwrap:function(){return this.parent().each(function(){ve.nodeName(this,"body")||ve(this).replaceWith(this.childNodes)}).end()},append:function(){return this.domManip(arguments,!0,function(e){1!==this.nodeType&&11!==this.nodeType&&9!==this.nodeType||this.appendChild(e)})},prepend:function(){return this.domManip(arguments,!0,function(e){1!==this.nodeType&&11!==this.nodeType&&9!==this.nodeType||this.insertBefore(e,this.firstChild)})},before:function(){return this.domManip(arguments,!1,function(e){this.parentNode&&this.parentNode.insertBefore(e,this)})},after:function(){return this.domManip(arguments,!1,function(e){this.parentNode&&this.parentNode.insertBefore(e,this.nextSibling)})},remove:function(e,t){for(var n,r=0;null!=(n=this[r]);r++)(!e||0<ve.filter(e,[n]).length)&&(t||1!==n.nodeType||ve.cleanData(Le(n)),n.parentNode&&(t&&ve.contains(n.ownerDocument,n)&&De(Le(n,"script")),n.parentNode.removeChild(n)));return this},empty:function(){for(var e,t=0;null!=(e=this[t]);t++){for(1===e.nodeType&&ve.cleanData(Le(e,!1));e.firstChild;)e.removeChild(e.firstChild);e.options&&ve.nodeName(e,"select")&&(e.options.length=0)}return this},clone:function(e,t){return e=null!=e&&e,t=null==t?e:t,this.map(function(){return ve.clone(this,e,t)})},html:function(e){return ve.access(this,function(e){var t=this[0]||{},n=0,r=this.length;if(e===w)return 1===t.nodeType?t.innerHTML.replace(pe,""):w;if("string"==typeof e&&!Pe.test(e)&&(ve.support.htmlSerialize||!he.test(e))&&(ve.support.leadingWhitespace||!ge.test(e))&&!Ee[(ye.exec(e)||["",""])[1].toLowerCase()]){e=e.replace(me,"<$1></$2>");try{for(;n<r;n++)1===(t=this[n]||{}).nodeType&&(ve.cleanData(Le(t,!1)),t.innerHTML=e);t=0}catch(e){}}t&&this.empty().append(e)},null,e,arguments.length)},replaceWith:function(e){return ve.isFunction(e)||"string"==typeof e||(e=ve(e).not(this).detach()),this.domManip([e],!0,function(e){var t=this.nextSibling,n=this.parentNode;n&&(ve(this).remove(),n.insertBefore(e,t))})},detach:function(e){return this.remove(e,!0)},domManip:function(n,r,i){n=y.apply([],n);var e,t,o,a,s,c,l,u,d=0,f=this.length,p=this,h=f-1,g=n[0],m=ve.isFunction(g);if(m||!(f<=1||"string"!=typeof g||ve.support.checkClone)&&we.test(g))return this.each(function(e){var t=p.eq(e);m&&(n[0]=g.call(this,e,r?t.html():w)),t.domManip(n,r,i)});if(f&&(e=(c=ve.buildFragment(n,this[0].ownerDocument,!1,this)).firstChild,1===c.childNodes.length&&(c=e),e)){for(r=r&&ve.nodeName(e,"tr"),o=(a=ve.map(Le(c,"script"),ke)).length;d<f;d++)t=c,d!==h&&(t=ve.clone(t,!0,!0),o&&ve.merge(a,Le(t,"script"))),i.call(r&&ve.nodeName(this[d],"table")?(l=this[d],u="tbody",l.getElementsByTagName(u)[0]||l.appendChild(l.ownerDocument.createElement(u))):this[d],t,d);if(o)for(s=a[a.length-1].ownerDocument,ve.map(a,Ae),d=0;d<o;d++)t=a[d],Ce.test(t.type||"")&&!ve._data(t,"globalEval")&&ve.contains(s,t)&&(t.src?ve.ajax({url:t.src,type:"GET",dataType:"script",async:!1,global:!1,throws:!0}):ve.globalEval((t.text||t.textContent||t.innerHTML||"").replace(Se,"")));c=e=null}return this}}),ve.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(e,a){ve.fn[e]=function(e){for(var t,n=0,r=[],i=ve(e),o=i.length-1;n<=o;n++)t=n===o?this:this.clone(!0),ve(i[n])[a](t),s.apply(r,t.get());return this.pushStack(r)}}),ve.extend({clone:function(e,t,n){var r,i,o,a,s,c=ve.contains(e.ownerDocument,e);if(ve.support.html5Clone||ve.isXMLDoc(e)||!he.test("<"+e.nodeName+">")?o=e.cloneNode(!0):(Ne.innerHTML=e.outerHTML,Ne.removeChild(o=Ne.firstChild)),!(ve.support.noCloneEvent&&ve.support.noCloneChecked||1!==e.nodeType&&11!==e.nodeType||ve.isXMLDoc(e)))for(r=Le(o),s=Le(e),a=0;null!=(i=s[a]);++a)r[a]&&je(i,r[a]);if(t)if(n)for(s=s||Le(e),r=r||Le(o),a=0;null!=(i=s[a]);a++)Ie(i,r[a]);else Ie(e,o);return 0<(r=Le(o,"script")).length&&De(r,!c&&Le(e,"script")),r=s=i=null,o},buildFragment:function(e,t,n,r){for(var i,o,a,s,c,l,u,d=e.length,f=de(t),p=[],h=0;h<d;h++)if((o=e[h])||0===o)if("object"===ve.type(o))ve.merge(p,o.nodeType?[o]:o);else if(xe.test(o)){for(s=s||f.appendChild(t.createElement("div")),c=(ye.exec(o)||["",""])[1].toLowerCase(),u=Ee[c]||Ee._default,s.innerHTML=u[1]+o.replace(me,"<$1></$2>")+u[2],i=u[0];i--;)s=s.lastChild;if(!ve.support.leadingWhitespace&&ge.test(o)&&p.push(t.createTextNode(ge.exec(o)[0])),!ve.support.tbody)for(i=(o="table"!==c||be.test(o)?"<table>"!==u[1]||be.test(o)?0:s:s.firstChild)&&o.childNodes.length;i--;)ve.nodeName(l=o.childNodes[i],"tbody")&&!l.childNodes.length&&o.removeChild(l);for(ve.merge(p,s.childNodes),s.textContent="";s.firstChild;)s.removeChild(s.firstChild);s=f.lastChild}else p.push(t.createTextNode(o));for(s&&f.removeChild(s),ve.support.appendChecked||ve.grep(Le(p,"input"),Fe),h=0;o=p[h++];)if((!r||-1===ve.inArray(o,r))&&(a=ve.contains(o.ownerDocument,o),s=Le(f.appendChild(o),"script"),a&&De(s),n))for(i=0;o=s[i++];)Ce.test(o.type||"")&&n.push(o);return s=null,f},cleanData:function(e,t){for(var n,r,i,o,a=0,s=ve.expando,c=ve.cache,l=ve.support.deleteExpando,u=ve.event.special;null!=(n=e[a]);a++)if((t||ve.acceptData(n))&&(o=(i=n[s])&&c[i])){if(o.events)for(r in o.events)u[r]?ve.event.remove(n,r):ve.removeEvent(n,r,o.handle);c[i]&&(delete c[i],l?delete n[s]:typeof n.removeAttribute!==v?n.removeAttribute(s):n[s]=null,d.push(i))}}});var Me,Be,Oe,qe=/alpha\([^)]*\)/i,_e=/opacity\s*=\s*([^)]*)/,$e=/^(top|right|bottom|left)$/,Re=/^(none|table(?!-c[ea]).+)/,ze=/^margin/,Xe=new RegExp("^("+p+")(.*)$","i"),We=new RegExp("^("+p+")(?!px)[a-z%]+$","i"),Ue=new RegExp("^([+-])=("+p+")","i"),Ve={BODY:"block"},Qe={position:"absolute",visibility:"hidden",display:"block"},Ye={letterSpacing:0,fontWeight:400},Je=["Top","Right","Bottom","Left"],Ge=["Webkit","O","Moz","ms"];function Ke(e,t){if(t in e)return t;for(var n=t.charAt(0).toUpperCase()+t.slice(1),r=t,i=Ge.length;i--;)if((t=Ge[i]+n)in e)return t;return r}function Ze(e,t){return e=t||e,"none"===ve.css(e,"display")||!ve.contains(e.ownerDocument,e)}function et(e,t){for(var n,r,i,o=[],a=0,s=e.length;a<s;a++)(r=e[a]).style&&(o[a]=ve._data(r,"olddisplay"),n=r.style.display,t?(o[a]||"none"!==n||(r.style.display=""),""===r.style.display&&Ze(r)&&(o[a]=ve._data(r,"olddisplay",it(r.nodeName)))):o[a]||(i=Ze(r),(n&&"none"!==n||!i)&&ve._data(r,"olddisplay",i?n:ve.css(r,"display"))));for(a=0;a<s;a++)(r=e[a]).style&&(t&&"none"!==r.style.display&&""!==r.style.display||(r.style.display=t?o[a]||"":"none"));return e}function tt(e,t,n){var r=Xe.exec(t);return r?Math.max(0,r[1]-(n||0))+(r[2]||"px"):t}function nt(e,t,n,r,i){for(var o=n===(r?"border":"content")?4:"width"===t?1:0,a=0;o<4;o+=2)"margin"===n&&(a+=ve.css(e,n+Je[o],!0,i)),r?("content"===n&&(a-=ve.css(e,"padding"+Je[o],!0,i)),"margin"!==n&&(a-=ve.css(e,"border"+Je[o]+"Width",!0,i))):(a+=ve.css(e,"padding"+Je[o],!0,i),"padding"!==n&&(a+=ve.css(e,"border"+Je[o]+"Width",!0,i)));return a}function rt(e,t,n){var r=!0,i="width"===t?e.offsetWidth:e.offsetHeight,o=Be(e),a=ve.support.boxSizing&&"border-box"===ve.css(e,"boxSizing",!1,o);if(i<=0||null==i){if(((i=Oe(e,t,o))<0||null==i)&&(i=e.style[t]),We.test(i))return i;r=a&&(ve.support.boxSizingReliable||i===e.style[t]),i=parseFloat(i)||0}return i+nt(e,t,n||(a?"border":"content"),r,o)+"px"}function it(e){var t=g,n=Ve[e];return n||("none"!==(n=ot(e,t))&&n||((t=((Me=(Me||ve("<iframe frameborder='0' width='0' height='0'/>").css("cssText","display:block !important")).appendTo(t.documentElement))[0].contentWindow||Me[0].contentDocument).document).write("<!doctype html><html><body>"),t.close(),n=ot(e,t),Me.detach()),Ve[e]=n),n}function ot(e,t){var n=ve(t.createElement(e)).appendTo(t.body),r=ve.css(n[0],"display");return n.remove(),r}ve.fn.extend({css:function(e,t){return ve.access(this,function(e,t,n){var r,i,o={},a=0;if(ve.isArray(t)){for(i=Be(e),r=t.length;a<r;a++)o[t[a]]=ve.css(e,t[a],!1,i);return o}return n!==w?ve.style(e,t,n):ve.css(e,t)},e,t,1<arguments.length)},show:function(){return et(this,!0)},hide:function(){return et(this)},toggle:function(e){var t="boolean"==typeof e;return this.each(function(){(t?e:Ze(this))?ve(this).show():ve(this).hide()})}}),ve.extend({cssHooks:{opacity:{get:function(e,t){if(t){var n=Oe(e,"opacity");return""===n?"1":n}}}},cssNumber:{columnCount:!0,fillOpacity:!0,fontWeight:!0,lineHeight:!0,opacity:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{float:ve.support.cssFloat?"cssFloat":"styleFloat"},style:function(e,t,n,r){if(e&&3!==e.nodeType&&8!==e.nodeType&&e.style){var i,o,a,s=ve.camelCase(t),c=e.style;if(t=ve.cssProps[s]||(ve.cssProps[s]=Ke(c,s)),a=ve.cssHooks[t]||ve.cssHooks[s],n===w)return a&&"get"in a&&(i=a.get(e,!1,r))!==w?i:c[t];if(!("string"===(o=typeof n)&&(i=Ue.exec(n))&&(n=(i[1]+1)*i[2]+parseFloat(ve.css(e,t)),o="number"),null==n||"number"===o&&isNaN(n)||("number"!==o||ve.cssNumber[s]||(n+="px"),ve.support.clearCloneStyle||""!==n||0!==t.indexOf("background")||(c[t]="inherit"),a&&"set"in a&&(n=a.set(e,n,r))===w)))try{c[t]=n}catch(e){}}},css:function(e,t,n,r){var i,o,a,s=ve.camelCase(t);return t=ve.cssProps[s]||(ve.cssProps[s]=Ke(e.style,s)),(a=ve.cssHooks[t]||ve.cssHooks[s])&&"get"in a&&(o=a.get(e,!0,n)),o===w&&(o=Oe(e,t,r)),"normal"===o&&t in Ye&&(o=Ye[t]),""===n||n?(i=parseFloat(o),!0===n||ve.isNumeric(i)?i||0:o):o},swap:function(e,t,n,r){var i,o,a={};for(o in t)a[o]=e.style[o],e.style[o]=t[o];for(o in i=n.apply(e,r||[]),t)e.style[o]=a[o];return i}}),h.getComputedStyle?(Be=function(e){return h.getComputedStyle(e,null)},Oe=function(e,t,n){var r,i,o,a=n||Be(e),s=a?a.getPropertyValue(t)||a[t]:w,c=e.style;return a&&(""!==s||ve.contains(e.ownerDocument,e)||(s=ve.style(e,t)),We.test(s)&&ze.test(t)&&(r=c.width,i=c.minWidth,o=c.maxWidth,c.minWidth=c.maxWidth=c.width=s,s=a.width,c.width=r,c.minWidth=i,c.maxWidth=o)),s}):g.documentElement.currentStyle&&(Be=function(e){return e.currentStyle},Oe=function(e,t,n){var r,i,o,a=n||Be(e),s=a?a[t]:w,c=e.style;return null==s&&c&&c[t]&&(s=c[t]),We.test(s)&&!$e.test(t)&&(r=c.left,(o=(i=e.runtimeStyle)&&i.left)&&(i.left=e.currentStyle.left),c.left="fontSize"===t?"1em":s,s=c.pixelLeft+"px",c.left=r,o&&(i.left=o)),""===s?"auto":s}),ve.each(["height","width"],function(e,i){ve.cssHooks[i]={get:function(e,t,n){if(t)return 0===e.offsetWidth&&Re.test(ve.css(e,"display"))?ve.swap(e,Qe,function(){return rt(e,i,n)}):rt(e,i,n)},set:function(e,t,n){var r=n&&Be(e);return tt(0,t,n?nt(e,i,n,ve.support.boxSizing&&"border-box"===ve.css(e,"boxSizing",!1,r),r):0)}}}),ve.support.opacity||(ve.cssHooks.opacity={get:function(e,t){return _e.test((t&&e.currentStyle?e.currentStyle.filter:e.style.filter)||"")?.01*parseFloat(RegExp.$1)+"":t?"1":""},set:function(e,t){var n=e.style,r=e.currentStyle,i=ve.isNumeric(t)?"alpha(opacity="+100*t+")":"",o=r&&r.filter||n.filter||"";((n.zoom=1)<=t||""===t)&&""===ve.trim(o.replace(qe,""))&&n.removeAttribute&&(n.removeAttribute("filter"),""===t||r&&!r.filter)||(n.filter=qe.test(o)?o.replace(qe,i):o+" "+i)}}),ve(function(){ve.support.reliableMarginRight||(ve.cssHooks.marginRight={get:function(e,t){if(t)return ve.swap(e,{display:"inline-block"},Oe,[e,"marginRight"])}}),!ve.support.pixelPosition&&ve.fn.position&&ve.each(["top","left"],function(e,n){ve.cssHooks[n]={get:function(e,t){if(t)return t=Oe(e,n),We.test(t)?ve(e).position()[n]+"px":t}}})}),ve.expr&&ve.expr.filters&&(ve.expr.filters.hidden=function(e){return e.offsetWidth<=0&&e.offsetHeight<=0||!ve.support.reliableHiddenOffsets&&"none"===(e.style&&e.style.display||ve.css(e,"display"))},ve.expr.filters.visible=function(e){return!ve.expr.filters.hidden(e)}),ve.each({margin:"",padding:"",border:"Width"},function(i,o){ve.cssHooks[i+o]={expand:function(e){for(var t=0,n={},r="string"==typeof e?e.split(" "):[e];t<4;t++)n[i+Je[t]+o]=r[t]||r[t-2]||r[0];return n}},ze.test(i)||(ve.cssHooks[i+o].set=tt)});var at=/%20/g,st=/\[\]$/,ct=/\r?\n/g,lt=/^(?:submit|button|image|reset|file)$/i,ut=/^(?:input|select|textarea|keygen)/i;function dt(n,e,r,i){var t;if(ve.isArray(e))ve.each(e,function(e,t){r||st.test(n)?i(n,t):dt(n+"["+("object"==typeof t?e:"")+"]",t,r,i)});else if(r||"object"!==ve.type(e))i(n,e);else for(t in e)dt(n+"["+t+"]",e[t],r,i)}ve.fn.extend({serialize:function(){return ve.param(this.serializeArray())},serializeArray:function(){return this.map(function(){var e=ve.prop(this,"elements");return e?ve.makeArray(e):this}).filter(function(){var e=this.type;return this.name&&!ve(this).is(":disabled")&&ut.test(this.nodeName)&&!lt.test(e)&&(this.checked||!He.test(e))}).map(function(e,t){var n=ve(this).val();return null==n?null:ve.isArray(n)?ve.map(n,function(e){return{name:t.name,value:e.replace(ct,"\r\n")}}):{name:t.name,value:n.replace(ct,"\r\n")}}).get()}}),ve.param=function(e,t){var n,r=[],i=function(e,t){t=ve.isFunction(t)?t():null==t?"":t,r[r.length]=encodeURIComponent(e)+"="+encodeURIComponent(t)};if(t===w&&(t=ve.ajaxSettings&&ve.ajaxSettings.traditional),ve.isArray(e)||e.jquery&&!ve.isPlainObject(e))ve.each(e,function(){i(this.name,this.value)});else for(n in e)dt(n,e[n],t,i);return r.join("&").replace(at,"+")},ve.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "),function(e,n){ve.fn[n]=function(e,t){return 0<arguments.length?this.on(n,null,e,t):this.trigger(n)}}),ve.fn.hover=function(e,t){return this.mouseenter(e).mouseleave(t||e)};var ft,pt,ht=ve.now(),gt=/\?/,mt=/#.*$/,vt=/([?&])_=[^&]*/,yt=/^(.*?):[ \t]*([^\r\n]*)\r?$/gm,bt=/^(?:GET|HEAD)$/,xt=/^\/\//,Pt=/^([\w.+-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/,Ht=ve.fn.load,wt={},Ct={},Tt="*/".concat("*");try{pt=e.href}catch(e){(pt=g.createElement("a")).href="",pt=pt.href}function St(o){return function(e,t){"string"!=typeof e&&(t=e,e="*");var n,r=0,i=e.toLowerCase().match(C)||[];if(ve.isFunction(t))for(;n=i[r++];)"+"===n[0]?(n=n.slice(1)||"*",(o[n]=o[n]||[]).unshift(t)):(o[n]=o[n]||[]).push(t)}}function Et(t,i,o,a){var s={},c=t===Ct;function l(e){var r;return s[e]=!0,ve.each(t[e]||[],function(e,t){var n=t(i,o,a);return"string"!=typeof n||c||s[n]?c?!(r=n):void 0:(i.dataTypes.unshift(n),l(n),!1)}),r}return l(i.dataTypes[0])||!s["*"]&&l("*")}function Nt(e,t){var n,r,i=ve.ajaxSettings.flatOptions||{};for(r in t)t[r]!==w&&((i[r]?e:n||(n={}))[r]=t[r]);return n&&ve.extend(!0,e,n),e}ft=Pt.exec(pt.toLowerCase())||[],ve.fn.load=function(e,t,n){if("string"!=typeof e&&Ht)return Ht.apply(this,arguments);var r,i,o,a=this,s=e.indexOf(" ");return 0<=s&&(r=e.slice(s,e.length),e=e.slice(0,s)),ve.isFunction(t)?(n=t,t=w):t&&"object"==typeof t&&(o="POST"),0<a.length&&ve.ajax({url:e,type:o,dataType:"html",data:t}).done(function(e){i=arguments,a.html(r?ve("<div>").append(ve.parseHTML(e)).find(r):e)}).complete(n&&function(e,t){a.each(n,i||[e.responseText,t,e])}),this},ve.each(["ajaxStart","ajaxStop","ajaxComplete","ajaxError","ajaxSuccess","ajaxSend"],function(e,t){ve.fn[t]=function(e){return this.on(t,e)}}),ve.each(["get","post"],function(e,i){ve[i]=function(e,t,n,r){return ve.isFunction(t)&&(r=r||n,n=t,t=w),ve.ajax({url:e,type:i,dataType:r,data:t,success:n})}}),ve.extend({active:0,lastModified:{},etag:{},ajaxSettings:{url:pt,type:"GET",isLocal:/^(?:about|app|app-storage|.+-extension|file|res|widget):$/.test(ft[1]),global:!0,processData:!0,async:!0,contentType:"application/x-www-form-urlencoded; charset=UTF-8",accepts:{"*":Tt,text:"text/plain",html:"text/html",xml:"application/xml, text/xml",json:"application/json, text/javascript"},contents:{xml:/xml/,html:/html/,json:/json/},responseFields:{xml:"responseXML",text:"responseText"},converters:{"* text":h.String,"text html":!0,"text json":ve.parseJSON,"text xml":ve.parseXML},flatOptions:{url:!0,context:!0}},ajaxSetup:function(e,t){return t?Nt(Nt(e,ve.ajaxSettings),t):Nt(ve.ajaxSettings,e)},ajaxPrefilter:St(wt),ajaxTransport:St(Ct),ajax:function(e,t){"object"==typeof e&&(t=e,e=w),t=t||{};var n,r,u,d,f,p,h,i,g=ve.ajaxSetup({},t),m=g.context||g,v=g.context&&(m.nodeType||m.jquery)?ve(m):ve.event,y=ve.Deferred(),b=ve.Callbacks("once memory"),x=g.statusCode||{},o={},a={},P=0,s="canceled",H={readyState:0,getResponseHeader:function(e){var t;if(2===P){if(!i)for(i={};t=yt.exec(d);)i[t[1].toLowerCase()]=t[2];t=i[e.toLowerCase()]}return null==t?null:t},getAllResponseHeaders:function(){return 2===P?d:null},setRequestHeader:function(e,t){var n=e.toLowerCase();return P||(e=a[n]=a[n]||e,o[e]=t),this},overrideMimeType:function(e){return P||(g.mimeType=e),this},statusCode:function(e){var t;if(e)if(P<2)for(t in e)x[t]=[x[t],e[t]];else H.always(e[H.status]);return this},abort:function(e){var t=e||s;return h&&h.abort(t),c(0,t),this}};if(y.promise(H).complete=b.add,H.success=H.done,H.error=H.fail,g.url=((e||g.url||pt)+"").replace(mt,"").replace(xt,ft[1]+"//"),g.type=t.method||t.type||g.method||g.type,g.dataTypes=ve.trim(g.dataType||"*").toLowerCase().match(C)||[""],null==g.crossDomain&&(n=Pt.exec(g.url.toLowerCase()),g.crossDomain=!(!n||n[1]===ft[1]&&n[2]===ft[2]&&(n[3]||("http:"===n[1]?80:443))==(ft[3]||("http:"===ft[1]?80:443)))),g.data&&g.processData&&"string"!=typeof g.data&&(g.data=ve.param(g.data,g.traditional)),Et(wt,g,t,H),2===P)return H;for(r in(p=g.global)&&0==ve.active++&&ve.event.trigger("ajaxStart"),g.type=g.type.toUpperCase(),g.hasContent=!bt.test(g.type),u=g.url,g.hasContent||(g.data&&(u=g.url+=(gt.test(u)?"&":"?")+g.data,delete g.data),!1===g.cache&&(g.url=vt.test(u)?u.replace(vt,"$1_="+ht++):u+(gt.test(u)?"&":"?")+"_="+ht++)),g.ifModified&&(ve.lastModified[u]&&H.setRequestHeader("If-Modified-Since",ve.lastModified[u]),ve.etag[u]&&H.setRequestHeader("If-None-Match",ve.etag[u])),(g.data&&g.hasContent&&!1!==g.contentType||t.contentType)&&H.setRequestHeader("Content-Type",g.contentType),H.setRequestHeader("Accept",g.dataTypes[0]&&g.accepts[g.dataTypes[0]]?g.accepts[g.dataTypes[0]]+("*"!==g.dataTypes[0]?", "+Tt+"; q=0.01":""):g.accepts["*"]),g.headers)H.setRequestHeader(r,g.headers[r]);if(g.beforeSend&&(!1===g.beforeSend.call(m,H,g)||2===P))return H.abort();for(r in s="abort",{success:1,error:1,complete:1})H[r](g[r]);if(h=Et(Ct,g,t,H)){H.readyState=1,p&&v.trigger("ajaxSend",[H,g]),g.async&&0<g.timeout&&(f=setTimeout(function(){H.abort("timeout")},g.timeout));try{P=1,h.send(o,c)}catch(e){if(!(P<2))throw e;c(-1,e)}}else c(-1,"No Transport");function c(e,t,n,r){var i,o,a,s,c,l=t;2!==P&&(P=2,f&&clearTimeout(f),h=w,d=r||"",H.readyState=0<e?4:0,n&&(s=function(e,t,n){var r,i,o,a,s=e.contents,c=e.dataTypes,l=e.responseFields;for(a in l)a in n&&(t[l[a]]=n[a]);for(;"*"===c[0];)c.shift(),i===w&&(i=e.mimeType||t.getResponseHeader("Content-Type"));if(i)for(a in s)if(s[a]&&s[a].test(i)){c.unshift(a);break}if(c[0]in n)o=c[0];else{for(a in n){if(!c[0]||e.converters[a+" "+c[0]]){o=a;break}r||(r=a)}o=o||r}if(o)return o!==c[0]&&c.unshift(o),n[o]}(g,H,n)),200<=e&&e<300||304===e?(g.ifModified&&((c=H.getResponseHeader("Last-Modified"))&&(ve.lastModified[u]=c),(c=H.getResponseHeader("etag"))&&(ve.etag[u]=c)),204===e?(i=!0,l="nocontent"):304===e?(i=!0,l="notmodified"):(l=(i=function(e,t){var n,r,i,o,a={},s=0,c=e.dataTypes.slice(),l=c[0];e.dataFilter&&(t=e.dataFilter(t,e.dataType));if(c[1])for(i in e.converters)a[i.toLowerCase()]=e.converters[i];for(;r=c[++s];)if("*"!==r){if("*"!==l&&l!==r){if(!(i=a[l+" "+r]||a["* "+r]))for(n in a)if((o=n.split(" "))[1]===r&&(i=a[l+" "+o[0]]||a["* "+o[0]])){!0===i?i=a[n]:!0!==a[n]&&(r=o[0],c.splice(s--,0,r));break}if(!0!==i)if(i&&e.throws)t=i(t);else try{t=i(t)}catch(e){return{state:"parsererror",error:i?e:"No conversion from "+l+" to "+r}}}l=r}return{state:"success",data:t}}(g,s)).state,o=i.data,i=!(a=i.error))):(a=l,!e&&l||(l="error",e<0&&(e=0))),H.status=e,H.statusText=(t||l)+"",i?y.resolveWith(m,[o,l,H]):y.rejectWith(m,[H,l,a]),H.statusCode(x),x=w,p&&v.trigger(i?"ajaxSuccess":"ajaxError",[H,g,i?o:a]),b.fireWith(m,[H,l]),p&&(v.trigger("ajaxComplete",[H,g]),--ve.active||ve.event.trigger("ajaxStop")))}return H},getScript:function(e,t){return ve.get(e,w,t,"script")},getJSON:function(e,t,n){return ve.get(e,t,n,"json")}}),ve.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/(?:java|ecma)script/},converters:{"text script":function(e){return ve.globalEval(e),e}}}),ve.ajaxPrefilter("script",function(e){e.cache===w&&(e.cache=!1),e.crossDomain&&(e.type="GET",e.global=!1)}),ve.ajaxTransport("script",function(t){if(t.crossDomain){var r,i=g.head||ve("head")[0]||g.documentElement;return{send:function(e,n){(r=g.createElement("script")).async=!0,t.scriptCharset&&(r.charset=t.scriptCharset),r.src=t.url,r.onload=r.onreadystatechange=function(e,t){(t||!r.readyState||/loaded|complete/.test(r.readyState))&&(r.onload=r.onreadystatechange=null,r.parentNode&&r.parentNode.removeChild(r),r=null,t||n(200,"success"))},i.insertBefore(r,i.firstChild)},abort:function(){r&&r.onload(w,!0)}}}});var kt=[],At=/(=)\?(?=&|$)|\?\?/;ve.ajaxSetup({jsonp:"callback",jsonpCallback:function(){var e=kt.pop()||ve.expando+"_"+ht++;return this[e]=!0,e}}),ve.ajaxPrefilter("json jsonp",function(e,t,n){var r,i,o,a=!1!==e.jsonp&&(At.test(e.url)?"url":"string"==typeof e.data&&!(e.contentType||"").indexOf("application/x-www-form-urlencoded")&&At.test(e.data)&&"data");if(a||"jsonp"===e.dataTypes[0])return r=e.jsonpCallback=ve.isFunction(e.jsonpCallback)?e.jsonpCallback():e.jsonpCallback,a?e[a]=e[a].replace(At,"$1"+r):!1!==e.jsonp&&(e.url+=(gt.test(e.url)?"&":"?")+e.jsonp+"="+r),e.converters["script json"]=function(){return o||ve.error(r+" was not called"),o[0]},e.dataTypes[0]="json",i=h[r],h[r]=function(){o=arguments},n.always(function(){h[r]=i,e[r]&&(e.jsonpCallback=t.jsonpCallback,kt.push(r)),o&&ve.isFunction(i)&&i(o[0]),o=i=w}),"script"});var Dt,It,jt=0,Lt=h.ActiveXObject&&function(){var e;for(e in Dt)Dt[e](w,!0)};function Ft(){try{return new h.XMLHttpRequest}catch(e){}}ve.ajaxSettings.xhr=h.ActiveXObject?function(){return!this.isLocal&&Ft()||function(){try{return new h.ActiveXObject("Microsoft.XMLHTTP")}catch(e){}}()}:Ft,It=ve.ajaxSettings.xhr(),ve.support.cors=!!It&&"withCredentials"in It,(It=ve.support.ajax=!!It)&&ve.ajaxTransport(function(l){var u;if(!l.crossDomain||ve.support.cors)return{send:function(e,a){var s,t,c=l.xhr();if(l.username?c.open(l.type,l.url,l.async,l.username,l.password):c.open(l.type,l.url,l.async),l.xhrFields)for(t in l.xhrFields)c[t]=l.xhrFields[t];l.mimeType&&c.overrideMimeType&&c.overrideMimeType(l.mimeType),l.crossDomain||e["X-Requested-With"]||(e["X-Requested-With"]="XMLHttpRequest");try{for(t in e)c.setRequestHeader(t,e[t])}catch(e){}c.send(l.hasContent&&l.data||null),u=function(e,t){var n,r,i,o;try{if(u&&(t||4===c.readyState))if(u=w,s&&(c.onreadystatechange=ve.noop,Lt&&delete Dt[s]),t)4!==c.readyState&&c.abort();else{o={},n=c.status,r=c.getAllResponseHeaders(),"string"==typeof c.responseText&&(o.text=c.responseText);try{i=c.statusText}catch(e){i=""}n||!l.isLocal||l.crossDomain?1223===n&&(n=204):n=o.text?200:404}}catch(e){t||a(-1,e)}o&&a(n,i,o,r)},l.async?4===c.readyState?setTimeout(u):(s=++jt,Lt&&(Dt||(Dt={},ve(h).unload(Lt)),Dt[s]=u),c.onreadystatechange=u):u()},abort:function(){u&&u(w,!0)}}});var Mt,Bt,Ot=/^(?:toggle|show|hide)$/,qt=new RegExp("^(?:([+-])=|)("+p+")([a-z%]*)$","i"),_t=/queueHooks$/,$t=[function(t,e,n){var r,i,o,a,s,c,l,u,d,f=this,p=t.style,h={},g=[],m=t.nodeType&&Ze(t);n.queue||(null==(u=ve._queueHooks(t,"fx")).unqueued&&(u.unqueued=0,d=u.empty.fire,u.empty.fire=function(){u.unqueued||d()}),u.unqueued++,f.always(function(){f.always(function(){u.unqueued--,ve.queue(t,"fx").length||u.empty.fire()})}));1===t.nodeType&&("height"in e||"width"in e)&&(n.overflow=[p.overflow,p.overflowX,p.overflowY],"inline"===ve.css(t,"display")&&"none"===ve.css(t,"float")&&(ve.support.inlineBlockNeedsLayout&&"inline"!==it(t.nodeName)?p.zoom=1:p.display="inline-block"));n.overflow&&(p.overflow="hidden",ve.support.shrinkWrapBlocks||f.always(function(){p.overflow=n.overflow[0],p.overflowX=n.overflow[1],p.overflowY=n.overflow[2]}));for(i in e)if(a=e[i],Ot.exec(a)){if(delete e[i],c=c||"toggle"===a,a===(m?"hide":"show"))continue;g.push(i)}if(o=g.length){"hidden"in(s=ve._data(t,"fxshow")||ve._data(t,"fxshow",{}))&&(m=s.hidden),c&&(s.hidden=!m),m?ve(t).show():f.done(function(){ve(t).hide()}),f.done(function(){var e;for(e in ve._removeData(t,"fxshow"),h)ve.style(t,e,h[e])});for(i=0;i<o;i++)r=g[i],l=f.createTween(r,m?s[r]:0),h[r]=s[r]||ve.style(t,r),r in s||(s[r]=l.start,m&&(l.end=l.start,l.start="width"===r||"height"===r?1:0))}}],Rt={"*":[function(e,t){var n,r,i=this.createTween(e,t),o=qt.exec(t),a=i.cur(),s=+a||0,c=1,l=20;if(o){if(n=+o[2],"px"!==(r=o[3]||(ve.cssNumber[e]?"":"px"))&&s)for(s=ve.css(i.elem,e,!0)||n||1;s/=c=c||".5",ve.style(i.elem,e,s+r),c!==(c=i.cur()/a)&&1!==c&&--l;);i.unit=r,i.start=s,i.end=o[1]?s+(o[1]+1)*n:n}return i}]};function zt(){return setTimeout(function(){Mt=w}),Mt=ve.now()}function Xt(o,e,t){var n,a,s,r,i=0,c=$t.length,l=ve.Deferred().always(function(){delete u.elem}),u=function(){if(a)return!1;for(var e=Mt||zt(),t=Math.max(0,d.startTime+d.duration-e),n=1-(t/d.duration||0),r=0,i=d.tweens.length;r<i;r++)d.tweens[r].run(n);return l.notifyWith(o,[d,n,t]),n<1&&i?t:(l.resolveWith(o,[d]),!1)},d=l.promise({elem:o,props:ve.extend({},e),opts:ve.extend(!0,{specialEasing:{}},t),originalProperties:e,originalOptions:t,startTime:Mt||zt(),duration:t.duration,tweens:[],createTween:function(e,t){var n=ve.Tween(o,d.opts,e,t,d.opts.specialEasing[e]||d.opts.easing);return d.tweens.push(n),n},stop:function(e){var t=0,n=e?d.tweens.length:0;if(a)return this;for(a=!0;t<n;t++)d.tweens[t].run(1);return e?l.resolveWith(o,[d,e]):l.rejectWith(o,[d,e]),this}}),f=d.props;for(!function(e,t){var n,r,i,o,a;for(i in e)if(r=ve.camelCase(i),o=t[r],n=e[i],ve.isArray(n)&&(o=n[1],n=e[i]=n[0]),i!==r&&(e[r]=n,delete e[i]),(a=ve.cssHooks[r])&&"expand"in a)for(i in n=a.expand(n),delete e[r],n)i in e||(e[i]=n[i],t[i]=o);else t[r]=o}(f,d.opts.specialEasing);i<c;i++)if(n=$t[i].call(d,o,f,d.opts))return n;return s=d,r=f,ve.each(r,function(e,t){for(var n=(Rt[e]||[]).concat(Rt["*"]),r=0,i=n.length;r<i;r++)if(n[r].call(s,e,t))return}),ve.isFunction(d.opts.start)&&d.opts.start.call(o,d),ve.fx.timer(ve.extend(u,{elem:o,anim:d,queue:d.opts.queue})),d.progress(d.opts.progress).done(d.opts.done,d.opts.complete).fail(d.opts.fail).always(d.opts.always)}function Wt(e,t,n,r,i){return new Wt.prototype.init(e,t,n,r,i)}function Ut(e,t){var n,r={height:e},i=0;for(t=t?1:0;i<4;i+=2-t)r["margin"+(n=Je[i])]=r["padding"+n]=e;return t&&(r.opacity=r.width=e),r}function Vt(e){return ve.isWindow(e)?e:9===e.nodeType&&(e.defaultView||e.parentWindow)}ve.Animation=ve.extend(Xt,{tweener:function(e,t){ve.isFunction(e)?(t=e,e=["*"]):e=e.split(" ");for(var n,r=0,i=e.length;r<i;r++)n=e[r],Rt[n]=Rt[n]||[],Rt[n].unshift(t)},prefilter:function(e,t){t?$t.unshift(e):$t.push(e)}}),((ve.Tween=Wt).prototype={constructor:Wt,init:function(e,t,n,r,i,o){this.elem=e,this.prop=n,this.easing=i||"swing",this.options=t,this.start=this.now=this.cur(),this.end=r,this.unit=o||(ve.cssNumber[n]?"":"px")},cur:function(){var e=Wt.propHooks[this.prop];return e&&e.get?e.get(this):Wt.propHooks._default.get(this)},run:function(e){var t,n=Wt.propHooks[this.prop];return this.options.duration?this.pos=t=ve.easing[this.easing](e,this.options.duration*e,0,1,this.options.duration):this.pos=t=e,this.now=(this.end-this.start)*t+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),n&&n.set?n.set(this):Wt.propHooks._default.set(this),this}}).init.prototype=Wt.prototype,(Wt.propHooks={_default:{get:function(e){var t;return null==e.elem[e.prop]||e.elem.style&&null!=e.elem.style[e.prop]?(t=ve.css(e.elem,e.prop,""))&&"auto"!==t?t:0:e.elem[e.prop]},set:function(e){ve.fx.step[e.prop]?ve.fx.step[e.prop](e):e.elem.style&&(null!=e.elem.style[ve.cssProps[e.prop]]||ve.cssHooks[e.prop])?ve.style(e.elem,e.prop,e.now+e.unit):e.elem[e.prop]=e.now}}}).scrollTop=Wt.propHooks.scrollLeft={set:function(e){e.elem.nodeType&&e.elem.parentNode&&(e.elem[e.prop]=e.now)}},ve.each(["toggle","show","hide"],function(e,r){var i=ve.fn[r];ve.fn[r]=function(e,t,n){return null==e||"boolean"==typeof e?i.apply(this,arguments):this.animate(Ut(r,!0),e,t,n)}}),ve.fn.extend({fadeTo:function(e,t,n,r){return this.filter(Ze).css("opacity",0).show().end().animate({opacity:t},e,n,r)},animate:function(t,e,n,r){var i=ve.isEmptyObject(t),o=ve.speed(e,n,r),a=function(){var e=Xt(this,ve.extend({},t),o);a.finish=function(){e.stop(!0)},(i||ve._data(this,"finish"))&&e.stop(!0)};return a.finish=a,i||!1===o.queue?this.each(a):this.queue(o.queue,a)},stop:function(i,e,o){var a=function(e){var t=e.stop;delete e.stop,t(o)};return"string"!=typeof i&&(o=e,e=i,i=w),e&&!1!==i&&this.queue(i||"fx",[]),this.each(function(){var e=!0,t=null!=i&&i+"queueHooks",n=ve.timers,r=ve._data(this);if(t)r[t]&&r[t].stop&&a(r[t]);else for(t in r)r[t]&&r[t].stop&&_t.test(t)&&a(r[t]);for(t=n.length;t--;)n[t].elem!==this||null!=i&&n[t].queue!==i||(n[t].anim.stop(o),e=!1,n.splice(t,1));!e&&o||ve.dequeue(this,i)})},finish:function(a){return!1!==a&&(a=a||"fx"),this.each(function(){var e,t=ve._data(this),n=t[a+"queue"],r=t[a+"queueHooks"],i=ve.timers,o=n?n.length:0;for(t.finish=!0,ve.queue(this,a,[]),r&&r.cur&&r.cur.finish&&r.cur.finish.call(this),e=i.length;e--;)i[e].elem===this&&i[e].queue===a&&(i[e].anim.stop(!0),i.splice(e,1));for(e=0;e<o;e++)n[e]&&n[e].finish&&n[e].finish.call(this);delete t.finish})}}),ve.each({slideDown:Ut("show"),slideUp:Ut("hide"),slideToggle:Ut("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(e,r){ve.fn[e]=function(e,t,n){return this.animate(r,e,t,n)}}),ve.speed=function(e,t,n){var r=e&&"object"==typeof e?ve.extend({},e):{complete:n||!n&&t||ve.isFunction(e)&&e,duration:e,easing:n&&t||t&&!ve.isFunction(t)&&t};return r.duration=ve.fx.off?0:"number"==typeof r.duration?r.duration:r.duration in ve.fx.speeds?ve.fx.speeds[r.duration]:ve.fx.speeds._default,null!=r.queue&&!0!==r.queue||(r.queue="fx"),r.old=r.complete,r.complete=function(){ve.isFunction(r.old)&&r.old.call(this),r.queue&&ve.dequeue(this,r.queue)},r},ve.easing={linear:function(e){return e},swing:function(e){return.5-Math.cos(e*Math.PI)/2}},ve.timers=[],ve.fx=Wt.prototype.init,ve.fx.tick=function(){var e,t=ve.timers,n=0;for(Mt=ve.now();n<t.length;n++)(e=t[n])()||t[n]!==e||t.splice(n--,1);t.length||ve.fx.stop(),Mt=w},ve.fx.timer=function(e){e()&&ve.timers.push(e)&&ve.fx.start()},ve.fx.interval=13,ve.fx.start=function(){Bt||(Bt=setInterval(ve.fx.tick,ve.fx.interval))},ve.fx.stop=function(){clearInterval(Bt),Bt=null},ve.fx.speeds={slow:600,fast:200,_default:400},ve.fx.step={},ve.expr&&ve.expr.filters&&(ve.expr.filters.animated=function(t){return ve.grep(ve.timers,function(e){return t===e.elem}).length}),ve.fn.offset=function(t){if(arguments.length)return t===w?this:this.each(function(e){ve.offset.setOffset(this,t,e)});var e,n,r={top:0,left:0},i=this[0],o=i&&i.ownerDocument;return o?(e=o.documentElement,ve.contains(e,i)?(typeof i.getBoundingClientRect!==v&&(r=i.getBoundingClientRect()),n=Vt(o),{top:r.top+(n.pageYOffset||e.scrollTop)-(e.clientTop||0),left:r.left+(n.pageXOffset||e.scrollLeft)-(e.clientLeft||0)}):r):void 0},ve.offset={setOffset:function(e,t,n){var r=ve.css(e,"position");"static"===r&&(e.style.position="relative");var i,o,a=ve(e),s=a.offset(),c=ve.css(e,"top"),l=ve.css(e,"left"),u={},d={};("absolute"===r||"fixed"===r)&&-1<ve.inArray("auto",[c,l])?(i=(d=a.position()).top,o=d.left):(i=parseFloat(c)||0,o=parseFloat(l)||0),ve.isFunction(t)&&(t=t.call(e,n,s)),null!=t.top&&(u.top=t.top-s.top+i),null!=t.left&&(u.left=t.left-s.left+o),"using"in t?t.using.call(e,u):a.css(u)}},ve.fn.extend({position:function(){if(this[0]){var e,t,n={top:0,left:0},r=this[0];return"fixed"===ve.css(r,"position")?t=r.getBoundingClientRect():(e=this.offsetParent(),t=this.offset(),ve.nodeName(e[0],"html")||(n=e.offset()),n.top+=ve.css(e[0],"borderTopWidth",!0),n.left+=ve.css(e[0],"borderLeftWidth",!0)),{top:t.top-n.top-ve.css(r,"marginTop",!0),left:t.left-n.left-ve.css(r,"marginLeft",!0)}}},offsetParent:function(){return this.map(function(){for(var e=this.offsetParent||g.documentElement;e&&!ve.nodeName(e,"html")&&"static"===ve.css(e,"position");)e=e.offsetParent;return e||g.documentElement})}}),ve.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"},function(t,i){var o=/Y/.test(i);ve.fn[t]=function(e){return ve.access(this,function(e,t,n){var r=Vt(e);if(n===w)return r?i in r?r[i]:r.document.documentElement[t]:e[t];r?r.scrollTo(o?ve(r).scrollLeft():n,o?n:ve(r).scrollTop()):e[t]=n},t,e,arguments.length,null)}}),ve.each({Height:"height",Width:"width"},function(o,a){ve.each({padding:"inner"+o,content:a,"":"outer"+o},function(r,e){ve.fn[e]=function(e,t){var n=arguments.length&&(r||"boolean"!=typeof e),i=r||(!0===e||!0===t?"margin":"border");return ve.access(this,function(e,t,n){var r;return ve.isWindow(e)?e.document.documentElement["client"+o]:9===e.nodeType?(r=e.documentElement,Math.max(e.body["scroll"+o],r["scroll"+o],e.body["offset"+o],r["offset"+o],r["client"+o])):n===w?ve.css(e,t,i):ve.style(e,t,n,i)},a,n?e:w,n,null)}})}),h.jQuery=h.$=ve,"function"==typeof define&&define.amd&&define.amd.jQuery&&define("jquery",[],function(){return ve})}(window),(H5P=window.H5P||{}).jQuery=jQuery.noConflict(!0),(H5P=H5P||{}).Event=function(e,t,n){this.type=e,this.data=t;var r=!1,i=!1,o=!1;void 0===n&&(n={}),!0===n.bubbles&&(r=!0),!0===n.external&&(i=!0),this.preventBubbling=function(){r=!1},this.getBubbles=function(){return r},this.scheduleForExternal=function(){return!(!i||o)&&(o=!0)}},H5P.EventDispatcher=function(){var i=this,a={};this.on=function(e,t,n){if("function"!=typeof t)throw TypeError("listener must be a function");i.trigger("newListener",{type:e,listener:t});var r={listener:t,thisArg:n};a[e]?a[e].push(r):a[e]=[r]},this.once=function(e,t,n){if(!(t instanceof Function))throw TypeError("listener must be a function");var r=function(e){i.off(e.type,r),t.call(this,e)};i.on(e,r,n)},this.off=function(e,t){if(void 0!==t&&!(t instanceof Function))throw TypeError("listener must be a function");if(void 0!==a[e]){if(void 0===t)return delete a[e],void i.trigger("removeListener",e);for(var n=0;n<a[e].length;n++)if(a[e][n].listener===t){a[e].splice(n,1),i.trigger("removeListener",e,{listener:t});break}a[e].length||delete a[e]}};var o=function(e,t){if(void 0!==a[e])for(var n=a[e].slice(),r=0;r<n.length;r++){var i=n[r],o=i.thisArg?i.thisArg:this;i.listener.call(o,t)}};this.trigger=function(e,t,n){if(void 0!==e){e instanceof String||"string"==typeof e?e=new H5P.Event(e,t,n):void 0!==t&&(e.data=t);var r=e.scheduleForExternal();o.call(this,e.type,e),o.call(this,"*",e),e.getBubbles()&&i.parent instanceof H5P.EventDispatcher&&(i.parent.trigger instanceof Function||"function"==typeof i.parent.trigger)&&i.parent.trigger(e),r&&H5P.externalDispatcher.trigger.call(this,e)}}},H5P.ActionBar=function(e,n){"use strict";function t(e){n.call(this);var r=this,i=!1,o=H5P.jQuery('<ul class="h5p-actions"></ul>'),t=function(e,t){var n=function(){r.trigger(e)};H5P.jQuery("<li/>",{class:"h5p-button h5p-noselect h5p-"+(t||e),role:"button",tabindex:0,title:H5P.t(e+"Description"),html:H5P.t(e),on:{click:n,keypress:function(e){32===e.which&&(n(),e.preventDefault())}},appendTo:o}),i=!0};e.export&&t("download","export"),e.copyright&&t("copyrights"),e.embed&&t("embed"),e.icon&&(H5P.jQuery('<li><a class="h5p-link" href="http://h5p.org" target="_blank" title="'+H5P.t("h5pDescription")+'"></a></li>').appendTo(o),i=!0),r.getDOMElement=function(){return o},r.hasActions=function(){return i}}return(t.prototype=Object.create(n.prototype)).constructor=t}(H5P.jQuery,H5P.EventDispatcher),H5P.ContentType=function(e,t){function n(){}return(n.prototype=new H5P.EventDispatcher).isRoot=function(){return e},n.prototype.getLibraryFilePath=function(e){return H5P.getLibraryPath(this.libraryInfo.versionedNameNoSpaces)+"/"+e},n},(H5P=H5P||{}).XAPIEvent=function(){H5P.Event.call(this,"xAPI",{statement:{}},{bubbles:!0,external:!0})},H5P.XAPIEvent.prototype=Object.create(H5P.Event.prototype),H5P.XAPIEvent.prototype.constructor=H5P.XAPIEvent,H5P.XAPIEvent.prototype.setScoredResult=function(e,t,n,r,i){if(this.data.statement.result={},void 0!==e&&(void 0===t?this.data.statement.result.score={raw:e}:(this.data.statement.result.score={min:0,max:t,raw:e},0<t&&(this.data.statement.result.score.scaled=Math.round(e/t*1e4)/1e4))),this.data.statement.result.completion=void 0===r?"completed"===this.getVerb()||"answered"===this.getVerb():r,void 0!==i&&(this.data.statement.result.success=i),n&&n.activityStartTime){var o=Math.round((Date.now()-n.activityStartTime)/10)/100;this.data.statement.result.duration="PT"+o+"S"}},H5P.XAPIEvent.prototype.setVerb=function(e){-1!==H5P.jQuery.inArray(e,H5P.XAPIEvent.allowedXAPIVerbs)?this.data.statement.verb={id:"http://adlnet.gov/expapi/verbs/"+e,display:{"en-US":e}}:void 0!==e.id&&(this.data.statement.verb=e)},H5P.XAPIEvent.prototype.getVerb=function(e){var t=this.data.statement;return"verb"in t?!0===e?t.verb:t.verb.id.slice(31):null},H5P.XAPIEvent.prototype.setObject=function(e){e.contentId&&(this.data.statement.object={id:this.getContentXAPIId(e),objectType:"Activity",definition:{extensions:{"http://h5p.org/x-api/h5p-local-content-id":e.contentId}}},e.subContentId?(this.data.statement.object.definition.extensions["http://h5p.org/x-api/h5p-subContentId"]=e.subContentId,"function"==typeof e.getTitle&&(this.data.statement.object.definition.name={"en-US":e.getTitle()})):H5PIntegration&&H5PIntegration.contents&&H5PIntegration.contents["cid-"+e.contentId].title&&(this.data.statement.object.definition.name={"en-US":H5P.createTitle(H5PIntegration.contents["cid-"+e.contentId].title)}))},H5P.XAPIEvent.prototype.setContext=function(e){if(e.parent&&(e.parent.contentId||e.parent.subContentId)){void 0===e.parent.subContentId?e.parent.contentId:e.parent.subContentId;this.data.statement.context={contextActivities:{parent:[{id:this.getContentXAPIId(e.parent),objectType:"Activity"}]}}}e.libraryInfo&&(void 0===this.data.statement.context&&(this.data.statement.context={contextActivities:{}}),this.data.statement.context.contextActivities.category=[{id:"http://h5p.org/libraries/"+e.libraryInfo.versionedNameNoSpaces,objectType:"Activity"}])},H5P.XAPIEvent.prototype.setActor=function(){if(void 0!==H5PIntegration.user)this.data.statement.actor={name:H5PIntegration.user.name,mbox:"mailto:"+H5PIntegration.user.mail,objectType:"Agent"};else{var t;try{localStorage.H5PUserUUID?t=localStorage.H5PUserUUID:(t=H5P.createUUID(),localStorage.H5PUserUUID=t)}catch(e){t="not-trackable-"+H5P.createUUID()}this.data.statement.actor={account:{name:t,homePage:H5PIntegration.siteUrl},objectType:"Agent"}}},H5P.XAPIEvent.prototype.getMaxScore=function(){return this.getVerifiedStatementValue(["result","score","max"])},H5P.XAPIEvent.prototype.getScore=function(){return this.getVerifiedStatementValue(["result","score","raw"])},H5P.XAPIEvent.prototype.getContentXAPIId=function(e){var t;return e.contentId&&H5PIntegration&&H5PIntegration.contents&&(t=H5PIntegration.contents["cid-"+e.contentId].url,e.subContentId&&(t+="?subContentId="+e.subContentId)),t},H5P.XAPIEvent.prototype.isFromChild=function(){var e=this.getVerifiedStatementValue(["context","contextActivities","parent",0,"id"]);return!e||-1===e.indexOf("subContentId")},H5P.XAPIEvent.prototype.getVerifiedStatementValue=function(e){for(var t=this.data.statement,n=0;n<e.length;n++){if(void 0===t[e[n]])return null;t=t[e[n]]}return t},H5P.XAPIEvent.allowedXAPIVerbs=["answered","asked","attempted","attended","commented","completed","exited","experienced","failed","imported","initialized","interacted","launched","mastered","passed","preferred","progressed","registered","responded","resumed","scored","shared","suspended","terminated","voided","downloaded","accessed-embed","accessed-copyright"],(H5P=H5P||{}).externalDispatcher=new H5P.EventDispatcher,H5P.EventDispatcher.prototype.triggerXAPI=function(e,t){this.trigger(this.createXAPIEventTemplate(e,t))},H5P.EventDispatcher.prototype.createXAPIEventTemplate=function(e,t){var n=new H5P.XAPIEvent;if(n.setActor(),n.setVerb(e),void 0!==t)for(var r in t)n.data.statement[r]=t[r];return"object"in n.data.statement||n.setObject(this),"context"in n.data.statement||n.setContext(this),n},H5P.EventDispatcher.prototype.triggerXAPICompleted=function(e,t,n){this.triggerXAPIScored(e,t,"completed",!0,n)},H5P.EventDispatcher.prototype.triggerXAPIScored=function(e,t,n,r,i){var o=this.createXAPIEventTemplate(n);o.setScoredResult(e,t,this,r,i),this.trigger(o)},H5P.EventDispatcher.prototype.setActivityStarted=function(){void 0===this.activityStartTime&&(void 0!==this.contentId&&void 0!==H5PIntegration.contents&&void 0!==H5PIntegration.contents["cid-"+this.contentId]&&this.triggerXAPI("attempted"),this.activityStartTime=Date.now())},H5P.xAPICompletedListener=function(e){if(("completed"===e.getVerb()||"answered"===e.getVerb())&&!e.getVerifiedStatementValue(["context","contextActivities","parent"])){var t=e.getScore(),n=e.getMaxScore(),r=e.getVerifiedStatementValue(["object","definition","extensions","http://h5p.org/x-api/h5p-local-content-id"]);H5P.setFinished(r,t,n)}},(H5P=H5P||{}).isFramed=window.self!==window.parent,H5P.$window=H5P.jQuery(window),H5P.instances=[],document.documentElement.requestFullScreen?H5P.fullScreenBrowserPrefix="":document.documentElement.webkitRequestFullScreen?(H5P.safariBrowser=navigator.userAgent.match(/version\/([.\d]+)/i),H5P.safariBrowser=null===H5P.safariBrowser?0:parseInt(H5P.safariBrowser[1]),(0===H5P.safariBrowser||6<H5P.safariBrowser)&&(H5P.fullScreenBrowserPrefix="webkit")):document.documentElement.mozRequestFullScreen?H5P.fullScreenBrowserPrefix="moz":document.documentElement.msRequestFullscreen&&(H5P.fullScreenBrowserPrefix="ms"),H5P.opened={},H5P.init=function(e){void 0===H5P.$body&&(H5P.$body=H5P.jQuery(document.body)),void 0===H5P.fullscreenSupported&&(H5P.fullscreenSupported=!(H5P.isFramed&&!1!==H5P.externalEmbed&&!(document.fullscreenEnabled||document.webkitFullscreenEnabled||document.mozFullScreenEnabled))),void 0===H5P.canHasFullScreen&&(H5P.canHasFullScreen=H5P.fullscreenSupported);H5P.jQuery(".h5p-content:not(.h5p-initialized)",e).each(function(){var e=H5P.jQuery(this).addClass("h5p-initialized"),n=H5P.jQuery('<div class="h5p-container"></div>').appendTo(e),i=e.data("content-id"),o=H5PIntegration.contents["cid-"+i];if(void 0===o)return H5P.error("No data for content id "+i+". Perhaps the library is gone?");var a={library:o.library,params:JSON.parse(o.jsonContent)};H5P.getUserData(i,"state",function(e,t){if(t)a.userDatas={state:t};else if(null===t&&H5PIntegration.saveFreq){delete o.contentUserData;var r=new H5P.Dialog("content-user-data-reset","Data Reset","<p>"+H5P.t("contentChanged")+"</p><p>"+H5P.t("startingOver")+'</p><div class="h5p-dialog-ok-button" tabIndex="0" role="button">OK</div>',n);H5P.jQuery(r).on("dialog-opened",function(e,t){var n=function(e){"click"!==e.type&&32!==e.which||(r.close(),H5P.deleteUserData(i,"state",0))};t.find(".h5p-dialog-ok-button").click(n).keypress(n)}),r.open()}});var t=H5P.newRunnable(a,i,n,!0,{standalone:!0});1==o.fullScreen&&H5P.fullscreenSupported&&H5P.jQuery('<div class="h5p-content-controls"><div role="button" tabindex="0" class="h5p-enable-fullscreen" title="'+H5P.t("fullscreen")+'"></div></div>').prependTo(n).children().click(function(){H5P.fullScreen(n,t)}).keydown(function(e){if(32===e.which||13===e.which)return H5P.fullScreen(n,t),!1});var r,s=o.displayOptions,c=!1;if(s.frame){if(s.copyright){var l=H5P.getCopyrights(t,a.params,i);l||(s.copyright=!1)}var u=new H5P.ActionBar(s),d=u.getDOMElement();u.on("download",function(){window.location.href=o.exportUrl,t.triggerXAPI("downloaded")}),u.on("copyrights",function(){new H5P.Dialog("copyrights",H5P.t("copyrightInformation"),l,n).open(),t.triggerXAPI("accessed-copyright")}),u.on("embed",function(){H5P.openEmbedDialog(d,o.embedCode,o.resizeCode,{width:e.width(),height:e.height()}),t.triggerXAPI("accessed-embed")}),u.hasActions()&&(c=!0,d.insertAfter(n))}if(e.addClass(c?"h5p-frame":"h5p-no-frame"),H5P.opened[i]=new Date,H5P.on(t,"finish",function(e){void 0!==e.data&&H5P.setFinished(i,e.data.score,e.data.maxScore,e.data.time)}),H5P.on(t,"xAPI",H5P.xAPICompletedListener),!1!==H5PIntegration.saveFreq&&(t.getCurrentState instanceof Function||"function"==typeof t.getCurrentState)){var f,p=function(){var e=t.getCurrentState();void 0!==e&&H5P.setUserData(i,"state",e,{deleteOnChange:!0}),H5PIntegration.saveFreq&&(f=setTimeout(p,1e3*H5PIntegration.saveFreq))};H5PIntegration.saveFreq&&(f=setTimeout(p,1e3*H5PIntegration.saveFreq)),H5P.on(t,"xAPI",function(e){var t=e.getVerb();"completed"!==t&&"progressed"!==t||(clearTimeout(f),f=setTimeout(p,3e3))})}if(H5P.isFramed)if(!1===H5P.externalEmbed){var h=window.frameElement;H5P.on(t,"resize",function(){clearTimeout(r),r=setTimeout(function(){!function(){if(!window.parent.H5P.isFullscreen){var e=h.parentElement.style.height;h.parentElement.style.height=h.parentElement.clientHeight+"px",h.style.height="1px",h.style.height=h.contentDocument.body.scrollHeight+"px",h.parentElement.style.height=e}}()},1)})}else if(H5P.communicator){var g=!1;H5P.communicator.on("ready",function(){H5P.communicator.send("hello")}),H5P.communicator.on("hello",function(){g=!0,document.body.style.height="auto",document.body.style.overflow="hidden",H5P.trigger(t,"resize")}),H5P.communicator.on("resizePrepared",function(e){H5P.communicator.send("resize",{scrollHeight:document.body.scrollHeight})}),H5P.communicator.on("resize",function(){H5P.trigger(t,"resize")}),H5P.on(t,"resize",function(){H5P.isFullscreen||(clearTimeout(r),r=setTimeout(function(){g?H5P.communicator.send("prepareResize",{scrollHeight:document.body.scrollHeight,clientHeight:document.body.clientHeight}):H5P.communicator.send("hello")},0))})}H5P.isFramed&&!1!==H5P.externalEmbed||H5P.jQuery(window.parent).resize(function(){window.parent.H5P.isFullscreen,H5P.trigger(t,"resize")}),H5P.instances.push(t),H5P.trigger(t,"resize")});H5P.jQuery("iframe.h5p-iframe:not(.h5p-initialized)",e).each(function(){var e=H5P.jQuery(this).addClass("h5p-initialized").data("content-id");this.contentDocument.open(),this.contentDocument.write('<!doctype html><html class="h5p-iframe"><head>'+H5P.getHeadTags(e)+'</head><body><div class="h5p-content" data-content-id="'+e+'"/></body></html>'),this.contentDocument.close()})},H5P.getHeadTags=function(e){var t=function(e){for(var t="",n=0;n<e.length;n++)t+='<link rel="stylesheet" href="'+e[n]+'">';return t},n=function(e){for(var t="",n=0;n<e.length;n++)t+='<script src="'+e[n]+'"><\/script>';return t};return'<base target="_parent">'+t(H5PIntegration.core.styles)+t(H5PIntegration.contents["cid-"+e].styles)+n(H5PIntegration.core.scripts)+n(H5PIntegration.contents["cid-"+e].scripts)+"<script>H5PIntegration = window.parent.H5PIntegration; var H5P = H5P || {}; H5P.externalEmbed = false;<\/script>"},H5P.communicator=window.postMessage&&window.addEventListener?new function(){var n={};window.addEventListener("message",function(e){window.parent===e.source&&"h5p"===e.data.context&&void 0!==n[e.data.action]&&n[e.data.action](e.data)},!1),this.on=function(e,t){n[e]=t},this.send=function(e,t){void 0===t&&(t={}),t.context="h5p",t.action=e,window.parent.postMessage(t,"*")}}:void 0,H5P.semiFullScreen=function(e,t,n,r){H5P.fullScreen(e,t,n,r,!0)},H5P.fullScreen=function(e,t,n,r,i){if(void 0===H5P.exitFullScreen){if(H5P.isFramed&&!1===H5P.externalEmbed)return window.parent.H5P.fullScreen(e,t,n,H5P.$body.get(),i),H5P.isFullscreen=!0,H5P.exitFullScreen=function(){window.parent.H5P.exitFullScreen()},void H5P.on(t,"exitFullScreen",function(){H5P.isFullscreen=!1,H5P.exitFullScreen=void 0});var o,a,s=e;if(void 0===r)$body=H5P.$body;else{$body=H5P.jQuery(r),o=$body.add(e.get());var c="#h5p-iframe-"+e.parent().data("content-id");e=(a=H5P.jQuery(c)).parent()}o=e.add(H5P.$body).add(o);var l=function(e){o.addClass(e),void 0!==a&&a.css("height","")},u=function(){H5P.trigger(t,"resize"),H5P.trigger(t,"focus"),H5P.trigger(t,"enterFullScreen")},d=function(e){H5P.isFullscreen=!1,o.removeClass(e),H5P.trigger(t,"resize"),H5P.trigger(t,"focus"),(H5P.exitFullScreen=void 0)!==n&&n(),H5P.trigger(t,"exitFullScreen")};if(H5P.isFullscreen=!0,void 0===H5P.fullScreenBrowserPrefix||!0===i){if(H5P.isFramed)return;l("h5p-semi-fullscreen");var f,p,h,g=H5P.jQuery('<div role="button" tabindex="0" class="h5p-disable-fullscreen" title="'+H5P.t("disableFullscreen")+'"></div>').appendTo(s.find(".h5p-content-controls")),m=H5P.exitFullScreen=function(){p?h.content=p:b.removeChild(h),g.remove(),$body.unbind("keyup",f),d("h5p-semi-fullscreen")};f=function(e){27===e.keyCode&&m()},g.click(m),$body.keyup(f);for(var v=document.getElementsByTagName("meta"),y=0;y<v.length;y++)if("viewport"===v[y].name){h=v[y],p=h.content;break}if(p||((h=document.createElement("meta")).name="viewport"),h.content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0",!p){var b=document.getElementsByTagName("head")[0];b.appendChild(h)}u()}else{l("h5p-fullscreen");var x,P="ms"===H5P.fullScreenBrowserPrefix?"MSFullscreenChange":H5P.fullScreenBrowserPrefix+"fullscreenchange";if(document.addEventListener(P,function(){if(void 0===x)return x=!1,void u();d("h5p-fullscreen"),document.removeEventListener(P,arguments.callee,!1)}),""===H5P.fullScreenBrowserPrefix)e[0].requestFullScreen();else{var H="ms"===H5P.fullScreenBrowserPrefix?"msRequestFullscreen":H5P.fullScreenBrowserPrefix+"RequestFullScreen",w="webkit"===H5P.fullScreenBrowserPrefix&&0===H5P.safariBrowser?Element.ALLOW_KEYBOARD_INPUT:void 0;e[0][H](w)}H5P.exitFullScreen=function(){""===H5P.fullScreenBrowserPrefix?document.exitFullscreen():"moz"===H5P.fullScreenBrowserPrefix?document.mozCancelFullScreen():document[H5P.fullScreenBrowserPrefix+"ExitFullscreen"]()}}}},H5P.getPath=function(e,t){var n,r=function(e){return e.match(/^[a-z0-9]+:\/\//i)};if(r(e))return e;var i="#tmp"===e.substr(-4,4);if(void 0===t||i){if(void 0===window.H5PEditor)return;n=H5PEditor.filesPath}else void 0!==H5PIntegration.contents&&H5PIntegration.contents["cid-"+t]&&(n=H5PIntegration.contents["cid-"+t].contentUrl),n||(n=H5PIntegration.url+"/content/"+t);return r(n)||(n=window.location.protocol+"//"+window.location.host+n),n+"/"+e},H5P.getContentPath=function(e){return H5PIntegration.url+"/content/"+e},H5P.classFromName=function(e){var t=e.split(".");return this[t[t.length-1]]},H5P.newRunnable=function(t,e,n,r,i){var o,a,s,c;try{s=(o=t.library.split(" ",2))[0],a=o[1].split(".",2)}catch(e){return H5P.error("Invalid library string: "+t.library)}if(t.params instanceof Object!=!0||t.params instanceof Array==!0)return H5P.error("Invalid library params for: "+t.library),H5P.error(t.params);try{o=o[0].split("."),c=window;for(var l=0;l<o.length;l++)c=c[o[l]];if("function"!=typeof c)throw null}catch(e){return H5P.error("Unable to find constructor for: "+t.library)}void 0===i&&(i={}),t.subContentId&&(i.subContentId=t.subContentId),t.userDatas&&t.userDatas.state&&H5PIntegration.saveFreq&&(i.previousState=t.userDatas.state);var u,d=i.standalone||!1;return c.prototype=H5P.jQuery.extend({},H5P.ContentType(d).prototype,c.prototype),void 0===(u=-1<H5P.jQuery.inArray(t.library,["H5P.CoursePresentation 1.0","H5P.CoursePresentation 1.1","H5P.CoursePresentation 1.2","H5P.CoursePresentation 1.3"])?new c(t.params,e):new c(t.params,e,i)).$&&(u.$=H5P.jQuery(u)),void 0===u.contentId&&(u.contentId=e),void 0===u.subContentId&&t.subContentId&&(u.subContentId=t.subContentId),void 0===u.parent&&i&&i.parent&&(u.parent=i.parent),void 0===u.libraryInfo&&(u.libraryInfo={versionedName:t.library,versionedNameNoSpaces:s+"-"+a[0]+"."+a[1],machineName:s,majorVersion:a[0],minorVersion:a[1]}),void 0!==n&&(n.toggleClass("h5p-standalone",d),u.attach(n),H5P.trigger(u,"domChanged",{$target:n,library:s,key:"newLibrary"},{bubbles:!0,external:!0}),void 0!==r&&r||H5P.trigger(u,"resize")),u},H5P.error=function(e){void 0!==window.console&&void 0!==console.error&&console.error(e.stack?e.stack:e)},H5P.t=function(e,t,n){if(void 0===n&&(n="H5P"),void 0===H5PIntegration.l10n[n])return'[Missing translation namespace "'+n+'"]';if(void 0===H5PIntegration.l10n[n][e])return'[Missing translation "'+e+'" in "'+n+'"]';var r=H5PIntegration.l10n[n][e];if(void 0!==t)for(var i in t)r=r.replace(i,t[i]);return r},H5P.Dialog=function(e,t,n,r){var i=this,o=H5P.jQuery('<div class="h5p-popup-dialog h5p-'+e+'-dialog">                              <div class="h5p-inner">                                <h2>'+t+'</h2>                                <div class="h5p-scroll-content">'+n+'</div>                                <div class="h5p-close" role="button" tabindex="0" title="'+H5P.t("close")+'">                              </div>                            </div>').insertAfter(r).click(function(){i.close()}).children(".h5p-inner").click(function(){return!1}).find(".h5p-close").click(function(){i.close()}).end().find("a").click(function(e){e.stopPropagation()}).end().end();i.open=function(){setTimeout(function(){o.addClass("h5p-open"),H5P.jQuery(i).trigger("dialog-opened",[o])},1)},i.close=function(){o.removeClass("h5p-open"),setTimeout(function(){o.remove()},200)}},H5P.getCopyrights=function(e,t,n){var r;if(void 0!==e.getCopyrights)try{r=e.getCopyrights()}catch(e){}return void 0===r&&(r=new H5P.ContentCopyrights,H5P.findCopyrights(r,t,n)),void 0!==r&&(r=r.toString()),r},H5P.findCopyrights=function(e,t,n){for(var r in t)if(t.hasOwnProperty(r))if("overrideSettings"!==r){var i=t[r];if(i instanceof Array)H5P.findCopyrights(e,i,n);else if(i instanceof Object)if(void 0===i.copyright||void 0===i.copyright.license||void 0===i.path||void 0===i.mime)H5P.findCopyrights(e,i,n);else{var o=new H5P.MediaCopyright(i.copyright);void 0!==i.width&&void 0!==i.height&&o.setThumbnail(new H5P.Thumbnail(H5P.getPath(i.path,n),i.width,i.height)),e.addMedia(o)}}else console.warn("The semantics field 'overrideSettings' is DEPRECATED and should not be used."),console.warn(t)},H5P.openEmbedDialog=function(e,t,n,d){var f=t+n,r=new H5P.Dialog("embed",H5P.t("embed"),'<textarea class="h5p-embed-code-container" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>'+H5P.t("size")+': <input type="text" value="'+Math.ceil(d.width)+'" class="h5p-embed-size"/> × <input type="text" value="'+Math.ceil(d.height)+'" class="h5p-embed-size"/> px<br/><div role="button" tabindex="0" class="h5p-expander">'+H5P.t("showAdvanced")+'</div><div class="h5p-expander-content"><p>'+H5P.t("advancedHelp")+'</p><textarea class="h5p-embed-code-container" autocorrect="off" autocapitalize="off" spellcheck="false">'+n+"</textarea></div>",e);H5P.jQuery(r).on("dialog-opened",function(e,n){var t=n.find(".h5p-inner"),r=t.find(".h5p-scroll-content"),i=r.outerHeight()-r.innerHeight(),o=function(){var e=t.height();r[0].scrollHeight+i>e?t.css("height",""):(t.css("height","auto"),e=t.height()),t.css("marginTop","-"+e/2+"px")},a=n.find(".h5p-embed-size:eq(0)"),s=n.find(".h5p-embed-size:eq(1)"),c=function(e,t){var n=parseFloat(e.val());return isNaN(n)?t:Math.ceil(n)},l=function(){n.find(".h5p-embed-code-container:first").val(f.replace(":w",c(a,d.width)).replace(":h",c(s,d.height)))};a.change(l),s.change(l),l(),n.find(".h5p-embed-code-container").each(function(e,t){H5P.jQuery(this).css("height",this.scrollHeight+"px").focus(function(){H5P.jQuery(this).select()})}),n.find(".h5p-embed-code-container").eq(0).select(),o();var u=function(){var e=H5P.jQuery(this),t=e.next();t.is(":visible")?(e.removeClass("h5p-open").text(H5P.t("showAdvanced")),t.hide()):(e.addClass("h5p-open").text(H5P.t("hideAdvanced")),t.show()),n.find(".h5p-embed-code-container").each(function(e,t){H5P.jQuery(this).css("height",this.scrollHeight+"px")}),o()};n.find(".h5p-expander").click(u).keypress(function(e){32===e.keyCode&&u.apply(this)})}),r.open()},H5P.ContentCopyrights=function(){var n,r=[],i=[];this.setLabel=function(e){n=e},this.addMedia=function(e){void 0!==e&&r.push(e)},this.addContent=function(e){void 0!==e&&i.push(e)},this.toString=function(){for(var e="",t=0;t<r.length;t++)e+=r[t];for(t=0;t<i.length;t++)e+=i[t];return""!==e&&(void 0!==n&&(e="<h3>"+n+"</h3>"+e),e='<div class="h5p-content-copyrights">'+e+"</div>"),e}},H5P.MediaCopyright=function(e,t,n,r){var i,o=new H5P.DefinitionList,a=function(e){return void 0===t||void 0===t[e]?H5P.t(e):t[e]},s=function(e,t){var n,r,i=H5P.copyrightLicenses[e],o="";"PD"===e&&t||(o+=i.hasOwnProperty("label")?i.label:i),i.versions&&(!i.versions.default||t&&i.versions[t]||(t=i.versions.default),t&&i.versions[t]&&(n=i.versions[t])),n&&(o&&(o+=" "),o+=n.hasOwnProperty("label")?n.label:n),i.hasOwnProperty("link")?r=i.link.replace(":version",i.linkVersions?i.linkVersions[t]:t):n&&i.hasOwnProperty("link")&&(r=n.link),r&&(o='<a href="'+r+'" target="_blank">'+o+"</a>");var a="";return"PD"!==e&&"C"!==e&&(a+=e),t&&"CC0 1.0"!==t&&(a&&"GNU GPL"!==e&&(a+=" "),a+=t),a&&(o+=" ("+a+")"),"C"===e&&(o+=" &copy;"),o};if(void 0!==e){for(var c in r)r.hasOwnProperty(c)&&(e[c]=r[c]);void 0===n&&(n=["title","author","year","source","license"]);for(var l=0;l<n.length;l++){var u=n[l];if(void 0!==e[u]){var d=e[u];"license"===u&&(d=s(e.license,e.version)),o.add(new H5P.Field(a(u),d))}}}this.setThumbnail=function(e){i=e},this.undisclosed=function(){if(1===o.size()){var e=o.get(0);if(e.getLabel()===a("license")&&e.getValue()===s("U"))return!0}return!1},this.toString=function(){var e="";return this.undisclosed()||(void 0!==i&&(e+=i),""!==(e+=o)&&(e='<div class="h5p-media-copyright">'+e+"</div>")),e}},H5P.Thumbnail=function(e,t,n){var r;void 0!==t&&(r=Math.round(t/n*100)),this.toString=function(){return'<img src="'+e+'" alt="'+H5P.t("thumbnail")+'" class="h5p-thumbnail" height="100"'+(void 0===r?"":' width="'+r+'"')+"/>"}},H5P.Field=function(e,t){this.getLabel=function(){return e},this.getValue=function(){return t}},H5P.DefinitionList=function(){var r=[];this.add=function(e){r.push(e)},this.size=function(){return r.length},this.get=function(e){return r[e]},this.toString=function(){for(var e="",t=0;t<r.length;t++){var n=r[t];e+="<dt>"+n.getLabel()+"</dt><dd>"+n.getValue()+"</dd>"}return""===e?e:'<dl class="h5p-definition-list">'+e+"</dl>"}},H5P.Coords=function(e,t,n,r){return this instanceof H5P.Coords?(this.x=0,this.y=0,this.w=1,this.h=1,"object"==typeof e?(this.x=e.x,this.y=e.y,this.w=e.w,this.h=e.h):(void 0!==e&&(this.x=e),void 0!==t&&(this.y=t),void 0!==n&&(this.w=n),void 0!==r&&(this.h=r)),this):new H5P.Coords(e,t,n,r)},H5P.libraryFromString=function(e){var t=/(.+)\s(\d+)\.(\d+)$/g.exec(e);return null!==t&&{machineName:t[1],majorVersion:t[2],minorVersion:t[3]}},H5P.getLibraryPath=function(e){return(void 0!==H5PIntegration.libraryUrl?H5PIntegration.libraryUrl+"/":H5PIntegration.url+"/libraries/")+e},H5P.cloneObject=function(e,t){var n=e instanceof Array?[]:{};for(var r in e)e.hasOwnProperty(r)&&(void 0!==t&&t&&"object"==typeof e[r]?n[r]=H5P.cloneObject(e[r],t):n[r]=e[r]);return n},H5P.trim=function(e){return e.replace(/^\s+|\s+$/g,"")},H5P.jsLoaded=function(e){return H5PIntegration.loadedJs=H5PIntegration.loadedJs||[],-1!==H5P.jQuery.inArray(e,H5PIntegration.loadedJs)},H5P.cssLoaded=function(e){return H5PIntegration.loadedCss=H5PIntegration.loadedCss||[],-1!==H5P.jQuery.inArray(e,H5PIntegration.loadedCss)},H5P.shuffleArray=function(e){if(e instanceof Array){var t,n,r,i=e.length;if(0===i)return!1;for(;--i;)t=Math.floor(Math.random()*(i+1)),n=e[i],r=e[t],e[i]=r,e[t]=n;return e}},H5P.setFinished=function(e,t,n,r){if(("number"==typeof t||t instanceof Number)&&!0===H5PIntegration.postUserStatistics){var i=function(e){return Math.round(e.getTime()/1e3)};H5P.jQuery.post(H5PIntegration.ajax.setFinished,{contentId:e,score:t,maxScore:n,opened:i(H5P.opened[e]),finished:i(new Date),time:r})}},Array.prototype.indexOf||(Array.prototype.indexOf=function(e){for(var t=0;t<this.length;t++)if(this[t]===e)return t;return-1}),void 0===String.prototype.trim&&(String.prototype.trim=function(){return H5P.trim(this)}),H5P.trigger=function(e,t,n,r){void 0!==e.trigger?e.trigger(t,n,r):void 0!==e.$&&void 0!==e.$.trigger&&e.$.trigger(t)},H5P.on=function(e,t,n){void 0!==e.on?e.on(t,n):void 0!==e.$&&void 0!==e.$.on&&e.$.on(t,n)},H5P.createUUID=function(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,function(e){var t=16*Math.random()|0;return("x"===e?t:3&t|8).toString(16)})},H5P.createTitle=function(e,t){if(!e)return"";void 0===t&&(t=60);var n=H5P.jQuery("<div></div>").text(e.replace(/(<([^>]+)>)/gi,"")).text();return n.length>t&&(n=n.substr(0,t-3)+"..."),n},function(l){function s(e,t,n,r,i,o,a,s){if(void 0!==H5PIntegration.user){var c={url:H5PIntegration.ajax.contentUserData.replace(":contentId",e).replace(":dataType",t).replace(":subContentId",n||0),dataType:"json",async:void 0===s||s};void 0!==i?(c.type="POST",c.data={data:null===i?0:i,preload:o?1:0,invalidate:a?1:0}):c.type="GET",void 0!==r&&(c.error=function(e,t){r(t)},c.success=function(e){e.success?!1!==e.data&&void 0!==e.data?r(void 0,e.data):r():r(e.message)}),l.ajax(c)}else r("Not signed in.")}H5P.getUserData=function(e,n,r,i){i||(i=0),H5PIntegration.contents=H5PIntegration.contents||{};var o=H5PIntegration.contents["cid-"+e]||{},a=o.contentUserData;if(a&&a[i]&&void 0!==a[i][n]){if("RESET"===a[i][n])return void r(void 0,null);try{r(void 0,JSON.parse(a[i][n]))}catch(e){r(e)}}else s(e,n,i,function(e,t){if(e||void 0===t)r(e,t);else{void 0===o.contentUserData&&(o.contentUserData=a={}),void 0===a[i]&&(a[i]={}),a[i][n]=t;try{r(void 0,JSON.parse(t))}catch(e){r(e)}}})},H5P.setUserData=function(e,t,n,r){var i=H5P.jQuery.extend(!0,{},{subContentId:0,preloaded:!0,deleteOnChange:!1,async:!0},r);try{n=JSON.stringify(n)}catch(e){return void(i.errorCallback&&i.errorCallback(e))}var o=H5PIntegration.contents["cid-"+e];void 0===o&&(o=H5PIntegration.contents["cid-"+e]={}),o.contentUserData||(o.contentUserData={});var a=o.contentUserData;void 0===a[i.subContentId]&&(a[i.subContentId]={}),n!==a[i.subContentId][t]&&(a[i.subContentId][t]=n,s(e,t,i.subContentId,function(e,t){i.errorCallback&&e&&i.errorCallback(e)},n,i.preloaded,i.deleteOnChange,i.async))},H5P.deleteUserData=function(e,t,n){n||(n=0);var r=H5PIntegration.contents["cid-"+e].contentUserData;r&&r[n]&&r[n][t]&&delete r[n][t],s(e,t,n,void 0,null)},l(document).ready(function(){var e={default:"4.0","4.0":H5P.t("licenseCC40"),"3.0":H5P.t("licenseCC30"),2.5:H5P.t("licenseCC25"),"2.0":H5P.t("licenseCC20"),"1.0":H5P.t("licenseCC10")};if(H5P.copyrightLicenses={U:H5P.t("licenseU"),"CC BY":{label:H5P.t("licenseCCBY"),link:"http://creativecommons.org/licenses/by/:version/legalcode",versions:e},"CC BY-SA":{label:H5P.t("licenseCCBYSA"),link:"http://creativecommons.org/licenses/by-sa/:version/legalcode",versions:e},"CC BY-ND":{label:H5P.t("licenseCCBYND"),link:"http://creativecommons.org/licenses/by-nd/:version/legalcode",versions:e},"CC BY-NC":{label:H5P.t("licenseCCBYNC"),link:"http://creativecommons.org/licenses/by-nc/:version/legalcode",versions:e},"CC BY-NC-SA":{label:H5P.t("licenseCCBYNCSA"),link:"http://creativecommons.org/licenses/by-nc-sa/:version/legalcode",versions:e},"CC BY-NC-ND":{label:H5P.t("licenseCCBYNCND"),link:"http://creativecommons.org/licenses/by-nc-nd/:version/legalcode",versions:e},"GNU GPL":{label:H5P.t("licenseGPL"),link:"http://www.gnu.org/licenses/gpl-:version-standalone.html",linkVersions:{v3:"3.0",v2:"2.0",v1:"1.0"},versions:{default:"v3",v3:H5P.t("licenseV3"),v2:H5P.t("licenseV2"),v1:H5P.t("licenseV1")}},PD:{label:H5P.t("licensePD"),versions:{"CC0 1.0":{label:H5P.t("licenseCC010"),link:"https://creativecommons.org/publicdomain/zero/1.0/"},"CC PDM":{label:H5P.t("licensePDM"),link:"https://creativecommons.org/publicdomain/mark/1.0/"}}},"ODC PDDL":'<a href="http://opendatacommons.org/licenses/pddl/1.0/" target="_blank">Public Domain Dedication and Licence</a>',"CC PDM":H5P.t("licensePDM"),C:H5P.t("licenseC")},H5P.isFramed&&!1===H5P.externalEmbed&&H5P.externalDispatcher.on("*",function(e){window.parent.H5P.externalDispatcher.trigger.call(this,e)}),H5P.preventInit||H5P.init(document.body),!1!==H5PIntegration.saveFreq){var i=0,t=function(){var e=(new Date).getTime();if(250<e-i){i=e;for(var t=0;t<H5P.instances.length;t++){var n=H5P.instances[t];if(n.getCurrentState instanceof Function||"function"==typeof n.getCurrentState){var r=n.getCurrentState();void 0!==r&&H5P.setUserData(n.contentId,"state",r,{deleteOnChange:!0,async:!1})}}}};H5P.$window.one("beforeunload unload",function(){H5P.$window.off("pagehide beforeunload unload"),t()}),H5P.$window.on("pagehide",t)}})}(H5P.jQuery),H5P.getLibraryPath=function(e){return H5PIntegration.pathIncludesVersion?H5PIntegration.url+"/"+e:H5PIntegration.url+"/"+e.split("-")[0]},H5P.getPath=function(e,t){var n;if(e.match(/^[a-z0-9]+:\/\//i))return e;if(void 0!==t)n=H5PIntegration.url+"/content";else{if(void 0===window.H5PEditor)return;n=H5PEditor.filesPath}return n+"/"+e};
+var H5P;
+! function(h, w) {
+    var t, n, v = typeof w,
+        g = h.document,
+        e = h.location,
+        r = h.jQuery,
+        i = h.$,
+        o = {},
+        d = [],
+        a = "1.9.1",
+        y = d.concat,
+        s = d.push,
+        u = d.slice,
+        c = d.indexOf,
+        l = o.toString,
+        m = o.hasOwnProperty,
+        f = a.trim,
+        ve = function(e, t) {
+            return new ve.fn.init(e, t, n)
+        },
+        p = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,
+        C = /\S+/g,
+        b = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,
+        x = /^(?:(<[\w\W]+>)[^>]*|#([\w-]*))$/,
+        P = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
+        H = /^[\],:{}\s]*$/,
+        T = /(?:^|:|,)(?:\s*\[)+/g,
+        S = /\\(?:["\\\/bfnrt]|u[\da-fA-F]{4})/g,
+        E = /"[^"\\\r\n]*"|true|false|null|-?(?:\d+\.|)\d+(?:[eE][+-]?\d+|)/g,
+        N = /^-ms-/,
+        k = /-([\da-z])/gi,
+        A = function(e, t) {
+            return t.toUpperCase()
+        },
+        D = function(e) {
+            (g.addEventListener || "load" === e.type || "complete" === g.readyState) && (I(), ve.ready())
+        },
+        I = function() {
+            g.addEventListener ? (g.removeEventListener("DOMContentLoaded", D, !1), h.removeEventListener("load", D, !1)) : (g.detachEvent("onreadystatechange", D), h.detachEvent("onload", D))
+        };
+
+    function j(e) {
+        var t = e.length,
+            n = ve.type(e);
+        return !ve.isWindow(e) && (!(1 !== e.nodeType || !t) || ("array" === n || "function" !== n && (0 === t || "number" == typeof t && 0 < t && t - 1 in e)))
+    }
+    ve.fn = ve.prototype = {
+        jquery: a,
+        constructor: ve,
+        init: function(e, t, n) {
+            var r, i;
+            if (!e) return this;
+            if ("string" == typeof e) {
+                if (!(r = "<" === e.charAt(0) && ">" === e.charAt(e.length - 1) && 3 <= e.length ? [null, e, null] : x.exec(e)) || !r[1] && t) return !t || t.jquery ? (t || n).find(e) : this.constructor(t).find(e);
+                if (r[1]) {
+                    if (t = t instanceof ve ? t[0] : t, ve.merge(this, ve.parseHTML(r[1], t && t.nodeType ? t.ownerDocument || t : g, !0)), P.test(r[1]) && ve.isPlainObject(t))
+                        for (r in t) ve.isFunction(this[r]) ? this[r](t[r]) : this.attr(r, t[r]);
+                    return this
+                }
+                if ((i = g.getElementById(r[2])) && i.parentNode) {
+                    if (i.id !== r[2]) return n.find(e);
+                    this.length = 1, this[0] = i
+                }
+                return this.context = g, this.selector = e, this
+            }
+            return e.nodeType ? (this.context = this[0] = e, this.length = 1, this) : ve.isFunction(e) ? n.ready(e) : (e.selector !== w && (this.selector = e.selector, this.context = e.context), ve.makeArray(e, this))
+        },
+        selector: "",
+        length: 0,
+        size: function() {
+            return this.length
+        },
+        toArray: function() {
+            return u.call(this)
+        },
+        get: function(e) {
+            return null == e ? this.toArray() : e < 0 ? this[this.length + e] : this[e]
+        },
+        pushStack: function(e) {
+            var t = ve.merge(this.constructor(), e);
+            return t.prevObject = this, t.context = this.context, t
+        },
+        each: function(e, t) {
+            return ve.each(this, e, t)
+        },
+        ready: function(e) {
+            return ve.ready.promise().done(e), this
+        },
+        slice: function() {
+            return this.pushStack(u.apply(this, arguments))
+        },
+        first: function() {
+            return this.eq(0)
+        },
+        last: function() {
+            return this.eq(-1)
+        },
+        eq: function(e) {
+            var t = this.length,
+                n = +e + (e < 0 ? t : 0);
+            return this.pushStack(0 <= n && n < t ? [this[n]] : [])
+        },
+        map: function(n) {
+            return this.pushStack(ve.map(this, function(e, t) {
+                return n.call(e, t, e)
+            }))
+        },
+        end: function() {
+            return this.prevObject || this.constructor(null)
+        },
+        push: s,
+        sort: [].sort,
+        splice: [].splice
+    }, ve.fn.init.prototype = ve.fn, ve.extend = ve.fn.extend = function() {
+        var e, t, n, r, i, o, a = arguments[0] || {},
+            s = 1,
+            c = arguments.length,
+            l = !1;
+        for ("boolean" == typeof a && (l = a, a = arguments[1] || {}, s = 2), "object" == typeof a || ve.isFunction(a) || (a = {}), c === s && (a = this, --s); s < c; s++)
+            if (null != (i = arguments[s]))
+                for (r in i) e = a[r], a !== (n = i[r]) && (l && n && (ve.isPlainObject(n) || (t = ve.isArray(n))) ? (t ? (t = !1, o = e && ve.isArray(e) ? e : []) : o = e && ve.isPlainObject(e) ? e : {}, a[r] = ve.extend(l, o, n)) : n !== w && (a[r] = n));
+        return a
+    }, ve.extend({
+        noConflict: function(e) {
+            return h.$ === ve && (h.$ = i), e && h.jQuery === ve && (h.jQuery = r), ve
+        },
+        isReady: !1,
+        readyWait: 1,
+        holdReady: function(e) {
+            e ? ve.readyWait++ : ve.ready(!0)
+        },
+        ready: function(e) {
+            if (!0 === e ? !--ve.readyWait : !ve.isReady) {
+                if (!g.body) return setTimeout(ve.ready);
+                (ve.isReady = !0) !== e && 0 < --ve.readyWait || (t.resolveWith(g, [ve]), ve.fn.trigger && ve(g).trigger("ready").off("ready"))
+            }
+        },
+        isFunction: function(e) {
+            return "function" === ve.type(e)
+        },
+        isArray: Array.isArray || function(e) {
+            return "array" === ve.type(e)
+        },
+        isWindow: function(e) {
+            return null != e && e == e.window
+        },
+        isNumeric: function(e) {
+            return !isNaN(parseFloat(e)) && isFinite(e)
+        },
+        type: function(e) {
+            return null == e ? String(e) : "object" == typeof e || "function" == typeof e ? o[l.call(e)] || "object" : typeof e
+        },
+        isPlainObject: function(e) {
+            if (!e || "object" !== ve.type(e) || e.nodeType || ve.isWindow(e)) return !1;
+            try {
+                if (e.constructor && !m.call(e, "constructor") && !m.call(e.constructor.prototype, "isPrototypeOf")) return !1
+            } catch (e) {
+                return !1
+            }
+            var t;
+            for (t in e);
+            return t === w || m.call(e, t)
+        },
+        isEmptyObject: function(e) {
+            var t;
+            for (t in e) return !1;
+            return !0
+        },
+        error: function(e) {
+            throw new Error(e)
+        },
+        parseHTML: function(e, t, n) {
+            if (!e || "string" != typeof e) return null;
+            "boolean" == typeof t && (n = t, t = !1), t = t || g;
+            var r = P.exec(e),
+                i = !n && [];
+            return r ? [t.createElement(r[1])] : (r = ve.buildFragment([e], t, i), i && ve(i).remove(), ve.merge([], r.childNodes))
+        },
+        parseJSON: function(e) {
+            return h.JSON && h.JSON.parse ? h.JSON.parse(e) : null === e ? e : "string" == typeof e && (e = ve.trim(e)) && H.test(e.replace(S, "@").replace(E, "]").replace(T, "")) ? new Function("return " + e)() : void ve.error("Invalid JSON: " + e)
+        },
+        parseXML: function(e) {
+            var t;
+            if (!e || "string" != typeof e) return null;
+            try {
+                h.DOMParser ? t = (new DOMParser).parseFromString(e, "text/xml") : ((t = new ActiveXObject("Microsoft.XMLDOM")).async = "false", t.loadXML(e))
+            } catch (e) {
+                t = w
+            }
+            return t && t.documentElement && !t.getElementsByTagName("parsererror").length || ve.error("Invalid XML: " + e), t
+        },
+        noop: function() {},
+        globalEval: function(e) {
+            e && ve.trim(e) && (h.execScript || function(e) {
+                h.eval.call(h, e)
+            })(e)
+        },
+        camelCase: function(e) {
+            return e.replace(N, "ms-").replace(k, A)
+        },
+        nodeName: function(e, t) {
+            return e.nodeName && e.nodeName.toLowerCase() === t.toLowerCase()
+        },
+        each: function(e, t, n) {
+            var r = 0,
+                i = e.length,
+                o = j(e);
+            if (n) {
+                if (o)
+                    for (; r < i && !1 !== t.apply(e[r], n); r++);
+                else
+                    for (r in e)
+                        if (!1 === t.apply(e[r], n)) break
+            } else if (o)
+                for (; r < i && !1 !== t.call(e[r], r, e[r]); r++);
+            else
+                for (r in e)
+                    if (!1 === t.call(e[r], r, e[r])) break;
+            return e
+        },
+        trim: f && !f.call("\ufeff ") ? function(e) {
+            return null == e ? "" : f.call(e)
+        } : function(e) {
+            return null == e ? "" : (e + "").replace(b, "")
+        },
+        makeArray: function(e, t) {
+            var n = t || [];
+            return null != e && (j(Object(e)) ? ve.merge(n, "string" == typeof e ? [e] : e) : s.call(n, e)), n
+        },
+        inArray: function(e, t, n) {
+            var r;
+            if (t) {
+                if (c) return c.call(t, e, n);
+                for (r = t.length, n = n ? n < 0 ? Math.max(0, r + n) : n : 0; n < r; n++)
+                    if (n in t && t[n] === e) return n
+            }
+            return -1
+        },
+        merge: function(e, t) {
+            var n = t.length,
+                r = e.length,
+                i = 0;
+            if ("number" == typeof n)
+                for (; i < n; i++) e[r++] = t[i];
+            else
+                for (; t[i] !== w;) e[r++] = t[i++];
+            return e.length = r, e
+        },
+        grep: function(e, t, n) {
+            var r = [],
+                i = 0,
+                o = e.length;
+            for (n = !!n; i < o; i++) n !== !!t(e[i], i) && r.push(e[i]);
+            return r
+        },
+        map: function(e, t, n) {
+            var r, i = 0,
+                o = e.length,
+                a = [];
+            if (j(e))
+                for (; i < o; i++) null != (r = t(e[i], i, n)) && (a[a.length] = r);
+            else
+                for (i in e) null != (r = t(e[i], i, n)) && (a[a.length] = r);
+            return y.apply([], a)
+        },
+        guid: 1,
+        proxy: function(e, t) {
+            var n, r, i;
+            return "string" == typeof t && (i = e[t], t = e, e = i), ve.isFunction(e) ? (n = u.call(arguments, 2), (r = function() {
+                return e.apply(t || this, n.concat(u.call(arguments)))
+            }).guid = e.guid = e.guid || ve.guid++, r) : w
+        },
+        access: function(e, t, n, r, i, o, a) {
+            var s = 0,
+                c = e.length,
+                l = null == n;
+            if ("object" === ve.type(n))
+                for (s in i = !0, n) ve.access(e, t, s, n[s], !0, o, a);
+            else if (r !== w && (i = !0, ve.isFunction(r) || (a = !0), l && (a ? (t.call(e, r), t = null) : (l = t, t = function(e, t, n) {
+                    return l.call(ve(e), n)
+                })), t))
+                for (; s < c; s++) t(e[s], n, a ? r : r.call(e[s], s, t(e[s], n)));
+            return i ? e : l ? t.call(e) : c ? t(e[0], n) : o
+        },
+        now: function() {
+            return (new Date).getTime()
+        }
+    }), ve.ready.promise = function(e) {
+        if (!t)
+            if (t = ve.Deferred(), "complete" === g.readyState) setTimeout(ve.ready);
+            else if (g.addEventListener) g.addEventListener("DOMContentLoaded", D, !1), h.addEventListener("load", D, !1);
+        else {
+            g.attachEvent("onreadystatechange", D), h.attachEvent("onload", D);
+            var n = !1;
+            try {
+                n = null == h.frameElement && g.documentElement
+            } catch (e) {}
+            n && n.doScroll && function t() {
+                if (!ve.isReady) {
+                    try {
+                        n.doScroll("left")
+                    } catch (e) {
+                        return setTimeout(t, 50)
+                    }
+                    I(), ve.ready()
+                }
+            }()
+        }
+        return t.promise(e)
+    }, ve.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(e, t) {
+        o["[object " + t + "]"] = t.toLowerCase()
+    }), n = ve(g);
+    var L = {};
+    ve.Callbacks = function(i) {
+        var e, n;
+        i = "string" == typeof i ? L[i] || (n = L[e = i] = {}, ve.each(e.match(C) || [], function(e, t) {
+            n[t] = !0
+        }), n) : ve.extend({}, i);
+        var r, t, o, a, s, c, l = [],
+            u = !i.once && [],
+            d = function(e) {
+                for (t = i.memory && e, o = !0, s = c || 0, c = 0, a = l.length, r = !0; l && s < a; s++)
+                    if (!1 === l[s].apply(e[0], e[1]) && i.stopOnFalse) {
+                        t = !1;
+                        break
+                    }
+                r = !1, l && (u ? u.length && d(u.shift()) : t ? l = [] : f.disable())
+            },
+            f = {
+                add: function() {
+                    if (l) {
+                        var e = l.length;
+                        ! function r(e) {
+                            ve.each(e, function(e, t) {
+                                var n = ve.type(t);
+                                "function" === n ? i.unique && f.has(t) || l.push(t) : t && t.length && "string" !== n && r(t)
+                            })
+                        }(arguments), r ? a = l.length : t && (c = e, d(t))
+                    }
+                    return this
+                },
+                remove: function() {
+                    return l && ve.each(arguments, function(e, t) {
+                        for (var n; - 1 < (n = ve.inArray(t, l, n));) l.splice(n, 1), r && (n <= a && a--, n <= s && s--)
+                    }), this
+                },
+                has: function(e) {
+                    return e ? -1 < ve.inArray(e, l) : !(!l || !l.length)
+                },
+                empty: function() {
+                    return l = [], this
+                },
+                disable: function() {
+                    return l = u = t = w, this
+                },
+                disabled: function() {
+                    return !l
+                },
+                lock: function() {
+                    return u = w, t || f.disable(), this
+                },
+                locked: function() {
+                    return !u
+                },
+                fireWith: function(e, t) {
+                    return t = [e, (t = t || []).slice ? t.slice() : t], !l || o && !u || (r ? u.push(t) : d(t)), this
+                },
+                fire: function() {
+                    return f.fireWith(this, arguments), this
+                },
+                fired: function() {
+                    return !!o
+                }
+            };
+        return f
+    }, ve.extend({
+        Deferred: function(e) {
+            var a = [
+                    ["resolve", "done", ve.Callbacks("once memory"), "resolved"],
+                    ["reject", "fail", ve.Callbacks("once memory"), "rejected"],
+                    ["notify", "progress", ve.Callbacks("memory")]
+                ],
+                i = "pending",
+                s = {
+                    state: function() {
+                        return i
+                    },
+                    always: function() {
+                        return c.done(arguments).fail(arguments), this
+                    },
+                    then: function() {
+                        var o = arguments;
+                        return ve.Deferred(function(i) {
+                            ve.each(a, function(e, t) {
+                                var n = t[0],
+                                    r = ve.isFunction(o[e]) && o[e];
+                                c[t[1]](function() {
+                                    var e = r && r.apply(this, arguments);
+                                    e && ve.isFunction(e.promise) ? e.promise().done(i.resolve).fail(i.reject).progress(i.notify) : i[n + "With"](this === s ? i.promise() : this, r ? [e] : arguments)
+                                })
+                            }), o = null
+                        }).promise()
+                    },
+                    promise: function(e) {
+                        return null != e ? ve.extend(e, s) : s
+                    }
+                },
+                c = {};
+            return s.pipe = s.then, ve.each(a, function(e, t) {
+                var n = t[2],
+                    r = t[3];
+                s[t[1]] = n.add, r && n.add(function() {
+                    i = r
+                }, a[1 ^ e][2].disable, a[2][2].lock), c[t[0]] = function() {
+                    return c[t[0] + "With"](this === c ? s : this, arguments), this
+                }, c[t[0] + "With"] = n.fireWith
+            }), s.promise(c), e && e.call(c, c), c
+        },
+        when: function(e) {
+            var i, t, n, r = 0,
+                o = u.call(arguments),
+                a = o.length,
+                s = 1 !== a || e && ve.isFunction(e.promise) ? a : 0,
+                c = 1 === s ? e : ve.Deferred(),
+                l = function(t, n, r) {
+                    return function(e) {
+                        n[t] = this, r[t] = 1 < arguments.length ? u.call(arguments) : e, r === i ? c.notifyWith(n, r) : --s || c.resolveWith(n, r)
+                    }
+                };
+            if (1 < a)
+                for (i = new Array(a), t = new Array(a), n = new Array(a); r < a; r++) o[r] && ve.isFunction(o[r].promise) ? o[r].promise().done(l(r, n, o)).fail(c.reject).progress(l(r, t, i)) : --s;
+            return s || c.resolveWith(n, o), c.promise()
+        }
+    }), ve.support = function() {
+        var o, e, t, n, r, i, a, s, c, l, u = g.createElement("div");
+        if (u.setAttribute("className", "t"), u.innerHTML = "  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>", e = u.getElementsByTagName("*"), t = u.getElementsByTagName("a")[0], !e || !t || !e.length) return {};
+        a = (r = g.createElement("select")).appendChild(g.createElement("option")), n = u.getElementsByTagName("input")[0], t.style.cssText = "top:1px;float:left;opacity:.5", o = {
+            getSetAttribute: "t" !== u.className,
+            leadingWhitespace: 3 === u.firstChild.nodeType,
+            tbody: !u.getElementsByTagName("tbody").length,
+            htmlSerialize: !!u.getElementsByTagName("link").length,
+            style: /top/.test(t.getAttribute("style")),
+            hrefNormalized: "/a" === t.getAttribute("href"),
+            opacity: /^0.5/.test(t.style.opacity),
+            cssFloat: !!t.style.cssFloat,
+            checkOn: !!n.value,
+            optSelected: a.selected,
+            enctype: !!g.createElement("form").enctype,
+            html5Clone: "<:nav></:nav>" !== g.createElement("nav").cloneNode(!0).outerHTML,
+            boxModel: "CSS1Compat" === g.compatMode,
+            deleteExpando: !0,
+            noCloneEvent: !0,
+            inlineBlockNeedsLayout: !1,
+            shrinkWrapBlocks: !1,
+            reliableMarginRight: !0,
+            boxSizingReliable: !0,
+            pixelPosition: !1
+        }, n.checked = !0, o.noCloneChecked = n.cloneNode(!0).checked, r.disabled = !0, o.optDisabled = !a.disabled;
+        try {
+            delete u.test
+        } catch (e) {
+            o.deleteExpando = !1
+        }
+        for (l in (n = g.createElement("input")).setAttribute("value", ""), o.input = "" === n.getAttribute("value"), n.value = "t", n.setAttribute("type", "radio"), o.radioValue = "t" === n.value, n.setAttribute("checked", "t"), n.setAttribute("name", "t"), (i = g.createDocumentFragment()).appendChild(n), o.appendChecked = n.checked, o.checkClone = i.cloneNode(!0).cloneNode(!0).lastChild.checked, u.attachEvent && (u.attachEvent("onclick", function() {
+                o.noCloneEvent = !1
+            }), u.cloneNode(!0).click()), {
+                submit: !0,
+                change: !0,
+                focusin: !0
+            }) u.setAttribute(s = "on" + l, "t"), o[l + "Bubbles"] = s in h || !1 === u.attributes[s].expando;
+        return u.style.backgroundClip = "content-box", u.cloneNode(!0).style.backgroundClip = "", o.clearCloneStyle = "content-box" === u.style.backgroundClip, ve(function() {
+            var e, t, n, r = "padding:0;margin:0;border:0;display:block;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;",
+                i = g.getElementsByTagName("body")[0];
+            i && ((e = g.createElement("div")).style.cssText = "border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px", i.appendChild(e).appendChild(u), u.innerHTML = "<table><tr><td></td><td>t</td></tr></table>", (n = u.getElementsByTagName("td"))[0].style.cssText = "padding:0;margin:0;border:0;display:none", c = 0 === n[0].offsetHeight, n[0].style.display = "", n[1].style.display = "none", o.reliableHiddenOffsets = c && 0 === n[0].offsetHeight, u.innerHTML = "", u.style.cssText = "box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%;", o.boxSizing = 4 === u.offsetWidth, o.doesNotIncludeMarginInBodyOffset = 1 !== i.offsetTop, h.getComputedStyle && (o.pixelPosition = "1%" !== (h.getComputedStyle(u, null) || {}).top, o.boxSizingReliable = "4px" === (h.getComputedStyle(u, null) || {
+                width: "4px"
+            }).width, (t = u.appendChild(g.createElement("div"))).style.cssText = u.style.cssText = r, t.style.marginRight = t.style.width = "0", u.style.width = "1px", o.reliableMarginRight = !parseFloat((h.getComputedStyle(t, null) || {}).marginRight)), typeof u.style.zoom !== v && (u.innerHTML = "", u.style.cssText = r + "width:1px;padding:1px;display:inline;zoom:1", o.inlineBlockNeedsLayout = 3 === u.offsetWidth, u.style.display = "block", u.innerHTML = "<div></div>", u.firstChild.style.width = "5px", o.shrinkWrapBlocks = 3 !== u.offsetWidth, o.inlineBlockNeedsLayout && (i.style.zoom = 1)), i.removeChild(e), e = u = n = t = null)
+        }), e = r = i = a = t = n = null, o
+    }();
+    var F = /(?:\{[\s\S]*\}|\[[\s\S]*\])$/,
+        M = /([A-Z])/g;
+
+    function B(e, t, n, r) {
+        if (ve.acceptData(e)) {
+            var i, o, a = ve.expando,
+                s = "string" == typeof t,
+                c = e.nodeType,
+                l = c ? ve.cache : e,
+                u = c ? e[a] : e[a] && a;
+            if (u && l[u] && (r || l[u].data) || !s || n !== w) return u || (c ? e[a] = u = d.pop() || ve.guid++ : u = a), l[u] || (l[u] = {}, c || (l[u].toJSON = ve.noop)), "object" != typeof t && "function" != typeof t || (r ? l[u] = ve.extend(l[u], t) : l[u].data = ve.extend(l[u].data, t)), i = l[u], r || (i.data || (i.data = {}), i = i.data), n !== w && (i[ve.camelCase(t)] = n), s ? null == (o = i[t]) && (o = i[ve.camelCase(t)]) : o = i, o
+        }
+    }
+
+    function O(e, t, n) {
+        if (ve.acceptData(e)) {
+            var r, i, o, a = e.nodeType,
+                s = a ? ve.cache : e,
+                c = a ? e[ve.expando] : ve.expando;
+            if (s[c]) {
+                if (t && (o = n ? s[c] : s[c].data)) {
+                    for ((r = 0, i = (t = ve.isArray(t) ? t.concat(ve.map(t, ve.camelCase)) : t in o ? [t] : (t = ve.camelCase(t)) in o ? [t] : t.split(" ")).length); r < i; r++) delete o[t[r]];
+                    if (!(n ? _ : ve.isEmptyObject)(o)) return
+                }(n || (delete s[c].data, _(s[c]))) && (a ? ve.cleanData([e], !0) : ve.support.deleteExpando || s != s.window ? delete s[c] : s[c] = null)
+            }
+        }
+    }
+
+    function q(e, t, n) {
+        if (n === w && 1 === e.nodeType) {
+            var r = "data-" + t.replace(M, "-$1").toLowerCase();
+            if ("string" == typeof(n = e.getAttribute(r))) {
+                try {
+                    n = "true" === n || "false" !== n && ("null" === n ? null : +n + "" === n ? +n : F.test(n) ? ve.parseJSON(n) : n)
+                } catch (e) {}
+                ve.data(e, t, n)
+            } else n = w
+        }
+        return n
+    }
+
+    function _(e) {
+        var t;
+        for (t in e)
+            if (("data" !== t || !ve.isEmptyObject(e[t])) && "toJSON" !== t) return !1;
+        return !0
+    }
+    ve.extend({
+        cache: {},
+        expando: "jQuery" + (a + Math.random()).replace(/\D/g, ""),
+        noData: {
+            embed: !0,
+            object: "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000",
+            applet: !0
+        },
+        hasData: function(e) {
+            return !!(e = e.nodeType ? ve.cache[e[ve.expando]] : e[ve.expando]) && !_(e)
+        },
+        data: function(e, t, n) {
+            return B(e, t, n)
+        },
+        removeData: function(e, t) {
+            return O(e, t)
+        },
+        _data: function(e, t, n) {
+            return B(e, t, n, !0)
+        },
+        _removeData: function(e, t) {
+            return O(e, t, !0)
+        },
+        acceptData: function(e) {
+            if (e.nodeType && 1 !== e.nodeType && 9 !== e.nodeType) return !1;
+            var t = e.nodeName && ve.noData[e.nodeName.toLowerCase()];
+            return !t || !0 !== t && e.getAttribute("classid") === t
+        }
+    }), ve.fn.extend({
+        data: function(t, e) {
+            var n, r, i = this[0],
+                o = 0,
+                a = null;
+            if (t === w) {
+                if (this.length && (a = ve.data(i), 1 === i.nodeType && !ve._data(i, "parsedAttrs"))) {
+                    for (n = i.attributes; o < n.length; o++)(r = n[o].name).indexOf("data-") || (r = ve.camelCase(r.slice(5)), q(i, r, a[r]));
+                    ve._data(i, "parsedAttrs", !0)
+                }
+                return a
+            }
+            return "object" == typeof t ? this.each(function() {
+                ve.data(this, t)
+            }) : ve.access(this, function(e) {
+                if (e === w) return i ? q(i, t, ve.data(i, t)) : null;
+                this.each(function() {
+                    ve.data(this, t, e)
+                })
+            }, null, e, 1 < arguments.length, null, !0)
+        },
+        removeData: function(e) {
+            return this.each(function() {
+                ve.removeData(this, e)
+            })
+        }
+    }), ve.extend({
+        queue: function(e, t, n) {
+            var r;
+            if (e) return t = (t || "fx") + "queue", r = ve._data(e, t), n && (!r || ve.isArray(n) ? r = ve._data(e, t, ve.makeArray(n)) : r.push(n)), r || []
+        },
+        dequeue: function(e, t) {
+            t = t || "fx";
+            var n = ve.queue(e, t),
+                r = n.length,
+                i = n.shift(),
+                o = ve._queueHooks(e, t);
+            "inprogress" === i && (i = n.shift(), r--), (o.cur = i) && ("fx" === t && n.unshift("inprogress"), delete o.stop, i.call(e, function() {
+                ve.dequeue(e, t)
+            }, o)), !r && o && o.empty.fire()
+        },
+        _queueHooks: function(e, t) {
+            var n = t + "queueHooks";
+            return ve._data(e, n) || ve._data(e, n, {
+                empty: ve.Callbacks("once memory").add(function() {
+                    ve._removeData(e, t + "queue"), ve._removeData(e, n)
+                })
+            })
+        }
+    }), ve.fn.extend({
+        queue: function(t, n) {
+            var e = 2;
+            return "string" != typeof t && (n = t, t = "fx", e--), arguments.length < e ? ve.queue(this[0], t) : n === w ? this : this.each(function() {
+                var e = ve.queue(this, t, n);
+                ve._queueHooks(this, t), "fx" === t && "inprogress" !== e[0] && ve.dequeue(this, t)
+            })
+        },
+        dequeue: function(e) {
+            return this.each(function() {
+                ve.dequeue(this, e)
+            })
+        },
+        delay: function(r, e) {
+            return r = ve.fx && ve.fx.speeds[r] || r, e = e || "fx", this.queue(e, function(e, t) {
+                var n = setTimeout(e, r);
+                t.stop = function() {
+                    clearTimeout(n)
+                }
+            })
+        },
+        clearQueue: function(e) {
+            return this.queue(e || "fx", [])
+        },
+        promise: function(e, t) {
+            var n, r = 1,
+                i = ve.Deferred(),
+                o = this,
+                a = this.length,
+                s = function() {
+                    --r || i.resolveWith(o, [o])
+                };
+            for ("string" != typeof e && (t = e, e = w), e = e || "fx"; a--;)(n = ve._data(o[a], e + "queueHooks")) && n.empty && (r++, n.empty.add(s));
+            return s(), i.promise(t)
+        }
+    });
+    var $, R, z = /[\t\r\n]/g,
+        X = /\r/g,
+        W = /^(?:input|select|textarea|button|object)$/i,
+        U = /^(?:a|area)$/i,
+        V = /^(?:checked|selected|autofocus|autoplay|async|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped)$/i,
+        Q = /^(?:checked|selected)$/i,
+        Y = ve.support.getSetAttribute,
+        J = ve.support.input;
+    ve.fn.extend({
+        attr: function(e, t) {
+            return ve.access(this, ve.attr, e, t, 1 < arguments.length)
+        },
+        removeAttr: function(e) {
+            return this.each(function() {
+                ve.removeAttr(this, e)
+            })
+        },
+        prop: function(e, t) {
+            return ve.access(this, ve.prop, e, t, 1 < arguments.length)
+        },
+        removeProp: function(e) {
+            return e = ve.propFix[e] || e, this.each(function() {
+                try {
+                    this[e] = w, delete this[e]
+                } catch (e) {}
+            })
+        },
+        addClass: function(t) {
+            var e, n, r, i, o, a = 0,
+                s = this.length,
+                c = "string" == typeof t && t;
+            if (ve.isFunction(t)) return this.each(function(e) {
+                ve(this).addClass(t.call(this, e, this.className))
+            });
+            if (c)
+                for (e = (t || "").match(C) || []; a < s; a++)
+                    if (r = 1 === (n = this[a]).nodeType && (n.className ? (" " + n.className + " ").replace(z, " ") : " ")) {
+                        for (o = 0; i = e[o++];) r.indexOf(" " + i + " ") < 0 && (r += i + " ");
+                        n.className = ve.trim(r)
+                    }
+            return this
+        },
+        removeClass: function(t) {
+            var e, n, r, i, o, a = 0,
+                s = this.length,
+                c = 0 === arguments.length || "string" == typeof t && t;
+            if (ve.isFunction(t)) return this.each(function(e) {
+                ve(this).removeClass(t.call(this, e, this.className))
+            });
+            if (c)
+                for (e = (t || "").match(C) || []; a < s; a++)
+                    if (r = 1 === (n = this[a]).nodeType && (n.className ? (" " + n.className + " ").replace(z, " ") : "")) {
+                        for (o = 0; i = e[o++];)
+                            for (; 0 <= r.indexOf(" " + i + " ");) r = r.replace(" " + i + " ", " ");
+                        n.className = t ? ve.trim(r) : ""
+                    }
+            return this
+        },
+        toggleClass: function(o, a) {
+            var s = typeof o,
+                c = "boolean" == typeof a;
+            return ve.isFunction(o) ? this.each(function(e) {
+                ve(this).toggleClass(o.call(this, e, this.className, a), a)
+            }) : this.each(function() {
+                if ("string" === s)
+                    for (var e, t = 0, n = ve(this), r = a, i = o.match(C) || []; e = i[t++];) n[(r = c ? r : !n.hasClass(e)) ? "addClass" : "removeClass"](e);
+                else s !== v && "boolean" !== s || (this.className && ve._data(this, "__className__", this.className), this.className = this.className || !1 === o ? "" : ve._data(this, "__className__") || "")
+            })
+        },
+        hasClass: function(e) {
+            for (var t = " " + e + " ", n = 0, r = this.length; n < r; n++)
+                if (1 === this[n].nodeType && 0 <= (" " + this[n].className + " ").replace(z, " ").indexOf(t)) return !0;
+            return !1
+        },
+        val: function(r) {
+            var e, i, o, t = this[0];
+            return arguments.length ? (o = ve.isFunction(r), this.each(function(e) {
+                var t, n = ve(this);
+                1 === this.nodeType && (null == (t = o ? r.call(this, e, n.val()) : r) ? t = "" : "number" == typeof t ? t += "" : ve.isArray(t) && (t = ve.map(t, function(e) {
+                    return null == e ? "" : e + ""
+                })), (i = ve.valHooks[this.type] || ve.valHooks[this.nodeName.toLowerCase()]) && "set" in i && i.set(this, t, "value") !== w || (this.value = t))
+            })) : t ? (i = ve.valHooks[t.type] || ve.valHooks[t.nodeName.toLowerCase()]) && "get" in i && (e = i.get(t, "value")) !== w ? e : "string" == typeof(e = t.value) ? e.replace(X, "") : null == e ? "" : e : void 0
+        }
+    }), ve.extend({
+        valHooks: {
+            option: {
+                get: function(e) {
+                    var t = e.attributes.value;
+                    return !t || t.specified ? e.value : e.text
+                }
+            },
+            select: {
+                get: function(e) {
+                    for (var t, n, r = e.options, i = e.selectedIndex, o = "select-one" === e.type || i < 0, a = o ? null : [], s = o ? i + 1 : r.length, c = i < 0 ? s : o ? i : 0; c < s; c++)
+                        if (((n = r[c]).selected || c === i) && (ve.support.optDisabled ? !n.disabled : null === n.getAttribute("disabled")) && (!n.parentNode.disabled || !ve.nodeName(n.parentNode, "optgroup"))) {
+                            if (t = ve(n).val(), o) return t;
+                            a.push(t)
+                        }
+                    return a
+                },
+                set: function(e, t) {
+                    var n = ve.makeArray(t);
+                    return ve(e).find("option").each(function() {
+                        this.selected = 0 <= ve.inArray(ve(this).val(), n)
+                    }), n.length || (e.selectedIndex = -1), n
+                }
+            }
+        },
+        attr: function(e, t, n) {
+            var r, i, o, a = e.nodeType;
+            if (e && 3 !== a && 8 !== a && 2 !== a) return typeof e.getAttribute === v ? ve.prop(e, t, n) : ((i = 1 !== a || !ve.isXMLDoc(e)) && (t = t.toLowerCase(), r = ve.attrHooks[t] || (V.test(t) ? R : $)), n === w ? r && i && "get" in r && null !== (o = r.get(e, t)) ? o : (typeof e.getAttribute !== v && (o = e.getAttribute(t)), null == o ? w : o) : null !== n ? r && i && "set" in r && (o = r.set(e, n, t)) !== w ? o : (e.setAttribute(t, n + ""), n) : void ve.removeAttr(e, t))
+        },
+        removeAttr: function(e, t) {
+            var n, r, i = 0,
+                o = t && t.match(C);
+            if (o && 1 === e.nodeType)
+                for (; n = o[i++];) r = ve.propFix[n] || n, V.test(n) ? !Y && Q.test(n) ? e[ve.camelCase("default-" + n)] = e[r] = !1 : e[r] = !1 : ve.attr(e, n, ""), e.removeAttribute(Y ? n : r)
+        },
+        attrHooks: {
+            type: {
+                set: function(e, t) {
+                    if (!ve.support.radioValue && "radio" === t && ve.nodeName(e, "input")) {
+                        var n = e.value;
+                        return e.setAttribute("type", t), n && (e.value = n), t
+                    }
+                }
+            }
+        },
+        propFix: {
+            tabindex: "tabIndex",
+            readonly: "readOnly",
+            for: "htmlFor",
+            class: "className",
+            maxlength: "maxLength",
+            cellspacing: "cellSpacing",
+            cellpadding: "cellPadding",
+            rowspan: "rowSpan",
+            colspan: "colSpan",
+            usemap: "useMap",
+            frameborder: "frameBorder",
+            contenteditable: "contentEditable"
+        },
+        prop: function(e, t, n) {
+            var r, i, o = e.nodeType;
+            if (e && 3 !== o && 8 !== o && 2 !== o) return (1 !== o || !ve.isXMLDoc(e)) && (t = ve.propFix[t] || t, i = ve.propHooks[t]), n !== w ? i && "set" in i && (r = i.set(e, n, t)) !== w ? r : e[t] = n : i && "get" in i && null !== (r = i.get(e, t)) ? r : e[t]
+        },
+        propHooks: {
+            tabIndex: {
+                get: function(e) {
+                    var t = e.getAttributeNode("tabindex");
+                    return t && t.specified ? parseInt(t.value, 10) : W.test(e.nodeName) || U.test(e.nodeName) && e.href ? 0 : w
+                }
+            }
+        }
+    }), R = {
+        get: function(e, t) {
+            var n = ve.prop(e, t),
+                r = "boolean" == typeof n && e.getAttribute(t),
+                i = "boolean" == typeof n ? J && Y ? null != r : Q.test(t) ? e[ve.camelCase("default-" + t)] : !!r : e.getAttributeNode(t);
+            return i && !1 !== i.value ? t.toLowerCase() : w
+        },
+        set: function(e, t, n) {
+            return !1 === t ? ve.removeAttr(e, n) : J && Y || !Q.test(n) ? e.setAttribute(!Y && ve.propFix[n] || n, n) : e[ve.camelCase("default-" + n)] = e[n] = !0, n
+        }
+    }, J && Y || (ve.attrHooks.value = {
+        get: function(e, t) {
+            var n = e.getAttributeNode(t);
+            return ve.nodeName(e, "input") ? e.defaultValue : n && n.specified ? n.value : w
+        },
+        set: function(e, t, n) {
+            if (!ve.nodeName(e, "input")) return $ && $.set(e, t, n);
+            e.defaultValue = t
+        }
+    }), Y || ($ = ve.valHooks.button = {
+        get: function(e, t) {
+            var n = e.getAttributeNode(t);
+            return n && ("id" === t || "name" === t || "coords" === t ? "" !== n.value : n.specified) ? n.value : w
+        },
+        set: function(e, t, n) {
+            var r = e.getAttributeNode(n);
+            return r || e.setAttributeNode(r = e.ownerDocument.createAttribute(n)), r.value = t += "", "value" === n || t === e.getAttribute(n) ? t : w
+        }
+    }, ve.attrHooks.contenteditable = {
+        get: $.get,
+        set: function(e, t, n) {
+            $.set(e, "" !== t && t, n)
+        }
+    }, ve.each(["width", "height"], function(e, n) {
+        ve.attrHooks[n] = ve.extend(ve.attrHooks[n], {
+            set: function(e, t) {
+                if ("" === t) return e.setAttribute(n, "auto"), t
+            }
+        })
+    })), ve.support.hrefNormalized || (ve.each(["href", "src", "width", "height"], function(e, n) {
+        ve.attrHooks[n] = ve.extend(ve.attrHooks[n], {
+            get: function(e) {
+                var t = e.getAttribute(n, 2);
+                return null == t ? w : t
+            }
+        })
+    }), ve.each(["href", "src"], function(e, t) {
+        ve.propHooks[t] = {
+            get: function(e) {
+                return e.getAttribute(t, 4)
+            }
+        }
+    })), ve.support.style || (ve.attrHooks.style = {
+        get: function(e) {
+            return e.style.cssText || w
+        },
+        set: function(e, t) {
+            return e.style.cssText = t + ""
+        }
+    }), ve.support.optSelected || (ve.propHooks.selected = ve.extend(ve.propHooks.selected, {
+        get: function(e) {
+            var t = e.parentNode;
+            return t && (t.selectedIndex, t.parentNode && t.parentNode.selectedIndex), null
+        }
+    })), ve.support.enctype || (ve.propFix.enctype = "encoding"), ve.support.checkOn || ve.each(["radio", "checkbox"], function() {
+        ve.valHooks[this] = {
+            get: function(e) {
+                return null === e.getAttribute("value") ? "on" : e.value
+            }
+        }
+    }), ve.each(["radio", "checkbox"], function() {
+        ve.valHooks[this] = ve.extend(ve.valHooks[this], {
+            set: function(e, t) {
+                if (ve.isArray(t)) return e.checked = 0 <= ve.inArray(ve(e).val(), t)
+            }
+        })
+    });
+    var G = /^(?:input|select|textarea)$/i,
+        K = /^key/,
+        Z = /^(?:mouse|contextmenu)|click/,
+        ee = /^(?:focusinfocus|focusoutblur)$/,
+        te = /^([^.]*)(?:\.(.+)|)$/;
+
+    function ne() {
+        return !0
+    }
+
+    function re() {
+        return !1
+    }
+    ve.event = {
+            global: {},
+            add: function(e, t, n, r, i) {
+                var o, a, s, c, l, u, d, f, p, h, g, m = ve._data(e);
+                if (m) {
+                    for (n.handler && (n = (c = n).handler, i = c.selector), n.guid || (n.guid = ve.guid++), (a = m.events) || (a = m.events = {}), (u = m.handle) || ((u = m.handle = function(e) {
+                            return typeof ve === v || e && ve.event.triggered === e.type ? w : ve.event.dispatch.apply(u.elem, arguments)
+                        }).elem = e), s = (t = (t || "").match(C) || [""]).length; s--;) p = g = (o = te.exec(t[s]) || [])[1], h = (o[2] || "").split(".").sort(), l = ve.event.special[p] || {}, p = (i ? l.delegateType : l.bindType) || p, l = ve.event.special[p] || {}, d = ve.extend({
+                        type: p,
+                        origType: g,
+                        data: r,
+                        handler: n,
+                        guid: n.guid,
+                        selector: i,
+                        needsContext: i && ve.expr.match.needsContext.test(i),
+                        namespace: h.join(".")
+                    }, c), (f = a[p]) || ((f = a[p] = []).delegateCount = 0, l.setup && !1 !== l.setup.call(e, r, h, u) || (e.addEventListener ? e.addEventListener(p, u, !1) : e.attachEvent && e.attachEvent("on" + p, u))), l.add && (l.add.call(e, d), d.handler.guid || (d.handler.guid = n.guid)), i ? f.splice(f.delegateCount++, 0, d) : f.push(d), ve.event.global[p] = !0;
+                    e = null
+                }
+            },
+            remove: function(e, t, n, r, i) {
+                var o, a, s, c, l, u, d, f, p, h, g, m = ve.hasData(e) && ve._data(e);
+                if (m && (u = m.events)) {
+                    for (l = (t = (t || "").match(C) || [""]).length; l--;)
+                        if (p = g = (s = te.exec(t[l]) || [])[1], h = (s[2] || "").split(".").sort(), p) {
+                            for (d = ve.event.special[p] || {}, f = u[p = (r ? d.delegateType : d.bindType) || p] || [], s = s[2] && new RegExp("(^|\\.)" + h.join("\\.(?:.*\\.|)") + "(\\.|$)"), c = o = f.length; o--;) a = f[o], !i && g !== a.origType || n && n.guid !== a.guid || s && !s.test(a.namespace) || r && r !== a.selector && ("**" !== r || !a.selector) || (f.splice(o, 1), a.selector && f.delegateCount--, d.remove && d.remove.call(e, a));
+                            c && !f.length && (d.teardown && !1 !== d.teardown.call(e, h, m.handle) || ve.removeEvent(e, p, m.handle), delete u[p])
+                        } else
+                            for (p in u) ve.event.remove(e, p + t[l], n, r, !0);
+                    ve.isEmptyObject(u) && (delete m.handle, ve._removeData(e, "events"))
+                }
+            },
+            trigger: function(e, t, n, r) {
+                var i, o, a, s, c, l, u, d = [n || g],
+                    f = m.call(e, "type") ? e.type : e,
+                    p = m.call(e, "namespace") ? e.namespace.split(".") : [];
+                if (a = l = n = n || g, 3 !== n.nodeType && 8 !== n.nodeType && !ee.test(f + ve.event.triggered) && (0 <= f.indexOf(".") && (f = (p = f.split(".")).shift(), p.sort()), o = f.indexOf(":") < 0 && "on" + f, (e = e[ve.expando] ? e : new ve.Event(f, "object" == typeof e && e)).isTrigger = !0, e.namespace = p.join("."), e.namespace_re = e.namespace ? new RegExp("(^|\\.)" + p.join("\\.(?:.*\\.|)") + "(\\.|$)") : null, e.result = w, e.target || (e.target = n), t = null == t ? [e] : ve.makeArray(t, [e]), c = ve.event.special[f] || {}, r || !c.trigger || !1 !== c.trigger.apply(n, t))) {
+                    if (!r && !c.noBubble && !ve.isWindow(n)) {
+                        for (s = c.delegateType || f, ee.test(s + f) || (a = a.parentNode); a; a = a.parentNode) d.push(a), l = a;
+                        l === (n.ownerDocument || g) && d.push(l.defaultView || l.parentWindow || h)
+                    }
+                    for (u = 0;
+                        (a = d[u++]) && !e.isPropagationStopped();) e.type = 1 < u ? s : c.bindType || f, (i = (ve._data(a, "events") || {})[e.type] && ve._data(a, "handle")) && i.apply(a, t), (i = o && a[o]) && ve.acceptData(a) && i.apply && !1 === i.apply(a, t) && e.preventDefault();
+                    if (e.type = f, !r && !e.isDefaultPrevented() && (!c._default || !1 === c._default.apply(n.ownerDocument, t)) && ("click" !== f || !ve.nodeName(n, "a")) && ve.acceptData(n) && o && n[f] && !ve.isWindow(n)) {
+                        (l = n[o]) && (n[o] = null), ve.event.triggered = f;
+                        try {
+                            n[f]()
+                        } catch (e) {}
+                        ve.event.triggered = w, l && (n[o] = l)
+                    }
+                    return e.result
+                }
+            },
+            dispatch: function(e) {
+                e = ve.event.fix(e);
+                var t, n, r, i, o, a, s = u.call(arguments),
+                    c = (ve._data(this, "events") || {})[e.type] || [],
+                    l = ve.event.special[e.type] || {};
+                if ((s[0] = e).delegateTarget = this, !l.preDispatch || !1 !== l.preDispatch.call(this, e)) {
+                    for (a = ve.event.handlers.call(this, e, c), t = 0;
+                        (i = a[t++]) && !e.isPropagationStopped();)
+                        for (e.currentTarget = i.elem, o = 0;
+                            (r = i.handlers[o++]) && !e.isImmediatePropagationStopped();) e.namespace_re && !e.namespace_re.test(r.namespace) || (e.handleObj = r, e.data = r.data, (n = ((ve.event.special[r.origType] || {}).handle || r.handler).apply(i.elem, s)) !== w && !1 === (e.result = n) && (e.preventDefault(), e.stopPropagation()));
+                    return l.postDispatch && l.postDispatch.call(this, e), e.result
+                }
+            },
+            handlers: function(e, t) {
+                var n, r, i, o, a = [],
+                    s = t.delegateCount,
+                    c = e.target;
+                if (s && c.nodeType && (!e.button || "click" !== e.type))
+                    for (; c != this; c = c.parentNode || this)
+                        if (1 === c.nodeType && (!0 !== c.disabled || "click" !== e.type)) {
+                            for (i = [], o = 0; o < s; o++) i[n = (r = t[o]).selector + " "] === w && (i[n] = r.needsContext ? 0 <= ve(n, this).index(c) : ve.find(n, this, null, [c]).length), i[n] && i.push(r);
+                            i.length && a.push({
+                                elem: c,
+                                handlers: i
+                            })
+                        }
+                return s < t.length && a.push({
+                    elem: this,
+                    handlers: t.slice(s)
+                }), a
+            },
+            fix: function(e) {
+                if (e[ve.expando]) return e;
+                var t, n, r, i = e.type,
+                    o = e,
+                    a = this.fixHooks[i];
+                for (a || (this.fixHooks[i] = a = Z.test(i) ? this.mouseHooks : K.test(i) ? this.keyHooks : {}), r = a.props ? this.props.concat(a.props) : this.props, e = new ve.Event(o), t = r.length; t--;) e[n = r[t]] = o[n];
+                return e.target || (e.target = o.srcElement || g), 3 === e.target.nodeType && (e.target = e.target.parentNode), e.metaKey = !!e.metaKey, a.filter ? a.filter(e, o) : e
+            },
+            props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
+            fixHooks: {},
+            keyHooks: {
+                props: "char charCode key keyCode".split(" "),
+                filter: function(e, t) {
+                    return null == e.which && (e.which = null != t.charCode ? t.charCode : t.keyCode), e
+                }
+            },
+            mouseHooks: {
+                props: "button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
+                filter: function(e, t) {
+                    var n, r, i, o = t.button,
+                        a = t.fromElement;
+                    return null == e.pageX && null != t.clientX && (i = (r = e.target.ownerDocument || g).documentElement, n = r.body, e.pageX = t.clientX + (i && i.scrollLeft || n && n.scrollLeft || 0) - (i && i.clientLeft || n && n.clientLeft || 0), e.pageY = t.clientY + (i && i.scrollTop || n && n.scrollTop || 0) - (i && i.clientTop || n && n.clientTop || 0)), !e.relatedTarget && a && (e.relatedTarget = a === e.target ? t.toElement : a), e.which || o === w || (e.which = 1 & o ? 1 : 2 & o ? 3 : 4 & o ? 2 : 0), e
+                }
+            },
+            special: {
+                load: {
+                    noBubble: !0
+                },
+                click: {
+                    trigger: function() {
+                        if (ve.nodeName(this, "input") && "checkbox" === this.type && this.click) return this.click(), !1
+                    }
+                },
+                focus: {
+                    trigger: function() {
+                        if (this !== g.activeElement && this.focus) try {
+                            return this.focus(), !1
+                        } catch (e) {}
+                    },
+                    delegateType: "focusin"
+                },
+                blur: {
+                    trigger: function() {
+                        if (this === g.activeElement && this.blur) return this.blur(), !1
+                    },
+                    delegateType: "focusout"
+                },
+                beforeunload: {
+                    postDispatch: function(e) {
+                        e.result !== w && (e.originalEvent.returnValue = e.result)
+                    }
+                }
+            },
+            simulate: function(e, t, n, r) {
+                var i = ve.extend(new ve.Event, n, {
+                    type: e,
+                    isSimulated: !0,
+                    originalEvent: {}
+                });
+                r ? ve.event.trigger(i, null, t) : ve.event.dispatch.call(t, i), i.isDefaultPrevented() && n.preventDefault()
+            }
+        }, ve.removeEvent = g.removeEventListener ? function(e, t, n) {
+            e.removeEventListener && e.removeEventListener(t, n, !1)
+        } : function(e, t, n) {
+            var r = "on" + t;
+            e.detachEvent && (typeof e[r] === v && (e[r] = null), e.detachEvent(r, n))
+        }, ve.Event = function(e, t) {
+            if (!(this instanceof ve.Event)) return new ve.Event(e, t);
+            e && e.type ? (this.originalEvent = e, this.type = e.type, this.isDefaultPrevented = e.defaultPrevented || !1 === e.returnValue || e.getPreventDefault && e.getPreventDefault() ? ne : re) : this.type = e, t && ve.extend(this, t), this.timeStamp = e && e.timeStamp || ve.now(), this[ve.expando] = !0
+        }, ve.Event.prototype = {
+            isDefaultPrevented: re,
+            isPropagationStopped: re,
+            isImmediatePropagationStopped: re,
+            preventDefault: function() {
+                var e = this.originalEvent;
+                this.isDefaultPrevented = ne, e && (e.preventDefault ? e.preventDefault() : e.returnValue = !1)
+            },
+            stopPropagation: function() {
+                var e = this.originalEvent;
+                this.isPropagationStopped = ne, e && (e.stopPropagation && e.stopPropagation(), e.cancelBubble = !0)
+            },
+            stopImmediatePropagation: function() {
+                this.isImmediatePropagationStopped = ne, this.stopPropagation()
+            }
+        }, ve.each({
+            mouseenter: "mouseover",
+            mouseleave: "mouseout"
+        }, function(e, i) {
+            ve.event.special[e] = {
+                delegateType: i,
+                bindType: i,
+                handle: function(e) {
+                    var t, n = e.relatedTarget,
+                        r = e.handleObj;
+                    return n && (n === this || ve.contains(this, n)) || (e.type = r.origType, t = r.handler.apply(this, arguments), e.type = i), t
+                }
+            }
+        }), ve.support.submitBubbles || (ve.event.special.submit = {
+            setup: function() {
+                if (ve.nodeName(this, "form")) return !1;
+                ve.event.add(this, "click._submit keypress._submit", function(e) {
+                    var t = e.target,
+                        n = ve.nodeName(t, "input") || ve.nodeName(t, "button") ? t.form : w;
+                    n && !ve._data(n, "submitBubbles") && (ve.event.add(n, "submit._submit", function(e) {
+                        e._submit_bubble = !0
+                    }), ve._data(n, "submitBubbles", !0))
+                })
+            },
+            postDispatch: function(e) {
+                e._submit_bubble && (delete e._submit_bubble, this.parentNode && !e.isTrigger && ve.event.simulate("submit", this.parentNode, e, !0))
+            },
+            teardown: function() {
+                if (ve.nodeName(this, "form")) return !1;
+                ve.event.remove(this, "._submit")
+            }
+        }), ve.support.changeBubbles || (ve.event.special.change = {
+            setup: function() {
+                if (G.test(this.nodeName)) return "checkbox" !== this.type && "radio" !== this.type || (ve.event.add(this, "propertychange._change", function(e) {
+                    "checked" === e.originalEvent.propertyName && (this._just_changed = !0)
+                }), ve.event.add(this, "click._change", function(e) {
+                    this._just_changed && !e.isTrigger && (this._just_changed = !1), ve.event.simulate("change", this, e, !0)
+                })), !1;
+                ve.event.add(this, "beforeactivate._change", function(e) {
+                    var t = e.target;
+                    G.test(t.nodeName) && !ve._data(t, "changeBubbles") && (ve.event.add(t, "change._change", function(e) {
+                        !this.parentNode || e.isSimulated || e.isTrigger || ve.event.simulate("change", this.parentNode, e, !0)
+                    }), ve._data(t, "changeBubbles", !0))
+                })
+            },
+            handle: function(e) {
+                var t = e.target;
+                if (this !== t || e.isSimulated || e.isTrigger || "radio" !== t.type && "checkbox" !== t.type) return e.handleObj.handler.apply(this, arguments)
+            },
+            teardown: function() {
+                return ve.event.remove(this, "._change"), !G.test(this.nodeName)
+            }
+        }), ve.support.focusinBubbles || ve.each({
+            focus: "focusin",
+            blur: "focusout"
+        }, function(e, t) {
+            var n = 0,
+                r = function(e) {
+                    ve.event.simulate(t, e.target, ve.event.fix(e), !0)
+                };
+            ve.event.special[t] = {
+                setup: function() {
+                    0 == n++ && g.addEventListener(e, r, !0)
+                },
+                teardown: function() {
+                    0 == --n && g.removeEventListener(e, r, !0)
+                }
+            }
+        }), ve.fn.extend({
+            on: function(e, t, n, r, i) {
+                var o, a;
+                if ("object" == typeof e) {
+                    for (o in "string" != typeof t && (n = n || t, t = w), e) this.on(o, t, n, e[o], i);
+                    return this
+                }
+                if (null == n && null == r ? (r = t, n = t = w) : null == r && ("string" == typeof t ? (r = n, n = w) : (r = n, n = t, t = w)), !1 === r) r = re;
+                else if (!r) return this;
+                return 1 === i && (a = r, (r = function(e) {
+                    return ve().off(e), a.apply(this, arguments)
+                }).guid = a.guid || (a.guid = ve.guid++)), this.each(function() {
+                    ve.event.add(this, e, r, n, t)
+                })
+            },
+            one: function(e, t, n, r) {
+                return this.on(e, t, n, r, 1)
+            },
+            off: function(e, t, n) {
+                var r, i;
+                if (e && e.preventDefault && e.handleObj) return r = e.handleObj, ve(e.delegateTarget).off(r.namespace ? r.origType + "." + r.namespace : r.origType, r.selector, r.handler), this;
+                if ("object" == typeof e) {
+                    for (i in e) this.off(i, t, e[i]);
+                    return this
+                }
+                return !1 !== t && "function" != typeof t || (n = t, t = w), !1 === n && (n = re), this.each(function() {
+                    ve.event.remove(this, e, n, t)
+                })
+            },
+            bind: function(e, t, n) {
+                return this.on(e, null, t, n)
+            },
+            unbind: function(e, t) {
+                return this.off(e, null, t)
+            },
+            delegate: function(e, t, n, r) {
+                return this.on(t, e, n, r)
+            },
+            undelegate: function(e, t, n) {
+                return 1 === arguments.length ? this.off(e, "**") : this.off(t, e || "**", n)
+            },
+            trigger: function(e, t) {
+                return this.each(function() {
+                    ve.event.trigger(e, t, this)
+                })
+            },
+            triggerHandler: function(e, t) {
+                var n = this[0];
+                if (n) return ve.event.trigger(e, t, n, !0)
+            }
+        }),
+        function(n, e) {
+            var t, P, H, o, r, h, l, w, g, C, i, m, v, a, s, y, u, T = "sizzle" + -new Date,
+                b = n.document,
+                x = {},
+                S = 0,
+                d = 0,
+                c = te(),
+                f = te(),
+                p = te(),
+                E = "undefined",
+                N = 1 << 31,
+                k = [],
+                A = k.pop,
+                D = k.push,
+                I = k.slice,
+                j = k.indexOf || function(e) {
+                    for (var t = 0, n = this.length; t < n; t++)
+                        if (this[t] === e) return t;
+                    return -1
+                },
+                L = "[\\x20\\t\\r\\n\\f]",
+                F = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
+                M = F.replace("w", "w#"),
+                B = "\\[" + L + "*(" + F + ")" + L + "*(?:([*^$|!~]?=)" + L + "*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|(" + M + ")|)|)" + L + "*\\]",
+                O = ":(" + F + ")(?:\\(((['\"])((?:\\\\.|[^\\\\])*?)\\3|((?:\\\\.|[^\\\\()[\\]]|" + B.replace(3, 8) + ")*)|.*)\\)|)",
+                q = new RegExp("^" + L + "+|((?:^|[^\\\\])(?:\\\\.)*)" + L + "+$", "g"),
+                _ = new RegExp("^" + L + "*," + L + "*"),
+                $ = new RegExp("^" + L + "*([\\x20\\t\\r\\n\\f>+~])" + L + "*"),
+                R = new RegExp(O),
+                z = new RegExp("^" + M + "$"),
+                X = {
+                    ID: new RegExp("^#(" + F + ")"),
+                    CLASS: new RegExp("^\\.(" + F + ")"),
+                    NAME: new RegExp("^\\[name=['\"]?(" + F + ")['\"]?\\]"),
+                    TAG: new RegExp("^(" + F.replace("w", "w*") + ")"),
+                    ATTR: new RegExp("^" + B),
+                    PSEUDO: new RegExp("^" + O),
+                    CHILD: new RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\(" + L + "*(even|odd|(([+-]|)(\\d*)n|)" + L + "*(?:([+-]|)" + L + "*(\\d+)|))" + L + "*\\)|)", "i"),
+                    needsContext: new RegExp("^" + L + "*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\(" + L + "*((?:-\\d)?\\d*)" + L + "*\\)|)(?=[^-]|$)", "i")
+                },
+                W = /[\x20\t\r\n\f]*[+~]/,
+                U = /^[^{]+\{\s*\[native code/,
+                V = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,
+                Q = /^(?:input|select|textarea|button)$/i,
+                Y = /^h\d$/i,
+                J = /'|\\/g,
+                G = /\=[\x20\t\r\n\f]*([^'"\]]*)[\x20\t\r\n\f]*\]/g,
+                K = /\\([\da-fA-F]{1,6}[\x20\t\r\n\f]?|.)/g,
+                Z = function(e, t) {
+                    var n = "0x" + t - 65536;
+                    return n != n ? t : n < 0 ? String.fromCharCode(n + 65536) : String.fromCharCode(n >> 10 | 55296, 1023 & n | 56320)
+                };
+            try {
+                I.call(b.documentElement.childNodes, 0)[0].nodeType
+            } catch (e) {
+                I = function(e) {
+                    for (var t, n = []; t = this[e++];) n.push(t);
+                    return n
+                }
+            }
+
+            function ee(e) {
+                return U.test(e + "")
+            }
+
+            function te() {
+                var n, r = [];
+                return n = function(e, t) {
+                    return r.push(e += " ") > H.cacheLength && delete n[r.shift()], n[e] = t
+                }
+            }
+
+            function ne(e) {
+                return e[T] = !0, e
+            }
+
+            function re(e) {
+                var t = C.createElement("div");
+                try {
+                    return e(t)
+                } catch (e) {
+                    return !1
+                } finally {
+                    t = null
+                }
+            }
+
+            function ie(e, t, n, r) {
+                var i, o, a, s, c, l, u, d, f, p;
+                if ((t ? t.ownerDocument || t : b) !== C && g(t), n = n || [], !e || "string" != typeof e) return n;
+                if (1 !== (s = (t = t || C).nodeType) && 9 !== s) return [];
+                if (!m && !r) {
+                    if (i = V.exec(e))
+                        if (a = i[1]) {
+                            if (9 === s) {
+                                if (!(o = t.getElementById(a)) || !o.parentNode) return n;
+                                if (o.id === a) return n.push(o), n
+                            } else if (t.ownerDocument && (o = t.ownerDocument.getElementById(a)) && y(t, o) && o.id === a) return n.push(o), n
+                        } else {
+                            if (i[2]) return D.apply(n, I.call(t.getElementsByTagName(e), 0)), n;
+                            if ((a = i[3]) && x.getByClassName && t.getElementsByClassName) return D.apply(n, I.call(t.getElementsByClassName(a), 0)), n
+                        }
+                    if (x.qsa && !v.test(e)) {
+                        if (u = !0, d = T, f = t, p = 9 === s && e, 1 === s && "object" !== t.nodeName.toLowerCase()) {
+                            for (l = le(e), (u = t.getAttribute("id")) ? d = u.replace(J, "\\$&") : t.setAttribute("id", d), d = "[id='" + d + "'] ", c = l.length; c--;) l[c] = d + ue(l[c]);
+                            f = W.test(e) && t.parentNode || t, p = l.join(",")
+                        }
+                        if (p) try {
+                            return D.apply(n, I.call(f.querySelectorAll(p), 0)), n
+                        } catch (e) {} finally {
+                            u || t.removeAttribute("id")
+                        }
+                    }
+                }
+                return function(e, t, n, r) {
+                    var i, o, a, s, c, l = le(e);
+                    if (!r && 1 === l.length) {
+                        if (2 < (o = l[0] = l[0].slice(0)).length && "ID" === (a = o[0]).type && 9 === t.nodeType && !m && H.relative[o[1].type]) {
+                            if (!(t = H.find.ID(a.matches[0].replace(K, Z), t)[0])) return n;
+                            e = e.slice(o.shift().value.length)
+                        }
+                        for (i = X.needsContext.test(e) ? 0 : o.length; i-- && (a = o[i], !H.relative[s = a.type]);)
+                            if ((c = H.find[s]) && (r = c(a.matches[0].replace(K, Z), W.test(o[0].type) && t.parentNode || t))) {
+                                if (o.splice(i, 1), !(e = r.length && ue(o))) return D.apply(n, I.call(r, 0)), n;
+                                break
+                            }
+                    }
+                    return h(e, l)(r, t, m, n, W.test(e)), n
+                }(e.replace(q, "$1"), t, n, r)
+            }
+
+            function oe(e, t) {
+                var n = t && e,
+                    r = n && (~t.sourceIndex || N) - (~e.sourceIndex || N);
+                if (r) return r;
+                if (n)
+                    for (; n = n.nextSibling;)
+                        if (n === t) return -1;
+                return e ? 1 : -1
+            }
+
+            function ae(t) {
+                return function(e) {
+                    return "input" === e.nodeName.toLowerCase() && e.type === t
+                }
+            }
+
+            function se(n) {
+                return function(e) {
+                    var t = e.nodeName.toLowerCase();
+                    return ("input" === t || "button" === t) && e.type === n
+                }
+            }
+
+            function ce(a) {
+                return ne(function(o) {
+                    return o = +o, ne(function(e, t) {
+                        for (var n, r = a([], e.length, o), i = r.length; i--;) e[n = r[i]] && (e[n] = !(t[n] = e[n]))
+                    })
+                })
+            }
+            for (t in r = ie.isXML = function(e) {
+                    var t = e && (e.ownerDocument || e).documentElement;
+                    return !!t && "HTML" !== t.nodeName
+                }, g = ie.setDocument = function(e) {
+                    var c = e ? e.ownerDocument || e : b;
+                    return c !== C && 9 === c.nodeType && c.documentElement && (i = (C = c).documentElement, m = r(c), x.tagNameNoComments = re(function(e) {
+                        return e.appendChild(c.createComment("")), !e.getElementsByTagName("*").length
+                    }), x.attributes = re(function(e) {
+                        e.innerHTML = "<select></select>";
+                        var t = typeof e.lastChild.getAttribute("multiple");
+                        return "boolean" !== t && "string" !== t
+                    }), x.getByClassName = re(function(e) {
+                        return e.innerHTML = "<div class='hidden e'></div><div class='hidden'></div>", !(!e.getElementsByClassName || !e.getElementsByClassName("e").length) && (e.lastChild.className = "e", 2 === e.getElementsByClassName("e").length)
+                    }), x.getByName = re(function(e) {
+                        e.id = T + 0, e.innerHTML = "<a name='" + T + "'></a><div name='" + T + "'></div>", i.insertBefore(e, i.firstChild);
+                        var t = c.getElementsByName && c.getElementsByName(T).length === 2 + c.getElementsByName(T + 0).length;
+                        return x.getIdNotName = !c.getElementById(T), i.removeChild(e), t
+                    }), H.attrHandle = re(function(e) {
+                        return e.innerHTML = "<a href='#'></a>", e.firstChild && typeof e.firstChild.getAttribute !== E && "#" === e.firstChild.getAttribute("href")
+                    }) ? {} : {
+                        href: function(e) {
+                            return e.getAttribute("href", 2)
+                        },
+                        type: function(e) {
+                            return e.getAttribute("type")
+                        }
+                    }, x.getIdNotName ? (H.find.ID = function(e, t) {
+                        if (typeof t.getElementById !== E && !m) {
+                            var n = t.getElementById(e);
+                            return n && n.parentNode ? [n] : []
+                        }
+                    }, H.filter.ID = function(e) {
+                        var t = e.replace(K, Z);
+                        return function(e) {
+                            return e.getAttribute("id") === t
+                        }
+                    }) : (H.find.ID = function(e, t) {
+                        if (typeof t.getElementById !== E && !m) {
+                            var n = t.getElementById(e);
+                            return n ? n.id === e || typeof n.getAttributeNode !== E && n.getAttributeNode("id").value === e ? [n] : void 0 : []
+                        }
+                    }, H.filter.ID = function(e) {
+                        var n = e.replace(K, Z);
+                        return function(e) {
+                            var t = typeof e.getAttributeNode !== E && e.getAttributeNode("id");
+                            return t && t.value === n
+                        }
+                    }), H.find.TAG = x.tagNameNoComments ? function(e, t) {
+                        if (typeof t.getElementsByTagName !== E) return t.getElementsByTagName(e)
+                    } : function(e, t) {
+                        var n, r = [],
+                            i = 0,
+                            o = t.getElementsByTagName(e);
+                        if ("*" === e) {
+                            for (; n = o[i++];) 1 === n.nodeType && r.push(n);
+                            return r
+                        }
+                        return o
+                    }, H.find.NAME = x.getByName && function(e, t) {
+                        if (typeof t.getElementsByName !== E) return t.getElementsByName(name)
+                    }, H.find.CLASS = x.getByClassName && function(e, t) {
+                        if (typeof t.getElementsByClassName !== E && !m) return t.getElementsByClassName(e)
+                    }, a = [], v = [":focus"], (x.qsa = ee(c.querySelectorAll)) && (re(function(e) {
+                        e.innerHTML = "<select><option selected=''></option></select>", e.querySelectorAll("[selected]").length || v.push("\\[" + L + "*(?:checked|disabled|ismap|multiple|readonly|selected|value)"), e.querySelectorAll(":checked").length || v.push(":checked")
+                    }), re(function(e) {
+                        e.innerHTML = "<input type='hidden' i=''/>", e.querySelectorAll("[i^='']").length && v.push("[*^$]=" + L + "*(?:\"\"|'')"), e.querySelectorAll(":enabled").length || v.push(":enabled", ":disabled"), e.querySelectorAll("*,:x"), v.push(",.*:")
+                    })), (x.matchesSelector = ee(s = i.matchesSelector || i.mozMatchesSelector || i.webkitMatchesSelector || i.oMatchesSelector || i.msMatchesSelector)) && re(function(e) {
+                        x.disconnectedMatch = s.call(e, "div"), s.call(e, "[s!='']:x"), a.push("!=", O)
+                    }), v = new RegExp(v.join("|")), a = new RegExp(a.join("|")), y = ee(i.contains) || i.compareDocumentPosition ? function(e, t) {
+                        var n = 9 === e.nodeType ? e.documentElement : e,
+                            r = t && t.parentNode;
+                        return e === r || !(!r || 1 !== r.nodeType || !(n.contains ? n.contains(r) : e.compareDocumentPosition && 16 & e.compareDocumentPosition(r)))
+                    } : function(e, t) {
+                        if (t)
+                            for (; t = t.parentNode;)
+                                if (t === e) return !0;
+                        return !1
+                    }, u = i.compareDocumentPosition ? function(e, t) {
+                        var n;
+                        return e === t ? (l = !0, 0) : (n = t.compareDocumentPosition && e.compareDocumentPosition && e.compareDocumentPosition(t)) ? 1 & n || e.parentNode && 11 === e.parentNode.nodeType ? e === c || y(b, e) ? -1 : t === c || y(b, t) ? 1 : 0 : 4 & n ? -1 : 1 : e.compareDocumentPosition ? -1 : 1
+                    } : function(e, t) {
+                        var n, r = 0,
+                            i = e.parentNode,
+                            o = t.parentNode,
+                            a = [e],
+                            s = [t];
+                        if (e === t) return l = !0, 0;
+                        if (!i || !o) return e === c ? -1 : t === c ? 1 : i ? -1 : o ? 1 : 0;
+                        if (i === o) return oe(e, t);
+                        for (n = e; n = n.parentNode;) a.unshift(n);
+                        for (n = t; n = n.parentNode;) s.unshift(n);
+                        for (; a[r] === s[r];) r++;
+                        return r ? oe(a[r], s[r]) : a[r] === b ? -1 : s[r] === b ? 1 : 0
+                    }, l = !1, [0, 0].sort(u), x.detectDuplicates = l), C
+                }, ie.matches = function(e, t) {
+                    return ie(e, null, null, t)
+                }, ie.matchesSelector = function(e, t) {
+                    if ((e.ownerDocument || e) !== C && g(e), t = t.replace(G, "='$1']"), x.matchesSelector && !m && (!a || !a.test(t)) && !v.test(t)) try {
+                        var n = s.call(e, t);
+                        if (n || x.disconnectedMatch || e.document && 11 !== e.document.nodeType) return n
+                    } catch (e) {}
+                    return 0 < ie(t, C, null, [e]).length
+                }, ie.contains = function(e, t) {
+                    return (e.ownerDocument || e) !== C && g(e), y(e, t)
+                }, ie.attr = function(e, t) {
+                    var n;
+                    return (e.ownerDocument || e) !== C && g(e), m || (t = t.toLowerCase()), (n = H.attrHandle[t]) ? n(e) : m || x.attributes ? e.getAttribute(t) : ((n = e.getAttributeNode(t)) || e.getAttribute(t)) && !0 === e[t] ? t : n && n.specified ? n.value : null
+                }, ie.error = function(e) {
+                    throw new Error("Syntax error, unrecognized expression: " + e)
+                }, ie.uniqueSort = function(e) {
+                    var t, n = [],
+                        r = 1,
+                        i = 0;
+                    if (l = !x.detectDuplicates, e.sort(u), l) {
+                        for (; t = e[r]; r++) t === e[r - 1] && (i = n.push(r));
+                        for (; i--;) e.splice(n[i], 1)
+                    }
+                    return e
+                }, o = ie.getText = function(e) {
+                    var t, n = "",
+                        r = 0,
+                        i = e.nodeType;
+                    if (i) {
+                        if (1 === i || 9 === i || 11 === i) {
+                            if ("string" == typeof e.textContent) return e.textContent;
+                            for (e = e.firstChild; e; e = e.nextSibling) n += o(e)
+                        } else if (3 === i || 4 === i) return e.nodeValue
+                    } else
+                        for (; t = e[r]; r++) n += o(t);
+                    return n
+                }, H = ie.selectors = {
+                    cacheLength: 50,
+                    createPseudo: ne,
+                    match: X,
+                    find: {},
+                    relative: {
+                        ">": {
+                            dir: "parentNode",
+                            first: !0
+                        },
+                        " ": {
+                            dir: "parentNode"
+                        },
+                        "+": {
+                            dir: "previousSibling",
+                            first: !0
+                        },
+                        "~": {
+                            dir: "previousSibling"
+                        }
+                    },
+                    preFilter: {
+                        ATTR: function(e) {
+                            return e[1] = e[1].replace(K, Z), e[3] = (e[4] || e[5] || "").replace(K, Z), "~=" === e[2] && (e[3] = " " + e[3] + " "), e.slice(0, 4)
+                        },
+                        CHILD: function(e) {
+                            return e[1] = e[1].toLowerCase(), "nth" === e[1].slice(0, 3) ? (e[3] || ie.error(e[0]), e[4] = +(e[4] ? e[5] + (e[6] || 1) : 2 * ("even" === e[3] || "odd" === e[3])), e[5] = +(e[7] + e[8] || "odd" === e[3])) : e[3] && ie.error(e[0]), e
+                        },
+                        PSEUDO: function(e) {
+                            var t, n = !e[5] && e[2];
+                            return X.CHILD.test(e[0]) ? null : (e[4] ? e[2] = e[4] : n && R.test(n) && (t = le(n, !0)) && (t = n.indexOf(")", n.length - t) - n.length) && (e[0] = e[0].slice(0, t), e[2] = n.slice(0, t)), e.slice(0, 3))
+                        }
+                    },
+                    filter: {
+                        TAG: function(t) {
+                            return "*" === t ? function() {
+                                return !0
+                            } : (t = t.replace(K, Z).toLowerCase(), function(e) {
+                                return e.nodeName && e.nodeName.toLowerCase() === t
+                            })
+                        },
+                        CLASS: function(e) {
+                            var t = c[e + " "];
+                            return t || (t = new RegExp("(^|" + L + ")" + e + "(" + L + "|$)")) && c(e, function(e) {
+                                return t.test(e.className || typeof e.getAttribute !== E && e.getAttribute("class") || "")
+                            })
+                        },
+                        ATTR: function(n, r, i) {
+                            return function(e) {
+                                var t = ie.attr(e, n);
+                                return null == t ? "!=" === r : !r || (t += "", "=" === r ? t === i : "!=" === r ? t !== i : "^=" === r ? i && 0 === t.indexOf(i) : "*=" === r ? i && -1 < t.indexOf(i) : "$=" === r ? i && t.slice(-i.length) === i : "~=" === r ? -1 < (" " + t + " ").indexOf(i) : "|=" === r && (t === i || t.slice(0, i.length + 1) === i + "-"))
+                            }
+                        },
+                        CHILD: function(p, e, t, h, g) {
+                            var m = "nth" !== p.slice(0, 3),
+                                v = "last" !== p.slice(-4),
+                                y = "of-type" === e;
+                            return 1 === h && 0 === g ? function(e) {
+                                return !!e.parentNode
+                            } : function(e, t, n) {
+                                var r, i, o, a, s, c, l = m !== v ? "nextSibling" : "previousSibling",
+                                    u = e.parentNode,
+                                    d = y && e.nodeName.toLowerCase(),
+                                    f = !n && !y;
+                                if (u) {
+                                    if (m) {
+                                        for (; l;) {
+                                            for (o = e; o = o[l];)
+                                                if (y ? o.nodeName.toLowerCase() === d : 1 === o.nodeType) return !1;
+                                            c = l = "only" === p && !c && "nextSibling"
+                                        }
+                                        return !0
+                                    }
+                                    if (c = [v ? u.firstChild : u.lastChild], v && f) {
+                                        for (s = (r = (i = u[T] || (u[T] = {}))[p] || [])[0] === S && r[1], a = r[0] === S && r[2], o = s && u.childNodes[s]; o = ++s && o && o[l] || (a = s = 0) || c.pop();)
+                                            if (1 === o.nodeType && ++a && o === e) {
+                                                i[p] = [S, s, a];
+                                                break
+                                            }
+                                    } else if (f && (r = (e[T] || (e[T] = {}))[p]) && r[0] === S) a = r[1];
+                                    else
+                                        for (;
+                                            (o = ++s && o && o[l] || (a = s = 0) || c.pop()) && ((y ? o.nodeName.toLowerCase() !== d : 1 !== o.nodeType) || !++a || (f && ((o[T] || (o[T] = {}))[p] = [S, a]), o !== e)););
+                                    return (a -= g) === h || a % h == 0 && 0 <= a / h
+                                }
+                            }
+                        },
+                        PSEUDO: function(e, o) {
+                            var t, a = H.pseudos[e] || H.setFilters[e.toLowerCase()] || ie.error("unsupported pseudo: " + e);
+                            return a[T] ? a(o) : 1 < a.length ? (t = [e, e, "", o], H.setFilters.hasOwnProperty(e.toLowerCase()) ? ne(function(e, t) {
+                                for (var n, r = a(e, o), i = r.length; i--;) e[n = j.call(e, r[i])] = !(t[n] = r[i])
+                            }) : function(e) {
+                                return a(e, 0, t)
+                            }) : a
+                        }
+                    },
+                    pseudos: {
+                        not: ne(function(e) {
+                            var r = [],
+                                i = [],
+                                s = h(e.replace(q, "$1"));
+                            return s[T] ? ne(function(e, t, n, r) {
+                                for (var i, o = s(e, null, r, []), a = e.length; a--;)(i = o[a]) && (e[a] = !(t[a] = i))
+                            }) : function(e, t, n) {
+                                return r[0] = e, s(r, null, n, i), !i.pop()
+                            }
+                        }),
+                        has: ne(function(t) {
+                            return function(e) {
+                                return 0 < ie(t, e).length
+                            }
+                        }),
+                        contains: ne(function(t) {
+                            return function(e) {
+                                return -1 < (e.textContent || e.innerText || o(e)).indexOf(t)
+                            }
+                        }),
+                        lang: ne(function(n) {
+                            return z.test(n || "") || ie.error("unsupported lang: " + n), n = n.replace(K, Z).toLowerCase(),
+                                function(e) {
+                                    var t;
+                                    do {
+                                        if (t = m ? e.getAttribute("xml:lang") || e.getAttribute("lang") : e.lang) return (t = t.toLowerCase()) === n || 0 === t.indexOf(n + "-")
+                                    } while ((e = e.parentNode) && 1 === e.nodeType);
+                                    return !1
+                                }
+                        }),
+                        target: function(e) {
+                            var t = n.location && n.location.hash;
+                            return t && t.slice(1) === e.id
+                        },
+                        root: function(e) {
+                            return e === i
+                        },
+                        focus: function(e) {
+                            return e === C.activeElement && (!C.hasFocus || C.hasFocus()) && !!(e.type || e.href || ~e.tabIndex)
+                        },
+                        enabled: function(e) {
+                            return !1 === e.disabled
+                        },
+                        disabled: function(e) {
+                            return !0 === e.disabled
+                        },
+                        checked: function(e) {
+                            var t = e.nodeName.toLowerCase();
+                            return "input" === t && !!e.checked || "option" === t && !!e.selected
+                        },
+                        selected: function(e) {
+                            return e.parentNode && e.parentNode.selectedIndex, !0 === e.selected
+                        },
+                        empty: function(e) {
+                            for (e = e.firstChild; e; e = e.nextSibling)
+                                if ("@" < e.nodeName || 3 === e.nodeType || 4 === e.nodeType) return !1;
+                            return !0
+                        },
+                        parent: function(e) {
+                            return !H.pseudos.empty(e)
+                        },
+                        header: function(e) {
+                            return Y.test(e.nodeName)
+                        },
+                        input: function(e) {
+                            return Q.test(e.nodeName)
+                        },
+                        button: function(e) {
+                            var t = e.nodeName.toLowerCase();
+                            return "input" === t && "button" === e.type || "button" === t
+                        },
+                        text: function(e) {
+                            var t;
+                            return "input" === e.nodeName.toLowerCase() && "text" === e.type && (null == (t = e.getAttribute("type")) || t.toLowerCase() === e.type)
+                        },
+                        first: ce(function() {
+                            return [0]
+                        }),
+                        last: ce(function(e, t) {
+                            return [t - 1]
+                        }),
+                        eq: ce(function(e, t, n) {
+                            return [n < 0 ? n + t : n]
+                        }),
+                        even: ce(function(e, t) {
+                            for (var n = 0; n < t; n += 2) e.push(n);
+                            return e
+                        }),
+                        odd: ce(function(e, t) {
+                            for (var n = 1; n < t; n += 2) e.push(n);
+                            return e
+                        }),
+                        lt: ce(function(e, t, n) {
+                            for (var r = n < 0 ? n + t : n; 0 <= --r;) e.push(r);
+                            return e
+                        }),
+                        gt: ce(function(e, t, n) {
+                            for (var r = n < 0 ? n + t : n; ++r < t;) e.push(r);
+                            return e
+                        })
+                    }
+                }, {
+                    radio: !0,
+                    checkbox: !0,
+                    file: !0,
+                    password: !0,
+                    image: !0
+                }) H.pseudos[t] = ae(t);
+            for (t in {
+                    submit: !0,
+                    reset: !0
+                }) H.pseudos[t] = se(t);
+
+            function le(e, t) {
+                var n, r, i, o, a, s, c, l = f[e + " "];
+                if (l) return t ? 0 : l.slice(0);
+                for (a = e, s = [], c = H.preFilter; a;) {
+                    for (o in n && !(r = _.exec(a)) || (r && (a = a.slice(r[0].length) || a), s.push(i = [])), n = !1, (r = $.exec(a)) && (n = r.shift(), i.push({
+                            value: n,
+                            type: r[0].replace(q, " ")
+                        }), a = a.slice(n.length)), H.filter) !(r = X[o].exec(a)) || c[o] && !(r = c[o](r)) || (n = r.shift(), i.push({
+                        value: n,
+                        type: o,
+                        matches: r
+                    }), a = a.slice(n.length));
+                    if (!n) break
+                }
+                return t ? a.length : a ? ie.error(e) : f(e, s).slice(0)
+            }
+
+            function ue(e) {
+                for (var t = 0, n = e.length, r = ""; t < n; t++) r += e[t].value;
+                return r
+            }
+
+            function de(s, e, t) {
+                var c = e.dir,
+                    l = t && "parentNode" === c,
+                    u = d++;
+                return e.first ? function(e, t, n) {
+                    for (; e = e[c];)
+                        if (1 === e.nodeType || l) return s(e, t, n)
+                } : function(e, t, n) {
+                    var r, i, o, a = S + " " + u;
+                    if (n) {
+                        for (; e = e[c];)
+                            if ((1 === e.nodeType || l) && s(e, t, n)) return !0
+                    } else
+                        for (; e = e[c];)
+                            if (1 === e.nodeType || l)
+                                if ((i = (o = e[T] || (e[T] = {}))[c]) && i[0] === a) {
+                                    if (!0 === (r = i[1]) || r === P) return !0 === r
+                                } else if ((i = o[c] = [a])[1] = s(e, t, n) || P, !0 === i[1]) return !0
+                }
+            }
+
+            function fe(i) {
+                return 1 < i.length ? function(e, t, n) {
+                    for (var r = i.length; r--;)
+                        if (!i[r](e, t, n)) return !1;
+                    return !0
+                } : i[0]
+            }
+
+            function pe(e, t, n, r, i) {
+                for (var o, a = [], s = 0, c = e.length, l = null != t; s < c; s++)(o = e[s]) && (n && !n(o, r, i) || (a.push(o), l && t.push(s)));
+                return a
+            }
+
+            function he(p, h, g, m, v, e) {
+                return m && !m[T] && (m = he(m)), v && !v[T] && (v = he(v, e)), ne(function(e, t, n, r) {
+                    var i, o, a, s = [],
+                        c = [],
+                        l = t.length,
+                        u = e || function(e, t, n) {
+                            for (var r = 0, i = t.length; r < i; r++) ie(e, t[r], n);
+                            return n
+                        }(h || "*", n.nodeType ? [n] : n, []),
+                        d = !p || !e && h ? u : pe(u, s, p, n, r),
+                        f = g ? v || (e ? p : l || m) ? [] : t : d;
+                    if (g && g(d, f, n, r), m)
+                        for (i = pe(f, c), m(i, [], n, r), o = i.length; o--;)(a = i[o]) && (f[c[o]] = !(d[c[o]] = a));
+                    if (e) {
+                        if (v || p) {
+                            if (v) {
+                                for (i = [], o = f.length; o--;)(a = f[o]) && i.push(d[o] = a);
+                                v(null, f = [], i, r)
+                            }
+                            for (o = f.length; o--;)(a = f[o]) && -1 < (i = v ? j.call(e, a) : s[o]) && (e[i] = !(t[i] = a))
+                        }
+                    } else f = pe(f === t ? f.splice(l, f.length) : f), v ? v(null, t, f, r) : D.apply(t, f)
+                })
+            }
+
+            function ge(e) {
+                for (var r, t, n, i = e.length, o = H.relative[e[0].type], a = o || H.relative[" "], s = o ? 1 : 0, c = de(function(e) {
+                        return e === r
+                    }, a, !0), l = de(function(e) {
+                        return -1 < j.call(r, e)
+                    }, a, !0), u = [function(e, t, n) {
+                        return !o && (n || t !== w) || ((r = t).nodeType ? c(e, t, n) : l(e, t, n))
+                    }]; s < i; s++)
+                    if (t = H.relative[e[s].type]) u = [de(fe(u), t)];
+                    else {
+                        if ((t = H.filter[e[s].type].apply(null, e[s].matches))[T]) {
+                            for (n = ++s; n < i && !H.relative[e[n].type]; n++);
+                            return he(1 < s && fe(u), 1 < s && ue(e.slice(0, s - 1)).replace(q, "$1"), t, s < n && ge(e.slice(s, n)), n < i && ge(e = e.slice(n)), n < i && ue(e))
+                        }
+                        u.push(t)
+                    }
+                return fe(u)
+            }
+
+            function me() {}
+            h = ie.compile = function(e, t) {
+                var n, m, v, y, b, x, r, i = [],
+                    o = [],
+                    a = p[e + " "];
+                if (!a) {
+                    for (t || (t = le(e)), n = t.length; n--;)(a = ge(t[n]))[T] ? i.push(a) : o.push(a);
+                    a = p(e, (m = o, b = (y = 0) < (v = i).length, x = 0 < m.length, r = function(e, t, n, r, i) {
+                        var o, a, s, c = [],
+                            l = 0,
+                            u = "0",
+                            d = e && [],
+                            f = null != i,
+                            p = w,
+                            h = e || x && H.find.TAG("*", i && t.parentNode || t),
+                            g = S += null == p ? 1 : Math.random() || .1;
+                        for (f && (w = t !== C && t, P = y); null != (o = h[u]); u++) {
+                            if (x && o) {
+                                for (a = 0; s = m[a++];)
+                                    if (s(o, t, n)) {
+                                        r.push(o);
+                                        break
+                                    }
+                                f && (S = g, P = ++y)
+                            }
+                            b && ((o = !s && o) && l--, e && d.push(o))
+                        }
+                        if (l += u, b && u !== l) {
+                            for (a = 0; s = v[a++];) s(d, c, t, n);
+                            if (e) {
+                                if (0 < l)
+                                    for (; u--;) d[u] || c[u] || (c[u] = A.call(r));
+                                c = pe(c)
+                            }
+                            D.apply(r, c), f && !e && 0 < c.length && 1 < l + v.length && ie.uniqueSort(r)
+                        }
+                        return f && (S = g, w = p), d
+                    }, b ? ne(r) : r))
+                }
+                return a
+            }, H.pseudos.nth = H.pseudos.eq, H.filters = me.prototype = H.pseudos, H.setFilters = new me, g(), ie.attr = ve.attr, ve.find = ie, ve.expr = ie.selectors, ve.expr[":"] = ve.expr.pseudos, ve.unique = ie.uniqueSort, ve.text = ie.getText, ve.isXMLDoc = ie.isXML, ve.contains = ie.contains
+        }(h);
+    var ie = /Until$/,
+        oe = /^(?:parents|prev(?:Until|All))/,
+        ae = /^.[^:#\[\.,]*$/,
+        se = ve.expr.match.needsContext,
+        ce = {
+            children: !0,
+            contents: !0,
+            next: !0,
+            prev: !0
+        };
+
+    function le(e, t) {
+        for (;
+            (e = e[t]) && 1 !== e.nodeType;);
+        return e
+    }
+
+    function ue(e, n, r) {
+        if (n = n || 0, ve.isFunction(n)) return ve.grep(e, function(e, t) {
+            return !!n.call(e, t, e) === r
+        });
+        if (n.nodeType) return ve.grep(e, function(e) {
+            return e === n === r
+        });
+        if ("string" == typeof n) {
+            var t = ve.grep(e, function(e) {
+                return 1 === e.nodeType
+            });
+            if (ae.test(n)) return ve.filter(n, t, !r);
+            n = ve.filter(n, t)
+        }
+        return ve.grep(e, function(e) {
+            return 0 <= ve.inArray(e, n) === r
+        })
+    }
+
+    function de(e) {
+        var t = fe.split("|"),
+            n = e.createDocumentFragment();
+        if (n.createElement)
+            for (; t.length;) n.createElement(t.pop());
+        return n
+    }
+    ve.fn.extend({
+        find: function(e) {
+            var t, n, r, i = this.length;
+            if ("string" != typeof e) return (r = this).pushStack(ve(e).filter(function() {
+                for (t = 0; t < i; t++)
+                    if (ve.contains(r[t], this)) return !0
+            }));
+            for (n = [], t = 0; t < i; t++) ve.find(e, this[t], n);
+            return (n = this.pushStack(1 < i ? ve.unique(n) : n)).selector = (this.selector ? this.selector + " " : "") + e, n
+        },
+        has: function(e) {
+            var t, n = ve(e, this),
+                r = n.length;
+            return this.filter(function() {
+                for (t = 0; t < r; t++)
+                    if (ve.contains(this, n[t])) return !0
+            })
+        },
+        not: function(e) {
+            return this.pushStack(ue(this, e, !1))
+        },
+        filter: function(e) {
+            return this.pushStack(ue(this, e, !0))
+        },
+        is: function(e) {
+            return !!e && ("string" == typeof e ? se.test(e) ? 0 <= ve(e, this.context).index(this[0]) : 0 < ve.filter(e, this).length : 0 < this.filter(e).length)
+        },
+        closest: function(e, t) {
+            for (var n, r = 0, i = this.length, o = [], a = se.test(e) || "string" != typeof e ? ve(e, t || this.context) : 0; r < i; r++)
+                for (n = this[r]; n && n.ownerDocument && n !== t && 11 !== n.nodeType;) {
+                    if (a ? -1 < a.index(n) : ve.find.matchesSelector(n, e)) {
+                        o.push(n);
+                        break
+                    }
+                    n = n.parentNode
+                }
+            return this.pushStack(1 < o.length ? ve.unique(o) : o)
+        },
+        index: function(e) {
+            return e ? "string" == typeof e ? ve.inArray(this[0], ve(e)) : ve.inArray(e.jquery ? e[0] : e, this) : this[0] && this[0].parentNode ? this.first().prevAll().length : -1
+        },
+        add: function(e, t) {
+            var n = "string" == typeof e ? ve(e, t) : ve.makeArray(e && e.nodeType ? [e] : e),
+                r = ve.merge(this.get(), n);
+            return this.pushStack(ve.unique(r))
+        },
+        addBack: function(e) {
+            return this.add(null == e ? this.prevObject : this.prevObject.filter(e))
+        }
+    }), ve.fn.andSelf = ve.fn.addBack, ve.each({
+        parent: function(e) {
+            var t = e.parentNode;
+            return t && 11 !== t.nodeType ? t : null
+        },
+        parents: function(e) {
+            return ve.dir(e, "parentNode")
+        },
+        parentsUntil: function(e, t, n) {
+            return ve.dir(e, "parentNode", n)
+        },
+        next: function(e) {
+            return le(e, "nextSibling")
+        },
+        prev: function(e) {
+            return le(e, "previousSibling")
+        },
+        nextAll: function(e) {
+            return ve.dir(e, "nextSibling")
+        },
+        prevAll: function(e) {
+            return ve.dir(e, "previousSibling")
+        },
+        nextUntil: function(e, t, n) {
+            return ve.dir(e, "nextSibling", n)
+        },
+        prevUntil: function(e, t, n) {
+            return ve.dir(e, "previousSibling", n)
+        },
+        siblings: function(e) {
+            return ve.sibling((e.parentNode || {}).firstChild, e)
+        },
+        children: function(e) {
+            return ve.sibling(e.firstChild)
+        },
+        contents: function(e) {
+            return ve.nodeName(e, "iframe") ? e.contentDocument || e.contentWindow.document : ve.merge([], e.childNodes)
+        }
+    }, function(r, i) {
+        ve.fn[r] = function(e, t) {
+            var n = ve.map(this, i, e);
+            return ie.test(r) || (t = e), t && "string" == typeof t && (n = ve.filter(t, n)), n = 1 < this.length && !ce[r] ? ve.unique(n) : n, 1 < this.length && oe.test(r) && (n = n.reverse()), this.pushStack(n)
+        }
+    }), ve.extend({
+        filter: function(e, t, n) {
+            return n && (e = ":not(" + e + ")"), 1 === t.length ? ve.find.matchesSelector(t[0], e) ? [t[0]] : [] : ve.find.matches(e, t)
+        },
+        dir: function(e, t, n) {
+            for (var r = [], i = e[t]; i && 9 !== i.nodeType && (n === w || 1 !== i.nodeType || !ve(i).is(n));) 1 === i.nodeType && r.push(i), i = i[t];
+            return r
+        },
+        sibling: function(e, t) {
+            for (var n = []; e; e = e.nextSibling) 1 === e.nodeType && e !== t && n.push(e);
+            return n
+        }
+    });
+    var fe = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video",
+        pe = / jQuery\d+="(?:null|\d+)"/g,
+        he = new RegExp("<(?:" + fe + ")[\\s/>]", "i"),
+        ge = /^\s+/,
+        me = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,
+        ye = /<([\w:]+)/,
+        be = /<tbody/i,
+        xe = /<|&#?\w+;/,
+        Pe = /<(?:script|style|link)/i,
+        He = /^(?:checkbox|radio)$/i,
+        we = /checked\s*(?:[^=]|=\s*.checked.)/i,
+        Ce = /^$|\/(?:java|ecma)script/i,
+        Te = /^true\/(.*)/,
+        Se = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+        Ee = {
+            option: [1, "<select multiple='multiple'>", "</select>"],
+            legend: [1, "<fieldset>", "</fieldset>"],
+            area: [1, "<map>", "</map>"],
+            param: [1, "<object>", "</object>"],
+            thead: [1, "<table>", "</table>"],
+            tr: [2, "<table><tbody>", "</tbody></table>"],
+            col: [2, "<table><tbody></tbody><colgroup>", "</colgroup></table>"],
+            td: [3, "<table><tbody><tr>", "</tr></tbody></table>"],
+            _default: ve.support.htmlSerialize ? [0, "", ""] : [1, "X<div>", "</div>"]
+        },
+        Ne = de(g).appendChild(g.createElement("div"));
+
+    function ke(e) {
+        var t = e.getAttributeNode("type");
+        return e.type = (t && t.specified) + "/" + e.type, e
+    }
+
+    function Ae(e) {
+        var t = Te.exec(e.type);
+        return t ? e.type = t[1] : e.removeAttribute("type"), e
+    }
+
+    function De(e, t) {
+        for (var n, r = 0; null != (n = e[r]); r++) ve._data(n, "globalEval", !t || ve._data(t[r], "globalEval"))
+    }
+
+    function Ie(e, t) {
+        if (1 === t.nodeType && ve.hasData(e)) {
+            var n, r, i, o = ve._data(e),
+                a = ve._data(t, o),
+                s = o.events;
+            if (s)
+                for (n in delete a.handle, a.events = {}, s)
+                    for (r = 0, i = s[n].length; r < i; r++) ve.event.add(t, n, s[n][r]);
+            a.data && (a.data = ve.extend({}, a.data))
+        }
+    }
+
+    function je(e, t) {
+        var n, r, i;
+        if (1 === t.nodeType) {
+            if (n = t.nodeName.toLowerCase(), !ve.support.noCloneEvent && t[ve.expando]) {
+                for (r in (i = ve._data(t)).events) ve.removeEvent(t, r, i.handle);
+                t.removeAttribute(ve.expando)
+            }
+            "script" === n && t.text !== e.text ? (ke(t).text = e.text, Ae(t)) : "object" === n ? (t.parentNode && (t.outerHTML = e.outerHTML), ve.support.html5Clone && e.innerHTML && !ve.trim(t.innerHTML) && (t.innerHTML = e.innerHTML)) : "input" === n && He.test(e.type) ? (t.defaultChecked = t.checked = e.checked, t.value !== e.value && (t.value = e.value)) : "option" === n ? t.defaultSelected = t.selected = e.defaultSelected : "input" !== n && "textarea" !== n || (t.defaultValue = e.defaultValue)
+        }
+    }
+
+    function Le(e, t) {
+        var n, r, i = 0,
+            o = typeof e.getElementsByTagName !== v ? e.getElementsByTagName(t || "*") : typeof e.querySelectorAll !== v ? e.querySelectorAll(t || "*") : w;
+        if (!o)
+            for (o = [], n = e.childNodes || e; null != (r = n[i]); i++) !t || ve.nodeName(r, t) ? o.push(r) : ve.merge(o, Le(r, t));
+        return t === w || t && ve.nodeName(e, t) ? ve.merge([e], o) : o
+    }
+
+    function Fe(e) {
+        He.test(e.type) && (e.defaultChecked = e.checked)
+    }
+    Ee.optgroup = Ee.option, Ee.tbody = Ee.tfoot = Ee.colgroup = Ee.caption = Ee.thead, Ee.th = Ee.td, ve.fn.extend({
+        text: function(e) {
+            return ve.access(this, function(e) {
+                return e === w ? ve.text(this) : this.empty().append((this[0] && this[0].ownerDocument || g).createTextNode(e))
+            }, null, e, arguments.length)
+        },
+        wrapAll: function(t) {
+            if (ve.isFunction(t)) return this.each(function(e) {
+                ve(this).wrapAll(t.call(this, e))
+            });
+            if (this[0]) {
+                var e = ve(t, this[0].ownerDocument).eq(0).clone(!0);
+                this[0].parentNode && e.insertBefore(this[0]), e.map(function() {
+                    for (var e = this; e.firstChild && 1 === e.firstChild.nodeType;) e = e.firstChild;
+                    return e
+                }).append(this)
+            }
+            return this
+        },
+        wrapInner: function(n) {
+            return ve.isFunction(n) ? this.each(function(e) {
+                ve(this).wrapInner(n.call(this, e))
+            }) : this.each(function() {
+                var e = ve(this),
+                    t = e.contents();
+                t.length ? t.wrapAll(n) : e.append(n)
+            })
+        },
+        wrap: function(t) {
+            var n = ve.isFunction(t);
+            return this.each(function(e) {
+                ve(this).wrapAll(n ? t.call(this, e) : t)
+            })
+        },
+        unwrap: function() {
+            return this.parent().each(function() {
+                ve.nodeName(this, "body") || ve(this).replaceWith(this.childNodes)
+            }).end()
+        },
+        append: function() {
+            return this.domManip(arguments, !0, function(e) {
+                1 !== this.nodeType && 11 !== this.nodeType && 9 !== this.nodeType || this.appendChild(e)
+            })
+        },
+        prepend: function() {
+            return this.domManip(arguments, !0, function(e) {
+                1 !== this.nodeType && 11 !== this.nodeType && 9 !== this.nodeType || this.insertBefore(e, this.firstChild)
+            })
+        },
+        before: function() {
+            return this.domManip(arguments, !1, function(e) {
+                this.parentNode && this.parentNode.insertBefore(e, this)
+            })
+        },
+        after: function() {
+            return this.domManip(arguments, !1, function(e) {
+                this.parentNode && this.parentNode.insertBefore(e, this.nextSibling)
+            })
+        },
+        remove: function(e, t) {
+            for (var n, r = 0; null != (n = this[r]); r++)(!e || 0 < ve.filter(e, [n]).length) && (t || 1 !== n.nodeType || ve.cleanData(Le(n)), n.parentNode && (t && ve.contains(n.ownerDocument, n) && De(Le(n, "script")), n.parentNode.removeChild(n)));
+            return this
+        },
+        empty: function() {
+            for (var e, t = 0; null != (e = this[t]); t++) {
+                for (1 === e.nodeType && ve.cleanData(Le(e, !1)); e.firstChild;) e.removeChild(e.firstChild);
+                e.options && ve.nodeName(e, "select") && (e.options.length = 0)
+            }
+            return this
+        },
+        clone: function(e, t) {
+            return e = null != e && e, t = null == t ? e : t, this.map(function() {
+                return ve.clone(this, e, t)
+            })
+        },
+        html: function(e) {
+            return ve.access(this, function(e) {
+                var t = this[0] || {},
+                    n = 0,
+                    r = this.length;
+                if (e === w) return 1 === t.nodeType ? t.innerHTML.replace(pe, "") : w;
+                if ("string" == typeof e && !Pe.test(e) && (ve.support.htmlSerialize || !he.test(e)) && (ve.support.leadingWhitespace || !ge.test(e)) && !Ee[(ye.exec(e) || ["", ""])[1].toLowerCase()]) {
+                    e = e.replace(me, "<$1></$2>");
+                    try {
+                        for (; n < r; n++) 1 === (t = this[n] || {}).nodeType && (ve.cleanData(Le(t, !1)), t.innerHTML = e);
+                        t = 0
+                    } catch (e) {}
+                }
+                t && this.empty().append(e)
+            }, null, e, arguments.length)
+        },
+        replaceWith: function(e) {
+            return ve.isFunction(e) || "string" == typeof e || (e = ve(e).not(this).detach()), this.domManip([e], !0, function(e) {
+                var t = this.nextSibling,
+                    n = this.parentNode;
+                n && (ve(this).remove(), n.insertBefore(e, t))
+            })
+        },
+        detach: function(e) {
+            return this.remove(e, !0)
+        },
+        domManip: function(n, r, i) {
+            n = y.apply([], n);
+            var e, t, o, a, s, c, l, u, d = 0,
+                f = this.length,
+                p = this,
+                h = f - 1,
+                g = n[0],
+                m = ve.isFunction(g);
+            if (m || !(f <= 1 || "string" != typeof g || ve.support.checkClone) && we.test(g)) return this.each(function(e) {
+                var t = p.eq(e);
+                m && (n[0] = g.call(this, e, r ? t.html() : w)), t.domManip(n, r, i)
+            });
+            if (f && (e = (c = ve.buildFragment(n, this[0].ownerDocument, !1, this)).firstChild, 1 === c.childNodes.length && (c = e), e)) {
+                for (r = r && ve.nodeName(e, "tr"), o = (a = ve.map(Le(c, "script"), ke)).length; d < f; d++) t = c, d !== h && (t = ve.clone(t, !0, !0), o && ve.merge(a, Le(t, "script"))), i.call(r && ve.nodeName(this[d], "table") ? (l = this[d], u = "tbody", l.getElementsByTagName(u)[0] || l.appendChild(l.ownerDocument.createElement(u))) : this[d], t, d);
+                if (o)
+                    for (s = a[a.length - 1].ownerDocument, ve.map(a, Ae), d = 0; d < o; d++) t = a[d], Ce.test(t.type || "") && !ve._data(t, "globalEval") && ve.contains(s, t) && (t.src ? ve.ajax({
+                        url: t.src,
+                        type: "GET",
+                        dataType: "script",
+                        async: !1,
+                        global: !1,
+                        throws: !0
+                    }) : ve.globalEval((t.text || t.textContent || t.innerHTML || "").replace(Se, "")));
+                c = e = null
+            }
+            return this
+        }
+    }), ve.each({
+        appendTo: "append",
+        prependTo: "prepend",
+        insertBefore: "before",
+        insertAfter: "after",
+        replaceAll: "replaceWith"
+    }, function(e, a) {
+        ve.fn[e] = function(e) {
+            for (var t, n = 0, r = [], i = ve(e), o = i.length - 1; n <= o; n++) t = n === o ? this : this.clone(!0), ve(i[n])[a](t), s.apply(r, t.get());
+            return this.pushStack(r)
+        }
+    }), ve.extend({
+        clone: function(e, t, n) {
+            var r, i, o, a, s, c = ve.contains(e.ownerDocument, e);
+            if (ve.support.html5Clone || ve.isXMLDoc(e) || !he.test("<" + e.nodeName + ">") ? o = e.cloneNode(!0) : (Ne.innerHTML = e.outerHTML, Ne.removeChild(o = Ne.firstChild)), !(ve.support.noCloneEvent && ve.support.noCloneChecked || 1 !== e.nodeType && 11 !== e.nodeType || ve.isXMLDoc(e)))
+                for (r = Le(o), s = Le(e), a = 0; null != (i = s[a]); ++a) r[a] && je(i, r[a]);
+            if (t)
+                if (n)
+                    for (s = s || Le(e), r = r || Le(o), a = 0; null != (i = s[a]); a++) Ie(i, r[a]);
+                else Ie(e, o);
+            return 0 < (r = Le(o, "script")).length && De(r, !c && Le(e, "script")), r = s = i = null, o
+        },
+        buildFragment: function(e, t, n, r) {
+            for (var i, o, a, s, c, l, u, d = e.length, f = de(t), p = [], h = 0; h < d; h++)
+                if ((o = e[h]) || 0 === o)
+                    if ("object" === ve.type(o)) ve.merge(p, o.nodeType ? [o] : o);
+                    else if (xe.test(o)) {
+                for (s = s || f.appendChild(t.createElement("div")), c = (ye.exec(o) || ["", ""])[1].toLowerCase(), u = Ee[c] || Ee._default, s.innerHTML = u[1] + o.replace(me, "<$1></$2>") + u[2], i = u[0]; i--;) s = s.lastChild;
+                if (!ve.support.leadingWhitespace && ge.test(o) && p.push(t.createTextNode(ge.exec(o)[0])), !ve.support.tbody)
+                    for (i = (o = "table" !== c || be.test(o) ? "<table>" !== u[1] || be.test(o) ? 0 : s : s.firstChild) && o.childNodes.length; i--;) ve.nodeName(l = o.childNodes[i], "tbody") && !l.childNodes.length && o.removeChild(l);
+                for (ve.merge(p, s.childNodes), s.textContent = ""; s.firstChild;) s.removeChild(s.firstChild);
+                s = f.lastChild
+            } else p.push(t.createTextNode(o));
+            for (s && f.removeChild(s), ve.support.appendChecked || ve.grep(Le(p, "input"), Fe), h = 0; o = p[h++];)
+                if ((!r || -1 === ve.inArray(o, r)) && (a = ve.contains(o.ownerDocument, o), s = Le(f.appendChild(o), "script"), a && De(s), n))
+                    for (i = 0; o = s[i++];) Ce.test(o.type || "") && n.push(o);
+            return s = null, f
+        },
+        cleanData: function(e, t) {
+            for (var n, r, i, o, a = 0, s = ve.expando, c = ve.cache, l = ve.support.deleteExpando, u = ve.event.special; null != (n = e[a]); a++)
+                if ((t || ve.acceptData(n)) && (o = (i = n[s]) && c[i])) {
+                    if (o.events)
+                        for (r in o.events) u[r] ? ve.event.remove(n, r) : ve.removeEvent(n, r, o.handle);
+                    c[i] && (delete c[i], l ? delete n[s] : typeof n.removeAttribute !== v ? n.removeAttribute(s) : n[s] = null, d.push(i))
+                }
+        }
+    });
+    var Me, Be, Oe, qe = /alpha\([^)]*\)/i,
+        _e = /opacity\s*=\s*([^)]*)/,
+        $e = /^(top|right|bottom|left)$/,
+        Re = /^(none|table(?!-c[ea]).+)/,
+        ze = /^margin/,
+        Xe = new RegExp("^(" + p + ")(.*)$", "i"),
+        We = new RegExp("^(" + p + ")(?!px)[a-z%]+$", "i"),
+        Ue = new RegExp("^([+-])=(" + p + ")", "i"),
+        Ve = {
+            BODY: "block"
+        },
+        Qe = {
+            position: "absolute",
+            visibility: "hidden",
+            display: "block"
+        },
+        Ye = {
+            letterSpacing: 0,
+            fontWeight: 400
+        },
+        Je = ["Top", "Right", "Bottom", "Left"],
+        Ge = ["Webkit", "O", "Moz", "ms"];
+
+    function Ke(e, t) {
+        if (t in e) return t;
+        for (var n = t.charAt(0).toUpperCase() + t.slice(1), r = t, i = Ge.length; i--;)
+            if ((t = Ge[i] + n) in e) return t;
+        return r
+    }
+
+    function Ze(e, t) {
+        return e = t || e, "none" === ve.css(e, "display") || !ve.contains(e.ownerDocument, e)
+    }
+
+    function et(e, t) {
+        for (var n, r, i, o = [], a = 0, s = e.length; a < s; a++)(r = e[a]).style && (o[a] = ve._data(r, "olddisplay"), n = r.style.display, t ? (o[a] || "none" !== n || (r.style.display = ""), "" === r.style.display && Ze(r) && (o[a] = ve._data(r, "olddisplay", it(r.nodeName)))) : o[a] || (i = Ze(r), (n && "none" !== n || !i) && ve._data(r, "olddisplay", i ? n : ve.css(r, "display"))));
+        for (a = 0; a < s; a++)(r = e[a]).style && (t && "none" !== r.style.display && "" !== r.style.display || (r.style.display = t ? o[a] || "" : "none"));
+        return e
+    }
+
+    function tt(e, t, n) {
+        var r = Xe.exec(t);
+        return r ? Math.max(0, r[1] - (n || 0)) + (r[2] || "px") : t
+    }
+
+    function nt(e, t, n, r, i) {
+        for (var o = n === (r ? "border" : "content") ? 4 : "width" === t ? 1 : 0, a = 0; o < 4; o += 2) "margin" === n && (a += ve.css(e, n + Je[o], !0, i)), r ? ("content" === n && (a -= ve.css(e, "padding" + Je[o], !0, i)), "margin" !== n && (a -= ve.css(e, "border" + Je[o] + "Width", !0, i))) : (a += ve.css(e, "padding" + Je[o], !0, i), "padding" !== n && (a += ve.css(e, "border" + Je[o] + "Width", !0, i)));
+        return a
+    }
+
+    function rt(e, t, n) {
+        var r = !0,
+            i = "width" === t ? e.offsetWidth : e.offsetHeight,
+            o = Be(e),
+            a = ve.support.boxSizing && "border-box" === ve.css(e, "boxSizing", !1, o);
+        if (i <= 0 || null == i) {
+            if (((i = Oe(e, t, o)) < 0 || null == i) && (i = e.style[t]), We.test(i)) return i;
+            r = a && (ve.support.boxSizingReliable || i === e.style[t]), i = parseFloat(i) || 0
+        }
+        return i + nt(e, t, n || (a ? "border" : "content"), r, o) + "px"
+    }
+
+    function it(e) {
+        var t = g,
+            n = Ve[e];
+        return n || ("none" !== (n = ot(e, t)) && n || ((t = ((Me = (Me || ve("<iframe frameborder='0' width='0' height='0'/>").css("cssText", "display:block !important")).appendTo(t.documentElement))[0].contentWindow || Me[0].contentDocument).document).write("<!doctype html><html><body>"), t.close(), n = ot(e, t), Me.detach()), Ve[e] = n), n
+    }
+
+    function ot(e, t) {
+        var n = ve(t.createElement(e)).appendTo(t.body),
+            r = ve.css(n[0], "display");
+        return n.remove(), r
+    }
+    ve.fn.extend({
+        css: function(e, t) {
+            return ve.access(this, function(e, t, n) {
+                var r, i, o = {},
+                    a = 0;
+                if (ve.isArray(t)) {
+                    for (i = Be(e), r = t.length; a < r; a++) o[t[a]] = ve.css(e, t[a], !1, i);
+                    return o
+                }
+                return n !== w ? ve.style(e, t, n) : ve.css(e, t)
+            }, e, t, 1 < arguments.length)
+        },
+        show: function() {
+            return et(this, !0)
+        },
+        hide: function() {
+            return et(this)
+        },
+        toggle: function(e) {
+            var t = "boolean" == typeof e;
+            return this.each(function() {
+                (t ? e : Ze(this)) ? ve(this).show(): ve(this).hide()
+            })
+        }
+    }), ve.extend({
+        cssHooks: {
+            opacity: {
+                get: function(e, t) {
+                    if (t) {
+                        var n = Oe(e, "opacity");
+                        return "" === n ? "1" : n
+                    }
+                }
+            }
+        },
+        cssNumber: {
+            columnCount: !0,
+            fillOpacity: !0,
+            fontWeight: !0,
+            lineHeight: !0,
+            opacity: !0,
+            orphans: !0,
+            widows: !0,
+            zIndex: !0,
+            zoom: !0
+        },
+        cssProps: {
+            float: ve.support.cssFloat ? "cssFloat" : "styleFloat"
+        },
+        style: function(e, t, n, r) {
+            if (e && 3 !== e.nodeType && 8 !== e.nodeType && e.style) {
+                var i, o, a, s = ve.camelCase(t),
+                    c = e.style;
+                if (t = ve.cssProps[s] || (ve.cssProps[s] = Ke(c, s)), a = ve.cssHooks[t] || ve.cssHooks[s], n === w) return a && "get" in a && (i = a.get(e, !1, r)) !== w ? i : c[t];
+                if (!("string" === (o = typeof n) && (i = Ue.exec(n)) && (n = (i[1] + 1) * i[2] + parseFloat(ve.css(e, t)), o = "number"), null == n || "number" === o && isNaN(n) || ("number" !== o || ve.cssNumber[s] || (n += "px"), ve.support.clearCloneStyle || "" !== n || 0 !== t.indexOf("background") || (c[t] = "inherit"), a && "set" in a && (n = a.set(e, n, r)) === w))) try {
+                    c[t] = n
+                } catch (e) {}
+            }
+        },
+        css: function(e, t, n, r) {
+            var i, o, a, s = ve.camelCase(t);
+            return t = ve.cssProps[s] || (ve.cssProps[s] = Ke(e.style, s)), (a = ve.cssHooks[t] || ve.cssHooks[s]) && "get" in a && (o = a.get(e, !0, n)), o === w && (o = Oe(e, t, r)), "normal" === o && t in Ye && (o = Ye[t]), "" === n || n ? (i = parseFloat(o), !0 === n || ve.isNumeric(i) ? i || 0 : o) : o
+        },
+        swap: function(e, t, n, r) {
+            var i, o, a = {};
+            for (o in t) a[o] = e.style[o], e.style[o] = t[o];
+            for (o in i = n.apply(e, r || []), t) e.style[o] = a[o];
+            return i
+        }
+    }), h.getComputedStyle ? (Be = function(e) {
+        return h.getComputedStyle(e, null)
+    }, Oe = function(e, t, n) {
+        var r, i, o, a = n || Be(e),
+            s = a ? a.getPropertyValue(t) || a[t] : w,
+            c = e.style;
+        return a && ("" !== s || ve.contains(e.ownerDocument, e) || (s = ve.style(e, t)), We.test(s) && ze.test(t) && (r = c.width, i = c.minWidth, o = c.maxWidth, c.minWidth = c.maxWidth = c.width = s, s = a.width, c.width = r, c.minWidth = i, c.maxWidth = o)), s
+    }) : g.documentElement.currentStyle && (Be = function(e) {
+        return e.currentStyle
+    }, Oe = function(e, t, n) {
+        var r, i, o, a = n || Be(e),
+            s = a ? a[t] : w,
+            c = e.style;
+        return null == s && c && c[t] && (s = c[t]), We.test(s) && !$e.test(t) && (r = c.left, (o = (i = e.runtimeStyle) && i.left) && (i.left = e.currentStyle.left), c.left = "fontSize" === t ? "1em" : s, s = c.pixelLeft + "px", c.left = r, o && (i.left = o)), "" === s ? "auto" : s
+    }), ve.each(["height", "width"], function(e, i) {
+        ve.cssHooks[i] = {
+            get: function(e, t, n) {
+                if (t) return 0 === e.offsetWidth && Re.test(ve.css(e, "display")) ? ve.swap(e, Qe, function() {
+                    return rt(e, i, n)
+                }) : rt(e, i, n)
+            },
+            set: function(e, t, n) {
+                var r = n && Be(e);
+                return tt(0, t, n ? nt(e, i, n, ve.support.boxSizing && "border-box" === ve.css(e, "boxSizing", !1, r), r) : 0)
+            }
+        }
+    }), ve.support.opacity || (ve.cssHooks.opacity = {
+        get: function(e, t) {
+            return _e.test((t && e.currentStyle ? e.currentStyle.filter : e.style.filter) || "") ? .01 * parseFloat(RegExp.$1) + "" : t ? "1" : ""
+        },
+        set: function(e, t) {
+            var n = e.style,
+                r = e.currentStyle,
+                i = ve.isNumeric(t) ? "alpha(opacity=" + 100 * t + ")" : "",
+                o = r && r.filter || n.filter || "";
+            ((n.zoom = 1) <= t || "" === t) && "" === ve.trim(o.replace(qe, "")) && n.removeAttribute && (n.removeAttribute("filter"), "" === t || r && !r.filter) || (n.filter = qe.test(o) ? o.replace(qe, i) : o + " " + i)
+        }
+    }), ve(function() {
+        ve.support.reliableMarginRight || (ve.cssHooks.marginRight = {
+            get: function(e, t) {
+                if (t) return ve.swap(e, {
+                    display: "inline-block"
+                }, Oe, [e, "marginRight"])
+            }
+        }), !ve.support.pixelPosition && ve.fn.position && ve.each(["top", "left"], function(e, n) {
+            ve.cssHooks[n] = {
+                get: function(e, t) {
+                    if (t) return t = Oe(e, n), We.test(t) ? ve(e).position()[n] + "px" : t
+                }
+            }
+        })
+    }), ve.expr && ve.expr.filters && (ve.expr.filters.hidden = function(e) {
+        return e.offsetWidth <= 0 && e.offsetHeight <= 0 || !ve.support.reliableHiddenOffsets && "none" === (e.style && e.style.display || ve.css(e, "display"))
+    }, ve.expr.filters.visible = function(e) {
+        return !ve.expr.filters.hidden(e)
+    }), ve.each({
+        margin: "",
+        padding: "",
+        border: "Width"
+    }, function(i, o) {
+        ve.cssHooks[i + o] = {
+            expand: function(e) {
+                for (var t = 0, n = {}, r = "string" == typeof e ? e.split(" ") : [e]; t < 4; t++) n[i + Je[t] + o] = r[t] || r[t - 2] || r[0];
+                return n
+            }
+        }, ze.test(i) || (ve.cssHooks[i + o].set = tt)
+    });
+    var at = /%20/g,
+        st = /\[\]$/,
+        ct = /\r?\n/g,
+        lt = /^(?:submit|button|image|reset|file)$/i,
+        ut = /^(?:input|select|textarea|keygen)/i;
+
+    function dt(n, e, r, i) {
+        var t;
+        if (ve.isArray(e)) ve.each(e, function(e, t) {
+            r || st.test(n) ? i(n, t) : dt(n + "[" + ("object" == typeof t ? e : "") + "]", t, r, i)
+        });
+        else if (r || "object" !== ve.type(e)) i(n, e);
+        else
+            for (t in e) dt(n + "[" + t + "]", e[t], r, i)
+    }
+    ve.fn.extend({
+        serialize: function() {
+            return ve.param(this.serializeArray())
+        },
+        serializeArray: function() {
+            return this.map(function() {
+                var e = ve.prop(this, "elements");
+                return e ? ve.makeArray(e) : this
+            }).filter(function() {
+                var e = this.type;
+                return this.name && !ve(this).is(":disabled") && ut.test(this.nodeName) && !lt.test(e) && (this.checked || !He.test(e))
+            }).map(function(e, t) {
+                var n = ve(this).val();
+                return null == n ? null : ve.isArray(n) ? ve.map(n, function(e) {
+                    return {
+                        name: t.name,
+                        value: e.replace(ct, "\r\n")
+                    }
+                }) : {
+                    name: t.name,
+                    value: n.replace(ct, "\r\n")
+                }
+            }).get()
+        }
+    }), ve.param = function(e, t) {
+        var n, r = [],
+            i = function(e, t) {
+                t = ve.isFunction(t) ? t() : null == t ? "" : t, r[r.length] = encodeURIComponent(e) + "=" + encodeURIComponent(t)
+            };
+        if (t === w && (t = ve.ajaxSettings && ve.ajaxSettings.traditional), ve.isArray(e) || e.jquery && !ve.isPlainObject(e)) ve.each(e, function() {
+            i(this.name, this.value)
+        });
+        else
+            for (n in e) dt(n, e[n], t, i);
+        return r.join("&").replace(at, "+")
+    }, ve.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "), function(e, n) {
+        ve.fn[n] = function(e, t) {
+            return 0 < arguments.length ? this.on(n, null, e, t) : this.trigger(n)
+        }
+    }), ve.fn.hover = function(e, t) {
+        return this.mouseenter(e).mouseleave(t || e)
+    };
+    var ft, pt, ht = ve.now(),
+        gt = /\?/,
+        mt = /#.*$/,
+        vt = /([?&])_=[^&]*/,
+        yt = /^(.*?):[ \t]*([^\r\n]*)\r?$/gm,
+        bt = /^(?:GET|HEAD)$/,
+        xt = /^\/\//,
+        Pt = /^([\w.+-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/,
+        Ht = ve.fn.load,
+        wt = {},
+        Ct = {},
+        Tt = "*/".concat("*");
+    try {
+        pt = e.href
+    } catch (e) {
+        (pt = g.createElement("a")).href = "", pt = pt.href
+    }
+
+    function St(o) {
+        return function(e, t) {
+            "string" != typeof e && (t = e, e = "*");
+            var n, r = 0,
+                i = e.toLowerCase().match(C) || [];
+            if (ve.isFunction(t))
+                for (; n = i[r++];) "+" === n[0] ? (n = n.slice(1) || "*", (o[n] = o[n] || []).unshift(t)) : (o[n] = o[n] || []).push(t)
+        }
+    }
+
+    function Et(t, i, o, a) {
+        var s = {},
+            c = t === Ct;
+
+        function l(e) {
+            var r;
+            return s[e] = !0, ve.each(t[e] || [], function(e, t) {
+                var n = t(i, o, a);
+                return "string" != typeof n || c || s[n] ? c ? !(r = n) : void 0 : (i.dataTypes.unshift(n), l(n), !1)
+            }), r
+        }
+        return l(i.dataTypes[0]) || !s["*"] && l("*")
+    }
+
+    function Nt(e, t) {
+        var n, r, i = ve.ajaxSettings.flatOptions || {};
+        for (r in t) t[r] !== w && ((i[r] ? e : n || (n = {}))[r] = t[r]);
+        return n && ve.extend(!0, e, n), e
+    }
+    ft = Pt.exec(pt.toLowerCase()) || [], ve.fn.load = function(e, t, n) {
+        if ("string" != typeof e && Ht) return Ht.apply(this, arguments);
+        var r, i, o, a = this,
+            s = e.indexOf(" ");
+        return 0 <= s && (r = e.slice(s, e.length), e = e.slice(0, s)), ve.isFunction(t) ? (n = t, t = w) : t && "object" == typeof t && (o = "POST"), 0 < a.length && ve.ajax({
+            url: e,
+            type: o,
+            dataType: "html",
+            data: t
+        }).done(function(e) {
+            i = arguments, a.html(r ? ve("<div>").append(ve.parseHTML(e)).find(r) : e)
+        }).complete(n && function(e, t) {
+            a.each(n, i || [e.responseText, t, e])
+        }), this
+    }, ve.each(["ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend"], function(e, t) {
+        ve.fn[t] = function(e) {
+            return this.on(t, e)
+        }
+    }), ve.each(["get", "post"], function(e, i) {
+        ve[i] = function(e, t, n, r) {
+            return ve.isFunction(t) && (r = r || n, n = t, t = w), ve.ajax({
+                url: e,
+                type: i,
+                dataType: r,
+                data: t,
+                success: n
+            })
+        }
+    }), ve.extend({
+        active: 0,
+        lastModified: {},
+        etag: {},
+        ajaxSettings: {
+            url: pt,
+            type: "GET",
+            isLocal: /^(?:about|app|app-storage|.+-extension|file|res|widget):$/.test(ft[1]),
+            global: !0,
+            processData: !0,
+            async: !0,
+            contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+            accepts: {
+                "*": Tt,
+                text: "text/plain",
+                html: "text/html",
+                xml: "application/xml, text/xml",
+                json: "application/json, text/javascript"
+            },
+            contents: {
+                xml: /xml/,
+                html: /html/,
+                json: /json/
+            },
+            responseFields: {
+                xml: "responseXML",
+                text: "responseText"
+            },
+            converters: {
+                "* text": h.String,
+                "text html": !0,
+                "text json": ve.parseJSON,
+                "text xml": ve.parseXML
+            },
+            flatOptions: {
+                url: !0,
+                context: !0
+            }
+        },
+        ajaxSetup: function(e, t) {
+            return t ? Nt(Nt(e, ve.ajaxSettings), t) : Nt(ve.ajaxSettings, e)
+        },
+        ajaxPrefilter: St(wt),
+        ajaxTransport: St(Ct),
+        ajax: function(e, t) {
+            "object" == typeof e && (t = e, e = w), t = t || {};
+            var n, r, u, d, f, p, h, i, g = ve.ajaxSetup({}, t),
+                m = g.context || g,
+                v = g.context && (m.nodeType || m.jquery) ? ve(m) : ve.event,
+                y = ve.Deferred(),
+                b = ve.Callbacks("once memory"),
+                x = g.statusCode || {},
+                o = {},
+                a = {},
+                P = 0,
+                s = "canceled",
+                H = {
+                    readyState: 0,
+                    getResponseHeader: function(e) {
+                        var t;
+                        if (2 === P) {
+                            if (!i)
+                                for (i = {}; t = yt.exec(d);) i[t[1].toLowerCase()] = t[2];
+                            t = i[e.toLowerCase()]
+                        }
+                        return null == t ? null : t
+                    },
+                    getAllResponseHeaders: function() {
+                        return 2 === P ? d : null
+                    },
+                    setRequestHeader: function(e, t) {
+                        var n = e.toLowerCase();
+                        return P || (e = a[n] = a[n] || e, o[e] = t), this
+                    },
+                    overrideMimeType: function(e) {
+                        return P || (g.mimeType = e), this
+                    },
+                    statusCode: function(e) {
+                        var t;
+                        if (e)
+                            if (P < 2)
+                                for (t in e) x[t] = [x[t], e[t]];
+                            else H.always(e[H.status]);
+                        return this
+                    },
+                    abort: function(e) {
+                        var t = e || s;
+                        return h && h.abort(t), c(0, t), this
+                    }
+                };
+            if (y.promise(H).complete = b.add, H.success = H.done, H.error = H.fail, g.url = ((e || g.url || pt) + "").replace(mt, "").replace(xt, ft[1] + "//"), g.type = t.method || t.type || g.method || g.type, g.dataTypes = ve.trim(g.dataType || "*").toLowerCase().match(C) || [""], null == g.crossDomain && (n = Pt.exec(g.url.toLowerCase()), g.crossDomain = !(!n || n[1] === ft[1] && n[2] === ft[2] && (n[3] || ("http:" === n[1] ? 80 : 443)) == (ft[3] || ("http:" === ft[1] ? 80 : 443)))), g.data && g.processData && "string" != typeof g.data && (g.data = ve.param(g.data, g.traditional)), Et(wt, g, t, H), 2 === P) return H;
+            for (r in (p = g.global) && 0 == ve.active++ && ve.event.trigger("ajaxStart"), g.type = g.type.toUpperCase(), g.hasContent = !bt.test(g.type), u = g.url, g.hasContent || (g.data && (u = g.url += (gt.test(u) ? "&" : "?") + g.data, delete g.data), !1 === g.cache && (g.url = vt.test(u) ? u.replace(vt, "$1_=" + ht++) : u + (gt.test(u) ? "&" : "?") + "_=" + ht++)), g.ifModified && (ve.lastModified[u] && H.setRequestHeader("If-Modified-Since", ve.lastModified[u]), ve.etag[u] && H.setRequestHeader("If-None-Match", ve.etag[u])), (g.data && g.hasContent && !1 !== g.contentType || t.contentType) && H.setRequestHeader("Content-Type", g.contentType), H.setRequestHeader("Accept", g.dataTypes[0] && g.accepts[g.dataTypes[0]] ? g.accepts[g.dataTypes[0]] + ("*" !== g.dataTypes[0] ? ", " + Tt + "; q=0.01" : "") : g.accepts["*"]), g.headers) H.setRequestHeader(r, g.headers[r]);
+            if (g.beforeSend && (!1 === g.beforeSend.call(m, H, g) || 2 === P)) return H.abort();
+            for (r in s = "abort", {
+                    success: 1,
+                    error: 1,
+                    complete: 1
+                }) H[r](g[r]);
+            if (h = Et(Ct, g, t, H)) {
+                H.readyState = 1, p && v.trigger("ajaxSend", [H, g]), g.async && 0 < g.timeout && (f = setTimeout(function() {
+                    H.abort("timeout")
+                }, g.timeout));
+                try {
+                    P = 1, h.send(o, c)
+                } catch (e) {
+                    if (!(P < 2)) throw e;
+                    c(-1, e)
+                }
+            } else c(-1, "No Transport");
+
+            function c(e, t, n, r) {
+                var i, o, a, s, c, l = t;
+                2 !== P && (P = 2, f && clearTimeout(f), h = w, d = r || "", H.readyState = 0 < e ? 4 : 0, n && (s = function(e, t, n) {
+                    var r, i, o, a, s = e.contents,
+                        c = e.dataTypes,
+                        l = e.responseFields;
+                    for (a in l) a in n && (t[l[a]] = n[a]);
+                    for (;
+                        "*" === c[0];) c.shift(), i === w && (i = e.mimeType || t.getResponseHeader("Content-Type"));
+                    if (i)
+                        for (a in s)
+                            if (s[a] && s[a].test(i)) {
+                                c.unshift(a);
+                                break
+                            }
+                    if (c[0] in n) o = c[0];
+                    else {
+                        for (a in n) {
+                            if (!c[0] || e.converters[a + " " + c[0]]) {
+                                o = a;
+                                break
+                            }
+                            r || (r = a)
+                        }
+                        o = o || r
+                    }
+                    if (o) return o !== c[0] && c.unshift(o), n[o]
+                }(g, H, n)), 200 <= e && e < 300 || 304 === e ? (g.ifModified && ((c = H.getResponseHeader("Last-Modified")) && (ve.lastModified[u] = c), (c = H.getResponseHeader("etag")) && (ve.etag[u] = c)), 204 === e ? (i = !0, l = "nocontent") : 304 === e ? (i = !0, l = "notmodified") : (l = (i = function(e, t) {
+                    var n, r, i, o, a = {},
+                        s = 0,
+                        c = e.dataTypes.slice(),
+                        l = c[0];
+                    e.dataFilter && (t = e.dataFilter(t, e.dataType));
+                    if (c[1])
+                        for (i in e.converters) a[i.toLowerCase()] = e.converters[i];
+                    for (; r = c[++s];)
+                        if ("*" !== r) {
+                            if ("*" !== l && l !== r) {
+                                if (!(i = a[l + " " + r] || a["* " + r]))
+                                    for (n in a)
+                                        if ((o = n.split(" "))[1] === r && (i = a[l + " " + o[0]] || a["* " + o[0]])) {
+                                            !0 === i ? i = a[n] : !0 !== a[n] && (r = o[0], c.splice(s--, 0, r));
+                                            break
+                                        }
+                                if (!0 !== i)
+                                    if (i && e.throws) t = i(t);
+                                    else try {
+                                        t = i(t)
+                                    } catch (e) {
+                                        return {
+                                            state: "parsererror",
+                                            error: i ? e : "No conversion from " + l + " to " + r
+                                        }
+                                    }
+                            }
+                            l = r
+                        }
+                    return {
+                        state: "success",
+                        data: t
+                    }
+                }(g, s)).state, o = i.data, i = !(a = i.error))) : (a = l, !e && l || (l = "error", e < 0 && (e = 0))), H.status = e, H.statusText = (t || l) + "", i ? y.resolveWith(m, [o, l, H]) : y.rejectWith(m, [H, l, a]), H.statusCode(x), x = w, p && v.trigger(i ? "ajaxSuccess" : "ajaxError", [H, g, i ? o : a]), b.fireWith(m, [H, l]), p && (v.trigger("ajaxComplete", [H, g]), --ve.active || ve.event.trigger("ajaxStop")))
+            }
+            return H
+        },
+        getScript: function(e, t) {
+            return ve.get(e, w, t, "script")
+        },
+        getJSON: function(e, t, n) {
+            return ve.get(e, t, n, "json")
+        }
+    }), ve.ajaxSetup({
+        accepts: {
+            script: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"
+        },
+        contents: {
+            script: /(?:java|ecma)script/
+        },
+        converters: {
+            "text script": function(e) {
+                return ve.globalEval(e), e
+            }
+        }
+    }), ve.ajaxPrefilter("script", function(e) {
+        e.cache === w && (e.cache = !1), e.crossDomain && (e.type = "GET", e.global = !1)
+    }), ve.ajaxTransport("script", function(t) {
+        if (t.crossDomain) {
+            var r, i = g.head || ve("head")[0] || g.documentElement;
+            return {
+                send: function(e, n) {
+                    (r = g.createElement("script")).async = !0, t.scriptCharset && (r.charset = t.scriptCharset), r.src = t.url, r.onload = r.onreadystatechange = function(e, t) {
+                        (t || !r.readyState || /loaded|complete/.test(r.readyState)) && (r.onload = r.onreadystatechange = null, r.parentNode && r.parentNode.removeChild(r), r = null, t || n(200, "success"))
+                    }, i.insertBefore(r, i.firstChild)
+                },
+                abort: function() {
+                    r && r.onload(w, !0)
+                }
+            }
+        }
+    });
+    var kt = [],
+        At = /(=)\?(?=&|$)|\?\?/;
+    ve.ajaxSetup({
+        jsonp: "callback",
+        jsonpCallback: function() {
+            var e = kt.pop() || ve.expando + "_" + ht++;
+            return this[e] = !0, e
+        }
+    }), ve.ajaxPrefilter("json jsonp", function(e, t, n) {
+        var r, i, o, a = !1 !== e.jsonp && (At.test(e.url) ? "url" : "string" == typeof e.data && !(e.contentType || "").indexOf("application/x-www-form-urlencoded") && At.test(e.data) && "data");
+        if (a || "jsonp" === e.dataTypes[0]) return r = e.jsonpCallback = ve.isFunction(e.jsonpCallback) ? e.jsonpCallback() : e.jsonpCallback, a ? e[a] = e[a].replace(At, "$1" + r) : !1 !== e.jsonp && (e.url += (gt.test(e.url) ? "&" : "?") + e.jsonp + "=" + r), e.converters["script json"] = function() {
+            return o || ve.error(r + " was not called"), o[0]
+        }, e.dataTypes[0] = "json", i = h[r], h[r] = function() {
+            o = arguments
+        }, n.always(function() {
+            h[r] = i, e[r] && (e.jsonpCallback = t.jsonpCallback, kt.push(r)), o && ve.isFunction(i) && i(o[0]), o = i = w
+        }), "script"
+    });
+    var Dt, It, jt = 0,
+        Lt = h.ActiveXObject && function() {
+            var e;
+            for (e in Dt) Dt[e](w, !0)
+        };
+
+    function Ft() {
+        try {
+            return new h.XMLHttpRequest
+        } catch (e) {}
+    }
+    ve.ajaxSettings.xhr = h.ActiveXObject ? function() {
+        return !this.isLocal && Ft() || function() {
+            try {
+                return new h.ActiveXObject("Microsoft.XMLHTTP")
+            } catch (e) {}
+        }()
+    } : Ft, It = ve.ajaxSettings.xhr(), ve.support.cors = !!It && "withCredentials" in It, (It = ve.support.ajax = !!It) && ve.ajaxTransport(function(l) {
+        var u;
+        if (!l.crossDomain || ve.support.cors) return {
+            send: function(e, a) {
+                var s, t, c = l.xhr();
+                if (l.username ? c.open(l.type, l.url, l.async, l.username, l.password) : c.open(l.type, l.url, l.async), l.xhrFields)
+                    for (t in l.xhrFields) c[t] = l.xhrFields[t];
+                l.mimeType && c.overrideMimeType && c.overrideMimeType(l.mimeType), l.crossDomain || e["X-Requested-With"] || (e["X-Requested-With"] = "XMLHttpRequest");
+                try {
+                    for (t in e) c.setRequestHeader(t, e[t])
+                } catch (e) {}
+                c.send(l.hasContent && l.data || null), u = function(e, t) {
+                    var n, r, i, o;
+                    try {
+                        if (u && (t || 4 === c.readyState))
+                            if (u = w, s && (c.onreadystatechange = ve.noop, Lt && delete Dt[s]), t) 4 !== c.readyState && c.abort();
+                            else {
+                                o = {}, n = c.status, r = c.getAllResponseHeaders(), "string" == typeof c.responseText && (o.text = c.responseText);
+                                try {
+                                    i = c.statusText
+                                } catch (e) {
+                                    i = ""
+                                }
+                                n || !l.isLocal || l.crossDomain ? 1223 === n && (n = 204) : n = o.text ? 200 : 404
+                            }
+                    } catch (e) {
+                        t || a(-1, e)
+                    }
+                    o && a(n, i, o, r)
+                }, l.async ? 4 === c.readyState ? setTimeout(u) : (s = ++jt, Lt && (Dt || (Dt = {}, ve(h).unload(Lt)), Dt[s] = u), c.onreadystatechange = u) : u()
+            },
+            abort: function() {
+                u && u(w, !0)
+            }
+        }
+    });
+    var Mt, Bt, Ot = /^(?:toggle|show|hide)$/,
+        qt = new RegExp("^(?:([+-])=|)(" + p + ")([a-z%]*)$", "i"),
+        _t = /queueHooks$/,
+        $t = [function(t, e, n) {
+            var r, i, o, a, s, c, l, u, d, f = this,
+                p = t.style,
+                h = {},
+                g = [],
+                m = t.nodeType && Ze(t);
+            n.queue || (null == (u = ve._queueHooks(t, "fx")).unqueued && (u.unqueued = 0, d = u.empty.fire, u.empty.fire = function() {
+                u.unqueued || d()
+            }), u.unqueued++, f.always(function() {
+                f.always(function() {
+                    u.unqueued--, ve.queue(t, "fx").length || u.empty.fire()
+                })
+            }));
+            1 === t.nodeType && ("height" in e || "width" in e) && (n.overflow = [p.overflow, p.overflowX, p.overflowY], "inline" === ve.css(t, "display") && "none" === ve.css(t, "float") && (ve.support.inlineBlockNeedsLayout && "inline" !== it(t.nodeName) ? p.zoom = 1 : p.display = "inline-block"));
+            n.overflow && (p.overflow = "hidden", ve.support.shrinkWrapBlocks || f.always(function() {
+                p.overflow = n.overflow[0], p.overflowX = n.overflow[1], p.overflowY = n.overflow[2]
+            }));
+            for (i in e)
+                if (a = e[i], Ot.exec(a)) {
+                    if (delete e[i], c = c || "toggle" === a, a === (m ? "hide" : "show")) continue;
+                    g.push(i)
+                }
+            if (o = g.length) {
+                "hidden" in (s = ve._data(t, "fxshow") || ve._data(t, "fxshow", {})) && (m = s.hidden), c && (s.hidden = !m), m ? ve(t).show() : f.done(function() {
+                    ve(t).hide()
+                }), f.done(function() {
+                    var e;
+                    for (e in ve._removeData(t, "fxshow"), h) ve.style(t, e, h[e])
+                });
+                for (i = 0; i < o; i++) r = g[i], l = f.createTween(r, m ? s[r] : 0), h[r] = s[r] || ve.style(t, r), r in s || (s[r] = l.start, m && (l.end = l.start, l.start = "width" === r || "height" === r ? 1 : 0))
+            }
+        }],
+        Rt = {
+            "*": [function(e, t) {
+                var n, r, i = this.createTween(e, t),
+                    o = qt.exec(t),
+                    a = i.cur(),
+                    s = +a || 0,
+                    c = 1,
+                    l = 20;
+                if (o) {
+                    if (n = +o[2], "px" !== (r = o[3] || (ve.cssNumber[e] ? "" : "px")) && s)
+                        for (s = ve.css(i.elem, e, !0) || n || 1; s /= c = c || ".5", ve.style(i.elem, e, s + r), c !== (c = i.cur() / a) && 1 !== c && --l;);
+                    i.unit = r, i.start = s, i.end = o[1] ? s + (o[1] + 1) * n : n
+                }
+                return i
+            }]
+        };
+
+    function zt() {
+        return setTimeout(function() {
+            Mt = w
+        }), Mt = ve.now()
+    }
+
+    function Xt(o, e, t) {
+        var n, a, s, r, i = 0,
+            c = $t.length,
+            l = ve.Deferred().always(function() {
+                delete u.elem
+            }),
+            u = function() {
+                if (a) return !1;
+                for (var e = Mt || zt(), t = Math.max(0, d.startTime + d.duration - e), n = 1 - (t / d.duration || 0), r = 0, i = d.tweens.length; r < i; r++) d.tweens[r].run(n);
+                return l.notifyWith(o, [d, n, t]), n < 1 && i ? t : (l.resolveWith(o, [d]), !1)
+            },
+            d = l.promise({
+                elem: o,
+                props: ve.extend({}, e),
+                opts: ve.extend(!0, {
+                    specialEasing: {}
+                }, t),
+                originalProperties: e,
+                originalOptions: t,
+                startTime: Mt || zt(),
+                duration: t.duration,
+                tweens: [],
+                createTween: function(e, t) {
+                    var n = ve.Tween(o, d.opts, e, t, d.opts.specialEasing[e] || d.opts.easing);
+                    return d.tweens.push(n), n
+                },
+                stop: function(e) {
+                    var t = 0,
+                        n = e ? d.tweens.length : 0;
+                    if (a) return this;
+                    for (a = !0; t < n; t++) d.tweens[t].run(1);
+                    return e ? l.resolveWith(o, [d, e]) : l.rejectWith(o, [d, e]), this
+                }
+            }),
+            f = d.props;
+        for (! function(e, t) {
+                var n, r, i, o, a;
+                for (i in e)
+                    if (r = ve.camelCase(i), o = t[r], n = e[i], ve.isArray(n) && (o = n[1], n = e[i] = n[0]), i !== r && (e[r] = n, delete e[i]), (a = ve.cssHooks[r]) && "expand" in a)
+                        for (i in n = a.expand(n), delete e[r], n) i in e || (e[i] = n[i], t[i] = o);
+                    else t[r] = o
+            }(f, d.opts.specialEasing); i < c; i++)
+            if (n = $t[i].call(d, o, f, d.opts)) return n;
+        return s = d, r = f, ve.each(r, function(e, t) {
+            for (var n = (Rt[e] || []).concat(Rt["*"]), r = 0, i = n.length; r < i; r++)
+                if (n[r].call(s, e, t)) return
+        }), ve.isFunction(d.opts.start) && d.opts.start.call(o, d), ve.fx.timer(ve.extend(u, {
+            elem: o,
+            anim: d,
+            queue: d.opts.queue
+        })), d.progress(d.opts.progress).done(d.opts.done, d.opts.complete).fail(d.opts.fail).always(d.opts.always)
+    }
+
+    function Wt(e, t, n, r, i) {
+        return new Wt.prototype.init(e, t, n, r, i)
+    }
+
+    function Ut(e, t) {
+        var n, r = {
+                height: e
+            },
+            i = 0;
+        for (t = t ? 1 : 0; i < 4; i += 2 - t) r["margin" + (n = Je[i])] = r["padding" + n] = e;
+        return t && (r.opacity = r.width = e), r
+    }
+
+    function Vt(e) {
+        return ve.isWindow(e) ? e : 9 === e.nodeType && (e.defaultView || e.parentWindow)
+    }
+    ve.Animation = ve.extend(Xt, {
+        tweener: function(e, t) {
+            ve.isFunction(e) ? (t = e, e = ["*"]) : e = e.split(" ");
+            for (var n, r = 0, i = e.length; r < i; r++) n = e[r], Rt[n] = Rt[n] || [], Rt[n].unshift(t)
+        },
+        prefilter: function(e, t) {
+            t ? $t.unshift(e) : $t.push(e)
+        }
+    }), ((ve.Tween = Wt).prototype = {
+        constructor: Wt,
+        init: function(e, t, n, r, i, o) {
+            this.elem = e, this.prop = n, this.easing = i || "swing", this.options = t, this.start = this.now = this.cur(), this.end = r, this.unit = o || (ve.cssNumber[n] ? "" : "px")
+        },
+        cur: function() {
+            var e = Wt.propHooks[this.prop];
+            return e && e.get ? e.get(this) : Wt.propHooks._default.get(this)
+        },
+        run: function(e) {
+            var t, n = Wt.propHooks[this.prop];
+            return this.options.duration ? this.pos = t = ve.easing[this.easing](e, this.options.duration * e, 0, 1, this.options.duration) : this.pos = t = e, this.now = (this.end - this.start) * t + this.start, this.options.step && this.options.step.call(this.elem, this.now, this), n && n.set ? n.set(this) : Wt.propHooks._default.set(this), this
+        }
+    }).init.prototype = Wt.prototype, (Wt.propHooks = {
+        _default: {
+            get: function(e) {
+                var t;
+                return null == e.elem[e.prop] || e.elem.style && null != e.elem.style[e.prop] ? (t = ve.css(e.elem, e.prop, "")) && "auto" !== t ? t : 0 : e.elem[e.prop]
+            },
+            set: function(e) {
+                ve.fx.step[e.prop] ? ve.fx.step[e.prop](e) : e.elem.style && (null != e.elem.style[ve.cssProps[e.prop]] || ve.cssHooks[e.prop]) ? ve.style(e.elem, e.prop, e.now + e.unit) : e.elem[e.prop] = e.now
+            }
+        }
+    }).scrollTop = Wt.propHooks.scrollLeft = {
+        set: function(e) {
+            e.elem.nodeType && e.elem.parentNode && (e.elem[e.prop] = e.now)
+        }
+    }, ve.each(["toggle", "show", "hide"], function(e, r) {
+        var i = ve.fn[r];
+        ve.fn[r] = function(e, t, n) {
+            return null == e || "boolean" == typeof e ? i.apply(this, arguments) : this.animate(Ut(r, !0), e, t, n)
+        }
+    }), ve.fn.extend({
+        fadeTo: function(e, t, n, r) {
+            return this.filter(Ze).css("opacity", 0).show().end().animate({
+                opacity: t
+            }, e, n, r)
+        },
+        animate: function(t, e, n, r) {
+            var i = ve.isEmptyObject(t),
+                o = ve.speed(e, n, r),
+                a = function() {
+                    var e = Xt(this, ve.extend({}, t), o);
+                    a.finish = function() {
+                        e.stop(!0)
+                    }, (i || ve._data(this, "finish")) && e.stop(!0)
+                };
+            return a.finish = a, i || !1 === o.queue ? this.each(a) : this.queue(o.queue, a)
+        },
+        stop: function(i, e, o) {
+            var a = function(e) {
+                var t = e.stop;
+                delete e.stop, t(o)
+            };
+            return "string" != typeof i && (o = e, e = i, i = w), e && !1 !== i && this.queue(i || "fx", []), this.each(function() {
+                var e = !0,
+                    t = null != i && i + "queueHooks",
+                    n = ve.timers,
+                    r = ve._data(this);
+                if (t) r[t] && r[t].stop && a(r[t]);
+                else
+                    for (t in r) r[t] && r[t].stop && _t.test(t) && a(r[t]);
+                for (t = n.length; t--;) n[t].elem !== this || null != i && n[t].queue !== i || (n[t].anim.stop(o), e = !1, n.splice(t, 1));
+                !e && o || ve.dequeue(this, i)
+            })
+        },
+        finish: function(a) {
+            return !1 !== a && (a = a || "fx"), this.each(function() {
+                var e, t = ve._data(this),
+                    n = t[a + "queue"],
+                    r = t[a + "queueHooks"],
+                    i = ve.timers,
+                    o = n ? n.length : 0;
+                for (t.finish = !0, ve.queue(this, a, []), r && r.cur && r.cur.finish && r.cur.finish.call(this), e = i.length; e--;) i[e].elem === this && i[e].queue === a && (i[e].anim.stop(!0), i.splice(e, 1));
+                for (e = 0; e < o; e++) n[e] && n[e].finish && n[e].finish.call(this);
+                delete t.finish
+            })
+        }
+    }), ve.each({
+        slideDown: Ut("show"),
+        slideUp: Ut("hide"),
+        slideToggle: Ut("toggle"),
+        fadeIn: {
+            opacity: "show"
+        },
+        fadeOut: {
+            opacity: "hide"
+        },
+        fadeToggle: {
+            opacity: "toggle"
+        }
+    }, function(e, r) {
+        ve.fn[e] = function(e, t, n) {
+            return this.animate(r, e, t, n)
+        }
+    }), ve.speed = function(e, t, n) {
+        var r = e && "object" == typeof e ? ve.extend({}, e) : {
+            complete: n || !n && t || ve.isFunction(e) && e,
+            duration: e,
+            easing: n && t || t && !ve.isFunction(t) && t
+        };
+        return r.duration = ve.fx.off ? 0 : "number" == typeof r.duration ? r.duration : r.duration in ve.fx.speeds ? ve.fx.speeds[r.duration] : ve.fx.speeds._default, null != r.queue && !0 !== r.queue || (r.queue = "fx"), r.old = r.complete, r.complete = function() {
+            ve.isFunction(r.old) && r.old.call(this), r.queue && ve.dequeue(this, r.queue)
+        }, r
+    }, ve.easing = {
+        linear: function(e) {
+            return e
+        },
+        swing: function(e) {
+            return .5 - Math.cos(e * Math.PI) / 2
+        }
+    }, ve.timers = [], ve.fx = Wt.prototype.init, ve.fx.tick = function() {
+        var e, t = ve.timers,
+            n = 0;
+        for (Mt = ve.now(); n < t.length; n++)(e = t[n])() || t[n] !== e || t.splice(n--, 1);
+        t.length || ve.fx.stop(), Mt = w
+    }, ve.fx.timer = function(e) {
+        e() && ve.timers.push(e) && ve.fx.start()
+    }, ve.fx.interval = 13, ve.fx.start = function() {
+        Bt || (Bt = setInterval(ve.fx.tick, ve.fx.interval))
+    }, ve.fx.stop = function() {
+        clearInterval(Bt), Bt = null
+    }, ve.fx.speeds = {
+        slow: 600,
+        fast: 200,
+        _default: 400
+    }, ve.fx.step = {}, ve.expr && ve.expr.filters && (ve.expr.filters.animated = function(t) {
+        return ve.grep(ve.timers, function(e) {
+            return t === e.elem
+        }).length
+    }), ve.fn.offset = function(t) {
+        if (arguments.length) return t === w ? this : this.each(function(e) {
+            ve.offset.setOffset(this, t, e)
+        });
+        var e, n, r = {
+                top: 0,
+                left: 0
+            },
+            i = this[0],
+            o = i && i.ownerDocument;
+        return o ? (e = o.documentElement, ve.contains(e, i) ? (typeof i.getBoundingClientRect !== v && (r = i.getBoundingClientRect()), n = Vt(o), {
+            top: r.top + (n.pageYOffset || e.scrollTop) - (e.clientTop || 0),
+            left: r.left + (n.pageXOffset || e.scrollLeft) - (e.clientLeft || 0)
+        }) : r) : void 0
+    }, ve.offset = {
+        setOffset: function(e, t, n) {
+            var r = ve.css(e, "position");
+            "static" === r && (e.style.position = "relative");
+            var i, o, a = ve(e),
+                s = a.offset(),
+                c = ve.css(e, "top"),
+                l = ve.css(e, "left"),
+                u = {},
+                d = {};
+            ("absolute" === r || "fixed" === r) && -1 < ve.inArray("auto", [c, l]) ? (i = (d = a.position()).top, o = d.left) : (i = parseFloat(c) || 0, o = parseFloat(l) || 0), ve.isFunction(t) && (t = t.call(e, n, s)), null != t.top && (u.top = t.top - s.top + i), null != t.left && (u.left = t.left - s.left + o), "using" in t ? t.using.call(e, u) : a.css(u)
+        }
+    }, ve.fn.extend({
+        position: function() {
+            if (this[0]) {
+                var e, t, n = {
+                        top: 0,
+                        left: 0
+                    },
+                    r = this[0];
+                return "fixed" === ve.css(r, "position") ? t = r.getBoundingClientRect() : (e = this.offsetParent(), t = this.offset(), ve.nodeName(e[0], "html") || (n = e.offset()), n.top += ve.css(e[0], "borderTopWidth", !0), n.left += ve.css(e[0], "borderLeftWidth", !0)), {
+                    top: t.top - n.top - ve.css(r, "marginTop", !0),
+                    left: t.left - n.left - ve.css(r, "marginLeft", !0)
+                }
+            }
+        },
+        offsetParent: function() {
+            return this.map(function() {
+                for (var e = this.offsetParent || g.documentElement; e && !ve.nodeName(e, "html") && "static" === ve.css(e, "position");) e = e.offsetParent;
+                return e || g.documentElement
+            })
+        }
+    }), ve.each({
+        scrollLeft: "pageXOffset",
+        scrollTop: "pageYOffset"
+    }, function(t, i) {
+        var o = /Y/.test(i);
+        ve.fn[t] = function(e) {
+            return ve.access(this, function(e, t, n) {
+                var r = Vt(e);
+                if (n === w) return r ? i in r ? r[i] : r.document.documentElement[t] : e[t];
+                r ? r.scrollTo(o ? ve(r).scrollLeft() : n, o ? n : ve(r).scrollTop()) : e[t] = n
+            }, t, e, arguments.length, null)
+        }
+    }), ve.each({
+        Height: "height",
+        Width: "width"
+    }, function(o, a) {
+        ve.each({
+            padding: "inner" + o,
+            content: a,
+            "": "outer" + o
+        }, function(r, e) {
+            ve.fn[e] = function(e, t) {
+                var n = arguments.length && (r || "boolean" != typeof e),
+                    i = r || (!0 === e || !0 === t ? "margin" : "border");
+                return ve.access(this, function(e, t, n) {
+                    var r;
+                    return ve.isWindow(e) ? e.document.documentElement["client" + o] : 9 === e.nodeType ? (r = e.documentElement, Math.max(e.body["scroll" + o], r["scroll" + o], e.body["offset" + o], r["offset" + o], r["client" + o])) : n === w ? ve.css(e, t, i) : ve.style(e, t, n, i)
+                }, a, n ? e : w, n, null)
+            }
+        })
+    }), h.jQuery = h.$ = ve, "function" == typeof define && define.amd && define.amd.jQuery && define("jquery", [], function() {
+        return ve
+    })
+}(window), (H5P = window.H5P || {}).jQuery = jQuery.noConflict(!0), (H5P = H5P || {}).Event = function(e, t, n) {
+        this.type = e, this.data = t;
+        var r = !1,
+            i = !1,
+            o = !1;
+        void 0 === n && (n = {}), !0 === n.bubbles && (r = !0), !0 === n.external && (i = !0), this.preventBubbling = function() {
+            r = !1
+        }, this.getBubbles = function() {
+            return r
+        }, this.scheduleForExternal = function() {
+            return !(!i || o) && (o = !0)
+        }
+    }, H5P.EventDispatcher = function() {
+        var i = this,
+            a = {};
+        this.on = function(e, t, n) {
+            if ("function" != typeof t) throw TypeError("listener must be a function");
+            i.trigger("newListener", {
+                type: e,
+                listener: t
+            });
+            var r = {
+                listener: t,
+                thisArg: n
+            };
+            a[e] ? a[e].push(r) : a[e] = [r]
+        }, this.once = function(e, t, n) {
+            if (!(t instanceof Function)) throw TypeError("listener must be a function");
+            var r = function(e) {
+                i.off(e.type, r), t.call(this, e)
+            };
+            i.on(e, r, n)
+        }, this.off = function(e, t) {
+            if (void 0 !== t && !(t instanceof Function)) throw TypeError("listener must be a function");
+            if (void 0 !== a[e]) {
+                if (void 0 === t) return delete a[e], void i.trigger("removeListener", e);
+                for (var n = 0; n < a[e].length; n++)
+                    if (a[e][n].listener === t) {
+                        a[e].splice(n, 1), i.trigger("removeListener", e, {
+                            listener: t
+                        });
+                        break
+                    }
+                a[e].length || delete a[e]
+            }
+        };
+        var o = function(e, t) {
+            if (void 0 !== a[e])
+                for (var n = a[e].slice(), r = 0; r < n.length; r++) {
+                    var i = n[r],
+                        o = i.thisArg ? i.thisArg : this;
+                    i.listener.call(o, t)
+                }
+        };
+        this.trigger = function(e, t, n) {
+            if (void 0 !== e) {
+                e instanceof String || "string" == typeof e ? e = new H5P.Event(e, t, n) : void 0 !== t && (e.data = t);
+                var r = e.scheduleForExternal();
+                o.call(this, e.type, e), o.call(this, "*", e), e.getBubbles() && i.parent instanceof H5P.EventDispatcher && (i.parent.trigger instanceof Function || "function" == typeof i.parent.trigger) && i.parent.trigger(e), r && H5P.externalDispatcher.trigger.call(this, e)
+            }
+        }
+    }, H5P.ActionBar = function(e, n) {
+        "use strict";
+
+        function t(e) {
+            n.call(this);
+            var r = this,
+                i = !1,
+                o = H5P.jQuery('<ul class="h5p-actions"></ul>'),
+                t = function(e, t) {
+                    var n = function() {
+                        r.trigger(e)
+                    };
+                    H5P.jQuery("<li/>", {
+                        class: "h5p-button h5p-noselect h5p-" + (t || e),
+                        role: "button",
+                        tabindex: 0,
+                        title: H5P.t(e + "Description"),
+                        html: H5P.t(e),
+                        on: {
+                            click: n,
+                            keypress: function(e) {
+                                32 === e.which && (n(), e.preventDefault())
+                            }
+                        },
+                        appendTo: o
+                    }), i = !0
+                };
+            e.export && t("download", "export"), e.copyright && t("copyrights"), e.embed && t("embed"), e.icon && (H5P.jQuery('<li><a class="h5p-link" href="http://h5p.org" target="_blank" title="' + H5P.t("h5pDescription") + '"></a></li>').appendTo(o), i = !0), r.getDOMElement = function() {
+                return o
+            }, r.hasActions = function() {
+                return i
+            }
+        }
+        return (t.prototype = Object.create(n.prototype)).constructor = t
+    }(H5P.jQuery, H5P.EventDispatcher), H5P.ContentType = function(e, t) {
+        function n() {}
+        return (n.prototype = new H5P.EventDispatcher).isRoot = function() {
+            return e
+        }, n.prototype.getLibraryFilePath = function(e) {
+            return H5P.getLibraryPath(this.libraryInfo.versionedNameNoSpaces) + "/" + e
+        }, n
+    }, (H5P = H5P || {}).XAPIEvent = function() {
+        H5P.Event.call(this, "xAPI", {
+            statement: {}
+        }, {
+            bubbles: !0,
+            external: !0
+        })
+    }, H5P.XAPIEvent.prototype = Object.create(H5P.Event.prototype), H5P.XAPIEvent.prototype.constructor = H5P.XAPIEvent, H5P.XAPIEvent.prototype.setScoredResult = function(e, t, n, r, i) {
+        if (this.data.statement.result = {}, void 0 !== e && (void 0 === t ? this.data.statement.result.score = {
+                raw: e
+            } : (this.data.statement.result.score = {
+                min: 0,
+                max: t,
+                raw: e
+            }, 0 < t && (this.data.statement.result.score.scaled = Math.round(e / t * 1e4) / 1e4))), this.data.statement.result.completion = void 0 === r ? "completed" === this.getVerb() || "answered" === this.getVerb() : r, void 0 !== i && (this.data.statement.result.success = i), n && n.activityStartTime) {
+            var o = Math.round((Date.now() - n.activityStartTime) / 10) / 100;
+            this.data.statement.result.duration = "PT" + o + "S"
+        }
+    }, H5P.XAPIEvent.prototype.setVerb = function(e) {
+        -1 !== H5P.jQuery.inArray(e, H5P.XAPIEvent.allowedXAPIVerbs) ? this.data.statement.verb = {
+            id: "http://adlnet.gov/expapi/verbs/" + e,
+            display: {
+                "en-US": e
+            }
+        } : void 0 !== e.id && (this.data.statement.verb = e)
+    }, H5P.XAPIEvent.prototype.getVerb = function(e) {
+        var t = this.data.statement;
+        return "verb" in t ? !0 === e ? t.verb : t.verb.id.slice(31) : null
+    }, H5P.XAPIEvent.prototype.setObject = function(e) {
+        e.contentId && (this.data.statement.object = {
+            id: this.getContentXAPIId(e),
+            objectType: "Activity",
+            definition: {
+                extensions: {
+                    "http://h5p.org/x-api/h5p-local-content-id": e.contentId
+                }
+            }
+        }, e.subContentId ? (this.data.statement.object.definition.extensions["http://h5p.org/x-api/h5p-subContentId"] = e.subContentId, "function" == typeof e.getTitle && (this.data.statement.object.definition.name = {
+            "en-US": e.getTitle()
+        })) : H5PIntegration && H5PIntegration.contents && H5PIntegration.contents["cid-" + e.contentId].title && (this.data.statement.object.definition.name = {
+            "en-US": H5P.createTitle(H5PIntegration.contents["cid-" + e.contentId].title)
+        }))
+    }, H5P.XAPIEvent.prototype.setContext = function(e) {
+        if (e.parent && (e.parent.contentId || e.parent.subContentId)) {
+            void 0 === e.parent.subContentId ? e.parent.contentId : e.parent.subContentId;
+            this.data.statement.context = {
+                contextActivities: {
+                    parent: [{
+                        id: this.getContentXAPIId(e.parent),
+                        objectType: "Activity"
+                    }]
+                }
+            }
+        }
+        e.libraryInfo && (void 0 === this.data.statement.context && (this.data.statement.context = {
+            contextActivities: {}
+        }), this.data.statement.context.contextActivities.category = [{
+            id: "http://h5p.org/libraries/" + e.libraryInfo.versionedNameNoSpaces,
+            objectType: "Activity"
+        }])
+    }, H5P.XAPIEvent.prototype.setActor = function() {
+        if (void 0 !== H5PIntegration.user) this.data.statement.actor = {
+            name: H5PIntegration.user.name,
+            mbox: "mailto:" + H5PIntegration.user.mail,
+            objectType: "Agent"
+        };
+        else {
+            var t;
+            try {
+                localStorage.H5PUserUUID ? t = localStorage.H5PUserUUID : (t = H5P.createUUID(), localStorage.H5PUserUUID = t)
+            } catch (e) {
+                t = "not-trackable-" + H5P.createUUID()
+            }
+            this.data.statement.actor = {
+                account: {
+                    name: t,
+                    homePage: H5PIntegration.siteUrl
+                },
+                objectType: "Agent"
+            }
+        }
+    }, H5P.XAPIEvent.prototype.getMaxScore = function() {
+        return this.getVerifiedStatementValue(["result", "score", "max"])
+    }, H5P.XAPIEvent.prototype.getScore = function() {
+        return this.getVerifiedStatementValue(["result", "score", "raw"])
+    }, H5P.XAPIEvent.prototype.getContentXAPIId = function(e) {
+        var t;
+        return e.contentId && H5PIntegration && H5PIntegration.contents && (t = H5PIntegration.contents["cid-" + e.contentId].url, e.subContentId && (t += "?subContentId=" + e.subContentId)), t
+    }, H5P.XAPIEvent.prototype.isFromChild = function() {
+        var e = this.getVerifiedStatementValue(["context", "contextActivities", "parent", 0, "id"]);
+        return !e || -1 === e.indexOf("subContentId")
+    }, H5P.XAPIEvent.prototype.getVerifiedStatementValue = function(e) {
+        for (var t = this.data.statement, n = 0; n < e.length; n++) {
+            if (void 0 === t[e[n]]) return null;
+            t = t[e[n]]
+        }
+        return t
+    }, H5P.XAPIEvent.allowedXAPIVerbs = ["answered", "asked", "attempted", "attended", "commented", "completed", "exited", "experienced", "failed", "imported", "initialized", "interacted", "launched", "mastered", "passed", "preferred", "progressed", "registered", "responded", "resumed", "scored", "shared", "suspended", "terminated", "voided", "downloaded", "accessed-embed", "accessed-copyright"], (H5P = H5P || {}).externalDispatcher = new H5P.EventDispatcher, H5P.EventDispatcher.prototype.triggerXAPI = function(e, t) {
+        this.trigger(this.createXAPIEventTemplate(e, t))
+    }, H5P.EventDispatcher.prototype.createXAPIEventTemplate = function(e, t) {
+        var n = new H5P.XAPIEvent;
+        if (n.setActor(), n.setVerb(e), void 0 !== t)
+            for (var r in t) n.data.statement[r] = t[r];
+        return "object" in n.data.statement || n.setObject(this), "context" in n.data.statement || n.setContext(this), n
+    }, H5P.EventDispatcher.prototype.triggerXAPICompleted = function(e, t, n) {
+        this.triggerXAPIScored(e, t, "completed", !0, n)
+    }, H5P.EventDispatcher.prototype.triggerXAPIScored = function(e, t, n, r, i) {
+        var o = this.createXAPIEventTemplate(n);
+        o.setScoredResult(e, t, this, r, i), this.trigger(o)
+    }, H5P.EventDispatcher.prototype.setActivityStarted = function() {
+        void 0 === this.activityStartTime && (void 0 !== this.contentId && void 0 !== H5PIntegration.contents && void 0 !== H5PIntegration.contents["cid-" + this.contentId] && this.triggerXAPI("attempted"), this.activityStartTime = Date.now())
+    }, H5P.xAPICompletedListener = function(e) {
+        if (("completed" === e.getVerb() || "answered" === e.getVerb()) && !e.getVerifiedStatementValue(["context", "contextActivities", "parent"])) {
+            var t = e.getScore(),
+                n = e.getMaxScore(),
+                r = e.getVerifiedStatementValue(["object", "definition", "extensions", "http://h5p.org/x-api/h5p-local-content-id"]);
+            H5P.setFinished(r, t, n)
+        }
+    }, (H5P = H5P || {}).isFramed = window.self !== window.parent, H5P.$window = H5P.jQuery(window), H5P.instances = [], document.documentElement.requestFullScreen ? H5P.fullScreenBrowserPrefix = "" : document.documentElement.webkitRequestFullScreen ? (H5P.safariBrowser = navigator.userAgent.match(/version\/([.\d]+)/i), H5P.safariBrowser = null === H5P.safariBrowser ? 0 : parseInt(H5P.safariBrowser[1]), (0 === H5P.safariBrowser || 6 < H5P.safariBrowser) && (H5P.fullScreenBrowserPrefix = "webkit")) : document.documentElement.mozRequestFullScreen ? H5P.fullScreenBrowserPrefix = "moz" : document.documentElement.msRequestFullscreen && (H5P.fullScreenBrowserPrefix = "ms"), H5P.opened = {}, H5P.init = function(e) {
+        void 0 === H5P.$body && (H5P.$body = H5P.jQuery(document.body)), void 0 === H5P.fullscreenSupported && (H5P.fullscreenSupported = !(H5P.isFramed && !1 !== H5P.externalEmbed && !(document.fullscreenEnabled || document.webkitFullscreenEnabled || document.mozFullScreenEnabled))), void 0 === H5P.canHasFullScreen && (H5P.canHasFullScreen = H5P.fullscreenSupported);
+        H5P.jQuery(".h5p-content:not(.h5p-initialized)", e).each(function() {
+            var e = H5P.jQuery(this).addClass("h5p-initialized"),
+                n = H5P.jQuery('<div class="h5p-container"></div>').appendTo(e),
+                i = e.data("content-id"),
+                o = H5PIntegration.contents["cid-" + i];
+            if (void 0 === o) return H5P.error("No data for content id " + i + ". Perhaps the library is gone?");
+            var a = {
+                library: o.library,
+                params: JSON.parse(o.jsonContent)
+            };
+            H5P.getUserData(i, "state", function(e, t) {
+                if (t) a.userDatas = {
+                    state: t
+                };
+                else if (null === t && H5PIntegration.saveFreq) {
+                    delete o.contentUserData;
+                    var r = new H5P.Dialog("content-user-data-reset", "Data Reset", "<p>" + H5P.t("contentChanged") + "</p><p>" + H5P.t("startingOver") + '</p><div class="h5p-dialog-ok-button" tabIndex="0" role="button">OK</div>', n);
+                    H5P.jQuery(r).on("dialog-opened", function(e, t) {
+                        var n = function(e) {
+                            "click" !== e.type && 32 !== e.which || (r.close(), H5P.deleteUserData(i, "state", 0))
+                        };
+                        t.find(".h5p-dialog-ok-button").click(n).keypress(n)
+                    }), r.open()
+                }
+            });
+            var t = H5P.newRunnable(a, i, n, !0, {
+                standalone: !0
+            });
+            1 == o.fullScreen && H5P.fullscreenSupported && H5P.jQuery('<div class="h5p-content-controls"><div role="button" tabindex="0" class="h5p-enable-fullscreen" title="' + H5P.t("fullscreen") + '"></div></div>').prependTo(n).children().click(function() {
+                H5P.fullScreen(n, t)
+            }).keydown(function(e) {
+                if (32 === e.which || 13 === e.which) return H5P.fullScreen(n, t), !1
+            });
+            var r, s = o.displayOptions,
+                c = !1;
+            if (s.frame) {
+                if (s.copyright) {
+                    var l = H5P.getCopyrights(t, a.params, i);
+                    l || (s.copyright = !1)
+                }
+                var u = new H5P.ActionBar(s),
+                    d = u.getDOMElement();
+                u.on("download", function() {
+                    window.location.href = o.exportUrl, t.triggerXAPI("downloaded")
+                }), u.on("copyrights", function() {
+                    new H5P.Dialog("copyrights", H5P.t("copyrightInformation"), l, n).open(), t.triggerXAPI("accessed-copyright")
+                }), u.on("embed", function() {
+                    H5P.openEmbedDialog(d, o.embedCode, o.resizeCode, {
+                        width: e.width(),
+                        height: e.height()
+                    }), t.triggerXAPI("accessed-embed")
+                }), u.hasActions() && (c = !0, d.insertAfter(n))
+            }
+            if (e.addClass(c ? "h5p-frame" : "h5p-no-frame"), H5P.opened[i] = new Date, H5P.on(t, "finish", function(e) {
+                    void 0 !== e.data && H5P.setFinished(i, e.data.score, e.data.maxScore, e.data.time)
+                }), H5P.on(t, "xAPI", H5P.xAPICompletedListener), !1 !== H5PIntegration.saveFreq && (t.getCurrentState instanceof Function || "function" == typeof t.getCurrentState)) {
+                var f, p = function() {
+                    var e = t.getCurrentState();
+                    void 0 !== e && H5P.setUserData(i, "state", e, {
+                        deleteOnChange: !0
+                    }), H5PIntegration.saveFreq && (f = setTimeout(p, 1e3 * H5PIntegration.saveFreq))
+                };
+                H5PIntegration.saveFreq && (f = setTimeout(p, 1e3 * H5PIntegration.saveFreq)), H5P.on(t, "xAPI", function(e) {
+                    var t = e.getVerb();
+                    "completed" !== t && "progressed" !== t || (clearTimeout(f), f = setTimeout(p, 3e3))
+                })
+            }
+            if (H5P.isFramed)
+                if (!1 === H5P.externalEmbed) {
+                    var h = window.frameElement;
+                    H5P.on(t, "resize", function() {
+                        clearTimeout(r), r = setTimeout(function() {
+                            ! function() {
+                                if (!window.parent.H5P.isFullscreen) {
+                                    var e = h.parentElement.style.height;
+                                    h.parentElement.style.height = h.parentElement.clientHeight + "px", h.style.height = "1px", h.style.height = h.contentDocument.body.scrollHeight + "px", h.parentElement.style.height = e
+                                }
+                            }()
+                        }, 1)
+                    })
+                } else if (H5P.communicator) {
+                var g = !1;
+                H5P.communicator.on("ready", function() {
+                    H5P.communicator.send("hello")
+                }), H5P.communicator.on("hello", function() {
+                    g = !0, document.body.style.height = "auto", document.body.style.overflow = "hidden", H5P.trigger(t, "resize")
+                }), H5P.communicator.on("resizePrepared", function(e) {
+                    H5P.communicator.send("resize", {
+                        scrollHeight: document.body.scrollHeight
+                    })
+                }), H5P.communicator.on("resize", function() {
+                    H5P.trigger(t, "resize")
+                }), H5P.on(t, "resize", function() {
+                    H5P.isFullscreen || (clearTimeout(r), r = setTimeout(function() {
+                        g ? H5P.communicator.send("prepareResize", {
+                            scrollHeight: document.body.scrollHeight,
+                            clientHeight: document.body.clientHeight
+                        }) : H5P.communicator.send("hello")
+                    }, 0))
+                })
+            }
+            H5P.isFramed && !1 !== H5P.externalEmbed || H5P.jQuery(window.parent).resize(function() {
+                window.parent.H5P.isFullscreen, H5P.trigger(t, "resize")
+            }), H5P.instances.push(t), H5P.trigger(t, "resize")
+        });
+        H5P.jQuery("iframe.h5p-iframe:not(.h5p-initialized)", e).each(function() {
+            var e = H5P.jQuery(this).addClass("h5p-initialized").data("content-id");
+            this.contentDocument.open(), this.contentDocument.write('<!doctype html><html class="h5p-iframe"><head>' + H5P.getHeadTags(e) + '</head><body><div class="h5p-content" data-content-id="' + e + '"/></body></html>'), this.contentDocument.close()
+        })
+    }, H5P.getHeadTags = function(e) {
+        var t = function(e) {
+                for (var t = "", n = 0; n < e.length; n++) t += '<link rel="stylesheet" href="' + e[n] + '">';
+                return t
+            },
+            n = function(e) {
+                for (var t = "", n = 0; n < e.length; n++) t += '<script src="' + e[n] + '"><\/script>';
+                return t
+            };
+        return '<base target="_parent">' + t(H5PIntegration.core.styles) + t(H5PIntegration.contents["cid-" + e].styles) + n(H5PIntegration.core.scripts) + n(H5PIntegration.contents["cid-" + e].scripts) + "<script>H5PIntegration = window.parent.H5PIntegration; var H5P = H5P || {}; H5P.externalEmbed = false;<\/script>"
+    }, H5P.communicator = window.postMessage && window.addEventListener ? new function() {
+        var n = {};
+        window.addEventListener("message", function(e) {
+            window.parent === e.source && "h5p" === e.data.context && void 0 !== n[e.data.action] && n[e.data.action](e.data)
+        }, !1), this.on = function(e, t) {
+            n[e] = t
+        }, this.send = function(e, t) {
+            void 0 === t && (t = {}), t.context = "h5p", t.action = e, window.parent.postMessage(t, "*")
+        }
+    } : void 0, H5P.semiFullScreen = function(e, t, n, r) {
+        H5P.fullScreen(e, t, n, r, !0)
+    }, H5P.fullScreen = function(e, t, n, r, i) {
+        if (void 0 === H5P.exitFullScreen) {
+            if (H5P.isFramed && !1 === H5P.externalEmbed) return window.parent.H5P.fullScreen(e, t, n, H5P.$body.get(), i), H5P.isFullscreen = !0, H5P.exitFullScreen = function() {
+                window.parent.H5P.exitFullScreen()
+            }, void H5P.on(t, "exitFullScreen", function() {
+                H5P.isFullscreen = !1, H5P.exitFullScreen = void 0
+            });
+            var o, a, s = e;
+            if (void 0 === r) $body = H5P.$body;
+            else {
+                $body = H5P.jQuery(r), o = $body.add(e.get());
+                var c = "#h5p-iframe-" + e.parent().data("content-id");
+                e = (a = H5P.jQuery(c)).parent()
+            }
+            o = e.add(H5P.$body).add(o);
+            var l = function(e) {
+                    o.addClass(e), void 0 !== a && a.css("height", "")
+                },
+                u = function() {
+                    H5P.trigger(t, "resize"), H5P.trigger(t, "focus"), H5P.trigger(t, "enterFullScreen")
+                },
+                d = function(e) {
+                    H5P.isFullscreen = !1, o.removeClass(e), H5P.trigger(t, "resize"), H5P.trigger(t, "focus"), (H5P.exitFullScreen = void 0) !== n && n(), H5P.trigger(t, "exitFullScreen")
+                };
+            if (H5P.isFullscreen = !0, void 0 === H5P.fullScreenBrowserPrefix || !0 === i) {
+                if (H5P.isFramed) return;
+                l("h5p-semi-fullscreen");
+                var f, p, h, g = H5P.jQuery('<div role="button" tabindex="0" class="h5p-disable-fullscreen" title="' + H5P.t("disableFullscreen") + '"></div>').appendTo(s.find(".h5p-content-controls")),
+                    m = H5P.exitFullScreen = function() {
+                        p ? h.content = p : b.removeChild(h), g.remove(), $body.unbind("keyup", f), d("h5p-semi-fullscreen")
+                    };
+                f = function(e) {
+                    27 === e.keyCode && m()
+                }, g.click(m), $body.keyup(f);
+                for (var v = document.getElementsByTagName("meta"), y = 0; y < v.length; y++)
+                    if ("viewport" === v[y].name) {
+                        h = v[y], p = h.content;
+                        break
+                    }
+                if (p || ((h = document.createElement("meta")).name = "viewport"), h.content = "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0", !p) {
+                    var b = document.getElementsByTagName("head")[0];
+                    b.appendChild(h)
+                }
+                u()
+            } else {
+                l("h5p-fullscreen");
+                var x, P = "ms" === H5P.fullScreenBrowserPrefix ? "MSFullscreenChange" : H5P.fullScreenBrowserPrefix + "fullscreenchange";
+                if (document.addEventListener(P, function() {
+                        if (void 0 === x) return x = !1, void u();
+                        d("h5p-fullscreen"), document.removeEventListener(P, arguments.callee, !1)
+                    }), "" === H5P.fullScreenBrowserPrefix) e[0].requestFullScreen();
+                else {
+                    var H = "ms" === H5P.fullScreenBrowserPrefix ? "msRequestFullscreen" : H5P.fullScreenBrowserPrefix + "RequestFullScreen",
+                        w = "webkit" === H5P.fullScreenBrowserPrefix && 0 === H5P.safariBrowser ? Element.ALLOW_KEYBOARD_INPUT : void 0;
+                    e[0][H](w)
+                }
+                H5P.exitFullScreen = function() {
+                    "" === H5P.fullScreenBrowserPrefix ? document.exitFullscreen() : "moz" === H5P.fullScreenBrowserPrefix ? document.mozCancelFullScreen() : document[H5P.fullScreenBrowserPrefix + "ExitFullscreen"]()
+                }
+            }
+        }
+    }, H5P.getPath = function(e, t) {
+        var n, r = function(e) {
+            return e.match(/^[a-z0-9]+:\/\//i)
+        };
+        if (r(e)) return e;
+        var i = "#tmp" === e.substr(-4, 4);
+        if (void 0 === t || i) {
+            if (void 0 === window.H5PEditor) return;
+            n = H5PEditor.filesPath
+        } else void 0 !== H5PIntegration.contents && H5PIntegration.contents["cid-" + t] && (n = H5PIntegration.contents["cid-" + t].contentUrl), n || (n = H5PIntegration.url + "/content/" + t);
+        return r(n) || (n = window.location.protocol + "//" + window.location.host + n), n + "/" + e
+    }, H5P.getContentPath = function(e) {
+        return H5PIntegration.url + "/content/" + e
+    }, H5P.classFromName = function(e) {
+        var t = e.split(".");
+        return this[t[t.length - 1]]
+    }, H5P.newRunnable = function(t, e, n, r, i) {
+        var o, a, s, c;
+        try {
+            s = (o = t.library.split(" ", 2))[0], a = o[1].split(".", 2)
+        } catch (e) {
+            return H5P.error("Invalid library string: " + t.library)
+        }
+        if (t.params instanceof Object != !0 || t.params instanceof Array == !0) return H5P.error("Invalid library params for: " + t.library), H5P.error(t.params);
+        try {
+            o = o[0].split("."), c = window;
+            for (var l = 0; l < o.length; l++) c = c[o[l]];
+            if ("function" != typeof c) throw null
+        } catch (e) {
+            return H5P.error("Unable to find constructor for: " + t.library)
+        }
+        void 0 === i && (i = {}), t.subContentId && (i.subContentId = t.subContentId), t.userDatas && t.userDatas.state && H5PIntegration.saveFreq && (i.previousState = t.userDatas.state);
+        var u, d = i.standalone || !1;
+        return c.prototype = H5P.jQuery.extend({}, H5P.ContentType(d).prototype, c.prototype), void 0 === (u = -1 < H5P.jQuery.inArray(t.library, ["H5P.CoursePresentation 1.0", "H5P.CoursePresentation 1.1", "H5P.CoursePresentation 1.2", "H5P.CoursePresentation 1.3"]) ? new c(t.params, e) : new c(t.params, e, i)).$ && (u.$ = H5P.jQuery(u)), void 0 === u.contentId && (u.contentId = e), void 0 === u.subContentId && t.subContentId && (u.subContentId = t.subContentId), void 0 === u.parent && i && i.parent && (u.parent = i.parent), void 0 === u.libraryInfo && (u.libraryInfo = {
+            versionedName: t.library,
+            versionedNameNoSpaces: s + "-" + a[0] + "." + a[1],
+            machineName: s,
+            majorVersion: a[0],
+            minorVersion: a[1]
+        }), void 0 !== n && (n.toggleClass("h5p-standalone", d), u.attach(n), H5P.trigger(u, "domChanged", {
+            $target: n,
+            library: s,
+            key: "newLibrary"
+        }, {
+            bubbles: !0,
+            external: !0
+        }), void 0 !== r && r || H5P.trigger(u, "resize")), u
+    }, H5P.error = function(e) {
+        void 0 !== window.console && void 0 !== console.error && console.error(e.stack ? e.stack : e)
+    }, H5P.t = function(e, t, n) {
+        if (void 0 === n && (n = "H5P"), void 0 === H5PIntegration.l10n[n]) return '[Missing translation namespace "' + n + '"]';
+        if (void 0 === H5PIntegration.l10n[n][e]) return '[Missing translation "' + e + '" in "' + n + '"]';
+        var r = H5PIntegration.l10n[n][e];
+        if (void 0 !== t)
+            for (var i in t) r = r.replace(i, t[i]);
+        return r
+    }, H5P.Dialog = function(e, t, n, r) {
+        var i = this,
+            o = H5P.jQuery('<div class="h5p-popup-dialog h5p-' + e + '-dialog">                              <div class="h5p-inner">                                <h2>' + t + '</h2>                                <div class="h5p-scroll-content">' + n + '</div>                                <div class="h5p-close" role="button" tabindex="0" title="' + H5P.t("close") + '">                              </div>                            </div>').insertAfter(r).click(function() {
+                i.close()
+            }).children(".h5p-inner").click(function() {
+                return !1
+            }).find(".h5p-close").click(function() {
+                i.close()
+            }).end().find("a").click(function(e) {
+                e.stopPropagation()
+            }).end().end();
+        i.open = function() {
+            setTimeout(function() {
+                o.addClass("h5p-open"), H5P.jQuery(i).trigger("dialog-opened", [o])
+            }, 1)
+        }, i.close = function() {
+            o.removeClass("h5p-open"), setTimeout(function() {
+                o.remove()
+            }, 200)
+        }
+    }, H5P.getCopyrights = function(e, t, n) {
+        var r;
+        if (void 0 !== e.getCopyrights) try {
+            r = e.getCopyrights()
+        } catch (e) {}
+        return void 0 === r && (r = new H5P.ContentCopyrights, H5P.findCopyrights(r, t, n)), void 0 !== r && (r = r.toString()), r
+    }, H5P.findCopyrights = function(e, t, n) {
+        for (var r in t)
+            if (t.hasOwnProperty(r))
+                if ("overrideSettings" !== r) {
+                    var i = t[r];
+                    if (i instanceof Array) H5P.findCopyrights(e, i, n);
+                    else if (i instanceof Object)
+                        if (void 0 === i.copyright || void 0 === i.copyright.license || void 0 === i.path || void 0 === i.mime) H5P.findCopyrights(e, i, n);
+                        else {
+                            var o = new H5P.MediaCopyright(i.copyright);
+                            void 0 !== i.width && void 0 !== i.height && o.setThumbnail(new H5P.Thumbnail(H5P.getPath(i.path, n), i.width, i.height)), e.addMedia(o)
+                        }
+                } else console.warn("The semantics field 'overrideSettings' is DEPRECATED and should not be used."), console.warn(t)
+    }, H5P.openEmbedDialog = function(e, t, n, d) {
+        var f = t + n,
+            r = new H5P.Dialog("embed", H5P.t("embed"), '<textarea class="h5p-embed-code-container" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>' + H5P.t("size") + ': <input type="text" value="' + Math.ceil(d.width) + '" class="h5p-embed-size"/> × <input type="text" value="' + Math.ceil(d.height) + '" class="h5p-embed-size"/> px<br/><div role="button" tabindex="0" class="h5p-expander">' + H5P.t("showAdvanced") + '</div><div class="h5p-expander-content"><p>' + H5P.t("advancedHelp") + '</p><textarea class="h5p-embed-code-container" autocorrect="off" autocapitalize="off" spellcheck="false">' + n + "</textarea></div>", e);
+        H5P.jQuery(r).on("dialog-opened", function(e, n) {
+            var t = n.find(".h5p-inner"),
+                r = t.find(".h5p-scroll-content"),
+                i = r.outerHeight() - r.innerHeight(),
+                o = function() {
+                    var e = t.height();
+                    r[0].scrollHeight + i > e ? t.css("height", "") : (t.css("height", "auto"), e = t.height()), t.css("marginTop", "-" + e / 2 + "px")
+                },
+                a = n.find(".h5p-embed-size:eq(0)"),
+                s = n.find(".h5p-embed-size:eq(1)"),
+                c = function(e, t) {
+                    var n = parseFloat(e.val());
+                    return isNaN(n) ? t : Math.ceil(n)
+                },
+                l = function() {
+                    n.find(".h5p-embed-code-container:first").val(f.replace(":w", c(a, d.width)).replace(":h", c(s, d.height)))
+                };
+            a.change(l), s.change(l), l(), n.find(".h5p-embed-code-container").each(function(e, t) {
+                H5P.jQuery(this).css("height", this.scrollHeight + "px").focus(function() {
+                    H5P.jQuery(this).select()
+                })
+            }), n.find(".h5p-embed-code-container").eq(0).select(), o();
+            var u = function() {
+                var e = H5P.jQuery(this),
+                    t = e.next();
+                t.is(":visible") ? (e.removeClass("h5p-open").text(H5P.t("showAdvanced")), t.hide()) : (e.addClass("h5p-open").text(H5P.t("hideAdvanced")), t.show()), n.find(".h5p-embed-code-container").each(function(e, t) {
+                    H5P.jQuery(this).css("height", this.scrollHeight + "px")
+                }), o()
+            };
+            n.find(".h5p-expander").click(u).keypress(function(e) {
+                32 === e.keyCode && u.apply(this)
+            })
+        }), r.open()
+    }, H5P.ContentCopyrights = function() {
+        var n, r = [],
+            i = [];
+        this.setLabel = function(e) {
+            n = e
+        }, this.addMedia = function(e) {
+            void 0 !== e && r.push(e)
+        }, this.addContent = function(e) {
+            void 0 !== e && i.push(e)
+        }, this.toString = function() {
+            for (var e = "", t = 0; t < r.length; t++) e += r[t];
+            for (t = 0; t < i.length; t++) e += i[t];
+            return "" !== e && (void 0 !== n && (e = "<h3>" + n + "</h3>" + e), e = '<div class="h5p-content-copyrights">' + e + "</div>"), e
+        }
+    }, H5P.MediaCopyright = function(e, t, n, r) {
+        var i, o = new H5P.DefinitionList,
+            a = function(e) {
+                return void 0 === t || void 0 === t[e] ? H5P.t(e) : t[e]
+            },
+            s = function(e, t) {
+                var n, r, i = H5P.copyrightLicenses[e],
+                    o = "";
+                "PD" === e && t || (o += i.hasOwnProperty("label") ? i.label : i), i.versions && (!i.versions.default || t && i.versions[t] || (t = i.versions.default), t && i.versions[t] && (n = i.versions[t])), n && (o && (o += " "), o += n.hasOwnProperty("label") ? n.label : n), i.hasOwnProperty("link") ? r = i.link.replace(":version", i.linkVersions ? i.linkVersions[t] : t) : n && i.hasOwnProperty("link") && (r = n.link), r && (o = '<a href="' + r + '" target="_blank">' + o + "</a>");
+                var a = "";
+                return "PD" !== e && "C" !== e && (a += e), t && "CC0 1.0" !== t && (a && "GNU GPL" !== e && (a += " "), a += t), a && (o += " (" + a + ")"), "C" === e && (o += " &copy;"), o
+            };
+        if (void 0 !== e) {
+            for (var c in r) r.hasOwnProperty(c) && (e[c] = r[c]);
+            void 0 === n && (n = ["title", "author", "year", "source", "license"]);
+            for (var l = 0; l < n.length; l++) {
+                var u = n[l];
+                if (void 0 !== e[u]) {
+                    var d = e[u];
+                    "license" === u && (d = s(e.license, e.version)), o.add(new H5P.Field(a(u), d))
+                }
+            }
+        }
+        this.setThumbnail = function(e) {
+            i = e
+        }, this.undisclosed = function() {
+            if (1 === o.size()) {
+                var e = o.get(0);
+                if (e.getLabel() === a("license") && e.getValue() === s("U")) return !0
+            }
+            return !1
+        }, this.toString = function() {
+            var e = "";
+            return this.undisclosed() || (void 0 !== i && (e += i), "" !== (e += o) && (e = '<div class="h5p-media-copyright">' + e + "</div>")), e
+        }
+    }, H5P.Thumbnail = function(e, t, n) {
+        var r;
+        void 0 !== t && (r = Math.round(t / n * 100)), this.toString = function() {
+            return '<img src="' + e + '" alt="' + H5P.t("thumbnail") + '" class="h5p-thumbnail" height="100"' + (void 0 === r ? "" : ' width="' + r + '"') + "/>"
+        }
+    }, H5P.Field = function(e, t) {
+        this.getLabel = function() {
+            return e
+        }, this.getValue = function() {
+            return t
+        }
+    }, H5P.DefinitionList = function() {
+        var r = [];
+        this.add = function(e) {
+            r.push(e)
+        }, this.size = function() {
+            return r.length
+        }, this.get = function(e) {
+            return r[e]
+        }, this.toString = function() {
+            for (var e = "", t = 0; t < r.length; t++) {
+                var n = r[t];
+                e += "<dt>" + n.getLabel() + "</dt><dd>" + n.getValue() + "</dd>"
+            }
+            return "" === e ? e : '<dl class="h5p-definition-list">' + e + "</dl>"
+        }
+    }, H5P.Coords = function(e, t, n, r) {
+        return this instanceof H5P.Coords ? (this.x = 0, this.y = 0, this.w = 1, this.h = 1, "object" == typeof e ? (this.x = e.x, this.y = e.y, this.w = e.w, this.h = e.h) : (void 0 !== e && (this.x = e), void 0 !== t && (this.y = t), void 0 !== n && (this.w = n), void 0 !== r && (this.h = r)), this) : new H5P.Coords(e, t, n, r)
+    }, H5P.libraryFromString = function(e) {
+        var t = /(.+)\s(\d+)\.(\d+)$/g.exec(e);
+        return null !== t && {
+            machineName: t[1],
+            majorVersion: t[2],
+            minorVersion: t[3]
+        }
+    }, H5P.getLibraryPath = function(e) {
+        return (void 0 !== H5PIntegration.libraryUrl ? H5PIntegration.libraryUrl + "/" : H5PIntegration.url + "/libraries/") + e
+    }, H5P.cloneObject = function(e, t) {
+        var n = e instanceof Array ? [] : {};
+        for (var r in e) e.hasOwnProperty(r) && (void 0 !== t && t && "object" == typeof e[r] ? n[r] = H5P.cloneObject(e[r], t) : n[r] = e[r]);
+        return n
+    }, H5P.trim = function(e) {
+        return e.replace(/^\s+|\s+$/g, "")
+    }, H5P.jsLoaded = function(e) {
+        return H5PIntegration.loadedJs = H5PIntegration.loadedJs || [], -1 !== H5P.jQuery.inArray(e, H5PIntegration.loadedJs)
+    }, H5P.cssLoaded = function(e) {
+        return H5PIntegration.loadedCss = H5PIntegration.loadedCss || [], -1 !== H5P.jQuery.inArray(e, H5PIntegration.loadedCss)
+    }, H5P.shuffleArray = function(e) {
+        if (e instanceof Array) {
+            var t, n, r, i = e.length;
+            if (0 === i) return !1;
+            for (; --i;) t = Math.floor(Math.random() * (i + 1)), n = e[i], r = e[t], e[i] = r, e[t] = n;
+            return e
+        }
+    }, H5P.setFinished = function(e, t, n, r) {
+        if (("number" == typeof t || t instanceof Number) && !0 === H5PIntegration.postUserStatistics) {
+            var i = function(e) {
+                return Math.round(e.getTime() / 1e3)
+            };
+            H5P.jQuery.post(H5PIntegration.ajax.setFinished, {
+                contentId: e,
+                score: t,
+                maxScore: n,
+                opened: i(H5P.opened[e]),
+                finished: i(new Date),
+                time: r
+            })
+        }
+    }, Array.prototype.indexOf || (Array.prototype.indexOf = function(e) {
+        for (var t = 0; t < this.length; t++)
+            if (this[t] === e) return t;
+        return -1
+    }), void 0 === String.prototype.trim && (String.prototype.trim = function() {
+        return H5P.trim(this)
+    }), H5P.trigger = function(e, t, n, r) {
+        void 0 !== e.trigger ? e.trigger(t, n, r) : void 0 !== e.$ && void 0 !== e.$.trigger && e.$.trigger(t)
+    }, H5P.on = function(e, t, n) {
+        void 0 !== e.on ? e.on(t, n) : void 0 !== e.$ && void 0 !== e.$.on && e.$.on(t, n)
+    }, H5P.createUUID = function() {
+        return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(e) {
+            var t = 16 * Math.random() | 0;
+            return ("x" === e ? t : 3 & t | 8).toString(16)
+        })
+    }, H5P.createTitle = function(e, t) {
+        if (!e) return "";
+        void 0 === t && (t = 60);
+        var n = H5P.jQuery("<div></div>").text(e.replace(/(<([^>]+)>)/gi, "")).text();
+        return n.length > t && (n = n.substr(0, t - 3) + "..."), n
+    },
+    function(l) {
+        function s(e, t, n, r, i, o, a, s) {
+            if (void 0 !== H5PIntegration.user) {
+                var c = {
+                    url: H5PIntegration.ajax.contentUserData.replace(":contentId", e).replace(":dataType", t).replace(":subContentId", n || 0),
+                    dataType: "json",
+                    async: void 0 === s || s
+                };
+                void 0 !== i ? (c.type = "POST", c.data = {
+                    data: null === i ? 0 : i,
+                    preload: o ? 1 : 0,
+                    invalidate: a ? 1 : 0
+                }) : c.type = "GET", void 0 !== r && (c.error = function(e, t) {
+                    r(t)
+                }, c.success = function(e) {
+                    e.success ? !1 !== e.data && void 0 !== e.data ? r(void 0, e.data) : r() : r(e.message)
+                }), l.ajax(c)
+            } else r("Not signed in.")
+        }
+        H5P.getUserData = function(e, n, r, i) {
+            i || (i = 0), H5PIntegration.contents = H5PIntegration.contents || {};
+            var o = H5PIntegration.contents["cid-" + e] || {},
+                a = o.contentUserData;
+            if (a && a[i] && void 0 !== a[i][n]) {
+                if ("RESET" === a[i][n]) return void r(void 0, null);
+                try {
+                    r(void 0, JSON.parse(a[i][n]))
+                } catch (e) {
+                    r(e)
+                }
+            } else s(e, n, i, function(e, t) {
+                if (e || void 0 === t) r(e, t);
+                else {
+                    void 0 === o.contentUserData && (o.contentUserData = a = {}), void 0 === a[i] && (a[i] = {}), a[i][n] = t;
+                    try {
+                        r(void 0, JSON.parse(t))
+                    } catch (e) {
+                        r(e)
+                    }
+                }
+            })
+        }, H5P.setUserData = function(e, t, n, r) {
+            var i = H5P.jQuery.extend(!0, {}, {
+                subContentId: 0,
+                preloaded: !0,
+                deleteOnChange: !1,
+                async: !0
+            }, r);
+            try {
+                n = JSON.stringify(n)
+            } catch (e) {
+                return void(i.errorCallback && i.errorCallback(e))
+            }
+            var o = H5PIntegration.contents["cid-" + e];
+            void 0 === o && (o = H5PIntegration.contents["cid-" + e] = {}), o.contentUserData || (o.contentUserData = {});
+            var a = o.contentUserData;
+            void 0 === a[i.subContentId] && (a[i.subContentId] = {}), n !== a[i.subContentId][t] && (a[i.subContentId][t] = n, s(e, t, i.subContentId, function(e, t) {
+                i.errorCallback && e && i.errorCallback(e)
+            }, n, i.preloaded, i.deleteOnChange, i.async))
+        }, H5P.deleteUserData = function(e, t, n) {
+            n || (n = 0);
+            var r = H5PIntegration.contents["cid-" + e].contentUserData;
+            r && r[n] && r[n][t] && delete r[n][t], s(e, t, n, void 0, null)
+        }, l(document).ready(function() {
+            var e = {
+                default: "4.0",
+                "4.0": H5P.t("licenseCC40"),
+                "3.0": H5P.t("licenseCC30"),
+                2.5: H5P.t("licenseCC25"),
+                "2.0": H5P.t("licenseCC20"),
+                "1.0": H5P.t("licenseCC10")
+            };
+            if (H5P.copyrightLicenses = {
+                    U: H5P.t("licenseU"),
+                    "CC BY": {
+                        label: H5P.t("licenseCCBY"),
+                        link: "http://creativecommons.org/licenses/by/:version/legalcode",
+                        versions: e
+                    },
+                    "CC BY-SA": {
+                        label: H5P.t("licenseCCBYSA"),
+                        link: "http://creativecommons.org/licenses/by-sa/:version/legalcode",
+                        versions: e
+                    },
+                    "CC BY-ND": {
+                        label: H5P.t("licenseCCBYND"),
+                        link: "http://creativecommons.org/licenses/by-nd/:version/legalcode",
+                        versions: e
+                    },
+                    "CC BY-NC": {
+                        label: H5P.t("licenseCCBYNC"),
+                        link: "http://creativecommons.org/licenses/by-nc/:version/legalcode",
+                        versions: e
+                    },
+                    "CC BY-NC-SA": {
+                        label: H5P.t("licenseCCBYNCSA"),
+                        link: "http://creativecommons.org/licenses/by-nc-sa/:version/legalcode",
+                        versions: e
+                    },
+                    "CC BY-NC-ND": {
+                        label: H5P.t("licenseCCBYNCND"),
+                        link: "http://creativecommons.org/licenses/by-nc-nd/:version/legalcode",
+                        versions: e
+                    },
+                    "GNU GPL": {
+                        label: H5P.t("licenseGPL"),
+                        link: "http://www.gnu.org/licenses/gpl-:version-standalone.html",
+                        linkVersions: {
+                            v3: "3.0",
+                            v2: "2.0",
+                            v1: "1.0"
+                        },
+                        versions: {
+                            default: "v3",
+                            v3: H5P.t("licenseV3"),
+                            v2: H5P.t("licenseV2"),
+                            v1: H5P.t("licenseV1")
+                        }
+                    },
+                    PD: {
+                        label: H5P.t("licensePD"),
+                        versions: {
+                            "CC0 1.0": {
+                                label: H5P.t("licenseCC010"),
+                                link: "https://creativecommons.org/publicdomain/zero/1.0/"
+                            },
+                            "CC PDM": {
+                                label: H5P.t("licensePDM"),
+                                link: "https://creativecommons.org/publicdomain/mark/1.0/"
+                            }
+                        }
+                    },
+                    "ODC PDDL": '<a href="http://opendatacommons.org/licenses/pddl/1.0/" target="_blank">Public Domain Dedication and Licence</a>',
+                    "CC PDM": H5P.t("licensePDM"),
+                    C: H5P.t("licenseC")
+                }, H5P.isFramed && !1 === H5P.externalEmbed && H5P.externalDispatcher.on("*", function(e) {
+                    window.parent.H5P.externalDispatcher.trigger.call(this, e)
+                }), H5P.preventInit || H5P.init(document.body), !1 !== H5PIntegration.saveFreq) {
+                var i = 0,
+                    t = function() {
+                        var e = (new Date).getTime();
+                        if (250 < e - i) {
+                            i = e;
+                            for (var t = 0; t < H5P.instances.length; t++) {
+                                var n = H5P.instances[t];
+                                if (n.getCurrentState instanceof Function || "function" == typeof n.getCurrentState) {
+                                    var r = n.getCurrentState();
+                                    void 0 !== r && H5P.setUserData(n.contentId, "state", r, {
+                                        deleteOnChange: !0,
+                                        async: !1
+                                    })
+                                }
+                            }
+                        }
+                    };
+                H5P.$window.one("beforeunload unload", function() {
+                    H5P.$window.off("pagehide beforeunload unload"), t()
+                }), H5P.$window.on("pagehide", t)
+            }
+        })
+    }(H5P.jQuery), H5P.getLibraryPath = function(e) {
+        return H5PIntegration.pathIncludesVersion ? H5PIntegration.url + "/" + e : H5PIntegration.url + "/" + e.split("-")[0]
+    }, H5P.getPath = function(e, t) {
+        var n;
+        if (e.match(/^[a-z0-9]+:\/\//i)) return e;
+        if (void 0 !== t) n = H5PIntegration.url + "/content";
+        else {
+            if (void 0 === window.H5PEditor) return;
+            n = H5PEditor.filesPath
+        }
+        return n + "/" + e
+    };

--- a/kolibri/core/content/static/assets/h5p-standalone-dist/js/h5p-standalone-frame.min.js
+++ b/kolibri/core/content/static/assets/h5p-standalone-dist/js/h5p-standalone-frame.min.js
@@ -131,7 +131,7 @@ var H5P;
         },
         ready: function(e) {
             if (!0 === e ? !--ve.readyWait : !ve.isReady) {
-                if (!g.body) return setTimeout(ve.ready);
+                if (!g.body || !window.hashiFinishedLoading) return setTimeout(ve.ready);
                 (ve.isReady = !0) !== e && 0 < --ve.readyWait || (t.resolveWith(g, [ve]), ve.fn.trigger && ve(g).trigger("ready").off("ready"))
             }
         },

--- a/kolibri/core/content/templates/content/h5p.html
+++ b/kolibri/core/content/templates/content/h5p.html
@@ -84,6 +84,8 @@
         <script type="text/javascript" src="{{ path }}"></script>
         {% endfor %}
 
+        <script type="text/javascript" src="dist/js/finished-loading.js"></script>
+
     </head>
     <body>
         <div class="h5p-content" data-content-id="1"/>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

H5P code was added around 0.12.0, and Hashi then changed approaches to a different style of async in 0.12.4, which seems to have broken the way H5P loads.

The H5P bootstrapping code runs first, and watches for the page to have finished loading (i.e. all the dependency scripts) before trying to start the app. When loaded by hashi, the page is already loaded, so it jumps the gun. This PR adds in an extra check so it... won't.

Slack context: https://learningequality.slack.com/archives/C0LK8QS9J/p1574708012271500

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

For reviewing, focus on the 2nd commit: https://github.com/learningequality/kolibri/commit/f8babd4822e42b5eecd4b7b46c0010d70cf40b8c

NOTE: this will likely be replaced by something @rtibbles does with Hashi itself on Monday. Assuming that works, this can be shuttered and closed.