### PR TITLE
Simplify and consolidate array aggregation code.

### DIFF
--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -26,8 +26,8 @@ from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger import models as logger_models
 from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.core.notifications.models import NotificationEventType
-from kolibri.core.sqlite.utils import repair_sqlite_db
 from kolibri.core.query import annotate_array_aggregate
+from kolibri.core.sqlite.utils import repair_sqlite_db
 
 
 # Intended to match  NotificationEventType


### PR DESCRIPTION
### Summary
Consolidate and simplify how we handle array aggregation for postgres/sqlite compatibility.

### Reviewer guidance
This systematizes something that was repeated across several different places, and does it as simply as is possible, I think. The main change in terms of code is putting the logic to either split the `GROUP_CONCAT` by `,` or to filter out null values for `ARRAY_AGG` into `convert_value` method of the Django aggregate object.

### References
More clean up in the same vein as #6166 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
