### PR TITLE
Clear importability stats when deleting items from channels to immediately update content listings

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -8,6 +8,7 @@ from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import set_content_invisible
+from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.content.utils.import_export_content import get_files_to_transfer
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.tasks.management.commands.base import AsyncCommand
@@ -42,6 +43,9 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
         logger.info("Deleting all channel metadata")
         with db_task_write_lock:
             channel.delete_content_tree_and_files()
+
+    # Clear any previously set channel availability stats for this channel
+    clear_channel_stats(channel.id)
 
     return delete_all_metadata
 

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -116,9 +116,7 @@ class DeleteContentTestCase(TransactionTestCase):
     fixtures = ["content_test.json"]
     the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_include_all_nodes_all_deleted(self, os_remove_mock, content_file_path):
+    def test_include_all_nodes_all_deleted(self):
         ContentNode.objects.all().update(available=True)
         include_ids = list(
             ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
@@ -128,11 +126,7 @@ class DeleteContentTestCase(TransactionTestCase):
         call_command("deletecontent", test_channel_id, node_ids=include_ids)
         self.assertEqual(ContentNode.objects.all().count(), 0)
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_include_all_nodes_other_channel_node_still_available(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_include_all_nodes_other_channel_node_still_available(self):
         include_ids = list(
             ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
                 "id", flat=True
@@ -155,11 +149,7 @@ class DeleteContentTestCase(TransactionTestCase):
         test.refresh_from_db()
         self.assertTrue(test.available)
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_include_all_nodes_force_delete_other_channel_node_not_available(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_include_all_nodes_force_delete_other_channel_node_not_available(self):
         include_ids = list(
             ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
                 "id", flat=True
@@ -184,11 +174,7 @@ class DeleteContentTestCase(TransactionTestCase):
         test.refresh_from_db()
         self.assertFalse(test.available)
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_exclude_all_nodes_force_delete_other_channel_node_not_available_no_delete(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_exclude_all_nodes_force_delete_other_channel_node_not_available_no_delete(self):
         exclude_ids = list(
             ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
                 "id", flat=True
@@ -218,6 +204,9 @@ class DeleteContentTestCase(TransactionTestCase):
             self.assertTrue(original.available)
         except ContentNode.DoesNotExist:
             self.fail("Content node has been deleted")
+
+    def test_deleting_channel_clears_stats_cache(self):
+        pass
 
     def tearDown(self):
         call_command("flush", interactive=False)

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -114,107 +114,76 @@ class DeleteContentTestCase(TransactionTestCase):
     """
 
     fixtures = ["content_test.json"]
-    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+
+    def _get_node_ids(self):
+        return list(
+            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
+                "id", flat=True
+            )
+        )
+
+    def _setup_test_node(self, node, available=True):
+        node.id = uuid.uuid4().hex
+        node.channel_id = uuid.uuid4().hex
+        node.available = available
+        node.parent = None
+        node.save()
+        return node
+
+    def _setup_test_files(self, original_node_id, test_node):
+        original = ContentNode.objects.get(id=original_node_id)
+        for file in original.files.all():
+            file.id = uuid.uuid4().hex
+            file.contentnode = test_node
+            file.supplementary = False
+            file.save()
+        return original
+
+    def _call_delete_command(self, **kwargs):
+        call_command("deletecontent", test_channel_id, **kwargs)
 
     def test_include_all_nodes_all_deleted(self):
         ContentNode.objects.all().update(available=True)
-        include_ids = list(
-            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
-                "id", flat=True
-            )
-        )
-        call_command("deletecontent", test_channel_id, node_ids=include_ids)
+        call_command("deletecontent", test_channel_id, node_ids=self._get_node_ids())
         self.assertEqual(ContentNode.objects.all().count(), 0)
 
     def test_include_all_nodes_other_channel_node_still_available(self):
-        include_ids = list(
-            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
-                "id", flat=True
-            )
-        )
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
-        test.id = uuid.uuid4().hex
-        test.channel_id = uuid.uuid4().hex
-        test.available = True
-        test.parent = None
-        test.save()
-        original = ContentNode.objects.get(id=original_id)
-        for file in original.files.all():
-            file.id = uuid.uuid4().hex
-            file.contentnode = test
-            file.supplementary = False
-            file.save()
-        call_command("deletecontent", test_channel_id, node_ids=include_ids)
+        test = self._setup_test_node(test)
+        self._setup_test_files(original_id, test)
+        self._call_delete_command(node_ids=self._get_node_ids())
         test.refresh_from_db()
         self.assertTrue(test.available)
 
     def test_include_all_nodes_force_delete_other_channel_node_not_available(self):
-        include_ids = list(
-            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
-                "id", flat=True
-            )
-        )
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
-        test.id = uuid.uuid4().hex
-        test.channel_id = uuid.uuid4().hex
-        test.available = True
-        test.parent = None
-        test.save()
-        original = ContentNode.objects.get(id=original_id)
-        for file in original.files.all():
-            file.id = uuid.uuid4().hex
-            file.contentnode = test
-            file.supplementary = False
-            file.save()
-        call_command(
-            "deletecontent", test_channel_id, node_ids=include_ids, force_delete=True
-        )
+        test = self._setup_test_node(test)
+        self._setup_test_files(original_id, test)
+        self._call_delete_command(node_ids=self._get_node_ids(), force_delete=True)
         test.refresh_from_db()
         self.assertFalse(test.available)
 
-    def test_exclude_all_nodes_force_delete_other_channel_node_not_available_no_delete(self):
-        exclude_ids = list(
-            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
-                "id", flat=True
-            )
-        )
+    def test_exclude_all_nodes_force_delete_other_channel_node_not_available_no_delete(
+        self,
+    ):
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
-        test.id = uuid.uuid4().hex
-        test.channel_id = uuid.uuid4().hex
-        test.available = False
-        test.parent = None
-        test.save()
-        original = ContentNode.objects.get(id=original_id)
-        for file in original.files.all():
-            file.id = uuid.uuid4().hex
-            file.contentnode = test
-            file.supplementary = False
-            file.save()
-        call_command(
-            "deletecontent",
-            test_channel_id,
-            exclude_node_ids=exclude_ids,
-            force_delete=True,
+        test = self._setup_test_node(test, available=False)
+        original = self._setup_test_files(original_id, test)
+        self._call_delete_command(
+            exclude_node_ids=self._get_node_ids(), force_delete=True
         )
         try:
-            original = ContentNode.objects.get(id=original_id)
             self.assertTrue(original.available)
         except ContentNode.DoesNotExist:
             self.fail("Content node has been deleted")
 
     @patch("kolibri.core.content.management.commands.deletecontent.clear_channel_stats")
     def test_deleting_channel_clears_stats_cache(self, channel_stats_clear_mock):
-        ContentNode.objects.all().update(available=True)
-        include_ids = list(
-            ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
-                "id", flat=True
-            )
-        )
         self.assertFalse(channel_stats_clear_mock.called)
-        call_command("deletecontent", test_channel_id, node_ids=include_ids)
+        self._call_delete_command(node_ids=self._get_node_ids())
         self.assertTrue(channel_stats_clear_mock.called)
 
     def tearDown(self):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Follows the basic approach of #6533, calling the `clear_channel_stats(channel_id)` utility right after resource metadata is deleted.

Fixes #6573 

### Reviewer guidance

1. Is this the best place to place the `clear_channel_stats` command. 
1. Does this work if deleting granularly or in whole channels in bulk, or whole single channels?


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
