### PR TITLE
Provide row number on all errors when doing bulk import

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -301,6 +301,7 @@ class Validator(object):
             # if there aren't any errors, let's add the user and classes
             if not error_flag:
                 self.check_classroom(row, username)
+                row["position"] = index + 1
                 self.users[username] = row
 
 
@@ -509,9 +510,10 @@ class Command(AsyncCommand):
             else:
                 if not values["password"]:
                     error = {
-                        "row": "USERNAME:{}".format(user),
+                        "row": users[user]["position"],
+                        "username": user,
                         "message": MESSAGES[REQUIRED_PASSWORD],
-                        "field": "password",
+                        "field": "PASSWORD",
                         "value": "*",
                     }
                     per_line_errors.append(error)

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -238,6 +238,7 @@ class ImportTestCase(TestCase):
         # validation when checking db content should trigger an error for '*'  password for a non-existing user:
         assert "'value': '*'" in result[1]
         assert "new_coach" in result[1]
+        assert "'row': 2" in result[1]
 
     def test_asterisk_in_password(self):
         _, first_filepath = tempfile.mkstemp(suffix=".csv")


### PR DESCRIPTION

### Summary
When using bulkimport, this PR adds metadata with the csv file row position for every user, so database validation can give the row position on errors.

Note: The backend also provides the username in this case. Not sure of how to use this in the frontend because for validation of csv errors the username is not available in many cases. 
Example: 

`INFO     Data errors: [{'row': 1, 'message': 'The password field is required. To leave the password unchanged in existing users, insert an asterisk (*)', 'field': 'PASSWORD', 'value': ''}, {'row': 2, 'username': 'new_coach2', 'message': 'The password field is required. To leave the password unchanged in existing users, insert an asterisk (*)', 'field': 'PASSWORD', 'value': '*'}]`

The first error is for a row that has been validated in csv (missed asterisk or password). Second  error has been detected while doing database validation (the user does not exist in the db, so asterisk is not valid)

### Reviewer guidance
Does it sound good enough?

### References

Fixes #6850


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
