### PR TITLE
Execute deletion within the session

### DIFF
--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -558,7 +558,7 @@ class ChannelImport(object):
                 self.check_cancelled()
 
                 # execute the actual query
-                self.destination.get_connection().execute(text(query))
+                self.destination.session.execute(text(query))
 
     def check_cancelled(self):
         if callable(self.cancel_check):


### PR DESCRIPTION
### Summary
* For import into sqlite databases channel import attempted to optimize deletion by checking if certain tables existed in the source db
* It did this outside of the scope of the session in which the sourcedb had been attached
* This led to breakage
* This fixes it by doing the deletion through the session in which the DB had been attached

### Reviewer guidance
Does it fix #6161 ?

### References
Fixes #6161

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
