### PR TITLE
Delete users from previous enrollments and assignments

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -607,14 +607,18 @@ class Command(AsyncCommand):
             # enrolled:
             to_remove = user.memberships.filter(collection__kind=CLASSROOM)
             if user.username in users_enrolled.keys():
-                to_remove.exclude(collection__name__in=users_enrolled[user.username]).delete()
+                to_remove.exclude(
+                    collection__name__in=users_enrolled[user.username]
+                ).delete()
             else:
                 to_remove.delete()
 
             # assigned:
             to_remove = user.roles.filter(collection__kind=CLASSROOM)
             if user.username in users_assigned.keys():
-                to_remove.exclude(collection__name__in=users_assigned[user.username]).delete()
+                to_remove.exclude(
+                    collection__name__in=users_assigned[user.username]
+                ).delete()
             else:
                 to_remove.delete()
 

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -12,6 +12,7 @@ from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 
 from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.constants.collection_kinds import CLASSROOM
 from kolibri.core.auth.constants.demographics import choices
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
@@ -149,6 +150,22 @@ def valid_name(username=True, allow_null=False):
             raise ValueError(v)
 
     return checker
+
+
+def reverse_dict(original):
+    """
+    Returns a dictionary based on an original dictionary
+    where previous keys are values and previous values pass
+    to be the keys
+    """
+    final = {}
+    for k, value in original.items():
+        if type(value) == list:
+            for v in value:
+                final.setdefault(v, []).append(k)
+        else:
+            final.setdefault(value, []).append(k)
+    return final
 
 
 class Validator(object):
@@ -425,7 +442,7 @@ class Command(AsyncCommand):
                 user_obj = FacilityUser.objects.get(
                     username=user, facility=self.default_facility
                 )
-                keeping_users.append(user_obj.id)
+                keeping_users.append(user_obj)
                 if self.compare_fields(user_obj, values):
                     update_users.append(user_obj)
             else:
@@ -510,7 +527,7 @@ class Command(AsyncCommand):
     def get_delete(self, options, keeping_users, update_classes):
         if not options["delete"]:
             return ([], [])
-        users_not_to_delete = keeping_users
+        users_not_to_delete = [u.id for u in keeping_users]
         admins = self.default_facility.get_admins()
         users_not_to_delete += admins.values_list("id", flat=True)
         if options["userid"]:
@@ -583,6 +600,24 @@ class Command(AsyncCommand):
             sys.exit(1)
         return
 
+    def remove_memberships(self, users, enrolled, assigned):
+        users_enrolled = reverse_dict(enrolled)
+        users_assigned = reverse_dict(assigned)
+        for user in users:
+            # enrolled:
+            to_remove = user.memberships.filter(collection__kind=CLASSROOM)
+            if user.username in users_enrolled.keys():
+                to_remove.exclude(collection__name__in=users_enrolled[user.username]).delete()
+            else:
+                to_remove.delete()
+
+            # assigned:
+            to_remove = user.roles.filter(collection__kind=CLASSROOM)
+            if user.username in users_assigned.keys():
+                to_remove.exclude(collection__name__in=users_assigned[user.username]).delete()
+            else:
+                to_remove.delete()
+
     def handle_async(self, *args, **options):
         # initialize stats data structures:
         self.overall_error = []
@@ -624,7 +659,6 @@ class Command(AsyncCommand):
             except (ValueError, FileNotFoundError, csv.Error) as e:
                 self.overall_error.append(MESSAGES[FILE_READ_ERROR].format(e))
                 self.exit_if_error()
-
             db_new_users, db_update_users, keeping_users = self.build_users_objects(
                 users
             )
@@ -660,7 +694,7 @@ class Command(AsyncCommand):
                 self.add_classes_memberships(
                     classes, users_data, db_new_classes + db_update_classes
                 )
-
+                self.remove_memberships(keeping_users, classes[0], classes[1])
             classes_report = {
                 "created": len(db_new_classes),
                 "updated": len(db_update_classes),


### PR DESCRIPTION
### Summary
When importing users from a csv file, any  user in the file should be removed from his previous assignements/enrolments if they are not stated in the csv file

### Reviewer guidance

1. Create classes and enrol and assign coaches
2. Export the csv file with the facility data
3. Modify the file, removing some classes from the users assigned and enroled fields
4. import the csv file and check that:

- Users have been deleted from their previous classes when being in the csv
- Users in the csv have been assigned or enrolled to the new classes 
- Users in the csv have kept the enrolled or assigned classes present in the csv fields
- Users not been in the csv have  not been affected

### References
Relates: #6674 



### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
