### PR TITLE
Fix modal jittering related to inner content height

### DIFF
--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -188,7 +188,7 @@
       contentSectionMaxHeight() {
         return {
           'max-height': `${this.maxContentHeight}px`,
-          height: `${this.contentHeight}px`,
+          'min-height': `${this.contentHeight}px`,
         };
       },
     },

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -235,7 +235,9 @@
        */
       updateContentSectionStyle: debounce(function() {
         if (this.$refs.title && this.$refs.actions) {
-          this.contentHeight = this.$refs.content.scrollHeight;
+          if (Math.abs(this.$refs.content.scrollHeight - this.contentHeight) >= 8) {
+            this.contentHeight = this.$refs.content.scrollHeight;
+          }
           const maxContentHeightCheck =
             this.windowHeight -
             this.$refs.title.clientHeight -

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -167,6 +167,7 @@
       return {
         lastFocus: null,
         maxContentHeight: '1000',
+        contentHeight: 0,
         scrollShadow: false,
         delayedEnough: false,
       };
@@ -185,7 +186,10 @@
         return 1000;
       },
       contentSectionMaxHeight() {
-        return { 'max-height': `${this.maxContentHeight}px` };
+        return {
+          'max-height': `${this.maxContentHeight}px`,
+          height: `${this.contentHeight}px`,
+        };
       },
     },
     created() {
@@ -231,12 +235,18 @@
        */
       updateContentSectionStyle: debounce(function() {
         if (this.$refs.title && this.$refs.actions) {
-          this.maxContentHeight =
+          this.contentHeight = this.$refs.content.scrollHeight;
+          const maxContentHeightCheck =
             this.windowHeight -
             this.$refs.title.clientHeight -
             this.$refs.actions.clientHeight -
             32;
-          this.scrollShadow = this.maxContentHeight < this.$refs.content.scrollHeight;
+          // to prevent max height from toggling between pixels
+          // we set a threshold of how many pixels the height should change before we update
+          if (Math.abs(maxContentHeightCheck - this.maxContentHeight) >= 8) {
+            this.maxContentHeight = maxContentHeightCheck;
+            this.scrollShadow = this.maxContentHeight < this.$refs.content.scrollHeight;
+          }
         }
       }, 50),
       emitCancelEvent() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

There is some behavior where the `maxContentHeight` keeps getting recalculated and keeps changing by `1px`, which causes the modal to jitter at certain dimensions. We resolve by putting a threshold of how much it can change (`8px`) before updating the `maxContentHeight`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Zoom in and out of the page, expand and contract the window to get modal to shake. Recommended modal is the privacy modal.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Resolves https://github.com/learningequality/kolibri/issues/4641.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
