### PR TITLE
Fix button alignment in Quiz Creation

### DIFF
--- a/packages/kolibri-components/src/buttons-and-links/buttons.scss
+++ b/packages/kolibri-components/src/buttons-and-links/buttons.scss
@@ -34,6 +34,7 @@ $raised-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14),
 
 a.button {
   display: inline-block; // helps with vertical layout
+  vertical-align: top;
 }
 
 .raised {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

After a rebase on release-v0.13.x I noticed the buttons in quiz creation were off.

Before:

![bad-buttons-1](https://user-images.githubusercontent.com/6356129/71063235-29f85780-2121-11ea-9bdc-9a29d8a4299c.gif)


I dug and found this PR: https://github.com/learningequality/kolibri/pull/6315

So did more digging and tried a dozen things and this change stuck. I added `vertical-align: top` to the `a.button` which that previous PR altered. 

With that, the after:

![good-buttons-1](https://user-images.githubusercontent.com/6356129/71063260-3381bf80-2121-11ea-9139-9d0424385dee.gif)

I checked in the following places (everywhere that I found `<BottomAppBar />` in use):

- Lesson resource management
- Quiz creation
- Lesson & Quiz Edit Details pages
- Content import pages
- Exam and Exercise pages in Learn

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Verify that this fixes the problem and doesn't cause new ones anywhere that this would be used.

Check all  modals that you can think of as well? 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6387

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
