### PR TITLE
Allow users to complete slideshow *and more!*

### DIFF
--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -220,7 +220,9 @@
         this.polyfillSlideObjectFit();
         this.setHooperListWidth();
         // Do this on nextTick to avoid sliding into position without proper resizing occurring.
-        this.$nextTick(() => this.$refs.slider.slideTo(this.extraFields.contentState.lastViewedSlideIndex));
+        this.$nextTick(() =>
+          this.$refs.slider.slideTo(this.extraFields.contentState.lastViewedSlideIndex)
+        );
       },
       updateContentState() {
         this.extraFields.contentState.highestViewedSlideIndex = this.highestViewedSlideIndex;

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -16,7 +16,12 @@
       <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
       <mat-svg v-else name="fullscreen" category="navigation" />
     </UiIconButton>
-    <Hooper v-if="slides.length" :initialSlide="extraFields.contentState.lastViewedSlideIndex" @slide="handleSlide" @loaded="initializeHooper">
+    <Hooper
+      v-if="slides.length"
+      :initialSlide="extraFields.contentState.lastViewedSlideIndex"
+      @slide="handleSlide"
+      @loaded="initializeHooper"
+    >
       <Slide v-for="(slide, index) in slides" :key="slide.id + index" :index="index">
         <div
           class="slideshow-slide-image-wrapper"
@@ -139,8 +144,8 @@
       }
     },
     beforeDestroy() {
-      this.updateContentState();
       this.updateProgress();
+      this.updateContentState();
       this.$emit('stopTracking');
     },
     methods: {
@@ -221,7 +226,15 @@
         this.$emit('updateContentState', this.extraFields.contentState);
       },
       updateProgress() {
-        this.$emit('updateProgress', (this.highestViewedSlideIndex + 1) / this.slides.length);
+        // updateProgress adds the percent to the existing value, so only pass
+        // the percentage of progress in this session, not the full percentage.
+        const progressPercent =
+          this.highestViewedSlideIndex + 1 === this.slides.length
+            ? 1.0
+            : (this.highestViewedSlideIndex -
+                this.extraFields.contentState.highestViewedSlideIndex) /
+              this.slides.length;
+        this.$emit('updateProgress', progressPercent);
       },
     },
     $trs: {

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -18,7 +18,7 @@
     </UiIconButton>
     <Hooper
       v-if="slides.length"
-      :initialSlide="extraFields.contentState.lastViewedSlideIndex"
+      ref="slider"
       @slide="handleSlide"
       @loaded="initializeHooper"
     >
@@ -219,6 +219,8 @@
         */
         this.polyfillSlideObjectFit();
         this.setHooperListWidth();
+        // Do this on nextTick to avoid sliding into position without proper resizing occurring.
+        this.$nextTick(() => this.$refs.slider.slideTo(this.extraFields.contentState.lastViewedSlideIndex));
       },
       updateContentState() {
         this.extraFields.contentState.highestViewedSlideIndex = this.highestViewedSlideIndex;

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -16,7 +16,7 @@
       <mat-svg v-if="isInFullscreen" name="fullscreen_exit" category="navigation" />
       <mat-svg v-else name="fullscreen" category="navigation" />
     </UiIconButton>
-    <Hooper v-if="slides.length" @slide="handleSlide" @loaded="initializeHooper">
+    <Hooper v-if="slides.length" :initialSlide="extraFields.contentState.lastViewedSlideIndex" @slide="handleSlide" @loaded="initializeHooper">
       <Slide v-for="(slide, index) in slides" :key="slide.id + index" :index="index">
         <div
           class="slideshow-slide-image-wrapper"
@@ -81,6 +81,7 @@
       isInFullscreen: false,
       slides: [],
       currentSlideIndex: 0,
+      highestViewedSlideIndex: 0,
     }),
     computed: {
       currentSlide() {
@@ -113,6 +114,11 @@
           this.setSlides(newData);
         }
       },
+      currentSlideIndex() {
+        if (this.currentSlideIndex + 1 === this.slides.length) {
+          this.updateProgress();
+        }
+      },
     },
     created() {
       if (this.defaultFile) {
@@ -120,6 +126,22 @@
       } else if (this.itemData) {
         this.setSlides(this.itemData);
       }
+    },
+    mounted() {
+      this.$emit('startTracking');
+      if (this.extraFields && this.extraFields.hasOwnProperty('contentState')) {
+        this.highestViewedSlideIndex = this.extraFields.contentState.highestViewedSlideIndex;
+      } else {
+        this.extraFields.contentState = {
+          highestViewedSlideIndex: 0,
+          lastViewedSlideIndex: 0,
+        };
+      }
+    },
+    beforeDestroy() {
+      this.updateContentState();
+      this.updateProgress();
+      this.$emit('stopTracking');
     },
     methods: {
       setSlidesFromDefaultFile(defaultFile) {
@@ -153,10 +175,13 @@
           ['sort_order'],
           ['asc']
         );
-        this.currentSlideIndex = 0;
+        this.currentSlideIndex = this.highestViewedSlideIndex;
       },
       handleSlide(payload) {
         this.currentSlideIndex = payload.currentSlide;
+        if (this.currentSlideIndex > this.highestViewedSlideIndex) {
+          this.highestViewedSlideIndex = this.currentSlideIndex;
+        }
       },
       slideTextId(id) {
         return 'descriptive-text-' + id;
@@ -189,6 +214,14 @@
         */
         this.polyfillSlideObjectFit();
         this.setHooperListWidth();
+      },
+      updateContentState() {
+        this.extraFields.contentState.highestViewedSlideIndex = this.highestViewedSlideIndex;
+        this.extraFields.contentState.lastViewedSlideIndex = this.currentSlideIndex;
+        this.$emit('updateContentState', this.extraFields.contentState);
+      },
+      updateProgress() {
+        this.$emit('updateProgress', (this.highestViewedSlideIndex + 1) / this.slides.length);
       },
     },
     $trs: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Slideshows previously did not track the user's progress. Now:

- Slideshow users will "complete" the content when they reach the last slide.

- Progress is updated `beforeDestroy`

- The slide users last viewed is stored in `extraFields` - and now when a user returns to a Slideshow, they start where they left off.

- User's "furthest progress" is also stored in `extraFields` so the component always knows "how far a learner has been" and can update progress accordingly.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Have the Slides! Slides! Slides! channel (token: nosov-pagif) imported.
- Log in as a user and view the Slideshow content.

__Partial Progress__

- Only go through a couple of slides.
- Go back one page.
- See that your blue progress indicator on the Slideshow's card has moved.
- View slideshow and progress a couple more slides (don't complete it yet)
- Go back one page again - verify that it has updated the progress.

__Complete Progress__

- Slide the slider until you get to the last slide.
- See the snackbar giving you your hard earned points.
- See that it is completed.
- Go back one page - see that it is completed.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6123

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
