### PR TITLE
allow null for number ranges

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -82,13 +82,15 @@ MESSAGES = {
 # Validators ###
 
 
-def number_range(min, max):
+def number_range(min, max, allow_null=False):
     """
     Return a value check function which raises a ValueError if the supplied
     value is less than `min` or greater than `max`.
     """
 
     def checker(v):
+        if allow_null and not v:
+            return checker
         if int(v) < min or int(v) > max:
             raise ValueError(v)
 
@@ -299,7 +301,7 @@ class Command(AsyncCommand):
         )
         validator.add_check(
             "BIRTH_YEAR",
-            number_range(1900, 99999),
+            number_range(1900, 99999, allow_null=True),
             MESSAGES[INVALID].format("BIRTH_YEAR"),
         )
         validator.add_check(


### PR DESCRIPTION
### Summary


`BIRTH_YEAR`  is optional when importing users from a csv

### Reviewer guidance

Using [mock.zip](https://github.com/learningequality/kolibri/files/4426602/mock.zip) as a csv file example:

`kolibri manage bulkimportusers ./mock.csv `

### References

Fixes #6749 
Relates #6674 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
