### PR TITLE
Clean up cherrypy config / instantiation

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -239,19 +239,21 @@ def configure_http_server(port):
         config={"/": {"tools.caching.on": False}},
     )
 
-    # Instantiate a new server object
-    server = cherrypy._cpserver.Server()
-
     # Configure the server
-    server.socket_host = LISTEN_ADDRESS
-    server.socket_port = port
-    server.thread_pool = conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"]
-    server.socket_timeout = conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"]
-    server.accepted_queue_size = conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"]
-    server.accepted_queue_timeout = conf.OPTIONS["Server"]["CHERRYPY_QUEUE_TIMEOUT"]
-
+    cherrypy.config.update(
+        {
+            "server.socket_host": LISTEN_ADDRESS,
+            "server.socket_port": port,
+            "server.thread_pool": conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"],
+            "server.socket_timeout": conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"],
+            "server.accepted_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
+            "server.accepted_queue_timeout": conf.OPTIONS["Server"][
+                "CHERRYPY_QUEUE_TIMEOUT"
+            ],
+        }
+    )
     # Subscribe this server
-    server.subscribe()
+    cherrypy.server.subscribe()
 
 
 def run_server(port, serve_http=True):
@@ -263,7 +265,6 @@ def run_server(port, serve_http=True):
 
     cherrypy.config.update(
         {
-            "environment": "production",
             "tools.expires.on": True,
             "tools.expires.secs": 31536000,
             "tools.caching.on": True,


### PR DESCRIPTION
### Summary

While debugging cherrypy logging, it became clear to me that we have some confusing elements in the way it's set up:

* [x] We should use a conventional config pattern, namely using the `.update()` method on the config dict
* [x] Do not create a new `Server()` - it's the same as the default one `cherrypy.server`, so it's a waste of CPU cycles.
* [ ] Make the effects of `environment: "production"` explicit
* [ ] Fix 2 cherrypy warnings (that are hidden because of `environment: "production"`)

### Reviewer guidance

Flagging this work, in case there are other efforts or issues wrt. cherrypy

### References

n/a

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
