### PR TITLE
Fixes for issues in 0.13 beta5

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -704,7 +704,7 @@ def _remoteimport(
         job.save_meta()
 
     # Skip importcontent step if updating and no nodes have changed
-    if is_updating and node_ids and len(node_ids) == 0:
+    if is_updating and (node_ids is not None) and len(node_ids) == 0:
         pass
     else:
         call_command(
@@ -748,7 +748,7 @@ def _diskimport(
         job.save_meta()
 
     # Skip importcontent step if updating and no nodes have changed
-    if is_updating and node_ids and len(node_ids) == 0:
+    if is_updating and (node_ids is not None) and len(node_ids) == 0:
         pass
     else:
         call_command(

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -48,7 +48,7 @@ export default {
     },
     channelIsInstalled(state) {
       return function findChannel(channelId) {
-        return find(state.channelList, { id: channelId });
+        return find(state.channelList, { id: channelId, available: true });
       };
     },
     channelIsBeingDeleted(state) {

--- a/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
@@ -13,10 +13,10 @@ import { getRemoteChannelByToken } from '../utils';
  */
 export function getAllRemoteChannels(store, publicChannels) {
   const { channelList } = store.rootState.manageContent;
-  const installedPrivateChannels = differenceBy(channelList, publicChannels, 'id').filter(
+  const installedUnlistedChannels = differenceBy(channelList, publicChannels, 'id').filter(
     channel => channel.available
   );
-  const promises = installedPrivateChannels.map(installedChannel =>
+  const promises = installedUnlistedChannels.map(installedChannel =>
     getRemoteChannelByToken(installedChannel.id)
       .then(([channel]) =>
         Promise.resolve({
@@ -48,6 +48,6 @@ export function getAllDriveChannels(store, drive) {
   });
 }
 
-export function fetchPrivateChannelInfo(store, channelId) {
+export function fetchUnlistedChannelInfo(store, channelId) {
   return getRemoteChannelByToken(channelId).then(channels => Array(channels));
 }

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -19,7 +19,7 @@
         />
       </template>
 
-      <template v-if="isPrivateChannel" v-slot:belowname>
+      <template v-if="isUnlistedChannel" v-slot:belowname>
         <KTooltip reference="lockicon" :refs="$refs" placement="top">
           {{ $tr('unlistedChannelTooltip') }}
         </KTooltip>
@@ -29,7 +29,7 @@
             class="lock-icon"
             icon="unlistedchannel"
           /><span
-            v-if="channel.newPrivateChannel"
+            v-if="channel.newUnlistedChannel"
             class="new-label"
             :style="{
               color: $themeTokens.textInverted,
@@ -124,7 +124,7 @@
           return this.$tr('channelSelectedNoFileSize');
         }
       },
-      isPrivateChannel() {
+      isUnlistedChannel() {
         // This is only defined when entering a remote import workflow,
         // so false !== undefined.
         return this.channel.public === false;

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -121,7 +121,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { taskIsClearable } from '../../constants';
+  import { taskIsClearable, TaskStatuses } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
 
   export default {
@@ -261,7 +261,16 @@
           ...sourceParams,
         }).then(task => {
           if (taskIsClearable(task)) {
-            this.readAndDeleteTask(task);
+            // If the task actually just failed, re-start the task
+            if (task.status === TaskStatuses.FAILED) {
+              this.startDiffStatsTask({
+                baseurl: task.baseurl,
+                driveId: task.drive_id,
+              });
+              TaskResource.deleteFinishedTask(task.id);
+            } else {
+              this.readAndDeleteTask(task);
+            }
           } else {
             this.watchedTaskId = task.id;
           }

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectDriveModal.vue
@@ -131,7 +131,9 @@
         })
         .then(() => {
           this.driveStatus = '';
-          this.selectedDriveId = this.enabledDrives.length === 1 ? this.enabledDrives[0].id : '';
+          if (this.enabledDrives.length > 0) {
+            this.selectedDriveId = this.enabledDrives[0].id;
+          }
         });
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -182,6 +182,14 @@
           file_size,
           total_resources,
         } = this.task;
+        // Special case for canceled exports
+        if (
+          (this.task.type === TaskTypes.DISKEXPORT ||
+            this.task.type === TaskTypes.DISKCONTENTEXPORT) &&
+          this.task.status === TaskStatuses.CANCELED
+        ) {
+          return '';
+        }
         if (file_size && total_resources) {
           const trPrefix = typeToTrPrefixMap[this.task.type];
           if (

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/TaskPanel.spec.js
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/TaskPanel.spec.js
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+import TaskPanel from '../TaskPanel';
+
+function makeWrapper(propsData) {
+  const wrapper = mount(TaskPanel, { propsData });
+  return { wrapper };
+}
+
+describe('TaskPanel', () => {
+  const exportTask = {
+    type: 'DISKCONTENTEXPORT',
+    status: 'CANCELED',
+    channel_name: 'Canceled disk export channel test',
+    started_by_username: 'Tester',
+    file_size: 5000,
+    total_resources: 500,
+  };
+
+  it('renders correctly when it is a canceled DISKCONTENTEXPORT task', () => {
+    const { wrapper } = makeWrapper({ task: exportTask });
+    // File size/resource numbers should not be shown for canceled exports
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly when it is a canceled DISKEXPORT task (bulk export)', () => {
+    const { wrapper } = makeWrapper({ task: { ...exportTask, type: 'DISKEXPORT' } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TaskPanel renders correctly when it is a canceled DISKCONTENTEXPORT task 1`] = `
+<div class="task-panel">
+  <div class="icon">
+    <mat-svg name="error" category="alert" style="fill: #d32f2f;" mode="out-in"></mat-svg>
+  </div>
+  <div class="details">
+    <p class="details-status" style="color: rgb(97, 97, 97);">
+      Canceled
+    </p>
+    <h2 class="details-description">
+      Export resources from 'Canceled disk export channel test'
+    </h2>
+    <!---->
+    <!---->
+    <p class="details-startedby" style="color: rgb(97, 97, 97);">
+      Started by 'Tester'
+    </p>
+  </div>
+  <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_37nh0f"><span>Clear</span>
+      <!----></button></div>
+</div>
+`;
+
+exports[`TaskPanel renders correctly when it is a canceled DISKEXPORT task (bulk export) 1`] = `
+<div class="task-panel">
+  <div class="icon">
+    <mat-svg name="error" category="alert" style="fill: #d32f2f;" mode="out-in"></mat-svg>
+  </div>
+  <div class="details">
+    <p class="details-status" style="color: rgb(97, 97, 97);">
+      Canceled
+    </p>
+    <h2 class="details-description">
+      Export 'Canceled disk export channel test'
+    </h2>
+    <!---->
+    <!---->
+    <p class="details-startedby" style="color: rgb(97, 97, 97);">
+      Started by 'Tester'
+    </p>
+  </div>
+  <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_37nh0f"><span>Clear</span>
+      <!----></button></div>
+</div>
+`;

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -72,7 +72,7 @@
     },
     computed: {
       versionNumber() {
-        if (this.channelOnDevice.version === undefined) {
+        if (!this.channelOnDevice.available || this.channelOnDevice.version === undefined) {
           return this.channel.version;
         }
         return this.channelOnDevice.version;

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -25,7 +25,6 @@
             :version="availableVersions.source"
             @click="handleClickViewNewVersion"
           />
-          <span v-else>{{ $tr('channelUpToDate') }}</span>
         </section>
         <ChannelContentsSummary
           :channel="transferredChannel"
@@ -302,7 +301,6 @@
       },
     },
     $trs: {
-      channelUpToDate: 'Channel up-to-date',
       pageLoadError: 'There was a problem loading this page…',
       problemFetchingChannel: {
         message: 'There was a problem getting the contents of this channel',

--- a/kolibri/plugins/device/assets/test/views/SelectDriveModal.spec.js
+++ b/kolibri/plugins/device/assets/test/views/SelectDriveModal.spec.js
@@ -107,6 +107,7 @@ describe('selectDriveModal component', () => {
     const channel = {
       id: 'channel_1',
       version: 1,
+      available: true,
     };
     store.commit('manageContent/wizard/SET_TRANSFERRED_CHANNEL', channel);
     store.state.manageContent.channelList = [{ ...channel }];
@@ -120,6 +121,7 @@ describe('selectDriveModal component', () => {
     const channel = {
       id: 'channel_2',
       version: 6,
+      available: true,
     };
     store.commit('manageContent/wizard/SET_TRANSFERRED_CHANNEL', channel);
     store.state.manageContent.channelList = [{ ...channel }];

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -208,21 +208,23 @@
       this.lastFocus = document.activeElement;
     },
     mounted() {
+      // Remove scrollbars from the <html> tag, so user's can't scroll while modal is open
+      window.document.documentElement.style['overflow'] = 'hidden';
       this.$nextTick(() => {
         if (this.$refs.modal && !this.$refs.modal.contains(document.activeElement)) {
           this.focusModal();
         }
       });
       window.addEventListener('focus', this.focusElementTest, true);
-      window.addEventListener('scroll', this.preventScroll, true);
       window.setTimeout(() => (this.delayedEnough = true), 500);
     },
     updated() {
       this.updateContentSectionStyle();
     },
     destroyed() {
+      // Restore scrollbars to <html> tag
+      window.document.documentElement.style['overflow'] = null;
       window.removeEventListener('focus', this.focusElementTest, true);
-      window.removeEventListener('scroll', this.preventScroll, true);
       // Wait for events to finish propagating before changing the focus.
       // Otherwise the `lastFocus` item receives events such as 'enter'.
       window.setTimeout(() => this.lastFocus.focus());
@@ -291,9 +293,6 @@
         if (!this.$refs.modal.contains(event.target)) {
           this.focusModal();
         }
-      },
-      preventScroll(event) {
-        event.preventDefault();
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary
1. Hide scrollbars on html tag when KModal is open Fixes #6212 
1. De-duplicate new unlisted channels on AvailableChannelsPage Fixes #6277 
1. Don’t show resource information for canceled export tasks Fixes #6251 
1. When upgrading channels, Make the ‘skip import’ guard against node_ids being None, so you don't download entire channels by accident Fixes #6262 
1. In SelectDriveModal, automatically select first drive on list, so user doesn't have to select it themselves
1. Don’t show upgrade notifications for not-available channels (code was not distinguishing between channels that have not had any resources dl-d yet)
1. Automatically retry a channeldiffstats task if a user goes to the new channel version page and the task fails (see #6282) Fixes #6229



### Reviewer guidance

1. First, try to break the new channel version page (if set up right you can use the upgraded channel for the next item)
1. Test out the fix for #6262 
1. Look at the changed code for the modals and see if it does anything potentially unsafe

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
