### PR TITLE
Fix scroll arrows in AppBar

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -215,7 +215,9 @@
     max-width: 200px;
     // overflow-x hidden seems to affect overflow-y also, so include a fixed height
     height: 16px;
-    overflow-x: hidden;
+    // overflow: hidden on both so that the -y doesn't show scroll buttons
+    // at certain zooms/screen sizes
+    overflow: hidden;
     text-overflow: ellipsis;
   }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I tried everything except zoom to replicate https://github.com/learningequality/kolibri/issues/6122 but @rtibbles found that zooming to 200% causes the issue to arise consistently!

I tested this on Debian Chromium v78.x 

This will ensure that the scroll arrows don't show on the username regardless of screen size.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Use the base 0.12.x branch.
- Login
- Zoom in (hold CTRL and hit +) until you're at 200% zoom.
- See the arrows appearing at the username at the top right.

- Checkout this branch
- See fix.

Additional: Check it in various languages and scripts and screen sizes and so on. I tested some Arabic text and everything shows fine without any issues with things being cut off vertically. Change your profile's username to long things, all caps things, anything that could potentially get cut off vertically.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6122

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
