### PR TITLE
Document issues with pre-commit from alternative git clients

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -161,6 +161,8 @@ The Python project-specific dependencies installed above will install ``nodeenv`
 Running the Kolibri server
 --------------------------
 
+.. _devserver:
+
 Development server
 ~~~~~~~~~~~~~~~~~~
 
@@ -198,7 +200,7 @@ Or:
 Development server - advanced
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The commands above will start multiple concurrent processes: one for the Django web server, and at least one more for the webpack devserver. If you'd like to start these processes separately, you can do it in two separate terminal windows.
+The commands above will start multiple concurrent processes: One for the Django web server, and at least one more for the webpack devserver. If you'd like to start these processes separately, you can do it in two separate terminal windows.
 
 In the first terminal you can start the django development server with this command:
 
@@ -381,9 +383,11 @@ We have a large number of reusable patterns, conventions, and components built i
 Linting and auto-formatting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Linting and code auto-formatting provided by Prettier and Black are run in the background automatically by default when you run the dev server.  It is a good to monitor for linting errors in the build process: while the build may complete, it will also issue warnings to the terminal.
+Linting and code auto-formatting provided by Prettier and Black are run in the background automatically by ``yarn run devserver`` (see :ref:`devserver`). You can monitor for linting errors and warnings in the terminal outputs of the dev server while it is running.
 
-A full set of linting and auto-formatting can also be applied by pre-commit hooks (instructions below). If those are bypassed or not triggered, our Travis CI builds will eventually fail.
+A full set of linting and auto-formatting can also be applied by pre-commit hooks (instructions below). The pre-commit hooks are identical to the automated build check by Travis CI in Pull Requests.
+
+.. tip:: As a convenience, many developers install linting and formatting plugins in their code editor (IDE). Installing ESLint, Prettier, Black, and Flake8 plugins in your editor will catch most (but not all) code-quality checks.
 
 You can manually run the auto-formatters using:
 
@@ -408,6 +412,8 @@ Pre-commit is already installed as a development dependency, but you also need t
   pre-commit install
 
 .. note:: Pre-commit can have issues running from alternative Git clients like GitUp. If you encounter problems while committing changes, run ``pre-commit uninstall`` to disable pre-commit.
+
+.. warning:: If you do not use any linting tools, your code is likely fail our server-side checks and you will need to update the PR in order to get it merged.
 
 
 Automated testing

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -383,7 +383,7 @@ Linting and auto-formatting
 
 Linting and code auto-formatting provided by Prettier and Black are run in the background automatically by default when you run the dev server.  It is a good to monitor for linting errors in the build process: while the build may complete, it will also issue warnings to the terminal.
 
-Linting and auto-formatting can also be run by the pre-commit hooks (installed earlier). If those are bypassed or not triggered, our Travis CI builds will also fail for unformatted code.
+A full set of linting and auto-formatting can also be applied by pre-commit hooks (instructions below). If those are bypassed or not triggered, our Travis CI builds will eventually fail.
 
 You can manually run the auto-formatters using:
 
@@ -399,11 +399,15 @@ Or to check the formatting without writing changes, run:
   yarn run lint-frontend
   yarn run fmt-backend:check
 
-To have code automatically formatted and checked for linting upon commit, you may use `pre-commit <http://pre-commit.com/>`__ this can help ensure clean, consistent code, and will prevent automated build checks due to linting errors. The pip package should already be installed from the Python dev dependency installation, but you need to install the git hooks using this command:
+`pre-commit <http://pre-commit.com/>`__ is used to apply a full set of checks and formatting automatically each time that ``git commit`` runs. If there are errors, the Git commit is aborted and you are asked to fix the error and run ``git commit`` again.
+
+Pre-commit is already installed as a development dependency, but you also need to enable it:
 
 .. code-block:: bash
 
   pre-commit install
+
+.. note:: Pre-commit can have issues running from alternative Git clients like GitUp. If you encounter problems while committing changes, run ``pre-commit uninstall`` to disable pre-commit.
 
 
 Automated testing


### PR DESCRIPTION
### Summary

I think it was already pretty evident from current developer docs that pre-commit is an option, not a requirement. Albeit a very convenient option :)

Address issues with pre-commit spawned from GitUp and potentially other alternative git clients

* Change text to explain how pre-commit works
* Add a bit note about other clients

![image](https://user-images.githubusercontent.com/374612/75606686-a0d1a980-5aef-11ea-9697-fc9645639a47.png)


### Reviewer guidance

Is this enough to close #6607 or should we instead reference the issue from the docs?

### References
#6607

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
