### PR TITLE
Report as Kolibri app server when running from within an app.

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -3,6 +3,7 @@ import urls from 'kolibri.urls';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
+import { isEmbeddedWebView } from 'kolibri.utils.browser';
 
 /* Function to fetch device info from the backend
  * and resolve validated data
@@ -14,8 +15,13 @@ export function getDeviceInfo() {
     data.free_space = data.content_storage_free_space;
     data.content_storage_free_space = bytesForHumans(data.content_storage_free_space);
 
-    if (response.headers.Server.includes('0.0.0.0')) data.server_type = 'Kolibri internal server';
-    else data.server_type = response.headers.Server;
+    if (response.headers.Server.includes('0.0.0.0')) {
+      if (isEmbeddedWebView()) {
+        data.server_type = 'Kolibri app server';
+      } else {
+        data.server_type = 'Kolibri internal server';
+      }
+    } else data.server_type = response.headers.Server;
 
     return data;
   });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

For reporting, we decided it was helpful to distinguish the Kolibri server running within the app from a local Kolibri server. This change checks if we're in an embedded WebView and reports the instance as "Kolibri app server" in that case.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check that the Device info tab on Mac reports "Kolibri app server" when running the Mac application, and that running from the command line still reports "Kolibri internal server".

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

fixes https://github.com/learningequality/kolibri-installer-mac/issues/26

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
