### PR TITLE
Headers in csv are mandatory

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -71,7 +71,7 @@ MESSAGES = {
         "Username only can contain characters, numbers and underscores"
     ),
     REQUIRED_COLUMN: _("The column '{}' is required"),
-    INVALID_HEADER: _("Mix of valid and invalid header labels found in first row"),
+    INVALID_HEADER: _("Mix of valid and/or invalid header labels found in first row"),
     NO_FACILITY: _(
         "No default facility exists, please make sure to provision this device before running this command"
     ),
@@ -608,6 +608,8 @@ class Command(AsyncCommand):
         with self.start_progress(total=100) as self.progress_update:
             # validate csv headers:
             has_header = self.csv_headers_validation(filepath)
+            if not has_header:
+                self.overall_error.append(MESSAGES[INVALID_HEADER])
             self.exit_if_error()
             self.progress_update(1)  # state=csv_headers
             try:


### PR DESCRIPTION

### Summary
When importing users from a csv file, to keep compatibility with previous importusers script the csv might have not headers.
However, after the spec changes in this project, with translatable headers, headers should be mandatory to do the import.
This PR returns an error if the right headers are not present.

### Reviewer guidance

Verify that a csv without headers can't be imported and the UI shows an appropiate error message


### References
Relates: #6674, #6716 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
