### PR TITLE
Don't delete users in previous classes when updating

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -656,9 +656,7 @@ class Command(AsyncCommand):
                     Classroom.objects.create(
                         name=classroom.name, parent=classroom.parent
                     )
-                # clear users from classes to be updated:
-                update_classes = [c.id for c in db_update_classes]
-                Membership.objects.filter(collection__in=update_classes).delete()
+
                 self.add_classes_memberships(
                     classes, users_data, db_new_classes + db_update_classes
                 )


### PR DESCRIPTION
### Summary
Don't clear memberships when updating classes. 
If the delete option is set, the users will have been deleted previously. If the option is not set, classes should keep their users

### Reviewer guidance

1. Create a classroom
2. Add users to the classroom
3. Export the data  in a csv file
4. Edit the csv file to add a new user to any of the classrooms
5. Import the modified csv file

Check classrooms keep their previous users and have the new users added.

### References

Fixes: #6786

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
