### PR TITLE
try to make the zombie test a little easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ cache:
 
 matrix:
   include:
+    - python: "3.6"
+      env:
+        - TOX_ENV=startup_provision_shutdown_without_zombies
+      script:
+       - tox -e $TOX_ENV
     - python: "2.7"
       env:
         - TOX_ENV=pythonlint2
@@ -81,11 +86,6 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=cext
-      script:
-       - tox -e $TOX_ENV
-    - python: "3.6"
-      env:
-        - TOX_ENV=startup_provision_shutdown_without_zombies
       script:
        - tox -e $TOX_ENV
 

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -7,7 +7,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-url = "http://localhost:8081/api/device/deviceprovision/"
+url = "http://localhost:8082/api/device/deviceprovision/"
 data = {
     "language_id": "en",
     "facility": {"name": "Atkinson Hall"},

--- a/tox.ini
+++ b/tox.ini
@@ -97,13 +97,13 @@ deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt
 commands =
-    - fuser 8081/tcp -k
-    kolibri start --port=8081
+    - fuser 8082/tcp -k
+    kolibri start --port=8082
     sleep 5
     python test/do_mock_provisioning.py
     kolibri stop
-
-    {toxinidir}/test/ensure_no_kolibris_running_on_port.sh 8081
+    sleep 5
+    {toxinidir}/test/ensure_no_kolibris_running_on_port.sh 8082
 
 
 [testenv:postgres]


### PR DESCRIPTION
### Summary
This is an attempt to get the zombie test passing by doing two things:
- wait 5 seconds after shutdown before checking for kolibri processes
- in case this test happens to be getting interference from other tox tests running in parallel, use a unique port.


### Reviewer guidance
Is CI passing?


### References

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
