### PR TITLE
Allow None in validate_language_id

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -38,7 +38,7 @@ class DeviceSerializerMixin(object):
         """
         Check that the language_id is supported by Kolibri
         """
-        if not check_for_language(language_id):
+        if language_id is not None and not check_for_language(language_id):
             raise serializers.ValidationError(_("Language is not supported by Kolibri"))
         return language_id
 


### PR DESCRIPTION
Fixes `language_id` validator for the `DeviceSettingViewset` by allowing `None` as a value.

Fixes #6557