### PR TITLE
Fix appearance of long label (in certain locales) and remove disabling for "select resources" buttons. 

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -98,15 +98,6 @@ export default {
         return null;
       };
     },
-    // Tasks that are active, complete, or failed.
-    // Canceling and canceled tasks are filtered here
-    // to hide them from users, but still let us clean
-    // them up when finished.
-    activeTaskList(state) {
-      return state.taskList.filter(
-        task => task.status !== TaskStatuses.CANCELING && task.status !== TaskStatuses.CANCELED
-      );
-    },
     managedTasks(state) {
       // Tasks that we want to show in the task manager - ignore channel metadata tasks here.
       return state.taskList.filter(

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -47,6 +47,8 @@
         <slot name="belowdescription"></slot>
       </div>
     </div>
+
+    <slot name="append"></slot>
   </div>
 
 </template>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -59,20 +59,22 @@
         </div>
       </template>
 
+      <template v-slot:append>
+        <div class="col-3">
+          <p v-if="multipleMode && $attrs.checked" class="selected-msg">
+            {{ channelSelectedMessage }}
+          </p>
+          <KRouterLink
+            v-if="!multipleMode"
+            :text="$tr('selectResourcesAction')"
+            :disabled="tasksInQueue"
+            :to="selectContentLink"
+            appearance="raised-button"
+          />
+        </div>
+      </template>
     </ChannelDetails>
 
-    <div class="col-3">
-      <p v-if="multipleMode && $attrs.checked" class="selected-msg">
-        {{ channelSelectedMessage }}
-      </p>
-      <KRouterLink
-        v-if="!multipleMode"
-        :text="$tr('selectResourcesAction')"
-        :disabled="tasksInQueue"
-        :to="selectContentLink"
-        appearance="raised-button"
-      />
-    </div>
 
   </div>
 
@@ -217,23 +219,9 @@
     margin-bottom: 3px;
   }
 
-  .col-2 {
-    min-width: 80px;
-    margin-right: 16px;
-    text-align: right;
-
-    .channel-list-item-sm & {
-      align-self: flex-end;
-      order: -1;
-      margin-right: 0;
-    }
-  }
-
   .col-3 {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    min-width: 200px;
 
     .channel-list-item-sm & {
       flex-direction: column;

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithImportDetails.vue
@@ -67,7 +67,6 @@
           <KRouterLink
             v-if="!multipleMode"
             :text="$tr('selectResourcesAction')"
-            :disabled="tasksInQueue"
             :to="selectContentLink"
             appearance="raised-button"
           />
@@ -115,7 +114,7 @@
       },
     },
     computed: {
-      ...mapGetters('manageContent', ['channelIsInstalled', 'activeTaskList']),
+      ...mapGetters('manageContent', ['channelIsInstalled']),
       channelSelectedMessage() {
         // Can't show file sizes when importing from drive
         if (this.channel.total_file_size) {
@@ -128,9 +127,6 @@
       },
       isUnlistedChannel() {
         return this.channel.public === false;
-      },
-      tasksInQueue() {
-        return this.activeTaskList.length > 0;
       },
       versionNumber() {
         const installed = this.channelIsInstalled(this.channel.id);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Implements a locale-independent fix for #6443 by making all three major columns in the relevant card component direct siblings of each other
. This ensures the "select resources" button isn't pushed off to the right.

Screenshot in Portuguese
<img width="1089" alt="Screen Shot 2020-02-11 at 12 59 58 PM" src="https://user-images.githubusercontent.com/10248067/74279052-0986ec80-4ccf-11ea-947d-ba4ed48f3935.png">

2. Removes logic that would disable the "Selected resource" button if any "active" tasks where in the task queue, which should fix #6528 , where in this button was functionally disabled, but was not styled at such.

3. Deletes some dead CSS, and the now-dead code for the activeTaskList getter
### Reviewer guidance

1. In IE11 and other browsers, check to see the "Selected resource" button is not cut off on the right edge for different locales.
1. In IE11 specifically, check to see that the importing resources workflow is not blocked at the Channel list when there are active tasks in the queue.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
