### PR TITLE
Ensure bulk import sets an empty string instead of None for demographic fields

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -405,14 +405,14 @@ class Command(AsyncCommand):
             password = make_password(password)
         else:
             password = DEFAULT_PASSWORD
-        gender = user_row.get(self.header_translation["GENDER"], None)
-        gender = None if gender.upper() == DEFERRED else gender
+        gender = user_row.get(self.header_translation["GENDER"], '')
+        gender = '' if gender.upper() == DEFERRED else gender
         if gender:
             gender = gender.strip().upper()
-        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], None)
-        birth_year = None if birth_year.upper() == DEFERRED else birth_year
-        id_number = user_row.get(self.header_translation["IDENTIFIER"], None)
-        id_number = None if id_number.upper() == DEFERRED else id_number
+        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], '')
+        birth_year = '' if birth_year.upper() == DEFERRED else birth_year
+        id_number = user_row.get(self.header_translation["IDENTIFIER"], '')
+        id_number = '' if id_number.upper() == DEFERRED else id_number
         full_name = user_row.get(self.header_translation["FULL_NAME"], None)
 
         return {

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -405,14 +405,14 @@ class Command(AsyncCommand):
             password = make_password(password)
         else:
             password = DEFAULT_PASSWORD
-        gender = user_row.get(self.header_translation["GENDER"], '')
-        gender = '' if gender.upper() == DEFERRED else gender
+        gender = user_row.get(self.header_translation["GENDER"], "")
+        gender = "" if gender.upper() == DEFERRED else gender
         if gender:
             gender = gender.strip().upper()
-        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], '')
-        birth_year = '' if birth_year.upper() == DEFERRED else birth_year
-        id_number = user_row.get(self.header_translation["IDENTIFIER"], '')
-        id_number = '' if id_number.upper() == DEFERRED else id_number
+        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], "")
+        birth_year = "" if birth_year.upper() == DEFERRED else birth_year
+        id_number = user_row.get(self.header_translation["IDENTIFIER"], "")
+        id_number = "" if id_number.upper() == DEFERRED else id_number
         full_name = user_row.get(self.header_translation["FULL_NAME"], None)
 
         return {

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -405,14 +405,13 @@ class Command(AsyncCommand):
             password = make_password(password)
         else:
             password = DEFAULT_PASSWORD
-        gender = user_row.get(self.header_translation["GENDER"], "")
-        gender = "" if gender.upper() == DEFERRED else gender
-        if gender:
-            gender = gender.strip().upper()
-        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], "")
-        birth_year = "" if birth_year.upper() == DEFERRED else birth_year
-        id_number = user_row.get(self.header_translation["IDENTIFIER"], "")
-        id_number = "" if id_number.upper() == DEFERRED else id_number
+
+        gender = user_row.get(self.header_translation["GENDER"], "").strip().upper()
+        gender = "" if gender == DEFERRED else gender
+        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], "").strip().upper()
+        birth_year = "" if birth_year == DEFERRED else birth_year
+        id_number = user_row.get(self.header_translation["IDENTIFIER"], "").strip().upper()
+        id_number = "" if id_number == DEFERRED else id_number
         full_name = user_row.get(self.header_translation["FULL_NAME"], None)
 
         return {

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -408,9 +408,13 @@ class Command(AsyncCommand):
 
         gender = user_row.get(self.header_translation["GENDER"], "").strip().upper()
         gender = "" if gender == DEFERRED else gender
-        birth_year = user_row.get(self.header_translation["BIRTH_YEAR"], "").strip().upper()
+        birth_year = (
+            user_row.get(self.header_translation["BIRTH_YEAR"], "").strip().upper()
+        )
         birth_year = "" if birth_year == DEFERRED else birth_year
-        id_number = user_row.get(self.header_translation["IDENTIFIER"], "").strip().upper()
+        id_number = (
+            user_row.get(self.header_translation["IDENTIFIER"], "").strip().upper()
+        )
         id_number = "" if id_number == DEFERRED else id_number
         full_name = user_row.get(self.header_translation["FULL_NAME"], None)
 

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -241,6 +241,6 @@ class ImportTestCase(TestCase):
         new_learner = FacilityUser.objects.get(username="new_learner")
         assert new_learner.gender == demographics.FEMALE
         assert new_learner.birth_year == "2001"
-        assert new_learner.id_number == "kalite"
+        assert new_learner.id_number == "KALITE"
         new_coach = FacilityUser.objects.get(username="new_coach")
         assert new_coach.gender == demographics.MALE


### PR DESCRIPTION
### Summary
Current FacilityUser model sets an empty string when there's no value for demographic fields.
bulkimportusers command that was using incorrectly None.


### Reviewer guidance
Importing twice the csv example file provided in #6787 should not produce any error


### References
Relates #6787


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
