### PR TITLE
Re-activate IndividualSelector, fix select-all disabled/checked states

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -25,7 +25,7 @@
         const selectable = {
           cursor: 'pointer',
           ':hover': {
-            backgroundColor: this.$themeTokens.fineLine,
+            backgroundColor: this.$themePalette.grey.v_100,
           },
         };
         return Object.assign(

--- a/kolibri/core/assets/src/views/PaginatedListContainer.vue
+++ b/kolibri/core/assets/src/views/PaginatedListContainer.vue
@@ -155,7 +155,6 @@
 
 <style lang="scss" scoped>
 
-  .actions-header,
   nav {
     text-align: right;
   }

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -3,11 +3,12 @@
   <div>
     <KCheckbox
       key="adHocLearners"
-      :label="$tr('individualLearnersLabel')"
       :checked="showAsChecked"
       :disabled="disabled"
       @change="toggleChecked"
-    />
+    >
+      <KLabeledIcon icon="people" :label="$tr('individualLearnersLabel')" />
+    </KCheckbox>
     <div v-if="showAsChecked">
       <div class="table-title">
         {{ $tr("selectedIndividualLearnersLabel") }}

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -35,8 +35,8 @@
                   <KCheckbox
                     key="selectAllOnPage"
                     :label="$tr('selectAllLabel')"
-                    :checked="allOfCurrentPageIsSelected"
-                    :disabled="disabled"
+                    :checked="selectAllCheckboxProps.checked"
+                    :disabled="selectAllCheckboxProps.disabled"
                     @change="selectVisiblePage"
                   />
                 </th>
@@ -97,6 +97,7 @@
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import uniq from 'lodash/uniq';
+  import countBy from 'lodash/countBy';
   import ClassSummaryResource from '../../../apiResources/classSummary';
   import commonCoachStrings from '../../common';
   import { userMatchesFilter, filterAndSortUsers } from '../../../userSearchUtils';
@@ -194,6 +195,21 @@
           return this.selectedAdHocIds.includes(visible.id);
         });
         return selectedVisibleLearners.length === this.currentPageLearners.length;
+      },
+      selectAllCheckboxProps() {
+        const counts = countBy(this.currentPageLearners, learner => {
+          if (this.learnerIsInSelectedGroup(learner.id)) {
+            return 'disabled';
+          } else if (this.selectedAdHocIds.includes(learner.id)) {
+            return 'checked';
+          } else {
+            return 'unchecked';
+          }
+        });
+        return {
+          disabled: counts.disabled === this.currentPageLearners.length,
+          checked: !counts.unchecked,
+        };
       },
       itemsPerPage() {
         return this.targetClassId ? SHORT_ITEMS_PER_PAGE : DEFAULT_ITEMS_PER_PAGE;

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -197,6 +197,7 @@
         return selectedVisibleLearners.length === this.currentPageLearners.length;
       },
       selectAllCheckboxProps() {
+        const currentCount = this.currentPageLearners.length;
         const counts = countBy(this.currentPageLearners, learner => {
           if (this.learnerIsInSelectedGroup(learner.id)) {
             return 'disabled';
@@ -207,8 +208,8 @@
           }
         });
         return {
-          disabled: counts.disabled === this.currentPageLearners.length,
-          checked: !counts.unchecked,
+          disabled: currentCount === counts.disabled || currentCount === 0,
+          checked: currentCount !== 0 && !counts.unchecked,
         };
       },
       itemsPerPage() {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -17,7 +17,6 @@
       @change="toggleGroup($event, group.id)"
     />
     <IndividualLearnerSelector
-      v-if="false"
       :selectedGroupIds="selectedGroupIds"
       :entireClassIsSelected="entireClassIsSelected"
       :initialAdHocLearners="initialAdHocLearners"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -3,19 +3,27 @@
   <div>
     <KRadioButton
       :value="true"
-      :label="coachString('entireClassLabel')"
       :currentValue="entireClassIsSelected"
       :disabled="disabled"
       @change="selectEntireClass()"
-    />
+    >
+      <KLabeledIcon
+        :label="coachString('entireClassLabel')"
+        icon="classroom"
+      />
+    </KRadioButton>
     <KCheckbox
       v-for="group in groups"
       :key="group.id"
-      :label="group.name"
       :checked="groupIsChecked(group.id)"
       :disabled="disabled"
       @change="toggleGroup($event, group.id)"
-    />
+    >
+      <KLabeledIcon
+        :label="group.name"
+        icon="group"
+      />
+    </KCheckbox>
     <IndividualLearnerSelector
       :selectedGroupIds="selectedGroupIds"
       :entireClassIsSelected="entireClassIsSelected"

--- a/packages/kolibri-components/src/KRadioButton.vue
+++ b/packages/kolibri-components/src/KRadioButton.vue
@@ -71,7 +71,7 @@
        */
       label: {
         type: String,
-        required: true,
+        required: false,
       },
       /**
        * Description for label


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Turns off the flag that hides the `IndividualLearnerSelector`
1. Fixes the checked/disabled states for the "Select All" checkbox in that Component. Fixes #6330 
1. Some style changes: lightens the `:hover` background for core table, so it doesn't hide greyed items. Adds a "People" icon next to  the "Select individuals" icon so it stands out more. Fixes #6260
1. Adds fix for #6335


Example:

<img width="1126" alt="Screen Shot 2020-01-07 at 4 32 49 PM" src="https://user-images.githubusercontent.com/10248067/71940608-bf5c9980-316b-11ea-9b96-c0a5050971df.png">

### Reviewer guidance

1. Try out the individual selector under more complicated cases, like having multiple pages of users, lots of groups, etc.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
