### PR TITLE
Kolibri Design System - Buttons

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -13,18 +13,13 @@
       :raised="false"
       :removeBrandDivider="true"
     >
-      <UiIconButton
+      <KIconButton
         slot="icon"
-        type="secondary"
-        :aria-label="$tr('openNav')"
-        style=""
+        icon="menu"
+        :color="$themeTokens.textInverted"
+        :ariaLabel="$tr('openNav')"
         @click="$emit('toggleSideNav')"
-      >
-        <KIcon
-          icon="menu"
-          :style="{ fill: $themeTokens.textInverted, verticalAlign: 'baseline' }"
-        />
-      </UiIconButton>
+      />
 
       <img
         v-if="$kolibriBranding.appBar.topLogo"
@@ -113,7 +108,7 @@
   import { mapGetters, mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
+  import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
@@ -131,7 +126,7 @@
     name: 'AppBar',
     components: {
       UiToolbar,
-      UiIconButton,
+      KIconButton,
       CoreMenu,
       UiButton,
       CoreMenuOption,

--- a/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
+++ b/kolibri/core/assets/src/views/AppError/TechnicalTextBlock.vue
@@ -20,7 +20,6 @@
       <KButton
         v-if="clipboardCapable"
         ref="copyButton"
-        class="copy-to-clipboard-button"
         :primary="false"
         :text="$tr('copyToClipboardButtonPrompt')"
       />
@@ -105,10 +104,6 @@
     white-space: pre;
     resize: none;
     border-radius: $radius;
-  }
-
-  .copy-to-clipboard-button {
-    margin-left: 0;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/FilterTextbox.vue
+++ b/kolibri/core/assets/src/views/FilterTextbox.vue
@@ -22,17 +22,14 @@
       :autofocus="autofocus"
     >
 
-    <UiIconButton
-      color="black"
+    <KIconButton
       size="small"
       class="k-filter-clear-button"
+      icon="clear"
       :class="model === '' ? '' : 'k-filter-clear-button-visible'"
-      :style="{ color: $themeTokens.text }"
       :ariaLabel="$tr('clear')"
       @click="model = ''"
-    >
-      <KIcon icon="clear" />
-    </UiIconButton>
+    />
   </div>
 
 </template>
@@ -42,7 +39,6 @@
 
   import throttle from 'lodash/throttle';
   import UiIcon from 'keen-ui/src/UiIcon';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   /**
    * Used to filter items via text input
    */
@@ -50,7 +46,6 @@
     name: 'FilterTextbox',
     components: {
       UiIcon,
-      UiIconButton,
     },
     props: {
       /**
@@ -130,7 +125,7 @@
 
   .k-filter-icon {
     position: absolute;
-    top: 9px;
+    top: 6px;
     left: 0;
     margin-right: 8px;
     margin-left: 8px;
@@ -151,7 +146,7 @@
 
   .k-filter-clear-button {
     position: absolute;
-    top: 9px;
+    top: 6px;
     right: 0;
     width: 24px;
     height: 24px;

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -19,53 +19,33 @@
       :class="$computedClass(linkStyle)"
     >
       <!-- TODO add aria label? -->
-      <UiIconButton
-        type="flat"
-        class="icon"
-        :style="{ fill: $themeTokens.textInverted }"
-        tabindex="-1"
-      >
-        <KIcon
-          v-if="icon === 'close'"
-          icon="close"
-          :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
-        />
-        <KIcon
-          v-else-if="icon === 'arrow_back' && !isRtl"
-          :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
-          icon="back"
-        />
-        <KIcon
-          v-else-if="icon === 'arrow_back' && isRtl"
-          :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
-          icon="forward"
-        />
-      </UiIconButton>
-    </router-link>
-
-    <UiIconButton
-      v-else
-      type="flat"
-      class="icon"
-      :style="{ fill: $themeTokens.textInverted }"
-      @click="$emit('navIconClick')"
-    >
-      <KIcon
+      <KIconButton
         v-if="icon === 'close'"
         icon="close"
-        :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
+        :color="$themeTokens.textInverted"
+        tabindex="-1"
       />
-      <KIcon
-        v-if="icon === 'arrow_back' && !isRtl"
+      <KIconButton
+        v-else
         icon="back"
-        :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
+        :color="$themeTokens.textInverted"
       />
-      <KIcon
-        v-if="icon === 'arrow_back' && isRtl"
-        icon="forward"
-        :style="{ fill: $themeTokens.textInverted, top: 0, height: '24px', width: '24px', }"
+    </router-link>
+    <span v-else slot="icon">
+      <KIconButton
+        v-if="icon === 'close'"
+        icon="close"
+        :color="$themeTokens.textInverted"
+        tabindex="-1"
+        @click="$emit('navIconClick')"
       />
-    </UiIconButton>
+      <KIconButton
+        v-else
+        icon="back"
+        :color="$themeTokens.textInverted"
+        @click="$emit('navIconClick')"
+      />
+    </span>
   </UiToolbar>
 
 </template>
@@ -74,14 +54,12 @@
 <script>
 
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import { validateLinkObject } from 'kolibri.utils.validators';
 
   export default {
     name: 'ImmersiveToolbar',
     components: {
       UiToolbar,
-      UiIconButton,
     },
     props: {
       appBarTitle: {

--- a/kolibri/core/assets/src/views/PaginatedListContainer.vue
+++ b/kolibri/core/assets/src/views/PaginatedListContainer.vue
@@ -24,26 +24,22 @@
       <span dir="auto" class="pagination-label">
         {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
       </span>
-      <UiIconButton
-        type="primary"
-        :ariaLabel="$tr('previousResults')"
-        :disabled="previousButtonDisabled"
-        size="small"
-        class="pagination-button"
-        @click="changePage(-1)"
-      >
-        <KIcon icon="back" class="arrow-icon" />
-      </UiIconButton>
-      <UiIconButton
-        type="primary"
-        :ariaLabel="$tr('nextResults')"
-        :disabled="nextButtonDisabled"
-        size="small"
-        class="pagination-button"
-        @click="changePage(+1)"
-      >
-        <KIcon icon="forward" class="arrow-icon" />
-      </UiIconButton>
+      <KButtonGroup>
+        <KIconButton
+          :ariaLabel="$tr('previousResults')"
+          :disabled="previousButtonDisabled"
+          size="small"
+          icon="back"
+          @click="changePage(-1)"
+        />
+        <KIconButton
+          :ariaLabel="$tr('nextResults')"
+          :disabled="nextButtonDisabled"
+          size="small"
+          icon="forward"
+          @click="changePage(+1)"
+        />
+      </KButtonGroup>
     </nav>
   </div>
 
@@ -53,13 +49,11 @@
 <script>
 
   import clamp from 'lodash/clamp';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
 
   export default {
     name: 'PaginatedListContainer',
     components: {
-      UiIconButton,
       FilterTextbox,
     },
     props: {
@@ -159,17 +153,8 @@
     text-align: right;
   }
 
-  .pagination-button {
-    margin-left: 8px;
-  }
-
   .text-filter {
     margin-top: 14px;
-  }
-
-  .arrow-icon {
-    position: relative;
-    top: -1px;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -19,20 +19,14 @@
             backgroundColor: $themeTokens.primary,
           }"
         >
-          <UiIconButton
-            ref="toggleButton"
-            :aria-label="$tr('closeNav')"
-            type="secondary"
-            color="white"
-            size="large"
+          <KIconButton
+            icon="close"
+            :color="$themeTokens.textInverted"
             class="side-nav-header-icon"
+            :ariaLabel="$tr('closeNav')"
+            size="large"
             @click="toggleNav"
-          >
-            <KIcon
-              icon="close"
-              :style="{ fill: $themeTokens.textInverted, top: 0, width: '24px', height: '24px', }"
-            />
-          </UiIconButton>
+          />
           <span
             class="side-nav-header-name"
             :style="{ color: $themeTokens.textInverted }"
@@ -134,7 +128,6 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
   import navComponents from 'kolibri.utils.navComponents';
   import PrivacyInfoModal from 'kolibri.coreVue.components.PrivacyInfoModal';
@@ -157,7 +150,6 @@
     name: 'SideNav',
     components: {
       CoreMenu,
-      UiIconButton,
       CoreLogo,
       SideNavDivider,
       PrivacyInfoModal,

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
@@ -11,20 +11,21 @@
     <span class="selected" :title="selectedLanguage.english_name">
       {{ selectedLanguage.lang_name }}
     </span>
-    <KButton
-      v-for="language in buttonLanguages"
-      :key="language.id"
-      :text="language.lang_name"
-      :title="language.english_name"
-      class="lang"
-      appearance="basic-link"
-      @click="switchLanguage(language.id)"
-    />
+    <KButtonGroup>
+      <KButton
+        v-for="language in buttonLanguages"
+        :key="language.id"
+        :text="language.lang_name"
+        :title="language.english_name"
+        class="lang"
+        appearance="basic-link"
+        @click="switchLanguage(language.id)"
+      />
+    </KButtonGroup>
     <KButton
       :text="$tr('showMoreLanguagesSelector')"
       :primary="false"
       appearance="flat-button"
-      class="more"
       @click="showLanguageModal = true"
     />
     <LanguageSwitcherModal
@@ -99,15 +100,6 @@
 
   .lang {
     @include font-family-language-names;
-
-    margin-right: 8px;
-    margin-left: 8px;
-  }
-
-  .more {
-    margin: 0;
-    margin-top: 8px;
-    margin-bottom: 8px;
   }
 
   .ta-l {

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherList.vue
@@ -1,19 +1,13 @@
 <template>
 
   <div>
-    <UiIconButton
-      type="secondary"
-      class="globe"
+    <KIconButton
+      icon="language"
       aria-hidden="true"
       tabindex="-1"
+      class="globe"
       @click="showLanguageModal = true"
-    >
-      <KIcon
-        icon="language"
-        style="top: 0; width: 24px; height: 24px;"
-      />
-    </UiIconButton>
-
+    />
     <span class="selected" :title="selectedLanguage.english_name">
       {{ selectedLanguage.lang_name }}
     </span>
@@ -47,7 +41,6 @@
 
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import languageSwitcherMixin from './mixin';
   import LanguageSwitcherModal from './LanguageSwitcherModal';
 
@@ -55,7 +48,6 @@
     name: 'LanguageSwitcherList',
     components: {
       LanguageSwitcherModal,
-      UiIconButton,
     },
     mixins: [responsiveWindowMixin, languageSwitcherMixin],
     data() {

--- a/kolibri/core/assets/src/views/sortable/DragSortWidget/index.vue
+++ b/kolibri/core/assets/src/views/sortable/DragSortWidget/index.vue
@@ -4,35 +4,33 @@
     class="sort-widget"
     :class="{ focused: hasFocus, 'not-focused': !hasFocus }"
   >
-    <UiIconButton
+    <KIconButton
       v-show="!isFirst"
       ref="upBtn"
+      icon="arrow_up"
       class="btn up"
-      type="flat"
+      size="mini"
       :ariaLabel="moveUpText"
       :class="{ visuallyhidden: !hasFocus }"
       @click="clickUp"
       @keyup.space="clickUp"
-    >
-      <KIcon icon="arrow_up" />
-    </UiIconButton>
+    />
     <!--
       Currently missing from material icon repo.
       See https://github.com/google/material-design-icons/issues/786
      -->
     <KIcon icon="drag" class="grip" style="top: 0; width: 24px; height: 24px" />
-    <UiIconButton
+    <KIconButton
       v-show="!isLast"
       ref="dnBtn"
+      icon="arrow_down"
       class="btn dn"
-      type="flat"
+      size="mini"
       :ariaLabel="moveDownText"
       :class="{ visuallyhidden: !hasFocus }"
       @click="clickDown"
       @keyup.space="clickDown"
-    >
-      <KIcon icon="arrow_down" />
-    </UiIconButton>
+    />
   </div>
 
 </template>
@@ -40,13 +38,8 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'DragSortWidget',
-    components: {
-      UiIconButton,
-    },
     props: {
       moveUpText: {
         type: String,
@@ -123,7 +116,6 @@
 
   .btn {
     position: absolute;
-    left: -6px;
     z-index: 2;
     transition: opacity $core-time ease;
   }
@@ -144,6 +136,8 @@
 
   .dn {
     top: 4px;
+    // Why do I have to do this? I do not know.
+    left: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
@@ -2,19 +2,14 @@
 
   <!-- TODO: move this to be a core KBackLink -->
   <span v-show="!$isPrint" class="offset">
-    <UiIconButton
-      type="flat"
-      class="icon"
-      tabIndex="-1"
-      aria-hidden="true"
-      @click="go"
-    >
-      <KIcon
+    <router-link :to="go">
+      <KLabeledIcon
         icon="back"
-        :style="{ fill: $themeTokens.primary, top: 0, height: '24px', width: '24px' }"
+        :label="text"
+        :color="$themeTokens.primary"
+        style="text-decoration: underline;"
       />
-    </UiIconButton>
-    <KRouterLink :to="to" :text="text" />
+    </router-link>
   </span>
 
 </template>
@@ -22,13 +17,8 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'BackLink',
-    components: {
-      UiIconButton,
-    },
     props: {
       text: {
         type: String,

--- a/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
@@ -2,14 +2,7 @@
 
   <!-- TODO: move this to be a core KBackLink -->
   <span v-show="!$isPrint" class="offset">
-    <router-link :to="go">
-      <KLabeledIcon
-        icon="back"
-        :label="text"
-        :color="$themeTokens.primary"
-        style="text-decoration: underline;"
-      />
-    </router-link>
+    <KRouterLink :to="to" icon="back" :text="text" />
   </span>
 
 </template>
@@ -27,11 +20,6 @@
       to: {
         type: Object,
         required: true,
-      },
-    },
-    methods: {
-      go() {
-        this.$router.push(this.to);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -14,7 +14,6 @@
             :primary="true"
             :text="coachString('openQuizLabel')"
             type="button"
-            style="margin: 0;"
             @click="showConfirmationModal = true"
           />
         </KGridItem>
@@ -30,7 +29,6 @@
           <KButton
             :text="coachString('closeQuizLabel')"
             type="submit"
-            style="margin: 0;"
             :appearanceOverrides="cancelStyleOverrides"
             @click="showCancellationModal = true"
           />

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -39,46 +39,30 @@
             :invalidText="numQuestIsInvalidText"
             class="number-field"
           />
-          <UiIconButton
-            type="flat"
+          <KIconButton
+            icon="minus_sign"
             aria-hidden="true"
             class="number-btn"
             :disabled="numQuestions === 1"
             @click="numQuestions -= 1"
-          >
-            <KIcon
-              icon="minus_sign"
-              style="top: 0; width: 24px; height: 24px;"
-            />
-          </UiIconButton>
-          <UiIconButton
-            type="flat"
+          />
+          <KIconButton
+            icon="plus_sign"
             aria-hidden="true"
             class="number-btn"
             :disabled="numQuestions === maxQs"
             @click="numQuestions += 1"
-          >
-            <KIcon
-              icon="plus_sign"
-              style="top: 0; width: 24px; height: 24px;"
-            />
-          </UiIconButton>
+          />
         </KGridItem>
       </KGrid>
       <div>
-        <UiIconButton
-          type="flat"
+        <KIconButton
+          icon="refresh"
           aria-hidden="true"
           tabindex="-1"
-          color="primary"
+          :color="$themeTokens.primary"
           @click="getNewQuestionSet"
-        >
-          <KIcon
-            icon="refresh"
-            style="top: 0; width: 24px; height: 24px;"
-            :color="$themeTokens.primary"
-          />
-        </UiIconButton>
+        />
         <KButton
           :text="$tr('randomize')"
           appearance="basic-link"
@@ -139,7 +123,6 @@
 
   import { mapState } from 'vuex';
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
@@ -157,7 +140,6 @@
       };
     },
     components: {
-      UiIconButton,
       BottomAppBar,
       QuestionListPreview,
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -100,17 +100,19 @@
       />
 
       <BottomAppBar style="z-index: 1062;">
-        <KRouterLink
-          appearance="flat-button"
-          :text="coreString('goBackAction')"
-          :to="toolbarRoute"
-        />
-        <KButton
-          :text="coreString('finishAction')"
-          :disabled="loadingNewQuestions"
-          primary
-          @click="submit"
-        />
+        <KButtonGroup>
+          <KRouterLink
+            appearance="flat-button"
+            :text="coreString('goBackAction')"
+            :to="toolbarRoute"
+          />
+          <KButton
+            :text="coreString('finishAction')"
+            :disabled="loadingNewQuestions"
+            primary
+            @click="submit"
+          />
+        </KButtonGroup>
       </BottomAppBar>
     </KPageContainer>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -49,24 +49,20 @@
             class="number-field"
             @blur="numQuestionsBlurred = true"
           />
-          <UiIconButton
-            type="flat"
+          <KIconButton
+            icon="minus_sign"
             aria-hidden="true"
             class="number-btn"
             :disabled="numQuestions === 1"
             @click="numQuestions -= 1"
-          >
-            <KIcon icon="minus_sign" style="top: 0; width: 24px; height: 24px;" />
-          </UiIconButton>
-          <UiIconButton
-            type="flat"
+          />
+          <KIconButton
+            icon="plus_sign"
             aria-hidden="true"
             class="number-btn"
             :disabled="numQuestions === maxQs"
             @click="numQuestions += 1"
-          >
-            <KIcon icon="plus_sign" style="top: 0; width: 24px; height: 24px;" />
-          </UiIconButton>
+          />
         </KGridItem>
       </KGrid>
 
@@ -145,7 +141,6 @@
   import UiAlert from 'kolibri.coreVue.components.UiAlert';
   import flatMap from 'lodash/flatMap';
   import pickBy from 'lodash/pickBy';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames } from '../../../constants/';
@@ -165,7 +160,6 @@
       LessonsSearchFilters,
       ResourceSelectionBreadcrumbs,
       ContentCardList,
-      UiIconButton,
       BottomAppBar,
     },
     mixins: [commonCoreStrings, commonCoach, responsiveWindowMixin],

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -114,16 +114,18 @@
         />
       </BottomAppBar>
       <BottomAppBar v-else>
-        <KRouterLink
-          appearance="flat-button"
-          :text="coreString('goBackAction')"
-          :to="toolbarRoute"
-        />
-        <KButton
-          :text="coreString('continueAction')"
-          primary
-          @click="continueProcess"
-        />
+        <KButtonGroup>
+          <KRouterLink
+            appearance="flat-button"
+            :text="coreString('goBackAction')"
+            :to="toolbarRoute"
+          />
+          <KButton
+            :text="coreString('continueAction')"
+            primary
+            @click="continueProcess"
+          />
+        </KButtonGroup>
       </BottomAppBar>
 
     </KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -45,30 +45,22 @@
               numFilteredUsers
             }) }}
           </span>
-          <UiIconButton
-            type="primary"
-            :ariaLabel="$tr('previousResults')"
-            :disabled="pageNum === 1"
-            size="small"
-            @click="goToPage(pageNum - 1)"
-          >
-            <KIcon
+          <KButtonGroup>
+            <KIconButton
               icon="keyboard_arrow_left"
-              style="top: 0; width: 24px; height 24px;"
+              :ariaLabel="$tr('previousResults')"
+              :disabled="pageNum === 1"
+              size="small"
+              @click="goToPage(pageNum - 1)"
             />
-          </UiIconButton>
-          <UiIconButton
-            type="primary"
-            :ariaLabel="$tr('nextResults')"
-            :disabled="numPages === 0 || pageNum === numPages"
-            size="small"
-            @click="goToPage(pageNum + 1)"
-          >
-            <KIcon
+            <KIconButton
               icon="keyboard_arrow_right"
-              style="top: 0; width: 24px; height 24px;"
+              :ariaLabel="$tr('nextResults')"
+              :disabled="numPages === 0 || pageNum === numPages"
+              size="small"
+              @click="goToPage(pageNum + 1)"
             />
-          </UiIconButton>
+          </KButtonGroup>
         </nav>
 
         <div class="footer">
@@ -93,7 +85,6 @@
   import { mapActions, mapGetters, mapState } from 'vuex';
   import differenceWith from 'lodash/differenceWith';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../../common';
@@ -103,7 +94,6 @@
   export default {
     name: 'GroupEnrollPage',
     components: {
-      UiIconButton,
       FilterTextbox,
       UserTable,
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -12,7 +12,6 @@
       <PlanHeader />
       <div class="ta-r">
         <KButton
-          class="new-group-button"
           :text="$tr('newGroupAction')"
           :primary="true"
           @click="openCreateGroupModal"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/SelectOptions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/SelectOptions.vue
@@ -11,7 +11,6 @@
       <KButton
         :text="coreString('removeAction')"
         :primary="true"
-        class="no-margin"
         @click="$emit('removeResource')"
       />
       <!-- TODO include undo button here -->
@@ -20,7 +19,6 @@
       v-else
       :text="$tr('addButtonLabel')"
       :primary="true"
-      class="no-margin"
       @click="$emit('addResource')"
     />
   </div>
@@ -57,10 +55,6 @@
     top: 4px;
     width: 20px;
     height: 20px;
-  }
-
-  .no-margin {
-    margin-right: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -29,36 +29,25 @@
       >
 
       <div class="buttons-wrapper">
-        <UiIconButton
-          color="black"
+        <KIconButton
+          icon="clear"
+          :color="$themePalette.black"
           size="small"
           class="clear-button"
           :class="searchTerm === '' ? '' : 'clear-button-visible'"
           :ariaLabel="$tr('clearButtonLabel')"
           @click="clearSearchTerm"
-        >
-          <KIcon
-            icon="clear"
-            style="top: 0; width: 24px; height: 24px;"
-          />
-        </UiIconButton>
-
+        />
         <div class="submit-button-wrapper" :style="{ backgroundColor: $themeTokens.primary }">
-          <UiIconButton
-            type="secondary"
-            color="white"
+          <KIconButton
+            icon="search"
+            :color="$themeTokens.textInverted"
             class="submit-button"
             :disabled="!searchTermHasChanged"
             :ariaLabel="$tr('startSearchButtonLabel')"
             :style="{ fill: $themeTokens.textInverted }"
             @click="search"
-          >
-            <KIcon
-              icon="search"
-              :color="$themeTokens.textInverted"
-              style="top: 0; width: 24px; height: 24px;"
-            />
-          </UiIconButton>
+          />
         </div>
       </div>
     </div>
@@ -70,14 +59,10 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'LessonsSearchBox',
-    components: {
-      UiIconButton,
-    },
     mixins: [commonCoreStrings],
     data() {
       return {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -4,14 +4,12 @@
     <slot></slot>
     <div class="report-controls-buttons">
 
-      <UiIconButton
+      <KIconButton
         ref="printButton"
-        type="flat"
+        icon="print"
         :aria-label="coachString('printReportAction')"
         @click.prevent="$print()"
-      >
-        <KIcon icon="print" />
-      </UiIconButton>
+      />
       <KTooltip
         reference="printButton"
         :refs="$refs"
@@ -19,15 +17,13 @@
         {{ coachString('printReportAction') }}
       </KTooltip>
 
-      <UiIconButton
+      <KIconButton
         v-if="!exportDisabled"
         ref="exportButton"
-        type="flat"
+        icon="get_app"
         :aria-label="coachString('exportCSVAction')"
         @click.prevent="$emit('export')"
-      >
-        <KIcon icon="get_app" />
-      </UiIconButton>
+      />
       <KTooltip
         reference="exportButton"
         :refs="$refs"
@@ -42,13 +38,11 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
   import commonCoach from '../common';
 
   export default {
     name: 'ReportsControls',
-    components: { UiIconButton },
     mixins: [commonCoach],
     props: {
       disableExport: {

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -29,7 +29,6 @@
         <p v-if="showUnlistedChannels">
           <KButton
             data-test="token-button"
-            class="token-button"
             :text="$tr('channelTokenButtonLabel')"
             appearance="raised-button"
             name="showtokenmodal"
@@ -399,10 +398,6 @@
   .channel-list-header {
     padding: 16px 0;
     font-size: 14px;
-  }
-
-  .token-button {
-    margin-left: 0;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -75,7 +75,6 @@
     </section>
     <section>
       <KButton
-        class="save-button"
         :text="coreString('saveAction')"
         appearance="raised-button"
         primary
@@ -233,10 +232,4 @@
 </script>
 
 
-<style lang="scss" scoped>
-
-  .save-button {
-    margin-left: 0;
-  }
-
-</style>
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -13,7 +13,7 @@
       >
       <KIcon
         v-else
-        icon="apps"
+        icon="channel"
         class="thumbnail-svg"
         :style="{ backgroundColor: $themePalette.grey.v_200 }"
       />

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -42,7 +42,6 @@
       <KButton
         :text="$tr('manageChannelAction')"
         :disabled="disabled"
-        class="manage-btn"
         @click="handleManageChannelAction"
       />
     </div>
@@ -148,10 +147,6 @@
       margin-top: 16px;
       text-align: right;
     }
-  }
-
-  .manage-btn {
-    margin: 0;
   }
 
   .private-icons {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -22,7 +22,6 @@
       <div style="text-align: right">
         <KButton
           :text="$tr('importMoreAction')"
-          style="margin: 0;"
           @click="shownModal = 'IMPORT_MORE'"
         />
       </div>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectNetworkAddressModal/SelectAddressForm.vue
@@ -84,18 +84,20 @@
         </transition>
       </KFixedGridItem>
       <KFixedGridItem span="3" alignment="right">
-        <KButton
-          :text="coreString('cancelAction')"
-          appearance="flat-button"
-          @click="$emit('cancel')"
-        />
-        <KButton
-          :text="coreString('continueAction')"
-          :primary="true"
-          :disabled="submitDisabled"
-          type="submit"
-          @click="handleSubmit"
-        />
+        <KButtonGroup>
+          <KButton
+            :text="coreString('cancelAction')"
+            appearance="flat-button"
+            @click="$emit('cancel')"
+          />
+          <KButton
+            :text="coreString('continueAction')"
+            :primary="true"
+            :disabled="submitDisabled"
+            type="submit"
+            @click="handleSubmit"
+          />
+        </KButtonGroup>
       </KFixedGridItem>
     </KFixedGrid>
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
@@ -3,18 +3,20 @@
   <BottomAppBar>
     <span class="message">{{ selectedMessage }}</span>
     <template v-if="actionType === 'manage'">
-      <KButton
-        :disabled="$attrs.disabled || buttonsDisabled"
-        :text="coreString('deleteAction')"
-        :primary="false"
-        @click="$emit('selectoption', 'DELETE')"
-      />
-      <KButton
-        :disabled="$attrs.disabled || buttonsDisabled"
-        :text="$tr('exportAction')"
-        :primary="true"
-        @click="$emit('selectoption', 'EXPORT')"
-      />
+      <KButtonGroup>
+        <KButton
+          :disabled="$attrs.disabled || buttonsDisabled"
+          :text="coreString('deleteAction')"
+          :primary="false"
+          @click="$emit('selectoption', 'DELETE')"
+        />
+        <KButton
+          :disabled="$attrs.disabled || buttonsDisabled"
+          :text="$tr('exportAction')"
+          :primary="true"
+          @click="$emit('selectoption', 'EXPORT')"
+        />
+      </KButtonGroup>
     </template>
 
     <KButton

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -27,7 +27,6 @@
           <KButton
             :text="$tr('import')"
             :primary="true"
-            class="import-btn"
             @click="startImportWorkflow()"
           />
         </KGridItem>
@@ -232,10 +231,6 @@
   .options-btn {
     margin: 0;
     margin-right: 16px;
-  }
-
-  .import-btn {
-    margin: 0;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -31,6 +31,7 @@
             <KButton
               appearance="flat-button"
               :text="permissionsButtonText(user.username)"
+              style="margin-top: 6px;"
               @click="goToUserPermissionsPage(user.id)"
             />
           </td>

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/BackLink.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/BackLink.vue
@@ -2,19 +2,14 @@
 
   <!-- TODO: move this to be a core KBackLink -->
   <span class="offset">
-    <UiIconButton
-      type="flat"
-      class="icon"
-      tabIndex="-1"
-      aria-hidden="true"
-      @click="go"
-    >
-      <KIcon
+    <router-link :to="go">
+      <KLabeledIcon
         icon="back"
-        :style="{ fill: $themeTokens.primary, top: 0, height: '24px', width: '24px' }"
+        :label="text"
+        :color="$themeTokens.primary"
+        style="text-decoration: underline;"
       />
-    </UiIconButton>
-    <KRouterLink :to="to" :text="text" />
+    </router-link>
   </span>
 
 </template>
@@ -22,13 +17,8 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'BackLink',
-    components: {
-      UiIconButton,
-    },
     props: {
       text: {
         type: String,

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -75,7 +75,6 @@
         <KButton
           :disabled="saveDisabled"
           :text="$tr('saveButton')"
-          class="no-margin"
           :primary="true"
           appearance="raised-button"
           @click="save()"
@@ -239,10 +238,6 @@
 
 
 <style lang="scss" scoped>
-
-  .no-margin {
-    margin-left: 0;
-  }
 
   table {
     line-height: 1.5em;

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubStyles.scss
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubStyles.scss
@@ -50,7 +50,7 @@ $bottom-bar-height: 54px;
     left: 50%;
     transform: translate(-50%, -50%) !important;
   }
-  svg {
+  /deep/ svg {
     border: 2px solid;
     border-radius: 50%;
   }

--- a/kolibri/plugins/epub_viewer/assets/src/views/NextButton.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/NextButton.vue
@@ -1,35 +1,21 @@
 <template>
 
-  <UiIconButton
+  <KIconButton
+    :icon="isRtl ? 'keyboard_arrow_left' : 'keyboard_arrow_right'"
     class="next-button"
     :class="{ 'next-button-white': color === 'white' }"
     :ariaLabel="$tr('goToNextPage')"
+    :color="color"
     @click="$emit('goToNextPage')"
-  >
-    <KIcon
-      v-if="!isRtl"
-      icon="keyboard_arrow_right"
-      :style="{ top: 0, height: '24px', width: '24px' }"
-    />
-    <KIcon
-      v-else
-      icon="keyboard_arrow_left"
-      :style="{ top: 0, height: '24px', width: '24px' }"
-    />
-  </UiIconButton>
+  />
 
 </template>
 
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'NextButton',
-    components: {
-      UiIconButton,
-    },
     props: {
       // TODO - refactor to use themes properly
       color: {
@@ -54,10 +40,14 @@
 
   .next-button {
     @include navigation-button;
+
+    svg {
+      border: 2px solid;
+    }
   }
 
   .next-button-white {
-    svg {
+    /deep/ svg {
       border-color: white;
       fill: white;
     }

--- a/kolibri/plugins/epub_viewer/assets/src/views/PreviousButton.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/PreviousButton.vue
@@ -1,35 +1,21 @@
 <template>
 
-  <UiIconButton
+  <KIconButton
+    :icon="isRtl ? 'keyboard_arrow_right' : 'keyboard_arrow_left'"
     class="previous-button"
     :class="{ 'previous-button-white': color === 'white' }"
+    :color="color"
     :ariaLabel="$tr('goToPreviousPage')"
     @click="$emit('goToPreviousPage')"
-  >
-    <KIcon
-      v-if="!isRtl"
-      icon="keyboard_arrow_left"
-      :style="{ top: 0, height: '24px', width: '24px' }"
-    />
-    <KIcon
-      v-else
-      icon="keyboard_arrow_right"
-      :style="{ top: 0, height: '24px', width: '24px' }"
-    />
-  </UiIconButton>
+  />
 
 </template>
 
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'PreviousButton',
-    components: {
-      UiIconButton,
-    },
     props: {
       // TODO - refactor to use themes properly
       color: {
@@ -57,7 +43,7 @@
   }
 
   .previous-button-white {
-    svg {
+    /deep/ svg {
       border-color: white;
       fill: white;
     }

--- a/kolibri/plugins/epub_viewer/assets/src/views/SearchButton.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SearchButton.vue
@@ -1,29 +1,20 @@
 <template>
 
-  <UiIconButton
-    type="secondary"
+  <KIconButton
+    icon="search"
     :ariaLabel="$tr('toggleSearchSideBar')"
     data-test="search button"
+    size="small"
     @click="$emit('click')"
-  >
-    <KIcon
-      icon="search"
-      style="top: 0; width: 24px; height: 24px;"
-    />
-  </UiIconButton>
+  />
 
 </template>
 
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'SearchButton',
-    components: {
-      UiIconButton,
-    },
     $trs: {
       toggleSearchSideBar: 'Toggle search',
     },

--- a/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
@@ -14,18 +14,14 @@
           :aria-label="$tr('enterSearchQuery')"
           @keyup.esc.stop
         >
-
-        <UiIconButton
-          type="secondary"
+        <KIconButton
+          icon="search"
           buttonType="submit"
           :ariaLabel="$tr('submitSearchQuery')"
           class="d-tc"
-        >
-          <KIcon
-            icon="search"
-            style="top: 0; width: 24px; height: 24px;"
-          />
-        </UiIconButton>
+          style="position: relative; top:4px; left: 8px;"
+          size="small"
+        />
       </div>
     </form>
 
@@ -91,7 +87,6 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import Mark from 'mark.js';
   import SideBar from './SideBar';
 
@@ -145,7 +140,6 @@
     name: 'SearchSideBar',
     components: {
       SideBar,
-      UiIconButton,
     },
     props: {
       book: {

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsButton.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsButton.vue
@@ -1,29 +1,20 @@
 <template>
 
-  <UiIconButton
-    type="secondary"
+  <KIconButton
+    icon="tune"
     :ariaLabel="$tr('toggleSettingsSideBar')"
     data-test="settings button"
+    size="small"
     @click="$emit('click')"
-  >
-    <KIcon
-      icon="tune"
-      style="top: 0; width: 24px; height: 24px;"
-    />
-  </UiIconButton>
+  />
 
 </template>
 
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'SettingsButton',
-    components: {
-      UiIconButton,
-    },
     $trs: {
       toggleSettingsSideBar: 'Toggle settings',
     },

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -11,7 +11,7 @@
             :disabled="decreaseFontSizeDisabled"
             @click="$emit('decreaseFontSize')"
           >
-            <KIcon icon="minus_sign" style="top: 0; width: 24px; height: 24px;" />
+            <KIcon slot="icon" icon="minus_sign" style="top: 0; width: 24px; height: 24px;" />
             <div class="truncate">
               {{ $tr('decrease') }}
             </div>
@@ -24,7 +24,7 @@
             :class="['settings-button', $computedClass(settingsButtonFocus)]"
             @click="$emit('increaseFontSize')"
           >
-            <KIcon icon="plus_sign" style="top: 0; width: 24px; height: 24px;" />
+            <KIcon slot="icon" icon="plus_sign" style="top: 0; width: 24px; height: 24px;" />
             <div class="truncate">
               {{ $tr('increase') }}
             </div>

--- a/kolibri/plugins/epub_viewer/assets/src/views/TocButton.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/TocButton.vue
@@ -1,29 +1,20 @@
 <template>
 
-  <UiIconButton
-    type="secondary"
+  <KIconButton
+    icon="list"
     :ariaLabel="$tr('toggleTocSideBar')"
     data-test="toc button"
+    size="small"
     @click="$emit('click')"
-  >
-    <KIcon
-      icon="list"
-      style="top: 0; width: 24px; height: 24px;"
-    />
-  </UiIconButton>
+  />
 
 </template>
 
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
-
   export default {
     name: 'TocButton',
-    components: {
-      UiIconButton,
-    },
     $trs: {
       toggleTocSideBar: 'Toggle table of contents',
     },

--- a/kolibri/plugins/epub_viewer/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/TopBar.vue
@@ -41,24 +41,13 @@
           @click="$emit('searchButtonClicked')"
         />
 
-        <UiIconButton
+        <KIconButton
           ref="fullscreenButton"
-          type="secondary"
+          :icon="isInFullscreen ? 'fullscreen_exit' : 'fullscreen'"
           :ariaLabel="$tr('toggleFullscreen')"
+          size="small"
           @click="$emit('fullscreenButtonClicked')"
-        >
-          <KIcon
-            v-if="isInFullscreen"
-            icon="fullscreen_exit"
-            style="top: 0; width: 24px; height: 24px;"
-          />
-          <KIcon
-            v-else
-            icon="fullscreen"
-            style="top: 0; width: 24px; height: 24px;"
-          />
-        </UiIconButton>
-
+        />
       </KGridItem>
     </KGrid>
   </div>
@@ -68,7 +57,6 @@
 
 <script>
 
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import TocButton from './TocButton';
   import SettingsButton from './SettingsButton';
   import SearchButton from './SearchButton';
@@ -76,7 +64,6 @@
   export default {
     name: 'TopBar',
     components: {
-      UiIconButton,
       TocButton,
       SettingsButton,
       SearchButton,

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -68,7 +68,6 @@
                 @click="register(facility)"
               />
               <KButton
-                class="sync"
                 appearance="raised-button"
                 :text="$tr('sync')"
                 :disabled="facilityTaskId !== '' || !facility.dataset.registered"
@@ -187,10 +186,6 @@
     padding: 4px;
     padding-top: 8px;
     text-align: right;
-
-    .sync {
-      margin-right: 0;
-    }
   }
 
   .name {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -60,19 +60,21 @@
             </div>
           </td>
           <td class="button-col">
-            <KButton
-              appearance="raised-button"
-              :text="$tr('register')"
-              :disabled="facilityTaskId !== ''"
-              @click="register(facility)"
-            />
-            <KButton
-              class="sync"
-              appearance="raised-button"
-              :text="$tr('sync')"
-              :disabled="facilityTaskId !== '' || !facility.dataset.registered"
-              @click="sync(facility)"
-            />
+            <KButtonGroup>
+              <KButton
+                appearance="raised-button"
+                :text="$tr('register')"
+                :disabled="facilityTaskId !== ''"
+                @click="register(facility)"
+              />
+              <KButton
+                class="sync"
+                appearance="raised-button"
+                :text="$tr('sync')"
+                :disabled="facilityTaskId !== '' || !facility.dataset.registered"
+                @click="sync(facility)"
+              />
+            </KButtonGroup>
           </td>
         </tr>
       </transition-group>

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -19,7 +19,6 @@
             <KButton
               :text="$tr('download')"
               :disabled="!availableSessionCSVLog"
-              class="download-button"
               @click="downloadSessionLog"
             />
           </p>
@@ -50,7 +49,6 @@
             <KButton
               :text="$tr('download')"
               :disabled="!availableSummaryCSVLog"
-              class="download-button"
               @click="downloadSummaryLog"
             />
           </p>
@@ -211,10 +209,6 @@
     margin-left: -8px;
     font-size: 0.8em;
     border-radius: $radius;
-  }
-
-  .download-button {
-    margin-left: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -40,22 +40,24 @@
         </div>
 
         <div>
-          <KButton
-            :primary="false"
-            appearance="raised-button"
-            :text="$tr('resetToDefaultSettings')"
-            name="reset-settings"
-            @click="showModal = true"
-          />
+          <KButtonGroup>
+            <KButton
+              :primary="false"
+              appearance="raised-button"
+              :text="$tr('resetToDefaultSettings')"
+              name="reset-settings"
+              @click="showModal = true"
+            />
 
-          <KButton
-            :primary="true"
-            appearance="raised-button"
-            :text="coreString('saveChangesAction')"
-            name="save-settings"
-            :disabled="!settingsHaveChanged"
-            @click="saveConfig()"
-          />
+            <KButton
+              :primary="true"
+              appearance="raised-button"
+              :text="coreString('saveChangesAction')"
+              name="save-settings"
+              :disabled="!settingsHaveChanged"
+              @click="saveConfig()"
+            />
+          </KButtonGroup>
         </div>
       </div>
     </template>

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -80,17 +80,19 @@
       </section>
 
       <div class="buttons">
-        <KButton
-          type="submit"
-          :text="coreString('saveAction')"
-          :disabled="busy"
-          :primary="true"
-        />
-        <KButton
-          :text="coreString('cancelAction')"
-          :disabled="busy"
-          @click="goToUserManagementPage()"
-        />
+        <KButtonGroup>
+          <KButton
+            type="submit"
+            :text="coreString('saveAction')"
+            :disabled="busy"
+            :primary="true"
+          />
+          <KButton
+            :text="coreString('cancelAction')"
+            :disabled="busy"
+            @click="goToUserManagementPage()"
+          />
+        </KButtonGroup>
       </div>
 
     </form>

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -94,17 +94,19 @@
         {{ $tr('forceLogoutWarning') }}
       </p>
       <div class="buttons">
-        <KButton
-          type="submit"
-          :text="coreString('saveAction')"
-          :disabled="formDisabled"
-          :primary="true"
-        />
-        <KButton
-          :text="cancelButtonText"
-          :disabled="formDisabled"
-          @click="goToUserManagementPage()"
-        />
+        <KButtonGroup>
+          <KButton
+            type="submit"
+            :text="coreString('saveAction')"
+            :disabled="formDisabled"
+            :primary="true"
+          />
+          <KButton
+            :text="cancelButtonText"
+            :disabled="formDisabled"
+            @click="goToUserManagementPage()"
+          />
+        </KButtonGroup>
       </div>
 
     </form>

--- a/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
@@ -2,20 +2,15 @@
 
   <div class="search-box-wrapper">
     <div ref="toggleBtnAndSearchBox">
-      <UiIconButton
+      <KIconButton
         v-show="searchBoxIsDropdown"
         ref="toggleBtn"
-        type="primary"
-        color="clear"
+        icon="search"
+        size="small"
+        style="margin-left: 8px;"
+        :color="$themeTokens.textInverted"
         @click="toggleDropdownSearchBox"
-      >
-        <KIcon
-          icon="search"
-          class="search-icon"
-          :color="$themeTokens.textInverted"
-          style="top: 0; height: 24px; width: 24px;"
-        />
-      </UiIconButton>
+      />
 
       <div
         v-show="searchBoxIsVisible"
@@ -40,13 +35,11 @@
 <script>
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import SearchBox from './SearchBox';
 
   export default {
     name: 'ActionBarSearchBox',
     components: {
-      UiIconButton,
       SearchBox,
     },
     mixins: [responsiveWindowMixin],

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -64,7 +64,6 @@ oriented data synchronization.
               <KButton
                 v-if="!complete"
                 appearance="raised-button"
-                class="question-btn"
                 :text="$tr('check')"
                 :primary="true"
                 :class="{ shaking: shake }"
@@ -74,7 +73,6 @@ oriented data synchronization.
               <KButton
                 v-else
                 appearance="raised-button"
-                class="question-btn"
                 :text="$tr('next')"
                 :primary="true"
                 @click="nextQuestion"
@@ -552,10 +550,6 @@ oriented data synchronization.
     padding-left: 8px;
     overflow-x: auto;
     overflow-y: hidden;
-  }
-
-  .question-btn {
-    margin: 0;
   }
 
   // checkAnswer btn animation

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -8,14 +8,14 @@
         class="content-carousel-previous-control"
         @click="previousSet"
       >
-        <UiIconButton
-          class="content-carousel-previous-control-button"
+        <KIconButton
+          icon="back"
+          appearance="raised-button"
+          class="content-carousel-control-button"
           :style="buttonTransforms"
           :disabled="isFirstSet"
           size="large"
-        >
-          <KIcon icon="back" style="top: 0; height: 24px; width: 24px;" />
-        </UiIconButton>
+        />
       </div>
 
       <transition-group
@@ -47,14 +47,14 @@
         class="content-carousel-next-control"
         @click="nextSet"
       >
-        <UiIconButton
-          class="content-carousel-next-control-button"
+        <KIconButton
+          icon="forward"
+          appearance="raised-button"
+          class="content-carousel-control-button"
           :style="buttonTransforms"
           :disabled="isLastSet"
           size="large"
-        >
-          <KIcon icon="forward" style="top: 0; height: 24px; width: 24px;" />
-        </UiIconButton>
+        />
       </div>
 
     </div>
@@ -69,7 +69,6 @@
 
   import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import ContentCard from './ContentCard';
 
   if (!ContentCard.mixins) {
@@ -84,7 +83,6 @@
   export default {
     name: 'ContentCardGroupCarousel',
     components: {
-      UiIconButton,
       ContentCard,
     },
     mixins: [responsiveElementMixin],
@@ -313,16 +311,11 @@
     }
   }
 
-  .content-carousel-next-control-button,
-  .content-carousel-previous-control-button {
-    @extend %dropshadow-1dp;
+  .content-carousel-control-button {
     // center align within hitbox
     position: absolute;
     top: 50%;
     left: 50%;
-    &:active {
-      @extend %dropshadow-8dp;
-    }
   }
 
   // position-specific styles for each control button

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -65,6 +65,7 @@
         <template v-if="licenseDescription">
           <KIconButton
             :icon="licenceDescriptionIsVisible ? 'arrow_up' : 'arrow_down'"
+            :ariaLabel="$tr('toggleLicenseDescription')"
             size="small"
             type="secondary"
             @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -63,23 +63,12 @@
         {{ $tr('license', { license: licenseShortName }) }}
 
         <template v-if="licenseDescription">
-          <UiIconButton
-            :ariaLabel="$tr('toggleLicenseDescription')"
+          <KIconButton
+            :icon="licenceDescriptionIsVisible ? 'arrow_up' : 'arrow_down'"
             size="small"
             type="secondary"
             @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"
-          >
-            <KIcon
-              v-if="licenceDescriptionIsVisible"
-              icon="arrow_up"
-              style="top: 0; height: 24px; width: 24px;"
-            />
-            <KIcon
-              v-else
-              icon="arrow_down"
-              style="top: 0; height: 24px; width: 24px;"
-            />
-          </UiIconButton>
+          />
           <div v-if="licenceDescriptionIsVisible" dir="auto" class="license-details">
             <p class="license-details-name">
               {{ licenseLongName }}
@@ -137,7 +126,6 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import markdownIt from 'markdown-it';
   import {
     licenseShortName,
@@ -174,7 +162,6 @@
       DownloadButton,
       AssessmentWrapper,
       MasteredSnackbars,
-      UiIconButton,
     },
     mixins: [commonLearnStrings],
     data() {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -44,27 +44,29 @@
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
-            <KButton
-              :disabled="questionNumber === exam.question_count - 1"
-              :primary="true"
-              class="footer-button"
-              :dir="layoutDirReset"
-              @click="goToQuestion(questionNumber + 1)"
-            >
-              {{ $tr('nextQuestion') }}
-              <KIcon icon="forward" color="white" class="forward-icon" />
-            </KButton>
-            <KButton
-              :disabled="questionNumber === 0"
-              :primary="true"
-              class="footer-button"
-              :dir="layoutDirReset"
-              :class="{ 'left-align': windowIsSmall }"
-              @click="goToQuestion(questionNumber - 1)"
-            >
-              <KIcon icon="back" color="white" class="back-icon" />
-              {{ $tr('previousQuestion') }}
-            </KButton>
+            <KButtonGroup>
+              <KButton
+                :disabled="questionNumber === exam.question_count - 1"
+                :primary="true"
+                class="footer-button"
+                :dir="layoutDirReset"
+                @click="goToQuestion(questionNumber + 1)"
+              >
+                {{ $tr('nextQuestion') }}
+                <KIcon icon="forward" color="white" class="forward-icon" />
+              </KButton>
+              <KButton
+                :disabled="questionNumber === 0"
+                :primary="true"
+                class="footer-button"
+                :dir="layoutDirReset"
+                :class="{ 'left-align': windowIsSmall }"
+                @click="goToQuestion(questionNumber - 1)"
+              >
+                <KIcon icon="back" color="white" class="back-icon" />
+                {{ $tr('previousQuestion') }}
+              </KButton>
+            </KButtonGroup>
 
             <!-- below prev/next buttons in tab and DOM order, in footer -->
             <div

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -53,7 +53,7 @@
                 @click="goToQuestion(questionNumber + 1)"
               >
                 {{ $tr('nextQuestion') }}
-                <KIcon icon="forward" color="white" class="forward-icon" />
+                <KIcon slot="iconAfter" icon="forward" color="white" class="forward-icon" />
               </KButton>
               <KButton
                 :disabled="questionNumber === 0"
@@ -63,7 +63,7 @@
                 :class="{ 'left-align': windowIsSmall }"
                 @click="goToQuestion(questionNumber - 1)"
               >
-                <KIcon icon="back" color="white" class="back-icon" />
+                <KIcon slot="icon" icon="back" color="white" class="back-icon" />
                 {{ $tr('previousQuestion') }}
               </KButton>
             </KButtonGroup>

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -100,7 +100,6 @@
                 :text="$tr('submitExam')"
                 :primary="false"
                 appearance="flat-button"
-                style="margin-left: 0"
                 @click="toggleModal"
               />
             </div>

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/Snackbar.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/Snackbar.vue
@@ -10,13 +10,12 @@
           <slot name="content"></slot>
         </div>
         <div class="cell close-container">
-          <UiIconButton
+          <KIconButton
+            icon="close"
             size="small"
             :ariaLabel="coreString('closeAction')"
             @click="$emit('close')"
-          >
-            <KIcon icon="close" style="top: 0; width: 24px; height: 24px;" />
-          </UiIconButton>
+          />
         </div>
       </div>
     </div>
@@ -29,13 +28,9 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
 
   export default {
     name: 'Snackbar',
-    components: {
-      UiIconButton,
-    },
     mixins: [commonCoreStrings],
     $trs: {},
   };

--- a/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/MasteredSnackbars/index.vue
@@ -11,7 +11,7 @@
         @close="currentSnackbar = SNACKBARS.NEXT_RESOURCE"
       >
         <template v-slot:icon>
-          <ProgressIcon :progress="1" />
+          <ProgressIcon :progress="1" style="position: relative; top: -2px;" />
         </template>
 
         <template v-slot:content>
@@ -46,6 +46,7 @@
             class="content-icon icon-bg"
             :kind="nextContent.kind"
             :showTooltip="true"
+            :color="$themeTokens.textInverted"
             :style="{ backgroundColor: iconBackgroundColor, color: $themeTokens.textInverted }"
           />
         </template>

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -25,27 +25,21 @@
         :placeholder="coreString('searchLabel')"
       >
       <div class="search-buttons-wrapper">
-        <UiIconButton
-          color="black"
+        <KIconButton
+          icon="clear"
+          :color="$themeTokens.text"
           size="small"
           class="search-clear-button"
           :class="searchQuery === '' ? '' : 'search-clear-button-visible'"
-          :style="{ color: $themeTokens.text }"
           :ariaLabel="$tr('clearButtonLabel')"
           @click="handleClickClear"
-        >
-          <KIcon
-            icon="clear"
-            style="top:0; width: 24px; height: 24px;"
-          />
-        </UiIconButton>
-
+        />
         <div
           class="search-submit-button-wrapper"
           :style="{ backgroundColor: $themeTokens.primaryDark }"
         >
-          <UiIconButton
-            type="secondary"
+          <KIconButton
+            :icon="icon"
             color="white"
             class="search-submit-button"
             :disabled="!searchUpdate"
@@ -53,20 +47,7 @@
             :style="{ fill: $themeTokens.textInverted }"
             :ariaLabel="$tr('startSearchButtonLabel')"
             @click="search"
-          >
-            <KIcon
-              v-if="icon === 'search'"
-              icon="search"
-              style="top:0; width: 24px; height: 24px;"
-              :color="$themeTokens.textInverted"
-            />
-            <KIcon
-              v-if="icon === 'arrow_forward'"
-              icon="forward"
-              style="top:0; width: 24px; height: 24px;"
-              :color="$themeTokens.textInverted"
-            />
-          </UiIconButton>
+          />
         </div>
       </div>
     </div>
@@ -121,7 +102,6 @@
 
   import maxBy from 'lodash/maxBy';
   import { mapGetters, mapState } from 'vuex';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames } from '../constants';
@@ -139,9 +119,6 @@
 
   export default {
     name: 'SearchBox',
-    components: {
-      UiIconButton,
-    },
     mixins: [commonCoreStrings],
     props: {
       icon: {
@@ -344,7 +321,6 @@
     width: 24px;
     height: 24px;
     margin-right: 6px;
-    margin-left: 6px;
     vertical-align: middle;
     visibility: hidden;
   }

--- a/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ProgressToolbar.vue
@@ -6,19 +6,12 @@
     textColor="white"
     :removeNavIcon="!displayNavIcon"
   >
-    <UiIconButton
+    <KIconButton
       slot="icon"
-      type="secondary"
+      icon="back"
       color="white"
-      :class="{ 'rtl-icon': isRtl }"
       @click="$emit('backButtonClicked')"
-    >
-      <KIcon
-        icon="back"
-        :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
-      />
-    </UiIconButton>
+    />
     {{ $tr('progressIndicator', { currentStep , totalSteps }) }}
 
   </UiToolbar>
@@ -29,13 +22,11 @@
 <script>
 
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
 
   export default {
     name: 'ProgressToolbar',
     components: {
       UiToolbar,
-      UiIconButton,
     },
     props: {
       currentStep: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -22,7 +22,6 @@
       </div>
 
       <KButton
-        class="onboarding-form-submit"
         :primary="true"
         type="submit"
         :text="submitText"
@@ -84,10 +83,6 @@
 
   .onboarding-form-description {
     margin-bottom: 8px;
-  }
-
-  .onboarding-form-submit {
-    margin: 0;
   }
 
   .form-footer {

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -35,20 +35,22 @@
       />
 
       <div class="buttons">
-        <KButton
-          class="no-margin"
-          :text="coreString('saveAction')"
-          :disabled="formDisabled"
-          type="submit"
-          primary
-        />
-        <KButton
-          :text="cancelButtonText"
-          :disabled="formDisabled"
-          appearance="raised-button"
-          :primary="false"
-          @click="$router.push($router.getRoute('PROFILE'))"
-        />
+        <KButtonGroup>
+          <KButton
+            class="no-margin"
+            :text="coreString('saveAction')"
+            :disabled="formDisabled"
+            type="submit"
+            primary
+          />
+          <KButton
+            :text="cancelButtonText"
+            :disabled="formDisabled"
+            appearance="raised-button"
+            :primary="false"
+            @click="$router.push($router.getRoute('PROFILE'))"
+          />
+        </KButtonGroup>
       </div>
     </form>
   </KPageContainer>

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -37,7 +37,6 @@
       <div class="buttons">
         <KButtonGroup>
           <KButton
-            class="no-margin"
             :text="coreString('saveAction')"
             :disabled="formDisabled"
             type="submit"

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -87,7 +87,6 @@
             :primary="true"
             :text="atFirstStep ? coreString('continueAction') : coreString('finishAction')"
             type="submit"
-            class="submit"
           />
         </p>
 
@@ -363,10 +362,6 @@
 
   .privacy-link {
     margin-top: 24px;
-  }
-
-  .submit {
-    margin-left: 0;
   }
 
   .select {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

~**WIP**~

1. Implement KButtonGroup (done) 
2. Implement KIconButton in lieu of UiIconButton
3. Misc KDS related fixes (ie, wrongly named icon that I found).

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

**General information about how to test this**

See: https://github.com/learningequality/kolibri-design-system/pull/16

**KButtonGroup**

Here is where I added the KButtonGroup - check these out:

- Facility Settings buttons
- Facility > Data - "Sync facility data" buttons right of the name of your facility.
- Device > Channels > Manage Channel
- Device > Channels > Import by network modal
- Facility > Users > New user form
- Facility > Users > Edit user form
- Learn > Quiz bottom bar
- Edit profile page
- I added this in a few other places since writing this description originally.

Here are a few other notes:

- Verify that I've not missed any places where two KButtons are near each other.
- Also verify that other button placements are not out of wack. It is worth noting that top-right table buttons (Coach / Facility) are now aligned flush with the right side of their container. There are likely other places where this may be noticeable.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/5900

Kolibri Design System PR: https://github.com/learningequality/kolibri-design-system/pull/16

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
