### PR TITLE
Add min-width to percentage to avoid word break

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -354,6 +354,8 @@
   }
 
   .details-percentage {
+    // min-width ensures num % stay on same line
+    min-width: 48px;
     margin-left: 16px;
     font-size: $fs1;
   }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes https://github.com/learningequality/kolibri/issues/6447

I added `min-width: 48px` to the percentage `<span>` tag. Now the % value will not break at any %

![fixed-percentage](https://user-images.githubusercontent.com/6356129/73492198-13226300-4365-11ea-9322-dd523019d790.png)

I have tested at various widths in Chrome & Firefox (Debian) and IE11 (Windows 7 Browserstack).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test in Firefox, Chrome, and/or IE11. The issue originated in IE11 on Windows 7 - but we should be sure the change doesn't break other browser/OS combos:

- Log in as super admin
- Go to Device > Import and start a task to import a very large channel.
- Go to "Task Manager" to view the task in progress.
- See that the "n %" is lined up properly (not breaking so that the number is above the %)
- Right click the "n %" and click "Inspect element". In the HTML shown, right click the `<span>` that wraps the "n %" and click "Edit as HTML".
- Update the N part of the "n %" and make it a 2-digit number. Do the same and make it 100% and make sure it never breaks.
- Test at multiple screen widths as well.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6447

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
