### PR TITLE
Set PAGE_NAME before SET_LOADING on immersive pages

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -6,6 +6,7 @@ import { PageNames } from '../../constants';
 import { _userState } from '../mappers';
 
 export function showLearnerClassEnrollmentPage(store, classId) {
+  store.commit('SET_PAGE_NAME', PageNames.CLASS_ENROLL_LEARNER);
   store.commit('CORE_SET_PAGE_LOADING', true);
   const facilityId = store.getters.currentFacilityId;
   // all users in facility
@@ -32,7 +33,6 @@ export function showLearnerClassEnrollmentPage(store, classId) {
         modalShown: false,
       });
       store.commit('CORE_SET_PAGE_LOADING', false);
-      store.commit('SET_PAGE_NAME', PageNames.CLASS_ENROLL_LEARNER);
     },
     error => {
       store.dispatch('handleApiError', error);
@@ -41,6 +41,7 @@ export function showLearnerClassEnrollmentPage(store, classId) {
 }
 
 export function showCoachClassAssignmentPage(store, classId) {
+  store.commit('SET_PAGE_NAME', PageNames.CLASS_ASSIGN_COACH);
   store.commit('CORE_SET_PAGE_LOADING', true);
   const facilityId = store.getters.currentFacilityId;
   // all users in facility
@@ -73,7 +74,6 @@ export function showCoachClassAssignmentPage(store, classId) {
         modalShown: false,
       });
       store.commit('CORE_SET_PAGE_LOADING', false);
-      store.commit('SET_PAGE_NAME', PageNames.CLASS_ASSIGN_COACH);
     },
     error => {
       store.dispatch('handleApiError', error);


### PR DESCRIPTION
### Summary

Fixes #6029 

On FacilityIndex, when we navigate to the learner enrollment or coach assignment page, CoreBase sets `loading` before it realizes it is on an immersive page. Because of this, we get a scenario where the loader is displayed as if it is a normal, non-immersive page:

**Before (learner enrollment)**
![before](https://user-images.githubusercontent.com/34431991/72392682-41ae0600-36f6-11ea-8c87-5688ad237a61.gif)


By setting the page name before we set `loading`, CoreBase recognizes whether or not the page is immersive _before_ showing the loading bar:

**After (learner enrollment)**
![gifsmallerscreen](https://user-images.githubusercontent.com/34431991/72392708-4bd00480-36f6-11ea-91fb-9233b57fd286.gif)


And some stills of the fixed load bar, since it's difficult to see:
![image](https://user-images.githubusercontent.com/34431991/72392270-3ad2c380-36f5-11ea-8317-79ffe812ca34.png)

![image](https://user-images.githubusercontent.com/34431991/72392271-3c9c8700-36f5-11ea-9bd6-83224800ed1a.png)

**Before (coach assignment)**

![before_coaches](https://user-images.githubusercontent.com/34431991/72397116-7923af00-3704-11ea-9a6e-9ddddfb1805e.gif)

**After (coach assignment)**

![after_coaches_slowmo](https://user-images.githubusercontent.com/34431991/72397119-7cb73600-3704-11ea-969d-59ee86d7186b.gif)

### Reviewer guidance
I don't imagine it would cause issues if the pagename is set before other steps performed in `showLearnerClassEnrollmentPage()` or `showCoachClassAssignmentPage()`, but please let me know if that actually is the case (or if there is a better way to implement this logic).


### References
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
