### PR TITLE
Verify that database backend isn't loaded when invoking status and stop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,11 @@ matrix:
       sudo: true
       env:
         - TOX_ENV=py3.7
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - TOX_ENV=illegaldbaccess
     - python: "2.7"
       env:
         - TOX_ENV=node10.x

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -86,7 +86,7 @@ base_option_spec = {
     "Database": {
         "DATABASE_ENGINE": {
             "type": "option",
-            "options": ("sqlite", "postgres"),
+            "options": ("sqlite", "postgres", "raise.importerror.if.loaded"),
             "default": "sqlite",
             "envvars": ("KOLIBRI_DATABASE_ENGINE",),
         },

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, pythonblack, frontendlint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, pythonblack, frontendlint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext, illegaldbaccess
 
 [testenv]
 usedevelop = True
@@ -33,6 +33,7 @@ basepython =
     frontendlint: python2.7
     nocext: python2.7
     cext: python2.7
+    illegaldbaccess: python3.7
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt
@@ -64,6 +65,17 @@ commands =
     coverage run -p kolibri stop
     # Run just tests in test/
     py.test --cov=kolibri --cov-report= --cov-append --color=no test/
+
+[testenv:illegaldbaccess]
+setenv =
+    KOLIBRI_DATABASE_ENGINE = raise.importerror.if.loaded
+commands =
+    # Start kolibri
+    coverage run -p kolibri start --port=8081
+    # Fetch status from Kolibri, raising an error in case the command tries to load the database
+    coverage run -p kolibri status
+    # Stop Kolibri, raising an error in case the command tries to load the database
+    coverage run -p kolibri stop
 
 # This briefly tests our static deps etc WITH cexts
 [testenv:cext]


### PR DESCRIPTION
### Summary

CC: @rtibbles @jredrejo @jamalex @ralphiee22 

Let's ensure that `stop` and `status` do not cause the database to be loaded since this can happen during upgrades.

In this PR, I propose that a simple solution could be to inject an invalid setting for the database backend to catch any unnecessary access. It already fails, so we need to investigate how that can be altered -- or if it can't, I can propose different ways to fail upon database access during stop/status commands.

Also of interest: The `manage shell` command is important to be able to access despite database issues.

The risk of accessing the database during stop/status is that a different database schema is loaded or different versions of Python libraries are applied on a SQLite database file used by another process. This could be a reason for the malformed database issues.

### Reviewer guidance

* Do you know if the currently failing database backend loading can be avoided?

### References

#6247 
#6201 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
