### PR TITLE
prevent double focus on immersive toolbar back link

### DIFF
--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -15,14 +15,15 @@
       v-if="hasRoute"
       slot="icon"
       :to="route"
-      :class="['link', $computedClass(linkStyle)]"
+      class="link"
+      :class="$computedClass(linkStyle)"
     >
       <!-- TODO add aria label? -->
       <UiIconButton
         type="flat"
         class="icon"
         :style="{fill: $themeTokens.textInverted}"
-        @click="$emit('navIconClick')"
+        tabindex="-1"
       >
         <mat-svg
           v-if="icon === 'close'"
@@ -150,6 +151,7 @@
   .link {
     display: inline-block;
     border-radius: 50%;
+    outline-offset: -4px;
   }
 
 </style>


### PR DESCRIPTION

### Summary

prevent keyboard focus on icon button nested inside a link

### Reviewer guidance

To me it looks like the button is just there for styling purposes, not event emitting. Is there anywhere this assumption is broken?

### References

fixes https://github.com/learningequality/kolibri/issues/6322

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
