### PR TITLE
i18n-update properly converts downloaded CSV to JSON

### DIFF
--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -311,7 +311,7 @@ def _csv_to_json():
             if "csv" not in file_name:
                 continue
 
-            if file_name is PERSEUS_CSV:
+            if file_name == PERSEUS_CSV:
                 csv_path = os.path.join(perseus_locale_dir_path, file_name)
             else:
                 csv_path = os.path.join(csv_locale_dir_path, file_name)
@@ -333,7 +333,8 @@ def _csv_to_json():
 
             data = _locale_data_from_csv(csv_data)
 
-            if file_name is PERSEUS_CSV:
+            if file_name == PERSEUS_CSV:
+                print(perseus_path)
                 utils.json_dump_formatted(
                     data, perseus_path, file_name.replace("csv", "json")
                 )

--- a/build_tools/i18n/crowdin.py
+++ b/build_tools/i18n/crowdin.py
@@ -334,7 +334,6 @@ def _csv_to_json():
             data = _locale_data_from_csv(csv_data)
 
             if file_name == PERSEUS_CSV:
-                print(perseus_path)
                 utils.json_dump_formatted(
                     data, perseus_path, file_name.replace("csv", "json")
                 )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Lesson learned. In Python `is` != `==`.

`is` compares both operands to see if they refer to the same object.
`==` compares both operands for equality.

At this part in a previous PR: https://github.com/learningequality/kolibri/pull/6052#discussion_r346313985

I meant to write `is` - but I wrote `in` so it was a quick change (like "oops! that's what I meant").

It worked with `in` because "string" is indeed __in__ "string" so that returned `True` when it ought to but `is` broke it.

Anyway - this just changes it to `==` and I've learned something very interesting.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Prepare your perseus repo
- `make i18n-update branch=release-v0.13.x`
- Check that all of the JSON files for every language are in the Persues repo's locale directory.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6109

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
