### PR TITLE
Fix incomplete content status

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -22,7 +22,6 @@
         :files="content.files"
         :available="content.available"
         :extraFields="extraFields"
-        @sessionInitialized="setWasIncomplete"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
@@ -42,7 +41,6 @@
         :channelId="channelId"
         :available="content.available"
         :extraFields="extraFields"
-        @sessionInitialized="setWasIncomplete"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateExerciseProgress"
@@ -267,6 +265,7 @@
         contentKind: this.content.kind,
       }).then(() => {
         this.sessionReady = true;
+        this.setWasIncomplete();
       });
     },
     beforeDestroy() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Upon completion of a resource, the points and next resource snackbars were not appearing (ref https://github.com/learningequality/kolibri/issues/6153). This happened because the `sessionInitialized` event is no longer fired, so the status of whether the learner had completed it was always that they had. This fixes the issue by making sure it's set after the session is initialized.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Videos are easy to test

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Issue: https://github.com/learningequality/kolibri/issues/6153

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
