### PR TITLE
Ensures against MAX SQLITE variables errors in most problematic potential places

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -350,7 +350,15 @@ class ClassroomViewSet(ValuesViewset):
     def consolidate(self, items):
         output = []
         items = sorted(items, key=lambda x: x["id"])
-        coach_ids = list(set([item["role__user__id"] for item in items]))
+        coach_ids = list(
+            set(
+                [
+                    item["role__user__id"]
+                    for item in items
+                    if item["role__user__id"] is not None
+                ]
+            )
+        )
         facility_roles = {
             obj.pop("user"): obj
             for obj in Role.objects.filter(

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -133,13 +133,7 @@ class IdFilter(FilterSet):
     ids = CharFilter(method="filter_ids")
 
     def filter_ids(self, queryset, name, value):
-        try:
-            # SQLITE_MAX_VARIABLE_NUMBER is 999 by default.
-            # It means 999 is the max number of params for a query
-            return queryset.filter(pk__in=value.split(",")[:900])
-        except ValueError:
-            # Catch in case of a poorly formed UUID
-            return queryset.none()
+        return queryset.filter_by_uuids(value.split(","))
 
     class Meta:
         fields = ["ids"]
@@ -296,7 +290,7 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
             return Response([])
         ids = ids.split(",")
         kind = self.request.query_params.get("descendant_kind", None)
-        nodes = models.ContentNode.objects.filter(id__in=ids, available=True)
+        nodes = models.ContentNode.objects.filter_by_uuids(ids).filter(available=True)
         data = []
         for node in nodes:
 
@@ -318,7 +312,9 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         if not ids:
             return Response([])
         ids = ids.split(",")
-        queryset = models.ContentNode.objects.filter(id__in=ids, available=True)
+        queryset = models.ContentNode.objects.filter_by_uuids(ids).filter(
+            available=True
+        )
         data = list(
             queryset.annotate(
                 num_assessments=SQSum(
@@ -342,9 +338,11 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         ids = self.request.query_params.get("ids", "").split(",")
         data = 0
         if ids and ids[0]:
-            nodes = models.ContentNode.objects.filter(
-                id__in=ids, available=True
-            ).prefetch_related("assessmentmetadata")
+            nodes = (
+                models.ContentNode.objects.filter_by_uuids(ids)
+                .filter(available=True)
+                .prefetch_related("assessmentmetadata")
+            )
             data = (
                 nodes.aggregate(Sum("assessmentmetadata__number_of_assessments"))[
                     "assessmentmetadata__number_of_assessments__sum"
@@ -381,9 +379,8 @@ class ContentNodeViewset(viewsets.ReadOnlyModelViewSet):
         if content_id_string:
             content_ids = content_id_string.split(",")
             counts = (
-                models.ContentNode.objects.filter(
-                    content_id__in=content_ids, available=True
-                )
+                models.ContentNode.objects.filter_by_content_ids(content_ids)
+                .filter(available=True)
                 .values("content_id")
                 .order_by()
                 .annotate(count=Count("content_id"))
@@ -533,19 +530,20 @@ class ContentNodeSlimViewset(ValuesViewset):
             ).values_list("content_id", flat=True)
 
             # If no logs, don't bother doing the other queries
-            if not completed_content_ids:
+            if not completed_content_ids.exists():
                 queryset = queryset.none()
             else:
-                completed_content_nodes = queryset.filter(
-                    content_id__in=completed_content_ids
+                completed_content_nodes = queryset.filter_by_content_ids(
+                    completed_content_ids
                 ).order_by()
 
                 # Filter to only show content that the user has not engaged in, so as not to be redundant with resume
                 queryset = (
-                    queryset.exclude(
-                        content_id__in=ContentSummaryLog.objects.filter(
-                            user=user
-                        ).values_list("content_id", flat=True)
+                    queryset.exclude_by_content_ids(
+                        ContentSummaryLog.objects.filter(user=user).values_list(
+                            "content_id", flat=True
+                        ),
+                        validate=False,
                     )
                     .filter(
                         Q(has_prerequisite__in=completed_content_nodes)
@@ -599,7 +597,9 @@ class ContentNodeSlimViewset(ValuesViewset):
             # .count scales with table size, so can get slow on larger channels
             count_cache_key = "content_count_for_popular"
             count = cache.get(count_cache_key) or min(pks.count(), 25)
-            queryset = queryset.filter(pk__in=sample(list(pks), count))
+            queryset = queryset.filter_by_uuids(
+                sample(list(pks), count), validate=False
+            )
             if not coach_content:
                 queryset = queryset.exclude(coach_content=True)
         else:
@@ -619,8 +619,8 @@ class ContentNodeSlimViewset(ValuesViewset):
                 .order_by("-content_id__count")
             )
 
-            most_popular = queryset.filter(
-                content_id__in=list(content_counts_sorted[:20])
+            most_popular = queryset.filter_by_content_ids(
+                list(content_counts_sorted[:20]), validate=False
             )
             queryset = most_popular.dedupe_by_content_id()
 
@@ -670,7 +670,9 @@ class ContentNodeSlimViewset(ValuesViewset):
             if not content_ids:
                 queryset = queryset.none()
             else:
-                resume = queryset.filter(content_id__in=list(content_ids[:10]))
+                resume = queryset.filter_by_content_ids(
+                    list(content_ids[:10]), validate=False
+                )
                 queryset = resume.dedupe_by_content_id()
 
         return Response(self.serialize(queryset))
@@ -735,7 +737,7 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
 
             # in each pass, don't take any items already in the result set
             matches = (
-                queryset.exclude(content_id__in=list(content_ids))
+                queryset.exclude_by_content_ids(list(content_ids), validate=False)
                 .filter(query)
                 .values("content_id", "id")[:BUFFER_SIZE]
             )
@@ -755,7 +757,7 @@ class ContentNodeSearchViewset(ContentNodeSlimViewset):
             if len(results) >= max_results:
                 break
 
-        results = queryset.filter(id__in=results)
+        results = queryset.filter_by_uuids(results, validate=False)
 
         # If no queries, just use an empty Q.
         all_queries_filter = union(all_queries) or Q()

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -217,7 +217,7 @@ class ContentNodeFilter(IdFilter):
         return queryset
 
     def filter_exclude_content_ids(self, queryset, name, value):
-        return queryset.exclude(content_id__in=value.split(","))
+        return queryset.exclude_by_content_ids(value.split(","))
 
 
 class OptionalPageNumberPagination(pagination.PageNumberPagination):

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -30,6 +30,7 @@ from django.db import connection
 from django.db import models
 from django.db.models import Min
 from django.db.models import Q
+from django.db.models import QuerySet
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.text import get_valid_filename
 from le_utils.constants import content_kinds
@@ -186,7 +187,7 @@ class File(base_models.File):
         )
 
 
-class LocalFileManager(models.Manager):
+class LocalFileManager(models.Manager, FilterByUUIDQuerysetMixin):
     def delete_unused_files(self):
         for file in self.get_unused_files():
             try:
@@ -260,6 +261,10 @@ class AssessmentMetaData(base_models.AssessmentMetaData):
     pass
 
 
+class ChannelMetadataQueryset(QuerySet, FilterByUUIDQuerysetMixin):
+    pass
+
+
 @python_2_unicode_compatible
 class ChannelMetadata(base_models.ChannelMetadata):
     """
@@ -274,6 +279,8 @@ class ChannelMetadata(base_models.ChannelMetadata):
     )
     order = models.PositiveIntegerField(default=0, null=True, blank=True)
     public = models.NullBooleanField()
+
+    objects = ChannelMetadataQueryset.as_manager()
 
     class Admin:
         pass

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -62,11 +62,17 @@ class ContentNodeQueryset(TreeQuerySet, FilterByUUIDQuerysetMixin):
                 .annotate(node_id=Min("id"))
                 .values_list("node_id", flat=True)
             )
-            return self.filter(id__in=deduped_ids)
+            return self.filter_by_uuids(deduped_ids)
 
         # when using postgres, we can call distinct on a specific column
         elif connection.vendor == "postgresql":
             return self.order_by("content_id").distinct("content_id")
+
+    def filter_by_content_ids(self, content_ids, validate=True):
+        return self._by_uuids(content_ids, validate, "content_id", True)
+
+    def exclude_by_content_ids(self, content_ids, validate=True):
+        return self._by_uuids(content_ids, validate, "content_id", False)
 
 
 class ContentNodeManager(

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -187,7 +187,7 @@ class File(base_models.File):
         )
 
 
-class LocalFileManager(models.Manager, FilterByUUIDQuerysetMixin):
+class LocalFileQueryset(models.QuerySet, FilterByUUIDQuerysetMixin):
     def delete_unused_files(self):
         for file in self.get_unused_files():
             try:
@@ -215,7 +215,7 @@ class LocalFile(base_models.LocalFile):
     The bottom layer of the contentDB schema, defines the local state of files on the device storage.
     """
 
-    objects = LocalFileManager()
+    objects = LocalFileQueryset.as_manager()
 
     class Admin:
         pass

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -43,7 +43,7 @@ def get_nodes_to_transfer(
 
     # if requested, filter down to only include particular topics/nodes
     if node_ids:
-        nodes_to_include = nodes_to_include.filter(pk__in=node_ids).get_descendants(
+        nodes_to_include = nodes_to_include.filter_by_uuids(node_ids).get_descendants(
             include_self=True
         )
 
@@ -53,12 +53,12 @@ def get_nodes_to_transfer(
 
     # filter down the query to remove files associated with nodes we've specifically been asked to exclude
     if exclude_node_ids:
-        nodes_to_exclude = ContentNode.objects.filter(
-            pk__in=exclude_node_ids
+        nodes_to_exclude = ContentNode.objects.filter_by_uuids(
+            exclude_node_ids
         ).get_descendants(include_self=True)
 
-        nodes_to_include = nodes_to_include.order_by().exclude(
-            pk__in=nodes_to_exclude.values("pk")
+        nodes_to_include = nodes_to_include.order_by().exclude_by_uuids(
+            nodes_to_exclude.values("pk")
         )
 
     # By default don't filter node ids by their underlying file importability
@@ -73,7 +73,7 @@ def get_nodes_to_transfer(
             channel_id, peer_id
         ).keys()
     if file_based_node_id_list is not None:
-        nodes_to_include = nodes_to_include.filter(pk__in=file_based_node_id_list)
+        nodes_to_include = nodes_to_include.filter_by_uuids(file_based_node_id_list)
     return nodes_to_include.filter(available=available).order_by()
 
 
@@ -118,7 +118,7 @@ def calculate_files_to_transfer(nodes_to_include, available):
 def _get_node_ids(node_ids):
 
     return (
-        ContentNode.objects.filter(pk__in=node_ids)
+        ContentNode.objects.filter_by_uuids(node_ids)
         .get_descendants(include_self=True)
         .values_list("id", flat=True)
     )

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -3,8 +3,13 @@ Mixins for Django REST Framework ViewSets
 """
 from uuid import UUID
 
-from django.db import connection
+from django.core.exceptions import EmptyResultSet
+from django.db import connection as django_connection
+from django.db.models import ForeignKey
 from django.db.models import QuerySet
+from django.db.models.fields import CharField
+from django.db.models.lookups import In
+from morango.models import UUIDField
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -51,6 +56,72 @@ class BulkDeleteMixin(object):
             self.perform_destroy(obj)
 
 
+class UUIDIn(In):
+    lookup_name = "uuidin"
+
+    # Modified from:
+    # https://github.com/django/django/blob/stable/1.11.x/django/db/models/lookups.py#L346
+
+    def process_rhs(self, compiler, connection):
+        db_rhs = getattr(self.rhs, "_db", None)
+        if db_rhs is not None and db_rhs != connection.alias:
+            raise ValueError(
+                "Subqueries aren't allowed across different databases. Force "
+                "the inner query to be evaluated using `list(inner_query)`."
+            )
+
+        if self.rhs_is_direct_value():
+            try:
+                rhs = set(self.rhs)
+            except TypeError:  # Unhashable items in self.rhs
+                rhs = self.rhs
+
+            if not rhs:
+                raise EmptyResultSet
+
+            # rhs should be an iterable; use batch_process_rhs() to
+            # prepare/transform those values.
+            sqls, sqls_params = self.batch_process_rhs(compiler, connection, rhs)
+            placeholder = "(" + ",".join("'{}'".format(p) for p in sqls_params) + ")"
+            sqls_params = tuple()
+            return (placeholder, sqls_params)
+        else:
+            return super(UUIDIn, self).process_rhs(compiler, connection)
+
+    def split_parameter_list_as_sql(self, compiler, connection):
+        # This is a special case for databases which limit the number of
+        # elements which can appear in an 'IN' clause.
+        max_in_list_size = connection.ops.max_in_list_size()
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.batch_process_rhs(compiler, connection)
+        in_clause_elements = ["("]
+        params = []
+        for offset in range(0, len(rhs_params), max_in_list_size):
+            if offset > 0:
+                in_clause_elements.append(" OR ")
+            in_clause_elements.append("%s IN (" % lhs)
+            params.extend(lhs_params)
+            sqls_params = tuple()
+            param_group = (
+                "("
+                + ",".join(
+                    "'{}'".format(p)
+                    for p in rhs_params[offset : offset + max_in_list_size]
+                )
+                + ")"
+            )
+            in_clause_elements.append(param_group)
+            in_clause_elements.append(")")
+            params.extend(sqls_params)
+        in_clause_elements.append(")")
+        return "".join(in_clause_elements), params
+
+
+UUIDField.register_lookup(UUIDIn)
+CharField.register_lookup(UUIDIn)
+ForeignKey.register_lookup(UUIDIn)
+
+
 class FilterByUUIDQuerysetMixin(object):
     """
     As a workaround to the SQLITE_MAX_VARIABLE_NUMBER, so we can avoid having to chunk our queries,
@@ -69,32 +140,25 @@ class FilterByUUIDQuerysetMixin(object):
         if isinstance(ids, QuerySet):
             # If we have been passed a queryset, we can shortcut and just filter by the field name
             # on the queryset itself.
-            kwargs = {"{}__in".format(field_name): ids}
-            if include:
-                return self.filter(**kwargs)
-            else:
-                return self.exclude(**kwargs)
-        # make a copy of the passed in list
-        ids_list = list(ids)
-        for (idx, identifier) in enumerate(ids_list):
-            if validate:
-                try:
-                    UUID(identifier, version=4)
-                except ValueError:
-                    # the string is not a valid hex code for a UUID, so we don't return any results
-                    return self.none()
-            # wrap the uuids in string quotations
-            if connection.vendor == "sqlite":
-                ids_list[idx] = "'{}'".format(identifier)
-            elif connection.vendor == "postgresql":
-                ids_list[idx] = "'{}'::uuid".format(identifier)
-        query_string = ",".join(ids_list)
-        column_name = self.model._meta.get_field(field_name).column
-        if include:
-            where_template = '"{}"."{}" in ({})'
+            lookup = "in"
         else:
-            where_template = '"{}"."{}" not in ({})'
-        where_clause = where_template.format(
-            self.model._meta.db_table, column_name, query_string
-        )
-        return self.extra(where=[where_clause])
+            # make a copy of the passed in list
+            ids_list = list(ids)
+            for (idx, identifier) in enumerate(ids_list):
+                if validate:
+                    try:
+                        UUID(identifier, version=4)
+                    except (TypeError, ValueError):
+                        # the value is not a valid hex code for a UUID, so we don't return any results
+                        return self.none()
+                # wrap the uuids in string quotations
+                if django_connection.vendor == "sqlite":
+                    ids_list[idx] = "'{}'".format(identifier)
+                elif django_connection.vendor == "postgresql":
+                    ids_list[idx] = "'{}'::uuid".format(identifier)
+            lookup = "uuidin"
+        kwargs = {"{}__{}".format(field_name, lookup): ids}
+        if include:
+            return self.filter(**kwargs)
+        else:
+            return self.exclude(**kwargs)

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -133,7 +133,8 @@ def get_public_file_checksums(request, version):
             return HttpResponseBadRequest("POST body must be either json or gzip")
         checksums = json.loads(data.decode("utf-8"))
         available_checksums = set(
-            LocalFile.objects.filter(available=True, id__in=checksums)
+            LocalFile.objects.filter(available=True)
+            .filter_by_uuids(checksums)
             .values_list("id", flat=True)
             .distinct()
         )

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -17,9 +17,9 @@ from rest_framework.response import Response
 
 from kolibri.core.auth import models as auth_models
 from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.content.models import ContentNode
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
@@ -50,7 +50,7 @@ def content_status_serializer(lesson_data, learners_data, classroom):  # noqa C9
     # to the same content_id.
     content_map = {
         n[0]: n[1]
-        for n in ContentNode.objects.filter(id__in=lesson_node_ids).values_list(
+        for n in ContentNode.objects.filter_by_uuids(lesson_node_ids).values_list(
             "id", "content_id"
         )
     }
@@ -349,7 +349,7 @@ class ClassSummaryViewSet(viewsets.ViewSet):
             for lesson in lesson_data
             for resource in lesson.pop("resources")
         }
-        query_content = ContentNode.objects.filter(id__in=all_node_ids)
+        query_content = ContentNode.objects.filter_by_uuids(all_node_ids)
         # final list of available nodes
         list_of_ids = [node.id for node in query_content]
         # determine a new list of node_ids for each lesson, removing/replacing missing content items

--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -162,7 +162,7 @@ class DeviceChannelOrderView(APIView):
             raise ParseError(
                 "Expected {} ids, but only received {}".format(total_channels, len(ids))
             )
-        if queryset.filter(id__in=ids).count() != len(ids):
+        if queryset.filter_by_uuids(ids).count() != len(ids):
             raise ParseError(
                 "List of ids does not match the available channels on the server"
             )


### PR DESCRIPTION
### Summary
* Uses @ralphiee22's magic UUID filtering methods in all places where there could potentially be a large number of ids being passed into an `id__in` or `pk__in` query.

* Updates to make it work with table joins, and column names that don't match the field name

* Also adds in usages for various `user_id__in` `content_id__in` etc.

### Reviewer guidance
Do tests still pass?
Do the updates to filter uuids logic make sense?
Is this too much/too high risk?

### References
Fixes #6157 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
