### PR TITLE
Reduce, Reuse: C extensions built for Linux abi3 share path

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -319,15 +319,6 @@ def parse_package_page(files, pk_version, index_url):  # noqa C901
             if index_url == PYPI_DOWNLOAD:
                 sys.exit(1)
 
-    # Copy the packages in cp34 to cp35, cp36, cp37 due to abi3 tag.
-    # https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-python-3-5-on-linux-or-macos
-    if index_url == PYPI_DOWNLOAD:
-        abi3_src = os.path.join(DIST_CEXT, "cp34", "Linux")
-        python_versions = ["cp35", "cp36", "cp37"]
-        for version in python_versions:
-            abi3_dst = os.path.join(DIST_CEXT, version, "Linux")
-            shutil.copytree(abi3_src, abi3_dst)
-
 
 def install(name, pk_version):
     """

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -8,13 +8,25 @@ def prepend_cext_path(dist_path):
     """
     Calculate the directory of C extensions and add it to sys.path if exists.
     """
+
     python_version = "cp" + str(sys.version_info.major) + str(sys.version_info.minor)
     system_name = platform.system()
     machine_name = platform.machine()
     dirname = os.path.join(dist_path, "cext", python_version, system_name)
 
+    # Cryptography builds for Linux target Python 3.4+ but the only existing
+    # build is labeled 3.4 (the lowest version supported). This is because all
+    # the builds work on 3.4+!
+    # Minimum version will change to Python 3.5 in future versions of
+    # cryptography.
+    # https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-python-3-6-on-linux-or-macos
+    # Untested for a future Python 3.9, so don't make it count for that one
+    if system_name == "Linux" and sys.version_info >= (3, 5):
+        python_version = "cp34"
+        dirname = os.path.join(dist_path, "cext", python_version, system_name)
+
     # For Linux system with cpython<3.3, there could be abi tags 'm' and 'mu'
-    if system_name == "Linux" and int(python_version[2:]) < 33:
+    elif system_name == "Linux" and sys.version_info < (3, 3):
         # encode with ucs2
         if sys.maxunicode == 65535:
             dirname = os.path.join(dirname, python_version + "m")


### PR DESCRIPTION
### Summary

* Installer size before: 99.5 MB (if py3.8 is added in #6845) 96.3 MB (w/o py3.8)
* Installer size after: 84.9 MB (14.6 MB or 11.4 MB saved) 
* Installed footprint reduced by ~52 MB

Rather than hard-copying the individual tree, we can point the env to the right location?

This is also an alternative way of adding cryptography 2.3 support on Python 3.8 (still not tested).

The installed footprint is 13 MB per Python platform for Linux, so that is 3.5, 3.6, 3.7, 3.8 = 52 MB.

Edit: Adding cp38 to 0.13.x added 3.6 MB to the .whl, so this change would save 14.4 MB on the .whl installer.

### Reviewer guidance

Anything that I missed @lyw07 ?

### References

I opened up #6845 for 0.13.x - but if this is simple enough to go in to an upcoming patch release for 0.13, we can also do that instead.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
