### PR TITLE
Hide coach user filters

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -170,6 +170,9 @@
       sortedExams() {
         return this._.orderBy(this.exams, ['date_created'], ['desc']);
       },
+      // Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
+      // Uncomment this once we use the filters again.
+      /*
       statusOptions() {
         return [
           {
@@ -186,6 +189,7 @@
           },
         ];
       },
+      */
       activeExams() {
         return this.sortedExams.filter(exam => exam.active === true);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -12,12 +12,18 @@
       <PlanHeader />
 
       <div class="filter-and-button">
+        <!-- Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
         <KSelect
           v-model="statusSelected"
           :label="coreString('showAction')"
           :options="statusOptions"
           :inline="true"
         />
+        -->
+        <!-- Remove this div - it makes sure the [NEW LESSON] button stays right-aligned
+            while the above <KSelect> is hidden
+        -->
+        <div>&nbsp;</div>
         <KRouterLink
           :primary="true"
           appearance="raised-button"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -14,7 +14,6 @@
       <div class="filter-and-button">
         <!-- Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
         <KSelect
-          v-show="false"
           v-model="filterSelection"
           :label="coreString('showAction')"
           :options="filterOptions"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -12,12 +12,19 @@
       <PlanHeader />
 
       <div class="filter-and-button">
+        <!-- Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
         <KSelect
+          v-show="false"
           v-model="filterSelection"
           :label="coreString('showAction')"
           :options="filterOptions"
           :inline="true"
         />
+        -->
+        <!-- Remove this div - it makes sure the [NEW LESSON] button stays right-aligned
+            while the above <KSelect> is hidden
+        -->
+        <div>&nbsp;</div>
         <KButton
           :primary="true"
           :text="coachString('newLessonAction')"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -11,12 +11,14 @@
     <KPageContainer>
       <ReportsHeader :title="$isPrint ? $tr('printLabel', {className}) : null" />
       <ReportsControls @export="exportCSV">
+        <!-- Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
         <KSelect
           v-model="filter"
           :label="coreString('showAction')"
           :options="filterOptions"
           :inline="true"
         />
+        -->
       </ReportsControls>
       <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -12,12 +12,14 @@
     <KPageContainer :class="{'print': $isPrint}">
       <ReportsHeader :title="$isPrint ? $tr('printLabel', {className}) : null" />
       <ReportsControls @export="exportCSV">
+        <!-- Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
         <KSelect
           v-model="filter"
           :label="coreString('showAction')"
           :options="filterOptions"
           :inline="true"
         />
+        -->
       </ReportsControls>
       <CoreTable :emptyMessage="emptyMessage">
         <thead slot="thead">


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Oof!

We didn't consider adjusting the filters on the Quiz / Lesson reports and plan pages when we updated the wording for the activation/closing flow.

Which means that we didn't make strings for them.

Which means we have to hide the filter boxes.

I commented them out and noted why in the comment.

In the Plan side, I had to add an empty div to ensure the "NEW THING" buttons stay right-aligned.

Per: https://github.com/learningequality/kolibri/issues/6174

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to Quizzes and Lessons in the Coach > Report and Coach > Plan pages. 

Make sure everything works and that you don't see filters on the right side above the table listing the quizzes and lessons.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6174

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
