### PR TITLE
Disable hashi on iOS

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -41,6 +41,10 @@
   import Hashi from 'hashi';
   import { nameSpace } from 'hashi/src/hashiBase';
 
+  // Regex vendored from https://github.com/faisalman/ua-parser-js/blob/master/src/ua-parser.js
+  const iOSTest = /ip[honead]{2,4}(?:.*os\s([\w]+)\slike\smac|;\sopera)/i;
+  const IE11Test = /(trident).+rv[:\s]([\w.]+).+like\sgecko/i;
+
   export default {
     name: 'Html5AppRendererIndex',
     components: {
@@ -57,11 +61,11 @@
         return nameSpace;
       },
       rooturl() {
-        // Due to a quirk of history, this will detect iOS and IE11.
-        // https://stackoverflow.com/a/9039885
-        const iOSorIE11 = /iPad|iPhone|iPod/.test(navigator.userAgent);
+        const iOSCheck = iOSTest.exec(navigator.userAgent);
+        const isOS8 = iOSCheck ? Number(iOSCheck[1].split('_')[0]) <= 8 : false;
+        const iOS8orIE11 = isOS8 || IE11Test.test(navigator.userAgent);
         // Skip hashi on requests for these browsers
-        return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
+        return this.defaultFile.storage_url + (iOS8orIE11 ? '?SKIP_HASHI=true' : '');
       },
     },
     mounted() {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -61,11 +61,10 @@
         return nameSpace;
       },
       rooturl() {
-        const iOSCheck = iOSTest.exec(navigator.userAgent);
-        const isOS8 = iOSCheck ? Number(iOSCheck[1].split('_')[0]) <= 8 : false;
-        const iOS8orIE11 = isOS8 || IE11Test.test(navigator.userAgent);
+        const isOS = iOSTest.test(navigator.userAgent);
+        const iOSorIE11 = isOS || IE11Test.test(navigator.userAgent);
         // Skip hashi on requests for these browsers
-        return this.defaultFile.storage_url + (iOS8orIE11 ? '?SKIP_HASHI=true' : '');
+        return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
       },
     },
     mounted() {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -61,8 +61,8 @@
         return nameSpace;
       },
       rooturl() {
-        const isOS = iOSTest.test(navigator.userAgent);
-        const iOSorIE11 = isOS || IE11Test.test(navigator.userAgent);
+        const iOS = iOSTest.test(navigator.userAgent);
+        const iOSorIE11 = iOS || IE11Test.test(navigator.userAgent);
         // Skip hashi on requests for these browsers
         return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
       },

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -57,7 +57,11 @@
         return nameSpace;
       },
       rooturl() {
-        return this.defaultFile.storage_url;
+        // Due to a quirk of history, this will detect iOS and IE11.
+        // https://stackoverflow.com/a/9039885
+        const iOSorIE11 = /iPad|iPhone|iPod/.test(navigator.userAgent);
+        // Skip hashi on requests for these browsers
+        return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
       },
     },
     mounted() {

--- a/packages/hashi/src/replaceScript.js
+++ b/packages/hashi/src/replaceScript.js
@@ -2,7 +2,7 @@ export function getScripts(doc) {
   const $scripts = doc.querySelectorAll('template[hashi-script="true"]');
   return [].map.call($scripts, $template => {
     const parentNode = $template.parentNode;
-    const node = $template.content.children[0];
+    const node = $template.content.childNodes[0];
     if ($template.hasAttribute('async')) {
       node.setAttribute('async', node.getAttribute('async') || true);
     } else {


### PR DESCRIPTION
### Summary
A previous bug fix (#6268) for Hashi had done a small refactor on how scripts are got from the page and loaded (in order to accommodate parsing the body and the head separately, so that HTML5 zips that rely on the body not being loaded as some sort of signal don't break).

Unfortunately, it was relying on the experimental `children` property of `DocumentFragment` as opposed to the canonical `childNodes` property. This caused a breakage in browsers that did not implement this experimental property.

### Reviewer guidance
Load up browserstack, choose iOS 8, and then use African Storybook or some other HTML5 content.

### References
Fixes #6624

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
