### PR TITLE
Options -> Manage

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -16,12 +16,11 @@
     </div>
 
     <div class="col-3">
-      <KDropdownMenu
-        :text="coreString('optionsLabel')"
+      <KButton
+        :text="$tr('manageChannelAction')"
         :disabled="disabled"
-        :options="dropdownOptions"
-        :position="dropdownPosition"
-        @select="handleManageChannelAction($event.value)"
+        class="manage-btn"
+        @click="handleManageChannelAction"
       />
     </div>
   </div>
@@ -58,29 +57,9 @@
       resourcesSizeText() {
         return bytesForHumans(this.channel.on_device_file_size);
       },
-      dropdownPosition() {
-        // On small screens, position to the left so it doesn't overflow the
-        // window and mess up the global layout.
-        return this.windowIsSmall ? 'bottom left' : 'bottom right';
-      },
-      dropdownOptions() {
-        return [
-          {
-            label: this.$tr('manageChannelAction'),
-            value: 'MANAGE_CHANNEL',
-          },
-          {
-            label: this.$tr('deleteChannelAction'),
-            value: 'DELETE_CHANNEL',
-          },
-        ];
-      },
     },
     methods: {
-      handleManageChannelAction(action) {
-        if (action === 'DELETE_CHANNEL') {
-          return this.$emit('select_delete');
-        }
+      handleManageChannelAction() {
         return this.$emit('select_manage', { ...this.channel });
       },
     },
@@ -89,7 +68,6 @@
         message: 'Manage',
         context: '\nOperation that can be performed on a channel',
       },
-      deleteChannelAction: 'Delete',
     },
   };
 
@@ -126,6 +104,10 @@
       margin-top: 16px;
       text-align: right;
     }
+  }
+
+  .manage-btn {
+    margin: 0;
   }
 
 </style>


### PR DESCRIPTION
### Summary

fixes https://github.com/learningequality/kolibri/issues/6079 by changing options to just be a 'manage' button. In other words: no export _or_ delete

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70407508-76dd7f00-19f9-11ea-927d-765581bc682f.png)| ![image](https://user-images.githubusercontent.com/2367265/70407499-6d541700-19f9-11ea-9000-93393bb91cfb.png)|


### Reviewer guidance

does this work as expected?

### References

https://github.com/learningequality/kolibri/issues/6079

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
