### PR TITLE
added backroute for immersive pages

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerPage.vue
@@ -33,7 +33,8 @@
     computed: {
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsGroupReportLessonExerciseLearnerListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsGroupReportLessonExerciseLearnerListPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionPage.vue
@@ -34,7 +34,8 @@
       ...mapState('questionDetail', ['title']),
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsGroupReportLessonExerciseQuestionListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsGroupReportLessonExerciseQuestionListPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerPage.vue
@@ -32,7 +32,8 @@
     computed: {
       ...mapState('examReportDetail', ['exam']),
       toolbarRoute() {
-        return this.classRoute('ReportsGroupReportQuizLearnerListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsGroupReportQuizLearnerListPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionPage.vue
@@ -33,7 +33,8 @@
     computed: {
       ...mapState('questionDetail', ['title', 'exam']),
       toolbarRoute() {
-        return this.classRoute('ReportsGroupReportQuizQuestionListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsGroupReportQuizQuestionListPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityExercisePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityExercisePage.vue
@@ -31,7 +31,8 @@
     computed: {
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsLearnerActivityPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLearnerActivityPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonExercisePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonExercisePage.vue
@@ -31,7 +31,8 @@
     computed: {
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsLearnerReportLessonPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLearnerReportLessonPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionPage.vue
@@ -33,7 +33,8 @@
     computed: {
       ...mapState('questionDetail', ['title']),
       toolbarRoute() {
-        return this.classRoute('ReportsLessonExerciseQuestionListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLessonExerciseQuestionListPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerExercisePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerExercisePage.vue
@@ -32,7 +32,8 @@
     computed: {
       ...mapState('exerciseDetail', ['exercise']),
       toolbarRoute() {
-        return this.classRoute('ReportsLessonLearnerPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsLessonLearnerPage', {});
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionPage.vue
@@ -33,7 +33,8 @@
     computed: {
       ...mapState('questionDetail', ['title', 'exam']),
       toolbarRoute() {
-        return this.classRoute('ReportsQuizQuestionListPage', {});
+        const backRoute = this.backRouteForQuery(this.$route.query);
+        return backRoute || this.classRoute('ReportsQuizQuestionListPage', {});
       },
     },
     methods: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Fixes #5889 
Added backroute for ReportsLessonExerciseLearnerPage

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
