### PR TITLE
Don't try to run git commands when running from inside the app.

### DIFF
--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -190,7 +190,7 @@ def get_git_describe(version):
 
     # Do not try to run git in app mode, as on Mac it will prompt the app user to install
     # developer tools. App packaging tools set sys.frozen to True, so we use that as our test.
-    if hasattr(sys, 'frozen'):
+    if hasattr(sys, "frozen"):
         return None
 
     valid_pattern = re.compile(r"^v[0-9-.]+(-(alpha|beta|rc)[0-9]+)?(-\d+-\w+)?$")

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -102,6 +102,7 @@ import os
 import pkgutil
 import re
 import subprocess
+import sys
 
 from .compat import parse_version
 from .lru_cache import lru_cache
@@ -186,6 +187,12 @@ def get_git_describe(version):
     Detects a valid tag, 1.2.3-<alpha|beta|rc>(-123-sha123)
     :returns: None if no git tag available (no git, no tags, or not in a repo)
     """
+
+    # Do not try to run git in app mode, as on Mac it will prompt the app user to install
+    # developer tools. App packaging tools set sys.frozen to True, so we use that as our test.
+    if hasattr(sys, 'frozen', False):
+        return None
+
     valid_pattern = re.compile(r"^v[0-9-.]+(-(alpha|beta|rc)[0-9]+)?(-\d+-\w+)?$")
     repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     try:

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -190,7 +190,7 @@ def get_git_describe(version):
 
     # Do not try to run git in app mode, as on Mac it will prompt the app user to install
     # developer tools. App packaging tools set sys.frozen to True, so we use that as our test.
-    if hasattr(sys, 'frozen', False):
+    if hasattr(sys, 'frozen'):
         return None
 
     valid_pattern = re.compile(r"^v[0-9-.]+(-(alpha|beta|rc)[0-9]+)?(-\d+-\w+)?$")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

On Mac, running git when the developer tools are not installed will prompt the user to install them. To avoid this, make sure we don't call git when running from within the app.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Run on a Mac without the developer tools installed, and make sure you are not prompted to install developer tools.

### References

fixes https://github.com/learningequality/kolibri-installer-mac/issues/31

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
