### PR TITLE
Show Python version in device info tab

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -1,3 +1,5 @@
+from sys import version_info
+
 from django.conf import settings
 from django.http.response import HttpResponseBadRequest
 from morango.models import InstanceIDModel
@@ -103,6 +105,9 @@ class DeviceInfoView(views.APIView):
         # Returns the named timezone for the server (the time above only includes the offset)
         info["server_timezone"] = settings.TIME_ZONE
         info["installer"] = installation_type()
+        info["python_version"] = "{major}.{minor}".format(
+            major=version_info.major, minor=version_info.minor
+        )
 
         return Response(info)
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -105,10 +105,9 @@ class DeviceInfoView(views.APIView):
         # Returns the named timezone for the server (the time above only includes the offset)
         info["server_timezone"] = settings.TIME_ZONE
         info["installer"] = installation_type()
-        info["python_version"] = "{major}.{minor}".format(
-            major=version_info.major, minor=version_info.minor
+        info["python_version"] = "{major}.{minor}.{micro}".format(
+            major=version_info.major, minor=version_info.minor, micro=version_info.micro
         )
-
         return Response(info)
 
 

--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -80,6 +80,7 @@
         return [
           `Version:           ${this.deviceInfo.version}`,
           `OS:                ${this.deviceInfo.os}`,
+          `Python:            ${this.deviceInfo.python_version}`,
           `Installer:         ${this.deviceInfo.installer}`,
           `Server:            ${this.deviceInfo.server_type}`,
           `Database:          ${this.deviceInfo.database_path}`,


### PR DESCRIPTION
### Summary
As requested by some users, knowing the Python version the server is running might be useful. This small change shows it in the Device info tab


### Reviewer guidance
Python version should be shown correctly in the device info tab

### References
Fixes #6462 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
