### PR TITLE
Zeroconf tweaks and error handling

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -46,6 +46,7 @@ class MockZeroconf(Zeroconf):
     def __init__(self, *args, **kwargs):
         self.browsers = {}
         self.services = {}
+        self._GLOBAL_DONE = True
 
     def get_service_info(self, type_, name, timeout=3000):
         id = _id_from_name(name)

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -105,7 +105,15 @@ class KolibriZeroconfListener(object):
     instances = {}
 
     def add_service(self, zeroconf, type, name):
-        info = zeroconf.get_service_info(type, name)
+        timeout = 5000
+        info = zeroconf.get_service_info(type, name, timeout=timeout)
+        if info is None:
+            logger.warn(
+                "Zeroconf network service information could not be retrieved within {} seconds".format(
+                    str(timeout / 1000.0)
+                )
+            )
+            return
         id = _id_from_name(name)
         ip = socket.inet_ntoa(info.address)
 

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -1,4 +1,3 @@
-import atexit
 import json
 import logging
 import socket
@@ -44,8 +43,6 @@ class KolibriZeroconfService(object):
         self.id = id
         self.port = port
         self.data = {key: json.dumps(val) for (key, val) in data.items()}
-
-        atexit.register(self.cleanup)
 
     def register(self):
 
@@ -207,6 +204,7 @@ def unregister_zeroconf_service():
     if ZEROCONF_STATE["service"] is not None:
         ZEROCONF_STATE["service"].cleanup()
     ZEROCONF_STATE["service"] = None
+    ZEROCONF_STATE["zeroconf"].close()
 
 
 def initialize_zeroconf_listener():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -52,7 +52,9 @@ class KolibriZeroconfService(object):
         if not ZEROCONF_STATE["zeroconf"]:
             initialize_zeroconf_listener()
 
-        assert self.info is None, "Service is already registered!"
+        if self.info is not None:
+            logger.error("Service is already registered!")
+            return
 
         i = 1
         id = self.id
@@ -88,7 +90,9 @@ class KolibriZeroconfService(object):
 
     def unregister(self):
 
-        assert self.info is not None, "Service is not registered!"
+        if self.info is None:
+            logging.error("Service is not registered!")
+            return
 
         ZEROCONF_STATE["zeroconf"].unregister_service(self.info)
 
@@ -148,7 +152,7 @@ class KolibriZeroconfListener(object):
                 )
 
                 logger.info(
-                    "Kolibri instance '%s' joined zeroconf network; service info: %s\n"
+                    "Kolibri instance '%s' joined zeroconf network; service info: %s"
                     % (id, self.instances[id])
                 )
 
@@ -156,11 +160,14 @@ class KolibriZeroconfListener(object):
                 import traceback
 
                 logger.warn(
-                    (
-                        "A new Kolibri instance '%s' was seen on the zeroconf network, "
-                        + "but we had trouble getting the information we needed about it.  This probably isn't a big deal!\n\n"
-                        + "service info:\n %s;\n\nThe following exception was raised:\n%s"
-                    )
+                    """
+                        A new Kolibri instance '%s' was seen on the zeroconf network,
+                        but we had trouble getting the information we needed about it.
+                        Service info:
+                        %s
+                        The following exception was raised:
+                        %s
+                        """
                     % (id, self.instances[id], traceback.format_exc(limit=1)),
                 )
             finally:
@@ -168,7 +175,7 @@ class KolibriZeroconfListener(object):
 
     def remove_service(self, zeroconf, type, name):
         id = _id_from_name(name)
-        logger.info("\nKolibri instance '%s' has left the zeroconf network.\n" % (id,))
+        logger.info("Kolibri instance '%s' has left the zeroconf network." % (id,))
 
         try:
             if id in self.instances:


### PR DESCRIPTION
### Summary
* Adds handling for a `get_service_info` timeout.
* Cleans up the Zeroconf thread before shutdown
* Removes bare asserts in zeroconf methods
* Cleans up logging statements to remove unnecessary line breaks

### Reviewer guidance
Run the server make sure everything looks dandy.
None of the changes should change the API we need to expose to zeroconf, but good to just double check!

### References
Fixes #6077
Fixes #6390

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
