### PR TITLE
Create a function to filter/exclude by uuid when using sqlalchemy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_install:
   - git describe --tags --always
   # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
-  - pip install -U pip codecov tox
+  - pip install -U pip codecov virtualenv==16.7.9 tox
   - . $HOME/.nvm/nvm.sh
   - nvm install 10
   - nvm use 10

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from .paths import get_content_file_name
 from .paths import get_content_storage_file_path
 from .sqlalchemybridge import Bridge
+from .sqlalchemybridge import filter_by_uuids
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import ChannelMetadata
@@ -33,7 +34,7 @@ def _MPTT_descendant_ids_statement(ContentNodeTable, node_ids):
     node_include = ContentNodeTable.alias()
     return select([ContentNodeTable.c.id]).where(
         and_(
-            node_include.c.id.in_(node_ids),
+            filter_by_uuids(node_include.c.id, node_ids),
             ContentNodeTable.c.lft >= node_include.c.lft,
             ContentNodeTable.c.lft <= node_include.c.rght,
             ContentNodeTable.c.tree_id == node_include.c.tree_id,

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -10,6 +10,7 @@ from sqlalchemy import or_
 from sqlalchemy import select
 
 from .sqlalchemybridge import Bridge
+from .sqlalchemybridge import filter_by_uuids
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
@@ -41,7 +42,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):
             and_(
                 FileTable.c.local_file_id == LocalFileTable.c.id,
                 or_(
-                    LocalFileTable.c.id.in_(checksums),
+                    filter_by_uuids(LocalFileTable.c.id, checksums),
                     LocalFileTable.c.available == True,  # noqa
                 ),
             ),

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -35,14 +35,15 @@ def get_channel_annotation_stats(channel_id, checksums=None):
     ContentNodeTable = bridge.get_table(ContentNode)
     FileTable = bridge.get_table(File)
     LocalFileTable = bridge.get_table(LocalFile)
-
     if checksums is not None:
         file_table = FileTable.join(
             LocalFileTable,
             and_(
                 FileTable.c.local_file_id == LocalFileTable.c.id,
                 or_(
-                    filter_by_uuids(LocalFileTable.c.id, checksums),
+                    # checksums are not uuids and have been got from
+                    # get_channel_stats_from_disk, so no need to validate them:
+                    filter_by_uuids(LocalFileTable.c.id, checksums, validate=False),
                     LocalFileTable.c.available == True,  # noqa
                 ),
             ),

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -354,7 +354,7 @@ def _by_uuids(field, ids, validate, include):
                 UUID(identifier, version=4)
             except (TypeError, ValueError):
                 # the value is not a valid hex code for a UUID, so we don't return any results
-                return UnaryExpression(field, modifier=operators.custom_op(query + ")"))
+                return UnaryExpression(field, modifier=operators.custom_op(query + "null)"))
         # wrap the uuids in string quotations
         if django_connection.vendor == "postgresql" and validate:
             ids_list[idx] = "'{}'::uuid".format(identifier)

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -356,9 +356,9 @@ def _by_uuids(field, ids, validate, include):
                 # the value is not a valid hex code for a UUID, so we don't return any results
                 return UnaryExpression(field, modifier=operators.custom_op(query + ")"))
         # wrap the uuids in string quotations
-        if django_connection.vendor == "sqlite":
-            ids_list[idx] = "'{}'".format(identifier)
-        elif django_connection.vendor == "postgresql":
+        if django_connection.vendor == "postgresql" and validate:
             ids_list[idx] = "'{}'::uuid".format(identifier)
+        else:  # sqlite or it's not an uuid
+            ids_list[idx] = "'{}'".format(identifier)
     placeholder = query + ",".join(ids_list) + ")"
     return UnaryExpression(field, modifier=operators.custom_op(placeholder))


### PR DESCRIPTION
### Summary
As Sqlite has a 900 limit in the number of parameters in a query we're finding seldom the `too many SQL variables` error in some of the queries.
When using Django ORM , this was fixed creating a new operator that does the query without parameters filter_by_uuids in #6378 

This PR takes a very similar approach for the cases where SQLAlchemy is used. The main difference is the creation of a new function returning an operator instead of creating an operator. SQLAlchemy models are created dinamically and overriding them is too complex (IMO).


### Reviewer guidance
Do tests still pass?
Are the issues fixed?
Do the updates to filter uuids logic make sense?

### References
Relates #6378 
Fixes #6518


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
