### PR TITLE
Remove sphinx from build-related dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,7 @@ requests==2.18.4
 cherrypy==13.0.1  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <13.1.0
 tempora<1.13  # derived no-upper-bounds dependency of cherrypy causing issues  # pyup: <1.13
 cheroot<6.2.0  # 6.2.0 introduced a namespaced pkg # pyup: <6.2.0
+more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 iceqube==0.0.4
 futures==3.1.1
 porter2stemmer==1.0

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,8 +1,7 @@
 # Requirements for building wheels
 # This does not depend on runtime stuff so we do not
 # include base.txt
-pex<1.3
-wheel
-setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore
+pex<1.6
+setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.8.2
 requests==2.18.4

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,5 @@
 # Requirements for building wheels
+# These requirements have to support Python 2.7
 # This does not depend on runtime stuff so we do not
 # include base.txt
 pex<1.6

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,10 +1,6 @@
 # Requirements for building wheels
 # This does not depend on runtime stuff so we do not
 # include base.txt
-sphinx
-sphinx-intl
-sphinx-rtd-theme
-sphinx-autobuild
 pex<1.3
 wheel
 setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,5 +4,5 @@
 pex<1.3
 wheel
 setuptools>=2.2,<20.11          # needed to get pex working # pyup: ignore
-beautifulsoup4
+beautifulsoup4==4.8.2
 requests==2.18.4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 # These are for building the docs
-sphinx==1.7.4
-sphinx_rtd_theme
-sphinx-intl
-sphinx-autobuild
+sphinx==2.4.4
+sphinx-intl==1.0.0
+sphinx-rtd-theme==0.4.3
+sphinx-autobuild==0.7.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,3 +3,5 @@
 # These are for building the docs
 sphinx==1.7.4
 sphinx_rtd_theme
+sphinx-intl
+sphinx-autobuild


### PR DESCRIPTION
### Summary

Test to see if Sphinx was ever necessary for building Kolibri.

Re: https://github.com/learningequality/kolibri/pull/6702#discussion_r399143095

### Reviewer guidance

Does the build work? If yes, I think it's safe to merge since the point of `build.txt` is to build Kolibri.

### References

https://github.com/learningequality/kolibri/pull/6702

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
