### PR TITLE
use page container in setup wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -22,13 +22,16 @@
         @backButtonClicked="goToPreviousStep"
       />
 
-      <component
-        :is="currentOnboardingForm"
-        :submitText="submitText"
-        class="body"
-        :class="!windowIsLarge ? 'mobile' : ''"
-        @submit="continueOnboarding"
-      />
+      <div class="page-wrapper">
+        <KPageContainer class="page-container">
+          <component
+            :is="currentOnboardingForm"
+            :submitText="submitText"
+            :class="!windowIsLarge ? 'mobile' : ''"
+            @submit="continueOnboarding"
+          />
+        </KPageContainer>
+      </div>
     </template>
 
   </div>
@@ -167,6 +170,16 @@
     margin-right: auto;
     margin-bottom: 32px;
     margin-left: auto;
+  }
+
+  .page-wrapper {
+    padding: 8px;
+  }
+
+  .page-container {
+    max-width: 650px;
+    padding: 36px;
+    margin: auto;
   }
 
   .mobile {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -1,7 +1,6 @@
 <template>
 
   <OnboardingForm
-    class="credentials-form"
     :header="$tr('adminAccountCreationHeader')"
     :description="$tr('adminAccountCreationDescription')"
     :submitText="submitText"
@@ -143,13 +142,9 @@
 
 <style lang="scss" scoped>
 
-  // Need to make this form narrower to fit Keen-UI components
-  .credentials-form {
-    width: 400px !important;
-  }
-
   .reminder {
     display: table;
+    max-width: 480px;
 
     .icon {
       display: table-cell;


### PR DESCRIPTION

### Summary

adds `KPageContainer` to setup wizard

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70820541-c7543400-1d8d-11ea-93cb-0cef386e55e3.png) | ![image](https://user-images.githubusercontent.com/2367265/70820520-b86d8180-1d8d-11ea-822c-e759db769032.png) |


### Reviewer guidance

any regression?

### References

no explicit issue to fix

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
