### PR TITLE
Batching and less DB intensive descendant queries for availability annotation

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -249,8 +249,12 @@ class Command(AsyncCommand):
             .count()
         )
 
+        dummy_bytes_for_annotation = annotation.calculate_dummy_progress_for_annotation(
+            node_ids, exclude_node_ids, total_bytes_to_transfer
+        )
+
         with self.start_progress(
-            total=total_bytes_to_transfer
+            total=total_bytes_to_transfer + dummy_bytes_for_annotation
         ) as overall_progress_update:
             exception = None  # Exception that is not caught by the retry logic
 
@@ -343,6 +347,7 @@ class Command(AsyncCommand):
                         number_of_skipped_files
                     )
                 )
+            overall_progress_update(dummy_bytes_for_annotation)
 
             if exception:
                 raise exception

--- a/kolibri/core/content/test/sqlalchemytesting.py
+++ b/kolibri/core/content/test/sqlalchemytesting.py
@@ -1,4 +1,5 @@
 from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import SharingPool
@@ -9,4 +10,6 @@ def django_connection_engine():
         return create_engine(
             get_default_db_string(), poolclass=SharingPool, convert_unicode=True
         )
-    return create_engine(get_default_db_string(), convert_unicode=True)
+    return create_engine(
+        get_default_db_string(), poolclass=NullPool, convert_unicode=True
+    )

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -777,7 +777,8 @@ class ImportContentTestCase(TestCase):
                 "destination",
                 node_ids=["32a941fb77c2576e8f6b294cde4c3b0c"],
             )
-            mock_overall_progress.assert_called_with(expected_file_size - src_file_size)
+
+            mock_overall_progress.assert_any_call(expected_file_size - src_file_size)
 
     @patch(
         "kolibri.core.content.management.commands.importcontent.transfer.FileDownload.finalize"

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -646,6 +646,17 @@ def recurse_annotation_up_tree(channel_id):
     bridge.end()
 
 
+def calculate_dummy_progress_for_annotation(node_ids, exclude_node_ids, total_progress):
+    num_annotation_constraints = len(node_ids or []) + len(exclude_node_ids or [])
+
+    # Calculate a percentage of the total progress to denote to annotation
+    # between 1 and 10
+    annotation_proportion = min(10, max(1, int(num_annotation_constraints / 500)))
+
+    # Create some progress proportional to annotation task
+    return annotation_proportion * total_progress / (100 - annotation_proportion)
+
+
 def propagate_forced_localfile_removal(localfiles):
     files = File.objects.filter(supplementary=False, local_file__in=localfiles)
     ContentNode.objects.filter(files__in=files).update(available=False)

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -232,7 +232,9 @@ def _calculate_batch_params(bridge, channel_id, node_ids, exclude_node_ids):
     # Aim for a constraint per batch count of about 250 on average
     # This means that there will be at most 750 parameters from the constraints
     # and should therefore also limit the overall SQL expression size.
-    dynamic_chunksize = min(CHUNKSIZE, ceil(250 * max_rght / (constraint_count or 1)))
+    dynamic_chunksize = int(
+        min(CHUNKSIZE, ceil(250 * max_rght / (constraint_count or 1)))
+    )
 
     return max_rght, dynamic_chunksize
 

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -10,7 +10,7 @@ from sqlalchemy import or_
 from sqlalchemy import select
 
 from .sqlalchemybridge import Bridge
-from .sqlalchemybridge import filter_by_uuids
+from .sqlalchemybridge import filter_by_checksums
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
@@ -41,9 +41,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):
             and_(
                 FileTable.c.local_file_id == LocalFileTable.c.id,
                 or_(
-                    # checksums are not uuids and have been got from
-                    # get_channel_stats_from_disk, so no need to validate them:
-                    filter_by_uuids(LocalFileTable.c.id, checksums, validate=False),
+                    filter_by_checksums(LocalFileTable.c.id, checksums),
                     LocalFileTable.c.available == True,  # noqa
                 ),
             ),

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -371,3 +371,15 @@ def _by_uuids(field, ids, validate, include):
             # empty case and don't return any results
             pass
     return UnaryExpression(field, modifier=operators.custom_op(empty_query))
+
+
+def filter_by_checksums(field, checksums):
+    query = "IN ("
+    # trick to workaround postgresql, it does not allow returning ():
+    empty_query = "IS NULL"
+    if checksums:
+        checksums_list = ["'{}'".format(identifier) for identifier in checksums]
+        return UnaryExpression(
+            field, modifier=operators.custom_op(query + ",".join(checksums_list) + ")")
+        )
+    return UnaryExpression(field, modifier=operators.custom_op(empty_query))


### PR DESCRIPTION
### Summary
0.13 subtly changed the concept of availability to connote user selection of what should be visible.
This required changing how we annotate the availability of content after an update, to preserve this.
This introduced a need to get all currently available nodes and annotate them and their descendants only.
The initial implementation of this resulted in highly intensive DB queries that caused a seemingly unending update request on the DB.
This PR resolves this by:
* copying a strategy from Django MPTT for doing the descendant queries
* batching updates so that larger channels are handled in smaller chunks, and that we are never applying too many constraints at once
* Treating topic nodes and non-topic nodes differently, as non-topic nodes have no descendants, so we do not need the same constraints.

As a bonus, it adds a little extra to the progress tracking so that the progress does not stall at 100% when annotating availability.

### Reviewer guidance
Note - I was able to replicate this in the shell by effectively making a high number of granular selections, this may help for testing this in the interface.

Does content import work as expected?
Is the code readable and the comments clear?


### References
Hopefully fixes #6602

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
