### PR TITLE
bypass port availability check when socket activation is used

### DIFF
--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -42,13 +42,16 @@ def check_port_availability(host, port):
     try:
         portend.free(host, port, timeout=PORT_AVAILABILITY_CHECK_TIMEOUT)
     except portend.Timeout:
-        # Port is occupied
-        logger.error(
-            "Port {} is occupied.\n"
-            "Please check that you do not have other processes "
-            "running on this port and try again.\n".format(port)
-        )
-        sys.exit(1)
+        # Bypass check when socket activation is used
+        # https://manpages.debian.org/testing/libsystemd-dev/sd_listen_fds.3.en.html#ENVIRONMENT
+        if not os.environ.get("LISTEN_PID", None):
+            # Port is occupied
+            logger.error(
+                "Port {} is occupied.\n"
+                "Please check that you do not have other processes "
+                "running on this port and try again.\n".format(port)
+            )
+            sys.exit(1)
 
 
 def check_content_directory_exists_and_writable():

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import portend
@@ -26,6 +27,15 @@ class SanityCheckTestCase(TestCase):
         with self.assertRaises(SystemExit):
             sanity_checks.check_port_availability("0.0.0.0", "8080")
             logging_mock.assert_called()
+
+    @patch("kolibri.utils.sanity_checks.logging.error")
+    @patch("kolibri.utils.sanity_checks.portend.free")
+    def test_socket_activation_support(self, portend_mock, logging_mock):
+        portend_mock.side_effect = portend.Timeout
+        # LISTEN_PID environment variable would be set if using socket activation
+        with patch.dict(os.environ, {"LISTEN_PID": "1234"}):
+            sanity_checks.check_port_availability("0.0.0.0", "8080")
+            logging_mock.assert_not_called()
 
     @patch("kolibri.utils.cli.get_version", return_value="")
     @patch("kolibri.utils.sanity_checks.logging.error")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to allow port availability sanity check to pass when socket activation is used on Linux.
When the systemd service uses socket activation, the port is occupied, and thus the sanity check would fail.
Since env var LISTEN_PID is set when socket activation is used: https://manpages.debian.org/testing/libsystemd-dev/sd_listen_fds.3.en.html#ENVIRONMENT, we can use it to bypass the check.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

case 1: old code, where socket activation is not supported
- install kolibri 0.13.0 deb installer
- add kolibri.socket(https://github.com/endlessm/eos-kolibri/blob/master/data/system/eos-kolibri-system-helper.socket.in) under /lib/systemd/system/
- run kolibri and check the log to see that kolibri fails to start because port 8080 is occupied

case 2: new code, where socket activation is supported, and when port is occupied by another server
- install kolibri deb installer from this PR
- run `python -m SimpleHTTPServer 8080` to occupy port 8080
- run kolibri and check the log to see that kolibri fails to start

case 3: new code, where socket activation is supported
- install kolibri deb installer from this PR
- add kolibri.socket(https://github.com/endlessm/eos-kolibri/blob/master/data/system/eos-kolibri-system-helper.socket.in) under /lib/systemd/system/
- run kolibri and check that kolibri starts successfully

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6434

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
