### PR TITLE
Add channel_name to bulk-task payload

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -68,7 +68,9 @@ def validate_content_task(request, task_description, require_channel=False):
     except KeyError:
         raise serializers.ValidationError("The channel_ids field is required.")
 
-    channel_name = get_channel_name(channel_id, require_channel)
+    channel_name = task_description.get(
+        "channel_name", get_channel_name(channel_id, require_channel)
+    )
 
     node_ids = task_description.get("node_ids", None)
     exclude_node_ids = task_description.get("exclude_node_ids", None)

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -329,6 +329,7 @@
       startMultipleChannelImport() {
         if (this.inLocalImportMode) {
           const taskParams = this.selectedChannels.map(x => ({
+            channel_name: x.name,
             channel_id: x.id,
             drive_id: this.selectedDrive.id,
           }));
@@ -344,6 +345,7 @@
         } else {
           const peer_id = this.inPeerImportMode ? this.selectedPeer.id : null;
           const taskParams = this.selectedChannels.map(x => ({
+            channel_name: x.name,
             channel_id: x.id,
             peer_id,
           }));


### PR DESCRIPTION

### Summary

Adds the channel_name field to the bulk task request, so there's no delay in showing the channel name in the task list. fixes #6616 

### Reviewer guidance

Do bulk whole-channel imports from network and disk and confirm the names are in the network request, and that channel names all show up immediately in the task manager cards.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
