### PR TITLE
Fix CSV export score and RTL transcript position

### DIFF
--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -35,7 +35,7 @@ export function avgScore(quiz = false) {
       name: coachStrings.$tr(quiz ? 'avgQuizScoreLabel' : 'avgScoreLabel'),
       key: 'avgScore',
       format(row) {
-        if (!row.avgScore) {
+        if (!row.avgScore && row.avgScore !== 0) {
           return '';
         }
 
@@ -148,7 +148,7 @@ export function score() {
       name: coachStrings.$tr('scoreLabel'),
       key: 'score',
       format: row => {
-        if (!row.statusObj.score) {
+        if (!row.statusObj.score && row.statusObj.score !== 0) {
           return '';
         }
 

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -535,6 +535,11 @@
     /deep/ .fill-space {
       height: auto;
     }
+
+    [dir='rtl'] & {
+      right: auto;
+      left: 0;
+    }
   }
 
   .wrapper:not(.transcript-wrap) .media-player-transcript {

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/TranscriptCue.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/TranscriptCue.vue
@@ -8,7 +8,6 @@
       { active },
       $computedClass(style)
     ]"
-    :dir="dir"
     :title="$tr('title', { startTime })"
     :aria-current="active.toString()"
     @click="triggerSeekEvent"
@@ -38,7 +37,6 @@
 <script>
 
   import videojs from 'video.js';
-  import { getLangDir } from 'kolibri.utils.i18n';
 
   const SPEAKER_REGEX = /<v ([^>]+)>/i;
 
@@ -47,16 +45,12 @@
     props: {
       cue: Object,
       mediaDuration: Number,
-      langCode: String,
       active: {
         type: Boolean,
         default: false,
       },
     },
     computed: {
-      dir() {
-        return getLangDir(this.langCode);
-      },
       speaker() {
         return this.cue.text.match(SPEAKER_REGEX)
           ? this.cue.text.replace(SPEAKER_REGEX, '$1')

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
@@ -1,6 +1,7 @@
 <template>
 
   <aside
+    :dir="languageDir"
     :class="['media-player-transcript', { showing }]"
     :aria-hidden="(!showing).toString()"
     :aria-label="$tr('label')"
@@ -26,7 +27,6 @@
         :key="cue.id"
         :ref="cue.id"
         :cue="cue"
-        :langCode="language"
         :active="activeCueIds.indexOf(cue.id) >= 0"
         :mediaDuration="mediaDuration"
         @seek="handleSeekEvent"
@@ -50,6 +50,7 @@
   import { mapState } from 'vuex';
   import { throttle } from 'frame-throttle';
 
+  import { getLangDir } from 'kolibri.utils.i18n';
   import TranscriptCue from './TranscriptCue';
 
   export default {
@@ -72,6 +73,9 @@
       },
       capStyle() {
         return { color: this.$themeTokens.annotation };
+      },
+      languageDir() {
+        return getLangDir(this.language);
       },
     },
     watch: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixes: https://github.com/learningequality/kolibri/issues/6261
Fixes: https://github.com/learningequality/kolibri/issues/6239
Also, moved language direction to transcript container to ensure transcript is displayed according to the language of the transcript.

Fixed transcript:
![screenshot-localhost_8000-2019 12](https://user-images.githubusercontent.com/819838/70581070-cee7c300-1b6a-11ea-83ee-e0814587d67d.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
