### PR TITLE
404 in CLI usage, add note on help for Django management commands

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -372,12 +372,13 @@ def update(old_version, new_version):
     cache.clear()
 
 
-main_help = """Kolibri management commands
+main_help = """Kolibri command-line utility
 
-For more information, see:
-https://kolibri.readthedocs.io/en/latest/advanced.html
+Details for each main command: kolibri COMMAND --help
 
-You can also run: kolibri COMMAND --help
+List of additional management commands: kolibri manage help
+
+For more information, see: https://kolibri.readthedocs.io/
 """
 
 


### PR DESCRIPTION
### Summary

Old link was broken. (CC: @radinamatic -- small risks implied when we re-organize docs, maybe we should start being more cautious, there are many links in community forums, too)

Added additional help for finding Django management sub-commands, because discovering them isn't possible by following the advice `kolibri <COMMAND> --help`: Running `kolibri manage --help`  does not give the list of available commands, but a set op general options for `manage`. The correct command is `kolibri manage help` which isn't directly deducible from the first set of instructions.

**There's one out-standing issue:** Click gives this pattern: `kolibri [OPTIONS] COMMAND [ARGS]...`. It auto-generates this string and then lists `Options` straight below as `--version` and `--help`. This is a bit wrong, it would be better if we just write the whole text.

### Before

```
Usage: kolibri [OPTIONS] COMMAND [ARGS]...

  Kolibri management commands

  For more information, see:
  https://kolibri.readthedocs.io/en/latest/advanced.html

  You can also run: kolibri COMMAND --help

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  manage    Django management commands.
  plugin    Manage Kolibri plugins
  services  Start worker processes
  shell     Launch a Django shell
  start     Start the Kolibri process
  status    Show the status of the Kolibri process
  stop      Stop the Kolibri process
```

### After

```
Usage: kolibri [OPTIONS] COMMAND [ARGS]...

  Kolibri command-line utility

  Details for each main command: kolibri <COMMAND> --help

  List of additional management commands: kolibri manage help

  For more information, see: https://kolibri.readthedocs.io/

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  manage    Django management commands.
  plugin    Manage Kolibri plugins
  services  Start worker processes
  shell     Launch a Django shell
  start     Start the Kolibri process
  status    Show the status of the Kolibri process
  stop      Stop the Kolibri process

```

### Reviewer guidance

Maybe we can target doing more stuff for `develop`, but would be nice not to ship 0.13 with a broken link and unhelpful help texts.

### References

None, just stumbled upon it when looking for help on José's profiling command.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
