### PR TITLE
don't allow scroll position to be negative

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -46,7 +46,7 @@
       };
     },
     computed: {
-      scrollPositionOr0() {
+      positiveScrollPosition() {
         // in case a negative number is passed in
         return Math.max(this.scrollPosition, 0);
       },
@@ -74,11 +74,11 @@
         };
       },
       pastMinScroll() {
-        return this.scrollPositionOr0 > TOP_THRESHOLD;
+        return this.positiveScrollPosition > TOP_THRESHOLD;
       },
     },
     watch: {
-      scrollPositionOr0(newVal, oldVal) {
+      positiveScrollPosition(newVal, oldVal) {
         if (!this.alwaysVisible) {
           this.handleNewScrollPosition(newVal, oldVal);
         }
@@ -116,12 +116,12 @@
           }
         }
 
-        this.resetDistanceDebounced(delta, this.scrollPositionOr0);
+        this.resetDistanceDebounced(delta, this.positiveScrollPosition);
       },
       // Reset the scrolling distance if user pauses scrolling for some time.
       resetDistance(delta, lastPos) {
         setTimeout(() => {
-          if (this.scrollPositionOr0 === lastPos) {
+          if (this.positiveScrollPosition === lastPos) {
             // Set to +/- 1 to maintain the direction
             this.scrollDistance = Math.sign(delta);
           }

--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -46,6 +46,10 @@
       };
     },
     computed: {
+      scrollPositionOr0() {
+        // in case a negative number is passed in
+        return Math.max(this.scrollPosition, 0);
+      },
       resetDistanceDebounced() {
         return debounce(this.resetDistance, 500);
       },
@@ -70,11 +74,11 @@
         };
       },
       pastMinScroll() {
-        return this.scrollPosition > TOP_THRESHOLD;
+        return this.scrollPositionOr0 > TOP_THRESHOLD;
       },
     },
     watch: {
-      scrollPosition(newVal, oldVal) {
+      scrollPositionOr0(newVal, oldVal) {
         if (!this.alwaysVisible) {
           this.handleNewScrollPosition(newVal, oldVal);
         }
@@ -112,12 +116,12 @@
           }
         }
 
-        this.resetDistanceDebounced(delta, this.scrollPosition);
+        this.resetDistanceDebounced(delta, this.scrollPositionOr0);
       },
       // Reset the scrolling distance if user pauses scrolling for some time.
       resetDistance(delta, lastPos) {
         setTimeout(() => {
-          if (this.scrollPosition === lastPos) {
+          if (this.scrollPositionOr0 === lastPos) {
             // Set to +/- 1 to maintain the direction
             this.scrollDistance = Math.sign(delta);
           }


### PR DESCRIPTION

### Summary

I noticed during browsing that at one point the validator for `scrollPosition` failed. Not sure how to reproduce.

### Reviewer guidance

I didn't observe any incorrect-looking behavior, but this PR puts a floor on the value because it seems from the validator like other logic expects it to be minimum 0.

### References

N/A

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
