### PR TITLE
Give the `KModal` fade transition a more specific name.

### DIFF
--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!-- Accessibility properties for the overlay -->
-  <transition name="fade" appear>
+  <transition name="modal-fade" appear>
     <div
       id="modal-window"
       ref="modal-overlay"
@@ -330,13 +330,13 @@
     @extend %momentum-scroll;
   }
 
-  .fade-enter-active,
-  .fade-leave-active {
+  .modal-fade-enter-active,
+  .modal-fade-leave-active {
     transition: all $core-time ease;
   }
 
-  .fade-enter,
-  .fade-leave-active {
+  .modal-fade-enter,
+  .modal-fade-leave-active {
     opacity: 0;
   }
 


### PR DESCRIPTION
### Summary
This will allow components in `KModal` slots to use the name 'fade' for their transitions.

### Reviewer guidance
To test this, start Kolibri and try opening and closing anything that uses `KModal`.  Make sure the fade looks real smooth.

### References
In working on the peer discovery UI, I wanted to fade the spinner in and out, and used a transition called "fade".  Unfortunately, this interfered with `KModal`'s fade transition, which was also called "fade", since spinner fade was in a slot of `KModal`, and thus its fade css was clashing.  

see here: https://www.notion.so/learningequality/0-13-0-bug-bash-3-7eeb57a21dd14aaa8f672dca9981f3f9?p=ab0cbc5da2ed4e25935c54898a29484f

This change will let components in `KModal` slots have transitions called "fade".

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
