### PR TITLE
Users export to csv - part 2

### DIFF
--- a/kolibri/core/query.py
+++ b/kolibri/core/query.py
@@ -2,6 +2,7 @@ from django.db import connection
 from django.db.models import Aggregate
 from django.db.models import IntegerField
 from django.db.models import Subquery
+from django.db.models.fields import CharField
 
 try:
     from django.contrib.postgres.aggregates import ArrayAgg
@@ -19,6 +20,17 @@ class SQSum(Subquery):
     # Include ALIAS at the end to support Postgres
     template = "(SELECT SUM(%(field)s) FROM (%(subquery)s) AS %(field)s__sum)"
     output_field = IntegerField()
+
+
+class GroupConcatSubquery(Subquery):
+    template = "(SELECT GROUP_CONCAT(%(field)s) FROM (%(subquery)s) AS %(field)s__sum)"
+    output_field = CharField()
+
+    def as_postgresql(self, compiler, connection):
+        self.template = (
+            "(SELECT STRING_AGG(%(field)s) FROM (%(subquery)s) AS %(field)s__sum)"
+        )
+        return super(GroupConcatSubquery, self).as_sql(compiler, connection)
 
 
 class GroupConcat(Aggregate):


### PR DESCRIPTION
### Summary

Continuation of #6716 to solve an issue when exporting assigned classes.

TODO: Gherkin scenarios and tests

Export to a csv file of users, their roles, classrooms and users assignments and enrollement to these classrooms.
The resulting csv follows the schema related at https://docs.google.com/document/d/1CobblEL--x7iyolahdY5f2PgGnTdvJetskIESyfDXP0/edit

The output format of the file will be the same used as an input for the `bulkimportusers` command

So far, this PR includes the backend part.
Using the command:
`kolibri manage bulkexportusers `
The output will produce a csv file in the kolibri temp folder. Other options of the command are 
`--output-file=`name_of_the_file  (to be created in the folder where the command is executed)
`--facility=`id_of_the_facility whose users will be exported (if not provided it will use the default facility)
`--overwrite` to overwrite, if exists, a previous file with the name of the output file

Using the frontend:
Export the users and check the data, specially enrolled and assigned classes match the current facility


### Reviewer guidance

- Try to execute the command in an existing Kolibri installation, example:

`kolibri manage bulkexportusers --output-file=kk.csv`

- Signed as an user with admin right in an existing kolibri server, do a POST to 
/api/tasks/tasks/exportuserstocsv/
Afterwards, looking at the /api/tasks/tasks/  page the job should be complete and including the csv filepath in its metadata. Example:
```
    {
        "status": "COMPLETED",
        "exception": "None",
        "traceback": "",
        "percentage": 1.0,
        "id": "10f07fee56f44cd29abbe0fec40ed615",
        "cancellable": false,
        "type": "EXPORTUSERSTOCSV",
        "started_by": "6a256feb4d882f5d90b862f83e789166",
        "overall_error": [],
        "users": 4,
        "filename": "tmpa6k0ibe_.download"
    }
```


### References
Relates #6674 , #6716



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
