### PR TITLE
Close video.js menu on click away

### DIFF
--- a/kolibri/plugins/media_player/assets/src/mixins/videojsButtonMixin.js
+++ b/kolibri/plugins/media_player/assets/src/mixins/videojsButtonMixin.js
@@ -17,6 +17,15 @@ export default function videojsButtonMixin(videojsComponent) {
       this.on(this.menuButton_.el().parentElement, 'mouseleave', () => {
         this.menu.hide();
       });
+
+      this.documentClickListener = e => {
+        if (this.el().contains(e.target)) {
+          return;
+        }
+
+        // This will cascade to triggering `unlock` event
+        this.unpressButton();
+      };
     }
 
     /**
@@ -42,6 +51,14 @@ export default function videojsButtonMixin(videojsComponent) {
       this.items.forEach(item => {
         menu.addItem(item);
         item.on('hide', () => this.unpressButton());
+      });
+
+      menu.on('lock', () => {
+        document.addEventListener('click', this.documentClickListener);
+      });
+
+      menu.on('unlock', () => {
+        document.removeEventListener('click', this.documentClickListener);
       });
 
       return menu;

--- a/kolibri/plugins/media_player/assets/src/mixins/videojsMenuVueMixin.js
+++ b/kolibri/plugins/media_player/assets/src/mixins/videojsMenuVueMixin.js
@@ -78,6 +78,11 @@ export default function videojsMenuVueMixin(vueComponent) {
      */
     doShow(lock = false) {
       const component = this.getVueComponent();
+
+      if (lock && !this.isLocked) {
+        this.trigger('lock');
+      }
+
       this.isLocked = this.isLocked || lock;
 
       if (!component || component.showing()) {
@@ -97,6 +102,7 @@ export default function videojsMenuVueMixin(vueComponent) {
         return;
       }
 
+      this.trigger('unlock');
       this.isLocked = false;
       component.hide(unlock);
     }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- The menus listen for any click events that occur outside of their bounds, and close themselves when that occurs
- The menus toggle closed when their main button is clicked and the menu is currently open

![media-player-menus](https://user-images.githubusercontent.com/819838/71019154-b61d6700-20ae-11ea-877a-6906d3283e7a.gif)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Ensure this change does not interfere with captioning controls.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/6036

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
