### PR TITLE
webpack tree shaking

### DIFF
--- a/packages/kolibri-tools/lib/bundleStats.js
+++ b/packages/kolibri-tools/lib/bundleStats.js
@@ -26,7 +26,7 @@ function buildWebpack(data, index, startCallback, doneCallback, options) {
   return compiler;
 }
 
-const { data, index, start } = getEnvVars();
+const { data, index, options, start } = getEnvVars();
 
 function build() {
   buildWebpack(
@@ -37,7 +37,8 @@ function build() {
     },
     () => {
       process.send('done');
-    }
+    },
+    options
   );
 }
 

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -150,6 +150,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
             objectAssign: 'Object.assign',
           },
           exclude: /node_modules\/vue/,
+          sideEffects: false,
         },
         {
           test: /\.css$/,
@@ -180,6 +181,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
       __filename: true,
     },
     optimization: {
+      usedExports: true,
       minimizer: [
         new TerserPlugin({
           cache: true,


### PR DESCRIPTION
### Summary

while investigating tree shaking in https://github.com/learningequality/kolibri/pull/5972 attempted to apply optimizations from https://webpack.js.org/guides/tree-shaking/

### Reviewer guidance


Note that tree shaking might not actually be occurring as we expected. According to [the docs](https://webpack.js.org/guides/tree-shaking/) we could add either `sideEffects`, `usedExports`, or both.

After running this, most bundles stayed the same size but these two got a bit lower:

| bundle | size before | size after |
|--|--|--|
|`kolibri.core.default_frontend` | 1.82 MB| 1.56 MB |
| `kolibri.plugins.epub_viewer.main` |695 KB | 687 KB|

However, it's not clear to me whether this change is safe - specifically because we don't know whether our modules do in fact have side effects or not...

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
