### PR TITLE
Make objects that access the database lazy to prevent DB access only during import

### DIFF
--- a/kolibri/utils/tests/test_cli_at_import.py
+++ b/kolibri/utils/tests/test_cli_at_import.py
@@ -1,5 +1,8 @@
 """
 Tests for `kolibri.utils.cli` module.
+These tests deliberately omit `@pytest.mark.django_db` from the tests,
+so that any attempt to access the Django database during the running
+of these cli methods will result in an error and test failure.
 """
 from __future__ import absolute_import
 from __future__ import print_function

--- a/kolibri/utils/tests/test_cli_at_import.py
+++ b/kolibri/utils/tests/test_cli_at_import.py
@@ -1,0 +1,35 @@
+"""
+Tests for `kolibri.utils.cli` module.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+from mock import patch
+
+
+@patch("sqlalchemy.create_engine")
+def test_status_no_db_access(create_engine_mock):
+    """
+    Tests that status does not try to access the database
+    """
+    try:
+        from kolibri.utils import cli
+
+        cli.status.callback()
+    except SystemExit:
+        pass
+    create_engine_mock.assert_not_called()
+
+
+@patch("sqlalchemy.create_engine")
+def test_stop_no_db_access(create_engine_mock):
+    """
+    Tests that status does not try to access the database
+    """
+    try:
+        from kolibri.utils import cli
+
+        cli.stop.callback()
+    except SystemExit:
+        pass
+    create_engine_mock.assert_not_called()


### PR DESCRIPTION
### Summary
Drawing inspiration from #6273 adds two tests to verify that neither the Django DB backend or the SQLAlchemy backends are accessing the database during the status and stop commands

Makes queue and scheduler object instantiation lazy to prevent inadvertent DB access.

### Reviewer guidance
Code make sense?

Note that I did not have to make any modifications to prevent access to the Django default DB.

### References
Supersedes #6273

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
