### PR TITLE
Preserve pigen image and container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ i18n-upload-glossary:
 	python build_tools/i18n/crowdin.py upload-glossary
 
 docker-clean:
-	docker container prune -f
-	docker image prune -f
+	docker container prune --filter "label!=build=pigen" -f
+	docker image prune --filter "label!=build=pigen" -a -f
 
 docker-whl: writeversion docker-envlist
 	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .


### PR DESCRIPTION

### Summary
Our building system prune all the docker images and containers after finishing.
When building the Raspberry Pi image, if the docker container is not kept, all the Debian system and packages are downloaded and installed once again in every run of the builder.
This PR keeps undeleted the image and container for the Raspberry Pi image. They should be deleted only when a new Debian distribuition for Raspberry is released, what happen every 2 years aproximately.


### Reviewer guidance
The pigen_work container and pi-gen images still exists in the building server after the image is built. 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
