### PR TITLE
set file total_size when file is compressed

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -203,7 +203,7 @@ class Command(AsyncCommand):
             .count()
         )
 
-        (files_to_download, total_bytes_to_transfer,) = calculate_files_to_transfer(
+        (files_to_download, total_bytes_to_transfer) = calculate_files_to_transfer(
             nodes_for_transfer, False
         )
 
@@ -356,9 +356,7 @@ class Command(AsyncCommand):
                 # is less than what we have marked in the database that we make up
                 # the difference so that the overall progress is never incorrect.
                 # This could happen, for example for a local transfer if a file
-                # has been replaced or corrupted (which we catch below) or for
-                # a remote transfer if the peer to peer transfer is is compressing
-                # files using gzip.
+                # has been replaced or corrupted (which we catch below)
                 overall_progress_update(f.file_size - filetransfer.total_size)
 
                 # If checksum of the destination file is different from the localfile

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -160,21 +160,19 @@ class FileDownload(Transfer):
         # initiate the download, check for status errors, and calculate download size
         self.response = self.session.get(self.source, stream=True, timeout=self.timeout)
         self.response.raise_for_status()
-        try:
-            self.total_size = int(self.response.headers["content-length"])
-        except Exception:
+
+        content_length = self.response.headers.get("content-length")
+        gcs_content_length = self.response.headers.get("X-Goog-Stored-Content-Length")
+        if content_length:
+            self.total_size = int(content_length)
+        elif gcs_content_length:
             # When a compressed file is saved on Google Cloud Storage,
             # content-length is not available in the header,
             # but we can use X-Goog-Stored-Content-Length.
-            gcs_content_length = self.response.headers.get(
-                "X-Goog-Stored-Content-Length"
-            )
-            if gcs_content_length:
-                self.total_size = int(gcs_content_length)
-            else:
-                # HACK: set the total_size very large so downloads are not considered "corrupted"
-                # in importcontent._start_file_transfer
-                self.total_size = 1e100
+            self.total_size = int(gcs_content_length)
+        else:
+            # Get size of response content when file is compressed through nginx.
+            self.total_size = len(self.response.content)
 
         self.started = True
 

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -162,7 +162,7 @@ class FileDownload(Transfer):
         self.response.raise_for_status()
 
         try:
-            self.total_size = self.response.headers["content-length"]
+            self.total_size = int(self.response.headers["content-length"])
         except KeyError:
             # When a compressed file is saved on Google Cloud Storage,
             # content-length is not available in the header,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When a file is compressed either on Cloudflare (e.g. json files) or Google Cloud Storage (content databases in the future), the content-length of the file would not be available in the response headers and thus the total_size of the file would be set to 1e100.

However, click's progress bar requires the file size value to be an integer. https://github.com/learningequality/kolibri/blob/release-v0.13.x/kolibri/core/tasks/management/commands/base.py#L32
The workaround is to get the value of `X-Goog-Stored-Content-Length` when `content-length` is not available in the headers.

When we do remote peer-to-peer import, and a file is compressed through nginx, the content-length of the file would not be available either. I don't know other ways of getting the size of the response except calculating the length of the response content (Please feel free to comment in the PR if there's a better way to handle this). If we continue to set the file size to `1e+100` in the case that file is gzipped, progress bar will have weird behavior when importing via webUI, and an error will occur when importing via CLI.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Test case 1:
1. run kolibri 0.13.0 beta
2. import channel `7ad6cdc532ea4e73a43a4c47b942c2a7` (this database file has been compressed) through `kolibri manage importchannel network 7ad6cdc532ea4e73a43a4c47b942c2a7` and see that there's an error saying it needs Int instead of Float.
3. run the kolibri installer from this PR
4. import the channel again through CLI and see that the channel database is imported successfully.
(no need to import content here)

Test case 2:
1. run kolibri 0.13.0 beta
2. import the content of the channel `nosov-pagif`
3. see that the progress bar has a weird large value
4. run the kolibri installer from this PR
5. import the content of the channel `nosov-pagif` and see that the progress bar works correctly

Test case 3:
1. run kolibri 0.13.0 beta
2. set up peer-to-peer import from kolibribeta.learningequality.org
3. import some html5 apps from CK-12
4. see that the progress bar has a weird large value
5. run the kolibri installer from this PR
6. set up peer-to-peer import from kolibribeta.learningequality.org
7. import html5 apps from CK-12 and see that the progress bar works correctly


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6170

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
