### PR TITLE
Add super admin filter to users page

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -122,6 +122,7 @@
           { label: this.coreString('learnersLabel'), value: UserKinds.LEARNER },
           { label: this.coreString('coachesLabel'), value: UserKinds.COACH },
           { label: this.$tr('admins'), value: UserKinds.ADMIN },
+          { label: this.$tr('superAdmins'), value: UserKinds.SUPERUSER },
         ];
       },
     },
@@ -157,6 +158,9 @@
         if (filterKind === UserKinds.ADMIN) {
           return user.kind === UserKinds.ADMIN || user.kind === UserKinds.SUPERUSER;
         }
+        if (filterKind === UserKinds.SUPERUSER) {
+          return user.kind === UserKinds.SUPERUSER;
+        }
         return filterKind === user.kind;
       },
       manageUserOptions(userId) {
@@ -191,6 +195,7 @@
     $trs: {
       searchText: 'Search for a user…',
       admins: 'Admins',
+      superAdmins: 'Super admins',
       newUserButtonLabel: 'New User',
       noUsersExist: 'No users exist',
       allUsersFilteredOut: "No users match the filter: '{filterText}'",


### PR DESCRIPTION

### Summary  
Fixes #4761 
Added super admin filter to users page.  

## Screenshots  
![Screenshot from 2020-03-06 12-02-40](https://user-images.githubusercontent.com/33183263/76058603-e3d5c600-5fa2-11ea-92da-ef3b3d433cc6.png)
![Screenshot from 2020-03-06 12-02-35](https://user-images.githubusercontent.com/33183263/76058608-e6382000-5fa2-11ea-9682-f5148b3ea0d2.png)
![Screenshot from 2020-03-06 12-02-26](https://user-images.githubusercontent.com/33183263/76058612-e89a7a00-5fa2-11ea-8d41-9678436852b1.png)


### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
