### PR TITLE
Fixes for IE11 and Firefox-specific bugs in 0.13.0

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -219,6 +219,7 @@
     // overflow-x hidden seems to affect overflow-y also, so include a fixed height
     height: 16px;
     overflow-x: hidden;
+    overflow-y: hidden;
     text-overflow: ellipsis;
   }
 

--- a/kolibri/core/assets/src/views/PrivacyInfoModal.vue
+++ b/kolibri/core/assets/src/views/PrivacyInfoModal.vue
@@ -2,10 +2,8 @@
 
   <KModal
     size="large"
-    :submitText="coreString('closeAction')"
     :title="coreString('usageAndPrivacyLabel')"
     @cancel="$emit('cancel')"
-    @submit="$emit('submit')"
   >
     <section v-if="!hideUsersSection">
       <h2>{{ coreString('usersLabel') }}</h2>
@@ -48,6 +46,17 @@
       <p>{{ $tr('kolibriAboutP4') }}</p>
       <p>{{ $tr('kolibriAboutP5') }}</p>
     </section>
+    <template v-slot:actions>
+      <!--
+        Need to inject a button without type="submit" attribute
+        so it doesn't force a submit event in the SetupWizard SuperuserCredentialsForm
+      -->
+      <KButton
+        :text="coreString('closeAction')"
+        primary
+        @click="$emit('submit')"
+      />
+    </template>
   </KModal>
 
 </template>

--- a/kolibri/core/assets/src/views/sortable/DragHandle.vue
+++ b/kolibri/core/assets/src/views/sortable/DragHandle.vue
@@ -18,9 +18,8 @@
         }
       },
     },
-    // render the first element passed in without a wrapper node
-    render() {
-      return this.$slots.default[0];
+    render(createElement) {
+      return createElement('div', [this.$slots.default[0]]);
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -232,6 +232,8 @@
   .col-3 {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
+    min-width: 200px;
 
     .channel-list-item-sm & {
       flex-direction: column;

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -223,7 +223,7 @@
     },
     destroyed() {
       // Restore scrollbars to <html> tag
-      window.document.documentElement.style['overflow'] = null;
+      window.document.documentElement.style['overflow'] = '';
       window.removeEventListener('focus', this.focusElementTest, true);
       // Wait for events to finish propagating before changing the focus.
       // Otherwise the `lastFocus` item receives events such as 'enter'.


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Fixes #6455 by having DragHandle render function return a single div.

Before

![IMG_1040](https://user-images.githubusercontent.com/10248067/73498289-b8433880-4371-11ea-9fb4-37d2b2cb9a14.jpg)


After

![IMG_1039](https://user-images.githubusercontent.com/10248067/73498016-f429ce00-4370-11ea-8e3d-f30ea4ad6219.JPG)

2. Fixes #6443 by giving the Card a min-width in the column with the "Select Resources" button

Before
<img width="1025" alt="Screen Shot 2020-01-30 at 3 06 53 PM" src="https://user-images.githubusercontent.com/10248067/73498427-2851be80-4372-11ea-9d3e-a5169384711a.png">

After

<img width="1035" alt="Screen Shot 2020-01-30 at 2 58 35 PM" src="https://user-images.githubusercontent.com/10248067/73498032-00ae2680-4371-11ea-875b-5f0e1ec97c07.png">

3. Fixes #6496 by giving the username section an overflow-y rule

Before
<img width="438" alt="Screen Shot 2020-01-24 at 1 43 51 PM" src="https://user-images.githubusercontent.com/10248067/73498130-381cd300-4371-11ea-90e2-6518e20f6d1b.png">

After

<img width="419" alt="Screen Shot 2020-01-30 at 2 59 23 PM" src="https://user-images.githubusercontent.com/10248067/73498107-26d3c680-4371-11ea-8a14-6a2ffddc8dc3.png">

4. Fixes #6444 by replacing the KModal default submit button with one that will not cause a form-submit event.

Before: See issue for video

After: After filling in form and pressing the "Close button" on the privacy modal, you will not be taken to the next step (7) in setup wizard

5. Fixes issue in IE11, where the scrollbar would be hidden, but not un-hidden after opening a modal.

### Reviewer guidance

All the issues except for Number 3 involve using IE11, so check that the issue is fixed in IE11 and doesn't any problems in other browsers (Firefox and Chromium).

Number 3 is easy to check in Firefox

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
