### PR TITLE
move 'new version' message next to current version label

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -40,6 +40,15 @@
       </template>
 
       <template v-slot:abovedescription>
+        <div v-if="newVersionAvailable">
+          <KIcon
+            class="update-icon"
+            icon="error"
+            :style="{fill: $themeTokens.primary}"
+          />
+          {{ $tr('newVersionMessage') }}
+          <KRouterLink :to="newChannelVersionPageRoute" :text="$tr('moreInformationLabel')" />
+        </div>
         <div v-if="onDevice" class="on-device">
           <KIcon
             class="check-icon"
@@ -50,15 +59,6 @@
         </div>
       </template>
 
-      <template v-if="newVersionAvailable" v-slot:belowdescription>
-        <KIcon
-          class="update-icon"
-          icon="error"
-          :style="{fill: $themeTokens.primary}"
-        />
-        {{ $tr('newVersionMessage') }}
-        <KRouterLink :to="newChannelVersionPageRoute" :text="$tr('moreInformationLabel')" />
-      </template>
     </ChannelDetails>
 
     <div class="col-3">


### PR DESCRIPTION
### Summary

moves the 'new version' message next to current version label

### Reviewer guidance

it seemed more natural to have them juxtaposed. thoughts?

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70870862-8145ce80-1f4d-11ea-899e-0317ca686a55.png)|![image](https://user-images.githubusercontent.com/2367265/70870858-7854fd00-1f4d-11ea-8b90-f8cead847741.png)|


### References

N/A

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
