### PR TITLE
Maintain channel order across list views

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -170,8 +170,21 @@
         'transferType',
       ]),
       allChannels() {
+        const uninstalledChannels = this.availableChannels.filter(uninstalledChannel => {
+          return !this.installedChannelsWithResources.find(
+            ({ id }) => id === uninstalledChannel.id
+          );
+        });
+
         // Need to de-duplicate channels in case user enters same token twice, etc.
-        return uniqBy([...this.newUnlistedChannels, ...this.availableChannels], 'id');
+        return uniqBy(
+          [
+            ...this.newUnlistedChannels,
+            ...this.installedChannelsWithResources,
+            ...uninstalledChannels,
+          ],
+          'id'
+        );
       },
       multipleMode() {
         const { multiple } = this.$route.query;

--- a/kolibri/plugins/device/assets/test/views/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/assets/test/views/AvailableChannelsPage.spec.js
@@ -105,9 +105,9 @@ describe('availableChannelsPage', () => {
     const channels = channelListItems();
     const channelNProps = n => channels.at(n).props();
     expect(channelNProps(0).onDevice).toEqual(true);
-    expect(channelNProps(1).onDevice).toEqual(false);
+    expect(channelNProps(1).onDevice).toEqual(true);
     expect(channelNProps(2).onDevice).toEqual(false);
-    expect(channelNProps(3).onDevice).toEqual(true);
+    expect(channelNProps(3).onDevice).toEqual(false);
   });
 
   it('IN LOCALIMPORT/REMOTEIMPORT, with no filters, all appear', () => {
@@ -151,7 +151,7 @@ describe('availableChannelsPage', () => {
     filter.vm.model = 'bir ch';
     await wrapper.vm.$nextTick();
     expect(filterComponent().vm.titleFilter).toEqual('bir ch');
-    testChannelVisibility(wrapper, [false, true, false, false]);
+    testChannelVisibility(wrapper, [false, false, true, false]);
   });
 
   it('with both filters, the correct channels appear', async () => {
@@ -163,7 +163,7 @@ describe('availableChannelsPage', () => {
     await wrapper.vm.$nextTick();
     lFilter.vm.selection = { label: 'German', value: 'de' };
     await wrapper.vm.$nextTick();
-    testChannelVisibility(wrapper, [false, false, true, false]);
+    testChannelVisibility(wrapper, [false, false, false, true]);
   });
 
   it('the "select" link goes to the correct place', () => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
 * Moves installed channels to top of the list on the import view. Fixes #6366 

Before Fix:

| Channel View        | Import View  |
| ------------- |:-------------:| 
| <img src="https://user-images.githubusercontent.com/34431991/72027793-ec7d7a80-3245-11ea-808d-95a9008ce724.png" width="300" height="600">    | <img src="https://user-images.githubusercontent.com/34431991/72028147-1f743e00-3247-11ea-8df5-315d8e88d3e2.png" width="300" height="600"> |

After Fix:

| Channel View        | Import View  |
| ------------- |:-------------:| 
| <img src="https://user-images.githubusercontent.com/34431991/72027793-ec7d7a80-3245-11ea-808d-95a9008ce724.png" width="300" height="600">      | <img src="https://user-images.githubusercontent.com/34431991/72027826-08811c00-3246-11ea-81ff-e888e3aa613b.png" width="300" height="600"> |

This also handles channels imported via token:
<img src="https://user-images.githubusercontent.com/34431991/72122882-1f4a7000-3325-11ea-993e-8fea822eadcb.png" width=300 height=600>

And once the unlisted channel is installed:

| Channel View        | Import View  |
| ------------- |:-------------:| 
| <img src="https://user-images.githubusercontent.com/34431991/72116010-801a7e00-330e-11ea-9e24-2af6becfd4b3.png" width="275" height="400">  | <img src="https://user-images.githubusercontent.com/34431991/72116031-8c9ed680-330e-11ea-860c-23f159e28d09.png" width="275" height="400"> |

If the unlisted channel is already installed and we try to import it again: 
<img src="https://user-images.githubusercontent.com/34431991/72191445-ced81e80-33c7-11ea-8a5e-9bc2e2c4dfb5.png" width="275" height="400">

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- ~~[ ] If this is an important user-facing change, PR or related issue has a 'changelog' label~~
- ~~[ ] If this includes an internal dependency change, a link to the diff is provided~~

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- ~~[ ] Critical user journeys are covered by Gherkin stories~~
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
