### PR TITLE
Maintain channel order when importing new resources

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -478,6 +478,8 @@ def calculate_next_order(channel, model=ChannelMetadata):
     latest_order = model.objects.latest("order").order
     if latest_order is None:
         channel.order = 1
-    else:
+
+    if channel.order is None or channel.order == 0:
         channel.order = latest_order + 1
+
     channel.save()


### PR DESCRIPTION
### Summary

Fixes #6376 

Currently, when importing new resources for an already-installed channel, the affected channel is moved to the bottom of the list (after tasks are cleared and the page is refreshed). This fix affects the `calculate_next_order()` method, which should now only set the channel as the last item on the list if it is a new, uninstalled channel. This means any existing/installed channels will maintain their position on the list.

**Before**

The current behavior, starting at the available channels page:

<img src="https://user-images.githubusercontent.com/34431991/72857228-a4694980-3c82-11ea-8735-b3b5c417d886.png" height="500" width="300">

We will import new resources for "Guía...", a channel that is already installed. We can see that it is moved to the top temporarily, after which it then shows up at the bottom.

| "New" channel is at the top | After task is cleared/page refreshed, it's moved to the bottom 
|------|-------|
| <img src="https://user-images.githubusercontent.com/34431991/72857247-b1863880-3c82-11ea-82a5-fa233532b187.png">  | <img src="https://user-images.githubusercontent.com/34431991/72857249-b3e89280-3c82-11ea-8d6a-241813e84de3.png"> |

**After**

We'll start with the following channel list:

<img width="474" alt="4  after_orig" src="https://user-images.githubusercontent.com/34431991/72857661-e6df5600-3c83-11ea-90ab-164d61650a6b.png">

And add new resources for HP LIFE. Now, HP LIFE should keep its original position:

| "New" channel is at the top | After task is cleared/page refreshed, channel keeps its position
|------|-------|
| <img width="428" alt="5  after_add_new" src="https://user-images.githubusercontent.com/34431991/72857665-ea72dd00-3c83-11ea-9342-b5cecd9b3571.png"> | <img width="380" alt="6  after_refresh_fixed" src="https://user-images.githubusercontent.com/34431991/72857668-ee066400-3c83-11ea-9ddb-535df95f97b8.png"> |

And for good measure, here's what happens when an entirely new/uninstalled channel is imported:

| "New" channel is at the top | "New" channel is at the bottom 
|------|-------|
|  <img src="https://user-images.githubusercontent.com/34431991/72857676-f65e9f00-3c83-11ea-9faa-527e312279e6.png"> | <img src="https://user-images.githubusercontent.com/34431991/72857677-f9f22600-3c83-11ea-8877-e5c43d695f3f.png"> |

### Reviewer guidance

`calculate_next_order()` is used in a couple different places; here are the top-level 'callers' from what I could tell:
- `importcontent.py/_transfer()`
- `scanforcontent.py/handle()`
- `upgrade.py/import_external_content_dbs()`
- `deletecontent.py/delete_metadata()`

I don't believe this will alter any of their expected behavior, but I think this is worth confirming.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
