### PR TITLE
Fix "Select Resources" button cut off

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -94,7 +94,9 @@
 
   .channel-detail-panel {
     display: flex;
-    width: 100%;
+    // Ensures even on IE11 that content
+    // fits at all screen sizes
+    flex-grow: 1;
   }
 
   .channel-name {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

While fixing an issue on IE11 (Windows 7 - Browserstack), I noticed this issue:

![broken-select-resources](https://user-images.githubusercontent.com/6356129/73499673-96e44b80-4375-11ea-9ee8-0cd9371e5e0f.png)

So I fixed it. Now it looks like this:

![broken-select-resources-FIXED](https://user-images.githubusercontent.com/6356129/73499686-a2377700-4375-11ea-8fdb-efa9157f007e.png)

The left part of the content was `width: 100%` - so to be sure the right side of the content (with the "Select Resources" button) always has the right width, I removed the `width: 100%` and replaced it with `flex-grow: 1`.

I've tested in Chrome & Firefox (Debian) and IE11 (Windows 7 - Browserstack) at multiple screen sizes without issue.

I couldn't find an issue reporting it.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Login as a super admin
- Go to Device and move to import content.
- See that the "Select Resource" buttons are not being cut off.
- Test at multiple screen sizes.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
