### PR TITLE
[DRAFT] add a 15-second throttle to navigation-based refresh of class summary

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -2,6 +2,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import flatten from 'lodash/flatten';
 import find from 'lodash/find';
+import throttle from 'lodash/throttle';
 
 import Vue from 'kolibri.lib.vue';
 import ClassSummaryResource from '../../apiResources/classSummary';
@@ -423,5 +424,8 @@ export default {
     refreshClassSummary(store) {
       return store.dispatch('loadClassSummary', store.state.id);
     },
+    refreshClassSummaryThrottled: throttle(store => {
+      return store.dispatch('refreshClassSummary');
+    }, 15000),
   },
 };

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -106,12 +106,11 @@ export default {
         ]).catch(error => {
           store.dispatch('handleError', error);
         });
-      } else {
-        // otherwise refresh but don't block
-        return store
-          .dispatch('classSummary/loadClassSummary', classId)
-          .catch(error => store.dispatch('handleApiError', error));
       }
+      // navigating within the same class, periodically refresh but don't block
+      return store
+        .dispatch('classSummary/refreshClassSummaryThrottled')
+        .catch(error => store.dispatch('handleApiError', error));
     },
   },
   modules: {


### PR DESCRIPTION
### Summary

adds a throttle to navigation-based class summary refreshing to avoid hitting the expensive endpoint unnecessarily often

### Reviewer guidance

does anything about the mixture of  `lodash.throttle`, promises, and vuex actions look wrong?

### References

* fixes https://github.com/learningequality/kolibri/issues/6143
* fixes https://github.com/learningequality/kolibri/issues/4811
* refs https://github.com/learningequality/kolibri/issues/5757

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
