### PR TITLE
Fix translation of csv headers

### DIFF
--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -37,20 +37,7 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 # TODO: decide whether these should be internationalized
-labels = OrderedDict(
-    (
-        ("username", _("Username ({})".format("USERNAME"))),
-        ("password", _("Password ({})".format("PASSWORD"))),
-        ("full_name", _("Full name ({})".format("FULL_NAME"))),
-        ("kind", _("User type ({})").format("USER_TYPE")),
-        ("id_number", _("Identifier ({})".format("IDENTIFIER"))),
-        ("birth_year", _("Birth year ({})".format("BIRTH_YEAR"))),
-        ("gender", _("Gender ({})".format("GENDER"))),
-        ("enrolled", _("Learner enrollment ({})".format("ENROLLED_IN"))),
-        ("assigned", _("Coach assignment ({})".format("ASSIGNED_TO"))),
-    )
-)
-
+labels = OrderedDict()
 db_columns = (
     "username",
     "id",
@@ -96,6 +83,23 @@ def map_output(obj):
         elif header in obj:
             mapped_obj[label] = obj[header]
     return mapped_obj
+
+
+def translate_labels():
+    global labels
+    labels = OrderedDict(
+        (
+            ("username", _("Username ({})").format("USERNAME")),
+            ("password", _("Password ({})").format("PASSWORD")),
+            ("full_name", _("Full name ({})").format("FULL_NAME")),
+            ("kind", _("User type ({})").format("USER_TYPE")),
+            ("id_number", _("Identifier ({})").format("IDENTIFIER")),
+            ("birth_year", _("Birth year ({})").format("BIRTH_YEAR")),
+            ("gender", _("Gender ({})").format("GENDER")),
+            ("enrolled", _("Learner enrollment ({})").format("ENROLLED_IN")),
+            ("assigned", _("Coach assignment ({})").format("ASSIGNED_TO")),
+        )
+    )
 
 
 def csv_file_generator(facility, filepath, overwrite=True):
@@ -211,6 +215,7 @@ class Command(AsyncCommand):
         # set language for the translation of the messages
         locale = settings.LANGUAGE_CODE if not options["locale"] else options["locale"]
         translation.activate(locale)
+        translate_labels()
 
         self.overall_error = []
         filepath = self.get_filepath(options)

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -37,7 +37,20 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 # TODO: decide whether these should be internationalized
-labels = OrderedDict()
+labels = OrderedDict(
+    (
+        ("username", _("Username ({})").format("USERNAME")),
+        ("password", _("Password ({})").format("PASSWORD")),
+        ("full_name", _("Full name ({})").format("FULL_NAME")),
+        ("kind", _("User type ({})").format("USER_TYPE")),
+        ("id_number", _("Identifier ({})").format("IDENTIFIER")),
+        ("birth_year", _("Birth year ({})").format("BIRTH_YEAR")),
+        ("gender", _("Gender ({})").format("GENDER")),
+        ("enrolled", _("Learner enrollment ({})").format("ENROLLED_IN")),
+        ("assigned", _("Coach assignment ({})").format("ASSIGNED_TO")),
+    )
+)
+
 db_columns = (
     "username",
     "id",

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -65,17 +65,17 @@ FILE_WRITE_ERROR = 9
 REQUIRED_PASSWORD = 10
 
 MESSAGES = {
-    UNEXPECTED_EXCEPTION: _("Unexpected exception [{}]: {}"),
-    TOO_LONG: _("'{}' is too long"),
-    INVALID: _("Not a valid '{}'"),
-    DUPLICATED_USERNAME: _("Duplicated Username"),
+    UNEXPECTED_EXCEPTION: _("Unexpected error [{}]: {}"),
+    TOO_LONG: _("Value in column '{}' is too many characters"),
+    INVALID: _("Invalid value in column '{}'"),
+    DUPLICATED_USERNAME: _("Username is duplicated"),
     INVALID_USERNAME: _(
         "Username only can contain characters, numbers and underscores"
     ),
     REQUIRED_COLUMN: _("The column '{}' is required"),
-    INVALID_HEADER: _("Mix of valid and/or invalid header labels found in first row"),
+    INVALID_HEADER: _("Invalid header label found in the first row"),
     NO_FACILITY: _(
-        "No default facility exists, please make sure to provision this device before running this command"
+        "No default facility exists. Make sure to provision this device before importing"
     ),
     FILE_READ_ERROR: _("Error trying to read csv file: {}"),
     FILE_WRITE_ERROR: _("Error trying to write csv file: {}"),

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -665,11 +665,13 @@ class TasksViewSet(viewsets.ViewSet):
         facility = request.user.facility.id
         job_type = "EXPORTUSERSTOCSV"
         job_metadata = {"type": job_type, "started_by": request.user.pk}
+        locale = get_language_from_request(request)
 
         job_id = priority_queue.enqueue(
             call_command,
             "bulkexportusers",
             facility=facility,
+            locale=locale,
             overwrite="true",
             extra_metadata=job_metadata,
             track_progress=True,

--- a/kolibri/locale/es_419/LC_MESSAGES/django.po
+++ b/kolibri/locale/es_419/LC_MESSAGES/django.po
@@ -61,11 +61,11 @@ msgstr "Género ({})"
 
 #: kolibri/core/auth/management/commands/bulkexportusers.py:49
 msgid "Learner enrollment ({})"
-msgstr "Estudiante inscripción ({})"
+msgstr "Inscrito como estudiante ({})"
 
 #: kolibri/core/auth/management/commands/bulkexportusers.py:50
 msgid "Coach assignment ({})"
-msgstr "Tutor asignación ({})"
+msgstr "Asignado como tutor ({})"
 
 #: kolibri/core/auth/management/commands/bulkimportusers.py:68
 msgid "Unexpected error [{}]: {}"
@@ -167,4 +167,3 @@ msgstr "Autorización del proveedor de OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Petición de permiso"
-

--- a/kolibri/locale/es_419/LC_MESSAGES/django.po
+++ b/kolibri/locale/es_419/LC_MESSAGES/django.po
@@ -73,7 +73,7 @@ msgstr "Error inesperado [{}]: {}"
 
 #: kolibri/core/auth/management/commands/bulkimportusers.py:69
 msgid "Value in column '{}' is too many characters"
-msgstr "Valor en la columna '{}' más dígitos del permitido"
+msgstr "El valor en la columna '{}' tiene más caracteres de los permitidos"
 
 #: kolibri/core/auth/management/commands/bulkimportusers.py:70
 msgid "Invalid value in column '{}'"


### PR DESCRIPTION
### Summary
Fix several issues for the translation of csv headers:
* Python `OrderedDict` structure ignores the laziness of `gettext_lazy`
* Wrong header formatting
* tasks api was not applying the locale when exporting

It also updates changes made in crowdin for some of the strings in the code and fixes a couple of translations.


### Reviewer guidance
Using Spanish in the browser (`es-419`, because `es_ES` is not translated) check the exported csv file has all the headers in Spanish


### References
Fixes #6853

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
