### PR TITLE
Fix progress bar regression from dummy progress tracking for annotation

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -631,7 +631,7 @@ def calculate_dummy_progress_for_annotation(node_ids, exclude_node_ids, total_pr
     annotation_proportion = min(10, max(1, int(num_annotation_constraints / 500)))
 
     # Create some progress proportional to annotation task
-    return annotation_proportion * total_progress / (100 - annotation_proportion)
+    return int(annotation_proportion * total_progress / (100 - annotation_proportion))
 
 
 def propagate_forced_localfile_removal(localfiles):

--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -2,7 +2,6 @@ import abc
 import logging
 import sys
 from collections import namedtuple
-from numbers import Integral
 
 import click
 from django.core.management.base import BaseCommand
@@ -30,9 +29,6 @@ class ProgressTracker:
         self.level = level
         self.update_callback = update_callback
 
-        # Check that the total is an integer, otherwise progress bars will be unpredictable
-        if type(total) is not Integral:
-            logger.warn("total argument should be an integer for progressbars to work")
         # Also check that we are not running Python 2:
         # https://github.com/learningequality/kolibri/issues/6597
         if sys.version_info[0] == 2:
@@ -42,6 +38,8 @@ class ProgressTracker:
             # as we only want to display progress bars from the command line.
             try:
                 click.get_current_context()
+                # Coerce to an integer for safety, as click uses Python `range` on this
+                # value, which requires an integer argument
                 # N.B. because we are only doing this in Python3, safe to just use int,
                 # as long is Py2 only
                 self.progressbar = click.progressbar(length=int(total), width=0)

--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -49,15 +49,9 @@ class ProgressTracker:
                 self.progressbar = None
 
     def update_progress(self, increment=1, message="", extra_data=None):
-        # Type check argument, as progressbars can break otherwise.
-        if type(increment) is not Integral:
-            logger.warn(
-                "increment argument should be an integer for progressbars to work"
-            )
         if self.progressbar:
-            # N.B. because we are only doing this in Python3, safe to just use int,
-            # as long is Py2 only
-            self.progressbar.update(int(increment))
+            # Click only enforces integers on the total (because it is implemented assuming a length)
+            self.progressbar.update(increment)
         self.progress += increment
         self.message = message
         self.extra_data = extra_data

--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -42,6 +42,8 @@ class ProgressTracker:
             # as we only want to display progress bars from the command line.
             try:
                 click.get_current_context()
+                # N.B. because we are only doing this in Python3, safe to just use int,
+                # as long is Py2 only
                 self.progressbar = click.progressbar(length=int(total), width=0)
             except RuntimeError:
                 self.progressbar = None
@@ -53,6 +55,8 @@ class ProgressTracker:
                 "increment argument should be an integer for progressbars to work"
             )
         if self.progressbar:
+            # N.B. because we are only doing this in Python3, safe to just use int,
+            # as long is Py2 only
             self.progressbar.update(int(increment))
         self.progress += increment
         self.message = message


### PR DESCRIPTION
### Summary
#6629 introduced non-integer progress totals to add dummy progress for the annotation task on large channels.
This resulted in a bug in progressbar updating, as it only handles integers #6731 
This PR fixes this by making sure the dummy progress is an integer, and giving a warning and coercing values being sent to the progress bars to integers.

### Reviewer guidance
Import a large channel from the command line in Python3. Verify that it works and does not error.

### References
Fixes #6731 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
