### PR TITLE
Add option to customize sandbox.

### DIFF
--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -49,14 +49,18 @@ class ContentRendererHook(WebpackBundleHook, WebpackInclusionMixin):
         # content renderers do not, as they may need to have styling for a different
         # text direction than the interface due to the text direction of content
         urls = [chunk["url"] for chunk in self.bundle]
-        tags = self.frontend_message_tag() + [
-            '<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {presets});</script>'.format(
-                kolibri_name="kolibriCoreAppGlobal",
-                bundle=self.unique_id,
-                urls='","'.join(urls),
-                presets=json.dumps(self.presets),
-            )
-        ]
+        tags = (
+            self.frontend_message_tag()
+            + self.plugin_data_tag()
+            + [
+                '<script>{kolibri_name}.registerContentRenderer("{bundle}", ["{urls}"], {presets});</script>'.format(
+                    kolibri_name="kolibriCoreAppGlobal",
+                    bundle=self.unique_id,
+                    urls='","'.join(urls),
+                    presets=json.dumps(self.presets),
+                )
+            ]
+        )
         return mark_safe("\n".join(tags))
 
 

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -21,7 +21,7 @@
         ref="iframe"
         class="iframe"
         :style="{ backgroundColor: $themePalette.grey.v_100 }"
-        sandbox="allow-scripts"
+        :sandbox="sandbox"
         frameBorder="0"
         :name="name"
         :src="rooturl"
@@ -40,6 +40,7 @@
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import Hashi from 'hashi';
   import { nameSpace } from 'hashi/src/hashiBase';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'Html5AppRendererIndex',
@@ -58,6 +59,9 @@
       },
       rooturl() {
         return this.defaultFile.storage_url;
+      },
+      sandbox() {
+        return plugin_data.sandbox;
       },
     },
     mounted() {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -61,7 +61,7 @@
         return this.defaultFile.storage_url;
       },
       sandbox() {
-        return plugin_data.sandbox;
+        return plugin_data.html5_sandbox_tokens;
       },
     },
     mounted() {

--- a/kolibri/plugins/html5_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/html5_viewer/kolibri_plugin.py
@@ -21,4 +21,4 @@ class HTML5AppAsset(content_hooks.ContentRendererHook):
 
     @property
     def plugin_data(self):
-        return {"sandbox": OPTIONS["HTML5"]["SANDBOX"]}
+        return {"html5_sandbox_tokens": OPTIONS["HTML5"]["SANDBOX"]}

--- a/kolibri/plugins/html5_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/html5_viewer/kolibri_plugin.py
@@ -7,13 +7,18 @@ from le_utils.constants import format_presets
 from kolibri.core.content import hooks as content_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils.conf import OPTIONS
 
 
 class HTML5AppPlugin(KolibriPluginBase):
-    pass
+    kolibri_options = "options"
 
 
 @register_hook
 class HTML5AppAsset(content_hooks.ContentRendererHook):
     bundle_id = "main"
     presets = (format_presets.HTML5_ZIP,)
+
+    @property
+    def plugin_data(self):
+        return {"sandbox": OPTIONS["HTML5"]["SANDBOX"]}

--- a/kolibri/plugins/html5_viewer/options.py
+++ b/kolibri/plugins/html5_viewer/options.py
@@ -1,0 +1,42 @@
+# Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+allowable_sandbox_tokens = set(
+    [
+        "allow-downloads-without-user-activation",
+        "allow-forms",
+        "allow-modals",
+        "allow-orientation-lock",
+        "allow-pointer-lock",
+        "allow-popups",
+        "allow-popups-to-escape-sandbox",
+        "allow-presentation",
+        "allow-same-origin",
+        "allow-scripts",
+        "allow-storage-access-by-user-activation ",
+        "allow-top-navigation",
+        "allow-top-navigation-by-user-activation",
+    ]
+)
+
+
+def clean_sandbox(sandbox_string):
+    """
+    Clean up sandbox string to ensure it only contains valid items.
+    """
+    sandbox_tokens = [
+        token
+        for token in sandbox_string.split(" ")
+        if token in allowable_sandbox_tokens
+    ]
+    return " ".join(sandbox_tokens)
+
+
+option_spec = {
+    "HTML5": {
+        "SANDBOX": {
+            "type": "string",
+            "default": "allow-scripts",
+            "envvars": ("KOLIBRI_HTML5_SANDBOX",),
+            "clean": clean_sandbox,
+        }
+    }
+}

--- a/kolibri/plugins/html5_viewer/options.py
+++ b/kolibri/plugins/html5_viewer/options.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 allowable_sandbox_tokens = set(
     [
@@ -22,11 +26,19 @@ def clean_sandbox(sandbox_string):
     """
     Clean up sandbox string to ensure it only contains valid items.
     """
-    sandbox_tokens = [
-        token
-        for token in sandbox_string.split(" ")
-        if token in allowable_sandbox_tokens
-    ]
+    sandbox_tokens = []
+    illegal_tokens = []
+    for token in sandbox_string.split(" "):
+        if token in allowable_sandbox_tokens:
+            sandbox_tokens.append(token)
+        else:
+            illegal_tokens.append(token)
+    if illegal_tokens:
+        logger.warn(
+            "Invalid sandbox token passed to options {}".format(
+                " ".join(illegal_tokens)
+            )
+        )
     return " ".join(sandbox_tokens)
 
 

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -154,9 +154,6 @@ def initialize_kolibri_plugin(plugin_name):
         logger.debug("Loaded kolibri plugin: {}".format(plugin_name))
         # If no exception is thrown, use this to find the plugin class.
         # Load a list of all class types in module
-        all_classes = [
-            cls for cls in plugin_module.__dict__.values() if isinstance(cls, type)
-        ]
         # Filter the list to only match the ones that belong to the module
         # and not the ones that have been imported
         plugin_package = (
@@ -164,9 +161,18 @@ def initialize_kolibri_plugin(plugin_name):
             if plugin_module.__package__
             else plugin_module.__name__.rpartition(".")[0]
         )
-        all_classes = filter(
-            lambda x: plugin_package + ".kolibri_plugin" == x.__module__, all_classes
-        )
+
+        def is_plugin_module(x):
+            return (
+                hasattr(x, "__module__")
+                and plugin_package + ".kolibri_plugin" == x.__module__
+            )
+
+        all_classes = [
+            cls
+            for cls in plugin_module.__dict__.values()
+            if is_plugin_module(cls) and isinstance(cls, type)
+        ]
         return initialize_plugins_and_hooks(all_classes, plugin_name)
 
     except ImportError as e:


### PR DESCRIPTION
### Summary
Adds a Kolibri option to customize the sandbox attribute in the HTML5 viewer plugin.
Adds sanitization of the option to only pass through allowed options.
Sets the sandbox attribute of the iframe in the HTML5 viewer plugin to the option.

### Reviewer guidance
Set e.g. this in `options.ini`:
```
[HTML5]
SANDBOX = allow-scripts allow-same-origin allow-bourne allow-forms
```
This should result in the sandbox attribute of the iframe in the HTML5 viewer being set to:
`allow-scripts allow-same-origin allow-forms`

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
