### PR TITLE
Temporarily disabling macOS build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,13 +7,13 @@ steps:
 
   - wait
 
-  - trigger: "kolibri-macos"
-    label: ":mac:"
-    build: &triggered_build_attributes
-      message: "${BUILDKITE_MESSAGE}"
-      env:
-        LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
-        LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
+  # - trigger: "kolibri-macos"
+  #   label: ":mac:"
+  #   build: &triggered_build_attributes
+  #     message: "${BUILDKITE_MESSAGE}"
+  #     env:
+  #       LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
+  #       LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
 
     # Android build only requires whl file
   # - label: Build Android APK
@@ -31,7 +31,11 @@ steps:
 
   - trigger: "kolibri-raspbian-image"
     label: ":raspberry-pi:"
-    build: *triggered_build_attributes
+    build: &triggered_build_attributes
+      message: "${BUILDKITE_MESSAGE}"
+      env:
+        LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
+        LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
     depends_on:
       - deb-build
 

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -35,7 +35,7 @@ mkdir -p dist
 buildkite-agent artifact download 'dist/*.pex' dist/
 buildkite-agent artifact download 'dist/*.whl' dist/
 buildkite-agent artifact download 'dist/*.tar.gz' dist/
-buildkite-agent artifact download 'dist/*.deb' dist/
+# buildkite-agent artifact download 'dist/*.deb' dist/
 buildkite-agent artifact download 'dist/*.exe' dist/
 buildkite-agent artifact download 'dist/*.dmg' dist/
 buildkite-agent artifact download 'dist/*.zip' dist/

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -35,9 +35,9 @@ mkdir -p dist
 buildkite-agent artifact download 'dist/*.pex' dist/
 buildkite-agent artifact download 'dist/*.whl' dist/
 buildkite-agent artifact download 'dist/*.tar.gz' dist/
-# buildkite-agent artifact download 'dist/*.deb' dist/
+buildkite-agent artifact download 'dist/*.deb' dist/
 buildkite-agent artifact download 'dist/*.exe' dist/
-buildkite-agent artifact download 'dist/*.dmg' dist/
+# buildkite-agent artifact download 'dist/*.dmg' dist/
 buildkite-agent artifact download 'dist/*.zip' dist/
 
 {

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -107,7 +107,7 @@ file_manifest = {
 file_order = [
     "deb",
     "zip",
-    "dmg",
+    # "dmg",
     "unsigned-exe",
     "signed-exe",
     # 'apk',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Mac builds have been timingout at the upload step as of late. Disabling until tomorrow, when I can get to the build machine for more debugging.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See if the mac build has stopped uploading without breaking the pipeline

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
