### PR TITLE
Add user interface for customizing the Kolibri device name

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -12,6 +12,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   confirmAction: 'Confirm',
   continueAction: 'Continue',
   deleteAction: 'Delete',
+  editAction: 'Edit',
   editDetailsAction: 'Edit details',
   finishAction: 'Finish',
   goBackAction: 'Go back',
@@ -37,6 +38,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   coachLabel: 'Coach',
   coachesLabel: 'Coaches',
   completedLabel: 'Completed',
+  deviceNameLabel: 'Device name',
   devicePermissionsLabel: 'Device permissions',
   facilityCoachLabel: 'Facility coach',
   facilityLabel: 'Facility',
@@ -63,6 +65,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   usernameLabel: 'Username',
   usersLabel: 'Users',
   viewMoreAction: 'View more',
+
+  // Notifications
+  changesSavedNotification: 'Changes saved',
+  changesNotSavedNotification: 'Changes not saved',
 
   // Errors
   requiredFieldError: 'This field is required',

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -46,9 +46,15 @@ class CachedDeviceConnectionChecker(object):
         self.base_url = base_url
 
     def check_device_info(self):
+        from kolibri.core.discovery.models import NetworkLocation
+
         info = check_device_info(self.base_url)
 
         if info:
+            # Update the underlying model at the same time as the cache
+            NetworkLocation.objects.filter(instance_id=info.get("instance_id")).update(
+                **info
+            )
             device_info_cache.set(self.base_url, info)
 
         return info

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
@@ -1,14 +1,36 @@
+import urls from 'kolibri.urls';
+import client from 'kolibri.client';
+
 export default {
   namespaced: true,
   state: {
     deviceInfo: {},
+    deviceName: null,
   },
   mutations: {
     SET_STATE(state, payload) {
       state.deviceInfo = payload.deviceInfo;
+      state.deviceName = payload.deviceInfo.device_name;
+    },
+    SET_DEVICE_NAME(state, name) {
+      state.deviceName = name;
     },
     RESET_STATE(state) {
       state.deviceInfo = {};
+      state.deviceName = null;
+    },
+  },
+  actions: {
+    updateDeviceName(store, name) {
+      return client({
+        path: urls['kolibri:core:devicename'](),
+        method: 'PATCH',
+        entity: {
+          name,
+        },
+      }).then(response => {
+        store.commit('SET_DEVICE_NAME', response.entity.name);
+      });
     },
   },
 };

--- a/kolibri/plugins/device/assets/src/views/DeviceNameModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceNameModal.vue
@@ -1,4 +1,3 @@
-
 <template>
 
   <KModal

--- a/kolibri/plugins/device/assets/src/views/DeviceNameModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceNameModal.vue
@@ -1,0 +1,85 @@
+
+<template>
+
+  <KModal
+    :title="coreString('deviceNameLabel')"
+    :submitText="coreString('saveAction')"
+    :cancelText="coreString('cancelAction')"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    <p>
+      {{ $tr('deviceNameExplanation') }}
+    </p>
+    <KTextbox
+      ref="name"
+      v-model.trim="name"
+      type="text"
+      :label="coreString('deviceNameLabel')"
+      :autofocus="true"
+      :invalid="nameIsInvalid"
+      :invalidText="nameIsInvalidText"
+      :maxlength="50"
+      @blur="nameBlurred = true"
+    />
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'DeviceNameModal',
+    mixins: [commonCoreStrings],
+    props: {
+      deviceName: {
+        type: String,
+        required: false,
+      },
+    },
+    data() {
+      return {
+        name: this.deviceName,
+        nameBlurred: false,
+        formSubmitted: false,
+      };
+    },
+    computed: {
+      nameIsInvalidText() {
+        if (this.nameBlurred || this.formSubmitted) {
+          if (this.name === '') {
+            return this.coreString('requiredFieldError');
+          }
+        }
+        return '';
+      },
+      nameIsInvalid() {
+        return Boolean(this.nameIsInvalidText);
+      },
+    },
+    methods: {
+      handleSubmit() {
+        this.formSubmitted = true;
+        if (this.nameIsInvalid) {
+          this.$refs.name.focus();
+        } else {
+          this.$emit('submit', this.name);
+        }
+      },
+    },
+    $trs: {
+      deviceNameExplanation: {
+        message:
+          'Giving this device a unique and meaningful name can help you and others in your network to recognize it',
+        context: 'Explanation of what the device name is',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
1. Adds field and modal at Device > Info page device name
1. Adds code to synchronize the zeroconf cache with the `DynamicNetworkLocation` table when new device info comes from peers.

<img width="1006" alt="Screen Shot 2020-04-02 at 3 25 36 PM" src="https://user-images.githubusercontent.com/10248067/78305731-8166db80-74f6-11ea-948f-826a3e207df7.png">

### Reviewer guidance

1. Verify that the UI matches the design and has the correct behavior for happy and sad paths.
1. Bonus: test out the name changing with another computer to verify name changes are propagated to peers in real-time.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
