### PR TITLE
Validate upon focusing as well as modification

### DIFF
--- a/packages/kolibri-components/src/KTextbox/index.vue
+++ b/packages/kolibri-components/src/KTextbox/index.vue
@@ -76,13 +76,6 @@
         required: false,
       },
       /**
-       * Only show validation text after user changes the input value
-       */
-      onlyShowValidationAfterChange: {
-        type: Boolean,
-        default: true,
-      },
-      /**
        * Whether or not to autofocus
        */
       autofocus: {
@@ -143,21 +136,18 @@
     data() {
       return {
         currentText: this.value,
-        changed: false,
+        changedOrFocused: false,
       };
     },
     computed: {
       showInvalidMessage() {
-        if (this.onlyShowValidationAfterChange) {
-          return this.invalid && this.changed;
-        }
-        return this.invalid;
+        return this.invalid && this.changedOrFocused;
       },
     },
     watch: {
       value(val) {
         this.currentText = val;
-        this.changed = true;
+        this.changedOrFocused = true;
       },
     },
     methods: {
@@ -185,6 +175,7 @@
        * Focuses on the textbox
        */
       focus() {
+        this.changedOrFocused = true;
         this.$refs.textbox.$el.querySelector('input').focus();
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Remove unneeded prop (for now?). 
Only validate upon modification or focus of textarea.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

goto http://127.0.0.1:8000/en/user/#/create_account
Try to submit the form and element should be focused with validation error message.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/6223.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
