### PR TITLE
make sure schedulers use timezone aware datetime object

### DIFF
--- a/kolibri/core/analytics/management/commands/ping.py
+++ b/kolibri/core/analytics/management/commands/ping.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
@@ -9,6 +8,7 @@ from kolibri.core.analytics.utils import DEFAULT_PING_INTERVAL
 from kolibri.core.analytics.utils import DEFAULT_SERVER_URL
 from kolibri.core.analytics.utils import ping_once
 from kolibri.core.analytics.utils import schedule_ping
+from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         once = options.get("once") or False
 
         if once:
-            started = datetime.now()
+            started = local_now()
             try:
                 ping_once(started, server)
             except Exception as e:

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -46,6 +46,7 @@ from kolibri.core.tasks.utils import db_task_write_lock
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.utils import conf
 from kolibri.utils.server import installation_type
+from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
 
@@ -376,7 +377,7 @@ def perform_ping(started, server=DEFAULT_SERVER_URL):
         "node_id": instance.node_id,
         "language": language,
         "timezone": timezone,
-        "uptime": int((datetime.datetime.now() - started).total_seconds() / 60),
+        "uptime": int((local_now() - started).total_seconds() / 60),
         "timestamp": localtime(),
         "installer": installation_type(),
     }
@@ -434,7 +435,7 @@ def _ping(started, server, checkrate):
     job = get_current_job()
     if job and job in scheduler:
         scheduler.change_execution_time(
-            job, datetime.datetime.now() + datetime.timedelta(seconds=checkrate * 60)
+            job, local_now() + datetime.timedelta(seconds=checkrate * 60)
         )
 
 
@@ -443,7 +444,7 @@ def schedule_ping(
     checkrate=DEFAULT_PING_CHECKRATE,
     interval=DEFAULT_PING_INTERVAL,
 ):
-    started = datetime.datetime.now()
+    started = local_now()
     scheduler.schedule(
         started,
         _ping,

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -84,7 +84,9 @@ class Scheduler(StorageMixin):
         Change a job's execution time.
         """
         if date_time.tzinfo is None:
-            raise ValueError("Must use a timezone aware datetime object for scheduling tasks")
+            raise ValueError(
+                "Must use a timezone aware datetime object for scheduling tasks"
+            )
 
         with self.session_scope() as session:
             scheduled_job = (
@@ -103,7 +105,7 @@ class Scheduler(StorageMixin):
         Returns: the Thread object.
         """
         t = InfiniteLoopThread(
-            self.check_schedule, thread_name="SCHEDULECHECKER", wait_between_runs=0.5,
+            self.check_schedule, thread_name="SCHEDULECHECKER", wait_between_runs=0.5
         )
         t.start()
         return t
@@ -149,7 +151,9 @@ class Scheduler(StorageMixin):
         if not interval and repeat != 0:
             raise ValueError("Must specify an interval if the task is repeating")
         if dt.tzinfo is None:
-            raise ValueError("Must use a timezone aware datetime object for scheduling tasks")
+            raise ValueError(
+                "Must use a timezone aware datetime object for scheduling tasks"
+            )
         if isinstance(func, Job):
             job = func
         # else, turn it into a job first.

--- a/kolibri/core/tasks/test/test_scheduler.py
+++ b/kolibri/core/tasks/test/test_scheduler.py
@@ -8,6 +8,8 @@ from sqlalchemy.pool import NullPool
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.queue import Queue
 from kolibri.core.tasks.scheduler import Scheduler
+from kolibri.utils.time_utils import local_now
+from kolibri.utils.time_utils import naive_utc_datetime
 
 
 @pytest.fixture
@@ -30,13 +32,13 @@ def scheduler(queue):
 
 class TestScheduler(object):
     def test_enqueue_at_a_function(self, scheduler):
-        job_id = scheduler.enqueue_at(datetime.datetime.utcnow(), id)
+        job_id = scheduler.enqueue_at(local_now(), id)
 
         # is the job recorded in the chosen backend?
         assert scheduler.get_job(job_id).job_id == job_id
 
     def test_enqueue_at_a_function_sets_time(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         job_id = scheduler.enqueue_at(now, id)
 
         with scheduler.session_scope() as session:
@@ -44,13 +46,11 @@ class TestScheduler(object):
                 scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
             )
             scheduled_time = scheduled_job.scheduled_time
-        assert scheduled_time == now
+        assert scheduled_time == naive_utc_datetime(now)
 
     def test_enqueue_at_preserves_extra_metadata(self, scheduler):
         metadata = {"saved": True}
-        job_id = scheduler.enqueue_at(
-            datetime.datetime.utcnow(), id, extra_metadata=metadata
-        )
+        job_id = scheduler.enqueue_at(local_now(), id, extra_metadata=metadata)
 
         # Do we get back the metadata we save?
         assert scheduler.get_job(job_id).extra_metadata == metadata
@@ -63,7 +63,7 @@ class TestScheduler(object):
 
     def test_enqueue_in_a_function_sets_time(self, scheduler):
         diff = datetime.timedelta(seconds=1000)
-        now = datetime.datetime.utcnow()
+        now = local_now()
         scheduler._now = lambda: now
         job_id = scheduler.enqueue_in(diff, id)
 
@@ -72,10 +72,10 @@ class TestScheduler(object):
                 scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
             )
             scheduled_time = scheduled_job.scheduled_time
-        assert scheduled_time == now + diff
+        assert scheduled_time == naive_utc_datetime(now) + diff
 
     def test_cancel_removes_job(self, scheduler):
-        job_id = scheduler.enqueue_at(datetime.datetime.utcnow(), id)
+        job_id = scheduler.enqueue_at(local_now(), id)
 
         scheduler.cancel(job_id)
 
@@ -83,7 +83,7 @@ class TestScheduler(object):
             scheduler.get_job(job_id)
 
     def test_schedule_a_function_sets_time(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         job_id = scheduler.schedule(now, id)
 
         with scheduler.session_scope() as session:
@@ -91,29 +91,39 @@ class TestScheduler(object):
                 scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
             )
             scheduled_time = scheduled_job.scheduled_time
-        assert scheduled_time == now
+        assert scheduled_time == naive_utc_datetime(now)
 
     def test_schedule_a_function_gives_value_error_without_datetime(self, scheduler):
         now = "test"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as error:
             scheduler.schedule(now, id)
+            assert "must be a datetime object" in str(error.value)
 
     def test_schedule_a_function_gives_value_error_repeat_zero_interval(
         self, scheduler
     ):
-        now = datetime.datetime.utcnow()
-        with pytest.raises(ValueError):
+        now = local_now()
+        with pytest.raises(ValueError) as error:
             scheduler.schedule(now, id, interval=0, repeat=None)
+            assert "specify an interval" in str(error.value)
+
+    def test_schedule_a_function_gives_value_error_not_timezone_aware_datetime(
+        self, scheduler
+    ):
+        now = datetime.datetime.utcnow()
+        with pytest.raises(ValueError) as error:
+            scheduler.schedule(now, id)
+            assert "timezone aware datetime object" in str(error.value)
 
     def test_scheduled_repeating_function_updates_old_job(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         old_id = scheduler.schedule(now, id, interval=1000, repeat=None)
         scheduler.check_schedule()
         new_id = scheduler.get_jobs()[0].job_id
         assert old_id == new_id
 
     def test_scheduled_repeating_function_sets_endless_repeat_new_job(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         scheduler.schedule(now, id, interval=1000, repeat=None)
         scheduler.check_schedule()
         with scheduler.session_scope() as session:
@@ -122,7 +132,7 @@ class TestScheduler(object):
         assert repeat is None
 
     def test_scheduled_repeating_function_enqueues_job(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         job_id = scheduler.schedule(now, id, interval=1000, repeat=None)
         scheduler.check_schedule()
         assert scheduler.queue.fetch_job(job_id).job_id == job_id
@@ -130,7 +140,7 @@ class TestScheduler(object):
     def test_scheduled_repeating_function_sets_new_job_with_one_fewer_repeats(
         self, scheduler
     ):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         scheduler.schedule(now, id, interval=1000, repeat=1)
         scheduler.check_schedule()
         with scheduler.session_scope() as session:
@@ -139,11 +149,13 @@ class TestScheduler(object):
         assert repeat == 0
 
     def test_scheduled_repeating_function_sets_new_job_at_interval(self, scheduler):
-        now = datetime.datetime.utcnow()
+        now = local_now()
         scheduler.schedule(now, id, interval=1000, repeat=1)
         scheduler._now = lambda: now
         scheduler.check_schedule()
         with scheduler.session_scope() as session:
             scheduled_job = scheduler._ns_query(session).one_or_none()
             scheduled_time = scheduled_job.scheduled_time
-        assert scheduled_time == now + datetime.timedelta(seconds=1000)
+        assert scheduled_time == naive_utc_datetime(now) + datetime.timedelta(
+            seconds=1000
+        )

--- a/kolibri/utils/time_utils.py
+++ b/kolibri/utils/time_utils.py
@@ -3,3 +3,7 @@ from django.utils import timezone
 
 def local_now():
     return timezone.localtime(timezone.now())
+
+
+def naive_utc_datetime(dt):
+    return timezone.make_naive(dt, timezone=timezone.utc)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to make sure schedulers use timezone aware datetime object `local_now()` in all places so that there will not be the occurrence of comparing UTC time with Pacific Time in the code. And at the same time, make sure the time of the schedulers saved to the database is UTC time since timestamp in database is not timezone aware.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. please check if all the `datetime.datetime.now()` related to schedulers have been replaced by `local_now()`. 
2. please also check if starting kolibri without internet would ping every second instead of every 15 minutes.
3. check the time in the scheduledjob table and see if it's UTC time

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6439

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
