### PR TITLE
Improve performance of facility class admin pages

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -33,20 +33,20 @@ from rest_framework.response import Response
 from .constants import collection_kinds
 from .constants import role_kinds
 from .filters import HierarchyRelationsFilter
+from .models import AdHocGroup
 from .models import Classroom
 from .models import Collection
 from .models import Facility
 from .models import FacilityDataset
 from .models import FacilityUser
-from .models import AdHocGroup
 from .models import LearnerGroup
 from .models import Membership
 from .models import Role
+from .serializers import AdHocGroupSerializer
 from .serializers import ClassroomSerializer
 from .serializers import FacilityDatasetSerializer
 from .serializers import FacilitySerializer
 from .serializers import FacilityUserSerializer
-from .serializers import AdHocGroupSerializer
 from .serializers import LearnerGroupSerializer
 from .serializers import MembershipSerializer
 from .serializers import PublicFacilitySerializer
@@ -148,9 +148,7 @@ class FacilityUserFilter(FilterSet):
     )
 
     def filter_member_of(self, queryset, name, value):
-        return HierarchyRelationsFilter(queryset).filter_by_hierarchy(
-            target_user=F("id"), ancestor_collection=value
-        )
+        return queryset.filter(memberships__collection=value)
 
     class Meta:
         model = FacilityUser

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -148,7 +148,7 @@ class FacilityUserFilter(FilterSet):
     )
 
     def filter_member_of(self, queryset, name, value):
-        return queryset.filter(memberships__collection=value)
+        return queryset.filter(Q(memberships__collection=value) | Q(facility=value))
 
     class Meta:
         model = FacilityUser


### PR DESCRIPTION
### Summary
The `HierarchyRelationsFilter` produces complex queries that are not performant. This results in very slow queries to the point of timing out in large class sizes when querying the facility user endpoint with a `member_of` query parameter.

This changes how the `member_of` query parameter filters users, by instead looking for a direct membership. This means that users will no longer show as members of a parent collection by virtue of being a member of the child collection. Practically, this makes no difference, as we do not allow such things to be set through the interface, but we should eventually make this necessary in order to enforce this properly in the code.

### Reviewer guidance
Load the Facility admin page for a specific class - make sure it loads, and is accurate.

### References
Query summary before the change:
![Screenshot from 2020-03-30 15-48-24](https://user-images.githubusercontent.com/1680573/77969366-70bc2880-729e-11ea-8ac1-c163f9444267.png)

Query summary after the change:
![Screenshot from 2020-03-30 15-48-36](https://user-images.githubusercontent.com/1680573/77969387-7b76bd80-729e-11ea-95fe-10e766128a77.png)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
