### PR TITLE
Use io.open instead of open in Crowdin CSV handling

### DIFF
--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -321,7 +321,9 @@ def _csv_to_json():
                 newline = None if sys.version_info[0] < 3 else ""
                 mode = "r+b" if sys.version_info[0] < 3 else "r"
                 encoding = None if sys.version_info[0] < 3 else "utf-8"
-                csv_file = io.open(csv_path, mode=mode, encoding=encoding, newline=newline)
+                csv_file = io.open(
+                    csv_path, mode=mode, encoding=encoding, newline=newline
+                )
             except EnvironmentError as e:
                 logging.info("Failed to find CSV file in: {}".format(csv_path))
                 continue

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -319,8 +319,10 @@ def _csv_to_json():
             # Account for csv reading differences in Pythons 2 and 3
             try:
                 newline = None if sys.version_info[0] < 3 else ""
-                csv_file = io.open(csv_path, mode="r", encoding="utf-8", newline=newline)
-            except FileNotFoundError as e:
+                mode = "r+b" if sys.version_info[0] < 3 else "r"
+                encoding = None if sys.version_info[0] < 3 else "utf-8"
+                csv_file = io.open(csv_path, mode=mode, encoding=encoding, newline=newline)
+            except EnvironmentError as e:
                 logging.info("Failed to find CSV file in: {}".format(csv_path))
                 continue
 

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -318,10 +318,8 @@ def _csv_to_json():
 
             # Account for csv reading differences in Pythons 2 and 3
             try:
-                if sys.version_info[0] < 3:
-                    csv_file = open(csv_path, "rb")
-                else:
-                    csv_file = open(csv_path, "r", newline="")
+                newline = None if sys.version_info[0] < 3 else ""
+                csv_file = io.open(csv_path, mode="r", encoding="utf-8", newline=newline)
             except FileNotFoundError as e:
                 logging.info("Failed to find CSV file in: {}".format(csv_path))
                 continue


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Does this: https://github.com/learningequality/kolibri/pull/6052#discussion_r346345491

Addressing this Issue: https://github.com/learningequality/kolibri/issues/6063

It isn't less verbose because `io.open` doesn't need encoding in Python 2, and needs `r+b` open mode so we needed additional conditionals.

The one necessary change unrelated to the previous note is that the `except` in that block needs to except `EnvironmentError` instead of `FileNotFoundError` - the latter is Python 3 exclusive.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

**Do this once with a Python 3 virtualenv, and once with a Python 2 virtualenv**

Have the Perseus exercise plugin installed and ready and installed in your current virtualenv 
 (ie, `pip install -e ../kolibri-exercise-perseus-plugin`) https://github.com/learningequality/kolibri-exercise-perseus-plugin

`make i18n-download branch=release-v0.13.x`

See that everything is successful - particularly at the end when it should say:

> INFO: Kolibri: CSV to JSON conversion succeeded!

If it says something like 

> INFO: Failed to find CSV file in: /home/jacob/Code/LearningEquality/kolibri/kolibri/locale/CSV_FILES/ach/kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.csv

Then that's okay - actually it means the error handling changed here works properly if it didn't find that file. If a bunch of files list like that - it's bad.

Go to your `kolibri/locale` directory and see that the paths where the JSON files are have been updated.

Try `git status` and see all of the JSON files that have been changed. This means that the CSV files were opened, read and converted to JSON files as expected.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6063

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
