### PR TITLE
Add user interface for customizing the Kolibri facility name

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -3,8 +3,6 @@ import { createTranslator } from 'kolibri.utils.i18n';
 export const coreStrings = createTranslator('CommonCoreStrings', {
   // actions
   cancelAction: 'Cancel',
-  changesSaved: 'Changes saved',
-  changesNotSaved: 'Changes were not saved',
   clearAction: {
     message: 'Clear',
     context:

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -3,6 +3,8 @@ import { createTranslator } from 'kolibri.utils.i18n';
 export const coreStrings = createTranslator('CommonCoreStrings', {
   // actions
   cancelAction: 'Cancel',
+  changesSaved: 'Changes saved',
+  changesNotSaved: 'Changes were not saved',
   clearAction: {
     message: 'Clear',
     context:

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -42,6 +42,8 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   devicePermissionsLabel: 'Device permissions',
   facilityCoachLabel: 'Facility coach',
   facilityLabel: 'Facility',
+  facilityName: 'Facility name',
+  facilityDuplicated: 'There is already a facility with this name on this device',
   fullNameLabel: 'Full name',
   genderLabel: 'Gender',
   identifierLabel: 'Identifier',

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -43,6 +43,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   facilityCoachLabel: 'Facility coach',
   facilityLabel: 'Facility',
   facilityName: 'Facility name',
+  facilityNameWithId: '{facilityName} ({id})',
   facilityDuplicated: 'There is already a facility with this name on this device',
   fullNameLabel: 'Full name',
   genderLabel: 'Gender',

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -10,6 +10,10 @@ export function saveFacilityName(store, payload) {
     },
   }).then(
     facility => {
+      store.commit('UPDATE_FACILITIES', {
+        oldName: store.state.facilityName,
+        newName: facility.name,
+      });
       store.commit('FACILITY_NAME_SAVED', facility.name);
     },
     error => {

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -1,5 +1,22 @@
-import { FacilityDatasetResource } from 'kolibri.resources';
+import { FacilityDatasetResource, FacilityResource } from 'kolibri.resources';
+
 import { notificationTypes } from '../../constants';
+
+export function saveFacilityName(store, payload) {
+  return FacilityResource.saveModel({
+    id: payload.id,
+    data: {
+      name: payload.name,
+    },
+  }).then(
+    facility => {
+      store.commit('FACILITY_NAME_SAVED', facility.name);
+    },
+    error => {
+      store.commit('FACILITY_NAME_NOT_SAVED', error);
+    }
+  );
+}
 
 export function saveFacilityConfig(store) {
   store.commit('CONFIG_PAGE_NOTIFY', null);

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -9,10 +9,11 @@ export function showFacilityConfigPage(store) {
   const resourceRequests = [
     FacilityResource.fetchModel({ id: FACILITY_ID }),
     FacilityDatasetResource.fetchCollection({ getParams: { facility_id: FACILITY_ID } }),
+    FacilityResource.fetchCollection(),
   ];
 
   return Promise.all(resourceRequests)
-    .then(function onSuccess([facility, facilityDatasets]) {
+    .then(function onSuccess([facility, facilityDatasets, facilities]) {
       const dataset = facilityDatasets[0]; // assumes for now is only one facility being managed
       store.commit('facilityConfig/SET_STATE', {
         facilityDatasetId: dataset.id,
@@ -23,7 +24,9 @@ export function showFacilityConfigPage(store) {
         // this copy is kept for the purpose of undoing if save fails
         settingsCopy: { ...dataset },
         notification: null,
+        facilities: facilities,
       });
+
       store.commit('CORE_SET_PAGE_LOADING', false);
     })
     .catch(function onFailure() {

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -9,7 +9,7 @@ export function showFacilityConfigPage(store) {
   const resourceRequests = [
     FacilityResource.fetchModel({ id: FACILITY_ID }),
     FacilityDatasetResource.fetchCollection({ getParams: { facility_id: FACILITY_ID } }),
-    FacilityResource.fetchCollection(),
+    FacilityResource.fetchCollection({ force: true }),
   ];
 
   return Promise.all(resourceRequests)

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -17,6 +17,7 @@ export function showFacilityConfigPage(store) {
       store.commit('facilityConfig/SET_STATE', {
         facilityDatasetId: dataset.id,
         facilityName: facility.name,
+        facilityId: facility.id,
         // this part of state is mutated as user interacts with form
         settings: { ...dataset },
         // this copy is kept for the purpose of undoing if save fails

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
@@ -53,6 +53,11 @@ export default {
       state.facilityNameError = false;
       state.facilityNameSaved = false;
     },
+    UPDATE_FACILITIES(state, payload) {
+      state.facilities.find(f => {
+        return f.name === payload.oldName;
+      }).name = payload.newName;
+    },
   },
   actions: {
     saveFacilityConfig,

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
@@ -10,6 +10,7 @@ function defaultState() {
     settingsCopy: {},
     facilityNameSaved: false,
     facilityNameError: false,
+    facilities: [],
   };
 }
 

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
@@ -1,12 +1,15 @@
-import { saveFacilityConfig, resetFacilityConfig } from './actions';
+import { saveFacilityConfig, resetFacilityConfig, saveFacilityName } from './actions';
 
 function defaultState() {
   return {
     facilityDatasetId: '',
+    facilityId: '',
     facilityName: '',
     notification: null,
     settings: {},
     settingsCopy: {},
+    facilityNameSaved: false,
+    facilityNameError: false,
   };
 }
 
@@ -38,9 +41,21 @@ export default {
     CONFIG_PAGE_COPY_SETTINGS(state) {
       state.settingsCopy = Object.assign({}, state.settings);
     },
+    FACILITY_NAME_SAVED(state, name) {
+      state.facilityName = name;
+      state.facilityNameSaved = true;
+    },
+    FACILITY_NAME_NOT_SAVED(state) {
+      state.facilityNameError = true;
+    },
+    RESET_FACILITY_NAME_STATES(state) {
+      state.facilityNameError = false;
+      state.facilityNameSaved = false;
+    },
   },
   actions: {
     saveFacilityConfig,
     resetFacilityConfig,
+    saveFacilityName,
   },
 };

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -76,9 +76,17 @@ export default [
       store.commit('manageSync/RESET_STATE');
     },
   },
+
   {
     name: PageNames.FACILITY_CONFIG_PAGE,
     path: '/settings',
+    handler: () => {
+      showFacilityConfigPage(store);
+    },
+  },
+  {
+    name: PageNames.FACILITY_CONFIG_PAGE,
+    path: '/all_facilities',
     handler: () => {
       showFacilityConfigPage(store);
     },

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -76,17 +76,9 @@ export default [
       store.commit('manageSync/RESET_STATE');
     },
   },
-
   {
     name: PageNames.FACILITY_CONFIG_PAGE,
     path: '/settings',
-    handler: () => {
-      showFacilityConfigPage(store);
-    },
-  },
-  {
-    name: PageNames.FACILITY_CONFIG_PAGE,
-    path: '/all_facilities',
     handler: () => {
       showFacilityConfigPage(store);
     },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -19,6 +19,7 @@
         :invalidText="nameIsInvalidText"
         :maxlength="50"
         @blur="nameBlurred = true"
+        @input="handleInput"
       />
     </div>
   </KModal>
@@ -29,6 +30,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { mapState } from 'vuex';
 
   export default {
     name: 'EditFacilityNameModal',
@@ -48,24 +50,26 @@
       };
     },
     computed: {
+      ...mapState('facilityConfig', ['facilities']),
       nameIsInvalidText() {
-        this.checkDuplicated();
-        if (this.nameBlurred || this.formSubmitted) {
-          if (this.name === '') {
-            return this.coreString('requiredFieldError');
-          }
-          if (this.isDuplicated) return this.coreString('facilityDuplicated');
+        if (this.name === '') {
+          return this.coreString('requiredFieldError');
         }
+        if (this.isDuplicated) return this.coreString('facilityDuplicated');
         return '';
       },
       nameIsInvalid() {
-        //facilityDuplicated
-        return Boolean(this.nameIsInvalidText);
+        return Boolean(this.nameIsInvalidText || this.isDuplicated);
       },
     },
     methods: {
-      checkDuplicated() {
-        this.isDuplicated = false;
+      handleInput($event) {
+        if (this.facilityName != $event) this.facilityNameIsUnique($event);
+      },
+      facilityNameIsUnique(value) {
+        this.isDuplicated = !!this.facilities.find(
+          ({ name }) => name.toLowerCase() === value.toLowerCase()
+        );
       },
       handleSubmit() {
         this.formSubmitted = true;

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -1,0 +1,92 @@
+<template>
+
+  <KModal
+    :title="$tr('title')"
+    :submitText="coreString('saveAction')"
+    :cancelText="coreString('cancelAction')"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    <div>
+      <p>{{ $tr('renameFacilityExplanation') }}</p>
+      <KTextbox
+        ref="name"
+        v-model.trim="name"
+        type="text"
+        :label="coreString('facilityName')"
+        :autofocus="true"
+        :invalid="nameIsInvalid"
+        :invalidText="nameIsInvalidText"
+        :maxlength="50"
+        @blur="nameBlurred = true"
+      />
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'EditFacilityNameModal',
+    mixins: [commonCoreStrings],
+    props: {
+      facilityName: {
+        type: String,
+        required: false,
+      },
+    },
+    data() {
+      return {
+        name: this.facilityName,
+        nameBlurred: false,
+        formSubmitted: false,
+        isDuplicated: false,
+      };
+    },
+    computed: {
+      nameIsInvalidText() {
+        this.checkDuplicated();
+        if (this.nameBlurred || this.formSubmitted) {
+          if (this.name === '') {
+            return this.coreString('requiredFieldError');
+          }
+          if (this.isDuplicated) return this.coreString('facilityDuplicated');
+        }
+        return '';
+      },
+      nameIsInvalid() {
+        //facilityDuplicated
+        return Boolean(this.nameIsInvalidText);
+      },
+    },
+    methods: {
+      checkDuplicated() {
+        this.isDuplicated = true;
+      },
+      handleSubmit() {
+        this.formSubmitted = true;
+        if (this.nameIsInvalid) {
+          this.$refs.name.focus();
+        } else {
+          this.$emit('submit', this.name);
+        }
+      },
+    },
+    $trs: {
+      renameFacilityExplanation: {
+        message:
+          'Warning: This will remain the same facility, and the new name may be synced to other devices that are also linked to this facility',
+        context: 'Explanation of what consequences renaming will have',
+      },
+      title: 'Rename facility',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -65,7 +65,7 @@
     },
     methods: {
       checkDuplicated() {
-        this.isDuplicated = true;
+        this.isDuplicated = false;
       },
       handleSubmit() {
         this.formSubmitted = true;

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -4,7 +4,6 @@
     :title="$tr('title')"
     :submitText="coreString('saveAction')"
     :cancelText="coreString('cancelAction')"
-    :submitDisabled="isSubmitDisabled"
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
@@ -48,7 +47,6 @@
         nameBlurred: false,
         formSubmitted: false,
         isDuplicated: false,
-        isSubmitDisabled: true,
       };
     },
     computed: {
@@ -66,8 +64,7 @@
     },
     methods: {
       handleInput($event) {
-        this.isSubmitDisabled = this.facilityName === $event;
-        if (!this.isSubmitDisabled) this.facilityNameIsUnique($event);
+        if (this.facilityName != $event) this.facilityNameIsUnique($event);
       },
       facilityNameIsUnique(value) {
         this.isDuplicated = !!this.facilities.find(

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -59,7 +59,7 @@
         return '';
       },
       nameIsInvalid() {
-        return Boolean(this.nameIsInvalidText || this.isDuplicated);
+        return Boolean(this.nameIsInvalidText);
       },
     },
     methods: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -39,7 +39,7 @@
     props: {
       facilityName: {
         type: String,
-        required: false,
+        required: true,
       },
     },
     data() {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/EditFacilityNameModal.vue
@@ -4,6 +4,7 @@
     :title="$tr('title')"
     :submitText="coreString('saveAction')"
     :cancelText="coreString('cancelAction')"
+    :submitDisabled="isSubmitDisabled"
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
@@ -47,6 +48,7 @@
         nameBlurred: false,
         formSubmitted: false,
         isDuplicated: false,
+        isSubmitDisabled: true,
       };
     },
     computed: {
@@ -64,7 +66,8 @@
     },
     methods: {
       handleInput($event) {
-        if (this.facilityName != $event) this.facilityNameIsUnique($event);
+        this.isSubmitDisabled = this.facilityName === $event;
+        if (!this.isSubmitDisabled) this.facilityNameIsUnique($event);
       },
       facilityNameIsUnique(value) {
         this.isDuplicated = !!this.facilities.find(

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -189,7 +189,7 @@
       },
       sendFacilityName(name) {
         this.showEditFacilityModal = false;
-        this.saveFacilityName({ name: name, id: this.facilityId });
+        if (name != this.facilityName) this.saveFacilityName({ name: name, id: this.facilityId });
       },
       saveConfig() {
         this.$store.dispatch('facilityConfig/saveFacilityConfig').then(() => {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -154,13 +154,13 @@
     watch: {
       facilityNameSaved(val) {
         if (val) {
-          this.createSnackbar(this.coreString('changesSaved'));
+          this.createSnackbar(this.coreString('changesSavedNotification'));
           this.$store.commit('facilityConfig/RESET_FACILITY_NAME_STATES');
         }
       },
       facilityNameError(val) {
         if (val) {
-          this.createSnackbar(this.coreString('changesNotSaved'));
+          this.createSnackbar(this.coreString('changesNotSavedNotification'));
           this.$store.commit('facilityConfig/RESET_FACILITY_NAME_STATES');
         }
       },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -23,7 +23,14 @@
       <div class="mb">
         <h2>{{ coreString('facilityLabel') }}</h2>
         <p class="current-facility-name">
-          {{ facilityName }}
+          {{ facilityName }} ({{ lastPartId }})
+          <KButton
+            appearance="basic-link"
+            :text="$tr('facilityNameEdit')"
+            name="edit-facilityname"
+            @click="showEditFacilityModal = true"
+          />
+
         </p>
       </div>
 
@@ -66,6 +73,13 @@
       @submit="resetToDefaultSettings"
       @cancel="showModal = false"
     />
+    <EditFacilityNameModal
+      v-if="showEditFacilityModal"
+      id="edit-facility"
+      :facilityName="facilityName"
+      @submit="saveFacilityName"
+      @cancel="showEditFacilityModal = false"
+    />
   </KPageContainer>
 
 </template>
@@ -79,6 +93,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
   import ConfirmResetModal from './ConfirmResetModal';
+  import EditFacilityNameModal from './EditFacilityNameModal';
   import Notifications from './ConfigPageNotifications';
 
   // See FacilityDataset in core.auth.models for details
@@ -100,17 +115,24 @@
     },
     components: {
       ConfirmResetModal,
+      EditFacilityNameModal,
       Notifications,
     },
     mixins: [commonCoreStrings],
     data() {
       return {
         showModal: false,
+        showEditFacilityModal: false,
         settingsCopy: {},
       };
     },
     computed: {
-      ...mapState('facilityConfig', ['facilityName', 'settings', 'notification']),
+      ...mapState('facilityConfig', [
+        'facilityName',
+        'facilityDatasetId',
+        'settings',
+        'notification',
+      ]),
       ...mapGetters(['isSuperuser']),
       settingsList: () => settingsList,
       settingsHaveChanged() {
@@ -122,6 +144,9 @@
           return getUrl() + '#/settings';
         }
         return null;
+      },
+      lastPartId() {
+        return this.facilityDatasetId.substr(this.facilityDatasetId.length - 4);
       },
     },
     mounted() {
@@ -143,6 +168,9 @@
         this.$store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
           this.copySettings();
         });
+      },
+      saveFacilityName() {
+        this.showEditFacilityModal = false;
       },
       saveConfig() {
         this.$store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
@@ -173,6 +201,7 @@
       pageHeader: 'Facility settings',
       resetToDefaultSettings: 'Reset to defaults',
       documentTitle: 'Configure Facility',
+      facilityNameEdit: 'Edit',
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -148,7 +148,7 @@
         return null;
       },
       lastPartId() {
-        return this.facilityId.substr(this.facilityId.length - 4);
+        return this.facilityId.slice(0, 4);
       },
     },
     watch: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -23,7 +23,7 @@
       <div class="mb">
         <h2>{{ coreString('facilityLabel') }}</h2>
         <p class="current-facility-name">
-          {{ facilityName }} ({{ lastPartId }})
+          {{ coreString('facilityNameWithId', { facilityName: facilityName, id: lastPartId }) }}
           <KButton
             appearance="basic-link"
             :text="coreString('editAction')"

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -10,6 +10,7 @@ const fakeFacility = {
   name: 'Nalanda Maths',
 };
 
+const fakeFacilities = [fakeFacility];
 const fakeDatasets = [
   {
     id: 'dataset_2',
@@ -44,6 +45,7 @@ describe('facility config page actions', () => {
     it('when resources load successfully', () => {
       FacilityStub.__getModelFetchReturns(fakeFacility);
       DatasetStub.__getCollectionFetchReturns(fakeDatasets);
+      FacilityStub.__getCollectionFetchReturns(fakeFacilities);
       const expectedState = {
         facilityDatasetId: 'dataset_2',
         facilityName: 'Nalanda Maths',
@@ -81,6 +83,7 @@ describe('facility config page actions', () => {
       it('when fetching Facility fails', () => {
         FacilityStub.__getModelFetchReturns('incomprehensible error', true);
         DatasetStub.__getCollectionFetchReturns(fakeDatasets);
+        FacilityStub.__getCollectionFetchReturns(fakeFacilities);
         return showFacilityConfigPage(store).then(() => {
           expect(commitStub).toHaveBeenCalledWith(
             'facilityConfig/SET_STATE',
@@ -92,6 +95,7 @@ describe('facility config page actions', () => {
       it('when fetching FacilityDataset fails', () => {
         FacilityStub.__getModelFetchReturns(fakeFacility);
         DatasetStub.__getCollectionFetchReturns('incomprehensible error', true);
+        FacilityStub.__getCollectionFetchReturns(fakeFacilities);
         return showFacilityConfigPage(store).then(() => {
           expect(commitStub).toHaveBeenCalledWith(
             'facilityConfig/SET_STATE',


### PR DESCRIPTION
### Summary
 Adds field and modal at Facility > Settings page facility name and edit the page.
 Facility name is saved and checked it's unique in the Device.

### Reviewer guidance
Verify that the UI matches the design and has the correct behavior 

![image](https://user-images.githubusercontent.com/1008178/78546515-d60f9c80-77fd-11ea-8b3f-df640fd69ecc.png)
![image](https://user-images.githubusercontent.com/1008178/78546574-f17aa780-77fd-11ea-816f-8a96f8c40e4f.png)


### References
…


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
