### PR TITLE
New gherkin stories for new 0.13 device settings

### DIFF
--- a/integration_testing/features/super-admin/super-admin-change-device-settings.feature
+++ b/integration_testing/features/super-admin/super-admin-change-device-settings.feature
@@ -1,0 +1,47 @@
+Feature: Super admin changes device settings
+  Super admin needs to be able to change the setting to allow guest access, to restrict learner access to assigned class resources, and to change the landing page for unauthenticated users
+
+  Background:
+    Given I am signed in to Kolibri as super admin user
+      And I am on *Device > Settings* page
+      And there are learner and coach user accounts created in the facility
+      And a channel has been imported from Kolibri Studio using a token
+      And there is another Kolibri instance on my network
+
+  Scenario: Allow guest browsing
+    Given the *Allow users to access content without signing in* checkbox is unchecked
+      And the *Landing page* option is set to the *Sign-in page*
+      And the *Learners should only see resources assigned to them in classes* is unchecked
+    When I check the *Allow users to access resources without signing in* checkbox
+      And I click the *Save* button
+      And I sign out
+    Then I see the *Continues as a guest* link on the sign-in page
+    When I click *Continues as a guest*
+    Then I see the *Learn > Channels* page
+
+  Scenario: The landing page is the learn page
+    Given the *Allow users to access content without signing in* checkbox is unchecked
+      And the *Landing page* option is set to the *Sign-in page*
+      And the *Learners should only see resources assigned to them in classes* is unchecked
+    When I select *Learn page* for the *Landing page*
+      And I click the *Save* button
+      And I sign out
+    Then I see immediately see the *Learn > Channels* page
+    When I sign-in as learner <username>
+    Then I see *Learn > Channels* page again
+
+  Scenario: Learners can only access assigned resources
+    Given the *Learners should only see resources assigned to them in classes* is unchecked
+      And the *Landing page* option is set to the *Sign-in page*
+      And the *Allow users to access content without signing in* checkbox is unchecked
+    When I check the *Learners should only see resources assigned to them in classes* checkbox
+      And I click the *Save* button
+      And I sign out
+    Then I do not see the *Continues as a guest* link on the sign-in page
+    When I sign-in as learner <username>
+    Then I see the *Learn > Classes* page
+      And I do not see the *Channels* or *Recommended* tabs
+
+Examples:
+| full_name | username | password |
+| John C.   | learner  | learner  |

--- a/integration_testing/features/super-admin/super-admin-change-peer-unlisted-import.feature
+++ b/integration_testing/features/super-admin/super-admin-change-peer-unlisted-import.feature
@@ -1,6 +1,8 @@
 Feature: Super admin changes device setting allowing unlisted channel peer import
   Super admin needs to be able to change the setting to allow other network computers to import the device's unlisted channels
 
+# For these scenarios you will need another Kolibri running on a discoverable device in the same LAN
+
   Background:
     Given I am signed in to Kolibri <instance1> as a super admin user
       And I am signed in to Kolibri <instance2> as a super admin user

--- a/integration_testing/features/super-admin/super-admin-change-peer-unlisted-import.feature
+++ b/integration_testing/features/super-admin/super-admin-change-peer-unlisted-import.feature
@@ -1,0 +1,47 @@
+Feature: Super admin changes device setting allowing unlisted channel peer import
+  Super admin needs to be able to change the setting to allow other network computers to import the device's unlisted channels
+
+  Background:
+    Given I am signed in to Kolibri <instance1> as a super admin user
+      And I am signed in to Kolibri <instance2> as a super admin user
+      And the public channel <public_channel> has been imported into <instance1>
+      And the unlisted channel <unlisted_channel> has been imported into <instance1> from using a token
+
+  Scenario: Another Kolibri instance is unable to import my unlisted channels
+    Given the *Allow other computers on this network to import my unlisted channels* checkbox is unchecked on *Device > Settings* page of <instance1>
+      And I am on *Device > Channels* page of <instance2>
+    When I click *Import*
+    Then I see *Select a source* modal
+    When I select *Local network or internet* and click *Continue*
+    Then I see *Select network address* modal
+      And I see <instance1> and its IP address <network_address1>
+    When I select <instance1>
+      And I click *Continue*
+    Then I see *Select resources for import*
+      And I see the public channel <public_channel>
+      And I do not see the unlisted channel <unlisted_channel>
+
+  Scenario: Change the setting to allow the import my unlisted channels
+    Given the *Allow other computers on this network to import my unlisted channels* checkbox is unchecked on *Device > Settings* page of <instance1>
+    When I click *Allow other computers on this network to import my unlisted channels*
+    Then *Allow other computers on this network to import my unlisted channels* becomes checked
+    When I click *Save*
+    Then I see *Settings have been updated*
+
+  Scenario: Another Kolibri instance is able to import my unlisted channels
+    Given the *Allow other computers on this network to import my unlisted channels* checkbox is checked on *Device > Settings* page of <instance1>
+      And I am on *Device > Channels* page of <instance2>
+    When I click *Import*
+    Then I see *Select a source* modal
+    When I select *Local network or internet* and click *Continue*
+    Then I see *Select network address* modal
+      And I see <instance1> and its IP address <network_address1>
+    When I select <instance1>
+      And click *Continue*
+    Then I see *Select resources for import*
+      And I see the public channel <public_channel>
+      And I see the unlisted channel <unlisted_channel>
+
+Examples:
+| instance1 | instance2 | network_address1 | network_address2 | public_channel | unlisted_channel    |
+| Kolibri A | Kolibri B | 192.168.0.5      | 192.168.0.6      | MIT Blossoms   | My Private Channel |


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Adds integration test stories for new device settings added to Kolibri, for the following settings:
- The ability to prevent peers from importing unlisted channels on the device
- The ability to set the default landing page to either the current default (the sign-in page) or the learn page
- The ability to prevent learners from accessing unassigned resources

As well as retaining the story for the guest access feature.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
@radinamatic 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/pull/6204

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
