### PR TITLE
Add focus trap to CoreMenu (Fixes #6043)

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -68,11 +68,12 @@
           v-show="userMenuDropdownIsOpen"
           ref="userMenuDropdown"
           class="user-menu-dropdown"
+          :isOpen="userMenuDropdownIsOpen"
           :raised="true"
           :containFocus="true"
           :showActive="false"
           :style="{ backgroundColor: $themeTokens.surface }"
-          @close="userMenuDropdownIsOpen = false"
+          @close="handleCoreMenuClose"
         >
           <template v-if="isUserLoggedIn" v-slot:header>
             <div class="role">
@@ -189,6 +190,12 @@
           this.userMenuDropdownIsOpen = false;
         }
         return event;
+      },
+      handleCoreMenuClose() {
+        this.userMenuDropdownIsOpen = false;
+        if (this.$refs.userMenuButton.$refs.button) {
+          this.$refs.userMenuButton.$refs.button.focus();
+        }
       },
       handleChangeLanguage() {
         this.$emit('showLanguageModal');

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -16,13 +16,21 @@
         <slot name="header"></slot>
       </div>
 
+      <div
+        v-if="containFocus"
+        class="ui-menu-focus-redirector"
+        tabindex="0"
+        @focus="handleFirstTrapFocus"
+      >
+      </div>
+
       <slot name="options"></slot>
 
       <div
         v-if="containFocus"
         class="ui-menu-focus-redirector"
         tabindex="0"
-        @focus="redirectFocus"
+        @focus="handleLastTrapFocus"
       >
       </div>
     </ul>
@@ -32,6 +40,8 @@
 
 
 <script>
+
+  import last from 'lodash/last';
 
   export default {
     name: 'CoreMenu',
@@ -53,10 +63,19 @@
         type: Boolean,
         default: false,
       },
+      isOpen: {
+        type: Boolean,
+        default: false,
+      },
     },
     provide() {
       return {
         showActive: this.showActive,
+      };
+    },
+    data() {
+      return {
+        containTopFocus: false,
       };
     },
     computed: {
@@ -68,10 +87,36 @@
       },
     },
 
+    watch: {
+      isOpen(val) {
+        if (val === false) {
+          this.containTopFocus = false;
+        }
+      },
+    },
     methods: {
-      redirectFocus(e) {
-        e.stopPropagation();
+      focusFirstOption() {
         this.$el.querySelector('.core-menu-option').focus();
+      },
+      focusLastOption() {
+        const lastOption = last(this.$el.querySelectorAll('.core-menu-option'));
+        if (lastOption) {
+          lastOption.focus();
+        }
+      },
+      handleFirstTrapFocus(e) {
+        e.stopPropagation();
+        if (!this.containTopFocus) {
+          // On first focus, redirect to first option, then activate trap
+          this.focusFirstOption();
+          this.containTopFocus = true;
+        } else {
+          this.focusLastOption();
+        }
+      },
+      handleLastTrapFocus(e) {
+        e.stopPropagation();
+        this.focusFirstOption();
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

CoreMenu had a focus trap element to go to the top of the list after tabbing the last element, but not when Shift-Tabbing at the first element. This adds that.

It also adds a UX convenience where the User button will be refocused when the user closes the dropdown menu.

![focus-trap](https://user-images.githubusercontent.com/10248067/72386768-dbfe5180-36d6-11ea-92d4-ee24b00d9419.gif)

### Reviewer guidance

Try this out when logged in and not logged in to see if there's any issues with variable options.

### References

Fixes #6043
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
