### PR TITLE
Coach Report details fix coach resource icon

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -86,7 +86,6 @@
               class="coach-content-label"
               :value="attemptLog.num_coach_contents || 0"
               :isTopic="false"
-              style="margin-top:-4px"
             />
           </a>
         </li>
@@ -174,6 +173,7 @@
 
   .coach-content-label {
     display: inline-block;
+    margin-top: -4px;
     margin-left: 8px;
     vertical-align: middle;
   }

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div :style="{ backgroundColor: $themeTokens.surface }">
-    <h3 class="header">
+    <h3 class="header" :style="iconStyle">
       {{ $tr('answerHistoryLabel') }}
     </h3>
 
@@ -29,6 +29,7 @@
             role="option"
             :aria-selected="isSelected(index).toString()"
             :tabindex="isSelected(index) ? 0 : -1"
+            :style="iconStyle"
             @click.prevent="setSelectedAttemptLog(index)"
             @keydown.enter="setSelectedAttemptLog(index)"
             @keydown.space.prevent="setSelectedAttemptLog(index)"
@@ -70,18 +71,24 @@
             />
             <p class="item">
               {{
-                coreString(
-                  'questionNumberLabel',
-                  {questionNumber: attemptLog.questionNumber}
-                )
+                windowIsLarge ?
+                  coreString(
+                    'questionNumberLabel',
+                    {questionNumber: attemptLog.questionNumber}
+                  )
+                  :
+                  // Add non-breaking space to preserve vertical centering
+                  "&nbsp;"
               }}
             </p>
+            <CoachContentLabel
+              v-if="windowIsLarge"
+              class="coach-content-label"
+              :value="attemptLog.num_coach_contents || 0"
+              :isTopic="false"
+              style="margin-top:-4px"
+            />
           </a>
-          <CoachContentLabel
-            class="coach-content-label"
-            :value="attemptLog.num_coach_contents || 0"
-            :isTopic="false"
-          />
         </li>
       </template>
     </ul>
@@ -94,13 +101,14 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   export default {
     name: 'AttemptLogList',
     components: {
       CoachContentLabel,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
       attemptLogs: {
         type: Array,
@@ -109,6 +117,18 @@
       selectedQuestionNumber: {
         type: Number,
         required: true,
+      },
+    },
+    computed: {
+      iconStyle() {
+        if (this.windowIsLarge) {
+          return {};
+        } else {
+          return {
+            textAlign: 'center',
+            padding: 0,
+          };
+        }
       },
     },
     mounted() {


### PR DESCRIPTION
- Hide coach resource icon on non-large screen
- Align coach resource icon on larger screens w/ text

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes: https://github.com/learningequality/kolibri/issues/6469 and makes a couple other changes.

- Coach Resource icon is aligned w/ the text on larger screens.
- < 840px we hide the "Question #" text and only show the checkmark or (x) icons.
- - We center those icons and the header at these screen sizes.

Tested in IE11 (Windows 7 - Browserstack) and Chrome/Firefox (Debian).

![01302020-better-icons](https://user-images.githubusercontent.com/6356129/73498024-fa1faf00-4370-11ea-8896-5ba67d7abe05.gif)


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Make a quiz with resources that have Coach Resources (the little blue reading person icon).
- Take that quiz as a learner
- Go to Coach > Reports >> Report for that Quiz
- See that the blue "Coach Resource" icon is aligned with the "Question #" text when your screen is wide.
- Make your screen less wide than 840px and see that the "Coach Resource" icon and the "Question #" icon are not visible. Also, the checkmark or red X icons are centered in their container per the gif.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6469

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
