### PR TITLE
Close connections that are left open

### DIFF
--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -128,10 +128,12 @@ def check_database_is_migrated():
     is in a proper state to be used. This must only be run after django initialization.
     """
     apps.check_apps_ready()
+    from django.db import connection
     from morango.models import InstanceIDModel
 
     try:
         InstanceIDModel.get_or_create_current_instance()[0]
+        connection.close()
         return
     except OperationalError:
         try:


### PR DESCRIPTION
### Summary
Close connections that are left open by the code to avoid db corruptions.


### Reviewer guidance

1. Start Kolibri
2. don't do any request 
3. check the files db.sqlite3-wal and db.sqlite3-shm do not exist in the Kolibri folder.

### References
Fixes #6534 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
