### PR TITLE
pin build dependencies

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,12 +1,12 @@
 # Requirements for building wheels
 # This does not depend on runtime stuff so we do not
 # include base.txt
-sphinx
-sphinx-intl
-sphinx-rtd-theme
-sphinx-autobuild
+sphinx==2.4.4
+sphinx-intl==1.0.0
+sphinx-rtd-theme==0.4.3
+sphinx-autobuild==0.7.1
 pex<1.3
 wheel
 setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore
-beautifulsoup4
+beautifulsoup4==4.8.2
 requests==2.18.4

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,7 +1,7 @@
 # Requirements for building wheels
 # This does not depend on runtime stuff so we do not
 # include base.txt
-sphinx==2.4.4
+sphinx==1.8.5
 sphinx-intl==1.0.0
 sphinx-rtd-theme==0.4.3
 sphinx-autobuild==0.7.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,2 @@
 -r base.txt
-
-# These are for building the docs
-sphinx==1.7.4
-sphinx_rtd_theme
+-r build.txt


### PR DESCRIPTION
started causing breakage in 0.13, but we probably need to pin these as far back as possible and merge forward

