### PR TITLE
Fixes to Android integrations to prevent errors

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -152,7 +152,8 @@ def _get_drive_usage(path):
         from jnius import autoclass
 
         StatFs = autoclass("android.os.StatFs")
-        stats = StatFs(path)
+        AndroidString = autoclass("java.lang.String")
+        stats = StatFs(AndroidString(path))
         return {
             "total": stats.getBlockCountLong() * stats.getBlockSizeLong(),
             "free": stats.getAvailableBlocksLong() * stats.getBlockSizeLong(),

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -532,14 +532,12 @@ def installation_type(cmd_line=None):  # noqa:C901
         elif "start" in cmd_line:
             install_type = "whl"
     if on_android():
-        from jnius import autoclass
 
-        context = autoclass("org.kivy.android.PythonActivity")
-        version_name = (
-            context.getPackageManager()
-            .getPackageInfo(context.getPackageName(), 0)
-            .versionName
-        )
-        install_type = "apk - {}".format(version_name)
+        version_name = os.environ.get("KOLIBRI_APK_VERSION_NAME")
+
+        if version_name:
+            install_type = "apk - {}".format(version_name)
+        else:
+            install_type = "apk"
 
     return install_type

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -196,8 +196,9 @@ def get_free_space(path=KOLIBRI_HOME):
             from jnius import autoclass
 
             StatFs = autoclass("android.os.StatFs")
+            AndroidString = autoclass("java.lang.String")
 
-            st = StatFs(KOLIBRI_HOME)
+            st = StatFs(AndroidString(path))
 
             try:
                 # for api version 18+


### PR DESCRIPTION
### Summary
Android-specific fixes that came up in the process of working on https://github.com/learningequality/kolibri-installer-android/pull/52.

- The server would die when run from a service (instead of an activity) because our `installation_type` code assumed it was running in the context of an activity.
- The Device > Info page was throwing a 500 because the path being passed in wasn't an `AndroidString`. The space checking was also unconditionally using `KOLIBRI_HOME` instead of the value of the `path` argument.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Will be testable in the context of the Android installer.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Pre-req for https://github.com/learningequality/kolibri-installer-android/pull/52

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
