### PR TITLE
Restoring google cloud storage upload for release.

### DIFF
--- a/.buildkite/upload_artifacts.py
+++ b/.buildkite/upload_artifacts.py
@@ -13,6 +13,7 @@ from os import listdir
 
 import requests
 from github3 import login
+from google.cloud import storage
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -21,8 +22,6 @@ REPO_OWNER = "learningequality"
 REPO_NAME = "kolibri"
 TAG = os.getenv("BUILDKITE_TAG")
 
-
-RELEASE_DIR = "release"
 PROJECT_PATH = os.path.join(os.getcwd())
 
 # Python packages artifact location
@@ -111,6 +110,8 @@ def upload_gh_release_artifacts(artifacts={}):
         logging.info("Uploading built assets to Github Release: %s" % release_name)
         for ext, artifact in artifacts.items():
             logging.info("Uploading release asset: %s" % (artifact.get("name")))
+
+            logging.info("Uploading to github")
             # For some reason github3 does not let us set a label at initial upload
             asset = release.upload_asset(
                 content_type=artifact["content_type"],
@@ -127,6 +128,16 @@ def upload_gh_release_artifacts(artifacts={}):
                 logging.error(
                     "Error uploading release asset: %s" % (artifact.get("name"))
                 )
+
+            logging.info("Uploading to Google")
+
+            client = storage.Client()
+            bucket = client.bucket("le-downloads")
+            blob = bucket.blob(
+                "kolibri-release-{artifact}".format(artifact=artifact["name"])
+            )
+            blob.upload_from_filename(filename=artifact["file_location"])
+            blob.make_public()
 
 
 def main():

--- a/requirements/pipeline.txt
+++ b/requirements/pipeline.txt
@@ -1,2 +1,3 @@
 requests==2.21.0
 github3.py==1.1.0
+google-cloud-storage==1.24.1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Apparently I was too thorough. In a semi-related talk with Richard, I realized that I'd wiped out GCS completely, removing the upload to GCS step. Bringing it back here... and everywhere since here.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Going to need to test this with a dummy release again. Once that's done, just make sure all buildkite and travis tests passed 👌 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#6671 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
