### PR TITLE
Set collection_kind not collection__kind on lesson assignments.

### DIFF
--- a/kolibri/core/lessons/viewsets.py
+++ b/kolibri/core/lessons/viewsets.py
@@ -4,6 +4,7 @@ from itertools import chain
 
 from django.db import connection
 from django.db.models import CharField
+from django.db.models import F
 from django_filters.rest_framework import DjangoFilterBackend
 
 from .serializers import LessonSerializer
@@ -104,7 +105,11 @@ class LessonViewset(ValuesViewset):
         assignments = {
             a["id"]: _process_item(a)
             for a in assignments.values(
-                "id", "collection", "collection__kind", "learner_ids", "assigned_by"
+                "id",
+                "collection",
+                "learner_ids",
+                "assigned_by",
+                collection_kind=F("collection__kind"),
             )
         }
         for item in items:


### PR DESCRIPTION
### Summary
* Regression caused by #6074 
* `collection_kind` was being encoded as `collection__kind` - this rectifies that.

### Reviewer guidance
Before:
![Screenshot from 2019-12-02 13-31-41](https://user-images.githubusercontent.com/1680573/69997038-1e454800-1508-11ea-9474-da324490409b.png)
After:
![Screenshot from 2019-12-02 13-27-06](https://user-images.githubusercontent.com/1680573/69997050-23a29280-1508-11ea-9ab1-6537ecc6ca62.png)


### References
Fixes #6182

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
