### PR TITLE
enable byte-range resuming of file imports

### DIFF
--- a/kolibri/core/content/management/commands/exportchannel.py
+++ b/kolibri/core/content/management/commands/exportchannel.py
@@ -28,15 +28,15 @@ class Command(AsyncCommand):
         logger.debug("Source file: {}".format(src))
         logger.debug("Destination file: {}".format(dest))
 
-        with transfer.FileCopy(src, dest) as copy:
+        with transfer.FileCopy(src, dest, cancel_check=self.is_cancelled) as copy:
 
             with self.start_progress(total=copy.total_size) as progress_update:
+                try:
+                    for block in copy:
+                        progress_update(len(block))
 
-                for block in copy:
-                    if self.is_cancelled():
-                        copy.cancel()
-                        break
-                    progress_update(len(block))
+                except transfer.TransferCanceled:
+                    pass
 
                 if self.is_cancelled():
                     try:

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -126,9 +126,7 @@ class Command(AsyncCommand):
 
         logger.debug("Destination: {}".format(dest))
 
-        self._start_file_transfer(
-            filetransfer, channel_id, dest, no_upgrade=no_upgrade
-        )
+        self._start_file_transfer(filetransfer, channel_id, dest, no_upgrade=no_upgrade)
         if self.is_cancelled():
             self.cancel()
 
@@ -155,9 +153,7 @@ class Command(AsyncCommand):
                     os.remove(dest)
                 except OSError as e:
                     logger.info(
-                        "Tried to remove {}, but exception {} occurred.".format(
-                            dest, e
-                        )
+                        "Tried to remove {}, but exception {} occurred.".format(dest, e)
                     )
             else:
                 # if upgrading, import the channel
@@ -178,9 +174,7 @@ class Command(AsyncCommand):
                         if node_ids and import_ran:
                             # annotate default channel db based on previously annotated leaf nodes
                             with db_task_write_lock:
-                                update_content_metadata(
-                                    channel_id, node_ids=node_ids
-                                )
+                                update_content_metadata(channel_id, node_ids=node_ids)
                     except channel_import.ImportCancelError:
                         # This will only occur if is_cancelled is True.
                         pass

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -358,7 +358,7 @@ class Command(AsyncCommand):
                 )
 
             if exception:
-                raise
+                raise exception
 
             if self.is_cancelled():
                 self.cancel()

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from time import sleep
 
 import requests
 from django.core.management.base import CommandError
@@ -15,7 +14,6 @@ from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.content.utils.import_export_content import calculate_files_to_transfer
 from kolibri.core.content.utils.import_export_content import compare_checksums
 from kolibri.core.content.utils.import_export_content import get_nodes_to_transfer
-from kolibri.core.content.utils.import_export_content import retry_import
 from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import db_task_write_lock
@@ -28,9 +26,8 @@ COPY_METHOD = "copy"
 
 logger = logging.getLogger(__name__)
 
-FILE_TRANSFERRED = 2
+FILE_TRANSFERRED = 0
 FILE_SKIPPED = 1
-FILE_NOT_TRANSFERRED = 0
 
 
 def lookup_channel_listing_status(channel_id, baseurl=None):
@@ -282,7 +279,7 @@ class Command(AsyncCommand):
                     url = paths.get_content_storage_remote_url(
                         filename, baseurl=baseurl
                     )
-                    filetransfer = transfer.FileDownload(url, dest, session=session)
+                    filetransfer = transfer.FileDownload(url, dest, session=session, asynccommand=self)
                 elif method == COPY_METHOD:
                     try:
                         srcpath = paths.get_content_storage_file_path(
@@ -294,22 +291,21 @@ class Command(AsyncCommand):
                         continue
                     filetransfer = transfer.FileCopy(srcpath, dest)
 
-                finished = False
                 try:
-                    while not finished:
-                        finished, status = self._start_file_transfer(
-                            f, filetransfer, overall_progress_update
-                        )
+                    status = self._start_file_transfer(
+                        f, filetransfer, overall_progress_update
+                    )
 
-                        if self.is_cancelled():
-                            break
+                    if self.is_cancelled():
+                        break
 
-                        if status == FILE_TRANSFERRED:
-                            file_checksums_to_annotate.append(f.id)
-                            transferred_file_size += f.file_size
-                        elif status == FILE_SKIPPED:
-                            number_of_skipped_files += 1
+                    if status == FILE_SKIPPED:
+                        number_of_skipped_files += 1
+                    else:
+                        file_checksums_to_annotate.append(f.id)
+                        transferred_file_size += f.file_size
                 except Exception as e:
+                    logger.error("An error occurred during content import: {}".format(e))
                     exception = e
                     break
 
@@ -345,7 +341,7 @@ class Command(AsyncCommand):
                 )
 
             if exception:
-                raise exception
+                raise
 
             if self.is_cancelled():
                 self.cancel()
@@ -356,23 +352,17 @@ class Command(AsyncCommand):
         """
         Start to transfer the file from network/disk to the destination.
         Return value:
-            * True, FILE_TRANSFERRED - successfully transfer the file.
-            * True, FILE_SKIPPED - the file does not exist so it is skipped.
-            * True, FILE_NOT_TRANSFERRED - the transfer is cancelled.
-            * False, FILE_NOT_TRANSFERRED - the transfer fails and needs to retry.
+            * FILE_TRANSFERRED - successfully transfer the file.
+            * FILE_SKIPPED - the file does not exist so it is skipped.
         """
         try:
-            # Save the current progress value
-            original_value = self.progresstrackers[0].progress
-            original_progress = self.progresstrackers[0].get_progress()
-
             with filetransfer, self.start_progress(
                 total=filetransfer.total_size
             ) as file_dl_progress_update:
                 for chunk in filetransfer:
                     if self.is_cancelled():
                         filetransfer.cancel()
-                        return True, FILE_NOT_TRANSFERRED
+                        return
                     length = len(chunk)
                     overall_progress_update(length)
                     file_dl_progress_update(length)
@@ -395,33 +385,17 @@ class Command(AsyncCommand):
                         "An error occurred during content import: {}".format(e)
                     )
                     os.remove(filetransfer.dest)
-                    return True, FILE_SKIPPED
+                    return FILE_SKIPPED
 
-            return True, FILE_TRANSFERRED
+            return FILE_TRANSFERRED
 
-        except Exception as e:
-            logger.error("An error occurred during content import: {}".format(e))
-            retry = retry_import(e, skip_404=True)
-
-            if retry:
-                # Restore the previous progress so that the progress bar will
-                # not reach over 100% later
-                self.progresstrackers[0].progress = original_value
-
-                self.progresstrackers[0].update_callback(
-                    original_progress.progress_fraction, original_progress
-                )
-
-                logger.info(
-                    "Waiting for 30 seconds before retrying import: {}\n".format(
-                        filetransfer.source
-                    )
-                )
-                sleep(30)
-                return False, FILE_NOT_TRANSFERRED
-            else:
+        except requests.exceptions.HTTPError or OSError as e:
+            if (
+                (isinstance(e, requests.exceptions.HTTPError) and e.response.status_code == 404)
+                or (isinstance(e, OSError) and e.errno == 2)
+            ):
                 overall_progress_update(f.file_size)
-                return True, FILE_SKIPPED
+                return FILE_SKIPPED
 
     def handle_async(self, *args, **options):
         if options["command"] == "network":

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -124,21 +124,16 @@ def _get_node_ids(node_ids):
     )
 
 
-def retry_import(e, **kwargs):
+def retry_import(e):
     """
     When an exception occurs during channel/content import, if
         * there is an Internet connection error or timeout error,
           or HTTPError where the error code is one of the RETRY_STATUS_CODE,
           return return True to retry the file transfer
-        * the file does not exist on the server or disk, skip the file and return False.
-          This only applies to content import not channel import.
-        * otherwise, raise the  exception.
     return value:
         * True - needs retry.
-        * False - file is skipped. Does not need retry.
+        * False - Does not need retry.
     """
-
-    skip_404 = kwargs.pop("skip_404")
 
     if (
         isinstance(e, ConnectionError)
@@ -149,14 +144,7 @@ def retry_import(e, **kwargs):
     ):
         return True
 
-    elif skip_404 and (
-        (isinstance(e, HTTPError) and e.response.status_code == 404)
-        or (isinstance(e, OSError) and e.errno == 2)
-    ):
-        return False
-
-    else:
-        raise e
+    return False
 
 
 def compare_checksums(file_name, file_id):

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -233,9 +233,12 @@ class FileDownload(Transfer):
             # When internet connection is lost at the beginning of start(),
             # self.response does not get an assigned value
             if hasattr(self, "response"):
-                # Use Content-Length header to check if range requests are supported
-                # For example, range requests are not supported on compressed files
-                byte_range_resume = self.response.headers.get("content-length", None)
+                # Use Accept-Ranges and Content-Length header to check if range
+                # requests are supported. For example, range requests are not
+                # supported on compressed files
+                byte_range_resume = self.response.headers.get(
+                    "accept-ranges", None
+                ) and self.response.headers.get("content-length", None)
                 resume_headers = self.response.request.headers
 
                 # Only use byte-range file resuming when sources support range requests

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -213,7 +213,6 @@ class FileDownload(Transfer):
     def resume(self):
         try:
             if self.asynccommand and self.asynccommand.is_cancelled():
-                self.cancel()
                 return
 
             logger.info(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to enable byte-range resuming of file imports so that when the internet connection is lost in the middle of importing a large file, retrying file import will start from where it stops earlier instead of starting from the beginning of the file. I use `Range` property in the request header to achieve this.

However, not all the files will be enabled with byte-range resuming. Files compressed with gzip (either done by us on Google Cloud Storage or done by Cloudflare), e.g. large channel database files, do not support range requests.

Here are some major changes I make in this PR:
- Byte-range resuming of importing files that are not compressed with gzip
- Move the retry logic from the commands python files to transfer.py to clean up the code and avoid keeping open new file handlers every 30 seconds
- Pass `is_cancelled()` to Transfer objects and raise `TransferCanceled` exception when users cancel the file transfer instead of calling `is_cancelled()` every iteration of file transfer. This is mainly to make code in `importchannel.py` simpler.
- Handle a case about retry import when internet connection is lost at the beginning of `start()`, where iteration of file content has not started yet, which we are not currently handling
- Edit and add tests based on the changes above

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I've done manual testing under the following circumstances:
- [x] channel import
- [x] channel import no internet/resume
- [x] content network import
- [x] content network import cancel
- [x] content network import no internet cancel
- [x] content network import no internet/resume
- [x] content local import
- [x] content local import cancel
- [x] content local import skip
- [x] content export
- [x] content export cancel

please feel free to let me know if you have any questions! Thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://www.notion.so/learningequality/Byte-range-resuming-of-file-imports-0755383c8810422291881c6a211780ed

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
