### PR TITLE
closing db connections after the info is retrieved

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,7 +1,7 @@
 import socket
 
 import mock
-from django.test import TestCase
+from django.test import TransactionTestCase
 from zeroconf import BadTypeInNameException
 from zeroconf import service_type_name
 from zeroconf import ServiceInfo
@@ -106,7 +106,7 @@ class MockZeroconf(Zeroconf):
     lambda: [MOCK_INTERFACE_IP],
 )
 @mock.patch("django.db.models.Manager.update_or_create")
-class TestNetworkSearch(TestCase):
+class TestNetworkSearch(TransactionTestCase):
     def test_initialize_zeroconf_listener(self, *mocks):
         assert ZEROCONF_STATE["listener"] is None
         initialize_zeroconf_listener()

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -98,6 +98,10 @@ class MockZeroconf(Zeroconf):
 
 
 @mock.patch(
+    "kolibri.core.discovery.utils.network.search.get_device_info",
+    return_value={"instance_id": MOCK_ID},
+)
+@mock.patch(
     "kolibri.core.discovery.utils.network.search._is_port_open", lambda *a, **kw: True
 )
 @mock.patch("kolibri.core.discovery.utils.network.search.Zeroconf", MockZeroconf)
@@ -112,10 +116,10 @@ class TestNetworkSearch(TransactionTestCase):
         initialize_zeroconf_listener()
         assert ZEROCONF_STATE["listener"] is not None
 
-    def test_register_zeroconf_service(self, mock_db):
+    def test_register_zeroconf_service(self, mock_db, get_device_mock):
         assert len(get_peer_instances()) == 0
         initialize_zeroconf_listener()
-        register_zeroconf_service(MOCK_PORT, {"instance_id": MOCK_ID})
+        register_zeroconf_service(MOCK_PORT)
         assert [x for x in get_peer_instances()] == [
             {
                 "id": MOCK_ID,
@@ -135,7 +139,7 @@ class TestNetworkSearch(TransactionTestCase):
                 ),
             }
         ]
-        register_zeroconf_service(MOCK_PORT, {"instance_id": MOCK_ID})
+        register_zeroconf_service(MOCK_PORT)
         unregister_zeroconf_service()
         assert len(get_peer_instances()) == 0
 

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -154,6 +154,8 @@ class KolibriZeroconfListener(object):
                     )
                     % (id, self.instances[id], traceback.format_exc(limit=1)),
                 )
+            finally:
+                connection.close()
 
     def remove_service(self, zeroconf, type, name):
         id = _id_from_name(name)
@@ -166,6 +168,7 @@ class KolibriZeroconfListener(object):
             pass
 
         DynamicNetworkLocation.objects.filter(pk=id).delete()
+        connection.close()
 
 
 def cleanup_database():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -5,6 +5,7 @@ import socket
 from contextlib import closing
 
 from django.core.exceptions import ValidationError
+from django.db import connection
 from zeroconf import get_all_addresses
 from zeroconf import NonUniqueNameException
 from zeroconf import ServiceInfo
@@ -169,6 +170,7 @@ class KolibriZeroconfListener(object):
 
 def cleanup_database():
     DynamicNetworkLocation.objects.all().delete()
+    connection.close()
 
 
 def register_zeroconf_service(port, device_info):

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -13,6 +13,7 @@ from zeroconf import USE_IP_OF_OUTGOING_INTERFACE
 from zeroconf import Zeroconf
 
 from kolibri.core.discovery.models import DynamicNetworkLocation
+from kolibri.core.public.utils import get_device_info
 
 logger = logging.getLogger(__name__)
 
@@ -171,13 +172,10 @@ class KolibriZeroconfListener(object):
         connection.close()
 
 
-def cleanup_database():
+def register_zeroconf_service(port):
+    device_info = get_device_info()
     DynamicNetworkLocation.objects.all().delete()
     connection.close()
-
-
-def register_zeroconf_service(port, device_info):
-    cleanup_database()
 
     id = device_info.get("instance_id")
 

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -5,7 +5,7 @@ import factory
 from django.core.urlresolvers import reverse
 from le_utils.constants import content_kinds
 from morango.models import InstanceIDModel
-from rest_framework.test import APITestCase
+from rest_framework.test import APITransactionTestCase
 from six import iteritems
 
 import kolibri
@@ -78,7 +78,7 @@ def create_mini_channel(
     )
 
 
-class PublicAPITestCase(APITestCase):
+class PublicAPITestCase(APITransactionTestCase):
     """
     IMPORTANT: These tests are to never be changed. They are enforcing a
     public API contract. If the tests fail, then the implementation needs

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -1,6 +1,5 @@
 import platform
 
-from django.db import connection
 from morango.models import InstanceIDModel
 
 import kolibri
@@ -18,5 +17,4 @@ def get_device_info():
         "device_name": instance_model.hostname,
         "operating_system": platform.system(),
     }
-    connection.close()
     return info

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -1,5 +1,6 @@
 import platform
 
+from django.db import connection
 from morango.models import InstanceIDModel
 
 import kolibri
@@ -17,5 +18,5 @@ def get_device_info():
         "device_name": instance_model.hostname,
         "operating_system": platform.system(),
     }
-
+    connection.close()
     return info

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -2,6 +2,8 @@ import copy
 import logging
 import uuid
 
+from django.db import connection
+
 from kolibri.core.tasks.utils import current_state_tracker
 from kolibri.core.tasks.utils import import_stringified_func
 from kolibri.core.tasks.utils import stringify_func
@@ -180,6 +182,9 @@ class Job(object):
                 raise e
 
             setattr(current_state_tracker, "job", None)
+
+            # Close any django connections opened here
+            connection.close()
 
             return result
 

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.urls.exceptions import NoReverseMatch
 from mock import patch
 from rest_framework.test import APITestCase
+from rest_framework.test import APITransactionTestCase
 
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.test.helpers import create_superuser
@@ -47,7 +48,7 @@ class KolibriTagNavigationTestCase(APITestCase):
         )
 
 
-class AllUrlsTest(APITestCase):
+class AllUrlsTest(APITransactionTestCase):
 
     # Allow codes that may indicate a poorly formed response
     # 412 is returned from endpoints that have required GET params when these are not supplied

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -99,15 +99,11 @@ class ServicesPlugin(SimplePlugin):
         scheduler.start_scheduler()
 
         # Register the Kolibri zeroconf service so it will be discoverable on the network
-        from kolibri.core.public.utils import get_device_info
-
-        device_info = get_device_info()
-
         from kolibri.core.discovery.utils.network.search import (
             register_zeroconf_service,
         )
 
-        register_zeroconf_service(port=self.port, device_info=device_info)
+        register_zeroconf_service(port=self.port)
 
     def stop(self):
         if self.workers is not None:


### PR DESCRIPTION
### Summary
Ensure to close the db connections when they are needed to avoid locks that can keep process stalled


### Reviewer guidance
are there any zombies around?


### References
Hopefully it will close #6245 


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
