### PR TITLE
Fix QueryDict AttributeError when upgrading channels by using `.get` instead of `.pop`

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -185,8 +185,8 @@ class TasksViewSet(viewsets.ViewSet):
     @list_route(methods=["post"])
     def startchannelupdate(self, request):
 
-        sourcetype = request.data.pop("sourcetype", None)
-        new_version = request.data.pop("new_version", None)
+        sourcetype = request.data.get("sourcetype", None)
+        new_version = request.data.get("new_version", None)
 
         if sourcetype == "remote":
             task = validate_remote_import_task(request, request.data)


### PR DESCRIPTION

### Summary

When trying to upgrade my PF SCORM channel, was getting:

```
ERROR    Internal Server Error: /api/tasks/tasks/startchannelupdate/
Traceback (most recent call last):
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/rest_framework/viewsets.py", line 116, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/d/Projects/le/k013x/kolibri/core/tasks/api.py", line 198, in startchannelupdate
    sourcetype = request.data.pop("sourcetype", None)
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/http/request.py", line 474, in pop
    self._assert_mutable()
  File "/Users/d/Projects/le/k013x/.venv/lib/python3.7/site-packages/django/http/request.py", line 432, in _assert_mutable
    raise AttributeError("This QueryDict instance is immutable")
AttributeError: This QueryDict instance is immutable
ERROR    "POST /api/tasks/tasks/startchannelupdate/ HTTP/1.1" 500 32102
```


### Reviewer guidance

Any reason this wouldn't be correct

### References

https://github.com/learningequality/kolibri/pull/6217

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
