### PR TITLE
Fix diskcache_cache declared in local namespace

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -21,13 +21,14 @@ def recreate_cache():
     os.mkdir(diskcache_location)
     diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
     diskcache_cache.close()
+    return diskcache_cache
 
 
 try:
     diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
     diskcache_cache.close()
 except DatabaseError:
-    recreate_cache()
+    diskcache_cache = recreate_cache()
 
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {


### PR DESCRIPTION
### Summary

Reported by @JamesKainer - thanks for doing all the work, James!

https://github.com/learningequality/kolibri-installer-debian/issues/90#issuecomment-612533476

```
● kolibri.service - LSB: kolibri daemon, an offline education platform
Loaded: loaded (/etc/init.d/kolibri; enabled; vendor preset: enabled)
Active: failed (Result: exit-code) since Sat 2020-04-11 18:39:51 BST; 2s ago
Process: 1108 ExecStart=/etc/init.d/kolibri start (code=exited, status=1/FAILURE)

Apr 11 18:39:51 kolibri[1108]: File "/usr/lib/python3/dist-packages/kolibri/core/tasks/queue.py", line 1, in
Apr 11 18:39:51 kolibri[1108]: from kolibri.core.tasks.job import Job
Apr 11 18:39:51 kolibri[1108]: File "/usr/lib/python3/dist-packages/kolibri/core/tasks/job.py", line 7, in
Apr 11 18:39:51 kolibri[1108]: from kolibri.core.tasks.utils import current_state_tracker
Apr 11 18:39:51 kolibri[1108]: File "/usr/lib/python3/dist-packages/kolibri/core/tasks/utils.py", line 9, in
Apr 11 18:39:51 kolibri[1108]: from kolibri.deployment.default.cache import diskcache_cache
Apr 11 18:39:51 kolibri[1108]: ImportError: cannot import name 'diskcache_cache' from 'kolibri.deployment.default.cache' (/usr/lib/python3/dist-packages/kolibri/deployment/default/cache.
Apr 11 18:39:51 systemd[1]: kolibri.service: Control process exited, code=exited, status=1/FAILURE
Apr 11 18:39:51 systemd[1]: kolibri.service: Failed with result 'exit-code'.
Apr 11 18:39:51 systemd[1]: Failed to start LSB: kolibri daemon, an offline education platform.
```

### Reviewer guidance

Seems straight-forward? 0.13.2 or next patch?

```
>>> try:
...     x=not_defined
... except:
...     x="defined"
... 
>>> x
'defined'
```

### References

Original implementation here:
https://github.com/learningequality/kolibri/pull/6511/

Broken here but with nicer code :)
https://github.com/learningequality/kolibri/pull/6567

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
