### PR TITLE
Move RunPython to a separate migration and transaction

### DIFF
--- a/kolibri/core/device/migrations/0005_auto_20191203_0951.py
+++ b/kolibri/core/device/migrations/0005_auto_20191203_0951.py
@@ -51,7 +51,6 @@ class Migration(migrations.Migration):
             name="allow_guest_access",
             field=models.BooleanField(default=True),
         ),
-        migrations.RunPython(migrate_allow_guest_access, revert_allow_guest_access),
         migrations.AddField(
             model_name="devicesettings",
             name="allow_learner_unassigned_resource_access",
@@ -71,4 +70,5 @@ class Migration(migrations.Migration):
                 max_length=7,
             ),
         ),
+        migrations.RunPython(migrate_allow_guest_access, revert_allow_guest_access),
     ]

--- a/kolibri/core/device/migrations/0005_auto_20191203_0951.py
+++ b/kolibri/core/device/migrations/0005_auto_20191203_0951.py
@@ -7,37 +7,6 @@ from django.db import migrations
 from django.db import models
 
 
-def migrate_allow_guest_access(apps, schema_editor):
-    FacilityDataset = apps.get_model("kolibriauth", "FacilityDataset")
-    DeviceSettings = apps.get_model("device", "DeviceSettings")
-
-    try:
-        default_facility = DeviceSettings.objects.get().default_facility
-        allow_guest_access = default_facility.dataset.allow_guest_access
-    except ObjectDoesNotExist:
-        allow_guest_access = (
-            FacilityDataset.objects.filter(allow_guest_access=False).count() <= 0
-        )
-
-    DeviceSettings.objects.update(allow_guest_access=allow_guest_access)
-
-
-def revert_allow_guest_access(apps, schema_editor):
-    FacilityDataset = apps.get_model("kolibriauth", "FacilityDataset")
-    DeviceSettings = apps.get_model("device", "DeviceSettings")
-
-    allow_guest_access = (
-        DeviceSettings.objects.filter(allow_guest_access=False).count() <= 0
-    )
-
-    try:
-        default_facility = DeviceSettings.objects.get().default_facility
-        default_facility.dataset.allow_guest_access = allow_guest_access
-        default_facility.dataset.save()
-    except ObjectDoesNotExist:
-        FacilityDataset.objects.update(allow_guest_access=allow_guest_access)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -70,5 +39,4 @@ class Migration(migrations.Migration):
                 max_length=7,
             ),
         ),
-        migrations.RunPython(migrate_allow_guest_access, revert_allow_guest_access),
     ]

--- a/kolibri/core/device/migrations/0006_migrate_guest_access.py
+++ b/kolibri/core/device/migrations/0006_migrate_guest_access.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import migrations
+from django.db import models
+from django.db.migrations.recorder import MigrationRecorder
+
+
+def migrate_allow_guest_access(apps, schema_editor):
+    # if this migration has been run, drop out because logic depends on a field that no longer exists
+    if MigrationRecorder.Migration.objects.filter(
+        app="kolibriauth",
+        name="0017_remove_facilitydataset_allow_guest_access",
+        applied__isnull=False,
+    ).exists():
+        return
+    FacilityDataset = apps.get_model("kolibriauth", "FacilityDataset")
+    DeviceSettings = apps.get_model("device", "DeviceSettings")
+
+    try:
+        default_facility = DeviceSettings.objects.get().default_facility
+        allow_guest_access = default_facility.dataset.allow_guest_access
+    except ObjectDoesNotExist:
+        allow_guest_access = (
+            FacilityDataset.objects.filter(allow_guest_access=False).count() <= 0
+        )
+
+    DeviceSettings.objects.update(allow_guest_access=allow_guest_access)
+
+
+def revert_allow_guest_access(apps, schema_editor):
+    # if this migration has been run, drop out because logic depends on a field that no longer exists
+    if MigrationRecorder.Migration.objects.filter(
+        app="kolibriauth",
+        name="0017_remove_facilitydataset_allow_guest_access",
+        applied__isnull=False,
+    ).exists():
+        return
+
+    FacilityDataset = apps.get_model("kolibriauth", "FacilityDataset")
+    DeviceSettings = apps.get_model("device", "DeviceSettings")
+
+    allow_guest_access = (
+        DeviceSettings.objects.filter(allow_guest_access=False).count() <= 0
+    )
+
+    try:
+        default_facility = DeviceSettings.objects.get().default_facility
+        default_facility.dataset.allow_guest_access = allow_guest_access
+        default_facility.dataset.save()
+    except ObjectDoesNotExist:
+        FacilityDataset.objects.update(allow_guest_access=allow_guest_access)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("device", "0005_auto_20191203_0951"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_allow_guest_access, revert_allow_guest_access),
+    ]


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We separate the schema migration from the data migration for allowing guest access. For devices that have already ran the migrations prior to this change, we check if the corresponding schema migration has been applied (removing `guest_access` field from `facility_dataset`). If it has been applied, we skip the data migration because the field has already been removed, and the logic relies on that field still existing. 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Any possible problems with the simple approach?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/6480.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
