### PR TITLE
Remove edit channel order in case of single channel

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -139,7 +139,11 @@
         return [
           { label: this.$tr('exportChannels'), value: 'EXPORT' },
           { label: this.$tr('deleteChannels'), value: 'DELETE' },
-          { label: this.$tr('editChannelOrder'), value: 'REARRANGE' },
+          {
+            label: this.$tr('editChannelOrder'),
+            value: 'REARRANGE',
+            disabled: this.installedChannelsWithResources.length === 1,
+          },
         ];
       },
     },


### PR DESCRIPTION
### Summary
Edit channel order option is not visible in the dropdown incase there is a single channel.Fixes #6558 

## GIF :-
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/33183263/74711622-76a7fe00-524a-11ea-987d-2d7d83bedc56.gif)


### Contributor Checklist
PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
