### PR TITLE
allow links to be colored independently

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/BackLink.vue
@@ -13,13 +13,13 @@
         v-if="!isRtl"
         name="arrow_back"
         category="navigation"
-        :style="{ fill: $themeTokens.primary }"
+        :style="{ fill: $themeTokens.link }"
       />
       <mat-svg
         v-else
         name="arrow_forward"
         category="navigation"
-        :style="{ fill: $themeTokens.primary }"
+        :style="{ fill: $themeTokens.link }"
       />
     </UiIconButton>
     <KRouterLink :to="to" :text="text" />

--- a/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
+++ b/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
@@ -52,6 +52,8 @@ class ProfuturoThemeHook(theme_hook.ThemeHook):
                 "primary": "brand.primary.v_600",
                 "appBar": "brand.secondary.v_900",
                 "appBarDark": "#001d27",
+                "link": "brand.secondary.v_700",
+                "linkDark": "brand.secondary.v_900",
             },
             theme_hook.SIGN_IN: {
                 theme_hook.BACKGROUND: static("pf-bg.jpg"),

--- a/packages/kolibri-components/src/buttons-and-links/buttonMixin.js
+++ b/packages/kolibri-components/src/buttons-and-links/buttonMixin.js
@@ -62,8 +62,8 @@ export default {
     },
     linkStyle() {
       return {
-        color: this.$themeTokens.primary,
-        ':hover': { color: this.$themeTokens.primaryDark },
+        color: this.$themeTokens.link,
+        ':hover': { color: this.$themeTokens.linkDark },
         ':focus': this.$coreOutline,
         ':disabled': { opacity: 0.5 },
       };

--- a/packages/kolibri-components/src/styles/colorsDefault.js
+++ b/packages/kolibri-components/src/styles/colorsDefault.js
@@ -8,6 +8,8 @@ export const defaultTokenMapping = {
   textDisabled: 'palette.grey.v_300',
   annotation: 'palette.grey.v_700',
   textInverted: 'palette.white',
+  link: 'brand.primary.v_400',
+  linkDark: 'brand.primary.v_700',
   loading: 'brand.secondary.v_200',
   focusOutline: 'brand.secondary.v_200',
   surface: 'palette.white',


### PR DESCRIPTION
Previously, links were always primary. This allows them to be any color, and for PF makes the PF links secondary instead of primary.

This will eventually need to be migrated to the design system