### PR TITLE
Pouring scorm on hashi

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -69,7 +69,14 @@
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
       });
-      this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {});
+      this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {}, {
+        userId: this.userId,
+        userFullName: this.userFullName,
+        progress: this.progress,
+        complete: this.progress < 1,
+        language: this.lang.id,
+        timeSpent: this.timeSpent,
+      });
       this.$emit('startTracking');
       this.startTime = now();
       this.pollProgress();

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -28,6 +28,10 @@ oriented data synchronization.
         :extraFields="extraFields"
         :assessment="true"
         :itemId="itemId"
+        :progress="progress"
+        :userId="userId"
+        :userFullName="userFullName"
+        :timeSpent="timeSpent"
         @answerGiven="answerGiven"
         @hintTaken="hintTaken"
         @itemError="handleItemError"
@@ -163,6 +167,22 @@ oriented data synchronization.
       extraFields: {
         type: Object,
         default: () => {},
+      },
+      // An explicit record of the current progress through this
+      // piece of content.
+      progress: {
+        type: Number,
+        default: 0,
+      },
+      // An identifier for the user interacting with this content
+      userId: {
+        type: String,
+      },
+      userFullName: {
+        type: String,
+      },
+      timeSpent: {
+        type: Number,
       },
     },
     data() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -22,6 +22,10 @@
         :files="content.files"
         :available="content.available"
         :extraFields="extraFields"
+        :progress="summaryProgress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="summaryTimeSpent"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
@@ -41,6 +45,10 @@
         :channelId="channelId"
         :available="content.available"
         :extraFields="extraFields"
+        :progress="summaryProgress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="summaryTimeSpent"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateExerciseProgress"
@@ -177,7 +185,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'pageMode']),
+      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'pageMode', 'currentUserId']),
       ...mapState(['pageName']),
       ...mapState('topicsTree', ['content', 'channel', 'recommended']),
       ...mapState('topicsTree', {
@@ -188,8 +196,10 @@
       ...mapState({
         masteryAttempts: state => state.core.logging.mastery.totalattempts,
         summaryProgress: state => state.core.logging.summary.progress,
+        summaryTimeSpent: state => state.core.logging.summary.time_spent,
         sessionProgress: state => state.core.logging.session.progress,
         extraFields: state => state.core.logging.summary.extra_fields,
+        fullName: state => state.core.session.full_name,
       }),
       isTopic() {
         return this.content.kind === ContentNodeKinds.TOPIC;

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -1,0 +1,237 @@
+/**
+ * This class offers an API-compatible replacement window.API for SCORM modules
+ * to be used when apps are run in sandbox mode.
+ *
+ * For more information, see:
+ * https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/
+ */
+import BaseShim from './baseShim';
+
+const logger = console; //eslint-disable-line no-console
+
+const TRUE = 'true';
+
+const NO_ERROR = 0;
+
+// Keys for which '_child' property is defined
+// For simplicity, we just list the entire path here
+// and the desired return value.
+const childKeys = {
+  'cmi.core._children':
+    'student_id,student_name,lesson_location,credit,lesson_status,entry,score,total_time,lesson_mode,exit,session_time',
+  'cmi.core.score._children': 'raw,min,max',
+  'cmi.objectives._children': 'id,score,status',
+  'cmi.student_data._children': '',
+  'cmi.student_preference._children': 'language',
+  'cmi.interactions._children':
+    'id,objectives,time,type,correct_responses,weighting,student_response,result,latency',
+};
+
+// Keys for which '_count' property is defined
+const countKeys = {
+  correct_responses: 'correct_responses',
+  interactions: 'interactions',
+  objectives: 'objectives',
+};
+
+// Values which we will just return an empty value from
+const emptyKeys = {
+  'cmi.comments_from_lms': 'cmi.comments_from_lms',
+  'cmi.launch_data': 'cmi.launch_data',
+};
+
+// Vendored and modified from
+// https://github.com/dfahlander/Dexie.js/blob/2337c0fcb093219c07723f81363b806d203f5c8b/src/functions/utils.ts#L118
+
+export function getByKeyPath(obj, keyPath) {
+  // http://www.w3.org/TR/IndexedDB/#steps-for-extracting-a-key-from-a-value-using-a-key-path
+  if (obj.hasOwnProperty(keyPath)) {
+    return obj[keyPath]; // This line is moved from last to first for optimization purpose.
+  }
+  if (!keyPath) {
+    return obj;
+  }
+  if (typeof keyPath !== 'string') {
+    const rv = [];
+    for (let i = 0, l = keyPath.length; i < l; ++i) {
+      rv.push(getByKeyPath(obj, keyPath[i]));
+    }
+    return rv;
+  }
+  const period = keyPath.indexOf('.');
+  if (period !== -1) {
+    const leadingKeyPath = keyPath.substr(0, period);
+    const innerObj = obj[leadingKeyPath];
+    const innerKeyPath = keyPath.substr(period + 1);
+    if (innerKeyPath === '_count' && countKeys[leadingKeyPath] && Array.isArray(obj)) {
+      return obj.length;
+    }
+    return innerObj === undefined ? undefined : getByKeyPath(innerObj, innerKeyPath);
+  }
+  return undefined;
+}
+
+export function setByKeyPath(obj, keyPath, value) {
+  if (!obj || keyPath === undefined) {
+    return;
+  }
+  if ('isFrozen' in Object && Object.isFrozen(obj)) {
+    return;
+  }
+  if (typeof keyPath !== 'string' && 'length' in keyPath) {
+    for (let i = 0, l = keyPath.length; i < l; ++i) {
+      setByKeyPath(obj, keyPath[i], value[i]);
+    }
+  } else {
+    const period = keyPath.indexOf('.');
+    if (period !== -1) {
+      const currentKeyPath = keyPath.substr(0, period);
+      const remainingKeyPath = keyPath.substr(period + 1);
+      if (remainingKeyPath === '') {
+        if (value === undefined) {
+          if (Array.isArray(obj) && !isNaN(parseInt(currentKeyPath))) {
+            obj.splice(currentKeyPath, 1);
+          } else {
+            delete obj[currentKeyPath];
+          }
+        } else {
+          obj[currentKeyPath] = value;
+        }
+      } else {
+        obj[currentKeyPath] = obj[currentKeyPath] || {};
+        setByKeyPath(obj[currentKeyPath], remainingKeyPath, value);
+      }
+    } else {
+      if (value === undefined) {
+        if (Array.isArray(obj) && !isNaN(parseInt(keyPath))) {
+          obj.splice(keyPath, 1);
+        } else {
+          delete obj[keyPath];
+        }
+      } else {
+        obj[keyPath] = value;
+      }
+    }
+  }
+}
+
+const userDataMap = {
+  'cmi.core.student_id': function(userData) {
+    return userData.userId || '';
+  },
+  'cmi.core.student_name': function(userData) {
+    return userData.userFullName || '';
+  },
+  'cmi.core.entry': function(userData) {
+    if (userData.progress) {
+      return userData.progress < 1 ? 'resume' : '';
+    }
+    return 'ab-initio';
+  },
+  'cmi.core.lesson_mode': function(userData) {
+    if (userData.userId) {
+      return userData.complete ? 'review' : 'normal';
+    }
+    return 'browse';
+  },
+  'cmi.core.credit': function(userData) {
+    return userData.userId ? 'credit' : 'no-credit';
+  },
+  'cmi.student_preference.language': function(userData) {
+    return userData.language ? userData.language : '';
+  },
+  'cmi.core.total_time': function(userData) {
+    return userData.timeSpent ? userData.timeSpent : 0;
+  },
+};
+
+export default class SCORM extends BaseShim {
+  constructor(mediator) {
+    super(mediator);
+    this.data = {};
+    this.nameSpace = 'SCORM';
+    this.__setData = this.__setData.bind(this);
+    this.on(this.events.STATEUPDATE, this.__setData);
+  }
+
+  __setData(data = {}, userData) {
+    this.data = data;
+    if (userData) {
+      for (let key in userDataMap) {
+        setByKeyPath(this.data, key, userDataMap[key](userData));
+      }
+    }
+  }
+
+  iframeInitialize() {
+    this.__setShimInterface();
+    // window.parent is our own shim, so we use regular assignment
+    // here to play nicely with the Proxy we are using.
+    try {
+      window.parent.API = this.shim;
+    } catch (e) {
+      if (e instanceof DOMException) {
+        // If this is a result of trying to touch a secure property
+        // this will be a DOMException error. Catch and just return nothing.
+        logger.warn(
+          'Tried to setup the SCORM API in a sandboxed environment, it will not be enabled'
+        );
+        return;
+      }
+      throw e;
+    }
+  }
+
+  __setShimInterface() {
+    const self = this;
+
+    class Shim {
+      LMSInitialize() {
+        logger.log('LMS Initialize called');
+        return TRUE;
+      }
+
+      LMSFinish() {
+        logger.log('LMS Finish called');
+        return TRUE;
+      }
+      LMSSetValue(CMIElement, value) {
+        setByKeyPath(self.data, CMIElement, value);
+        logger.log(`LMSSetValue called with path: ${CMIElement} and value ${value}`);
+        self.stateUpdated();
+      }
+
+      LMSGetValue(CMIElement) {
+        logger.log(`LMSGetValue called with path: ${CMIElement}`);
+        if (childKeys[CMIElement]) {
+          return childKeys[CMIElement];
+        }
+        if (emptyKeys[CMIElement]) {
+          return '';
+        }
+        return getByKeyPath(self.data, CMIElement);
+      }
+
+      LMSCommit() {
+        logger.log('LMS Commit called');
+      }
+
+      LMSGetLastError() {
+        return NO_ERROR;
+      }
+
+      LMSGetErrorString(errorCode) {
+        logger.log(`LMS Get Error String called with code ${errorCode}`);
+        return '';
+      }
+
+      LMSGetDiagnostic(errorCode) {
+        logger.log(`LMS Get Diagnostic called with code ${errorCode}`);
+        return '';
+      }
+    }
+    this.shim = new Shim();
+
+    return this.shim;
+  }
+}

--- a/packages/hashi/src/baseShim.js
+++ b/packages/hashi/src/baseShim.js
@@ -6,8 +6,8 @@ export default class BaseShim {
     this.events = Object.assign({}, events);
   }
 
-  setData(data) {
-    this.__setData(data);
+  setData(data, userData) {
+    this.__setData(data, userData);
     this.stateUpdated();
   }
 

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -2,6 +2,7 @@ import Mediator from './mediator';
 import LocalStorage from './localStorage';
 import SessionStorage from './sessionStorage';
 import Cookie from './cookie';
+import SCORM from './SCORM';
 import { events, nameSpace } from './hashiBase';
 import patchXMLHttpRequest from './monkeyPatchXMLHttpRequest';
 import patchCrossOrigin from './monkeyPatchCORSMediaElements';
@@ -36,6 +37,10 @@ export default class SandboxEnvironment {
     this.cookie = new Cookie(this.mediator);
 
     this.cookie.iframeInitialize();
+
+    this.SCORM = new SCORM(this.mediator);
+
+    this.SCORM.iframeInitialize();
 
     patchXMLHttpRequest();
 

--- a/packages/kolibri-components/src/content/mixin.js
+++ b/packages/kolibri-components/src/content/mixin.js
@@ -126,6 +126,22 @@ export default {
       type: Boolean,
       default: false,
     },
+    // An explicit record of the current progress through this
+    // piece of content.
+    progress: {
+      type: Number,
+      default: 0,
+    },
+    // An identifier for the user interacting with this content
+    userId: {
+      type: String,
+    },
+    userFullName: {
+      type: String,
+    },
+    timeSpent: {
+      type: Number,
+    },
   },
   computed: {
     defaultItemPreset() {


### PR DESCRIPTION
### Summary
* Adds SCORM API into Hashi when not sandboxed
* Adds special handling for `_children` and `_count` keys
* Persists SCORM data out to ContentSummaryLogs through usual Hashi mechanism
* Injects user data and relevant session data into ContentRenderers and then injects into Hashi.

### Reviewer guidance
Use SCORM packages or the SCORM debug package https://github.com/jleyva/scorm-debugger to see the behaviour.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
