### PR TITLE
Fix missing "new version available" message in AvailableChannelsPage

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -175,20 +175,22 @@
         // We concatenate these arrays to keep to keep the same ordering from the
         // ManageContentPage, where installed channels are pushed to the front,
         // with their custom ordering.
-        const installedChannels = this.installedChannelsWithResources.map(channel => {
-          // Merge in version data to show the new-version notification
-          const match = find(this.availableChannels, { id: channel.id });
-          if (match) {
-            return {
-              ...channel,
-              installed_version: channel.version,
-              // match.latest_version is defined for unlisted channels.
-              // For public channels, match.version is the version reported by Studio.
-              // See getAllRemoteChannels action for details.
-              latest_version: match.latest_version || match.version,
-            };
-          }
-        }).filter(Boolean);
+        const installedChannels = this.installedChannelsWithResources
+          .map(channel => {
+            // Merge in version data to show the new-version notification
+            const match = find(this.availableChannels, { id: channel.id });
+            if (match) {
+              return {
+                ...channel,
+                installed_version: channel.version,
+                // match.latest_version is defined for unlisted channels.
+                // For public channels, match.version is the version reported by Studio.
+                // See getAllRemoteChannels action for details.
+                latest_version: match.latest_version || match.version,
+              };
+            }
+          })
+          .filter(Boolean);
         const notInstalledChannels = differenceBy(
           this.availableChannels,
           this.installedChannelsWithResources,

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -107,6 +107,8 @@
 <script>
 
   import { mapState, mapMutations, mapGetters } from 'vuex';
+  import find from 'lodash/find';
+  import differenceBy from 'lodash/differenceBy';
   import omit from 'lodash/omit';
   import some from 'lodash/some';
   import uniqBy from 'lodash/uniqBy';
@@ -170,19 +172,31 @@
         'transferType',
       ]),
       allChannels() {
-        const uninstalledChannels = this.availableChannels.filter(uninstalledChannel => {
-          return !this.installedChannelsWithResources.find(
-            ({ id }) => id === uninstalledChannel.id
-          );
-        });
-
+        // We concatenate these arrays to keep to keep the same ordering from the
+        // ManageContentPage, where installed channels are pushed to the front,
+        // with their custom ordering.
+        const installedChannels = this.installedChannelsWithResources.map(channel => {
+          // Merge in version data to show the new-version notification
+          const match = find(this.availableChannels, { id: channel.id });
+          if (match) {
+            return {
+              ...channel,
+              installed_version: channel.version,
+              // match.latest_version is defined for unlisted channels.
+              // For public channels, match.version is the version reported by Studio.
+              // See getAllRemoteChannels action for details.
+              latest_version: match.latest_version || match.version,
+            };
+          }
+        }).filter(Boolean);
+        const notInstalledChannels = differenceBy(
+          this.availableChannels,
+          this.installedChannelsWithResources,
+          'id'
+        );
         // Need to de-duplicate channels in case user enters same token twice, etc.
         return uniqBy(
-          [
-            ...this.newUnlistedChannels,
-            ...this.installedChannelsWithResources,
-            ...uninstalledChannels,
-          ],
+          [...this.newUnlistedChannels, ...installedChannels, ...notInstalledChannels],
           'id'
         );
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixes an issue where `latest_version` and `available_version` metadata wasn't being passed through to channel objects in the AvailableChannels page.

### Reviewer guidance

1. Test that the new-version notification shows up on private channels, public channels, and channels on USB drives. For public channels, one can modify the `content_channelmetadata` table `version` column to simulate a downgrade (clicking through to the upgrade page won't work though).

### References

Fixes #6718 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
