### PR TITLE
Only show cancel button when tasks are cancellable.

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -72,6 +72,7 @@
 
     <div class="buttons" :class="{'button-lift': taskIsRunning}">
       <KButton
+        v-if="taskIsCancellable || taskIsClearable"
         :disabled="taskIsCanceling"
         :text="buttonLabel"
         appearance="flat-button"
@@ -138,7 +139,7 @@
     },
     computed: {
       buttonLabel() {
-        if (taskIsClearable(this.task)) {
+        if (this.taskIsClearable) {
           return this.coreString('clearAction');
         }
         return this.coreString('cancelAction');
@@ -157,6 +158,12 @@
       },
       taskIsFailed() {
         return this.task.status === TaskStatuses.FAILED || this.taskIsCanceled;
+      },
+      taskIsCancellable() {
+        return this.task.cancellable;
+      },
+      taskIsClearable() {
+        return taskIsClearable(this.task);
       },
       descriptionText() {
         const trName = typeToTrMap[this.task.type];


### PR DESCRIPTION
### Summary
Only show the cancel button when tasks are cancellable

### Reviewer guidance
Does the deletion task not show the cancel button?
Do other tasks still show it?

### References
Fixes #6250

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
