### PR TITLE
Only handle signals propagating from the current process in cherrypy

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -282,6 +282,16 @@ def run_server(port, serve_http=True):
     pid_plugin = CleanUpPIDPlugin(cherrypy.engine)
     pid_plugin.subscribe()
 
+    process_pid = os.getpid()
+
+    original_handler = cherrypy.engine.signal_handler._handle_signal
+
+    def handler(signum, frame):
+        if os.getpid() == process_pid:
+            original_handler(signum, frame)
+
+    cherrypy.engine.signal_handler._handle_signal = handler
+
     cherrypy.engine.signal_handler.handlers.update(
         {
             "SIGINT": cherrypy.engine.exit,


### PR DESCRIPTION
### Summary
The process pool executor copies the current signal handler into the child processes (see here: https://bugs.python.org/msg308652), as a result failing process pool jobs were triggering a SIGTERM - this had slightly weird side effects because it was being handled in a handler that referred to objects in a different process.

This PR attempts to fix this by recording the parent process PID and then comparing that with the current PID whenever the handler is called - the signal handler is only invoked in the case that the signal originated in the parent process.

### Reviewer guidance
Can you provision a server without getting weird SIGTERMs on MacOS without C extensions installed?

### References
Fixes #6307 (hopefully)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
