### PR TITLE
SCORM integration into Hashi redux

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -548,26 +548,22 @@ function _updateProgress(store, sessionProgress, summaryProgress, forceSave = fa
 }
 
 /**
- * Sets the progress of the current content item to progressPercent
+ * Sets the progress of the current content item to progressPercent.
+ * This is for renderers that track state internally and have their own
+ * way of calculating completion. They are responsible to load any previous
+ * session state if they need to use that when calculating progress.
  * To be called periodically by content renderers on interval or on pause
  * Must be called after initContentSession
  * @param {float} progressPercent
  * @param {boolean} forceSave
  */
 export function updateProgress(store, { progressPercent, forceSave = false }) {
-  /* Create aliases for logs */
-  const summaryLog = store.getters.logging.summary;
-  const sessionLog = store.getters.logging.session;
-
   /* Calculate progress based on progressPercent */
   // TODO rtibbles: Delegate this to the renderers?
   progressPercent = progressPercent || 0;
   const sessionProgress = Math.min(1, progressPercent);
-  const summaryProgress = summaryLog.id
-    ? Math.min(1, summaryLog.progress_before_current_session + sessionProgress)
-    : 0;
 
-  return _updateProgress(store, sessionProgress, summaryProgress, forceSave);
+  return _updateProgress(store, sessionProgress, sessionProgress, forceSave);
 }
 
 /**

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -548,7 +548,7 @@ function _updateProgress(store, sessionProgress, summaryProgress, forceSave = fa
 }
 
 /**
- * Update the progress percentage
+ * Sets the progress of the current content item to progressPercent
  * To be called periodically by content renderers on interval or on pause
  * Must be called after initContentSession
  * @param {float} progressPercent
@@ -562,11 +562,32 @@ export function updateProgress(store, { progressPercent, forceSave = false }) {
   /* Calculate progress based on progressPercent */
   // TODO rtibbles: Delegate this to the renderers?
   progressPercent = progressPercent || 0;
-  const sessionProgress = Math.min(1, sessionLog.progress + progressPercent);
+  const sessionProgress = Math.min(1, progressPercent);
   const summaryProgress = summaryLog.id
     ? Math.min(1, summaryLog.progress_before_current_session + sessionProgress)
     : 0;
 
+  return _updateProgress(store, sessionProgress, summaryProgress, forceSave);
+}
+
+/**
+ * Adds progressPercent to the current progress percentage
+ * To be called periodically by content renderers on interval or on pause
+ * Must be called after initContentSession
+ * @param {float} progressPercent
+ * @param {boolean} forceSave
+ */
+export function addProgress(store, { progressPercent, forceSave = false }) {
+  const summaryLog = store.getters.logging.summary;
+  const sessionLog = store.getters.logging.session;
+
+  progressPercent = progressPercent || 0;
+  const totalPercent = sessionLog.progress + progressPercent;
+
+  const sessionProgress = Math.min(1, totalPercent);
+  const summaryProgress = summaryLog.id
+    ? Math.min(1, summaryLog.progress_before_current_session + sessionProgress)
+    : 0;
   return _updateProgress(store, sessionProgress, summaryProgress, forceSave);
 }
 

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -86,15 +86,6 @@
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
       });
-      this.hashi.onProgressUpdate(progress => {
-        // If hashi does some progress updating, stop our automatic
-        // progress updating.
-        if (this.timeout) {
-          clearTimeout(this.timeout);
-          this.timeout = null;
-        }
-        this.$emit('updateProgress', progress);
-      });
       this.hashi.initialize(
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData
@@ -112,7 +103,11 @@
     methods: {
       recordProgress() {
         const totalTime = now() - this.startTime;
-        this.$emit('updateProgress', Math.max(0, totalTime / 3000000));
+        const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
+        this.$emit(
+          'updateProgress',
+          hashiProgress === null ? Math.max(0, totalTime / 3000000) : hashiProgress
+        );
         this.pollProgress();
       },
       pollProgress() {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -84,12 +84,13 @@
                 let rawPercent = 1;
                 let rawScore = score.raw;
 
-                // TODO: Needs testing with ranges outside 0-100, all content so far specifying min and max
-                // have these values, so behavior is the same as if they were not set.
+                // TODO: Needs testing with ranges outside 0-100, all content so far specifying
+                // min and max have these values, so behavior is the same as if they were not set.
                 if (score.min && score.max) {
                   // rawPercent = percent per range increment
                   // preMin = highest value before min, what to subtract from the range
-                  // rawScore = value from 1 to (max - preMin), assumes min and max are positive numbers
+                  // rawScore = value from 1 to (max - preMin), assumes min and max are
+                  // positive numbers
                   // this way we can calculate progress percent as value * incrementPercent
                   const preMin = Math.min(0, score.min - 1);
                   rawPercent = (score.max - preMin) / 100;

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -63,6 +63,23 @@
       sandbox() {
         return plugin_data.html5_sandbox_tokens;
       },
+      userData() {
+        return {
+          userId: this.userId,
+          userFullName: this.userFullName,
+          progress: this.progress,
+          complete: this.progress >= 1,
+          language: this.lang.id,
+          timeSpent: this.timeSpent,
+        };
+      },
+    },
+    watch: {
+      userData(newValue) {
+        if (newValue && this.hashi) {
+          this.hashi.updateData({ userData: newValue });
+        }
+      },
     },
     mounted() {
       this.hashi = new Hashi({ iframe: this.$refs.iframe, now });
@@ -78,14 +95,10 @@
         }
         this.$emit('updateProgress', progress);
       });
-      this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {}, {
-        userId: this.userId,
-        userFullName: this.userFullName,
-        progress: this.progress,
-        complete: this.progress >= 1,
-        language: this.lang.id,
-        timeSpent: this.timeSpent,
-      });
+      this.hashi.initialize(
+        (this.extraFields && this.extraFields.contentState) || {},
+        this.userData
+      );
       this.$emit('startTracking');
       this.startTime = now();
       this.pollProgress();

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -69,7 +69,14 @@
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
       });
-      this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {});
+      this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {}, {
+        userId: this.userId,
+        userFullName: this.userFullName,
+        progress: this.progress,
+        complete: this.progress < 1,
+        language: this.lang.id,
+        timeSpent: this.timeSpent,
+      });
       this.$emit('startTracking');
       this.startTime = now();
       this.pollProgress();

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -51,6 +51,7 @@
     data() {
       return {
         isInFullscreen: false,
+        useScormScoreAsProgress: true,
       };
     },
     computed: {
@@ -68,12 +69,46 @@
       this.hashi = new Hashi({ iframe: this.$refs.iframe, now });
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
+        if (data.SCORM && data.SCORM.version) {
+          if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+          }
+          if (data.SCORM.cmi && data.SCORM.cmi.core) {
+            const core = data.SCORM.cmi.core;
+            if (this.useScormScoreAsProgress) {
+              let score = core.score;
+              if (score) {
+                // If min and max are not set, raw will be a value in the range 0-100. Source:
+                // https://support.scorm.com/hc/en-us/articles/206166466-cmi-score-raw-whole-numbers-
+                let rawPercent = 1;
+                let rawScore = score.raw;
+
+                // TODO: Needs testing with ranges outside 0-100, all content so far specifying min and max
+                // have these values, so behavior is the same as if they were not set.
+                if (score.min && score.max) {
+                  // rawPercent = percent per range increment
+                  // preMin = highest value before min, what to subtract from the range
+                  // rawScore = value from 1 to (max - preMin), assumes min and max are positive numbers
+                  // this way we can calculate progress percent as value * incrementPercent
+                  const preMin = Math.min(0, score.min - 1);
+                  rawPercent = (score.max - preMin) / 100;
+                  rawScore = rawScore - preMin;
+                }
+
+                // Convert the raw value to a percentage increment.
+                let percent = (rawScore * rawPercent) / 100;
+                this.$emit('updateProgress', Math.min(1, Math.max(0, percent)));
+              }
+            }
+          }
+        }
       });
       this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {}, {
         userId: this.userId,
         userFullName: this.userFullName,
         progress: this.progress,
-        complete: this.progress < 1,
+        complete: this.progress >= 1,
         language: this.lang.id,
         timeSpent: this.timeSpent,
       });

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -28,6 +28,10 @@ oriented data synchronization.
         :extraFields="extraFields"
         :assessment="true"
         :itemId="itemId"
+        :progress="progress"
+        :userId="userId"
+        :userFullName="userFullName"
+        :timeSpent="timeSpent"
         @answerGiven="answerGiven"
         @hintTaken="hintTaken"
         @itemError="handleItemError"
@@ -163,6 +167,22 @@ oriented data synchronization.
       extraFields: {
         type: Object,
         default: () => {},
+      },
+      // An explicit record of the current progress through this
+      // piece of content.
+      progress: {
+        type: Number,
+        default: 0,
+      },
+      // An identifier for the user interacting with this content
+      userId: {
+        type: String,
+      },
+      userFullName: {
+        type: String,
+      },
+      timeSpent: {
+        type: Number,
       },
     },
     data() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -29,6 +29,7 @@
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
+        @addProgress="addProgress"
         @updateContentState="updateContentState"
       />
 
@@ -285,6 +286,7 @@
       ...mapActions({
         initSessionAction: 'initContentSession',
         updateProgressAction: 'updateProgress',
+        addProgressAction: 'addProgress',
         startTracking: 'startTrackingProgress',
         stopTracking: 'stopTrackingProgress',
         updateContentNodeState: 'updateContentState',
@@ -297,6 +299,12 @@
           updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
         );
         this.$emit('updateProgress', progressPercent);
+      },
+      addProgress(progressPercent, forceSave = false) {
+        this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
+        );
+        this.$emit('addProgress', progressPercent);
       },
       updateExerciseProgress(progressPercent) {
         this.$emit('updateProgress', progressPercent);

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -22,6 +22,10 @@
         :files="content.files"
         :available="content.available"
         :extraFields="extraFields"
+        :progress="summaryProgress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="summaryTimeSpent"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
@@ -41,6 +45,10 @@
         :channelId="channelId"
         :available="content.available"
         :extraFields="extraFields"
+        :progress="summaryProgress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="summaryTimeSpent"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateExerciseProgress"
@@ -177,7 +185,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'pageMode']),
+      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'pageMode', 'currentUserId']),
       ...mapState(['pageName']),
       ...mapState('topicsTree', ['content', 'channel', 'recommended']),
       ...mapState('topicsTree', {
@@ -188,8 +196,10 @@
       ...mapState({
         masteryAttempts: state => state.core.logging.mastery.totalattempts,
         summaryProgress: state => state.core.logging.summary.progress,
+        summaryTimeSpent: state => state.core.logging.summary.time_spent,
         sessionProgress: state => state.core.logging.session.progress,
         extraFields: state => state.core.logging.summary.extra_fields,
+        fullName: state => state.core.session.full_name,
       }),
       isTopic() {
         return this.content.kind === ContentNodeKinds.TOPIC;

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -402,7 +402,7 @@
       },
       recordProgress() {
         this.$emit(
-          'updateProgress',
+          'addProgress',
           Math.max(
             0,
             (this.dummyTime - this.progressStartingPoint) / Math.floor(this.player.duration())

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -579,6 +579,8 @@ export default class SCORM extends BaseShim {
     class Shim {
       LMSInitialize() {
         logger.debug('LMS Initialize called');
+        self.data.version = '1.2';
+        self.stateUpdated();
         return TRUE;
       }
 
@@ -610,7 +612,7 @@ export default class SCORM extends BaseShim {
         } catch (e) {
           if (e instanceof TypeError && e.name === SCORM_ERROR_NAME) {
             error = e.message;
-            return '';
+            return BLANK;
           }
           throw e;
         }
@@ -619,6 +621,7 @@ export default class SCORM extends BaseShim {
       LMSCommit() {
         error = ERRORS.NO_ERROR;
         logger.debug('LMS Commit called');
+        return TRUE;
       }
 
       LMSGetLastError() {
@@ -627,12 +630,12 @@ export default class SCORM extends BaseShim {
 
       LMSGetErrorString(errorCode) {
         logger.debug(`LMS Get Error String called with code ${errorCode}`);
-        return '';
+        return BLANK;
       }
 
       LMSGetDiagnostic(errorCode) {
         logger.debug(`LMS Get Diagnostic called with code ${errorCode}`);
-        return '';
+        return BLANK;
       }
     }
     this.shim = new Shim();

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -83,13 +83,19 @@ function singleAlphaNumeric(s) {
   return s.length === 1 && alphaNumeric.test(s);
 }
 
+function isStringLike(value) {
+  // Note: explicitly using double equals here instead of triple equals
+  // to check that we have a coerceable type (so exclude undefined, null, and functions)
+  return String(value) == value;
+}
+
 const trueFalse = /[01tf]/;
 
 const CMIFeedback = {
   validate(value, obj) {
     if (value === BLANK) {
       return true;
-    } else if (!value) {
+    } else if (!isStringLike(value)) {
       return false;
     }
     // Coerce the value to a string for validation
@@ -533,9 +539,7 @@ export function setByKeyPath(obj, keyPath, value, localSchema) {
       (innerSchema.values && !innerSchema.values[value]) ||
       // Otherwise, if there is no defined type and nothing else is set for
       // validation, just check that the value is valid as a string.
-      // Note: explicitly using double equals here instead of triple equals
-      // to check that we have a coerceable type (so exclude undefined, null, and functions)
-      (!innerSchema.type && String(value) == value)
+      (!innerSchema.type && !isStringLike(value))
     ) {
       throwError(ERRORS.INCORRECT_DATA_TYPE);
     }

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -11,139 +11,526 @@ const logger = console; //eslint-disable-line no-console
 
 const TRUE = 'true';
 
-const NO_ERROR = 0;
+const FALSE = 'false';
 
-// Keys for which '_child' property is defined
-// For simplicity, we just list the entire path here
-// and the desired return value.
-const childKeys = {
-  'cmi.core._children':
-    'student_id,student_name,lesson_location,credit,lesson_status,entry,score,total_time,lesson_mode,exit,session_time',
-  'cmi.core.score._children': 'raw,min,max',
-  'cmi.objectives._children': 'id,score,status',
-  'cmi.student_data._children': '',
-  'cmi.student_preference._children': 'language',
-  'cmi.interactions._children':
-    'id,objectives,time,type,correct_responses,weighting,student_response,result,latency',
+const BLANK = '';
+
+const ERRORS = {
+  NO_ERROR: 0,
+  GENERAL_EXCEPTION: 101,
+  INVALID_ARGUMENT_ERROR: 201,
+  ELEMENT_CANNOT_HAVE_CHILDREN: 202,
+  ELEMENT_NOT_AN_ARRAY: 203,
+  NOT_INITIALIZED: 301,
+  NOT_IMPLEMENTED_ERROR: 401,
+  ELEMENT_IS_KEYWORD: 402,
+  ELEMENT_IS_READ_ONLY: 403,
+  ELEMENT_IS_WRITE_ONLY: 404,
+  INCORRECT_DATA_TYPE: 405,
 };
 
-// Keys for which '_count' property is defined
-const countKeys = {
-  correct_responses: 'correct_responses',
-  interactions: 'interactions',
-  objectives: 'objectives',
+const READ_WRITE = {
+  // For reverse lookup purposes, these constants must match
+  RO: 'RO',
+  RW: 'RW',
+  WO: 'WO',
 };
 
-// Values which we will just return an empty value from
-const emptyKeys = {
-  'cmi.comments_from_lms': 'cmi.comments_from_lms',
-  'cmi.launch_data': 'cmi.launch_data',
+const CMIDecimal = {
+  validate(value) {
+    return !isNaN(value);
+  },
 };
+
+// Not clear whether the hours and minutes are optional, but setting them as so for safety.
+/* eslint-disable max-len */
+const timeSpanRegex = /(?:([0-9]{4}|[0-9]{2}):)?(?:([0-5][0-9]):)?([0-5][0-9](?:\.[0-9]{1,2})?)/;
+/* eslint-enable */
+
+const CMITimeSpan = {
+  validate(value) {
+    return timeSpanRegex.test(value);
+  },
+  convertFromSeconds(seconds) {
+    const format = value => (value < 10 ? '0' + value : value);
+    // Round seconds to two decimal places
+    const s = Math.round((seconds % 60) * 100) / 100;
+    const m = Math.floor((seconds % 3600) / 60);
+    const h = Math.floor(seconds / 3600);
+    // CMITimeSpan has a limit of 4 digits for hours, so return ''
+    // here for safety if the number is too large
+    if (h >= 10000) {
+      return '';
+    }
+    return `${format(h)}:${format(m)}:${format(s)}`;
+  },
+};
+
+// This is a 24 hour clock time, so requires all digits.
+/* eslint-disable max-len */
+const timeRegex = /((?:[0-1][0-9]|2[0-3])):([0-5][0-9]):([0-5][0-9](?:\.[0-9]{1,2})?)/;
+/* eslint-enable */
+
+const CMITime = {
+  validate(value) {
+    return timeRegex.test(value);
+  },
+};
+
+const alphaNumeric = /[0-9a-z]/;
+
+function singleAlphaNumeric(s) {
+  return s.length === 1 && alphaNumeric.test(s);
+}
+
+const trueFalse = /[01tf]/;
+
+const CMIFeedback = {
+  validate(value, obj) {
+    if (value === BLANK) {
+      return true;
+    } else if (!value) {
+      return false;
+    }
+    // Coerce the value to a string for validation
+    value = String(value);
+    if (obj.type === 'true-false') {
+      return trueFalse.test(value) && value.length === 1;
+    }
+    if (obj.type === 'choice') {
+      if (value[0] === '{') {
+        if (value[value.length - 1] === '}') {
+          value = value.substring(1, value.length - 1);
+        } else {
+          return false;
+        }
+      }
+      return value.split(',').every(singleAlphaNumeric);
+    }
+    if (obj.type === 'fill-in' || obj.type === 'performance') {
+      if (value.length <= 255) {
+        return true;
+      }
+      return false;
+    }
+    if (obj.type === 'numeric') {
+      return CMIDecimal.validate(value);
+    }
+    if (obj.type === 'likert') {
+      return alphaNumeric.test(String(value)) && value.length === 1;
+    }
+    if (obj.type === 'matching') {
+      if (value[0] === '{') {
+        if (value[value.length - 1] === '}') {
+          value = value.substring(1, value.length - 1);
+        } else {
+          return false;
+        }
+      }
+      return value.split(',').every(s => {
+        return s.length === 3 && s.split('.').every(singleAlphaNumeric);
+      });
+    }
+    if (obj.type === 'sequencing') {
+      return value.split(',').every(singleAlphaNumeric);
+    }
+  },
+};
+
+const SCORE_SCHEMA = {
+  hasChildren: true,
+  raw: {
+    type: CMIDecimal,
+    readWrite: READ_WRITE.RW,
+  },
+  min: {
+    type: CMIDecimal,
+    readWrite: READ_WRITE.RW,
+  },
+  max: {
+    type: CMIDecimal,
+    readWrite: READ_WRITE.RW,
+  },
+};
+
+const STATUS_SCHEMA = {
+  readWrite: READ_WRITE.RW,
+  values: {
+    passed: 'passed',
+    completed: 'completed',
+    failed: 'failed',
+    incomplete: 'incomplete',
+    browsed: 'browsed',
+    'not attempted': 'not attempted',
+    '': '',
+  },
+};
+
+const SCHEMA = {
+  cmi: {
+    hasChildren: true,
+    core: {
+      hasChildren: true,
+      student_id: {
+        fromUserData(userData) {
+          return userData.userId || '';
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      student_name: {
+        fromUserData(userData) {
+          return userData.userFullName || '';
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      lesson_location: {
+        readWrite: READ_WRITE.RW,
+      },
+      credit: {
+        fromUserData(userData) {
+          return userData.userId ? 'credit' : 'no-credit';
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      lesson_status: STATUS_SCHEMA,
+      entry: {
+        fromUserData(userData) {
+          if (userData.progress) {
+            return userData.progress < 1 ? 'resume' : '';
+          }
+          return 'ab-initio';
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      score: SCORE_SCHEMA,
+      total_time: {
+        type: CMITimeSpan,
+        fromUserData(userData) {
+          return CMITimeSpan.convertFromSeconds(userData.timeSpent ? userData.timeSpent : 0);
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      lesson_mode: {
+        fromUserData(userData) {
+          if (userData.userId) {
+            return userData.complete ? 'review' : 'normal';
+          }
+          return 'browse';
+        },
+        readWrite: READ_WRITE.RO,
+      },
+      exit: {
+        readWrite: READ_WRITE.WO,
+        values: {
+          'time-out': 'time-out',
+          suspend: 'suspend',
+          logout: 'logout',
+          '': '',
+        },
+      },
+      session_time: {
+        type: CMITimeSpan,
+        readWrite: READ_WRITE.WO,
+      },
+    },
+    launch_data: {
+      readWrite: READ_WRITE.RO,
+    },
+    comments: {
+      readWrite: READ_WRITE.RW,
+    },
+    comments_from_lms: {
+      readWrite: READ_WRITE.RO,
+    },
+    objectives: {
+      hasChildren: true,
+      arraySchema: {
+        id: {
+          readWrite: READ_WRITE.RW,
+        },
+        score: SCORE_SCHEMA,
+        status: STATUS_SCHEMA,
+      },
+    },
+    // We don't currently support any of the student_data subkeys
+    student_data: {
+      hasChildren: true,
+      mastery_score: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RO,
+      },
+      max_time_allowed: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RO,
+      },
+      time_limit_action: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RO,
+      },
+    },
+    student_preference: {
+      hasChildren: true,
+      language: {
+        fromUserData(userData) {
+          return userData.language ? userData.language : '';
+        },
+        readWrite: READ_WRITE.RW,
+      },
+      audio: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RW,
+      },
+      speed: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RW,
+      },
+      text: {
+        notImplemented: true,
+        readWrite: READ_WRITE.RW,
+      },
+    },
+    interactions: {
+      hasChildren: true,
+      arraySchema: {
+        id: {
+          readWrite: READ_WRITE.RW,
+        },
+        objectives: {
+          arraySchema: {
+            id: {
+              readWrite: READ_WRITE.WO,
+            },
+          },
+        },
+        time: {
+          type: CMITime,
+          readWrite: READ_WRITE.WO,
+        },
+        type: {
+          readWrite: READ_WRITE.WO,
+          values: {
+            'true-false': 'true-false',
+            choice: 'choice',
+            'fill-in': 'fill-in',
+            matching: 'matching',
+            performance: 'performance',
+            sequencing: 'sequencing',
+            likert: 'likert',
+            numeric: 'numeric',
+            '': '',
+          },
+        },
+        correct_responses: {
+          arraySchema: {
+            pattern: {
+              readWrite: READ_WRITE.WO,
+            },
+          },
+        },
+        weighting: {
+          type: CMIDecimal,
+          readWrite: READ_WRITE.WO,
+        },
+        student_response: {
+          type: CMIFeedback,
+          readWrite: READ_WRITE.WO,
+        },
+        result: {
+          readWrite: READ_WRITE.WO,
+          validate(value) {
+            const values = {
+              correct: 'correct',
+              wrong: 'wrong',
+              unanticipated: 'unanticipated',
+              neutral: 'neutral',
+              '': '',
+            };
+            return CMIDecimal.validate(value) || values[value];
+          },
+        },
+        latency: {
+          readWrite: READ_WRITE.WO,
+          type: CMITimeSpan,
+        },
+      },
+    },
+  },
+};
+
+const SCORM_ERROR_NAME = 'SCORMError';
+
+function throwError(errorCode) {
+  const error = TypeError(errorCode);
+  error.name = SCORM_ERROR_NAME;
+  throw error;
+}
 
 // Vendored and modified from
 // https://github.com/dfahlander/Dexie.js/blob/2337c0fcb093219c07723f81363b806d203f5c8b/src/functions/utils.ts#L118
 
-export function getByKeyPath(obj, keyPath) {
+export function getByKeyPath(obj, keyPath, localSchema, userData) {
+  // If a keyPath is empty, if no schema exists for it, or if it is not a string
+  // throw an invalid argument error.
+  if (!keyPath || !localSchema || typeof keyPath !== 'string') {
+    throwError(ERRORS.INVALID_ARGUMENT_ERROR);
+  }
+  // If we are trying to read from a write only property, throw an error
+  if (localSchema[keyPath] && localSchema[keyPath].readWrite === READ_WRITE.WO) {
+    throwError(ERRORS.ELEMENT_IS_WRITE_ONLY);
+  }
+  // If we have defined how this is derived from user data that is fed in from
+  // Kolibri, then return this value instead of looking for it in our data object.
+  if (localSchema[keyPath] && localSchema[keyPath].fromUserData) {
+    return localSchema[keyPath].fromUserData(userData);
+  }
   // http://www.w3.org/TR/IndexedDB/#steps-for-extracting-a-key-from-a-value-using-a-key-path
-  if (obj.hasOwnProperty(keyPath)) {
-    return obj[keyPath]; // This line is moved from last to first for optimization purpose.
-  }
-  if (!keyPath) {
-    return obj;
-  }
-  if (typeof keyPath !== 'string') {
-    const rv = [];
-    for (let i = 0, l = keyPath.length; i < l; ++i) {
-      rv.push(getByKeyPath(obj, keyPath[i]));
-    }
-    return rv;
+  // This works for getting values from Objects by key and from Arrays by index
+  if (obj && obj.hasOwnProperty(keyPath)) {
+    return obj[keyPath];
   }
   const period = keyPath.indexOf('.');
+  // If there is a separator still in the keyPath
   if (period !== -1) {
     const leadingKeyPath = keyPath.substr(0, period);
-    const innerObj = obj[leadingKeyPath];
+    const innerObj = obj ? obj[leadingKeyPath] : obj;
     const innerKeyPath = keyPath.substr(period + 1);
-    if (innerKeyPath === '_count' && countKeys[leadingKeyPath] && Array.isArray(obj)) {
-      return obj.length;
+    let innerSchema = localSchema[leadingKeyPath];
+    if (innerSchema && innerSchema.arraySchema) {
+      // If the inner schema is for an array, pass
+      // the arraySchema instead
+      innerSchema = innerSchema.arraySchema;
+    } else if (!isNaN(leadingKeyPath)) {
+      // If the path is indexing into an array,
+      // we keep the array schema from the parent
+      innerSchema = localSchema;
     }
-    return innerObj === undefined ? undefined : getByKeyPath(innerObj, innerKeyPath);
+    if (innerKeyPath === '_count') {
+      // If the inner key is requesting a count, we check that we have a valid schema
+      // for the keyPath up until this point, and check that this is for an array in the schema
+      if (localSchema[leadingKeyPath] && localSchema[leadingKeyPath].arraySchema) {
+        // It is, so first we check if the data object has an array
+        if (Array.isArray(innerObj)) {
+          // If so, return this array's length
+          return innerObj.length;
+        } else {
+          // If not, it is effectively a zero length array
+          return 0;
+        }
+      } else {
+        // Otherwise, they tried to get the length of an element that is not an array in the
+        // schema - throw the appropriate error.
+        throwError(ERRORS.ELEMENT_NOT_AN_ARRAY);
+      }
+    }
+    if (innerKeyPath === '_children') {
+      // If the inner key is requesting the children, check to see that we have a valid schema
+      // for the keyPath up until this point, and check that this has children
+      if (localSchema[leadingKeyPath] && localSchema[leadingKeyPath].hasChildren) {
+        // If so, return the child keys of the appropriate inner schema (by using innerSchema
+        // we can expose the children of array properties as well).
+        return (
+          Object.keys(innerSchema)
+            // Filter out the `hasChildren` key which is our own special marker.
+            // Also filter out keys that we have not implemented yet.
+            .filter(key => key !== 'hasChildren' && !innerSchema[key].notImplemented)
+            .join(',')
+        );
+      } else {
+        // Otherwise, they tried to get the children of a property that does not allow it
+        // throw the appropriate error.
+        throwError(ERRORS.ELEMENT_CANNOT_HAVE_CHILDREN);
+      }
+    }
+    // Recurse further to get the data we are after.
+    return getByKeyPath(innerObj, innerKeyPath, innerSchema, userData);
   }
-  return undefined;
+  // If we have got to this point, we do not a representation of the relevant
+  // keyPath in the object, and we have finished recursing through the keyPath
+  // Check if the remaining keyPath is in the schema at all and if we support it
+  if (localSchema[keyPath] && !localSchema[keyPath].notImplemented) {
+    // If so, just return a blank response, which is always valid.
+    return BLANK;
+  } else if (localSchema[keyPath] && localSchema[keyPath].notImplemented) {
+    // If it is in the schema but not implemented, return the appropriate error
+    throwError(ERRORS.NOT_IMPLEMENTED_ERROR);
+  }
+  // Otherwise, this is not a valid argument, so throw here.
+  throwError(ERRORS.INVALID_ARGUMENT_ERROR);
 }
 
-export function setByKeyPath(obj, keyPath, value) {
-  if (!obj || keyPath === undefined) {
-    return;
+export function setByKeyPath(obj, keyPath, value, localSchema) {
+  // Can't set blank keyPaths on non-existent schemas that are not strings!
+  if (!keyPath || !localSchema || typeof keyPath !== 'string') {
+    throwError(ERRORS.INVALID_ARGUMENT_ERROR);
   }
-  if ('isFrozen' in Object && Object.isFrozen(obj)) {
-    return;
-  }
-  if (typeof keyPath !== 'string' && 'length' in keyPath) {
-    for (let i = 0, l = keyPath.length; i < l; ++i) {
-      setByKeyPath(obj, keyPath[i], value[i]);
+  // Check to see if we still need to recurse the keyPath
+  const period = keyPath.indexOf('.');
+  if (period !== -1) {
+    // If so, get the first part of the keyPath before the first separator
+    const leadingKeyPath = keyPath.substr(0, period);
+    // Get the remainder of the keyPath after the first separator
+    const innerKeyPath = keyPath.substr(period + 1);
+    // Try getting the relevant subsection of the schema for this subsection
+    // of the keyPath
+    let innerSchema = localSchema[leadingKeyPath];
+    if (innerSchema && innerSchema.arraySchema) {
+      // If the inner schema is for an array, pass
+      // the arraySchema instead
+      innerSchema = innerSchema.arraySchema;
+      // Set the inner object to an Array here, to prevent it
+      // being set to an object later:
+      obj[leadingKeyPath] = obj[leadingKeyPath] || [];
+    } else if (!isNaN(leadingKeyPath)) {
+      // If the path is indexing into an array,
+      // we keep the array schema from the parent
+      innerSchema = localSchema;
     }
+    // If the remaining key path we are after is either for a count or children
+    // we can raise an error here, as we are not allowed to set these.
+    if (innerKeyPath === '_count' || innerKeyPath === '_children') {
+      throwError(ERRORS.ELEMENT_IS_KEYWORD);
+    }
+    // In case we have not set any data in this part of the object before,
+    // initialize the key to a blank object if not already initialized.
+    obj[leadingKeyPath] = obj[leadingKeyPath] || {};
+    // Recurse the key path setting!
+    setByKeyPath(obj[leadingKeyPath], innerKeyPath, value, innerSchema);
   } else {
-    const period = keyPath.indexOf('.');
-    if (period !== -1) {
-      const currentKeyPath = keyPath.substr(0, period);
-      const remainingKeyPath = keyPath.substr(period + 1);
-      if (remainingKeyPath === '') {
-        if (value === undefined) {
-          if (Array.isArray(obj) && !isNaN(parseInt(currentKeyPath))) {
-            obj.splice(currentKeyPath, 1);
-          } else {
-            delete obj[currentKeyPath];
-          }
-        } else {
-          obj[currentKeyPath] = value;
-        }
-      } else {
-        obj[currentKeyPath] = obj[currentKeyPath] || {};
-        setByKeyPath(obj[currentKeyPath], remainingKeyPath, value);
-      }
-    } else {
-      if (value === undefined) {
-        if (Array.isArray(obj) && !isNaN(parseInt(keyPath))) {
-          obj.splice(keyPath, 1);
-        } else {
-          delete obj[keyPath];
-        }
-      } else {
-        obj[keyPath] = value;
-      }
+    const innerSchema = localSchema[keyPath];
+    // If we are trying to write to a read only property, throw an error
+    if (innerSchema && innerSchema.readWrite === READ_WRITE.RO) {
+      throwError(ERRORS.ELEMENT_IS_READ_ONLY);
     }
+    // If we are trying to write to a property we have not implemented, throw an error
+    if (innerSchema && innerSchema.notImplemented) {
+      throwError(ERRORS.NOT_IMPLEMENTED_ERROR);
+    }
+    // If we are trying to write to a property that does not exist on the schema, throw an error
+    if (!innerSchema) {
+      throwError(ERRORS.INVALID_ARGUMENT_ERROR);
+    }
+    // Conduct validation based on the schema we have inferred.
+    if (
+      // First check if we have a defined type and run validation against it
+      (innerSchema.type && !innerSchema.type.validate(value, obj)) ||
+      // If there is a directly defined validation function on the schema,
+      // check that
+      (innerSchema.validate && !innerSchema.validate(value, obj)) ||
+      // If the schema defines a set of allowed values, check that it is
+      // included.
+      (innerSchema.values && !innerSchema.values[value]) ||
+      // Otherwise, if there is no defined type and nothing else is set for
+      // validation, just check that the value is valid as a string.
+      // Note: explicitly using double equals here instead of triple equals
+      // to check that we have a coerceable type (so exclude undefined, null, and functions)
+      (!innerSchema.type && String(value) == value)
+    ) {
+      throwError(ERRORS.INCORRECT_DATA_TYPE);
+    }
+    // If we've got this far, we can set the value!
+    obj[keyPath] = value;
   }
 }
-
-const userDataMap = {
-  'cmi.core.student_id': function(userData) {
-    return userData.userId || '';
-  },
-  'cmi.core.student_name': function(userData) {
-    return userData.userFullName || '';
-  },
-  'cmi.core.entry': function(userData) {
-    if (userData.progress) {
-      return userData.progress < 1 ? 'resume' : '';
-    }
-    return 'ab-initio';
-  },
-  'cmi.core.lesson_mode': function(userData) {
-    if (userData.userId) {
-      return userData.complete ? 'review' : 'normal';
-    }
-    return 'browse';
-  },
-  'cmi.core.credit': function(userData) {
-    return userData.userId ? 'credit' : 'no-credit';
-  },
-  'cmi.student_preference.language': function(userData) {
-    return userData.language ? userData.language : '';
-  },
-  'cmi.core.total_time': function(userData) {
-    return userData.timeSpent ? userData.timeSpent : 0;
-  },
-};
 
 export default class SCORM extends BaseShim {
   constructor(mediator) {
@@ -187,48 +574,64 @@ export default class SCORM extends BaseShim {
   __setShimInterface() {
     const self = this;
 
+    let error = ERRORS.NO_ERROR;
+
     class Shim {
       LMSInitialize() {
-        logger.log('LMS Initialize called');
+        logger.debug('LMS Initialize called');
         return TRUE;
       }
 
       LMSFinish() {
-        logger.log('LMS Finish called');
+        logger.debug('LMS Finish called');
         return TRUE;
       }
       LMSSetValue(CMIElement, value) {
-        setByKeyPath(self.data, CMIElement, value);
-        logger.log(`LMSSetValue called with path: ${CMIElement} and value ${value}`);
+        error = ERRORS.NO_ERROR;
+        logger.debug(`LMSSetValue called with path: ${CMIElement} and value ${value}`);
+        try {
+          setByKeyPath(self.data, CMIElement, value, SCHEMA);
+        } catch (e) {
+          if (e instanceof TypeError && e.name === SCORM_ERROR_NAME) {
+            error = e.message;
+            return FALSE;
+          }
+          throw e;
+        }
         self.stateUpdated();
+        return TRUE;
       }
 
       LMSGetValue(CMIElement) {
-        logger.log(`LMSGetValue called with path: ${CMIElement}`);
-        if (childKeys[CMIElement]) {
-          return childKeys[CMIElement];
+        error = ERRORS.NO_ERROR;
+        logger.debug(`LMSGetValue called with path: ${CMIElement}`);
+        try {
+          return getByKeyPath(self.data, CMIElement, SCHEMA, self.userData);
+        } catch (e) {
+          if (e instanceof TypeError && e.name === SCORM_ERROR_NAME) {
+            error = e.message;
+            return '';
+          }
+          throw e;
         }
-        if (emptyKeys[CMIElement]) {
-          return '';
-        }
-        return getByKeyPath(self.data, CMIElement);
       }
 
       LMSCommit() {
-        logger.log('LMS Commit called');
+        error = ERRORS.NO_ERROR;
+        logger.debug('LMS Commit called');
       }
 
       LMSGetLastError() {
-        return NO_ERROR;
+        return error;
       }
 
       LMSGetErrorString(errorCode) {
-        logger.log(`LMS Get Error String called with code ${errorCode}`);
+        logger.debug(`LMS Get Error String called with code ${errorCode}`);
         return '';
       }
 
       LMSGetDiagnostic(errorCode) {
-        logger.log(`LMS Get Diagnostic called with code ${errorCode}`);
+        logger.debug(`LMS Get Diagnostic called with code ${errorCode}`);
         return '';
       }
     }

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -1,0 +1,237 @@
+/**
+ * This class offers an API-compatible replacement window.API for SCORM modules
+ * to be used when apps are run in sandbox mode.
+ *
+ * For more information, see:
+ * https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/
+ */
+import BaseShim from './baseShim';
+
+const logger = console; //eslint-disable-line no-console
+
+const TRUE = 'true';
+
+const NO_ERROR = 0;
+
+// Keys for which '_child' property is defined
+// For simplicity, we just list the entire path here
+// and the desired return value.
+const childKeys = {
+  'cmi.core._children':
+    'student_id,student_name,lesson_location,credit,lesson_status,entry,score,total_time,lesson_mode,exit,session_time',
+  'cmi.core.score._children': 'raw,min,max',
+  'cmi.objectives._children': 'id,score,status',
+  'cmi.student_data._children': '',
+  'cmi.student_preference._children': 'language',
+  'cmi.interactions._children':
+    'id,objectives,time,type,correct_responses,weighting,student_response,result,latency',
+};
+
+// Keys for which '_count' property is defined
+const countKeys = {
+  correct_responses: 'correct_responses',
+  interactions: 'interactions',
+  objectives: 'objectives',
+};
+
+// Values which we will just return an empty value from
+const emptyKeys = {
+  'cmi.comments_from_lms': 'cmi.comments_from_lms',
+  'cmi.launch_data': 'cmi.launch_data',
+};
+
+// Vendored and modified from
+// https://github.com/dfahlander/Dexie.js/blob/2337c0fcb093219c07723f81363b806d203f5c8b/src/functions/utils.ts#L118
+
+export function getByKeyPath(obj, keyPath) {
+  // http://www.w3.org/TR/IndexedDB/#steps-for-extracting-a-key-from-a-value-using-a-key-path
+  if (obj.hasOwnProperty(keyPath)) {
+    return obj[keyPath]; // This line is moved from last to first for optimization purpose.
+  }
+  if (!keyPath) {
+    return obj;
+  }
+  if (typeof keyPath !== 'string') {
+    const rv = [];
+    for (let i = 0, l = keyPath.length; i < l; ++i) {
+      rv.push(getByKeyPath(obj, keyPath[i]));
+    }
+    return rv;
+  }
+  const period = keyPath.indexOf('.');
+  if (period !== -1) {
+    const leadingKeyPath = keyPath.substr(0, period);
+    const innerObj = obj[leadingKeyPath];
+    const innerKeyPath = keyPath.substr(period + 1);
+    if (innerKeyPath === '_count' && countKeys[leadingKeyPath] && Array.isArray(obj)) {
+      return obj.length;
+    }
+    return innerObj === undefined ? undefined : getByKeyPath(innerObj, innerKeyPath);
+  }
+  return undefined;
+}
+
+export function setByKeyPath(obj, keyPath, value) {
+  if (!obj || keyPath === undefined) {
+    return;
+  }
+  if ('isFrozen' in Object && Object.isFrozen(obj)) {
+    return;
+  }
+  if (typeof keyPath !== 'string' && 'length' in keyPath) {
+    for (let i = 0, l = keyPath.length; i < l; ++i) {
+      setByKeyPath(obj, keyPath[i], value[i]);
+    }
+  } else {
+    const period = keyPath.indexOf('.');
+    if (period !== -1) {
+      const currentKeyPath = keyPath.substr(0, period);
+      const remainingKeyPath = keyPath.substr(period + 1);
+      if (remainingKeyPath === '') {
+        if (value === undefined) {
+          if (Array.isArray(obj) && !isNaN(parseInt(currentKeyPath))) {
+            obj.splice(currentKeyPath, 1);
+          } else {
+            delete obj[currentKeyPath];
+          }
+        } else {
+          obj[currentKeyPath] = value;
+        }
+      } else {
+        obj[currentKeyPath] = obj[currentKeyPath] || {};
+        setByKeyPath(obj[currentKeyPath], remainingKeyPath, value);
+      }
+    } else {
+      if (value === undefined) {
+        if (Array.isArray(obj) && !isNaN(parseInt(keyPath))) {
+          obj.splice(keyPath, 1);
+        } else {
+          delete obj[keyPath];
+        }
+      } else {
+        obj[keyPath] = value;
+      }
+    }
+  }
+}
+
+const userDataMap = {
+  'cmi.core.student_id': function(userData) {
+    return userData.userId || '';
+  },
+  'cmi.core.student_name': function(userData) {
+    return userData.userFullName || '';
+  },
+  'cmi.core.entry': function(userData) {
+    if (userData.progress) {
+      return userData.progress < 1 ? 'resume' : '';
+    }
+    return 'ab-initio';
+  },
+  'cmi.core.lesson_mode': function(userData) {
+    if (userData.userId) {
+      return userData.complete ? 'review' : 'normal';
+    }
+    return 'browse';
+  },
+  'cmi.core.credit': function(userData) {
+    return userData.userId ? 'credit' : 'no-credit';
+  },
+  'cmi.student_preference.language': function(userData) {
+    return userData.language ? userData.language : '';
+  },
+  'cmi.core.total_time': function(userData) {
+    return userData.timeSpent ? userData.timeSpent : 0;
+  },
+};
+
+export default class SCORM extends BaseShim {
+  constructor(mediator) {
+    super(mediator);
+    this.data = {};
+    this.nameSpace = 'SCORM';
+    this.__setData = this.__setData.bind(this);
+    this.on(this.events.STATEUPDATE, this.__setData);
+  }
+
+  __setData(data = {}, userData) {
+    this.data = data;
+    if (userData) {
+      for (let key in userDataMap) {
+        setByKeyPath(this.data, key, userDataMap[key](userData));
+      }
+    }
+  }
+
+  iframeInitialize() {
+    this.__setShimInterface();
+    // window.parent is our own shim, so we use regular assignment
+    // here to play nicely with the Proxy we are using.
+    try {
+      window.parent.API = this.shim;
+    } catch (e) {
+      if (e instanceof DOMException) {
+        // If this is a result of trying to touch a secure property
+        // this will be a DOMException error. Catch and just return nothing.
+        logger.warn(
+          'Tried to setup the SCORM API in a sandboxed environment, it will not be enabled'
+        );
+        return;
+      }
+      throw e;
+    }
+  }
+
+  __setShimInterface() {
+    const self = this;
+
+    class Shim {
+      LMSInitialize() {
+        logger.log('LMS Initialize called');
+        return TRUE;
+      }
+
+      LMSFinish() {
+        logger.log('LMS Finish called');
+        return TRUE;
+      }
+      LMSSetValue(CMIElement, value) {
+        setByKeyPath(self.data, CMIElement, value);
+        logger.log(`LMSSetValue called with path: ${CMIElement} and value ${value}`);
+        self.stateUpdated();
+      }
+
+      LMSGetValue(CMIElement) {
+        logger.log(`LMSGetValue called with path: ${CMIElement}`);
+        if (childKeys[CMIElement]) {
+          return childKeys[CMIElement];
+        }
+        if (emptyKeys[CMIElement]) {
+          return '';
+        }
+        return getByKeyPath(self.data, CMIElement);
+      }
+
+      LMSCommit() {
+        logger.log('LMS Commit called');
+      }
+
+      LMSGetLastError() {
+        return NO_ERROR;
+      }
+
+      LMSGetErrorString(errorCode) {
+        logger.log(`LMS Get Error String called with code ${errorCode}`);
+        return '';
+      }
+
+      LMSGetDiagnostic(errorCode) {
+        logger.log(`LMS Get Diagnostic called with code ${errorCode}`);
+        return '';
+      }
+    }
+    this.shim = new Shim();
+
+    return this.shim;
+  }
+}

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -95,9 +95,12 @@ const CMIFeedback = {
     // Coerce the value to a string for validation
     value = String(value);
     if (obj.type === 'true-false') {
+      // Single character matching the valid true false characters
       return trueFalse.test(value) && value.length === 1;
     }
     if (obj.type === 'choice') {
+      // Choice is comma separated list of 0-9 and a-z
+      // Can also be wrapped in curly braces
       if (value[0] === '{') {
         if (value[value.length - 1] === '}') {
           value = value.substring(1, value.length - 1);
@@ -108,18 +111,24 @@ const CMIFeedback = {
       return value.split(',').every(singleAlphaNumeric);
     }
     if (obj.type === 'fill-in' || obj.type === 'performance') {
+      // Ensure it doesn't exceed the max length
       if (value.length <= 255) {
         return true;
       }
       return false;
     }
     if (obj.type === 'numeric') {
+      // Just validate that it's a number
       return CMIDecimal.validate(value);
     }
     if (obj.type === 'likert') {
+      // A single alphanumeric character
       return alphaNumeric.test(String(value)) && value.length === 1;
     }
     if (obj.type === 'matching') {
+      // Like the choice type, except that the comma separated
+      // values are pairs separted by '.'
+      // e.g. 'a.b,1.c'
       if (value[0] === '{') {
         if (value[value.length - 1] === '}') {
           value = value.substring(1, value.length - 1);
@@ -132,8 +141,11 @@ const CMIFeedback = {
       });
     }
     if (obj.type === 'sequencing') {
+      // Comma separated list of single characters
       return value.split(',').every(singleAlphaNumeric);
     }
+    // No type, return true as we can't validate
+    return true;
   },
 };
 
@@ -554,8 +566,6 @@ export default class SCORM extends BaseShim {
 
   iframeInitialize() {
     this.__setShimInterface();
-    // window.parent is our own shim, so we use regular assignment
-    // here to play nicely with the Proxy we are using.
     try {
       window.parent.API = this.shim;
     } catch (e) {

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -149,18 +149,20 @@ export default class SCORM extends BaseShim {
   constructor(mediator) {
     super(mediator);
     this.data = {};
+    this.userData = {};
     this.nameSpace = 'SCORM';
     this.__setData = this.__setData.bind(this);
+    this.__setUserData = this.__setUserData.bind(this);
     this.on(this.events.STATEUPDATE, this.__setData);
+    this.on(this.events.USERDATAUPDATE, this.__setUserData);
   }
 
-  __setData(data = {}, userData) {
+  __setData(data = {}) {
     this.data = data;
-    if (userData) {
-      for (let key in userDataMap) {
-        setByKeyPath(this.data, key, userDataMap[key](userData));
-      }
-    }
+  }
+
+  __setUserData(userData = {}) {
+    this.userData = userData;
   }
 
   iframeInitialize() {

--- a/packages/hashi/src/baseShim.js
+++ b/packages/hashi/src/baseShim.js
@@ -43,8 +43,4 @@ export default class BaseShim {
   userDataUpdated() {
     this.sendMessage(this.events.USERDATAUPDATE, this.userData);
   }
-
-  updateProgress(progress) {
-    this.sendMessage(this.events.PROGRESSUPDATE, progress);
-  }
 }

--- a/packages/hashi/src/baseShim.js
+++ b/packages/hashi/src/baseShim.js
@@ -6,9 +6,16 @@ export default class BaseShim {
     this.events = Object.assign({}, events);
   }
 
-  setData(data, userData) {
-    this.__setData(data, userData);
+  setData(data) {
+    this.__setData(data);
     this.stateUpdated();
+  }
+
+  setUserData(data) {
+    if (this.__setUserData) {
+      this.__setUserData(data);
+      this.userDataUpdated();
+    }
   }
 
   sendMessage(event, data) {
@@ -31,5 +38,9 @@ export default class BaseShim {
 
   stateUpdated() {
     this.sendMessage(this.events.STATEUPDATE, this.data);
+  }
+
+  userDataUpdated() {
+    this.sendMessage(this.events.USERDATAUPDATE, this.userData);
   }
 }

--- a/packages/hashi/src/baseShim.js
+++ b/packages/hashi/src/baseShim.js
@@ -6,8 +6,8 @@ export default class BaseShim {
     this.events = Object.assign({}, events);
   }
 
-  setData(data) {
-    this.__setData(data);
+  setData(data, userData) {
+    this.__setData(data, userData);
     this.stateUpdated();
   }
 

--- a/packages/hashi/src/baseShim.js
+++ b/packages/hashi/src/baseShim.js
@@ -43,4 +43,8 @@ export default class BaseShim {
   userDataUpdated() {
     this.sendMessage(this.events.USERDATAUPDATE, this.userData);
   }
+
+  updateProgress(progress) {
+    this.sendMessage(this.events.PROGRESSUPDATE, progress);
+  }
 }

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -2,6 +2,7 @@ export const events = {
   READYCHECK: 'readycheck',
   READY: 'ready',
   STATEUPDATE: 'stateupdate',
+  USERDATAUPDATE: 'userdataupdate',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -3,6 +3,7 @@ export const events = {
   READY: 'ready',
   STATEUPDATE: 'stateupdate',
   USERDATAUPDATE: 'userdataupdate',
+  PROGRESSUPDATE: 'progressupdate',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -3,7 +3,6 @@ export const events = {
   READY: 'ready',
   STATEUPDATE: 'stateupdate',
   USERDATAUPDATE: 'userdataupdate',
-  PROGRESSUPDATE: 'progressupdate',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -56,11 +56,7 @@ export default class SandboxEnvironment {
       callback: executePage,
     });
 
-    // Send a ready message in case the outer Hashi has already initialized
-    this.mediator.sendMessage({ nameSpace, event: events.READY, data: true });
-
-    // Set up a listener for a ready check event in case the iframe hashi has
-    // initialized first.
+    // Set up a listener for a ready check event.
     this.mediator.registerMessageHandler({
       nameSpace,
       event: events.READYCHECK,
@@ -68,5 +64,9 @@ export default class SandboxEnvironment {
         this.mediator.sendMessage({ nameSpace, event: events.READY, data: true });
       },
     });
+
+    // At this point we are ready, so send the message, in case we misssed the
+    // the ready check request.
+    this.mediator.sendMessage({ nameSpace, event: events.READY, data: true });
   }
 }

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -2,6 +2,7 @@ import Mediator from './mediator';
 import LocalStorage from './localStorage';
 import SessionStorage from './sessionStorage';
 import Cookie from './cookie';
+import SCORM from './SCORM';
 import { events, nameSpace } from './hashiBase';
 import patchXMLHttpRequest from './monkeyPatchXMLHttpRequest';
 import patchCrossOrigin from './monkeyPatchCORSMediaElements';
@@ -36,6 +37,10 @@ export default class SandboxEnvironment {
     this.cookie = new Cookie(this.mediator);
 
     this.cookie.iframeInitialize();
+
+    this.SCORM = new SCORM(this.mediator);
+
+    this.SCORM.iframeInitialize();
 
     patchXMLHttpRequest();
 

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -103,6 +103,9 @@ export default class MainClient {
       storage.on(events.STATEUPDATE, () => {
         this.mediator.sendLocalMessage({ nameSpace, event: events.STATEUPDATE, data: this.data });
       });
+      storage.on(events.PROGRESSUPDATE, progress => {
+        this.mediator.sendLocalMessage({ nameSpace, event: events.PROGRESSUPDATE, data: progress });
+      });
     });
   }
   get data() {
@@ -124,5 +127,9 @@ export default class MainClient {
 
   onStateUpdate(callback) {
     this.on(events.STATEUPDATE, callback);
+  }
+
+  onProgressUpdate(callback) {
+    this.on(events.PROGRESSUPDATE, callback);
   }
 }

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -73,6 +73,13 @@ export default class MainClient {
     });
   }
 
+  getProgress() {
+    // Return any calculated progress from the storage APIs
+    // So far, only the SCORM shim supports this
+    // If no progress has been reported, this will be null.
+    return this.storage.SCORM.__calculateProgress();
+  }
+
   __setData(contentState, userData) {
     this.updateData({ contentState, userData });
     if (this.now) {
@@ -84,9 +91,6 @@ export default class MainClient {
       const storage = this.storage[key];
       storage.on(events.STATEUPDATE, () => {
         this.mediator.sendLocalMessage({ nameSpace, event: events.STATEUPDATE, data: this.data });
-      });
-      storage.on(events.PROGRESSUPDATE, progress => {
-        this.mediator.sendLocalMessage({ nameSpace, event: events.PROGRESSUPDATE, data: progress });
       });
     });
   }

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -65,7 +65,8 @@ export default class MainClient {
   __setData(contentState, userData) {
     Object.keys(this.storage).forEach(key => {
       const storage = this.storage[key];
-      storage.setData(contentState[storage.nameSpace], userData);
+      storage.setData(contentState[storage.nameSpace]);
+      storage.setUserData(userData);
       storage.on(events.STATEUPDATE, () => {
         this.mediator.sendLocalMessage({ nameSpace, event: events.STATEUPDATE, data: this.data });
       });

--- a/packages/hashi/test/iframeClient.spec.js
+++ b/packages/hashi/test/iframeClient.spec.js
@@ -27,12 +27,12 @@ describe('Hashi iframeClient', () => {
         });
       });
     });
-    it('should bind a listener to a ready event to call the setScripts callback', () => {
+    it('should bind a listener to a ready event to call the executePage callback', () => {
       expect(hashi.mediator.__messageHandlers[nameSpace][events.READY].length).toBe(1);
     });
-    it('should call the loadPage method when the ready event is triggered', () => {
-      const loadPage = jest.fn();
-      hashi.mediator.__messageHandlers[nameSpace][events.READY] = [loadPage];
+    it('should call the executePage method when the ready event is triggered', () => {
+      const executePage = jest.fn();
+      hashi.mediator.__messageHandlers[nameSpace][events.READY] = [executePage];
       hashi.mediator.sendMessage = jest.fn();
       return new Promise(resolve => {
         hashi.mediator.registerMessageHandler({
@@ -44,7 +44,7 @@ describe('Hashi iframeClient', () => {
         });
         hashi.mediator.sendLocalMessage({ nameSpace, event: events.READY });
       }).then(() => {
-        expect(loadPage).toHaveBeenCalled();
+        expect(executePage).toHaveBeenCalled();
       });
     });
   });

--- a/packages/hashi/test/mainClient.spec.js
+++ b/packages/hashi/test/mainClient.spec.js
@@ -152,18 +152,6 @@ describe('Hashi mainClient', () => {
         expect(storage.on.mock.calls[0][0]).toEqual(events.STATEUPDATE);
       });
     });
-    it('should call on with the progressupdate event', () => {
-      hashi.mediator.sendMessage = jest.fn();
-      Object.keys(hashi.storage).forEach(key => {
-        const storage = hashi.storage[key];
-        storage.on = jest.fn();
-      });
-      hashi.__setListeners();
-      Object.keys(hashi.storage).forEach(key => {
-        const storage = hashi.storage[key];
-        expect(storage.on.mock.calls[1][0]).toEqual(events.PROGRESSUPDATE);
-      });
-    });
   });
   describe('data getter', () => {
     it('should return the data from each of the storage objects in a namespaced object', () => {

--- a/packages/kolibri-components/src/content/mixin.js
+++ b/packages/kolibri-components/src/content/mixin.js
@@ -126,6 +126,22 @@ export default {
       type: Boolean,
       default: false,
     },
+    // An explicit record of the current progress through this
+    // piece of content.
+    progress: {
+      type: Number,
+      default: 0,
+    },
+    // An identifier for the user interacting with this content
+    userId: {
+      type: String,
+    },
+    userFullName: {
+      type: String,
+    },
+    timeSpent: {
+      type: Number,
+    },
   },
   computed: {
     defaultItemPreset() {


### PR DESCRIPTION
### Summary

* Adds SCORM API into Hashi when not sandboxed
* Implements the full SCORM 1.2 API
* Implements input validation and error returns
* Persists SCORM data out to ContentSummaryLogs through usual Hashi mechanism
* Injects user data and relevant session data into ContentRenderers and then injects into Hashi.
* Propagates progress calculations to HTML5 app renderer to emit as progress updates
* Integrates bug fix by @kollivier for non-video progress setting
* Watches passed in user data and propagates it into Hashi when it updates


### Reviewer guidance
Run the SCORM debugger automated tests: https://github.com/jleyva/scorm-debugger - should result in errors only for non-implemented APIs. N.B. on a non-fresh summary log, you will get more errors, as it will not expect prior session data to have persisted.

### References
Amalgamates #6683 and #6694

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
