### PR TITLE
Make json load error handling py2/3 compatible.

### DIFF
--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -50,7 +50,7 @@ class ConfigDict(dict):
                 with open(conf_file, "r") as kolibri_conf_file:
                     self.update(json.load(kolibri_conf_file))
                 return
-            except json.JSONDecodeError:
+            except ValueError:
                 logger.warn(
                     "Attempted to load kolibri_settings.json but encountered a file that could not be decoded as valid JSON."
                 )


### PR DESCRIPTION
### Summary
Switches to `ValueError` from `JSONDecodeError` for python 2 compatibility.

### Reviewer guidance
Should work even if the `plugins.json` file is not valid JSON.

### References
Fixes issue reported by @radinamatic here: https://github.com/learningequality/kolibri/pull/6166#issuecomment-562560219

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
