### PR TITLE
Less brittle upload step

### DIFF
--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -32,13 +32,7 @@ fi
 PYTHON_CMD="$PYTHON_PATH .buildkite/upload_artifacts.py"
 echo "Now excuting  upload artifacts script..."
 mkdir -p dist
-buildkite-agent artifact download 'dist/*.pex' dist/
-buildkite-agent artifact download 'dist/*.whl' dist/
-buildkite-agent artifact download 'dist/*.tar.gz' dist/
-buildkite-agent artifact download 'dist/*.deb' dist/
-buildkite-agent artifact download 'dist/*.exe' dist/
-# buildkite-agent artifact download 'dist/*.dmg' dist/
-buildkite-agent artifact download 'dist/*.zip' dist/
+buildkite-agent artifact download 'dist/*' dist/
 
 {
     buildkite-agent artifact download '*.exe' dist/ --step "Sign Windows installer"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Having the download step download the entire `dist` folder (where everything is uploaded) rather than naming each file explicitly.

Allows for the step to succeed despite previous steps not having happened (as is the model for our block-by-default triggered builds).

Also provides relief for the issues we occasionally face from the rPi image, as it somtimes fails silently. That being the case, no zip file is uploaded to Builkdite and the download portion of the GCS upload step fails. 

Going back to relase 0.13 as that's when rPi was introduced.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Builds should pass. Down the line, they should pass regardless of whether we decided to build the pi image (and any other triggered build) or not.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Aims to fix the same issue (and a bit more) as #6402

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
