### PR TITLE
Ensure adhocgroup is managed in notifications

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -17,6 +17,7 @@ from kolibri.core.auth.filters import HierarchyRelationsFilter
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.decorators import query_params_required
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
@@ -153,7 +154,8 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
             except (Collection.DoesNotExist, ValueError):
                 return []
         if collection.kind == collection_kinds.CLASSROOM:
-            classroom_groups = LearnerGroup.objects.filter(parent=collection)
+            classroom_groups = list(LearnerGroup.objects.filter(parent=collection))
+            classroom_groups += list(AdHocGroup.objects.filter(parent=collection))
             learner_groups = [group.id for group in classroom_groups]
             learner_groups.append(collection_id)
             notifications_query = LearnerProgressNotification.objects.filter(

--- a/kolibri/plugins/coach/assets/src/constants/lessonsConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/lessonsConstants.js
@@ -15,5 +15,6 @@ export const LessonsPageNames = {
 
 export const CollectionTypes = {
   LEARNERGROUP: 'learnergroup',
+  ADHOCLEARNERSGROUP: 'adhoclearnersgroup',
   CLASSROOM: 'classroom',
 };

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -320,6 +320,7 @@ export default {
     // whenever this module's state changes.
     notificationModuleData(state) {
       return {
+        adHocGroupsMap: state.adHocGroupsMap,
         learners: state.learnerMap,
         learnerGroups: state.groupMap,
         lessons: state.lessonMap,

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -116,10 +116,11 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
           firstUserName: firstUser.user,
           firstUserId: firstUser.user_id,
           total: partitioning.hasEvent.length,
+          // not used for Needs Help
           completesCollection:
             partitioning.rest.length === 0 &&
             // If the collection kind is ad hoc, always make this false
-            collection.collection_kind == CollectionTypes.ADHOCLEARNERSGROUP, // not used for Needs Help
+            collection.collection_kind == CollectionTypes.ADHOCLEARNERSGROUP,
         },
       });
     }

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -104,7 +104,7 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
       // will have a notification shown.
       if (collection.collection_kind === CollectionTypes.ADHOCLEARNERSGROUP) {
         partitioning.hasEvent.forEach((userId, idx) => {
-          const user = find(allEvents, event => {
+          const user = find(orderBy(allEvents, 'timestamp', ['desc']), event => {
             return event.user_id === userId;
           });
           summaryEvents.push({

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -120,7 +120,7 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
           completesCollection:
             partitioning.rest.length === 0 &&
             // If the collection kind is ad hoc, always make this false
-            collection.collection_kind == CollectionTypes.ADHOCLEARNERSGROUP,
+            collection.collection_kind !== CollectionTypes.ADHOCLEARNERSGROUP,
         },
       });
     }

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import find from 'lodash/find';
 import maxBy from 'lodash/maxBy';
 import { NotificationObjects } from '../../constants/notificationsConstants';
+import { CollectionTypes } from '../../constants/lessonsConstants';
 import { partitionCollectionByEvents, getCollectionsForAssignment } from './gettersUtils';
 
 const { LESSON, RESOURCE, QUIZ } = NotificationObjects;
@@ -115,7 +116,10 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
           firstUserName: firstUser.user,
           firstUserId: firstUser.user_id,
           total: partitioning.hasEvent.length,
-          completesCollection: partitioning.rest.length === 0, // not used for Needs Help
+          completesCollection:
+            partitioning.rest.length === 0 &&
+            // If the collection kind is ad hoc, always make this false
+            collection.collection_kind == CollectionTypes.ADHOCLEARNERSGROUP, // not used for Needs Help
         },
       });
     }

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/LessonsBlock.vue
@@ -19,7 +19,7 @@
       <ItemProgressDisplay
         :name="tableRow.name"
         :tally="tableRow.tally"
-        :groupNames="tableRow.groups"
+        :groupNames="groupAndAdHocLearnerNames(tableRow.groups, tableRow.assignments)"
         :hasAssignments="tableRow.hasAssignments"
         :to="classRoute('ReportsLessonLearnerListPage', { lessonId: tableRow.key })"
       />
@@ -59,6 +59,7 @@
             tally: this.getLessonStatusTally(lesson.id, assigned),
             groups: lesson.groups.map(groupId => this.groupMap[groupId].name),
             hasAssignments: assigned.length > 0,
+            assignments: lesson.assignments,
           };
         });
       },
@@ -77,6 +78,14 @@
           }
         });
         return last;
+      },
+      groupAndAdHocLearnerNames(groups, assignments) {
+        const adHocGroup = this.adHocGroups.find(group => assignments.includes(group.id));
+        let adHocLearners = [];
+        if (adHocGroup) {
+          adHocLearners = adHocGroup.member_ids.map(learnerId => this.learnerMap[learnerId].name);
+        }
+        return groups.concat(adHocLearners);
       },
     },
     $trs: {},

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/QuizzesBlock.vue
@@ -78,8 +78,8 @@
         });
         return last;
       },
-      groupAndAdHocLearnerNames(groups, examAssignments) {
-        const adHocGroup = this.adHocGroups.find(group => examAssignments.includes(group.id));
+      groupAndAdHocLearnerNames(groups, assignments) {
+        const adHocGroup = this.adHocGroups.find(group => assignments.includes(group.id));
         let adHocLearners = [];
         if (adHocGroup) {
           adHocLearners = adHocGroup.member_ids.map(learnerId => this.learnerMap[learnerId].name);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Notifications for activity related to individual learners is now addressed re: https://github.com/learningequality/kolibri/issues/6341

**NOTE** that when a learner has activity and is assigned as part of a group - the notification card will say something like `Group 2 - Lesson 1`.

There is no such item for "Individual learners" but it may be worth considering if we should put a string saying "Individually assigned" in that context the next time we're able to add strings.

**NOTE 2** typically groups of events on the same item would be combined into things like "Radina and N others completed The Quiz" or "Everyone in Group 1 started Lesson #1". Individual learners are not grouped similarly so the "Everyone..." type events are not shown at all. The "Learner and N others..." types are also not used here because those types of notifications link to Reports > Groups reports and there is not a report like that for Individual learners. Therefore, Individual learners notifications are all individually listed in Class Home > Class Activity.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

__Quizzes__

- Create a quiz, assign only individual learners.
- Create a quiz, assign a group and individual learners.
- Open the "Class Home" for that class as coach.
- Take the quizzes as both individual learners and learners who are a part of the group you assigned.
- See all started and completed notifications showing in the Class Home page for the learners as expected.

- Repeat by adding an Individual Learner to an existing quiz (existed prior to you testing this) if you have one.

__Lessons__

- Do the same as above, but with Lessons.
- Note also that "Needs help" notifications should appear so try answering 3 questions incorrectly as an individual learner.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6341

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
