### PR TITLE
Updates to UI messages

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
@@ -19,14 +19,14 @@ const nStrings = createTranslator('NotificationStrings', {
   // started
   individualStarted: `{learnerName} started '{itemName}'`,
   multipleStarted: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} started '{itemName}'`,
-  wholeClassStarted: `Everyone in '{className}' started '{itemName}'`,
+  wholeClassStarted: `Everyone started '{itemName}'`,
   wholeGroupStarted: `Everyone in '{groupName}' started '{itemName}'`,
   everyoneStarted: `Everyone started '{itemName}'`,
 
   // completed
   individualCompleted: `{learnerName} completed '{itemName}'`,
   multipleCompleted: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} completed '{itemName}'`,
-  wholeClassCompleted: `Everyone in '{className}' completed '{itemName}'`,
+  wholeClassCompleted: `Everyone completed '{itemName}'`,
   wholeGroupCompleted: `Everyone in '{groupName}' completed '{itemName}'`,
   everyoneCompleted: `Everyone completed '{itemName}'`,
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
@@ -87,7 +87,7 @@
     },
     $trs: {
       someTasksComplete:
-        '{done, number} of {total, number} {done, plural, one {task} other {tasks}} complete',
+        '{done, number} of {total, plural, one {{total, number} task} other {{total, number} tasks}} complete',
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/UserPage/__test__/UserPage.spec.js
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/__test__/UserPage.spec.js
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import makeStore from '../../../../test/makeStore';
+import UserPage from '../index';
+
+function makeWrapper() {
+  const store = makeStore();
+  const wrapper = mount(UserPage, {
+    store,
+  });
+  return { wrapper, store };
+}
+
+// Intentionally made to not match any 'kind' filter
+const unicornUser = { id: '1', kind: 'UNICORN', username: 'unicorn', full_name: 'unicorn' };
+const coachUser = { id: '1', kind: 'coach', username: 'coach', full_name: 'coach' };
+
+describe('UserPage component', () => {
+  describe('message in empty states', () => {
+    function getUserTableEmptyMessage(wrapper) {
+      return wrapper.find({ name: 'UserTable' }).props().emptyMessage;
+    }
+
+    it('when there are no users', () => {
+      const { wrapper } = makeWrapper();
+      expect(getUserTableEmptyMessage(wrapper)).toEqual('No users exist');
+    });
+
+    const testCases = [
+      ['learner', 'No learners exist'],
+      ['coach', 'No coaches exist'],
+      ['superuser', 'No super admins exist'],
+      ['coach', 'No coaches exist'],
+      ['admin', 'No admins exist'],
+    ];
+
+    test.each(testCases)('when filter is %s', async (kind, expected) => {
+      const { wrapper, store } = makeWrapper();
+      store.state.userManagement.facilityUsers = [{ ...unicornUser }];
+      wrapper.setData({ roleFilter: { value: kind } });
+      await wrapper.vm.$nextTick();
+      expect(getUserTableEmptyMessage(wrapper)).toEqual(expected);
+    });
+
+    it('if a keyword filter is applied, the empty message is "no users match..."', async () => {
+      const { wrapper, store } = makeWrapper();
+      store.state.userManagement.facilityUsers = [{ ...coachUser }];
+      wrapper.setData({ roleFilter: { value: 'coach' } });
+      wrapper.find({ name: 'PaginatedListContainer' }).setData({ filterInput: 'coachy' });
+      await wrapper.vm.$nextTick();
+      expect(getUserTableEmptyMessage(wrapper)).toEqual("No users match the filter: 'coachy'");
+    });
+  });
+});

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -133,6 +133,19 @@
       emptyMessageForItems(items, filterText) {
         if (this.facilityUsers.length === 0) {
           return this.$tr('noUsersExist');
+        } else if (this.roleFilter && filterText === '') {
+          switch (this.roleFilter.value) {
+            case UserKinds.LEARNER:
+              return this.$tr('noLearnersExist');
+            case UserKinds.COACH:
+              return this.$tr('noCoachesExist');
+            case UserKinds.ADMIN:
+              return this.$tr('noAdminsExist');
+            case UserKinds.SUPERUSER:
+              return this.$tr('noSuperAdminsExist');
+            default:
+              return '';
+          }
         } else if (items.length === 0) {
           return this.$tr('allUsersFilteredOut', { filterText });
         }
@@ -201,6 +214,10 @@
       allUsersFilteredOut: "No users match the filter: '{filterText}'",
       optionsButtonLabel: 'Options',
       resetUserPassword: 'Reset password',
+      noLearnersExist: 'No learners exist',
+      noCoachesExist: 'No coaches exist',
+      noSuperAdminsExist: 'No super admins exist',
+      noAdminsExist: 'No admins exist',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
@@ -10,11 +10,11 @@
         :key="SNACKBARS.POINTS"
         @close="currentSnackbar = SNACKBARS.NEXT_RESOURCE"
       >
-        <template>
+        <template v-slot:icon>
           <ProgressIcon :progress="1" />
         </template>
 
-        <template>
+        <template v-slot:content>
           <PointsIcon class="points-icon" />
           <div
             class="points-amount"
@@ -41,7 +41,7 @@
         :key="SNACKBARS.NEXT_RESOURCE"
         @close="$emit('close')"
       >
-        <template>
+        <template v-slot:icon>
           <ContentIcon
             class="content-icon icon-bg"
             :kind="nextContent.kind"
@@ -50,7 +50,7 @@
           />
         </template>
 
-        <template>
+        <template v-slot:content>
           <router-link
             class="rm-link-style"
             :style="{ color: $themeTokens.text }"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
1. Fix ’n of m tasks complete’ message so that "tasks" agrees with the "N" value. Fixes #6192
2. Removes class name from 'Everybody [in class] finished "The resource"' notifications in the coach home page. Fixes #5016 
3. Fixes missing v-slot directive in MasteredSnackbars causing them to look empty. Regression from #6445.
4. Add 4 new messsages e.g. "No coaches exist" to Device > User page. Fixes #6571

### Reviewer guidance

1. Check to see that the new messages are reflected in the UI correctly.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
