### PR TITLE
Refactor migration check and add regression tests

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -259,12 +259,9 @@ class KolibriDjangoCommand(click.Command):
         super(KolibriDjangoCommand, self).__init__(*args, **kwargs)
 
     def invoke(self, ctx):
-        """
-        Initialize Kolibri and run sanity checks.
-        """
-        # Check if the current user is the kolibri user when running kolibri from Debian installer.
         initialize()
 
+        # Remove parameters that are not for Django management command
         for param in initialize_params:
             ctx.params.pop(param.name)
         return super(KolibriDjangoCommand, self).invoke(ctx)

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -174,8 +174,6 @@ initialize_params = base_params + [
 
 def _migrate_databases():
     """
-    Internal help function:
-
     Try to migrate all active databases. This should not be called unless Django has
     been initialized.
     """

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -139,15 +139,13 @@ def check_django_stack_ready():
 
 def check_database_is_migrated():
     """
-    This checks that certain aspects of migration are completed, but it
-    does not actually verify whether all migrations are run, as this is
+    This function checks that the database instance id model is
+    initialized. It must only be run after Django initialization.
+
+    It does not actually verify whether all migrations are run, as this is
     assumed to be a part of Kolibri version number checking. When a
     Kolibri version change is detected, we run migrations. Checking that
-    migrations are run for every startup, is assumed too costly.
-
-    This function checks that the database instance id model is
-    initialized to check if the database is in a proper state to be
-    used. This must only be run after Django initialization.
+    migrations are run for every startup would be costly.
     """
     from django.db import connection
     from morango.models import InstanceIDModel

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -5,7 +5,6 @@ import sys
 
 import portend
 from django.apps import apps
-from django.core.management import call_command
 from django.db.utils import OperationalError
 
 from .conf import KOLIBRI_HOME
@@ -18,6 +17,29 @@ from .server import NotRunning
 logger = logging.getLogger(__name__)
 
 PORT_AVAILABILITY_CHECK_TIMEOUT = 2
+
+
+class SanityException(RuntimeError):
+    pass
+
+
+class DatabaseNotMigrated(SanityException):
+    def __init__(self, *args, **kwargs):
+        self.db_exception = kwargs.get("db_exception")
+        super(DatabaseNotMigrated, self).__init__(
+            "An exception occurred for which it is assumed that the "
+            "database is not fully migrated.\n\n"
+            "Exception: {}".format(str(self.db_exception))
+        )
+
+
+class DatabaseInaccessible(SanityException):
+    def __init__(self, *args, **kwargs):
+        self.db_exception = kwargs.get("db_exception")
+        super(DatabaseNotMigrated, self).__init__(
+            "Not able to access the database while checking it.\n\n"
+            "Exception: {}".format(str(self.db_exception))
+        )
 
 
 def check_other_kolibri_running(port):
@@ -110,26 +132,23 @@ def check_log_file_location():
             shutil.move(old_log_path, new_log_path)
 
 
-def migrate_databases():
-    """
-    Try to migrate all active databases. This should not be called unless Django has
-    been initialized.
-    """
-    from django.conf import settings
-
-    for database in settings.DATABASES:
-        call_command("migrate", interactive=False, database=database)
-
-    # load morango fixtures needed for certificate related operations
-    call_command("loaddata", "scopedefinitions")
+def check_django_stack_ready():
+    """Checks that all Django apps are loaded"""
+    apps.check_apps_ready()
 
 
 def check_database_is_migrated():
     """
-    Use a check that the database instance id model is initialized to check if the database
-    is in a proper state to be used. This must only be run after django initialization.
+    This checks that certain aspects of migration are completed, but it
+    does not actually verify whether all migrations are run, as this is
+    assumed to be a part of Kolibri version number checking. When a
+    Kolibri version change is detected, we run migrations. Checking that
+    migrations are run for every startup, is assumed too costly.
+
+    This function checks that the database instance id model is
+    initialized to check if the database is in a proper state to be
+    used. This must only be run after Django initialization.
     """
-    apps.check_apps_ready()
     from django.db import connection
     from morango.models import InstanceIDModel
 
@@ -137,21 +156,10 @@ def check_database_is_migrated():
         InstanceIDModel.get_or_create_current_instance()[0]
         connection.close()
         return
-    except OperationalError:
-        try:
-            migrate_databases()
-            return
-        except Exception as e:
-            logging.error(
-                "Tried to migrate the database but another error occurred: {}".format(e)
-            )
+    except OperationalError as e:
+        raise DatabaseNotMigrated(db_exception=e)
     except Exception as e:
-        logging.error(
-            "Tried to check that the database was accessible and an error occurred: {}".format(
-                e
-            )
-        )
-    sys.exit(1)
+        raise DatabaseInaccessible(db_exception=e)
 
 
 def check_default_options_exist():


### PR DESCRIPTION
### Summary

Changes:

* Some assumptions about what "checks" should do are a bit unintuitive to me when our checks are performing migrations all by themselves.
* I also reworked the `initialize()` function to be easier to read as a sequential piece of logic.
* Added two regression tests.

Reading the code in sequential order, I also find it a bit weird, why we only check and auto-run migrations after checking if the version has been bumped (which runs migrations). I would like to have a comment on that behavior and include it in the code. CC: @rtibbles 

Since the changes in 0.13.1 already went through some testing, I'm happy to postpone this change.

### Reviewer guidance

I would like a review that tries to spot additional oddities that we might fix? I mean, now that `initialize()` is assembled into one function, is it easier to see what is happening?

### References

#6403 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
