### PR TITLE
Alter django postgres test settings to prevent error

### DIFF
--- a/kolibri/deployment/default/settings/postgres_test.py
+++ b/kolibri/deployment/default/settings/postgres_test.py
@@ -30,6 +30,6 @@ DATABASES = {
         "PASSWORD": "",
         "NAME": os.environ.get("POSTGRES_DB") or "default",  # noqa
         "OPTIONS": {"isolation_level": isolation_level},
-        "TEST": {"NAME": "travis_ci_default"},
+        "TEST": {"MIRROR": "default"},
     },
 }


### PR DESCRIPTION
### Summary
Use MIRROR to show that DBs are the same.

### Reviewer guidance
Does Travis pass?

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
