### PR TITLE
Disable arrows on Paginated Lists if there are no results in the table

### DIFF
--- a/kolibri/core/assets/src/views/PaginatedListContainer.vue
+++ b/kolibri/core/assets/src/views/PaginatedListContainer.vue
@@ -17,7 +17,7 @@
     </KGrid>
 
     <div>
-      <slot v-bind="{items: visibleFilteredItems, filterInput}"></slot>
+      <slot v-bind="{ items: visibleFilteredItems, filterInput }"></slot>
     </div>
 
     <nav>
@@ -27,22 +27,22 @@
       <UiIconButton
         type="primary"
         :ariaLabel="$tr('previousResults')"
-        :disabled="pageNum === 1"
+        :disabled="previousButtonDisabled"
         size="small"
         class="pagination-button"
         @click="changePage(-1)"
       >
-        <KIcon icon="back" style="position: relative; top: -1px;" />
+        <KIcon icon="back" class="arrow-icon" />
       </UiIconButton>
       <UiIconButton
         type="primary"
         :ariaLabel="$tr('nextResults')"
-        :disabled="pageNum === 0 || pageNum === numPages"
+        :disabled="nextButtonDisabled"
         size="small"
         class="pagination-button"
         @click="changePage(+1)"
       >
-        <KIcon icon="forward" style="position: relative; top: -1px;" />
+        <KIcon icon="forward" class="arrow-icon" />
       </UiIconButton>
     </nav>
   </div>
@@ -115,6 +115,12 @@
       visibleFilteredItems() {
         return this.filteredItems.slice(this.startRange, this.endRange);
       },
+      previousButtonDisabled() {
+        return this.pageNum === 1 || this.numFilteredItems === 0;
+      },
+      nextButtonDisabled() {
+        return this.pageNum === 0 || this.pageNum === this.numPages || this.numFilteredItems === 0;
+      },
     },
     watch: {
       numFilteredItems: {
@@ -145,7 +151,7 @@
 
   .actions-header,
   nav {
-    text-align: end;
+    text-align: right;
   }
 
   .pagination-button {
@@ -154,6 +160,11 @@
 
   .text-filter {
     margin-top: 14px;
+  }
+
+  .arrow-icon {
+    position: relative;
+    top: -1px;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Disables the forward arrow button in PaginatedListContainer if there are no results (e.g. when the filter does not match anything)
1. Some code style changes to match new ESLint rules
1. Change CSS rule for `nav` fixes #6335
1. Clamps the page range to fix unusual behavior in old versions of MS Edge. Fixes #6454 

This is what it should look like. Before, the right button would not be disabled.

![Screen Shot 2020-01-13 at 2 08 19 PM](https://user-images.githubusercontent.com/10248067/72296315-28318f00-360e-11ea-9eb3-a82f77e93801.png)
…

### Reviewer guidance

@mrpau-julius , can you see if this fixes the bug you saw in #6454 using Edge 20?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
