### PR TITLE
peer discovery: UI cleanup

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -219,7 +219,6 @@
             this.resetSelectedAddress();
             this.stage = this.Stages.FETCHING_SUCCESSFUL;
             this.savedAddressesInitiallyFetched = true;
-            this.saved = true;
           })
           .catch(() => {
             this.stage = this.Stages.FETCHING_FAILED;

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/__test__/SelectAddressForm.spec.js
@@ -57,15 +57,6 @@ describe('SelectAddressForm', () => {
     fetchDynamicAddresses.mockResolvedValue(addresses);
   });
 
-  it('shows a loading message when fetching addresses', () => {
-    // and continue button and new address buttons are disabled
-    const { els } = makeWrapper();
-    expect(els.KModal().props().submitDisabled).toEqual(true);
-    expect(els.newAddressButton().isVisible()).toEqual(false);
-    expect(els.uiAlert().exists()).toEqual(true);
-    expect(els.uiAlert().text()).toEqual('Looking for available addresses…');
-  });
-
   it('shows one address for each one fetched', async () => {
     const { els, wrapper } = makeWrapper();
     await wrapper.vm.$nextTick();


### PR DESCRIPTION
### Summary
Fixes three peer importing UI issues:
- makes the "Searching" spinner fade in and out smoothly
- ensures that the `KModal` fade transition isn't blocked
- prevents the "no devices yet" message from showing abruptly before initial network location fetching has even completed.


### Reviewer guidance
Try the peer importing dialog and make sure everything looks smooth!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [-] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
