### PR TITLE
OperationalError not caught, retry moved

### DIFF
--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -23,8 +23,20 @@ while not application and tries_remaining:
     try:
         application = get_wsgi_application()
     except OperationalError:
-        # an OperationalError happens when sqlite vacuum is being executed. the db is locked
+        # An OperationalError happens when sqlite vacuum is being
+        # executed. the db is locked
+        print(
+            "Database assumed to be undergoing a VACUUM, retrying again in {} seconds...".format(
+                interval
+            )
+        )
         tries_remaining -= 1
         time.sleep(interval)
+
 if not application:
-    print("Could not start Kolibri")
+    print(
+        "Could not start Kolibri with {} retries. Trying one last time".format(
+            tries_remaining
+        )
+    )
+    application = get_wsgi_application()

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -26,6 +26,5 @@ while not application and tries_remaining:
         # an OperationalError happens when sqlite vacuum is being executed. the db is locked
         tries_remaining -= 1
         time.sleep(interval)
-        application = get_wsgi_application()  # try again one last time
 if not application:
     print("Could not start Kolibri")


### PR DESCRIPTION
### Summary

The former behavior meant that the second retry would not catching an `OperationalError`, crashing Kolibri. The intention was that 6 retries would be done (60 seconds of retries), instead only 1 retry would be done after 10 seconds.

### Reviewer guidance

Add it for a 0.13.x patch release or wait?

### References

None, this was just random code reading.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
