### PR TITLE
Clear importability stats when channel is upgraded.

### DIFF
--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -11,6 +11,7 @@ from ...utils import transfer
 from ...utils.annotation import update_content_metadata
 from ...utils.import_export_content import retry_import
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.errors import KolibriUpgradeError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import db_task_write_lock
@@ -185,6 +186,9 @@ class Command(AsyncCommand):
                                     update_content_metadata(
                                         channel_id, node_ids=node_ids
                                     )
+                            if import_ran:
+                                # Clear any previously set channel availability stats for this channel
+                                clear_channel_stats(channel_id)
                         except channel_import.ImportCancelError:
                             # This will only occur if is_cancelled is True.
                             pass

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -177,6 +177,33 @@ class ImportChannelTestCase(TestCase):
         cancel_mock.assert_called_with()
         import_channel_mock.assert_not_called()
 
+    @patch(
+        "kolibri.core.content.management.commands.importchannel.paths.get_content_database_file_url"
+    )
+    @patch(
+        "kolibri.core.content.management.commands.importchannel.paths.get_content_database_file_path"
+    )
+    @patch(
+        "kolibri.core.content.management.commands.importchannel.transfer.FileDownload"
+    )
+    @patch("kolibri.core.content.management.commands.importchannel.clear_channel_stats")
+    def test_remote_successful_import_clears_stats_cache(
+        self,
+        channel_stats_clear_mock,
+        FileDownloadMock,
+        local_path_mock,
+        remote_path_mock,
+        start_progress_mock,
+        import_channel_mock,
+    ):
+        local_path = tempfile.mkstemp()[1]
+        local_path_mock.return_value = local_path
+        remote_path_mock.return_value = "notest"
+        FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
+        import_channel_mock.return_value = True
+        call_command("importchannel", "network", self.the_channel_id)
+        self.assertTrue(channel_stats_clear_mock.called)
+
 
 @patch(
     "kolibri.core.content.management.commands.importcontent.lookup_channel_listing_status",

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -36,3 +36,8 @@ class CrossProcessCache(object):
         caches["default"].set(key, value, timeout=timeout, version=version)
         if cache_options["CACHE_BACKEND"] != "redis":
             caches["process_cache"].set(key, value, timeout=timeout, version=version)
+
+    def delete(self, key, version=None):
+        caches["default"].delete(key, version=version)
+        if cache_options["CACHE_BACKEND"] != "redis":
+            caches["process_cache"].delete(key, version=version)


### PR DESCRIPTION
### Summary
Clears cached importability stats for a channel whenever it is upgraded.
Adds a test to ensure that this happens

### Reviewer guidance
Does it resolve #6521?
1) Go to import channel once, but don't import anything
2) Update the channel with a new content node
3) Go to import again and check that the new content node appears

### References
Should fix #6521

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
