### PR TITLE
Parallel task execution for UI blocking tasks

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -162,7 +162,8 @@ class Command(AsyncCommand):
             with db_task_write_lock:
                 sync_client.initiate_pull(Filter(dataset_id))
         if not no_push:
-            sync_client.initiate_push(Filter(dataset_id))
+            with db_task_write_lock:
+                sync_client.initiate_push(Filter(dataset_id))
 
         with db_task_write_lock:
             create_superuser_and_provision_device(

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -17,6 +17,7 @@ from kolibri.core.content.utils.import_export_content import compare_checksums
 from kolibri.core.content.utils.import_export_content import get_nodes_to_transfer
 from kolibri.core.content.utils.import_export_content import retry_import
 from kolibri.core.tasks.management.commands.base import AsyncCommand
+from kolibri.core.tasks.utils import db_task_write_lock
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.utils import conf
 
@@ -290,12 +291,13 @@ class Command(AsyncCommand):
                     exception = e
                     break
 
-            annotation.set_content_visibility(
-                channel_id,
-                file_checksums_to_annotate,
-                node_ids=node_ids,
-                exclude_node_ids=exclude_node_ids,
-            )
+            with db_task_write_lock:
+                annotation.set_content_visibility(
+                    channel_id,
+                    file_checksums_to_annotate,
+                    node_ids=node_ids,
+                    exclude_node_ids=exclude_node_ids,
+                )
 
             resources_after_transfer = (
                 ContentNode.objects.filter(channel_id=channel_id, available=True)

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -11,6 +11,7 @@ from django.conf import settings
 
 import kolibri
 from kolibri.core.tasks.main import scheduler
+from kolibri.core.tasks.utils import db_task_write_lock
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.time_utils import local_now
 
@@ -188,11 +189,12 @@ def perform_vacuum(database=db.DEFAULT_DB_ALIAS):
     connection = db.connections[database]
     if connection.vendor == "sqlite":
         try:
-            db.close_old_connections()
-            db.connections.close_all()
-            cursor = connection.cursor()
-            cursor.execute("vacuum;")
-            connection.close()
+            with db_task_write_lock:
+                db.close_old_connections()
+                db.connections.close_all()
+                cursor = connection.cursor()
+                cursor.execute("vacuum;")
+                connection.close()
         except Exception as e:
             logger.error(e)
             new_msg = (

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -10,8 +10,6 @@ from kolibri.core.tasks.scheduler import Scheduler
 from kolibri.core.tasks.worker import Worker
 from kolibri.utils import conf
 
-app = "kolibri"
-
 
 if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
     connection = create_engine(
@@ -56,10 +54,18 @@ def checkout(dbapi_connection, connection_record, connection_proxy):
         )
 
 
-queue = Queue(app, connection=connection)
+task_queue_name = "kolibri"
+
+priority_queue_name = "no_waiting"
+
+priority_queue = Queue(priority_queue_name, connection=connection)
+
+queue = Queue(task_queue_name, connection=connection)
 
 scheduler = Scheduler(queue=queue, connection=connection)
 
 
-def initialize_worker():
-    return Worker(app, connection=connection, num_workers=1)
+def initialize_workers():
+    regular_worker = Worker(task_queue_name, connection=connection, num_workers=1)
+    priority_worker = Worker(priority_queue_name, connection=connection, num_workers=3)
+    return regular_worker, priority_worker

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -16,7 +16,7 @@ from kolibri.deployment.default.cache import diskcache_location
 current_state_tracker = compat.local()
 
 
-db_task_write_lock = RLock(Cache(diskcache_location))
+db_task_write_lock = RLock(Cache(diskcache_location), "db_task_write_lock")
 
 
 def get_current_job():

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -3,13 +3,20 @@ import logging
 import time
 import uuid
 
+from diskcache import Cache
+from diskcache import RLock
+
 from kolibri.core.tasks import compat
+from kolibri.deployment.default.cache import diskcache_location
 
 
 # An object on which to store data about the current job
 # So far the only use is to track the job, but other metadata
 # could be added.
 current_state_tracker = compat.local()
+
+
+db_task_write_lock = RLock(Cache(diskcache_location))
 
 
 def get_current_job():

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -7,6 +7,8 @@ from kolibri.utils.conf import OPTIONS
 
 cache_options = OPTIONS["Cache"]
 
+diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
+
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {
     "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -29,7 +31,7 @@ built_files_cache = {
 # inside asynchronous tasks.
 process_cache = {
     "BACKEND": "diskcache.DjangoCache",
-    "LOCATION": os.path.join(KOLIBRI_HOME, "process_cache"),
+    "LOCATION": diskcache_location,
     "OPTIONS": {"MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"]},
 }
 


### PR DESCRIPTION
### Summary
* Adds a priority queue for UI blocking tasks
* Adds a separate worker process with 3 workers to process UI blocking tasks
* Adds a DB write lock to prevent async tasks fighting over the database

### Reviewer guidance
Does the code make sense?
Does channel metadata import happen quickly in spite of queued content import jobs?

### References
Fixes #6178 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
