### PR TITLE
Show special permissions license descriptions when they exist.

### DIFF
--- a/kolibri/core/assets/src/utils/licenseTranslations.js
+++ b/kolibri/core/assets/src/utils/licenseTranslations.js
@@ -236,6 +236,13 @@ export function licenseLongName(leUtilsLicenseName) {
 
 // Translated license descriptions, aimed at creators of the content
 export function licenseDescriptionForCreator(leUtilsLicenseName, leUtilsLicenseDescription) {
+  if (
+    leUtilsLicenseName === 'Special Permissions' &&
+    leUtilsLicenseDescription &&
+    leUtilsLicenseDescription.length
+  ) {
+    return leUtilsLicenseDescription;
+  }
   if (licenseDescriptionCreatorStrings[leUtilsLicenseName]) {
     return creatorDescriptionTranslator.$tr(leUtilsLicenseName);
   }
@@ -244,6 +251,13 @@ export function licenseDescriptionForCreator(leUtilsLicenseName, leUtilsLicenseD
 
 // Translated license descriptions, aimed at users and consumers of the content
 export function licenseDescriptionForConsumer(leUtilsLicenseName, leUtilsLicenseDescription) {
+  if (
+    leUtilsLicenseName === 'Special Permissions' &&
+    leUtilsLicenseDescription &&
+    leUtilsLicenseDescription.length
+  ) {
+    return leUtilsLicenseDescription;
+  }
   if (licenseDescriptionConsumerStrings[leUtilsLicenseName]) {
     return consumerDescriptionTranslator.$tr(leUtilsLicenseName);
   }


### PR DESCRIPTION
### Summary
* Shows special permissions license descriptions when they exist instead of translations of the generic text

### Reviewer guidance
Can you set a special permissions license description on Studio and have it rendered in Kolibri?

### References
Fixes #6326 

After:
![Screenshot from 2020-05-04 16-12-01](https://user-images.githubusercontent.com/1680573/81022421-6a334a80-8e22-11ea-8398-2779dd0dc355.png)


----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
