### PR TITLE
use raise instead of raise e to show full traceback

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -176,7 +176,7 @@ class Job(object):
 
             try:
                 result = func(*args, **kwargs)
-            except Exception as e:
+            except Exception:
                 # If any error occurs, clear the job tracker and reraise
                 setattr(current_state_tracker, "job", None)
                 # Close any django connections opened here

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -181,7 +181,7 @@ class Job(object):
                 setattr(current_state_tracker, "job", None)
                 # Close any django connections opened here
                 connection.close()
-                raise e
+                raise
 
             setattr(current_state_tracker, "job", None)
 

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -225,6 +225,6 @@ def _reraise_with_traceback(f):
         except Exception as e:
             traceback_str = traceback.format_exc()
             e.traceback = traceback_str
-            raise e
+            raise
 
     return wrap


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the issue that when an exception occurs inside a job, the full error traceback would not be shown, making it harder to debug where the error is from. 
I replaced `raise e` with `raise` here because `raise e` creates a new stack trace based on the current location. I find [this blog post](https://www.markbetz.net/2014/04/30/re-raising-exceptions-in-python/) explaining the differences well.

note: there are some other occurrences of usng `raise e` in the import retry logic, I will open another PR to address it, along with my changes to the retry logic.
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. install kolibri 0.13.0
2. raise a random exception inside an iceqube job. for example, raise Exception before [this line](https://github.com/learningequality/kolibri/blob/release-v0.13.x/kolibri/core/content/utils/transfer.py#L188).
3. start to import content and get the following error traceback:
```
ERROR    Job 10d75a8fb7594c6fbdd1414effb320e2 raised an exception: Traceback (most recent call last):
  File "kolibri/core/tasks/worker.py", line 73, in handle_finished_future
    result = future.result()
  File "python2.7/site-packages/concurrent/futures/_base.py", line 422, in result
    return self.__get_result()
  File "python2.7/site-packages/concurrent/futures/thread.py", line 62, in run
    result = self.fn(*self.args, **self.kwargs)
  File "kolibri/core/tasks/worker.py", line 228, in wrap
    raise e
Exception: test exception!
```
4. install kolibri from this PR's installers
5. raise an exception in the same line as the one you put in #2
6. import some content and get the following error traceback:
```
ERROR    Job 262c134cee7f4a6aae5de247c34b3942 raised an exception: Traceback (most recent call last):
  File "kolibri/core/tasks/worker.py", line 73, in handle_finished_future
    result = future.result()
  File "python2.7/site-packages/concurrent/futures/_base.py", line 422, in result
    return self.__get_result()
  File "python2.7/site-packages/concurrent/futures/thread.py", line 62, in run
    result = self.fn(*self.args, **self.kwargs)
  File "kolibri/core/tasks/worker.py", line 224, in wrap
    return f(*args, **kwargs)
  File "kolibri/core/tasks/job.py", line 178, in y
    result = func(*args, **kwargs)
  File "python2.7/site-packages/django/core/management/__init__.py", line 131, in call_command
    return command.execute(*args, **defaults)
  File "python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "kolibri/core/tasks/management/commands/base.py", line 96, in handle
    return self.handle_async(*args, **options)
  File "kolibri/core/content/management/commands/importchannel.py", line 209, in handle_async
    options["channel_id"], options["baseurl"], options["no_upgrade"]
  File "kolibri/core/content/management/commands/importchannel.py", line 96, in download_channel
    self._transfer(DOWNLOAD_METHOD, channel_id, baseurl, no_upgrade=no_upgrade)
  File "kolibri/core/content/management/commands/importchannel.py", line 133, in _transfer
    filetransfer, channel_id, dest, no_upgrade=no_upgrade
  File "kolibri/core/content/management/commands/importchannel.py", line 195, in _start_file_transfer
    retry_import(e, skip_404=False)
  File "kolibri/core/content/utils/import_export_content.py", line 159, in retry_import
    raise e
Exception: test exception!
```
### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#6452 

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
