### PR TITLE
Fix corrupted sqlite databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_install:
   - git describe --tags --always
   # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
-  - pip install -U pip codecov tox
+  - pip install -U pip codecov virtualenv==16.7.9 tox
   - . $HOME/.nvm/nvm.sh
   - nvm install 10
   - nvm use 10

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -41,12 +41,12 @@ class KolibriCoreConfig(AppConfig):
         """
 
         if connection.vendor == "sqlite":
-            if connection.alias == 'notifications_db':
+            if connection.alias == "notifications_db":
                 broken_db = False
                 try:
                     cursor = connection.cursor()
-                    quick_check = cursor.execute('PRAGMA quick_check').fetchone()[0]
-                    broken_db = quick_check != 'ok'
+                    quick_check = cursor.execute("PRAGMA quick_check").fetchone()[0]
+                    broken_db = quick_check != "ok"
                 except DatabaseError:
                     broken_db = True
                 if broken_db:

--- a/kolibri/core/notifications/tasks.py
+++ b/kolibri/core/notifications/tasks.py
@@ -3,7 +3,11 @@ import threading
 import time
 
 from django.db import connection
+from django.db import connections
 from django.db import transaction
+from django.db.utils import OperationalError
+
+from kolibri.core.sqlite.utils import repair_sqlite_db
 
 logging = logger.getLogger(__name__)
 
@@ -59,6 +63,8 @@ class AsyncNotificationQueue:
                 for fn in self.running:
                     try:
                         fn()
+                    except OperationalError:
+                        repair_sqlite_db(connections["notifications_db"])
                     except Exception as e:
                         # Catch all exceptions and log, otherwise the background process will end
                         # and no more logs will be saved!

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -23,16 +23,20 @@ def common_clean(db_name, db_file):
 def regenerate_database(connection):
     # procedure to create from scratch a sqlite database when using Django ORM
     from django.db.migrations.recorder import MigrationRecorder
+
     connection.close()
-    common_clean(connection.alias, connection.get_connection_params()['database'])
+    common_clean(connection.alias, connection.get_connection_params()["database"])
     if connection.alias == "notifications_db":
         logger.error("Regenerating {}".format(connection.alias))
         # delete the db migrations and run them again
         connection_migrations = MigrationRecorder(connection).Migration
-        connection_migrations.objects.filter(app='notifications').delete()
+        connection_migrations.objects.filter(app="notifications").delete()
         call_command(
-            "migrate", interactive=False, verbosity=False,
-            app_label="notifications", database="notifications_db"
+            "migrate",
+            interactive=False,
+            verbosity=False,
+            app_label="notifications",
+            database="notifications_db",
         )
         call_command("migrate", interactive=False, verbosity=False)
 
@@ -52,16 +56,17 @@ def repair_sqlite_db(connection):
     else:
         orm = "django"
         conn_name = connection.alias
-        original_path = connection.get_connection_params()['database']
+        original_path = connection.get_connection_params()["database"]
 
-    fname = "{con}_{dtm}.dump".format(con=conn_name,
-                                      dtm=datetime.now().strftime("%Y-%m-%d_%H-%M-%S"))
+    fname = "{con}_{dtm}.dump".format(
+        con=conn_name, dtm=datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    )
     if not os.path.exists(dest_folder):
         os.makedirs(dest_folder)
     backup_path = os.path.join(dest_folder, fname)
     copyfile(original_path, backup_path)
 
-    if orm == 'sqlalchemy':
+    if orm == "sqlalchemy":
         # Remove current file, it will be automatically regenerated
         common_clean(conn_name, original_path)
         logger.error("Regenerating {}".format(connection.name))

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 def common_clean(db_name, db_file):
+    # let's remove the damaged db files
     if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
         return
-    # let's remove the old files
     os.remove(db_file)
     logger.error("{} is corrupted".format(db_name))
 

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -1,0 +1,89 @@
+import io
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from shutil import copyfile
+
+from django.conf import settings
+from django.core.management import call_command
+from django.db.utils import DatabaseError
+
+logger = logging.getLogger(__name__)
+
+
+def common_clean(db_name, db_file):
+    if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
+        return
+    # let's remove the old files
+    os.remove(db_file)
+    logger.error("{} is corrupted".format(db_name))
+
+
+def regenerate_database(connection):
+    # procedure to create from scratch a sqlite database when using Django ORM
+    from django.db.migrations.recorder import MigrationRecorder
+    connection.close()
+    common_clean(connection.alias, connection.get_connection_params()['database'])
+    if connection.alias == "notifications_db":
+        logger.error("Regenerating {}".format(connection.alias))
+        # delete the db migrations and run them again
+        connection_migrations = MigrationRecorder(connection).Migration
+        connection_migrations.objects.filter(app='notifications').delete()
+        call_command(
+            "migrate", interactive=False, verbosity=False,
+            app_label="notifications", database="notifications_db"
+        )
+        call_command("migrate", interactive=False, verbosity=False)
+
+
+def repair_sqlite_db(connection):
+    from kolibri.core.deviceadmin.utils import KWARGS_IO_WRITE
+    from kolibri.core.deviceadmin.utils import default_backup_folder
+
+    if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
+        return
+    # First let's do a file_backup
+    dest_folder = default_backup_folder()
+    if hasattr(connection, "name"):
+        orm = "sqlalchemy"
+        conn_name = connection.name
+        original_path = connection.url.database
+    else:
+        orm = "django"
+        conn_name = connection.alias
+        original_path = connection.get_connection_params()['database']
+
+    fname = "{con}_{dtm}.dump".format(con=conn_name,
+                                      dtm=datetime.now().strftime("%Y-%m-%d_%H-%M-%S"))
+    if not os.path.exists(dest_folder):
+        os.makedirs(dest_folder)
+    backup_path = os.path.join(dest_folder, fname)
+    copyfile(original_path, backup_path)
+
+    if orm == 'sqlalchemy':
+        # Remove current file, it will be automatically regenerated
+        common_clean(conn_name, original_path)
+        logger.error("Regenerating {}".format(connection.name))
+        return
+
+    # now, let's try to repair it, if possible:
+    # os.remove(original_path)
+    fixed_db_path = "{}.2".format(original_path)
+    with io.open(fixed_db_path, **KWARGS_IO_WRITE) as f:
+        # If the connection hasn't been opened yet, then open it
+        try:
+            for line in connection.connection.iterdump():
+                f.write(line)
+            connection.close()
+            copyfile(fixed_db_path, original_path)
+            # let's check if the tables are there:
+            cursor = connection.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+            if len(cursor.fetchall()) == 0:  # no way, the db has no tables
+                regenerate_database(connection)
+        except (DatabaseError, sqlite3.DatabaseError):
+            # no way, the db is totally broken
+            regenerate_database(connection)
+        finally:
+            os.remove(fixed_db_path)

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -10,6 +10,7 @@ from sqlalchemy import PickleType
 from sqlalchemy import String
 from sqlalchemy.ext.declarative import declarative_base
 
+from kolibri.core.sqlite.utils import repair_sqlite_db
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
@@ -60,7 +61,10 @@ class Scheduler(StorageMixin):
             if connection is None:
                 connection = self.queue.storage.engine
         elif connection:
-            self.queue = queue(connection=connection)
+            try:
+                self.queue = queue(connection=connection)
+            except TypeError:
+                repair_sqlite_db(connection)
 
         self._schedule_checker = None
 

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -10,7 +10,6 @@ from sqlalchemy import PickleType
 from sqlalchemy import String
 from sqlalchemy.ext.declarative import declarative_base
 
-from kolibri.core.sqlite.utils import repair_sqlite_db
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
@@ -61,10 +60,7 @@ class Scheduler(StorageMixin):
             if connection is None:
                 connection = self.queue.storage.engine
         elif connection:
-            try:
-                self.queue = queue(connection=connection)
-            except TypeError:
-                repair_sqlite_db(connection)
+            self.queue = queue(connection=connection)
 
         self._schedule_checker = None
 

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -184,7 +184,7 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
             except (LearnerProgressNotification.DoesNotExist):
                 return []
             except DatabaseError:
-                repair_sqlite_db(connections['notifications_db'])
+                repair_sqlite_db(connections["notifications_db"])
 
         return notifications_query.order_by("-id")
 
@@ -200,7 +200,7 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
                 request, *args, **kwargs
             )
         except DatabaseError:
-            repair_sqlite_db(connections['notifications_db'])
+            repair_sqlite_db(connections["notifications_db"])
 
         # L
         logging_interval = datetime.datetime.now() - datetime.timedelta(minutes=5)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -185,8 +185,8 @@ class ClassroomNotificationsViewset(viewsets.ReadOnlyModelViewSet):
             except (LearnerProgressNotification.DoesNotExist):
                 return []
             except DatabaseError:
-                return []
                 repair_sqlite_db(connections["notifications_db"])
+                return []
 
         return notifications_query.order_by("-id")
 


### PR DESCRIPTION
### Summary
This PR tries to automate the repairing and, if repairing is not possible, creating again sqlite damaged databases.
It deals both with Django ORM connections (for `notifications.sqlite3`) and with SQLAlchemy connections (for `job_storage.sqlite3`).

Ideally these procedures should never been executed. Whenever we find in the logs they have been executed we should find out the reason and fix it if it's due to some code problem.



### Reviewer guidance
Does the code make sense?
Are there other places in the code where we should enclose db connections in a `try...catch` to capture `DatabaseError` exceptions and call the `repair_sqlite_db` function?


### References
Relates: #6482

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
