### PR TITLE
Check status before writing startup lock to prevent false negatives.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -432,6 +432,12 @@ def start(port, background):
     Start the server on given port.
     """
 
+    serve_http = OPTIONS["Server"]["CHERRYPY_START"]
+
+    if serve_http:
+        # Check if the port is occupied
+        check_other_kolibri_running(port)
+
     create_startup_lock(port)
 
     # Check if the content directory exists when Kolibri runs after the first time.
@@ -445,8 +451,6 @@ def start(port, background):
     if sys.platform == "darwin":
         background = False
 
-    serve_http = OPTIONS["Server"]["CHERRYPY_START"]
-
     if not background:
         logger.info("Running Kolibri")
 
@@ -454,8 +458,6 @@ def start(port, background):
         logger.info("Running Kolibri as background process")
 
     if serve_http:
-        # Check if the port is occupied
-        check_other_kolibri_running(port)
 
         __, urls = server.get_urls(listen_port=port)
         if not urls:


### PR DESCRIPTION
### Summary
We have a sanity check to make sure another Kolibri isn't running before we start the server, this was being invoked *after* we were writing the startup lock, resulting in false negatives.

This invokes the check before we write the startup lock to prevent the status check reading the startup lock and thinking that Kolibri is not running.

### Reviewer guidance
Start Kolibri.
Start another Kolibri on a different port - it should not let you.
(both should use the same kolibri home dir)

### References
Fixes #6408

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
