### PR TITLE
remove text and increase size of spinner

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -76,10 +76,9 @@
     <KFixedGrid slot="actions" class="actions" numCols="4">
       <KFixedGridItem span="1">
         <transition name="spinner-fade">
-          <div v-if="discoveringPeers" class="searching-indicator">
+          <div v-if="discoveringPeers">
             <KLabeledIcon>
-              <KCircularLoader slot="icon" :size="16" :stroke="6" />
-              {{ $tr('searchingText') }}
+              <KCircularLoader slot="icon" :size="32" :stroke="4" />
             </KLabeledIcon>
           </div>
         </transition>
@@ -301,11 +300,6 @@
         context:
           "\nRefers to the Kolibri's capability to import resources from other devices in the same *local* network (LAN), as opposed to importing from Studio which is online.",
       },
-      searchingText: {
-        message: 'Searching',
-        context:
-          '\nKolibri will search for nearby Kolibri devices every so often. While doing so, this text will be presented to the user',
-      },
     },
   };
 
@@ -321,11 +315,6 @@
   .radio-button {
     display: inline-block;
     width: 75%;
-  }
-
-  .searching-indicator {
-    padding-top: 18px;
-    font-size: 12px;
   }
 
   .spinner-fade-leave-active,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -78,7 +78,7 @@
         <transition name="spinner-fade">
           <div v-if="discoveringPeers">
             <KLabeledIcon>
-              <KCircularLoader slot="icon" :size="32" :stroke="4" />
+              <KCircularLoader slot="icon" :size="16" :stroke="6" class="loader" />
             </KLabeledIcon>
           </div>
         </transition>
@@ -342,6 +342,11 @@
   hr {
     border: 0;
     border-bottom: 1px solid #cbcbcb;
+  }
+
+  .loader {
+    position: relative;
+    top: 12px;
   }
 
 </style>


### PR DESCRIPTION
### Summary

 based on feedback from @khangmach 

> Let's remove the 'searching' text indicator. Just the loader should suffice as an indicator. Hehe..

| before | after |
|--|--|
|![2019-12-15 20 57 00](https://user-images.githubusercontent.com/2367265/70880396-a2261800-1f7d-11ea-9183-26fd9ba5e4f9.gif)|![2019-12-15 20 55 42](https://user-images.githubusercontent.com/2367265/70880399-a4887200-1f7d-11ea-927b-7a6e1896d910.gif)|




### Reviewer guidance

any issues?


### References

https://www.notion.so/learningequality/0-13-0-bug-bash-3-7eeb57a21dd14aaa8f672dca9981f3f9?p=4f7b5269d2104f1c8e4d7d78ed6e126d

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
