### PR TITLE
Decode JSON from JSONField.

### DIFF
--- a/kolibri/core/analytics/migrations/0001_initial.py
+++ b/kolibri/core/analytics/migrations/0001_initial.py
@@ -3,9 +3,10 @@
 from __future__ import unicode_literals
 
 import django.db.models.deletion
-import jsonfield.fields
 from django.db import migrations
 from django.db import models
+
+import kolibri.core.fields
 
 
 class Migration(migrations.Migration):
@@ -25,7 +26,7 @@ class Migration(migrations.Migration):
                 ("version_range", models.CharField(max_length=50)),
                 ("timestamp", models.DateField()),
                 ("link_url", models.CharField(blank=True, max_length=150)),
-                ("i18n", jsonfield.fields.JSONField(default={})),
+                ("i18n", kolibri.core.fields.JSONField(default={})),
                 ("active", models.BooleanField(default=True)),
                 (
                     "source",

--- a/kolibri/core/analytics/models.py
+++ b/kolibri/core/analytics/models.py
@@ -2,11 +2,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from jsonfield import JSONField
 
 from .constants import nutrition_endpoints
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.general import IsOwn
+from kolibri.core.fields import JSONField
 
 
 class PingbackNotification(models.Model):

--- a/kolibri/core/content/base_models.py
+++ b/kolibri/core/content/base_models.py
@@ -68,7 +68,6 @@ into legacy_models.py to allow for referencing during channel import of older da
 from __future__ import print_function
 
 from django.db import models
-from jsonfield import JSONField
 from le_utils.constants import content_kinds
 from le_utils.constants import file_formats
 from le_utils.constants import format_presets
@@ -78,6 +77,7 @@ from mptt.models import MPTTModel
 from mptt.models import TreeForeignKey
 
 from kolibri.core.fields import DateTimeTzField
+from kolibri.core.fields import JSONField
 
 
 class ContentTag(models.Model):

--- a/kolibri/core/content/migrations/0004_auto_20170825_1038.py
+++ b/kolibri/core/content/migrations/0004_auto_20170825_1038.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import django.db.models.deletion
 import django.db.models.manager
-import jsonfield.fields
 import morango.models
 import mptt.fields
 from django.db import migrations
@@ -22,9 +21,9 @@ class Migration(migrations.Migration):
             name="AssessmentMetaData",
             fields=[
                 ("id", morango.models.UUIDField(primary_key=True, serialize=False)),
-                ("assessment_item_ids", jsonfield.fields.JSONField(default=[])),
+                ("assessment_item_ids", kolibri.core.fields.JSONField(default=[])),
                 ("number_of_assessments", models.IntegerField()),
-                ("mastery_model", jsonfield.fields.JSONField(default={})),
+                ("mastery_model", kolibri.core.fields.JSONField(default={})),
                 ("randomize", models.BooleanField(default=False)),
                 ("is_manipulable", models.BooleanField(default=False)),
             ],

--- a/kolibri/core/exams/migrations/0001_initial.py
+++ b/kolibri/core/exams/migrations/0001_initial.py
@@ -3,10 +3,11 @@
 from __future__ import unicode_literals
 
 import django.db.models.deletion
-import jsonfield.fields
 import morango.models
 from django.db import migrations
 from django.db import models
+
+import kolibri.core.fields
 
 
 class Migration(migrations.Migration):
@@ -39,7 +40,7 @@ class Migration(migrations.Migration):
                 ("question_count", models.IntegerField()),
                 (
                     "question_sources",
-                    jsonfield.fields.JSONField(blank=True, default=[]),
+                    kolibri.core.fields.JSONField(blank=True, default=[]),
                 ),
                 ("seed", models.IntegerField(default=1)),
                 ("active", models.BooleanField(default=False)),

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 
 from .permissions import UserCanReadExamAssignmentData
 from .permissions import UserCanReadExamData
@@ -9,6 +8,7 @@ from kolibri.core.auth.models import AbstractFacilityDataModel
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
+from kolibri.core.fields import JSONField
 from kolibri.core.notifications.models import LearnerProgressNotification
 
 

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import re
 
 import pytz
@@ -6,6 +7,8 @@ from django.db.backends.utils import typecast_timestamp
 from django.db.models.fields import Field
 from django.utils import timezone
 from django.utils.six import string_types
+from jsonfield import JSONField as JSONFieldBase
+
 
 date_time_format = "%Y-%m-%d %H:%M:%S.%f"
 tz_format = "({tz})"
@@ -94,3 +97,23 @@ class DateTimeTzField(Field):
     def value_from_object_json_compatible(self, obj):
         if self.value_from_object(obj):
             return create_timezonestamp(self.value_from_object(obj))
+
+
+class JSONField(JSONFieldBase):
+    def from_db_value(self, value, expression, connection, context):
+        if isinstance(value, string_types):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                pass
+
+        return value
+
+    def to_python(self, value):
+        if isinstance(value, string_types):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                pass
+
+        return value

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -104,7 +104,7 @@ class JSONField(JSONFieldBase):
         if isinstance(value, string_types):
             try:
                 return json.loads(value)
-            except json.JSONDecodeError:
+            except ValueError:
                 pass
 
         return value
@@ -113,7 +113,7 @@ class JSONField(JSONFieldBase):
         if isinstance(value, string_types):
             try:
                 return json.loads(value)
-            except json.JSONDecodeError:
+            except ValueError:
                 pass
 
         return value

--- a/kolibri/core/lessons/migrations/0001_initial.py
+++ b/kolibri/core/lessons/migrations/0001_initial.py
@@ -3,11 +3,11 @@
 from __future__ import unicode_literals
 
 import django.db.models.deletion
-import jsonfield.fields
 import morango.models
-from django.conf import settings
 from django.db import migrations
 from django.db import models
+
+import kolibri.core.fields
 
 
 class Migration(migrations.Migration):
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                     "description",
                     models.CharField(blank=True, default="", max_length=200),
                 ),
-                ("resources", jsonfield.fields.JSONField(blank=True, default=[])),
+                ("resources", kolibri.core.fields.JSONField(blank=True, default=[])),
                 ("is_active", models.BooleanField(default=False)),
                 ("is_archived", models.BooleanField(default=False)),
                 (

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from jsonfield import JSONField
 
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import AbstractFacilityDataModel
@@ -9,6 +8,7 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.fields import DateTimeTzField
+from kolibri.core.fields import JSONField
 from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.utils.time_utils import local_now
 

--- a/kolibri/core/lessons/viewsets.py
+++ b/kolibri/core/lessons/viewsets.py
@@ -1,4 +1,3 @@
-import json
 from itertools import chain
 
 from django.db.models import F
@@ -64,7 +63,6 @@ class LessonViewset(ValuesViewset):
 
     field_map = {
         "classroom": _map_lesson_classroom,
-        "resources": lambda x: json.loads(x["resources"]),
     }
 
     def consolidate(self, items):

--- a/kolibri/core/logger/migrations/0001_initial.py
+++ b/kolibri/core/logger/migrations/0001_initial.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 
 import django.core.validators
 import django.db.models.deletion
-import jsonfield.fields
 import morango.models
 from django.db import migrations
 from django.db import models
+
+import kolibri.core.fields
 
 
 class Migration(migrations.Migration):
@@ -60,12 +61,12 @@ class Migration(migrations.Migration):
                 ("hinted", models.BooleanField(default=False)),
                 (
                     "answer",
-                    jsonfield.fields.JSONField(blank=True, default={}, null=True),
+                    kolibri.core.fields.JSONField(blank=True, default={}, null=True),
                 ),
                 ("simple_answer", models.CharField(blank=True, max_length=200)),
                 (
                     "interaction_history",
-                    jsonfield.fields.JSONField(blank=True, default=[]),
+                    kolibri.core.fields.JSONField(blank=True, default=[]),
                 ),
                 (
                     "dataset",
@@ -115,7 +116,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("kind", models.CharField(max_length=200)),
-                ("extra_fields", jsonfield.fields.JSONField(blank=True, default={})),
+                ("extra_fields", kolibri.core.fields.JSONField(blank=True, default={})),
                 (
                     "dataset",
                     models.ForeignKey(
@@ -177,7 +178,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("kind", models.CharField(max_length=200)),
-                ("extra_fields", jsonfield.fields.JSONField(blank=True, default={})),
+                ("extra_fields", kolibri.core.fields.JSONField(blank=True, default={})),
                 (
                     "dataset",
                     models.ForeignKey(
@@ -238,12 +239,12 @@ class Migration(migrations.Migration):
                 ("hinted", models.BooleanField(default=False)),
                 (
                     "answer",
-                    jsonfield.fields.JSONField(blank=True, default={}, null=True),
+                    kolibri.core.fields.JSONField(blank=True, default={}, null=True),
                 ),
                 ("simple_answer", models.CharField(blank=True, max_length=200)),
                 (
                     "interaction_history",
-                    jsonfield.fields.JSONField(blank=True, default=[]),
+                    kolibri.core.fields.JSONField(blank=True, default=[]),
                 ),
                 ("content_id", morango.models.UUIDField()),
                 ("channel_id", morango.models.UUIDField()),
@@ -320,7 +321,7 @@ class Migration(migrations.Migration):
                     "_morango_partition",
                     models.CharField(editable=False, max_length=128),
                 ),
-                ("mastery_criterion", jsonfield.fields.JSONField(default={})),
+                ("mastery_criterion", kolibri.core.fields.JSONField(default={})),
                 ("start_timestamp", models.DateTimeField()),
                 ("end_timestamp", models.DateTimeField(blank=True, null=True)),
                 ("completion_timestamp", models.DateTimeField(blank=True, null=True)),

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -20,7 +20,6 @@ from django.core.validators import MaxValueValidator
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 from morango.models import SyncableModelQuerySet
 from morango.models import UUIDField
 
@@ -33,6 +32,7 @@ from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.permissions.general import IsOwn
 from kolibri.core.exams.models import Exam
 from kolibri.core.fields import DateTimeTzField
+from kolibri.core.fields import JSONField
 from kolibri.utils.time_utils import local_now
 
 

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -1,5 +1,3 @@
-import json
-
 from django.db import connections
 from django.db.models import Count
 from django.db.models import F
@@ -201,7 +199,6 @@ def serialize_users(queryset):
 
 
 def _map_lesson(item):
-    item["resources"] = json.loads(item["resources"])
     item["node_ids"] = [resource["contentnode_id"] for resource in item["resources"]]
     return item
 
@@ -227,7 +224,6 @@ def serialize_lessons(queryset):
 
 
 def _map_exam(item):
-    item["question_sources"] = json.loads(item["question_sources"])
     item["assignments"] = item.pop("exam_assignments")
     return item
 

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -1,5 +1,3 @@
-import json
-
 from django.db.models import Count
 from django.db.models import OuterRef
 from django.db.models import Q
@@ -50,7 +48,6 @@ class LearnerClassroomViewset(ValuesViewset):
         )
         lesson_content_ids = set()
         for lesson in lessons:
-            lesson["resources"] = json.loads(lesson["resources"])
             lesson_content_ids |= set(
                 (resource["content_id"] for resource in lesson["resources"])
             )
@@ -185,7 +182,6 @@ class LearnerLessonViewset(ValuesViewset):
 
     field_map = {
         "classroom": _map_lesson_classroom,
-        "resources": lambda x: json.loads(x["resources"]),
     }
 
     def get_queryset(self):


### PR DESCRIPTION
### Summary
The JSONField library that we currently use does not properly implement `to_python` and `from_db_value` meaning that `.values` calls return strings instead of the appropriate Python objects.

This PR fixes this, and removes the workarounds that it had required.

### Reviewer guidance
Do tests pass? Any concerns with the JSONField parsing?

I think this is low risk, but could also be retargeted to develop.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
