### PR TITLE
Fix errors on postgres startup

### DIFF
--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -204,7 +204,9 @@ def unregister_zeroconf_service():
     if ZEROCONF_STATE["service"] is not None:
         ZEROCONF_STATE["service"].cleanup()
     ZEROCONF_STATE["service"] = None
-    ZEROCONF_STATE["zeroconf"].close()
+    if ZEROCONF_STATE["zeroconf"] is not None:
+        ZEROCONF_STATE["zeroconf"].close()
+    ZEROCONF_STATE["zeroconf"] = None
 
 
 def initialize_zeroconf_listener():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -206,7 +206,6 @@ def unregister_zeroconf_service():
     ZEROCONF_STATE["service"] = None
     if ZEROCONF_STATE["zeroconf"] is not None:
         ZEROCONF_STATE["zeroconf"].close()
-    ZEROCONF_STATE["zeroconf"] = None
 
 
 def initialize_zeroconf_listener():


### PR DESCRIPTION
### Summary
Pushes the SQLite database corruption check to after registering multiprocess listeners to prevent trying to access a non-existent `pid` attribute on the connection.
Do a None check on the zeroconf object before calling close on it.

### Reviewer guidance
Can you startup Kolibri with postgres?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
