### PR TITLE
convert contentnode ids to hex strings in channel stats during import

### DIFF
--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -11,7 +11,7 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.fields import create_timezonestamp
-from django.db import connection
+from uuid import UUID
 
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
@@ -439,11 +439,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     @property
     def channel_stats(self):
         channel_stats = self.context["channel_stats"]
-        if connection.vendor == "postgresql" and channel_stats is not None:
-            # Convert ContentNode IDs to hex strings since they are stored as UUID
-            # objects when Kolibri connects to a PostgreSQL database
+        if channel_stats is not None:
+            # Convert ContentNode IDs to hex strings if they are UUID
+            # objects
             stats_convert_id = {}
             for key in channel_stats.keys():
+                if not isinstance(key, UUID):
+                    return channel_stats
                 contentnode_id = key.hex
                 stats_convert_id[contentnode_id] = channel_stats[key]
             channel_stats = stats_convert_id

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -439,13 +439,13 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     @property
     def channel_stats(self):
         channel_stats = self.context["channel_stats"]
-        if connection.vendor == "postgresql":
-            # Convert channel IDs to hex strings since they are stored as UUID
+        if connection.vendor == "postgresql" and channel_stats is not None:
+            # Convert ContentNode IDs to hex strings since they are stored as UUID
             # objects when Kolibri connects to a PostgreSQL database
             stats_convert_id = {}
             for key in channel_stats.keys():
-                channel_id = key.hex
-                stats_convert_id[channel_id] = channel_stats[key]
+                contentnode_id = key.hex
+                stats_convert_id[contentnode_id] = channel_stats[key]
             channel_stats = stats_convert_id
         return channel_stats
 

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -147,7 +147,8 @@ class FilterByUUIDQuerysetMixin(object):
             for (idx, identifier) in enumerate(ids_list):
                 if validate:
                     try:
-                        UUID(identifier, version=4)
+                        if not isinstance(identifier, UUID):
+                            UUID(identifier, version=4)
                     except (TypeError, ValueError):
                         # the value is not a valid hex code for a UUID, so we don't return any results
                         return self.none()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix two issues:
1. when Kolibri connects to postgresql, the ids stored in the variable `channel_stats` are UUID objects. So when we try to search the contentnode id's hex string in `channel_stats` during import, it thinks the contentnode id doesn't exist in the dictionary, thus making `num_coach_contents`, `coach_content`, `total_resources` and `importable` all False or 0 regardless their actual value.

2. users are unable to import content from disk with postgresql. This is because `UUID(identifier, version=4)` is creating a UUID object on top of the UUID object `identifier`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check if channel import works when connecting to postgresql

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

fixes https://github.com/learningequality/kolibri/issues/6541

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
