### PR TITLE
Help text improvement

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -641,7 +641,7 @@ def setup_logging(debug=False):
 @main.command(
     cls=KolibriDjangoCommand,
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
-    help="Invoke a Django management command",
+    help="Django management commands, see also 'kolibri manage help'",
 )
 @click.pass_context
 def manage(ctx):

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -641,7 +641,7 @@ def setup_logging(debug=False):
 @main.command(
     cls=KolibriDjangoCommand,
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
-    help="Django management commands, see also 'kolibri manage help'",
+    help="Django management commands. See also 'kolibri manage help'",
 )
 @click.pass_context
 def manage(ctx):


### PR DESCRIPTION
### Summary

When people run `kolibri --help`, we need to ad a substantial lead to where further information can be found.

### Reviewer guidance

Note that this text is severely truncated by Click, so we cannot make the sentence any longer

```
Commands:
  manage    Django management commands, see also 'kolibri manage help'.
  plugin    Manage Kolibri plugins
  services  Start worker processes
  shell     Launch a Django shell
  start     Start the Kolibri process
  status    Show the status of the Kolibri process
  stop      Stop the Kolibri process
```

### References

n/a

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
