### PR TITLE
update phrasing of log-in prompt

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
@@ -169,7 +169,7 @@
     $trs: {
       plusPoints: '+ { maxPoints, number } Points',
       next: 'Next:',
-      signIn: 'Sign in or create an account to save points you earn',
+      signIn: 'Sign in or create an account to begin earning points',
     },
   };
 


### PR DESCRIPTION

### Summary

From @jeepurs 

> When you're not logged in and you finish a content and earn points, but are told to log in or make an account, if the user proceeds to log in their record/points does not reflect the content they've just completed. It is a completely clean slate when they make a new account
>
>  clarify the wording a bit. The way it's written now it's not necessarily untruthful but I would imagine some users feeling misled


### Reviewer guidance

This PR changes the prompt from 

> Sign in or create an account to save points you earn

to

> Sign in or create an account to begin earning points

### References

https://github.com/learningequality/clearinghouse/issues/471

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
