### PR TITLE
Always regenarate cache.db when kolibri starts

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -2,7 +2,6 @@ import copy
 import os
 import shutil
 import sys
-from sqlite3 import DatabaseError
 
 from diskcache import Cache
 
@@ -14,12 +13,11 @@ cache_options = OPTIONS["Cache"]
 pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
 
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
-try:
-    diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
-except DatabaseError:
-    shutil.rmtree(diskcache_location, ignore_errors=True)
-    os.mkdir(diskcache_location)
-    diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
+# always delete previous cache whenever the app starts, to avoid deadlocks:
+shutil.rmtree(diskcache_location, ignore_errors=True)
+os.mkdir(diskcache_location)
+
+diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
 diskcache_cache.close()
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -36,6 +36,7 @@ from .system import become_daemon
 from kolibri.core.deviceadmin.utils import IncompatibleDatabase
 from kolibri.core.upgrade import matches_version
 from kolibri.core.upgrade import run_upgrades
+from kolibri.deployment.default.cache import recreate_cache
 from kolibri.plugins import config
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins.utils import autoremove_unavailable_plugins
@@ -433,6 +434,7 @@ def start(port, background):
 
     # Clear old sessions up
     call_command("clearsessions")
+    recreate_cache()
 
     # On Mac, Python crashes when forking the process, so prevent daemonization until we can figure out
     # a better fix. See https://github.com/learningequality/kolibri/issues/4821
@@ -586,6 +588,7 @@ def services(port, background):
     """
 
     create_startup_lock(None)
+    recreate_cache()
 
     logger.info("Starting Kolibri background services")
 


### PR DESCRIPTION
### Summary
Removes previous cache.db files to avoid deadlocks if the application is shutdown abruptly.
It does it when `kolibri start `or `services` is called, not when `manage` commands are done to avoid deleting acquired locks.

### Reviewer guidance
Can think of any nuances?

### References
Fixes #6502

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
