### PR TITLE
Remove unnecessary special handling for internal plugin upgrades.

### DIFF
--- a/kolibri/plugins/registry.py
+++ b/kolibri/plugins/registry.py
@@ -37,10 +37,8 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 
-import kolibri
 from kolibri.plugins import config
 from kolibri.plugins.utils import initialize_kolibri_plugin
-from kolibri.plugins.utils import is_external_plugin
 from kolibri.plugins.utils import is_plugin_updated
 from kolibri.plugins.utils import MultiplePlugins
 from kolibri.plugins.utils import PluginDoesNotExist
@@ -79,11 +77,8 @@ class Registry(object):
                     plugin_object = initialize_kolibri_plugin(app)
                     self._apps[app] = plugin_object
                     if is_plugin_updated(app):
-                        if is_external_plugin(app):
-                            config["UPDATED_PLUGINS"].add(app)
-                            config.save()
-                        else:
-                            config.update_plugin_version(app, kolibri.__version__)
+                        config["UPDATED_PLUGINS"].add(app)
+                        config.save()
             except (MultiplePlugins, ImportError):
                 logger.warn("Cannot initialize plugin {}".format(app))
             except PluginDoesNotExist:


### PR DESCRIPTION
### Summary
For reasons that escape me, I added special handling of internal plugins for upgrades, which prevented upgrade logic being run on them, this removes that special handling.

### Reviewer guidance
Does it fix #6304

### References
Fixes #6304

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
