### PR TITLE
add configurable sidenav header text

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -37,7 +37,7 @@
           <span
             class="side-nav-header-name"
             :style="{ color: $themeTokens.textInverted }"
-          >{{ $tr('kolibri') }}</span>
+          >{{ sideNavTitleText }}</span>
         </div>
 
         <div
@@ -201,6 +201,9 @@
         return [...topComponents, SideNavDivider, ...accountComponents, logout].filter(
           this.filterByRole
         );
+      },
+      sideNavTitleText() {
+        return this.$theme.sideNav.title ? this.$theme.sideNav.title : this.$tr('kolibri');
       },
     },
     watch: {

--- a/kolibri/plugins/default_theme/kolibri_plugin.py
+++ b/kolibri/plugins/default_theme/kolibri_plugin.py
@@ -62,6 +62,7 @@ class DefaultThemeHook(theme_hook.ThemeHook):
             },
             # side-nav config
             theme_hook.SIDE_NAV: {
+                theme_hook.TITLE: None,  # use default: "Kolibri"
                 theme_hook.BRANDED_FOOTER: {},
                 theme_hook.SHOW_K_FOOTER_LOGO: True,
             },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Allows sidenav header text to be configurable.
![Screen Shot 2019-12-02 at 3 29 06 PM](https://user-images.githubusercontent.com/6361732/70003608-8865e900-1518-11ea-9e0a-c9b0c8fe09a5.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Specify the title to be something else besides `None` and it should now appear in the sidenav.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

VF related branding issue.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
