### PR TITLE
Fix error notification ui for save settings 

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfigPageNotifications.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfigPageNotifications.vue
@@ -19,7 +19,7 @@
 
     <UiAlert
       v-if="notification === notificationTypes.SAVE_FAILURE"
-      type="success"
+      type="error"
       @dismiss="dismiss()"
     >
       {{ $tr('saveFailure') }}


### PR DESCRIPTION

### Summary
Fixes #4150 
Changed error notification for save settings from green box to red box.

## Attached gif  
![img](https://im6.ezgif.com/tmp/ezgif-6-cc54e1595721.gif)

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
