### PR TITLE
update piwheels url for cryptography rpi packages download - 0.10.x

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -8,9 +8,9 @@ import sys
 import requests
 from bs4 import BeautifulSoup
 
-DIST_CEXT = 'kolibri/dist/cext'
-PYPI_DOWNLOAD = 'https://pypi.python.org/simple/'
-PIWHEEL_DOWNLOAD = 'https://www.piwheels.hostedpi.com/simple/'
+DIST_CEXT = "kolibri/dist/cext"
+PYPI_DOWNLOAD = "https://pypi.python.org/simple/"
+PIWHEEL_DOWNLOAD = "https://www.piwheels.org/simple/"
 
 
 def get_path_with_arch(platform, path, abi, implementation, python_version):
@@ -20,41 +20,68 @@ def get_path_with_arch(platform, path, abi, implementation, python_version):
 
     # Split the platform into two parts.
     # For example: manylinux1_x86_64 to Linux, x86_64
-    platform_split = platform.replace('manylinux1', 'Linux').split('_', 1)
+    platform_split = platform.replace("manylinux1", "Linux").split("_", 1)
 
     # Windows 32-bit's machine name is x86.
-    if platform_split[0] == 'win32':
-        return os.path.join(path, 'Windows', 'x86')
+    if platform_split[0] == "win32":
+        return os.path.join(path, "Windows", "x86")
     # Windows 64-bit
-    elif platform_split[0] == 'win':
-        return os.path.join(path, 'Windows', 'AMD64')
+    elif platform_split[0] == "win":
+        return os.path.join(path, "Windows", "AMD64")
 
     # Prior to CPython 3.3, there were two ABI-incompatible ways of building CPython
     # There could be abi tag 'm' for narrow-unicode and abi tag 'mu' for wide-unicode
-    if implementation == 'cp' and int(python_version) < 33:
+    if implementation == "cp" and int(python_version) < 33:
         return os.path.join(path, platform_split[0], abi, platform_split[1])
 
     return os.path.join(path, platform_split[0], platform_split[1])
 
 
-def download_package(path, platform, version, implementation, abi, name, pk_version, index_url):
+def download_package(
+    path, platform, version, implementation, abi, name, pk_version, index_url
+):
     """
     Download the package according to platform, python version, implementation and abi.
     """
-    return_code = subprocess.call([
-        'python', 'kolibripip.pex', 'download', '-q', '-d', path, '--platform', platform,
-        '--python-version', version, '--implementation', implementation,
-        '--abi', abi, '-i', index_url, '{}=={}'.format(name, pk_version)
-    ])
+    return_code = subprocess.call(
+        [
+            "python",
+            "kolibripip.pex",
+            "download",
+            "-q",
+            "-d",
+            path,
+            "--platform",
+            platform,
+            "--python-version",
+            version,
+            "--implementation",
+            implementation,
+            "--abi",
+            abi,
+            "-i",
+            index_url,
+            "{}=={}".format(name, pk_version),
+        ]
+    )
 
     # When downloaded as a tar.gz, convert to a wheel file first.
     # This is specifically for pycparser package.
     files = os.listdir(path)
     for file in files:
-        if file.endswith('tar.gz'):
-            subprocess.call([
-                'python', 'kolibripip.pex', 'wheel', '-q', '-w',
-                path, os.path.join(path, file), '--no-deps'])
+        if file.endswith("tar.gz"):
+            subprocess.call(
+                [
+                    "python",
+                    "kolibripip.pex",
+                    "wheel",
+                    "-q",
+                    "-w",
+                    path,
+                    os.path.join(path, file),
+                    "--no-deps",
+                ]
+            )
             os.remove(os.path.join(path, file))
 
     return return_code
@@ -66,18 +93,27 @@ def install_package_by_wheel(path):
     """
     files = os.listdir(path)
     for file in files:
-        return_code = subprocess.call([
-            'python', 'kolibripip.pex', 'install', '-q', '-t',
-            path, os.path.join(path, file), '--no-deps'
-        ])
+        return_code = subprocess.call(
+            [
+                "python",
+                "kolibripip.pex",
+                "install",
+                "-q",
+                "-t",
+                path,
+                os.path.join(path, file),
+                "--no-deps",
+            ]
+        )
         if return_code == 1:
-            sys.exit('\nInstallation failed for package {}.\n'.format(file))
+            sys.exit("\nInstallation failed for package {}.\n".format(file))
         else:
             # Clean up the whl file and dist-info folder
             os.remove(os.path.join(path, file))
             shutil.rmtree(
-                os.path.join(
-                    path, '-'.join(file.split('-', 2)[:2])+'.dist-info'), ignore_errors=True)
+                os.path.join(path, "-".join(file.split("-", 2)[:2]) + ".dist-info"),
+                ignore_errors=True,
+            )
 
 
 def parse_package_page(files, pk_version, index_url):
@@ -85,7 +121,7 @@ def parse_package_page(files, pk_version, index_url):
     Parse the PYPI and Piwheels link for the package and install the desired wheel files.
     """
 
-    for file in files.find_all('a'):
+    for file in files.find_all("a"):
         # We are not going to install the packages if they are:
         #   * not a whl file
         #   * not the version specified in requirements.txt
@@ -93,7 +129,7 @@ def parse_package_page(files, pk_version, index_url):
         #   * not macosx or win_x64 platforms,
         #     since the process of setup wizard has been fast enough
 
-        file_name_chunks = file.string.split('-')
+        file_name_chunks = file.string.split("-")
 
         # When the length of file_name_chunks is 2, it means the file is tar.gz.
         if len(file_name_chunks) == 2:
@@ -102,27 +138,36 @@ def parse_package_page(files, pk_version, index_url):
         package_version = file_name_chunks[1]
         package_name = file_name_chunks[0]
         python_version = file_name_chunks[2][2:]
-        platform = file_name_chunks[4].split('.')[0]
+        platform = file_name_chunks[4].split(".")[0]
         implementation = file_name_chunks[2][:2]
         abi = file_name_chunks[3]
 
         if package_version != pk_version:
             continue
-        if python_version == '26':
+        if python_version == "26":
             continue
-        if 'macosx' in platform:
+        if "macosx" in platform:
             continue
-        if 'win_amd64' in platform and python_version != '34':
+        if "win_amd64" in platform and python_version != "34":
             continue
 
-        print('Installing {}...'.format(file.string))
+        print("Installing {}...".format(file.string))
 
         version_path = os.path.join(DIST_CEXT, file_name_chunks[2])
-        package_path = get_path_with_arch(platform, version_path, abi, implementation, python_version)
+        package_path = get_path_with_arch(
+            platform, version_path, abi, implementation, python_version
+        )
 
         download_return = download_package(
-            package_path, platform, python_version, implementation, abi, package_name,
-            pk_version, index_url)
+            package_path,
+            platform,
+            python_version,
+            implementation,
+            abi,
+            package_name,
+            pk_version,
+            index_url,
+        )
 
         # Successfully download package
         if download_return == 0:
@@ -130,7 +175,7 @@ def parse_package_page(files, pk_version, index_url):
         # Download failed
         else:
             # see https://github.com/learningequality/kolibri/issues/4656
-            print('\nDownload failed for package {}.\n'.format(file.string))
+            print("\nDownload failed for package {}.\n".format(file.string))
 
             # We still need to have the program exit with error
             # if something wrong with PyPi download.
@@ -146,10 +191,10 @@ def install(name, pk_version):
     for link in links:
         r = requests.get(link + name)
         if r.status_code == 200:
-            files = BeautifulSoup(r.content, 'html.parser')
+            files = BeautifulSoup(r.content, "html.parser")
             parse_package_page(files, pk_version, link)
         else:
-            sys.exit('\nUnable to find package {} on {}.\n'.format(name, link))
+            sys.exit("\nUnable to find package {} on {}.\n".format(name, link))
 
 
 def parse_requirements(args):
@@ -159,17 +204,23 @@ def parse_requirements(args):
     """
     with open(args.file) as f:
         for line in f:
-            char_list = line.split('==')
+            char_list = line.split("==")
             if len(char_list) == 2:
                 # Install package according to its name and version
                 install(char_list[0].strip(), char_list[1].strip())
             else:
-                sys.exit('\nName format in cext.txt is incorrect. Should be \'packageName==packageVersion\'.\n')
+                sys.exit(
+                    "\nName format in cext.txt is incorrect. Should be 'packageName==packageVersion'.\n"
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Parsing the requirement.txt file argument
-    parser = argparse.ArgumentParser(description="Downloading and installing Python C extensions tool.")
-    parser.add_argument('--file', required=True, help='The name of the requirements.txt')
+    parser = argparse.ArgumentParser(
+        description="Downloading and installing Python C extensions tool."
+    )
+    parser.add_argument(
+        "--file", required=True, help="The name of the requirements.txt"
+    )
     args = parser.parse_args()
     parse_requirements(args)

--- a/kolibri/plugins/device_management/assets/test/views/channels-grid.spec.js
+++ b/kolibri/plugins/device_management/assets/test/views/channels-grid.spec.js
@@ -100,8 +100,8 @@ describe('channelsGrid component', () => {
     const { channelListItems } = getElements(wrapper);
     return wrapper.vm.$nextTick().then(() => {
       const items = channelListItems();
-      expect(items.at(1).props().channel.id).to.equal('awesome_channel');
-      expect(items.at(0).props().channel.id).to.equal('beautiful_channel');
+      expect(items.at(0).props().channel.id).to.equal('awesome_channel');
+      expect(items.at(1).props().channel.id).to.equal('beautiful_channel');
     });
   });
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

previously piwheels download url has been deprecated, so updating the url in the script to be the latest one.
the only major change is the piwheels download url change. other changes are due to black formatting.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check if the build passes. thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/piwheels/packages/issues/112

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
