### PR TITLE
fix up layout for import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -22,6 +22,7 @@
       <div style="text-align: right">
         <KButton
           :text="$tr('importMoreAction')"
+          style="margin: 0;"
           @click="shownModal = 'IMPORT_MORE'"
         />
       </div>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -17,14 +17,14 @@
         @click="handleClickViewNewVersion"
       />
 
+      <ChannelContentsSummary :channel="channel" />
+
       <div style="text-align: right">
         <KButton
           :text="$tr('importMoreAction')"
           @click="shownModal = 'IMPORT_MORE'"
         />
       </div>
-
-      <ChannelContentsSummary :channel="channel" />
 
       <transition mode="out-in">
         <KLinearLoader v-if="!currentNode" :delay="false" />

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
@@ -1,49 +1,29 @@
 <template>
 
   <BottomAppBar>
-    <KGrid
-      class="selection-bottom-bar"
-      :class="{'selection-bottom-bar-sm': windowIsSmall}"
-    >
-      <KGridItem
-        :layout12="{span: 8}"
-        :layout4="{span: 4}"
-        :layout="{alignment: 'right'}"
-        class="message"
-      >
-        <span>{{ selectedMessage }}</span>
-      </KGridItem>
+    <span class="message">{{ selectedMessage }}</span>
+    <template v-if="actionType === 'manage'">
+      <KButton
+        :disabled="$attrs.disabled || buttonsDisabled"
+        :text="coreString('deleteAction')"
+        :primary="false"
+        @click="$emit('selectoption', 'DELETE')"
+      />
+      <KButton
+        :disabled="$attrs.disabled || buttonsDisabled"
+        :text="$tr('exportAction')"
+        :primary="true"
+        @click="$emit('selectoption', 'EXPORT')"
+      />
+    </template>
 
-      <KGridItem
-        :layout12="{span: buttonsGridSpan}"
-        :layout4="{span: 4}"
-        :layout="{alignment: 'right'}"
-        class="buttons"
-      >
-        <template v-if="actionType === 'manage'">
-          <KButton
-            :disabled="$attrs.disabled || buttonsDisabled"
-            :text="coreString('deleteAction')"
-            :primary="false"
-            @click="$emit('selectoption', 'DELETE')"
-          />
-          <KButton
-            :disabled="$attrs.disabled || buttonsDisabled"
-            :text="$tr('exportAction')"
-            :primary="true"
-            @click="$emit('selectoption', 'EXPORT')"
-          />
-        </template>
-
-        <KButton
-          v-else
-          :disabled="$attrs.disabled || buttonsDisabled"
-          :text="confirmButtonLabel"
-          :primary="true"
-          @click="$emit('clickconfirm')"
-        />
-      </KGridItem>
-    </KGrid>
+    <KButton
+      v-else
+      :disabled="$attrs.disabled || buttonsDisabled"
+      :text="confirmButtonLabel"
+      :primary="true"
+      @click="$emit('clickconfirm')"
+    />
   </BottomAppBar>
 
 </template>
@@ -102,9 +82,6 @@
           export: this.$tr('exportAction'),
           delete: this.$tr('deleteAction'),
         }[this.actionType];
-      },
-      buttonsGridSpan() {
-        return this.actionType === 'manage' ? 4 : 2;
       },
       buttonsDisabled() {
         if (this.objectType === 'resource') {
@@ -183,19 +160,8 @@
 <style lang="scss" scoped>
 
   .message {
-    margin: auto;
-  }
-
-  .buttons {
-    .selection-bottom-bar-sm & {
-      margin-right: 0;
-    }
-  }
-
-  .selection-bottom-bar-sm {
-    button:last-of-type {
-      margin-right: 0;
-    }
+    display: inline-block;
+    margin-right: 16px;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -96,6 +96,10 @@
 
 <style lang="scss" scoped>
 
+  .channel-header {
+    margin-top: 16px;
+  }
+
   .thumbnail {
     max-width: 200px;
   }


### PR DESCRIPTION

### Summary

* move 'import more' button closer to content
* simplify bottom bar layout to make it more responsive


| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70554961-fe7ad900-1b32-11ea-8e9b-cd95f7d0e7c1.png) |![image](https://user-images.githubusercontent.com/2367265/70554930-f0c55380-1b32-11ea-8b1b-297aedbe4e30.png)|

### Reviewer guidance

look good?

### References

fixes https://github.com/learningequality/kolibri/issues/6248

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
