### PR TITLE
Fix Device > Channels page not reflecting custom order in Firefox

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -121,10 +121,12 @@
         return this.managedTasks.filter(task => task.status === TaskStatuses.COMPLETED).length;
       },
       sortedChannels() {
-        return sortBy(
-          this.installedChannelsWithResources,
-          channel => -this.channelOrders[channel.id]
-        );
+        return sortBy(this.installedChannelsWithResources, channel => {
+          // Push Channels with Tasks to the top
+          const order = -this.channelOrders[channel.id];
+          // Need to explicitly return a number to correctly sort in Firefox
+          return Number.isNaN(order) ? 1 : order;
+        });
       },
       channelsAreInstalled() {
         return this.installedChannelsWithResources.length > 0;


### PR DESCRIPTION
### Summary

Fixes a bug where the custom channel order wasn't being sorted properly on Firefox because of a difference in how Lodash/sortby works on that browser.

### Reviewer guidance

1. Does the custom order show on all browsers?
1. When there is a Task involving a channel, does that channel get pushed to the top?

### References

Fixes #6729

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
