### PR TITLE
Add serializable isolation db connection for postgres

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -161,7 +161,7 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
             "HOST": conf.OPTIONS["Database"]["DATABASE_HOST"],
             "PORT": conf.OPTIONS["Database"]["DATABASE_PORT"],
         },
-        "default_serializable": {
+        "default-serializable": {
             "ENGINE": "django.db.backends.postgresql",
             "NAME": conf.OPTIONS["Database"]["DATABASE_NAME"],
             "PASSWORD": conf.OPTIONS["Database"]["DATABASE_PASSWORD"],

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -27,6 +27,14 @@ from kolibri.utils import conf
 from kolibri.utils import i18n
 from kolibri.utils.logger import get_logging_config
 
+try:
+    isolation_level = None
+    import psycopg2  # noqa
+
+    isolation_level = psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE
+except ImportError:
+    pass
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 # import kolibri, so we can get the path to the module.
@@ -152,7 +160,16 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
             "USER": conf.OPTIONS["Database"]["DATABASE_USER"],
             "HOST": conf.OPTIONS["Database"]["DATABASE_HOST"],
             "PORT": conf.OPTIONS["Database"]["DATABASE_PORT"],
-        }
+        },
+        "default_serializable": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": conf.OPTIONS["Database"]["DATABASE_NAME"],
+            "PASSWORD": conf.OPTIONS["Database"]["DATABASE_PASSWORD"],
+            "USER": conf.OPTIONS["Database"]["DATABASE_USER"],
+            "HOST": conf.OPTIONS["Database"]["DATABASE_HOST"],
+            "PORT": conf.OPTIONS["Database"]["DATABASE_PORT"],
+            "OPTIONS": {"isolation_level": isolation_level},
+        },
     }
 
 

--- a/kolibri/deployment/default/settings/postgres_test.py
+++ b/kolibri/deployment/default/settings/postgres_test.py
@@ -7,6 +7,15 @@ from __future__ import unicode_literals
 
 from .test import *  # noqa
 
+try:
+    isolation_level = None
+    import psycopg2  # noqa
+
+    isolation_level = psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE
+except ImportError:
+    pass
+
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -14,5 +23,12 @@ DATABASES = {
         "PASSWORD": "",
         "NAME": os.environ.get("POSTGRES_DB") or "default",  # noqa
         "TEST": {"NAME": "travis_ci_default"},
-    }
+    },
+    "default_serializable": {
+        "ENGINE": "django.db.backends.postgresql",
+        "USER": "postgres",
+        "PASSWORD": "",
+        "NAME": os.environ.get("POSTGRES_DB") or "default",  # noqa
+        "OPTIONS": {"isolation_level": isolation_level},
+    },
 }

--- a/kolibri/deployment/default/settings/postgres_test.py
+++ b/kolibri/deployment/default/settings/postgres_test.py
@@ -24,7 +24,7 @@ DATABASES = {
         "NAME": os.environ.get("POSTGRES_DB") or "default",  # noqa
         "TEST": {"NAME": "travis_ci_default"},
     },
-    "default_serializable": {
+    "default-serializable": {
         "ENGINE": "django.db.backends.postgresql",
         "USER": "postgres",
         "PASSWORD": "",

--- a/kolibri/deployment/default/settings/postgres_test.py
+++ b/kolibri/deployment/default/settings/postgres_test.py
@@ -30,5 +30,6 @@ DATABASES = {
         "PASSWORD": "",
         "NAME": os.environ.get("POSTGRES_DB") or "default",  # noqa
         "OPTIONS": {"isolation_level": isolation_level},
+        "TEST": {"NAME": "travis_ci_default"},
     },
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ kolibri_exercise_perseus_plugin==1.3.0
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.4.10
+morango==0.4.11
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ kolibri_exercise_perseus_plugin==1.3.0
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.4.11
+morango==0.4.12
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ kolibri_exercise_perseus_plugin==1.3.0
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.4.9
+morango==0.4.10
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5


### PR DESCRIPTION
### Summary

SQLite and Postgres have different default [read isolation levels](https://www.geeksforgeeks.org/transaction-isolation-levels-dbms/). SQLite defaults to the "safest" option, which is "serializable", whereas postgres defaults to "read committed". This means that if a transaction reads some data, then in parallel another transaction that writes some data completes, and then the first transaction reads more data, there may be inconsistencies in the two sets of data the first transaction reads -- i.e. it's not a reliable "snapshot" of the database at a particular point in time (c.f. "non-repeatable reads" and "phantom reads").

At the time we built Morango, Kolibri only supported SQlite, which is what we used for our more intensive manual concurrency testing. When we added support for Postgres, we had assumed that it would be at least as robust on this front as SQLite. This type of edge-case mass concurrency testing is very difficult to capture in automated tests, so we don't currently have coverage.

On KDP, this led to some issues where data wasn't being deserialized from the underlying datastore into the Kolibri app models. No data was lost, but it wasn't showing up in the app layer. This was because the deserialization process loops over all the models and then at the very end clears their "dirty" bits. If new records are written into the datastore from an incoming sync in parallel, they may accidentally also have their "dirty bit" cleared, and hence not be deserialized in future batches.

This PR switches the Postgres connection that Morango uses for its large snapshot transactions to have read isolation level of "SERIALIZABLE", which matches SQLite.  

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
