### PR TITLE
Improve progress reporting when bulk-importing channels

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -759,7 +759,8 @@ def _diskimport(
     # Add the channel name if it wasn't added initially
     if job and job.extra_metadata.get("channel_name", "") == "":
         job.extra_metadata["channel_name"] = get_channel_name(channel_id)
-        job.save_meta()
+
+    job.save_meta()
 
     # Skip importcontent step if updating and no nodes have changed
     if is_updating and (node_ids is not None) and len(node_ids) == 0:

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -66,7 +66,7 @@ def validate_content_task(request, task_description, require_channel=False):
     try:
         channel_id = task_description["channel_id"]
     except KeyError:
-        raise serializers.ValidationError("The channel_ids field is required.")
+        raise serializers.ValidationError("The channel_id field is required.")
 
     channel_name = get_channel_name(channel_id, require_channel)
 
@@ -233,7 +233,7 @@ class TasksViewSet(viewsets.ViewSet):
         job_ids = []
 
         for task in tasks:
-            task.update({"type": "REMOTEIMPORT"})
+            task.update({"type": "REMOTEIMPORT", "database_ready": False})
             import_job_id = queue.enqueue(
                 _remoteimport,
                 task["channel_id"],
@@ -241,6 +241,7 @@ class TasksViewSet(viewsets.ViewSet):
                 peer_id=task["peer_id"],
                 extra_metadata=task,
                 cancellable=True,
+                track_progress=True,
             )
             job_ids.append(import_job_id)
 
@@ -305,7 +306,7 @@ class TasksViewSet(viewsets.ViewSet):
         job_ids = []
 
         for task in tasks:
-            task.update({"type": "DISKIMPORT"})
+            task.update({"type": "DISKIMPORT", "database_ready": False})
             import_job_id = queue.enqueue(
                 _diskimport,
                 task["channel_id"],
@@ -454,7 +455,6 @@ class TasksViewSet(viewsets.ViewSet):
     def startdiskexport(self, request):
         """
         Export a channel to a local drive, and copy content to the drive.
-
         """
 
         task = validate_local_export_task(request, request.data)
@@ -481,7 +481,6 @@ class TasksViewSet(viewsets.ViewSet):
     def startdataportalsync(self, request):
         """
         Initiate a PUSH sync with Kolibri Data Portal.
-
         """
         task = {
             "facility": request.data["facility"],
@@ -697,11 +696,19 @@ def _remoteimport(
         check_for_cancel=check_for_cancel,
     )
 
-    # Add the channel name if it wasn't added initially
+    # Make some real-time updates to the metadata
     job = get_current_job()
+
+    # Signal to UI that the DB-downloading step is done so it knows to display
+    # progress correctly
+    job.update_progress(0, 1.0)
+    job.extra_metadata["database_ready"] = True
+
+    # Add the channel name if it wasn't added initially
     if job and job.extra_metadata.get("channel_name", "") == "":
         job.extra_metadata["channel_name"] = get_channel_name(channel_id)
-        job.save_meta()
+
+    job.save_meta()
 
     # Skip importcontent step if updating and no nodes have changed
     if is_updating and (node_ids is not None) and len(node_ids) == 0:
@@ -741,8 +748,15 @@ def _diskimport(
         check_for_cancel=check_for_cancel,
     )
 
-    # Add the channel name if it wasn't added initially
+    # Make some real-time updates to the metadata
     job = get_current_job()
+
+    # Signal to UI that the DB-downloading step is done so it knows to display
+    # progress correctly
+    job.update_progress(0, 1.0)
+    job.extra_metadata["database_ready"] = True
+
+    # Add the channel name if it wasn't added initially
     if job and job.extra_metadata.get("channel_name", "") == "":
         job.extra_metadata["channel_name"] = get_channel_name(channel_id)
         job.save_meta()

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -37,13 +37,13 @@
         <template v-if="taskIsRunning">
           <KLinearLoader
             class="k-linear-loader"
-            type="determinate"
+            :type="loaderType"
             :delay="false"
             :progress="task.percentage * 100"
             :style="{backgroundColor: $themeTokens.fineLine}"
           />
-          <span class="details-percentage">
-            {{ $tr('progressPercentage', { progress: task.percentage }) }}
+          <span v-if="taskPercentage" class="details-percentage">
+            {{ $tr('progressPercentage', { progress: taskPercentage }) }}
           </span>
         </template>
         <template v-else-if="taskIsCanceling">
@@ -164,6 +164,19 @@
       },
       taskIsClearable() {
         return taskIsClearable(this.task);
+      },
+      taskPercentage() {
+        if (this.task.database_ready === false) {
+          return null;
+        }
+        return this.task.percentage;
+      },
+      loaderType() {
+        // Show an indeterminate loader while bulk import is still in pre-importcontent step.
+        if (this.taskPercentage === null) {
+          return 'indeterminate';
+        }
+        return 'determinate';
       },
       descriptionText() {
         const trName = typeToTrMap[this.task.type];


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Turns on progress tracking for remoteimport type tasks.
1. Makes some changes to the `_disk/remoteimport` functions to help the UI know when to start showing a progress bar (prevents the 0 -> 100 -> 0% jump). Updates UI accordingly



### Reviewer guidance

1. Try out bulk importing. The Task progress bar should go from indeterminate (metadata still downloading) to 0% to e.g. 5% (content downloading) to 100% (done).

### References

Fixes #6633

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
