### PR TITLE
Try to prevent accessing objects from undefined content objects in contentMap

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -9,6 +9,7 @@ import maxBy from 'lodash/maxBy';
 import map from 'lodash/map';
 import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
 import filter from 'lodash/filter';
+import get from 'lodash/get';
 import sortBy from 'lodash/sortBy';
 import orderBy from 'lodash/orderBy';
 import { PageNames } from '../constants';
@@ -219,6 +220,10 @@ export default {
     },
   },
   methods: {
+    // This is a safer way to get the content kind to quickly patch #6552
+    contentIdIsForExercise(contentId) {
+      return get(this.contentMap, [contentId, 'kind']) === 'exercise';
+    },
     classRoute(name, params = {}, query = {}) {
       if (this.classId) {
         params.classId = this.classId;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -107,7 +107,7 @@
       exercisesCompleted(contentStatuses) {
         const statuses = contentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind === 'exercise' &&
+            this.contentIdIsForExercise(status.content_id) &&
             status.status === this.STATUSES.completed
         );
         return statuses.length;
@@ -115,7 +115,7 @@
       resourcesViewed(contentStatuses) {
         const statuses = contentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind !== 'exercise' &&
+            !this.contentIdIsForExercise(status.content_id) &&
             status.status !== this.STATUSES.notStarted
         );
         return statuses.length;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -101,7 +101,7 @@
       exercisesCompleted() {
         const statuses = this.learnerContentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind === 'exercise' &&
+            this.contentIdIsForExercise(status.content_id) &&
             status.status === this.STATUSES.completed
         );
         return statuses.length;
@@ -109,7 +109,7 @@
       resourcesViewed() {
         const statuses = this.learnerContentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind !== 'exercise' &&
+            !this.contentIdIsForExercise(status.content_id) &&
             status.status !== this.STATUSES.notStarted
         );
         return statuses.length;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -107,7 +107,7 @@
       exercisesCompleted(contentStatuses) {
         const statuses = contentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind === 'exercise' &&
+            this.contentIdIsForExercise(status.content_id) &&
             status.status === this.STATUSES.completed
         );
         return statuses.length;
@@ -115,7 +115,7 @@
       resourcesViewed(contentStatuses) {
         const statuses = contentStatuses.filter(
           status =>
-            this.contentMap[status.content_id].kind !== 'exercise' &&
+            !this.contentIdIsForExercise(status.content_id) &&
             status.status !== this.STATUSES.notStarted
         );
         return statuses.length;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Replaces a potentially unsafe object access `this.contentMap[id].kind` in various page (see screen shot for which files this happens).

![Screen Shot 2020-02-13 at 12 21 34 PM](https://user-images.githubusercontent.com/10248067/74477755-be044800-4e60-11ea-9e6e-2779ab8be5b4.png)


Fixes #6552 

### Reviewer guidance
In the code,

1. make sure there were no typos
1. make sure commonCoach mixin is in all the components

I'm not sure how to reproduce this. It's possible, for the Kolibribeta server, the lesson that causes this breakage was never "cleaned" up by the fix implemented in #5140 because the channel was deleted before that PR was merged.

For manual testing, you can manually add bad ids into the code and confirm that the page still works, example: in LearnerListPage.vue.


```diff
      exercisesCompleted(contentStatuses) {
        const statuses = contentStatuses.filter(
          status =>
-            this.contentIdIsForExercise(status.content_id) &&
+            this.contentIdIsForExercise(status.content_id + "!") &&
            status.status === this.STATUSES.completed
        );
        return statuses.length;
      },

```

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
