### PR TITLE
Bump ifcfg to 0.20

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ morango==0.4.9
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5
-ifcfg==0.19
+ifcfg==0.20
 sqlalchemy==1.2.10
 semver==2.8.1
 django-redis-cache==2.0.0


### PR DESCRIPTION
### Summary

The latest `ifcfg` fails loudly if `ip` and `ifconfig` are unavailable on Unix-based systems. I'm not sure what issues this can cause with automated testing, so I'm opening this to see.

Diff: https://github.com/ftao/python-ifcfg/compare/releases/0.19...master

### Reviewer guidance

None really, this is not an urgent update.

### References

n/a

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
