### PR TITLE
Dispatch handleApiError when a general error happens using csv import/export

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/importCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/importCSV/actions.js
@@ -42,8 +42,11 @@ function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitF
 
     if (task && task.status === TaskStatuses.COMPLETED) {
       store.commit(commitFinish, task);
-      // TaskResource.deleteFinishedTask(taskId);
     } else if (task && task.status === TaskStatuses.FAILED) {
+      if (typeof task.overall_error === 'undefined') {
+        store.dispatch('handleApiError', task.traceback, { root: true });
+      }
+
       store.commit('SET_FAILED', task);
     }
   } else {


### PR DESCRIPTION
### Summary
Previously, if a backend error happened while importing or exporting users from a csv file, the user only show a blank screen (See #6787)

This PR uses our general handleApiError mechanism to show the complete information to the end user.
![error1](https://user-images.githubusercontent.com/1008178/80736630-ae68d700-8b12-11ea-8a21-59bb9db08696.png)
![error2](https://user-images.githubusercontent.com/1008178/80736635-b0329a80-8b12-11ea-8def-4ffa426b4a77.png)


### Reviewer guidance
An easy way to trigger a backend error is not launching the services part of Kolibri, then the backend error will happen after importing any csv file.

### References
Really fixes #6787


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
