### PR TITLE
Wait for triggered builds during release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
         # Determines whether build will be autoblocked or not.
         # Autoblock unless there's a tag associated with the commit. Usually a release.
-        AUTOBLOCK: "${BUILDKITE_TAG:false}"
+        LE_KOLIBRI_RELEASE: "${BUILDKITE_TAG:-false}"
 
     # Android build only requires whl file
   # - label: Build Android APK
@@ -41,7 +41,7 @@ steps:
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
         # Determines whether build will be autoblocked or not.
         # Autoblock unless there's a tag associated with the commit. Usually a release.
-        AUTOBLOCK: "${BUILDKITE_TAG:false}"
+        LE_KOLIBRI_RELEASE: "${BUILDKITE_TAG:-false}"
     depends_on:
       - deb-build
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,6 @@ steps:
 
   - trigger: "kolibri-macos"
     label: ":mac:"
-    async: true
     build:
       message: "${BUILDKITE_MESSAGE}"
       env:
@@ -32,7 +31,6 @@ steps:
 
   - trigger: "kolibri-raspbian-image"
     label: ":raspberry-pi:"
-    async: true
     build:
       message: "${BUILDKITE_MESSAGE}"
       env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,9 @@ steps:
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
+        # Determines whether build will be autoblocked or not.
+        # Autoblock unless there's a tag associated with the commit. Usually a release.
+        AUTOBLOCK: "${BUILDKITE_TAG:false}"
 
     # Android build only requires whl file
   # - label: Build Android APK
@@ -36,6 +39,9 @@ steps:
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
+        # Determines whether build will be autoblocked or not.
+        # Autoblock unless there's a tag associated with the commit. Usually a release.
+        AUTOBLOCK: "${BUILDKITE_TAG:false}"
     depends_on:
       - deb-build
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Running into issues using the `async` flag during releases, where we're meant to upload artifacts to the github release page. The issue is a bit of a race condition, where even if the triggered builds have started, the upload step may begin without them. This is similar to a few of the reasons the HTML page was phased out.

Have a more concrete fix in mind, where we would upload to the GH release in each individual pipeline, but I don't think that's in scope for this project. Either way, removing `async` shouldn't have much of an impact since we're autoblocking most of the time anyway.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
