### PR TITLE
Pre-commit hook to disallow auto-named migrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,45 @@ repos:
         language: system
         files: \.(js|vue|scss|css)$
         exclude: '^kolibri/core/static/assets/fonts/.+?\.css$|^kolibri/core/content/static/assets/'
+- repo: local
+  hooks:
+  - id: no-auto-migrations
+    name: no auto-named migrations
+    entry: We do not allow _auto_ in migration names. Please give the migration a telling name.
+    language: fail
+    files: .*/migrations/.*_auto_.*\.py$
+    exclude: ^
+      (?x)^(
+        kolibri/core/auth/migrations/0002_auto_20170608_2125\.py|
+        kolibri/core/auth/migrations/0003_auto_20170621_0958\.py|
+        kolibri/core/auth/migrations/0004_auto_20170816_1607\.py|
+        kolibri/core/auth/migrations/0005_auto_20170818_1203\.py|
+        kolibri/core/auth/migrations/0006_auto_20171206_1207\.py|
+        kolibri/core/auth/migrations/0007_auto_20171226_1125\.py|
+        kolibri/core/auth/migrations/0008_auto_20180222_1244\.py|
+        kolibri/core/auth/migrations/0009_auto_20180301_1123\.py|
+        kolibri/core/auth/migrations/0010_auto_20180320_1320\.py|
+        kolibri/core/auth/migrations/0013_auto_20180917_1213\.py|
+        kolibri/core/auth/migrations/0014_auto_20190815_1421\.py|
+        kolibri/core/content/migrations/0003_auto_20170607_1212\.py|
+        kolibri/core/content/migrations/0004_auto_20170825_1038\.py|
+        kolibri/core/content/migrations/0005_auto_20171009_0903\.py|
+        kolibri/core/content/migrations/0006_auto_20171128_1703\.py|
+        kolibri/core/content/migrations/0007_auto_20180212_1155\.py|
+        kolibri/core/content/migrations/0008_auto_20180429_1709\.py|
+        kolibri/core/content/migrations/0009_auto_20180410_1139\.py|
+        kolibri/core/content/migrations/0011_auto_20180907_1017\.py|
+        kolibri/core/content/migrations/0012_auto_20180910_1702\.py|
+        kolibri/core/content/migrations/0013_auto_20180919_1142\.py|
+        kolibri/core/content/migrations/0014_auto_20181218_1132\.py|
+        kolibri/core/content/migrations/0015_auto_20190125_1715\.py|
+        kolibri/core/content/migrations/0016_auto_20190124_1639\.py|
+        kolibri/core/content/migrations/0017_auto_20190415_1855\.py|
+        kolibri/core/device/migrations/0004_auto_20190306_0553\.py|
+        kolibri/core/device/migrations/0005_auto_20191203_0951\.py|
+        kolibri/core/exams/migrations/0003_auto_20190426_1015\.py|
+        kolibri/core/lessons/migrations/0002_auto_20180221_1115\.py|
+        kolibri/core/logger/migrations/0002_auto_20170518_1031\.py|
+        kolibri/core/logger/migrations/0003_auto_20170531_1140\.py|
+        kolibri/core/logger/migrations/0005_auto_20180514_1419\.py|
+      )$


### PR DESCRIPTION
### Summary

Solution from, credits due @adamchainz
https://adamj.eu/tech/2020/02/24/how-to-disallow-auto-named-django-migrations/

### Reviewer guidance

~Are you okay about how the exceptions from our legacy is listed?~

It's seemed necessary because we will start running pre-commit on everything in Travis, ~but:~

~We could actually skip the list of excluded files, because the pre-commit rule is something that will only trigger locally when a migration file is edited and can then be skipped locally with `git commit --no-verify`. I'm just not reaaallly sure, and I found the list to be a nice and accurate account of WHY those files are even there when we have a rule against it :)~

So my final conclusion would be this:

* Add the rule, keep the list, later in life we might rename or clean up old migrations and remove the list.

Update: Using `--all-files` will capture any added `_auto_` migration files in CI, so using `--no-verify` or not installing pre-commit is NOT an option to bypass the test.

### References

Fixes #6515 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
