### PR TITLE
Don't try to run upgrades on a non-existent plugin.

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -293,6 +293,13 @@ class PluginUpdateManager(object):
 
         app_configs = []
         plugin_instance = registered_plugins.get(plugin_name)
+        if plugin_instance is None:
+            logger.error(
+                "Tried to run upgrades for plugin {} but it doesn't exist".format(
+                    plugin_name
+                )
+            )
+            return
         for app in plugin_instance.INSTALLED_APPS:
             if not isinstance(app, AppConfig) and isinstance(app, str):
                 app = apps.get_containing_app_config(app)


### PR DESCRIPTION
### Summary
* Catch edge case in plugin upgrade

### Reviewer guidance
This is a little hard to test, but if you have enabled a plugin that doesn't exist on this branch, then this might get triggered.
This is a low risk change and catches an edge case.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
