### PR TITLE
enable legacy_alter_table pragma

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -42,7 +42,7 @@ class KolibriCoreConfig(AppConfig):
             cursor = connection.cursor()
 
             # Shorten the default WAL autocheckpoint from 1000 pages to 500
-            cursor.execute(CONNECTION_PRAGMAS)
+            cursor.executescript(CONNECTION_PRAGMAS)
 
             # We don't turn on the following pragmas, because they have negligible
             # performance impact. For reference, here's what we've tested:

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -24,7 +24,7 @@ from kolibri.core.sqlite.pragmas import START_PRAGMAS
 
 def set_sqlite_connection_pragma(dbapi_connection, connection_record):
     cursor = dbapi_connection.cursor()
-    cursor.execute(CONNECTION_PRAGMAS)
+    cursor.executescript(CONNECTION_PRAGMAS)
     cursor.close()
 
 

--- a/kolibri/core/sqlite/pragmas.py
+++ b/kolibri/core/sqlite/pragmas.py
@@ -1,3 +1,3 @@
-CONNECTION_PRAGMAS = "PRAGMA wal_autocheckpoint=500;"
+CONNECTION_PRAGMAS = "PRAGMA wal_autocheckpoint=500; PRAGMA legacy_alter_table = ON;"
 
 START_PRAGMAS = "PRAGMA journal_mode=WAL;"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to enable the legacy_alter_table pragma introduced in sqlite 3.26.0, based on Richard's suggestion in https://github.com/learningequality/kolibri/issues/6158, so the tests can pass locally when sqlite >= 3.26.0 is used.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check when running `tox -r -e py3.7 -- kolibri/plugins/device/test/test_api.py` with sqlite >= 3.26.0, it does not throw the error below:
```
def execute(self, query, params=None):
        if params is None:
>           return Database.Cursor.execute(self, query)
E           django.db.utils.OperationalError: Problem installing fixtures: no such table: content_contentnode__old
```

please feel free to let me know if you have any questions! thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6158

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
