### PR TITLE
learner quiz view updates

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -15,10 +15,10 @@ import { ClassesPageNames } from '../../constants';
 import { contentState } from '../coreLearn/utils';
 import { calcQuestionsAnswered } from './utils';
 
-export function showExam(store, params, alreadyLoaded) {
+export function showExam(store, params, alreadyOnQuiz) {
   const questionNumber = Number(params.questionNumber);
   const { classId, examId } = params;
-  if (!alreadyLoaded) {
+  if (!alreadyOnQuiz) {
     store.commit('CORE_SET_PAGE_LOADING', true);
   }
   store.commit('SET_PAGE_NAME', ClassesPageNames.EXAM_VIEWER);

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -15,10 +15,12 @@ import { ClassesPageNames } from '../../constants';
 import { contentState } from '../coreLearn/utils';
 import { calcQuestionsAnswered } from './utils';
 
-export function showExam(store, params) {
+export function showExam(store, params, alreadyLoaded) {
   const questionNumber = Number(params.questionNumber);
   const { classId, examId } = params;
-  store.commit('CORE_SET_PAGE_LOADING', true);
+  if (!alreadyLoaded) {
+    store.commit('CORE_SET_PAGE_LOADING', true);
+  }
   store.commit('SET_PAGE_NAME', ClassesPageNames.EXAM_VIEWER);
   // Reset examAttemptLogs, so that it will not merge into another exam.
   store.commit('RESET_EXAM_ATTEMPT_LOGS');

--- a/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
@@ -41,8 +41,12 @@ export default [
   {
     name: ClassesPageNames.EXAM_VIEWER,
     path: '/classes/:classId/exam/:examId/:questionNumber',
-    handler: toRoute => {
-      showExam(store, toRoute.params);
+    handler: (toRoute, fromRoute) => {
+      const alreadyLoaded =
+        fromRoute.name === ClassesPageNames.EXAM_VIEWER &&
+        toRoute.params.examId === fromRoute.params.examId &&
+        toRoute.params.classId === fromRoute.params.classId;
+      showExam(store, toRoute.params, alreadyLoaded);
     },
   },
   {

--- a/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
@@ -42,11 +42,11 @@ export default [
     name: ClassesPageNames.EXAM_VIEWER,
     path: '/classes/:classId/exam/:examId/:questionNumber',
     handler: (toRoute, fromRoute) => {
-      const alreadyLoaded =
+      const alreadyOnQuiz =
         fromRoute.name === ClassesPageNames.EXAM_VIEWER &&
         toRoute.params.examId === fromRoute.params.examId &&
         toRoute.params.classId === fromRoute.params.classId;
-      showExam(store, toRoute.params, alreadyLoaded);
+      showExam(store, toRoute.params, alreadyOnQuiz);
     },
   },
   {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -1,27 +1,28 @@
 <template>
 
-  <div :style="{ backgroundColor: $themeTokens.surface }">
+  <div>
     <ul class="history-list">
-      <template v-for="(question, index) in questions">
-        <li
-          :key="index"
-          :style="liStyle(index)"
+      <li
+        v-for="(question, index) in questions"
+        :key="index"
+        class="list-item"
+      >
+        <button
+          :class="$computedClass(liStyle(index))"
+          :disabled="questionNumber === index"
           class="clickable"
           @click="$emit('goToQuestion', index)"
         >
-          <svg class="item svg-item">
-            <circle
-              cx="32"
-              cy="32"
-              r="8"
-              :style="{ fill: isAnswered(question) ? 'purple' : 'lightgrey' }"
-            />
-          </svg>
-          <p class="item">
+          <KIcon
+            class="dot"
+            icon="dot"
+            :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
+          />
+          <div class="text">
             {{ questionText(index + 1) }}
-          </p>
-        </li>
-      </template>
+          </div>
+        </button>
+      </li>
     </ul>
   </div>
 
@@ -52,8 +53,15 @@
         return ((this.attemptLogs[question.exercise_id] || {})[question.question_id] || {}).answer;
       },
       liStyle(index) {
+        if (this.questionNumber === index) {
+          return {
+            backgroundColor: this.$themePalette.grey.v_200,
+          };
+        }
         return {
-          backgroundColor: this.questionNumber === index ? this.$themePalette.grey.v_200 : '',
+          ':hover': {
+            backgroundColor: this.$themePalette.grey.v_100,
+          },
         };
       },
     },
@@ -67,6 +75,8 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri.styles.definitions';
+
   .history-list {
     max-height: inherit;
     padding-left: 0;
@@ -74,26 +84,32 @@
     list-style-type: none;
   }
 
-  .item {
-    float: left;
-    margin: 0;
-    font-size: 0.9em;
-    line-height: 64px;
-  }
-
-  .svg-item {
-    width: 64px;
-    height: 64px;
-  }
-
-  li {
-    height: 64px;
-    clear: both;
-    border: 0;
+  .list-item {
+    margin-bottom: 4px;
   }
 
   .clickable {
-    cursor: pointer;
+    @extend %md-decelerate-func;
+
+    position: relative;
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: 0;
+    border-radius: 4px;
+    outline-offset: -2px;
+    transition: background-color $core-time;
+  }
+
+  .dot {
+    position: absolute;
+    top: 18px;
+    left: 16px;
+  }
+
+  .text {
+    margin: 16px;
+    margin-left: 48px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -5,6 +5,7 @@
       <li
         v-for="(question, index) in questions"
         :key="index"
+        :ref="`item-${index}`"
         class="list-item"
       >
         <button
@@ -33,6 +34,14 @@
 
   import { mapState } from 'vuex';
 
+  function isAboveContainer(element, container) {
+    return element.offsetTop < container.scrollTop;
+  }
+
+  function isBelowContainer(element, container) {
+    return element.offsetTop + element.offsetHeight > container.offsetHeight + container.scrollTop;
+  }
+
   export default {
     name: 'AnswerHistory',
     props: {
@@ -40,10 +49,29 @@
         type: Number,
         required: true,
       },
+      // hack to get access to the scrolling pane
+      wrapperComponentRefs: {
+        type: Object,
+        required: true,
+      },
     },
     computed: {
       ...mapState('examViewer', ['questions']),
       ...mapState({ attemptLogs: 'examAttemptLogs' }),
+    },
+    watch: {
+      questionNumber(index) {
+        // If possible, scroll it into view
+        const element = this.$refs[`item-${index}`][0];
+        if (element && element.scrollIntoView && this.wrapperComponentRefs.questionListWrapper) {
+          const container = this.wrapperComponentRefs.questionListWrapper.$el;
+          if (isAboveContainer(element, container)) {
+            element.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
+          } else if (isBelowContainer(element, container)) {
+            element.scrollIntoView({ block: 'end', inline: 'nearest', behavior: 'smooth' });
+          }
+        }
+      },
     },
     methods: {
       questionText(num) {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -1,31 +1,29 @@
 <template>
 
-  <div>
-    <ul class="history-list">
-      <li
-        v-for="(question, index) in questions"
-        :key="index"
-        :ref="`item-${index}`"
-        class="list-item"
+  <ul class="history-list">
+    <li
+      v-for="(question, index) in questions"
+      :key="index"
+      :ref="`item-${index}`"
+      class="list-item"
+    >
+      <button
+        :class="$computedClass(liStyle(index))"
+        :disabled="questionNumber === index"
+        class="clickable"
+        @click="$emit('goToQuestion', index)"
       >
-        <button
-          :class="$computedClass(liStyle(index))"
-          :disabled="questionNumber === index"
-          class="clickable"
-          @click="$emit('goToQuestion', index)"
-        >
-          <KIcon
-            class="dot"
-            icon="dot"
-            :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
-          />
-          <div class="text">
-            {{ questionText(index + 1) }}
-          </div>
-        </button>
-      </li>
-    </ul>
-  </div>
+        <KIcon
+          class="dot"
+          icon="dot"
+          :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
+        />
+        <div class="text">
+          {{ questionText(index + 1) }}
+        </div>
+      </button>
+    </li>
+  </ul>
 
 </template>
 
@@ -109,6 +107,7 @@
     max-height: inherit;
     padding-left: 0;
     margin: 0;
+    margin-top: 16px;
     list-style-type: none;
   }
 
@@ -123,6 +122,7 @@
     display: block;
     width: 100%;
     text-align: left;
+    user-select: none;
     border: 0;
     border-radius: 4px;
     outline-offset: -2px;

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -8,7 +8,7 @@
       class="list-item"
     >
       <button
-        :class="$computedClass(liStyle(index))"
+        :class="buttonClass(index)"
         :disabled="questionNumber === index"
         class="clickable"
         @click="$emit('goToQuestion', index)"
@@ -78,17 +78,16 @@
       isAnswered(question) {
         return ((this.attemptLogs[question.exercise_id] || {})[question.question_id] || {}).answer;
       },
-      liStyle(index) {
+      buttonClass(index) {
         if (this.questionNumber === index) {
-          return {
-            backgroundColor: this.$themePalette.grey.v_200,
-          };
+          return this.$computedClass({ backgroundColor: this.$themePalette.grey.v_200 });
         }
-        return {
+        return this.$computedClass({
+          backgroundColor: this.$themeTokens.surface,
           ':hover': {
             backgroundColor: this.$themePalette.grey.v_100,
           },
-        };
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -3,7 +3,12 @@
   <div>
     <KGrid :gridStyle="gridStyle">
       <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
-      <KGridItem v-if="windowIsLarge" ref="questionListWrapper" :layout12="{ span: 4 }" class="column-pane">
+      <KGridItem
+        v-if="windowIsLarge"
+        ref="questionListWrapper"
+        :layout12="{ span: 4 }"
+        class="column-pane"
+      >
         <div class="column-contents-wrapper">
           <KPageContainer>
             <AnswerHistory

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -2,11 +2,13 @@
 
   <div>
     <KGrid :gridStyle="gridStyle">
-      <KGridItem v-if="windowIsLarge" :layout12="{ span: 4 }" class="column-pane">
+      <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
+      <KGridItem v-if="windowIsLarge" ref="questionListWrapper" :layout12="{ span: 4 }" class="column-pane">
         <div class="column-contents-wrapper">
           <KPageContainer>
             <AnswerHistory
               :questionNumber="questionNumber"
+              :wrapperComponentRefs="this.$refs"
               @goToQuestion="goToQuestion"
             />
           </KPageContainer>


### PR DESCRIPTION
### Summary

* uses real buttons instead of divs with click handlers, enabling keyboard navigation
* updated to use design system colors, spacing, and icon component
* prevent the entire component from reloading when the user is on the same quiz, which prevents scroll reset behavior
* when possible (supported by the browser), smoothly scroll questions into view as necessary


| before | after |
|--|--|
|![2019-12-15 14 02 26](https://user-images.githubusercontent.com/2367265/70870070-f01e2a00-1f43-11ea-9895-534c2ae814ff.gif)|![2019-12-15 13 59 55](https://user-images.githubusercontent.com/2367265/70870074-f4e2de00-1f43-11ea-85ee-e5a20ec0c12e.gif)|

### Reviewer guidance

This change is a bit more significant than I would really like at this stage, but it has some big improvements so let's give it test.

It also uses some hacks for a child component to get access to a parent component scrolling div which I don't really like

### References

fixes https://github.com/learningequality/kolibri/issues/4834

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
