### PR TITLE
inline download button and timestamp text

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -22,6 +22,8 @@
               class="download-button"
               @click="downloadSessionLog"
             />
+            <span v-if="noSessionLogs"> {{ $tr('noLogsYet') }} </span>
+            <GeneratedElapsedTime v-else :date="sessionDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">
             {{ $tr('noDownload') }}
@@ -30,8 +32,7 @@
             <DataPageTaskProgress />
           </p>
           <p v-else>
-            <span v-if="noSessionLogs"> {{ $tr('noLogsYet') }} </span>
-            <GeneratedElapsedTime v-else :date="sessionDateCreated" />
+
             <KButton
               appearance="basic-link"
               :text="noSessionLogs ? $tr('generateLog') : $tr('regenerateLog')"
@@ -53,6 +54,8 @@
               class="download-button"
               @click="downloadSummaryLog"
             />
+            <span v-if="noSummaryLogs"> {{ $tr('noLogsYet') }} </span>
+            <GeneratedElapsedTime v-else :date="summaryDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">
             {{ $tr('noDownload') }}
@@ -61,8 +64,6 @@
             <DataPageTaskProgress />
           </p>
           <p v-else>
-            <span v-if="noSummaryLogs"> {{ $tr('noLogsYet') }} </span>
-            <GeneratedElapsedTime v-else :date="summaryDateCreated" />
             <KButton
               appearance="basic-link"
               :text="noSummaryLogs ? $tr('generateLog') : $tr('regenerateLog')"

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -22,7 +22,7 @@
               class="download-button"
               @click="downloadSessionLog"
             />
-            <span v-if="noSessionLogs"> {{ $tr('noLogsYet') }} </span>
+            <span v-if="noSessionLogs">{{ $tr('noLogsYet') }}</span>
             <GeneratedElapsedTime v-else :date="sessionDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -54,7 +54,7 @@
               class="download-button"
               @click="downloadSummaryLog"
             />
-            <span v-if="noSummaryLogs"> {{ $tr('noLogsYet') }} </span>
+            <span v-if="noSummaryLogs">{{ $tr('noLogsYet') }}</span>
             <GeneratedElapsedTime v-else :date="summaryDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -23,7 +23,7 @@
               @click="downloadSessionLog"
             />
             <span v-if="noSessionLogs">{{ $tr('noLogsYet') }}</span>
-            <GeneratedElapsedTime v-else :date="sessionDateCreated" />
+            <GeneratedElapsedTime v-else-if="sessionDateCreated" :date="sessionDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">
             {{ $tr('noDownload') }}

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -55,7 +55,7 @@
               @click="downloadSummaryLog"
             />
             <span v-if="noSummaryLogs">{{ $tr('noLogsYet') }}</span>
-            <GeneratedElapsedTime v-else :date="summaryDateCreated" />
+            <GeneratedElapsedTime v-else-if="summaryDateCreated" :date="summaryDateCreated" />
           </p>
           <p v-if="cannotDownload" :style="noDlStyle">
             {{ $tr('noDownload') }}


### PR DESCRIPTION
### Summary

The timestamp text is moved such that it is inline with the download button in session logs as well as in summary logs.

Fixes #5798
----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md

## Before
![Screenshot from 2020-03-15 21-23-43](https://user-images.githubusercontent.com/33806116/76705117-aa6c2b80-6703-11ea-82c2-38b5e9dbe077.png)
## After
![Screenshot from 2020-03-15 21-19-16](https://user-images.githubusercontent.com/33806116/76705153-ea331300-6703-11ea-98af-860ae3340f62.png)
