### PR TITLE
Force debian version when building the package

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,3 @@ steps:
 
   - label: Upload artifacts
     command: .buildkite/setup_and_upload_artifact.sh && docker image prune -f -a
-
-  - label: Sign Windows installer
-    command: .buildkite/sign_windows_installer.bat
-    agents:
-      queue: "windows-sign"

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -13,7 +13,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-PIP_CMD="$PIP_PATH install --upgrade gcloud"
+PIP_CMD="$PIP_PATH install --upgrade google-cloud-storage"
 echo "Running $PIP_CMD..."
 $PIP_CMD
 if [ $? -ne 0 ]; then

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -7,7 +7,7 @@ PIP_PATH="$SCRIPTPATH/env/bin/pip"
 PYTHON_PATH="$SCRIPTPATH/env/bin/python"
 
 echo "Now creating virtualenv..."
-virtualenv -p python3 env
+virtualenv -p python3.5 env
 if [ $? -ne 0 ]; then
     echo ".. Abort!  Can't create virtualenv."
     exit 1

--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -13,14 +13,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-PIP_CMD="$PIP_PATH install --upgrade google-cloud-storage"
-echo "Running $PIP_CMD..."
-$PIP_CMD
-if [ $? -ne 0 ]; then
-    echo ".. Abort!  Can't install '$PIP_CMD'."
-    exit 1
-fi
-
 PIP_CMD="$PIP_PATH install -r requirements/pipeline.txt"
 echo "Running $PIP_CMD..."
 $PIP_CMD

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -21,7 +21,7 @@ import sys
 from os import listdir
 
 import requests
-from gcloud import storage
+from google.cloud import storage
 from github3 import login
 
 logging.getLogger().setLevel(logging.INFO)

--- a/docker/build_debian.dockerfile
+++ b/docker/build_debian.dockerfile
@@ -30,7 +30,7 @@ CMD cd /kolibribuild && \
     DEB_VERSION=`echo -n "$KOLIBRI_VERSION" | sed -s 's/^\+\.\+\.\+\([abc]\|\.dev\)/\~\0/g'` && \
     cd kolibri-source* && \
     ls /kolibridist && \
-    uupdate --no-symlink -v "$DEB_VERSION" /kolibridist/kolibri-$KOLIBRI_VERSION.tar.gz && \
+    uupdate --no-symlink -b -v "$DEB_VERSION" /kolibridist/kolibri-$KOLIBRI_VERSION.tar.gz && \
     cd "../kolibri-source-$DEB_VERSION" && \
     debuild --no-lintian -us -uc -Zgzip -z3 && \
     cd .. && \

--- a/requirements/pipeline.txt
+++ b/requirements/pipeline.txt
@@ -1,2 +1,3 @@
 requests==2.21.0
+google-cloud-storage==1.24.1
 github3.py==1.1.0

--- a/requirements/pipeline.txt
+++ b/requirements/pipeline.txt
@@ -1,2 +1,2 @@
-requests==2.10.0
+requests==2.21.0
 github3.py==1.1.0

--- a/requirements/pipeline.txt
+++ b/requirements/pipeline.txt
@@ -1,2 +1,2 @@
 requests==2.10.0
-github3.py==0.9.6
+github3.py==1.1.0


### PR DESCRIPTION
### Summary
Current Docker setup to build the Kolibri debian package uses uupdate, which by default will always update one version to a new upstream version.
With this change we force the version to be built, allowing packaging releases that have a lower version than the last one.


### Reviewer guidance

Does it build both new and old versions of the package?


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
