### PR TITLE
update channel diff header nesting, layout, and loading behavior

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -78,10 +78,7 @@
     </section>
 
     <dl>
-      <template
-        v-for="(note, idx) in sortedVersionNotes"
-        v-if="note.version >= currentVersion"
-      >
+      <template v-for="(note, idx) in sortedFilteredVersionNotes">
         <dt :key="`dt-${idx}`">
           {{ $tr('versionNumberHeader', { version: note.version }) }}
         </dt>
@@ -177,13 +174,13 @@
           addressId: this.$route.query.address_id,
         });
       },
-      sortedVersionNotes() {
+      sortedFilteredVersionNotes() {
         const versionArray = map(this.versionNotes, (val, key) => {
           return {
             version: Number(key),
             notes: val,
           };
-        });
+        }).filter(note => note.version >= this.currentVersion);
         return sortBy(versionArray, note => -note.version);
       },
       watchedTaskHasFinished() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -80,7 +80,7 @@
     <dl>
       <template
         v-for="(note, idx) in sortedVersionNotes"
-        v-show="note.version >= currentVersion"
+        v-if="note.version >= currentVersion"
       >
         <dt :key="`dt-${idx}`">
           {{ $tr('versionNumberHeader', { version: note.version }) }}

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -1,8 +1,8 @@
 <template>
 
-  <div>
+  <div v-if="!loadingChannel">
 
-    <section v-if="!loadingChannel">
+    <section>
       <h1>
         {{ versionAvailableText }}
       </h1>
@@ -12,16 +12,16 @@
       </p>
     </section>
 
-    <div style="height: 32px" aria-hidden="true"></div>
-
-    <section v-if="!loadingChannel && !loadingTask">
-      <h3>
-        {{ $tr('versionChangesHeader', {
-          oldVersion: currentVersion,
-          newVersion: nextVersion
-        }) }}
-      </h3>
-      <table>
+    <section>
+      <p>
+        <strong>
+          {{ $tr('versionChangesHeader', {
+            oldVersion: currentVersion,
+            newVersion: nextVersion
+          }) }}
+        </strong>
+      </p>
+      <table v-if="!loadingChannel && !loadingTask">
         <tr>
           <th>{{ $tr('resourcesAvailableForImport') }}</th>
           <td class="col-2">
@@ -60,41 +60,36 @@
           </td>
         </tr>
       </table>
-
-      <div style="height: 24px" aria-hidden="true"></div>
-
-      <KButton
-        class="button"
-        :text="$tr('updateChannelAction')"
-        appearance="raised-button"
-        :primary="true"
-        @click="showModal = true"
+      <KLinearLoader
+        v-else
+        :indeterminate="true"
+        :delay="false"
       />
+
+      <BottomAppBar>
+        <KButton
+          :text="$tr('updateChannelAction')"
+          appearance="raised-button"
+          :primary="true"
+          :disabled="loadingChannel || loadingTask"
+          @click="showModal = true"
+        />
+      </BottomAppBar>
     </section>
 
-    <div style="height: 48px" aria-hidden="true"></div>
-
-    <section v-if="!loadingChannel">
-      <div
+    <dl>
+      <template
         v-for="(note, idx) in sortedVersionNotes"
         v-show="note.version >= currentVersion"
-        :key="idx"
       >
-        <h2>
+        <dt :key="`dt-${idx}`">
           {{ $tr('versionNumberHeader', { version: note.version }) }}
-        </h2>
-        <p dir="auto">
+        </dt>
+        <dd :key="`dd-${idx}`" dir="auto">
           {{ note.notes }}
-        </p>
-      </div>
-    </section>
-
-    <!-- Load the channel immediately, then the diff stats -->
-    <KLinearLoader
-      v-if="loadingChannel || loadingTask"
-      :indeterminate="true"
-      :delay="false"
-    />
+        </dd>
+      </template>
+    </dl>
 
     <KModal
       v-if="showModal"
@@ -108,6 +103,12 @@
       <p>{{ $tr('updateConfirmationQuestion', { channelName, version: nextVersion }) }}</p>
     </KModal>
   </div>
+  <KLinearLoader
+    v-else
+    :indeterminate="true"
+    :delay="false"
+    class="main-loader"
+  />
 
 </template>
 
@@ -120,6 +121,7 @@
   import map from 'lodash/map';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import { taskIsClearable, TaskStatuses } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
@@ -133,6 +135,7 @@
     },
     components: {
       CoreInfoIcon,
+      BottomAppBar,
     },
     mixins: [commonCoreStrings],
     data() {
@@ -337,12 +340,8 @@
     font-size: 24px;
   }
 
-  h2 {
-    font-size: 20px;
-  }
-
-  .button {
-    margin-left: 0;
+  .main-loader {
+    margin-top: 8px;
   }
 
   /deep/ .k-tooltip {
@@ -363,8 +362,10 @@
     margin-left: 16px;
   }
 
-  tr {
-    height: 2em;
+  td,
+  th {
+    padding-top: 4px;
+    padding-bottom: 4px;
   }
 
   th {
@@ -378,6 +379,14 @@
 
   td.col-2 {
     min-width: 120px;
+  }
+
+  dt {
+    font-weight: bold;
+  }
+
+  dd {
+    margin-bottom: 8px;
   }
 
 </style>


### PR DESCRIPTION

### Summary

issues observed with current page:

* unconventional spacing
* header levels don't nest semantically according to the information hierarchy
* loading behaviors are a bit jarring
* inefficient use of screen real estate

This PR removes custom spacing and uses `<strong>` and a definition list instead of sub-headers. It also moves the call to action to a bottom bar.

Finally, it updates the loading behavior to put the loaders where things have not yet appeared, rather than always at the bottom of the screen


_Note on 'after' screenshots below: they incorrectly show all changes rather than just diffs, but this was fixed in f8432d7307b46410268419acc900d734398fb7b8_

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/70876609-17d6b780-1f6f-11ea-8518-eedd5dced0e2.png) |![image](https://user-images.githubusercontent.com/2367265/70877614-068faa00-1f73-11ea-9af7-359d3622765f.png)|
|![2019-12-15 19 43 38](https://user-images.githubusercontent.com/2367265/70877855-0c39bf80-1f74-11ea-8656-ab0348db3613.gif)|![2019-12-15 19 42 50](https://user-images.githubusercontent.com/2367265/70877860-0f34b000-1f74-11ea-90b9-bafbfd1b0044.gif)|




### Reviewer guidance

@khangmach @jonboiser thoughts?

### References

N/A

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
