### PR TITLE
Cancel all background tasks on shutdown

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -179,6 +179,8 @@ class Job(object):
             except Exception as e:
                 # If any error occurs, clear the job tracker and reraise
                 setattr(current_state_tracker, "job", None)
+                # Close any django connections opened here
+                connection.close()
                 raise e
 
             setattr(current_state_tracker, "job", None)

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -83,6 +83,8 @@ class Worker(object):
     def shutdown(self, wait=False):
         self.job_checker.stop()
         self.shutdown_workers(wait=wait)
+        if wait:
+            self.job_checker.join()
 
     def start_job_checker(self):
         """

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -42,6 +42,10 @@ class Worker(object):
         self.job_checker = self.start_job_checker()
 
     def shutdown_workers(self, wait=True):
+        # First cancel all running jobs
+        for job_id in self.future_job_mapping:
+            self.cancel(job_id)
+        # Now shutdown the workers
         self.workers.shutdown(wait=wait)
 
     def start_workers(self, num_workers):

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -40,7 +40,7 @@ from django.conf.urls import url
 from django.conf.urls.static import static
 
 from .views import GuestRedirectView
-from .views import HealthCheckView
+from .views import StatusCheckView
 from .views import logout_view
 from .views import RootURLRedirectView
 from .views import set_language
@@ -65,7 +65,7 @@ core_urlpatterns = [
     url(r"^api/", include("kolibri.core.api_urls")),
     url(r"", include(i18n_patterns(lang_prefixed_patterns))),
     url(r"", include("kolibri.core.content.urls")),
-    url(r"^health/", HealthCheckView.as_view(), name="health_check"),
+    url(r"^status/", StatusCheckView.as_view(), name="status_check"),
 ]
 
 

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -40,6 +40,7 @@ from django.conf.urls import url
 from django.conf.urls.static import static
 
 from .views import GuestRedirectView
+from .views import HealthCheckView
 from .views import logout_view
 from .views import RootURLRedirectView
 from .views import set_language
@@ -64,6 +65,7 @@ core_urlpatterns = [
     url(r"^api/", include("kolibri.core.api_urls")),
     url(r"", include(i18n_patterns(lang_prefixed_patterns))),
     url(r"", include("kolibri.core.content.urls")),
+    url(r"^health/", HealthCheckView.as_view(), name="health_check"),
 ]
 
 

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -179,3 +179,11 @@ class RootURLRedirectView(View):
 @method_decorator(cache_no_user_data, name="dispatch")
 class UnsupportedBrowserView(TemplateView):
     template_name = "kolibri/unsupported_browser.html"
+
+
+class HealthCheckView(View):
+    def get(self, request):
+        """
+        Confirms that the server is up
+        """
+        return HttpResponse()

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -181,7 +181,7 @@ class UnsupportedBrowserView(TemplateView):
     template_name = "kolibri/unsupported_browser.html"
 
 
-class HealthCheckView(View):
+class StatusCheckView(View):
     def get(self, request):
         """
         Confirms that the server is up

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -402,7 +402,7 @@ def get_status():  # noqa: max-complexity=16
         else "/" + conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
     )
 
-    check_url = "http://{}:{}{}health/".format("127.0.0.1", listen_port, prefix)
+    check_url = "http://{}:{}{}status/".format("127.0.0.1", listen_port, prefix)
 
     if conf.OPTIONS["Server"]["CHERRYPY_START"]:
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -396,7 +396,13 @@ def get_status():  # noqa: max-complexity=16
 
     listen_port = port
 
-    check_url = "http://{}:{}".format("127.0.0.1", listen_port)
+    prefix = (
+        conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+        if conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"] == "/"
+        else "/" + conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+    )
+
+    check_url = "http://{}:{}{}health/".format("127.0.0.1", listen_port, prefix)
 
     if conf.OPTIONS["Server"]["CHERRYPY_START"]:
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import threading
 from subprocess import CalledProcessError
 from subprocess import check_output
 
@@ -8,7 +9,9 @@ import cherrypy
 import ifcfg
 import requests
 from cherrypy.process.plugins import SimplePlugin
+from cherrypy.process.wspbus import states
 from django.conf import settings
+from six import create_bound_method
 
 import kolibri
 from .system import kill_pid
@@ -250,6 +253,54 @@ def configure_http_server(port):
     server.subscribe()
 
 
+def _block(self, interval=0.1):
+    """Wait for the EXITING state, KeyboardInterrupt or SystemExit.
+    This function is intended to be called only by the main thread.
+    After waiting for the EXITING state, it also waits for all threads
+    to terminate, and then calls os.execv if self.execv is True. This
+    design allows another thread to call bus.restart, yet have the main
+    thread perform the actual execv call (required on some platforms).
+    Copied and modified from:
+    https://github.com/cherrypy/cherrypy/blob/master/cherrypy/process/wspbus.py#L326
+    """
+    try:
+        self.wait(states.EXITING, interval=interval, channel="main")
+    except (KeyboardInterrupt, IOError):
+        # The time.sleep call might raise
+        # "IOError: [Errno 4] Interrupted function call" on KBInt.
+        self.log("Keyboard Interrupt: shutting down bus")
+        self.exit()
+    except SystemExit:
+        self.log("SystemExit raised: shutting down bus")
+        self.exit()
+        raise
+
+    # Waiting for ALL child threads to finish is necessary on OS X.
+    # See https://github.com/cherrypy/cherrypy/issues/581.
+    # It's also good to let them all shut down before allowing
+    # the main thread to call atexit handlers.
+    # See https://github.com/cherrypy/cherrypy/issues/751.
+    self.log("Waiting for child threads to terminate...")
+    for t in threading.enumerate():
+        # Validate the we're not trying to join the MainThread
+        # that will cause a deadlock and the case exist when
+        # implemented as a windows service and in any other case
+        # that another thread executes cherrypy.engine.exit()
+        if (
+            t != threading.currentThread()
+            and not isinstance(t, threading._MainThread)
+            # Note that any dummy (external) threads are
+            # always daemonic.
+            and not t.daemon
+        ):
+            self.log("Waiting for thread %s." % t.getName())
+            # Give each thread 10s to finish up
+            t.join(10)
+
+    # Call sys.exit to raise SystemExit in child threads
+    sys.exit()
+
+
 def run_server(port, serve_http=True):
     # Unsubscribe the default server
     cherrypy.server.unsubscribe()
@@ -291,6 +342,8 @@ def run_server(port, serve_http=True):
             original_handler(signum, frame)
 
     cherrypy.engine.signal_handler._handle_signal = handler
+
+    cherrypy.engine.block = create_bound_method(_block, cherrypy.engine)
 
     cherrypy.engine.signal_handler.handlers.update(
         {

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -60,7 +60,7 @@ def _kill_pid(pid, softkill_signal_number):
         return
     # give some time for the process to clean itself up gracefully bfore we force anything
     i = 0
-    while pid_exists(pid) and i < 10:
+    while pid_exists(pid) and i < 60:
         time.sleep(0.5)
         i += 1
     # if process didn't exit cleanly, make one last effort to kill it

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -48,6 +48,7 @@ def _posix_pid_exists(pid):
 
 def _kill_pid(pid, softkill_signal_number):
     """Kill a PID by sending a signal, starting with a softer one and then escalating as needed"""
+    logger.info("Initiating shutdown of Kolibri")
     try:
         logger.debug("Attempting to soft kill process with pid %d..." % pid)
         os.kill(pid, softkill_signal_number)
@@ -58,7 +59,9 @@ def _kill_pid(pid, softkill_signal_number):
             "Soft kill signal could not be sent (OSError); process may not exist?"
         )
         return
-    # give some time for the process to clean itself up gracefully bfore we force anything
+    if pid_exists(pid):
+        logger.info("Waiting for Kolibri to finish shutting down")
+    # give some time for the process to clean itself up gracefully before we force anything
     i = 0
     while pid_exists(pid) and i < 60:
         time.sleep(0.5)


### PR DESCRIPTION
### Summary
* Cancels all running background tasks on shutdown
* Cleans up Django db connections when a task raises an exception
* Don't wait forever for threads to terminate, and call sys.exit to get them to exit gracefully

### Reviewer guidance
Should prevent zombie processes after a task is triggered and the server then shut down.

### References
Fixes #6374

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
