### PR TITLE
Align local pre-commit with CI-based linting (Tox and Travis)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,8 @@ repos:
         kolibri/core/logger/migrations/0003_auto_20170531_1140\.py|
         kolibri/core/logger/migrations/0005_auto_20180514_1419\.py|
       )$
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+#      language_version: python2.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,4 +69,5 @@ repos:
     rev: stable
     hooks:
     - id: black
+      args: [--exclude, '/(\.git|\.tox|\.venv|build|static|dist|node_modules)/']
 #      language_version: python2.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,5 +69,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      args: [--exclude, '/(\.git|\.tox|\.venv|build|static|dist|node_modules)/']
-#      language_version: python2.7
+      args: [--exclude, '/(\.git|\.tox|\.venv|build|static|dist|node_modules|kolibripip.pex)/']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: (\.git/|\.tox/|\.venv/|build/|static/|dist/|node_modules/|kolibripip\.pex)
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
@@ -69,4 +70,3 @@ repos:
     rev: stable
     hooks:
     - id: black
-      args: [--exclude, '/(\.git|\.tox|\.venv|build|static|dist|node_modules|kolibripip.pex)/']

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ matrix:
 
 
 before_install:
+  # Can likely be removed once we stop using Trusty
+  # https://github.com/travis-ci/travis-ci/issues/8920
+  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   - git fetch
   - git describe --tags --always
   # Required until this is fixed: https://github.com/travis-ci/travis-ci/issues/9112

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
   directories:
     - node_modules
     - $HOME/.cache/pip
+    - $HOME/.cache/pre-commit
 
 matrix:
   include:
@@ -33,9 +34,6 @@ matrix:
     - python: "3.6"
       env:
         - TOX_ENV=pythonlint3
-    - python: "3.6"
-      env:
-        - TOX_ENV=pythonblack
     - python: "2.7"
       env:
         - TOX_ENV=licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
        - tox -e $TOX_ENV
     - python: "3.6"
       env:
-        - TOX_ENV=pythonlint3
+        - TOX_ENV=lint
     - python: "2.7"
       env:
         - TOX_ENV=licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,6 @@ matrix:
         - TOX_ENV=postgres
     - python: "2.7"
       env:
-        - TOX_ENV=frontendlint
-      script:
-       - tox -e $TOX_ENV
-    - python: "2.7"
-      env:
         - TOX_ENV=nocext
       script:
        - tox -e $TOX_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ test = pytest
 [flake8]
 max-line-length = 160
 max-complexity = 10
-exclude = kolibri/*/migrations/*,kolibri/dist/*
+exclude = kolibri/*/migrations/*,kolibri/dist/*,kolibripip.pex
 
 # Ignore non-PEP8-compliant rules so that the Black formatter can be used
 ignore = E203,W503
@@ -18,7 +18,7 @@ multi_line_output = 5
 line_length = 160
 indent = '    '
 combine_as_imports = true
-skip = wsgi.py,docs,env,cli.py,test,.eggs,build,setup.py
+skip = wsgi.py,docs,env,cli.py,test,.eggs,build,setup.py,kolibripip.pex
 
 [coverage:run]
 branch = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, lint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -27,7 +27,7 @@ basepython =
     pypy: pypy
     docs: python3.5
     pythonlint2: python2.7
-    pythonlint3: python3.6
+    lint: python3.6
     node10.x: python2.7
     nocext: python2.7
     cext: python2.7
@@ -125,11 +125,16 @@ commands =
 [testenv:pythonlint2]
 deps = flake8
 commands =
+    # Ensure we didn't put py3-only syntax
     flake8 kolibri
 
-[testenv:pythonlint3]
+[testenv:lint]
 deps = pre-commit
 commands =
+    # Install yarn dependencies
+    yarn
+    # Node-sass gets mardy if we don't do this.
+    npm rebuild node-sass
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, frontendlint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -28,9 +28,7 @@ basepython =
     docs: python3.5
     pythonlint2: python2.7
     pythonlint3: python3.6
-    pythonblack: python3.6
     node10.x: python2.7
-    frontendlint: python2.7
     nocext: python2.7
     cext: python2.7
     startup_provision_shutdown_without_zombies: python3.6
@@ -125,15 +123,13 @@ commands =
     # rm -rf {env:KOLIBRI_HOME}
 
 [testenv:pythonlint2]
-deps =
-    -r{toxinidir}/requirements/dev.txt
+deps = pre-commit
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 
 [testenv:pythonlint3]
-deps =
-    -r{toxinidir}/requirements/dev.txt
+deps = pre-commit
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
@@ -157,14 +153,6 @@ commands =
 [testenv:node10.x]
 whitelist_externals = {[node_base]whitelist_externals}
 commands = {[node_base]commands}
-
-[testenv:frontendlint]
-whitelist_externals = {[node_base]whitelist_externals}
-commands =
-    yarn
-    # Node-sass gets mardy if we don't do this.
-    npm rebuild node-sass
-    yarn run lint-frontend
 
 [conditional_testing_base]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -123,10 +123,9 @@ commands =
     # rm -rf {env:KOLIBRI_HOME}
 
 [testenv:pythonlint2]
-deps = pre-commit
+deps = flake8
 commands =
-    pre-commit install -f --install-hooks
-    pre-commit run --all-files
+    flake8 kolibri
 
 [testenv:pythonlint3]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, pythonblack, frontendlint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, pythonlint3, frontendlint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -128,21 +128,15 @@ commands =
 deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
-    flake8 kolibri
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
 
 [testenv:pythonlint3]
 deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
-    flake8 kolibri
-
-[testenv:pythonblack]
-# black is unpinned because they have no useful version semantics,
-# so better to break immediately and decide from there
-deps =
-    black
-commands =
-    black --check --diff --exclude '/(\.git|\.tox|\.venv|build|static|dist|node_modules)/' .
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
# Summary

* Removes frontendlint and pythonblack tox entries (they are now part of "pythonlint3")
* ...also removes said entries from Travis, hence quicker
* All calls to pre-commit now happen through the same configuration
* Caching on travis potentially improved

Does anyone else get frustrated when their code breaks a CI linting check because black isn't in pre-commit?

Having it in pre-commit is much faster, as it just lints changed files.

### Reviewer guidance

~I didn't care to pin the black version. Does it matter?~

Edit: We use Black without pinning in tox.ini as well, so we always run the latest version.

### References

This partly solves #5409

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
