### PR TITLE
Pin pickle protocol to 2 for 2/3 compatibility.

### DIFF
--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -16,6 +16,7 @@ from kolibri.core.tasks.job import State
 from kolibri.core.tasks.queue import Queue
 from kolibri.core.tasks.storage import StorageMixin
 from kolibri.core.tasks.utils import InfiniteLoopThread
+from kolibri.utils.conf import OPTIONS
 
 Base = declarative_base()
 
@@ -41,7 +42,7 @@ class ScheduledJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType(protocol=2))
+    obj = Column(PickleType(protocol=OPTIONS["Python"]["PICKLE_PROTOCOL"]))
 
     scheduled_time = Column(DateTime())
 

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -41,7 +41,7 @@ class ScheduledJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType)
+    obj = Column(PickleType(protocol=2))
 
     scheduled_time = Column(DateTime())
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.job import State
+from kolibri.utils.conf import OPTIONS
 
 Base = declarative_base()
 
@@ -43,7 +44,7 @@ class ORMJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType(protocol=2))
+    obj = Column(PickleType(protocol=OPTIONS["Python"]["PICKLE_PROTOCOL"]))
 
     time_created = Column(DateTime(timezone=True), server_default=func.now())
     time_updated = Column(DateTime(timezone=True), server_onupdate=func.now())

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -43,7 +43,7 @@ class ORMJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType)
+    obj = Column(PickleType(protocol=2))
 
     time_created = Column(DateTime(timezone=True), server_default=func.now())
     time_updated = Column(DateTime(timezone=True), server_onupdate=func.now())

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -3,11 +3,10 @@ import logging
 import time
 import uuid
 
-from diskcache import Cache
 from diskcache import RLock
 
 from kolibri.core.tasks import compat
-from kolibri.deployment.default.cache import diskcache_location
+from kolibri.deployment.default.cache import diskcache_cache
 
 
 # An object on which to store data about the current job
@@ -16,7 +15,7 @@ from kolibri.deployment.default.cache import diskcache_location
 current_state_tracker = compat.local()
 
 
-db_task_write_lock = RLock(Cache(diskcache_location), "db_task_write_lock")
+db_task_write_lock = RLock(diskcache_cache, "db_task_write_lock")
 
 
 def get_current_job():

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -2,12 +2,18 @@ import copy
 import os
 import sys
 
+from diskcache import Cache
+
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.conf import OPTIONS
 
 cache_options = OPTIONS["Cache"]
 
+pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
+
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
+
+diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
 
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {
@@ -32,7 +38,11 @@ built_files_cache = {
 process_cache = {
     "BACKEND": "diskcache.DjangoCache",
     "LOCATION": diskcache_location,
-    "OPTIONS": {"MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"]},
+    "OPTIONS": {
+        "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
+        # Pin pickle protocol for Python 2 compatibility
+        "disk_pickle_protocol": pickle_protocol,
+    },
 }
 
 
@@ -49,6 +59,8 @@ if cache_options["CACHE_BACKEND"] == "redis":
         "OPTIONS": {
             "PASSWORD": cache_options["CACHE_PASSWORD"],
             "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
+            # Pin pickle protocol for Python 2 compatibility
+            "PICKLE_VERSION": pickle_protocol,
         },
     }
     default_cache = copy.deepcopy(base_cache)

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -167,6 +167,13 @@ base_option_spec = {
             "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
     },
+    "Python": {
+        "PICKLE_PROTOCOL": {
+            "type": "integer",
+            "default": 2,
+            "envvars": ("KOLIBRI_PICKLE_PROTOCOL",),
+        },
+    },
 }
 
 


### PR DESCRIPTION
### Summary
Pins the pickle protocol for pickling async task jobs to `2` so that they are compatible with Python 2/3.

### Reviewer guidance
Does the server start? Can you run a task?

### References
Fixes #6317

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
