### PR TITLE
Button alignment

### DIFF
--- a/packages/kolibri-components/src/buttons-and-links/buttons.scss
+++ b/packages/kolibri-components/src/buttons-and-links/buttons.scss
@@ -33,7 +33,7 @@ $raised-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14),
 }
 
 a.button {
-  display: inline-table; // helps with vertical layout
+  display: inline-block; // helps with vertical layout
 }
 
 .raised {


### PR DESCRIPTION
### Summary

switches link-based buttons from `inline-table` to `inline-block`

### Reviewer guidance

I haven't fully tested the implications of this wide-ranging change, but the update seems much more "correct" than the old CSS added in 7fa8bc4587f71fc389d923f2b468180217967833

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70857517-d1b52180-1ea4-11ea-93a4-3cddf3bb1063.png) |![image](https://user-images.githubusercontent.com/2367265/70857511-b3e7bc80-1ea4-11ea-86b3-1652899916e7.png)|

### References

fixes https://github.com/learningequality/kolibri/issues/6285

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
