### PR TITLE
Turn services handling into a cherrypy plugin to prevent zombie processes

### DIFF
--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -20,9 +20,6 @@ from kolibri.core.tasks.utils import InfiniteLoopThread
 Base = declarative_base()
 
 
-DEFAULT_INTERVAL = 60
-
-
 class ScheduledJob(Base):
     """
     The DB representation of a scheduled job,
@@ -52,7 +49,7 @@ class ScheduledJob(Base):
 
 
 class Scheduler(StorageMixin):
-    def __init__(self, queue=None, connection=None, interval=DEFAULT_INTERVAL):
+    def __init__(self, queue=None, connection=None):
         if connection is None and not isinstance(queue, Queue):
             raise ValueError("One of either connection or queue must be specified")
         elif isinstance(queue, Queue):
@@ -61,8 +58,6 @@ class Scheduler(StorageMixin):
                 connection = self.queue.storage.engine
         elif connection:
             self.queue = queue(connection=connection)
-
-        self.interval = interval
 
         self._schedule_checker = None
 
@@ -102,9 +97,7 @@ class Scheduler(StorageMixin):
         Returns: the Thread object.
         """
         t = InfiniteLoopThread(
-            self.check_schedule,
-            thread_name="SCHEDULECHECKER",
-            wait_between_runs=self.interval,
+            self.check_schedule, thread_name="SCHEDULECHECKER", wait_between_runs=0.5,
         )
         t.start()
         return t

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -445,7 +445,7 @@ def start(port, background):
     if sys.platform == "darwin":
         background = False
 
-    run_cherrypy = OPTIONS["Server"]["CHERRYPY_START"]
+    serve_http = OPTIONS["Server"]["CHERRYPY_START"]
 
     if not background:
         logger.info("Running Kolibri")
@@ -453,7 +453,7 @@ def start(port, background):
     else:
         logger.info("Running Kolibri as background process")
 
-    if run_cherrypy:
+    if serve_http:
         # Check if the port is occupied
         check_other_kolibri_running(port)
 
@@ -491,7 +491,7 @@ def start(port, background):
 
         become_daemon(**kwargs)
 
-    server.start(port=port, run_cherrypy=run_cherrypy)
+    server.start(port=port, serve_http=serve_http)
 
 
 @main.command(cls=KolibriCommand, help="Stop the Kolibri process")
@@ -616,7 +616,7 @@ def services(port, background):
 
         become_daemon(**kwargs)
 
-    server.services(port=port)
+    server.start(port=port, serve_http=False)
 
 
 def setup_logging(debug=False):


### PR DESCRIPTION
### Summary
* Turns services management into a cherrypy plugin
* Consolidate all services management under cherrypy

### Reviewer guidance
Does it prevent zombies?

### References
Hopefully fixes behaviour that has been surfaced with some consistency in #6279

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
