### PR TITLE
Add Python 3.8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,13 @@ matrix:
       sudo: true
       env:
         - TOX_ENV=py3.7
+
+    - python: 3.8
+      dist: bionic
+      sudo: true
+      env:
+        - TOX_ENV=py3.8
+
     - python: "2.7"
       env:
         - TOX_ENV=node10.x

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,pypy}, pythonlint2, lint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
+envlist = py{2.7,3.4,3.5,3.6,3.7,3.8,pypy}, pythonlint2, lint, node10.x, docs, node, postgres, pythonbuild{2.7,3.4,3.5,3.6,3.7}, cext, nocext
 
 [testenv]
 usedevelop = True
@@ -24,6 +24,7 @@ basepython =
     py3.5: python3.5
     py3.6: python3.6
     py3.7: python3.7
+    py3.8: python3.8
     pypy: pypy
     docs: python3.5
     pythonlint2: python2.7


### PR DESCRIPTION
# Summary

This could make Python 3.8 support official from 0.14 (if it works).

### Reviewer guidance

n/a

### References

n/a

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
