### PR TITLE
more button alignment

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -36,7 +36,9 @@
           <tr>
             <th>{{ coachString('titleLabel') }}</th>
             <th>{{ coachString('recipientsLabel') }}</th>
-            <th>{{ coachString('statusLabel') }}</th>
+            <th class="center-text">
+              {{ coachString('statusLabel') }}
+            </th>
           </tr>
         </thead>
         <transition-group slot="tbody" tag="tbody" name="list">
@@ -61,13 +63,12 @@
               />
             </td>
 
-            <td>
+            <td class="center-text button-col core-table-button-col">
               <!-- Open quiz button -->
               <KButton
                 v-if="!exam.active && !exam.archive"
                 :text="coachString('openQuizLabel')"
                 appearance="flat-button"
-                class="table-left-aligned-button"
                 @click="showOpenConfirmationModal = true; modalQuizId=exam.id"
               />
               <!-- Close quiz button -->
@@ -75,14 +76,10 @@
                 v-if="exam.active && !exam.archive"
                 :text="coachString('closeQuizLabel')"
                 appearance="flat-button"
-                class="table-left-aligned-button"
                 @click="showCloseConfirmationModal = true; modalQuizId=exam.id;"
               />
               <!-- Closed quiz label -->
-              <div
-                v-if="exam.archive"
-                class="quiz-closed-label"
-              >
+              <div v-if="exam.archive">
                 {{ coachString('quizClosedLabel') }}
               </div>
             </td>
@@ -276,9 +273,8 @@
     text-align: center;
   }
 
-  .table-left-aligned-button {
-    // Remove all margins except a new negative left margin
-    margin: 0 0 0 -1rem;
+  .button-col {
+    vertical-align: middle;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -31,7 +31,7 @@
             </th>
             <th>{{ coreString('progressLabel') }}</th>
             <th>{{ coachString('recipientsLabel') }}</th>
-            <th v-show="!$isPrint">
+            <th v-show="!$isPrint" class="center-text">
               {{ coachString('statusLabel') }}
             </th>
           </tr>
@@ -62,7 +62,10 @@
                 :hasAssignments="tableRow.hasAssignments"
               />
             </td>
-            <td v-show="!$isPrint" class="status">
+            <td
+              v-show="!$isPrint"
+              class="center-text button-col core-table-button-col"
+            >
               <!-- Open quiz button -->
               <KButton
                 v-if="!tableRow.active && !tableRow.archive"
@@ -268,17 +271,12 @@
 
   @import '../common/print-table';
 
-  td.status {
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-  .quiz-closed-label {
-    padding: 0;
-    margin: 0.75rem 0;
+  .center-text {
+    text-align: center;
   }
 
-  .table-left-aligned-button {
-    margin: 0.5rem 0 0.5rem -1rem;
+  .button-col {
+    vertical-align: middle;
   }
 
 </style>


### PR DESCRIPTION

### Summary

The design and implementation had buttons left-aligned with the header in the table. This however caused the hover state to be clipped.

The current implementation also didn't have text vertically-aligned with the rest of the row.

### Reviewer guidance

This PR makes a slight change to the design and implementation and centers the button column contents both vertically and horizontally. This is a deviation from our normal top- and either left- or right-alignment, I think this is probably the cleanest solution given the heterogenous contents of the column.

@jtamiace @nucleogenesis let me know what you think.

| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/2367265/70858403-8f94db80-1eb6-11ea-8c53-b116e39fc2e8.png) | ![image](https://user-images.githubusercontent.com/2367265/70858405-93c0f900-1eb6-11ea-870f-dda187193d51.png)|
|![image](https://user-images.githubusercontent.com/2367265/70858409-9cb1ca80-1eb6-11ea-9256-6343c0e3cf97.png)| ![image](https://user-images.githubusercontent.com/2367265/70858410-a2a7ab80-1eb6-11ea-9c08-9400b2c104e3.png)|








----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
