### PR TITLE
improved webpack error reporting

### DIFF
--- a/kolibri/core/templates/kolibri/webpack_error.html
+++ b/kolibri/core/templates/kolibri/webpack_error.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Webpack Error</title>
+  <style>
+    body {
+      margin: 64px;
+      font-family: sans-serif;
+      background-color: #333;
+      color: #e0e4ea;
+    }
+    h2 {
+      font-size: smaller;
+    }
+  </style>
+</head>
+<body>
+  <h1>Webpack Error</h1>
+  <p>{{ message }}</p>
+  {% for key, value in extra_info.items %}
+  <h2>{{ key }}</h2>
+  <p>
+    <pre>{{ value }}</pre>
+  </p>
+  {% endfor %}
+</body>
+</html>

--- a/kolibri/core/webpack/middleware.py
+++ b/kolibri/core/webpack/middleware.py
@@ -1,0 +1,28 @@
+import logging
+
+from django.shortcuts import render
+
+from .hooks import WebpackError
+
+
+logger = logging.getLogger(__name__)
+
+
+class WebpackErrorHandler:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, WebpackError):
+            logger.error("WebpackError: {}".format(str(exception)))
+            for key in exception.extra_info:
+                logger.error("{}: {}".format(key, exception.extra_info[key]))
+            context = {
+                "message": str(exception),
+                "extra_info": exception.extra_info,
+            }
+            return render(request, "kolibri/webpack_error.html", context)
+        return None
+
+    def __call__(self, request):
+        return self.get_response(request)

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -91,7 +91,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
-    "kolibri.core.webpack.middleware.WebpackErrorHandler",
 ]
 
 # By default don't cache anything unless it explicitly requests it to!

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -91,6 +91,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
+    "kolibri.core.webpack.middleware.WebpackErrorHandler",
 ]
 
 # By default don't cache anything unless it explicitly requests it to!

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 from .base import *  # noqa isort:skip @UnusedWildImport
 
+# Settings might be tuples, so switch to lists
 INSTALLED_APPS = list(INSTALLED_APPS) + ["rest_framework_swagger"]  # noqa F405
+webpack_middleware = "kolibri.core.webpack.middleware.WebpackErrorHandler"
+MIDDLEWARE = list(MIDDLEWARE) + [webpack_middleware]  # noqa F405
 
 INTERNAL_IPS = ["127.0.0.1"]
 


### PR DESCRIPTION

### Summary

Current webpack errors were swallowing some useful info and being treated as "unhandled" exceptions, when they could be handled.

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/76359694-e9037f80-62d8-11ea-8c8d-303b2ac53059.png) | ![image](https://user-images.githubusercontent.com/2367265/76359659-e56ff880-62d8-11ea-911d-d042620f6ac5.png) |

### Reviewer guidance

Does this look like the right way to implement things?


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
