### PR TITLE
Set cues only for selected language

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -63,3 +63,4 @@ Please feel free to add your name to this list if you make a PR
 * Carol Willing (willingc)
 * Yixuan Liu (yil039)
 * Blaine Jester (bjester)
+* Brandon Nguyen (bransgithub)

--- a/kolibri/plugins/media_player/assets/src/modules/captions/index.js
+++ b/kolibri/plugins/media_player/assets/src/modules/captions/index.js
@@ -153,6 +153,8 @@ export default {
       );
     },
     setTrackList(store, trackList) {
+      let { language } = store.state;
+
       if (store.state.trackList) {
         store.state.trackListeners.forEach(({ trackId, event, listener }) => {
           const track = store.getters.tracks.find(track => track.id === trackId);
@@ -185,8 +187,12 @@ export default {
         const addCue = track.addCue.bind(track);
         track.addCue = (...args) => {
           const result = addCue(...args);
-          store.dispatch('setCuesFromTrack', track);
-          store.dispatch('setActiveCuesFromTrack', track);
+
+          if (track.language == language) {
+            store.dispatch('setCuesFromTrack', track);
+            store.dispatch('setActiveCuesFromTrack', track);
+          }
+
           return result;
         };
         track.addCue.overridden = true;


### PR DESCRIPTION
### Summary

Fixes #6397 

In mediaPlayer/captions, SET_CUES is called regardless of the current language. Because of this, the mediaPlayer's transcript may be in unexpected languages when the page first loads:

![before_trimmed](https://user-images.githubusercontent.com/34431991/72636916-c3d04180-3925-11ea-924f-fdc662d1d977.gif)

By only setting SET_CUES when the track is in our expected language, we should now only see cues shown in said language:

![after](https://user-images.githubusercontent.com/34431991/72636753-5c19f680-3925-11ea-80ef-fc5db3fe3fd5.gif)

### Reviewer guidance

…

### References

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
