### PR TITLE
In TaskBar, count clearable tasks as "done" and make label consistent with progress bar

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -8,15 +8,17 @@
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
   >
-    <LessonContentPreviewPage
-      :currentContentNode="currentContentNode"
-      :isSelected="isSelected"
-      :questions="preview.questions"
-      :displaySelectOptions="true"
-      :completionData="preview.completionData"
-      @addResource="handleAddResource"
-      @removeResource="handleRemoveResource"
-    />
+    <KPageContainer>
+      <LessonContentPreviewPage
+        :currentContentNode="currentContentNode"
+        :isSelected="isSelected"
+        :questions="preview.questions"
+        :displaySelectOptions="true"
+        :completionData="preview.completionData"
+        @addResource="handleAddResource"
+        @removeResource="handleRemoveResource"
+      />
+    </KPageContainer>
   </CoreBase>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -4,6 +4,7 @@
     :immersivePage="true"
     immersivePageIcon="arrow_back"
     :immersivePageRoute="toolbarRoute"
+    :immersivePagePrimary="true"
     :appBarTitle="appBarTitle"
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
@@ -43,7 +44,7 @@
         return Boolean(this.selectedExercises[this.currentContentNode.id]);
       },
       appBarTitle() {
-        return this.$tr('createNewExamLabel');
+        return this.currentContentNode.title;
       },
     },
     beforeDestroy() {
@@ -64,7 +65,7 @@
     $trs: {
       added: "Added '{item}'",
       removed: "Removed '{item}'",
-      createNewExamLabel: 'Create new quiz',
+      // createNewExamLabel: 'Create new quiz',
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
@@ -1,12 +1,12 @@
 <template>
 
   <div class="progress-bar">
-    <p v-if="totalTasks">
+    <p v-if="totalTasks > 0">
       {{ tasksString }}
     </p>
     <p>
       <KLinearLoader
-        v-if="totalTasks >0"
+        v-if="totalTasks > 0"
         class="k-linear-loader"
         :delay="false"
         :progress="progress"
@@ -33,7 +33,6 @@
   import { mapGetters } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import countBy from 'lodash/countBy';
   import some from 'lodash/some';
   import sumBy from 'lodash/sumBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -61,18 +60,24 @@
       totalTasks() {
         return this.managedTasks.length;
       },
-      taskCounts() {
-        return countBy(this.managedTasks, 'status');
+      clearableTasks() {
+        return this.managedTasks.filter(t => taskIsClearable(t));
       },
-      doneTasks() {
-        return this.taskCounts.COMPLETED || 0;
+      inProgressTasks() {
+        return this.managedTasks.filter(t => !taskIsClearable(t));
       },
       progress() {
-        const inProgressTasks = this.managedTasks.filter(t => t.status !== 'COMPLETED');
-        return ((this.doneTasks + sumBy(inProgressTasks, 'percentage')) / this.totalTasks) * 100;
+        return (
+          ((this.clearableTasks.length + sumBy(this.inProgressTasks, 'percentage')) /
+            this.totalTasks) *
+          100
+        );
       },
       tasksString() {
-        return this.$tr('someTasksComplete', { done: this.doneTasks, total: this.totalTasks });
+        return this.$tr('someTasksComplete', {
+          done: this.clearableTasks.length,
+          total: this.totalTasks,
+        });
       },
     },
     methods: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
1. Changes how tasks are counted in TaskBar component. Canceled, failed, or complete tasks are counted as "Done" (as in they aren't running anymore). Queued and running tasks are counted as "in-progress". This is reflected in the text label as "(# clearable task) of (# all tasks) done". In the progress bar the numerator is (# clearable tasks) + (Sum of percentages of in-progess tasks).

Example: 1 canceled task + 1 completed task + 2 in-progress tasks

![Screen Shot 2019-12-18 at 2 06 52 PM](https://user-images.githubusercontent.com/10248067/71127584-38398880-21a0-11ea-8836-c679165d653a.png)

![Screen Shot 2019-12-18 at 2 06 48 PM](https://user-images.githubusercontent.com/10248067/71127595-3b347900-21a0-11ea-879f-7d8b4722ba1e.png)

### Reviewer guidance

1. Try to run a diversity of Tasks; see if the TaskBar is consistent

### References

Fixes #6177 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
