### PR TITLE
alternate strategy for checking langs

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.utils.translation import check_for_language
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
@@ -13,6 +12,7 @@ from kolibri.core.auth.serializers import FacilityUserSerializer
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.device.utils import provision_device
+from kolibri.utils import i18n
 
 
 class DevicePermissionsSerializer(serializers.ModelSerializer):
@@ -38,7 +38,7 @@ class DeviceSerializerMixin(object):
         """
         Check that the language_id is supported by Kolibri
         """
-        if not check_for_language(language_id):
+        if language_id not in i18n.KOLIBRI_SUPPORTED_LANGUAGES:
             raise serializers.ValidationError(_("Language is not supported by Kolibri"))
         return language_id
 

--- a/kolibri/core/device/translation.py
+++ b/kolibri/core/device/translation.py
@@ -11,14 +11,12 @@ from django.urls import Resolver404
 from django.urls.resolvers import RegexURLResolver
 from django.utils.translation import get_language
 from django.utils.translation import LANGUAGE_SESSION_KEY
-from django.utils.translation.trans_real import check_for_language
-from django.utils.translation.trans_real import get_language_from_path
-from django.utils.translation.trans_real import get_languages
 from django.utils.translation.trans_real import get_supported_language_variant
 from django.utils.translation.trans_real import language_code_re
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 from kolibri.core.device.utils import get_device_setting
+from kolibri.utils import i18n
 
 
 def get_device_language():
@@ -51,6 +49,13 @@ def get_settings_language():
         return settings.LANGUAGE_CODE
 
 
+def get_language_from_path(path_info):
+    for code in i18n.SUPPORTED_LANG_CODES:
+        if code in path_info:
+            return code
+    return None
+
+
 def get_language_from_request_and_is_from_path(request):  # noqa complexity-16
     """
     Analyzes the request to find what language the user wants the system to
@@ -75,19 +80,13 @@ def get_language_from_request_and_is_from_path(request):  # noqa complexity-16
         # URL, so let the language code setting carry on from here.
         pass
 
-    supported_lang_codes = get_languages()
-
     lang_code = get_language_from_path(request.path_info)
-    if lang_code in supported_lang_codes and lang_code is not None:
+    if lang_code in i18n.SUPPORTED_LANG_CODES and lang_code is not None:
         return lang_code, True
 
     if hasattr(request, "session"):
         lang_code = request.session.get(LANGUAGE_SESSION_KEY)
-        if (
-            lang_code in supported_lang_codes
-            and lang_code is not None
-            and check_for_language(lang_code)
-        ):
+        if lang_code in i18n.SUPPORTED_LANG_CODES and lang_code is not None:
             return lang_code, False
 
     device_language = get_device_language()

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -9,7 +9,6 @@ from django.urls import translate_url
 from django.utils.decorators import method_decorator
 from django.utils.six.moves.urllib.parse import urlsplit
 from django.utils.six.moves.urllib.parse import urlunsplit
-from django.utils.translation import check_for_language
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
@@ -27,6 +26,7 @@ from kolibri.core.device.translation import get_settings_language
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.hooks import RoleBasedRedirectHook
+from kolibri.utils import i18n
 
 
 # Modified from django.views.i18n
@@ -39,7 +39,7 @@ def set_language(request):
     """
     lang_code = request.POST.get(LANGUAGE_QUERY_PARAMETER)
     next_url = urlsplit(request.POST.get("next")) if request.POST.get("next") else None
-    if lang_code and check_for_language(lang_code):
+    if lang_code and lang_code not in i18n.KOLIBRI_SUPPORTED_LANGUAGES:
         if next_url and is_valid_path(next_url.path):
             # If it is a recognized Kolibri path, then translate it to the new language and return it.
             next_path = urlunsplit(

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -35,3 +35,4 @@ def _get_supported_language_info():
 
 # Kolibri format
 KOLIBRI_SUPPORTED_LANGUAGES = _get_supported_language_info()
+SUPPORTED_LANG_CODES = [lang.get("intl_code") for lang in KOLIBRI_SUPPORTED_LANGUAGES]


### PR DESCRIPTION


### Summary

Something has changed since 0.12 which makes django's internal language checkers no longer pick up langs from here:

https://github.com/learningequality/kolibri/blob/d88298d6f1c84cfe6b18b456aea964523acacc32/kolibri/deployment/default/settings/base.py#L172-L213


### Reviewer guidance

previously, some of these special langs didn't work.

Does this fix things and not cause regressions?

### References


https://learningequality.slack.com/archives/CQFFU1KMF/p1576882399071000


----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
