### PR TITLE
Disable the download button when running in the app on Mac…

### DIFF
--- a/kolibri/core/assets/src/utils/browser.js
+++ b/kolibri/core/assets/src/utils/browser.js
@@ -19,4 +19,22 @@ export function isAndroidWebView() {
   return isAndroid && isWebview;
 }
 
+/**
+ * Detects if we are running inside an embedded web view.
+ */
+export function isEmbeddedWebView() {
+  const ua = window.navigator.userAgent;
+  const isMac = /Macintosh/.test(ua);
+  let isEmbedded = false;
+
+  // Embedded WebViews on Mac have no app identifier, while all the major browsers do, so check
+  // for browser app strings and mark as embedded if none are found.
+  // TODO: Simplify this by updating the embedded browser's user agent to add KolibriApp or similar.
+  if (isMac) {
+    isEmbedded = !(/Safari/.test(ua) || /Chrome/.test(ua) || /Firefox/.test(ua));
+  }
+
+  return isEmbedded || isAndroidWebView();
+}
+
 export const fullscreenApiIsSupported = ScreenFull.enabled && !isAndroidWebView();

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -86,7 +86,7 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
-  import { isAndroidWebView } from 'kolibri.utils.browser';
+  import { isEmbeddedWebView } from 'kolibri.utils.browser';
   import urls from 'kolibri.urls';
   import { FacilityResource } from 'kolibri.resources';
   import { PageNames } from '../../constants';
@@ -118,7 +118,7 @@
       ...mapState(['pageName']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       cannotDownload() {
-        return isAndroidWebView();
+        return isEmbeddedWebView();
       },
       inDataExportPage() {
         return this.pageName === PageNames.DATA_EXPORT_PAGE;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -128,7 +128,7 @@
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
-  import { isAndroidWebView } from 'kolibri.utils.browser';
+  import { isEmbeddedWebView } from 'kolibri.utils.browser';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import markdownIt from 'markdown-it';
   import {
@@ -199,7 +199,7 @@
           return (
             this.downloadableFiles.length &&
             this.content.kind !== ContentNodeKinds.EXERCISE &&
-            !isAndroidWebView()
+            !isEmbeddedWebView()
           );
         }
         return false;


### PR DESCRIPTION
…  as well as Android.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Since it does not make sense to download files that are already on the machine, we are disabling content download from within the app. This implements that change in the Mac app.

(Note that we may want to consider implementing an "Open Content" or similar button in the apps eventually.)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

This can be tested by running the Mac app and checking that the Download Content button does not appear. Since this touches code paths run by Android as well, it would be good if at some point we could have someone check the Android build as well.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
