### PR TITLE
Ensure startup/provision/shutdown don't leave zombie Kolibris behind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,11 @@ matrix:
         - TOX_ENV=cext
       script:
        - tox -e $TOX_ENV
+    - python: "3.7"
+      env:
+        - TOX_ENV=startup_provision_shutdown_without_zombies
+      script:
+       - tox -e $TOX_ENV
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
         - TOX_ENV=cext
       script:
        - tox -e $TOX_ENV
-    - python: "3.7"
+    - python: "3.6"
       env:
         - TOX_ENV=startup_provision_shutdown_without_zombies
       script:

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -1,0 +1,52 @@
+import logging
+from sys import exit
+from time import sleep
+from time import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+url = "http://localhost:8081/api/device/deviceprovision/"
+data = {
+    "language_id": "en",
+    "facility": {"name": "Atkinson Hall"},
+    "preset": "nonformal",
+    "settings": {
+        "allow_guest_access": True,
+        "learner_can_sign_up": True,
+        "learner_can_edit_name": True,
+        "learner_can_edit_username": True,
+        "learner_can_login_with_no_password": True,
+    },
+    "superuser": {
+        "full_name": "Billy",
+        "username": "Joel",
+        "password": "123",
+        "gender": "NOT_SPECIFIED",
+        "birth_year": "NOT_SPECIFIED",
+    },
+}
+
+num_tries = 0
+status_code = None
+timeout = 30  # wait for kolibri to start
+
+now = time()
+
+print("mock provisioning...")
+while time() < now + timeout and status_code != 201:
+    num_tries += 1
+    sleep(1)
+    try:
+        response = requests.post(url, json=data)
+        status_code = response.status_code
+    except requests.exceptions.RequestException:
+        pass
+
+if status_code == 201:
+    print("success!")
+    exit(0)
+else:
+    print("failed with status %i" % status_code)
+    exit(1)

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -28,15 +28,12 @@ data = {
     },
 }
 
-num_tries = 0
 status_code = None
 timeout = 30  # wait for kolibri to start
-
 now = time()
 
 print("mock provisioning...")
 while time() < now + timeout and status_code != 201:
-    num_tries += 1
     sleep(1)
     try:
         response = requests.post(url, json=data)

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -12,8 +12,8 @@ data = {
     "language_id": "en",
     "facility": {"name": "Atkinson Hall"},
     "preset": "nonformal",
+    "allow_guest_access": True,
     "settings": {
-        "allow_guest_access": True,
         "learner_can_sign_up": True,
         "learner_can_edit_name": True,
         "learner_can_edit_username": True,

--- a/test/ensure_no_kolibris_running_on_port.sh
+++ b/test/ensure_no_kolibris_running_on_port.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Checking for processes running on $1/tcp..."
+running_kolibris=`lsof -i -P -U | grep $1 | grep kolibri`
+echo $running_kolibris
+
+if [ `lsof -i -P -U | grep $1 | grep kolibri | grep -c '^'` -gt "0" ]; then
+    # looks like kolibri is running!
+    exit 1
+else
+    exit 0
+fi

--- a/test/ensure_no_kolibris_running_on_port.sh
+++ b/test/ensure_no_kolibris_running_on_port.sh
@@ -4,7 +4,7 @@ echo "Checking for processes running on $1/tcp..."
 running_kolibris=`lsof -i -P -U | grep $1 | grep kolibri`
 echo $running_kolibris
 
-if [ `lsof -i -P -U | grep $1 | grep kolibri | grep -c '^'` -gt "0" ]; then
+if [ `lsof -i -P -U | grep $1 | grep kolibri | grep LISTEN | grep -c '^'` -gt "0" ]; then
     # looks like kolibri is running!
     exit 1
 else

--- a/tox.ini
+++ b/tox.ini
@@ -90,17 +90,16 @@ commands =
 
 [testenv:startup_provision_shutdown_without_zombies]
 passenv = TOX_ENV
-whitelist_externals = fuser
-setenv =
-     PYTHONPATH = "{toxinidir}:{toxinidir}/kolibri/dist"
-     KOLIBRI_HOME = {envtmpdir}/.kolibri_test_startup_process
+whitelist_externals =
+    fuser
+    sleep
 deps =
     -r{toxinidir}/requirements/test.txt
-    -r{toxinidir}/requirements/build.txt
+    -r{toxinidir}/requirements/base.txt
 commands =
-    {[python_build_base]commands}
     - fuser 8081/tcp -k
     kolibri start --port=8081
+    sleep 5
     python test/do_mock_provisioning.py
     kolibri stop
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ basepython =
     frontendlint: python2.7
     nocext: python2.7
     cext: python2.7
-    startup_provision_shutdown_without_zombies: python3.7
+    startup_provision_shutdown_without_zombies: python3.6
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -61,13 +61,9 @@ commands =
     make staticdeps
     # Start and stop kolibri
     coverage run -p kolibri start --port=8081
-
-    lsof -i -P | grep 8081
-
-
-    ; coverage run -p kolibri stop
+    coverage run -p kolibri stop
     # Run just tests in test/
-    ; py.test --cov=kolibri --cov-report= --cov-append --color=no test/
+    py.test --cov=kolibri --cov-report= --cov-append --color=no test/
 
 # This briefly tests our static deps etc WITH cexts
 [testenv:cext]

--- a/tox.ini
+++ b/tox.ini
@@ -61,9 +61,13 @@ commands =
     make staticdeps
     # Start and stop kolibri
     coverage run -p kolibri start --port=8081
-    coverage run -p kolibri stop
+
+    lsof -i -P | grep 8081
+
+
+    ; coverage run -p kolibri stop
     # Run just tests in test/
-    py.test --cov=kolibri --cov-report= --cov-append --color=no test/
+    ; py.test --cov=kolibri --cov-report= --cov-append --color=no test/
 
 # This briefly tests our static deps etc WITH cexts
 [testenv:cext]
@@ -86,6 +90,27 @@ commands =
     coverage run -p kolibri stop
     # Run just tests in test/
     py.test --cov=kolibri --cov-report= --cov-append --color=no test/
+
+[testenv:startup_provision_shutdown_without_zombies]
+passenv = TOX_ENV
+whitelist_externals = fuser
+setenv =
+     PYTHONPATH = "{toxinidir}:{toxinidir}/kolibri/dist"
+     KOLIBRI_HOME = {envtmpdir}/.kolibri_test_startup_process
+basepython =
+    startup_process: python3.7
+deps =
+    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/build.txt
+commands =
+    {[python_build_base]commands}
+    - fuser 8081/tcp -k
+    kolibri start --port=8081
+    python test/do_mock_provisioning.py
+    kolibri stop
+
+    {toxinidir}/test/ensure_no_kolibris_running_on_port.sh 8081
+
 
 [testenv:postgres]
 passenv = TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ basepython =
     frontendlint: python2.7
     nocext: python2.7
     cext: python2.7
+    startup_provision_shutdown_without_zombies: python3.7
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt
@@ -93,8 +94,6 @@ whitelist_externals = fuser
 setenv =
      PYTHONPATH = "{toxinidir}:{toxinidir}/kolibri/dist"
      KOLIBRI_HOME = {envtmpdir}/.kolibri_test_startup_process
-basepython =
-    startup_process: python3.7
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/build.txt


### PR DESCRIPTION
### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Currently, doing a startup, provision and shutdown of Kolibri 0.13 leaves z0mb13 kolibri processes in its wake... yikes!

This PR is just a failing regression test for now, and is intended as a base for fixing the issue!
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
