### PR TITLE
Only auto-delete individual tasks when they finish

### DIFF
--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -67,6 +67,7 @@ class ChannelMetadataSerializer(serializers.ModelSerializer):
             "version",
             "available",
             "num_coach_contents",
+            "public",
         )
 
 

--- a/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
@@ -6,6 +6,7 @@ import pick from 'lodash/fp/pick';
 import { TaskStatuses, TaskTypes } from '../../../constants';
 
 const logging = logger.getLogger(__filename);
+
 export function cancelTask(store, taskId) {
   return new Promise(resolve => {
     let cancelWatch;
@@ -15,7 +16,7 @@ export function cancelTask(store, taskId) {
         TaskStatuses.CANCELED,
       () => {
         cancelWatch();
-        TaskResource.deleteFinishedTasks().then(resolve);
+        TaskResource.deleteFinishedTask(taskId).then(resolve);
       }
     );
     TaskResource.cancelTask(taskId);

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -51,6 +51,12 @@ export default {
         return find(state.channelList, { id: channelId, available: true });
       };
     },
+    channelIsOnDevice(state) {
+      // Channel data just needs to exist, but doesn't need to be available
+      return function findChannel(channelId) {
+        return find(state.channelList, { id: channelId });
+      };
+    },
     channelIsBeingDeleted(state) {
       return function beingDeleted(channelId) {
         const match = find(state.taskList, {

--- a/kolibri/plugins/device/assets/src/modules/wizard/actions/selectContentActions.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/actions/selectContentActions.js
@@ -10,7 +10,7 @@ import { getChannelWithContentSizes } from '../apiChannelMetadata';
 export function loadChannelMetadata(store) {
   let dbPromise;
   const { transferredChannel } = store.state.manageContent.wizard;
-  const channelOnDevice = store.getters['manageContent/channelIsInstalled'](transferredChannel.id);
+  const channelOnDevice = store.getters['manageContent/channelIsOnDevice'](transferredChannel.id);
 
   // If channel _is_ on the device, but not "available" (i.e. no resources installed yet)
   // _and_ has been updated, then download the metadata

--- a/kolibri/plugins/device/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/utils.js
@@ -56,9 +56,14 @@ export function downloadChannelMetadata(store = coreStore) {
     .then(completedTask => {
       const { taskId, cancelled } = completedTask;
       if (taskId && !cancelled) {
-        return TaskResource.deleteFinishedTasks().then(() => {
-          return getChannelWithContentSizes(transferredChannel.id);
-        });
+        return TaskResource.deleteFinishedTask(taskId)
+          .then(() => {
+            return getChannelWithContentSizes(transferredChannel.id);
+          })
+          .catch(() => {
+            // Fail silently just in case something happens
+            return getChannelWithContentSizes(transferredChannel.id);
+          });
       }
       return Promise.reject({ errorType: ErrorTypes.CHANNEL_TASK_ERROR });
     });

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -254,18 +254,27 @@
     margin-left: 8px;
   }
 
-  .new-label {
-    position: absolute;
-    top: 3px;
-    padding: 2px 5px 2px 4px;
-    margin-left: 8px;
-    font-size: 14px;
-    border-radius: 2px;
-  }
-
   .private-icons {
     position: relative;
     display: inline-block;
+    margin-top: -3px;
+    margin-bottom: 3px;
+    vertical-align: top;
+  }
+
+  .new-label {
+    position: absolute;
+    top: 2px;
+    display: inline-block;
+    padding: 2px 8px;
+    margin-left: 8px;
+    font-size: 14px;
+    font-weight: bold;
+    border-radius: 2px;
+
+    .channel-list-item-sm & {
+      top: -2px;
+    }
   }
 
   .selected-msg {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -125,8 +125,6 @@
         }
       },
       isUnlistedChannel() {
-        // This is only defined when entering a remote import workflow,
-        // so false !== undefined.
         return this.channel.public === false;
       },
       tasksInQueue() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -155,6 +155,7 @@
   }
 
   .private-icons {
+    position: relative;
     display: inline-block;
     margin-top: -3px;
     margin-bottom: 3px;
@@ -167,10 +168,17 @@
   }
 
   .new-label {
-    padding: 2px 5px 2px 4px;
+    position: absolute;
+    top: 2px;
+    padding: 2px 8px;
     margin-left: 8px;
     font-size: 14px;
+    font-weight: bold;
     border-radius: 2px;
+
+    .panel-sm & {
+      top: -2px;
+    }
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -120,6 +120,16 @@
     padding: 16px 0;
   }
 
+  svg.lock-icon {
+    width: 24px;
+    height: 24px;
+
+    .panel-sm & {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
   .col-2 {
     min-width: 80px;
     margin-right: 16px;
@@ -146,7 +156,14 @@
 
   .private-icons {
     display: inline-block;
+    margin-top: -3px;
+    margin-bottom: 3px;
     vertical-align: top;
+
+    .panel-sm & {
+      margin-top: -1px;
+      margin-bottom: 1px;
+    }
   }
 
   .new-label {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -5,7 +5,20 @@
     :class="{'panel-sm': windowIsSmall}"
     :style="{ borderTop: `1px solid ${$themePalette.grey.v_200}` }"
   >
-    <ChannelDetails :channel="channel" />
+    <ChannelDetails :channel="channel">
+
+      <template v-if="showNewLabel" v-slot:belowname>
+        <div class="private-icons">
+          <span
+            class="new-label"
+            :style="{
+              color: $themeTokens.textInverted,
+              backgroundColor: $themeTokens.success
+            }"
+          >{{ WithImportDetailsStrings.$tr('newLabel') }}</span>
+        </div>
+      </template>
+    </ChannelDetails>
 
     <div
       class="col-2"
@@ -35,7 +48,11 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import ChannelDetails from './ChannelDetails';
+  import WithImportDetails from './WithImportDetails';
+
+  const WithImportDetailsStrings = crossComponentTranslator(WithImportDetails);
 
   export default {
     name: 'WithSizeAndOptions',
@@ -52,10 +69,17 @@
         type: Boolean,
         default: false,
       },
+      showNewLabel: {
+        type: Boolean,
+        required: false,
+      },
     },
     computed: {
       resourcesSizeText() {
         return bytesForHumans(this.channel.on_device_file_size);
+      },
+      WithImportDetailsStrings() {
+        return WithImportDetailsStrings;
       },
     },
     methods: {
@@ -108,6 +132,18 @@
 
   .manage-btn {
     margin: 0;
+  }
+
+  .private-icons {
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .new-label {
+    padding: 2px 5px 2px 4px;
+    margin-left: 8px;
+    font-size: 14px;
+    border-radius: 2px;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -7,9 +7,19 @@
   >
     <ChannelDetails :channel="channel">
 
-      <template v-if="showNewLabel" v-slot:belowname>
+      <template v-slot:belowname>
         <div class="private-icons">
+          <KTooltip reference="lockicon" :refs="$refs" placement="top">
+            {{ WithImportDetailsStrings.$tr('unlistedChannelTooltip') }}
+          </KTooltip>
+          <KIcon
+            v-if="channel.public === false"
+            ref="lockicon"
+            class="lock-icon"
+            icon="unlistedchannel"
+          />
           <span
+            v-if="showNewLabel"
             class="new-label"
             :style="{
               color: $themeTokens.textInverted,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
@@ -45,13 +45,7 @@
 
   export default {
     name: 'TasksBar',
-    components: {},
     mixins: [commonCoreStrings, responsiveWindowMixin],
-    props: {},
-    data() {
-      return {};
-    },
-
     computed: {
       ...mapGetters('manageContent', ['managedTasks']),
       clearCompletedString() {
@@ -79,6 +73,14 @@
       },
       tasksString() {
         return this.$tr('someTasksComplete', { done: this.doneTasks, total: this.totalTasks });
+      },
+    },
+    watch: {
+      doneTasks(val, oldVal) {
+        // Just refresh the channel list whenever anything finishes to get the latest version
+        if (val > oldVal) {
+          this.$store.dispatch('manageContent/refreshChannelList');
+        }
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
@@ -75,14 +75,6 @@
         return this.$tr('someTasksComplete', { done: this.doneTasks, total: this.totalTasks });
       },
     },
-    watch: {
-      doneTasks(val, oldVal) {
-        // Just refresh the channel list whenever anything finishes to get the latest version
-        if (val > oldVal) {
-          this.$store.dispatch('manageContent/refreshChannelList');
-        }
-      },
-    },
     methods: {
       handleClickClearAll() {
         TaskResource.deleteFinishedTasks();

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
@@ -1,5 +1,6 @@
 import find from 'lodash/find';
 import { TaskResource, ChannelResource, RemoteChannelResource } from 'kolibri.resources';
+import { TaskTypes } from '../../constants';
 import { NetworkLocationResource } from '../../apiResources';
 
 const kolibriStudioUrl = 'https://studio.learningequality.org';
@@ -98,7 +99,7 @@ export function fetchOrTriggerChannelDiffStatsTask(params) {
   }
 
   return TaskResource.fetchCollection({ force: true }).then(tasks => {
-    const match = find(tasks, taskAttrs);
+    const match = find(tasks, { ...taskAttrs, type: TaskTypes.CHANNELDIFFSTATS });
     if (match) {
       return match;
     } else {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -84,7 +84,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import taskNotificationMixin from '../taskNotificationMixin';
-  import { PageNames } from '../../constants';
+  import { PageNames, TaskStatuses } from '../../constants';
   import SelectTransferSourceModal from './SelectTransferSourceModal';
   import ChannelPanel from './ChannelPanel/WithSizeAndOptions';
   import DeleteChannelModal from './DeleteChannelModal';
@@ -111,8 +111,15 @@
       };
     },
     computed: {
-      ...mapGetters('manageContent', ['installedChannelsWithResources', 'channelIsBeingDeleted']),
+      ...mapGetters('manageContent', [
+        'installedChannelsWithResources',
+        'channelIsBeingDeleted',
+        'managedTasks',
+      ]),
       ...mapState('manageContent/wizard', ['pageName']),
+      doneTasks() {
+        return this.managedTasks.filter(task => task.status === TaskStatuses.COMPLETED).length;
+      },
       sortedChannels() {
         return sortBy(
           this.installedChannelsWithResources,
@@ -149,6 +156,12 @@
         },
         immediate: true,
         deep: true,
+      },
+      doneTasks(val, oldVal) {
+        // Just refresh the channel list whenever anything finishes to get the latest version
+        if (val > oldVal) {
+          this.refreshChannelList();
+        }
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -13,11 +13,12 @@
         </KTooltip>
         <h1>
           <KLabeledIcon icon="channel" :label="channel.name" />
-          <KIcon
+          <!-- Commenting out this icon because we've lost the channel.public attribute -->
+          <!-- <KIcon
             ref="lockicon"
             class="lock-icon"
             icon="unlistedchannel"
-          />
+          /> -->
         </h1>
       </div>
       <p class="version">

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -13,12 +13,12 @@
         </KTooltip>
         <h1>
           <KLabeledIcon icon="channel" :label="channel.name" />
-          <!-- Commenting out this icon because we've lost the channel.public attribute -->
-          <!-- <KIcon
+          <KIcon
+            v-if="channel.public === false"
             ref="lockicon"
             class="lock-icon"
             icon="unlistedchannel"
-          /> -->
+          />
         </h1>
       </div>
       <p class="version">

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -114,7 +114,7 @@
       };
     },
     computed: {
-      ...mapGetters('manageContent', ['channelIsInstalled']),
+      ...mapGetters('manageContent', ['channelIsOnDevice']),
       ...mapState('manageContent', ['taskList']),
       ...mapGetters('manageContent/wizard', [
         'inLocalImportMode',
@@ -154,7 +154,7 @@
         return undefined;
       },
       channelOnDevice() {
-        return this.channelIsInstalled(this.transferredChannel.id) || {};
+        return this.channelIsOnDevice(this.transferredChannel.id) || {};
       },
       availableVersions() {
         return {

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -66,7 +66,7 @@ function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitF
       const task = completed[0];
       if (task.status === TaskStatuses.COMPLETED) {
         store.commit(commitFinish, new Date());
-        TaskResource.deleteFinishedTasks();
+        TaskResource.deleteFinishedTask(taskId);
       }
     }
   } else {


### PR DESCRIPTION
### Summary

1. Updates the places where we clear out the whole queue after a task completes under the old only-one-task-at-a-time model with code to only clear out the task that was being watched for whatever reason. Fixes #6140 
1. ~Removes the lock icon on the SelectContentPage that used to be shown conditionally when a channel is unlisted (relies on a `channel.public` field that has been lost in recent changes)~
1. Add 'public' field to ChannelMetadataSerializer, so that the unlisted channel icon would show. This icon shows strictly when public = false, and not when public = null just in case the channel was never given an annotation.
1. Fixes code in NewChannelVersionPage that would short circuit a new CHANNELDIFFSTATS task if a similar looking task (but not the same kind of Task) of a different type was in the queue. Provides a solution to #6229 
1. Add channel list updating logic described in #6314

### Reviewer guidance

1. Can test the fix for #6140 by starting and finishing some tasks, then starting an import from Kolibri Studio (preferably a channel that you have not already downloaded the sqlite3 file for). This will not clear out the tasks from the Task Manager.
1. Test the fix for the channeldiffstats issue, by importing from a private channel on Studio. Don't clear out your queue. Then update the channel and re-view the upgrade page. Without this change, you should see the empty diffstats table. With this change, you should not see an empty table. This could be dependent on the order of things in the queue, so make sure the import task is towards the top.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
