### PR TITLE
KOLIBRI_ZEROCONF_DISABLE to disable zeroconf broadcaster and listener

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -130,6 +130,11 @@ base_option_spec = {
             "default": False,
             "envvars": ("KOLIBRI_SERVER_PROFILE",),
         },
+        "ZEROCONF_DISABLE": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_ZEROCONF_DISABLE",),
+        },
     },
     "Paths": {
         "CONTENT_DIR": {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -98,23 +98,26 @@ class ServicesPlugin(SimplePlugin):
 
         scheduler.start_scheduler()
 
-        # Register the Kolibri zeroconf service so it will be discoverable on the network
-        from kolibri.core.discovery.utils.network.search import (
-            register_zeroconf_service,
-        )
+        if not conf.OPTIONS["Server"]["ZEROCONF_DISABLE"]:
+            # Register the Kolibri zeroconf service so it will be discoverable on the network
+            from kolibri.core.discovery.utils.network.search import (
+                register_zeroconf_service,
+            )
 
-        register_zeroconf_service(port=self.port)
+            register_zeroconf_service(port=self.port)
 
     def stop(self):
         scheduler.shutdown_scheduler()
         if self.workers is not None:
             for worker in self.workers:
                 worker.shutdown()
-        from kolibri.core.discovery.utils.network.search import (
-            unregister_zeroconf_service,
-        )
 
-        unregister_zeroconf_service()
+        if not conf.OPTIONS["Server"]["ZEROCONF_DISABLE"]:
+            from kolibri.core.discovery.utils.network.search import (
+                unregister_zeroconf_service,
+            )
+
+            unregister_zeroconf_service()
 
         if self.workers is not None:
             for worker in self.workers:

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -99,7 +99,7 @@ class ServicesPlugin(SimplePlugin):
         scheduler.start_scheduler()
 
         if not conf.OPTIONS["Server"]["ZEROCONF_DISABLE"]:
-            # Register the Kolibri zeroconf service so it will be discoverable on the network
+            # Kolibri zeroconf service: Periodically scans network and broadcasts self
             from kolibri.core.discovery.utils.network.search import (
                 register_zeroconf_service,
             )

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -38,12 +38,12 @@ while time() < now + timeout and status_code != 201:
     try:
         response = requests.post(url, json=data)
         status_code = response.status_code
-    except requests.exceptions.RequestException:
-        pass
+    except requests.exceptions.RequestException as e:
+        print("Exception requesting provisioning API: {}".format(e))
 
 if status_code == 201:
     print("success!")
     exit(0)
 else:
-    print("failed with status %i" % status_code)
+    print("failed with status {}".format(status_code))
     exit(1)


### PR DESCRIPTION
### Summary

A problem is reported in shutdown behavior of the Zeroconf service, so suggesting at the very least that it can be switched off -- both to test and to hot-fix potential issues.

https://community.learningequality.org/t/stop-job-on-raspberry-pi-when-shutting-down/1482/10

### Reviewer guidance

Can be released into 0.13.x?

### References

#6610

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
