### PR TITLE
Stop optimizing pi build via container reuse + cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,6 @@ steps:
     async: true
     build:
       message: "${BUILDKITE_MESSAGE}"
-      branch: "autoblock"
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ i18n-upload-glossary:
 	python build_tools/i18n/crowdin.py upload-glossary
 
 docker-clean:
-	docker container prune --filter "label!=build=pigen" -f
-	docker image prune --filter "label!=build=pigen" -a -f
+	docker container prune -f
+	docker image prune -f
 
 docker-whl: writeversion docker-envlist
 	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .


### PR DESCRIPTION
Revert "Prune based on the image label"
This reverts commit 8554e8eac45691d3884dff341605841febb9643c.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Removes the optimizations put in place to speed up pi build. We don't build it for every PR anymore, and the optimization introduced caching problems where the pi build would silently fail. 

Should also speed up the other builds, as their images are retained and don't have to be constantly redownloaded. (the `-a` flag made things pretty aggressive in the `docker-clean` recipe.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Make sure trigger step completes almost immediately to verify that the block is still in place.

If not done already, trigger a pi build. Ensure that the pi build was successful.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


- https://github.com/learningequality/pi-gen/pull/7 - Container retention disabled
- https://github.com/learningequality/pi-gen/pull/6 - Block enabled by default in master branch
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md