### PR TITLE
Remove ‘rtl-icon’ class from Login/LogoutSideNavEntry

### DIFF
--- a/kolibri/core/assets/src/views/LogoutSideNavEntry.vue
+++ b/kolibri/core/assets/src/views/LogoutSideNavEntry.vue
@@ -3,7 +3,6 @@
   <CoreMenuOption
     :label="$tr('signOut')"
     :link="url"
-    :class="{ 'rtl-icon': isRtl }"
     icon="logout"
   />
 

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -284,13 +284,12 @@
   .narrow-container {
     max-width: 500px;
     margin: auto;
+    overflow: visible;
   }
 
   .form {
     max-width: 400px;
-    padding-bottom: 75px;
     margin-right: auto;
-    margin-bottom: 20px;
     margin-left: auto;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -411,13 +411,12 @@
   .narrow-container {
     max-width: 500px;
     margin: auto;
+    overflow: visible;
   }
 
   .form {
     max-width: 400px;
-    padding-bottom: 75px;
     margin-right: auto;
-    margin-bottom: 20px;
     margin-left: auto;
   }
 

--- a/kolibri/plugins/user/assets/src/views/LoginSideNavEntry.vue
+++ b/kolibri/plugins/user/assets/src/views/LoginSideNavEntry.vue
@@ -4,7 +4,6 @@
     :label="coreString('signInLabel')"
     :link="url"
     icon="login"
-    :class="{ 'rtl-icon': isRtl }"
   />
 
 </template>
@@ -24,7 +23,6 @@
       CoreMenuOption,
     },
     mixins: [commonCoreStrings],
-    $trs: {},
     computed: {
       url() {
         return urls['kolibri:kolibri.plugins.user:user']();

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -201,11 +201,11 @@
   .narrow-container {
     max-width: 500px;
     margin: auto;
+    overflow: visible;
   }
 
   .form {
     max-width: 400px;
-    min-height: 600px;
     margin: auto;
   }
 


### PR DESCRIPTION
### Summary
1. Remove 'rtl-icon' class from top-level div. A similar rule is applied in KIcon, so should probably be ok.
1. Also adds a fix for #6168 

Logout Icon (when logged-in)
![Screen Shot 2019-12-26 at 10 44 55 AM](https://user-images.githubusercontent.com/10248067/71486821-1312ce80-27cd-11ea-83c1-408071566695.png)

Login Icon (when not logged-in)

![Screen Shot 2019-12-26 at 10 44 42 AM](https://user-images.githubusercontent.com/10248067/71486823-13ab6500-27cd-11ea-8936-773471747c28.png)


### Reviewer guidance

1. For fix (1), view site in RTL language and check side nav when logged-in/out
1. For fix (2) view all Facility User editing pages (i.e. own profile, other person's profile, new user creation)

### References
Fixes #6428


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
