### PR TITLE
Fixes command line import without node_id and exclude_node_id args.

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -56,7 +56,7 @@ class Command(AsyncCommand):
             "-n",
             # Split the comma separated string we get, into a list of strings
             type=lambda x: x.split(","),
-            default=[],
+            default=None,
             required=False,
             dest="node_ids",
             help=node_ids_help_text,
@@ -73,7 +73,7 @@ class Command(AsyncCommand):
             "--exclude_node_ids",
             # Split the comma separated string we get, into a list of string
             type=lambda x: x.split(","),
-            default=[],
+            default=None,
             required=False,
             dest="exclude_node_ids",
             help=exclude_node_ids_help_text,

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -33,6 +33,20 @@ FILE_SKIPPED = 1
 FILE_NOT_TRANSFERRED = 0
 
 
+def lookup_channel_listing_status(channel_id, baseurl=None):
+    """
+    Look up the listing status of the channel from the remote, this is surfaced as a
+    `public` boolean field.
+    """
+    resp = requests.get(get_channel_lookup_url(identifier=channel_id, baseurl=baseurl))
+
+    if resp.status_code != 200:
+        return None
+
+    (channel_info,) = resp.json()
+    return channel_info.get("public", None)
+
+
 class Command(AsyncCommand):
     def add_arguments(self, parser):
         # let's save the parser in case we need to print a help statement
@@ -223,7 +237,7 @@ class Command(AsyncCommand):
 
         # If we're downloading, check listing status
         if method == DOWNLOAD_METHOD:
-            public = self.lookup_channel_listing_status(
+            public = lookup_channel_listing_status(
                 channel_id=channel_id, baseurl=baseurl
             )
 
@@ -435,18 +449,3 @@ class Command(AsyncCommand):
                     options["command"]
                 )
             )
-
-    def lookup_channel_listing_status(self, channel_id, baseurl=None):
-        """
-        Look up the listing status of the channel from the remote, this is surfaced as a
-        `public` boolean field.
-        """
-        resp = requests.get(
-            get_channel_lookup_url(identifier=channel_id, baseurl=baseurl)
-        )
-
-        if resp.status_code == 404:
-            return None
-
-        (channel_info,) = resp.json()
-        return channel_info.get("public", None)


### PR DESCRIPTION
### Summary
Selective node annotation relies on `node_ids` and `exclude_node_ids` to be `None` to ignore the argument, but the importcontent command defaults these to `[]`, causing no nodes to be annotated on a full import from the command line.
This changes the defaults to `None`.

### Reviewer guidance
Import a channel completely from the command line using:
```
kolibri manage importchannel network <channel_id>
kolibri manage importcontent network <channel_id>
```
Verify that the content is visible.

### References
Fixes #6296

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
