### PR TITLE
Fix blank AppBar title on Learner Quiz Pages

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -1,5 +1,6 @@
 import {
   ContentNodeResource,
+  ClassroomResource,
   ExamResource,
   ExamLogResource,
   ExamAttemptLogResource,
@@ -32,6 +33,7 @@ export function showExam(store, params, alreadyOnQuiz) {
     store.commit('CORE_SET_PAGE_LOADING', false);
   } else {
     const promises = [
+      ClassroomResource.fetchModel({ id: classId }),
       ExamResource.fetchModel({ id: examId }),
       ExamLogResource.fetchCollection({ getParams: examParams }),
       ExamAttemptLogResource.fetchCollection({ getParams: examParams }),
@@ -39,7 +41,9 @@ export function showExam(store, params, alreadyOnQuiz) {
     ];
     ConditionalPromise.all(promises).only(
       samePageCheckGenerator(store),
-      ([exam, examLogs, examAttemptLogs]) => {
+      ([classroom, exam, examLogs, examAttemptLogs]) => {
+        store.commit('classAssignments/SET_CURRENT_CLASSROOM', classroom);
+
         // Local copy of exam attempt logs
         const attemptLogs = {};
 


### PR DESCRIPTION
### Summary

Fixes #6323 

Currently, refreshing a quiz page or navigating to it directly results in a blank app bar title:

![before](https://user-images.githubusercontent.com/34431991/73496626-a1efa980-437e-11ea-98a4-2d5406d05a9b.gif)

By fetching the LearnerClassroomResource based on the classId param, we can set the classroom name/title whenever the page loads:

![after](https://user-images.githubusercontent.com/34431991/73496693-c9df0d00-437e-11ea-9715-6d27316ce30c.gif)

### Reviewer guidance

…

### References

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
