### PR TITLE
Change recommended back to resume

### DIFF
--- a/kolibri/plugins/learn/assets/src/constants.js
+++ b/kolibri/plugins/learn/assets/src/constants.js
@@ -24,12 +24,6 @@ export const PageModes = {
   EXAM: 'EXAM',
 };
 
-export const RecommendedPages = [
-  PageNames.RECOMMENDED_POPULAR,
-  PageNames.RECOMMENDED_RESUME,
-  PageNames.RECOMMENDED_NEXT_STEPS,
-];
-
 export const ClassesPageNames = {
   ALL_CLASSES: 'ALL_CLASSES',
   CLASS_ASSIGNMENTS: 'CLASS_ASSIGNMENTS',

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -14,6 +14,8 @@ import {
 } from '../modules/recommended/handlers';
 import { showChannels } from '../modules/topicsRoot/handlers';
 import { PageNames, ClassesPageNames } from '../constants';
+import RecommendedPage from '../views/RecommendedPage';
+import RecommendedSubpage from '../views/RecommendedSubpage';
 import classesRoutes from './classesRoutes';
 
 export default [
@@ -42,6 +44,7 @@ export default [
     handler: () => {
       showRecommended(store);
     },
+    component: RecommendedPage,
   },
   {
     name: PageNames.SEARCH,
@@ -86,6 +89,7 @@ export default [
     handler: () => {
       showPopularPage(store);
     },
+    component: RecommendedSubpage,
   },
   {
     name: PageNames.RECOMMENDED_RESUME,
@@ -93,6 +97,7 @@ export default [
     handler: () => {
       showResumePage(store);
     },
+    component: RecommendedSubpage,
   },
   {
     name: PageNames.RECOMMENDED_NEXT_STEPS,
@@ -100,6 +105,7 @@ export default [
     handler: () => {
       showNextStepsPage(store);
     },
+    component: RecommendedSubpage,
   },
   {
     path: '*',

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -18,6 +18,7 @@
     <div>
       <Breadcrumbs v-if="pageName !== 'TOPICS_CONTENT'" />
       <component :is="currentPage" />
+      <router-view />
     </div>
 
     <UpdateYourProfileModal
@@ -42,13 +43,11 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
-  import { PageNames, RecommendedPages, ClassesPageNames } from '../constants';
+  import { PageNames, ClassesPageNames } from '../constants';
   import commonLearnStrings from './commonLearnStrings';
   import ChannelsPage from './ChannelsPage';
   import TopicsPage from './TopicsPage';
   import ContentPage from './ContentPage';
-  import RecommendedPage from './RecommendedPage';
-  import RecommendedSubpage from './RecommendedSubpage';
   import ContentUnavailablePage from './ContentUnavailablePage';
   import Breadcrumbs from './Breadcrumbs';
   import SearchPage from './SearchPage';
@@ -69,7 +68,6 @@
     [PageNames.TOPICS_CHANNEL]: TopicsPage,
     [PageNames.TOPICS_TOPIC]: TopicsPage,
     [PageNames.TOPICS_CONTENT]: ContentPage,
-    [PageNames.RECOMMENDED]: RecommendedPage,
     [PageNames.CONTENT_UNAVAILABLE]: ContentUnavailablePage,
     [PageNames.SEARCH]: SearchPage,
     [ClassesPageNames.EXAM_VIEWER]: ExamPage,
@@ -116,9 +114,6 @@
         return this.facilityConfig.allow_guest_access || this.isUserLoggedIn;
       },
       currentPage() {
-        if (RecommendedPages.includes(this.pageName)) {
-          return RecommendedSubpage;
-        }
         return pageNameToComponentMap[this.pageName] || null;
       },
       immersivePageProps() {

--- a/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
@@ -44,7 +44,7 @@
 
     <template v-if="resume.length">
       <ContentCardGroupHeader
-        :header="learnString('resumeLabel')"
+        :header="learnIndexString('documentTitleForResume')"
         :viewMorePageLink="resumePageLink"
         :showViewMore="resume.length > trimmedResume.length"
       />
@@ -75,6 +75,7 @@
   import ContentCardGroupCarousel from './ContentCardGroupCarousel';
   import ContentCardGroupGrid from './ContentCardGroupGrid';
   import ContentCardGroupHeader from './ContentCardGroupHeader';
+  import learnIndexStrings from './learnIndexStrings';
 
   const mobileCarouselLimit = 3;
   const desktopCarouselLimit = 15;
@@ -91,7 +92,7 @@
       ContentCardGroupGrid,
       ContentCardGroupHeader,
     },
-    mixins: [commonLearnStrings, responsiveWindowMixin],
+    mixins: [commonLearnStrings, responsiveWindowMixin, learnIndexStrings],
     computed: {
       ...mapState('recommended', ['nextSteps', 'popular', 'resume']),
       carouselLimit() {

--- a/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedPage.vue
@@ -44,7 +44,7 @@
 
     <template v-if="resume.length">
       <ContentCardGroupHeader
-        :header="learnString('recommendedLabel')"
+        :header="learnString('resumeLabel')"
         :viewMorePageLink="resumePageLink"
         :showViewMore="resume.length > trimmedResume.length"
       />

--- a/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
@@ -39,7 +39,7 @@
           case PageNames.RECOMMENDED_POPULAR:
             return this.$tr('documentTitleForPopular');
           case PageNames.RECOMMENDED_RESUME:
-            return this.learnString('recommendedLabel');
+            return this.learnString('resumeLabel');
           case PageNames.RECOMMENDED_NEXT_STEPS:
             return this.$tr('documentTitleForNextSteps');
           default:
@@ -51,7 +51,7 @@
           case PageNames.RECOMMENDED_POPULAR:
             return this.$tr('popularPageHeader');
           case PageNames.RECOMMENDED_RESUME:
-            return this.learnString('recommendedLabel');
+            return this.learnString('resumeLabel');
           case PageNames.RECOMMENDED_NEXT_STEPS:
             return this.$tr('nextStepsPageHeader');
           default:

--- a/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
+++ b/kolibri/plugins/learn/assets/src/views/RecommendedSubpage.vue
@@ -19,6 +19,7 @@
   import { PageNames } from '../constants';
   import ContentCardGroupGrid from './ContentCardGroupGrid';
   import commonLearnStrings from './commonLearnStrings';
+  import learnIndexStrings from './learnIndexStrings';
 
   export default {
     name: 'RecommendedSubpage',
@@ -30,7 +31,7 @@
     components: {
       ContentCardGroupGrid,
     },
-    mixins: [commonLearnStrings],
+    mixins: [commonLearnStrings, learnIndexStrings],
     computed: {
       ...mapState(['pageName']),
       ...mapState('recommended/subpage', ['recommendations']),
@@ -39,7 +40,7 @@
           case PageNames.RECOMMENDED_POPULAR:
             return this.$tr('documentTitleForPopular');
           case PageNames.RECOMMENDED_RESUME:
-            return this.learnString('resumeLabel');
+            return this.learnIndexString('documentTitleForResume');
           case PageNames.RECOMMENDED_NEXT_STEPS:
             return this.$tr('documentTitleForNextSteps');
           default:
@@ -51,7 +52,7 @@
           case PageNames.RECOMMENDED_POPULAR:
             return this.$tr('popularPageHeader');
           case PageNames.RECOMMENDED_RESUME:
-            return this.learnString('resumeLabel');
+            return this.learnIndexString('documentTitleForResume');
           case PageNames.RECOMMENDED_NEXT_STEPS:
             return this.$tr('nextStepsPageHeader');
           default:

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -4,7 +4,6 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
   // Labels
   learnLabel: 'Learn',
   recommendedLabel: 'Recommended',
-  resumeLabel: 'Resume',
 });
 
 export default {

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -4,6 +4,7 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
   // Labels
   learnLabel: 'Learn',
   recommendedLabel: 'Recommended',
+  resumeLabel: 'Resume',
 });
 
 export default {

--- a/kolibri/plugins/learn/assets/src/views/learnIndexStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/learnIndexStrings.js
@@ -1,0 +1,12 @@
+import { crossComponentTranslator } from 'kolibri.utils.i18n';
+import LearnIndex from './LearnIndex';
+
+const learnIndexStrings = crossComponentTranslator(LearnIndex);
+
+export default {
+  methods: {
+    learnIndexString(key) {
+      return learnIndexStrings.$tr(key);
+    },
+  },
+};


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Change `recommended` text back to `resume`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Interact with content, but don't complete. Does the resume section appear?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Both next steps and resume appeared for me.
https://github.com/learningequality/kolibri/issues/6155

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
