### PR TITLE
Fix learner sign-in redirect and landing when set to Learn page

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -69,6 +69,7 @@ from .permissions.general import IsSelf
 from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
 from kolibri.core.auth.constants.morango_scope_definitions import FULL_FACILITY
 from kolibri.core.auth.constants.morango_scope_definitions import SINGLE_USER
+from kolibri.core.device.utils import allow_learner_unassigned_resource_access
 from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import set_device_settings
@@ -492,7 +493,7 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
 
     @property
     def can_access_unassigned_content(self):
-        return get_device_setting("allow_learner_unassigned_resource_access", True)
+        return allow_learner_unassigned_resource_access()
 
 
 class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -44,6 +44,13 @@ def allow_guest_access():
     return is_landing_page(LANDING_PAGE_LEARN)
 
 
+def allow_learner_unassigned_resource_access():
+    if get_device_setting("allow_learner_unassigned_resource_access", True):
+        return True
+
+    return is_landing_page(LANDING_PAGE_LEARN)
+
+
 def allow_peer_unlisted_channel_import():
     return get_device_setting("allow_peer_unlisted_channel_import", False)
 

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -17,8 +17,8 @@ from __future__ import unicode_literals
 from abc import abstractproperty
 
 from kolibri.core.webpack.hooks import WebpackBundleHook
-from kolibri.core.webpack.hooks import WebpackInclusionSyncMixin
 from kolibri.core.webpack.hooks import WebpackInclusionASyncMixin
+from kolibri.core.webpack.hooks import WebpackInclusionSyncMixin
 from kolibri.plugins.hooks import define_hook
 from kolibri.plugins.hooks import KolibriHook
 from kolibri.plugins.utils import plugin_url
@@ -35,7 +35,7 @@ class NavigationHook(WebpackBundleHook):
 class RoleBasedRedirectHook(KolibriHook):
     # User role to redirect for
     @abstractproperty
-    def role(self):
+    def roles(self):
         pass
 
     # URL to redirect to

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -88,7 +88,7 @@ def logout_view(request):
 
 def get_urls_by_role(role):
     for hook in RoleBasedRedirectHook.registered_hooks:
-        if hook.role == role:
+        if role in hook.roles:
             yield hook.url
 
 
@@ -97,7 +97,7 @@ def get_url_by_role(role, first_login):
         (
             hook
             for hook in RoleBasedRedirectHook.registered_hooks
-            if hook.role == role and hook.first_login == first_login
+            if role in hook.roles and hook.first_login == first_login
         ),
         None,
     )
@@ -109,7 +109,7 @@ def get_url_by_role(role, first_login):
             (
                 hook
                 for hook in RoleBasedRedirectHook.registered_hooks
-                if hook.role == role and hook.first_login is False
+                if role in hook.roles and hook.first_login is False
             ),
             None,
         )

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -17,7 +17,7 @@ class Coach(KolibriPluginBase):
 
 @register_hook
 class CoachRedirect(RoleBasedRedirectHook):
-    role = COACH
+    roles = (COACH,)
 
     @property
     def url(self):

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -22,7 +22,7 @@ class DeviceManagementAsset(WebpackBundleHook):
 
 @register_hook
 class DeviceFirstTimeRedirect(RoleBasedRedirectHook):
-    role = SUPERUSER
+    roles = (SUPERUSER,)
     first_login = True
 
     @property

--- a/kolibri/plugins/facility/kolibri_plugin.py
+++ b/kolibri/plugins/facility/kolibri_plugin.py
@@ -21,7 +21,7 @@ class FacilityManagementAsset(WebpackBundleHook):
 
 @register_hook
 class FacilityRedirect(RoleBasedRedirectHook):
-    role = ADMIN
+    roles = (ADMIN,)
 
     @property
     def url(self):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -24,11 +24,11 @@ class Learn(KolibriPluginBase):
 @register_hook
 class LearnRedirect(RoleBasedRedirectHook):
     @property
-    def role(self):
+    def roles(self):
         if is_landing_page(LANDING_PAGE_LEARN):
-            return ANONYMOUS
+            return (ANONYMOUS, LEARNER)
 
-        return LEARNER
+        return (LEARNER,)
 
     @property
     def url(self):

--- a/kolibri/plugins/user/kolibri_plugin.py
+++ b/kolibri/plugins/user/kolibri_plugin.py
@@ -29,11 +29,11 @@ class UserAsset(webpack_hooks.WebpackBundleHook):
 @register_hook
 class LogInRedirect(RoleBasedRedirectHook):
     @property
-    def role(self):
+    def roles(self):
         if is_landing_page(LANDING_PAGE_LEARN):
-            return None
+            return (None,)
 
-        return ANONYMOUS
+        return (ANONYMOUS,)
 
     @property
     def url(self):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixes a couple bugs from bug bash when the landing page setting is set to Learn:
- When signing in as a Learner (but not as other roles), you were presented with a 404
- When the setting to restrict learner access to only assigned resources was enabled prior to setting the landing page to Learn, the Landing page was the Classes page and no resources were accessible. The landing page setting should take precedence over that setting.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Be sure to use a clean incognito window, and to sign in with a learner account.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://www.notion.so/learningequality/0896d9162a524683861091a48e9d4467?v=c298338a1ebf4b11b2cbaab5b34f84ba

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
