### PR TITLE
Only display invalid text if user changes input value

### DIFF
--- a/packages/kolibri-components/src/KTextbox/index.vue
+++ b/packages/kolibri-components/src/KTextbox/index.vue
@@ -7,7 +7,7 @@
       class="textbox"
       :label="label"
       :disabled="disabled"
-      :invalid="invalid"
+      :invalid="showInvalidMessage"
       :error="invalidText"
       :autofocus="autofocus"
       :maxlength="maxlength"
@@ -76,6 +76,13 @@
         required: false,
       },
       /**
+       * Text displayed if user changes value in input
+       */
+      onlyShowValidationAfterChange: {
+        type: Boolean,
+        default: true,
+      },
+      /**
        * Whether or not to autofocus
        */
       autofocus: {
@@ -134,11 +141,23 @@
       },
     },
     data() {
-      return { currentText: this.value };
+      return {
+        currentText: this.value,
+        changed: false,
+      };
+    },
+    computed: {
+      showInvalidMessage() {
+        if (this.onlyShowValidationAfterChange) {
+          return this.invalid && this.changed;
+        }
+        return this.invalid;
+      },
     },
     watch: {
       value(val) {
         this.currentText = val;
+        this.changed = true;
       },
     },
     methods: {

--- a/packages/kolibri-components/src/KTextbox/index.vue
+++ b/packages/kolibri-components/src/KTextbox/index.vue
@@ -76,7 +76,7 @@
         required: false,
       },
       /**
-       * Text displayed if user changes value in input
+       * Only show validation text after user changes the input value
        */
       onlyShowValidationAfterChange: {
         type: Boolean,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We only show the error text if the user has interacted with the textarea.
![Dec-03-2019 18-03-58](https://user-images.githubusercontent.com/6361732/70106142-ad7d5900-15f7-11ea-9ca2-96f96e031df0.gif)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Tab through some forms.
Fill out a textarea, then completely delete it to get error to show.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Resolves https://github.com/learningequality/kolibri/issues/2184.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
