### PR TITLE
Fix Snackbar overlay not covering any open modals, plus keyboard a11y fixes

### DIFF
--- a/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
@@ -21,6 +21,7 @@
       <button
         v-if="action"
         class="ui-snackbar-action-button"
+        :class="buttonClass"
         :style="{ color: $themeTokens.textInverted }"
         @click.stop="onActionClick"
       >
@@ -40,7 +41,16 @@
       message: String,
       action: String,
     },
-
+    computed: {
+      buttonClass() {
+        return this.$computedClass({
+          ':focus': {
+            ...this.$coreOutline,
+            outlineOffset: 6,
+          },
+        });
+      },
+    },
     methods: {
       onClick() {
         this.$emit('click');

--- a/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/KeenUiSnackbar.vue
@@ -27,6 +27,7 @@
       >
         {{ action }}
       </button>
+      <slot name="inner-focus-trap"></slot>
     </div>
   </div>
 

--- a/kolibri/core/assets/src/views/CoreSnackbar/index.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/index.vue
@@ -7,8 +7,9 @@
     >
     </div>
     <transition name="snackbar" @leave-to="clearSnackbar">
-      <UiSnackbar
+      <KeenUiSnackbar
         v-show="isVisible"
+        id="coresnackbar"
         ref="snackbar"
         class="snackbar"
         :message="text"
@@ -26,13 +27,13 @@
 <script>
 
   import { mapActions } from 'vuex';
-  import UiSnackbar from './KeenUiSnackbar';
+  import KeenUiSnackbar from './KeenUiSnackbar';
 
   /* Snackbars are used to display notification. */
   export default {
     name: 'CoreSnackbar',
     components: {
-      UiSnackbar,
+      KeenUiSnackbar,
     },
     props: {
       /* Text of notification to be displayed */

--- a/kolibri/core/assets/src/views/CoreSnackbar/index.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/index.vue
@@ -6,7 +6,8 @@
       class="snackbar-backdrop"
     >
     </div>
-    <transition name="snackbar" @leave-to="clearSnackbar">
+    <div v-if="backdrop" tabindex="0" @focus="handleTrapFocus"></div>
+    <transition name="snackbar" @leave-to="clearSnackbar" @enter="handleOnEnter">
       <KeenUiSnackbar
         v-show="isVisible"
         id="coresnackbar"
@@ -90,7 +91,6 @@
         this.timeout = window.setTimeout(this.hideSnackbar, this.duration);
       }
       if (this.backdrop) {
-        window.addEventListener('focus', this.containFocus, true);
         this.previouslyFocusedElement = document.activeElement;
         this.previouslyFocusedElement.blur();
       }
@@ -100,7 +100,6 @@
         window.clearTimeout(this.timeout);
       }
       if (this.backdrop) {
-        window.removeEventListener('focus', this.containFocus, true);
         this.previouslyFocusedElement.focus();
       }
     },
@@ -110,15 +109,21 @@
         this.isVisible = false;
         this.$emit('hide');
       },
-      containFocus(event) {
-        // Return focus to snackbar if trying to go into document but outside of snackbar
-        if (event.target !== window && !this.$refs.snackbar.$el.contains(event.target)) {
-          this.$refs.snackbar.$el.focus();
-        }
-      },
       handleActionClick() {
         this.isVisible = false;
         this.$emit('actionClicked');
+      },
+      focusSnackbarElement() {
+        this.$refs.snackbar.$el.focus();
+      },
+      handleOnEnter() {
+        if (this.backdrop) {
+          this.focusSnackbarElement();
+        }
+      },
+      handleTrapFocus(e) {
+        e.stopPropagation();
+        this.focusSnackbarElement();
       },
     },
   };

--- a/kolibri/core/assets/src/views/CoreSnackbar/index.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/index.vue
@@ -111,10 +111,8 @@
         this.$emit('hide');
       },
       containFocus(event) {
-        if (event.target === window) {
-          return;
-        }
-        if (!this.$refs.snackbar.$el.contains(event.target)) {
+        // Return focus to snackbar if trying to go into document but outside of snackbar
+        if (event.target !== window && !this.$refs.snackbar.$el.contains(event.target)) {
           this.$refs.snackbar.$el.focus();
         }
       },

--- a/kolibri/core/assets/src/views/CoreSnackbar/index.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/index.vue
@@ -1,12 +1,11 @@
 <template>
 
   <div>
-    <div
-      v-if="backdrop"
-      class="snackbar-backdrop"
-    >
-    </div>
-    <div v-if="backdrop" tabindex="0" @focus="handleTrapFocus"></div>
+    <template v-if="backdrop">
+      <div class="snackbar-backdrop"></div>
+      <!-- Prevent focus from leaving the this container -->
+      <div tabindex="0" @focus="trapFocus"></div>
+    </template>
     <transition name="snackbar" @leave-to="clearSnackbar" @enter="handleOnEnter">
       <KeenUiSnackbar
         v-show="isVisible"
@@ -18,7 +17,11 @@
         tabindex="0"
         :style="styles"
         @action-click="handleActionClick"
-      />
+      >
+        <template #inner-focus-trap>
+          <div tabindex="0" @focus="trapFocus"></div>
+        </template>
+      </KeenUiSnackbar>
     </transition>
   </div>
 
@@ -121,7 +124,7 @@
           this.focusSnackbarElement();
         }
       },
-      handleTrapFocus(e) {
+      trapFocus(e) {
         e.stopPropagation();
         this.focusSnackbarElement();
       },
@@ -141,6 +144,9 @@
     left: 0;
     z-index: 24;
     margin: 16px;
+    &:focus {
+      outline-style: none !important;
+    }
   }
 
   .snackbar-backdrop {

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -274,23 +274,18 @@
         this.$refs.modal.focus();
       },
       focusElementTest(event) {
-        // switching apps - not relevant
-        if (event.target === window) {
-          return;
-        }
-        // not sure when this would be true
-        if (!this.$refs.modal) {
-          return;
-        }
-        // addresses https://github.com/learningequality/kolibri/issues/3824
-        if (
-          event.target === this.$refs.modal ||
-          this.$refs.modal.contains(event.target.activeElement)
-        ) {
+        const { target } = event;
+        const noopOnFocus =
+          target.id === 'coresnackbar' || // keyboard focusing on snackbar
+          target === window || // switching apps
+          !this.$refs.modal || // if $refs.modal isn't available
+          target === this.$refs.modal || // addresses #3824
+          this.$refs.modal.contains(target.activeElement);
+        if (noopOnFocus) {
           return;
         }
         // focus has escaped the modal - put it back!
-        if (!this.$refs.modal.contains(event.target)) {
+        if (!this.$refs.modal.contains(target)) {
           this.focusModal();
         }
       },
@@ -312,7 +307,8 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 24;
+    // z-index needs to be one less than .snackbar-backdrop
+    z-index: 15;
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.7);

--- a/packages/kolibri-components/src/KModal.vue
+++ b/packages/kolibri-components/src/KModal.vue
@@ -276,12 +276,17 @@
       focusElementTest(event) {
         const { target } = event;
         const noopOnFocus =
-          target.id === 'coresnackbar' || // keyboard focusing on snackbar
           target === window || // switching apps
           !this.$refs.modal || // if $refs.modal isn't available
           target === this.$refs.modal || // addresses #3824
           this.$refs.modal.contains(target.activeElement);
         if (noopOnFocus) {
+          return;
+        }
+        // Fixes possible infinite recursion when disconnection snackbars appear
+        // along with KModal (#6301)
+        const $coreSnackbar = document.getElementById('coresnackbar');
+        if ($coreSnackbar && $coreSnackbar.contains(event.target)) {
           return;
         }
         // focus has escaped the modal - put it back!


### PR DESCRIPTION

### Summary

1. Addresses #6301 by simply making the Snackbar overlay div one z-index level higher than the KModal overlay div.
1. Adds a keyboard-focus outline to the snackbar action button and fixes an issue where focus would be trapped on the snackbar div, making the action button inaccessible when the snackbar backdrop was applied.


### Reviewer guidance

1. Test out the scenario in #6301 (e.g. open a modal and turn off the server). Make sure things still work when using keyboard only as well as mouse.
1. To test out the keyboard accessibility in other context, try accessing the snackbar while editing lessons (since the snackbar will have an "undo" action) when you remove items.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
