### PR TITLE
temporarily disable android build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,13 +14,13 @@ steps:
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
-    
+
     # Android build only requires whl file
-  - label: Build Android APK
-    env:
-      KOLIBRI_ANDROID_BUILD_MODE: dev
-    command: &android_build
-      - .buildkite/build_apk.sh
+  # - label: Build Android APK
+  #   env:
+  #     KOLIBRI_ANDROID_BUILD_MODE: dev
+  #   command: &android_build
+  #     - .buildkite/build_apk.sh
 
   - label: Build Windows installer
     command: .buildkite/build_windows_installer.sh
@@ -32,7 +32,7 @@ steps:
   - trigger: "kolibri-raspbian-image"
     label: ":raspberry-pi:"
     build: *triggered_build_attributes
-    depends_on: 
+    depends_on:
       - deb-build
 
   - wait
@@ -59,11 +59,11 @@ steps:
     agents:
       queue: "windows-sign"
 
-  - block: "Build release APK?"
-  - label: "Build Release APK"
-    env:
-      KOLIBRI_ANDROID_BUILD_MODE: release
-    command: *android_build
+  # - block: "Build release APK?"
+  # - label: "Build Release APK"
+  #   env:
+  #     KOLIBRI_ANDROID_BUILD_MODE: release
+  #   command: *android_build
 
   - block: "Test .debs?"
   - label: Test on Trusty, Xenial, Bionic


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

this PR is to temporarily disable android build on buildkite.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check if the build passes on buildkite without andriod builds.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
