### PR TITLE
Bring Back Mac

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,13 +7,14 @@ steps:
 
   - wait
 
-  # - trigger: "kolibri-macos"
-  #   label: ":mac:"
-  #   build: &triggered_build_attributes
-  #     message: "${BUILDKITE_MESSAGE}"
-  #     env:
-  #       LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
-  #       LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
+  - trigger: "kolibri-macos"
+    label: ":mac:"
+    async: true
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      env:
+        LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
+        LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
 
     # Android build only requires whl file
   # - label: Build Android APK

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,7 +32,7 @@ steps:
   - trigger: "kolibri-raspbian-image"
     label: ":raspberry-pi:"
     async: true
-    build: &triggered_build_attributes
+    build:
       message: "${BUILDKITE_MESSAGE}"
       branch: "autoblock"
       env:

--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -107,7 +107,7 @@ file_manifest = {
 file_order = [
     "deb",
     "zip",
-    # "dmg",
+    "dmg",
     "unsigned-exe",
     "signed-exe",
     # 'apk',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Mac app was removed due to some breaks and time concerns. Reintroducing here, with async enabled so that we can move on with the vision of auto-blocked builds. We can figure out the download page later.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Build completes, even if mac app wasn't built.
- Mac build hits a block step immediately. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#6494 enabled this.
Uses: https://github.com/learningequality/kolibri-installer-mac/pull/59
Relies on #6600. Will rebase once merged.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
