### PR TITLE
Html5parse tests

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -38,6 +38,16 @@ class ZipContentTestCase(TestCase):
     )
     empty_html_name = "empty.html"
     empty_html_str = ""
+    doctype_name = "doctype.html"
+    doctype = """
+    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+    """
+    doctype_str = doctype + "<html><head><script>test</script></head></html>"
+    html5_doctype_name = "html5_doctype.html"
+    html5_doctype = "<!DOCTYPE HTML>"
+    html5_doctype_str = (
+        html5_doctype + "<html><head><script>test</script></head></html>"
+    )
     test_name_1 = "testfile1.txt"
     test_str_1 = "This is a test!"
     test_name_2 = "testfile2.txt"
@@ -64,6 +74,8 @@ class ZipContentTestCase(TestCase):
             zf.writestr(self.script_name, self.script_str)
             zf.writestr(self.async_script_name, self.async_script_str)
             zf.writestr(self.empty_html_name, self.empty_html_str)
+            zf.writestr(self.doctype_name, self.doctype_str)
+            zf.writestr(self.html5_doctype_name, self.html5_doctype_str)
             zf.writestr(self.test_name_1, self.test_str_1)
             zf.writestr(self.test_name_2, self.test_str_2)
 
@@ -188,6 +200,18 @@ class ZipContentTestCase(TestCase):
             self.zip_file_base_url + self.script_name + "?SKIP_HASHI=true"
         )
         self.assertEqual(next(response.streaming_content).decode(), self.script_str)
+
+    def test_request_for_html_doctype_return_with_doctype(self, filename_patch):
+        response = self.client.get(self.zip_file_base_url + self.doctype_name)
+        content = response.content.decode("utf-8")
+        self.assertEqual(
+            content[:92].lower().replace("  ", " "), self.doctype.strip().lower()
+        )
+
+    def test_request_for_html5_doctype_return_with_doctype(self, filename_patch):
+        response = self.client.get(self.zip_file_base_url + self.html5_doctype_name)
+        content = response.content.decode("utf-8")
+        self.assertEqual(content[:15].lower(), self.html5_doctype.strip().lower())
 
     def test_request_for_html_body_script_return_correct_length_header(
         self, filename_patch

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -290,7 +290,11 @@ class ZipContentView(View):
         zipped_path = get_path_or_404(zipped_filename)
 
         # Sometimes due to URL concatenation, we get URLs with double-slashes in them, like //path/to/file.html.
-        # Normalize the path by converting those double-slashes to a single slash.
+        # If it is a leading double slash (i.e. /zipcontent/filename.zip//file.html) then it will get passed
+        # to zipcontent as a single leading slash - detect this and remove if present.
+        if embedded_filepath.startswith("/"):
+            embedded_filepath = embedded_filepath[1:]
+        # Normalize the path by converting double-slashes occurring later in the path to a single slash.
         embedded_filepath = embedded_filepath.replace("//", "/")
 
         # if client has a cached version, use that (we can safely assume nothing has changed, due to MD5)


### PR DESCRIPTION
### Summary
* Adds tests for maintaing doctype in HTML parsing in zipcontent
* Adds tests for extra slash robustness in file path parsing in zipcontent
* Tweaks behaviour for doctype to pass tests
* Tweaks behaviour for extra slash robustness to pass tests

### Reviewer guidance
Does everything still work as expected for the target HTML5 apps?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
