### PR TITLE
Correct pipenv link in getting_started docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -111,7 +111,7 @@ Environment variables
 Environment variables can be set in many ways, including:
 
 * adding them to a ``~/.bash_profile`` file (for Bash) or a similar file in your shell of choice
-* using a ``.env`` file for this project, `loaded with Pipenv <https://docs.pipenv.org/en/latest/advanced/#automatic-loading-of-env>`_
+* using a ``.env`` file for this project, `loaded with Pipenv <https://pipenv.kennethreitz.org/en/latest/advanced/#automatic-loading-of-env>`_
 * setting them temporarily in the current Bash session using ``EXPORT`` or similar (not recommended except for testing)
 
 There are two environment variables you should plan to set:


### PR DESCRIPTION
# Summary 
Pipenv Link corrected in getting_started docs.Fixes #6577 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
