### PR TITLE
make max-len linting less strict

### DIFF
--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -174,11 +174,11 @@ module.exports = {
       ERROR,
       2, // Base indent spaces
       {
-        'attribute': 1,
-        'baseIndent': 1,
-        'closeBracket': 0,
-        'alignAttributesVertically': true,
-      }
+        attribute: 1,
+        baseIndent: 1,
+        closeBracket: 0,
+        alignAttributesVertically: true,
+      },
     ],
     'vue/static-class-names-order': ERROR,
     'vue/no-deprecated-scope-attribute': ERROR,

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -68,7 +68,22 @@ module.exports = {
         ignoreStrings: true,
         ignoreTemplateLiterals: true,
         ignoreUrls: true,
+        ignoreTrailingComments: true,
       },
+    ],
+    'vue/max-len': [
+      ERROR,
+      {
+        code: 100,
+        template: 100,
+        comments: 100,
+        ignoreUrls: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+        ignoreHTMLTextContents: true,
+        ignoreTrailingComments: true,
+      },
+
     ],
     'vue/attribute-hyphenation': [ERROR, 'never'],
     'vue/require-default-prop': OFF,


### PR DESCRIPTION

### Summary

* make the max-len of vue files less strict
* permit trailing comments in JS to get long
* apply prettier to eslint config

### Reviewer guidance

This was mainly motivated by wanting `ignoreHTMLTextContents` to be `true` for the design system documentation, so long paragraphs can be soft- instead of hard-wrapped.

In the process, also ignored some other situations that seemed reasonable.

### References

https://eslint.vuejs.org/rules/max-len.html

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
