### PR TITLE
Copy userSearchUtils to coach

### DIFF
--- a/kolibri/plugins/coach/assets/src/userSearchUtils.js
+++ b/kolibri/plugins/coach/assets/src/userSearchUtils.js
@@ -1,0 +1,14 @@
+import { localeCompare } from 'kolibri.utils.i18n';
+
+export function userMatchesFilter(user, searchFilter) {
+  const searchTerms = searchFilter.split(/\s+/).map(val => val.toLowerCase());
+  const fullName = user.full_name.toLowerCase();
+  const username = user.username.toLowerCase();
+  return searchTerms.every(term => fullName.includes(term) || username.includes(term));
+}
+
+export function filterAndSortUsers(users, pred, sortByKey = 'username') {
+  return users.filter(pred).sort((a, b) => {
+    return localeCompare(a[sortByKey], b[sortByKey]);
+  });
+}

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -109,10 +109,7 @@
   import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../../common';
-  import {
-    userMatchesFilter,
-    filterAndSortUsers,
-  } from '../../../../../../facility/assets/src/userSearchUtils';
+  import { userMatchesFilter, filterAndSortUsers } from '../../../userSearchUtils';
   import UserTable from '../../../../../../facility/assets/src/views/UserTable';
 
   export default {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -78,10 +78,7 @@
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoachStrings from '../../common';
-  import {
-    userMatchesFilter,
-    filterAndSortUsers,
-  } from '../../../../../../device/assets/src/userSearchUtils';
+  import { userMatchesFilter, filterAndSortUsers } from '../../../userSearchUtils';
 
   export default {
     name: 'IndividualLearnerSelector',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

There were two places where files in Coach were going `../../../../../../../` to get to Facility or Device to borrow the userSearchUtils - that's bad.

Less bad is just copying that file containing two simple functions into Coach. It's unlikely to change for any reason so the duplication is unlikely to be an issue. If it does change - it's probably going to be for a plugin-specific purpose anyway so I figure it's better to copy it for now.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to add learners to a group and see that the table of users works as expected when you go to filter it.

This also will be applied to the Individual learners selection but this version is currently behind that PR... so there will be some rebasing to do (very simple, one line to fix) whenever this PR and https://github.com/learningequality/kolibri/pull/6149 meet.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6058

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
