### PR TITLE
update piwheels url for cryptography rpi packages download - 0.13

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -15,7 +15,7 @@ DIST_CEXT = os.path.join(
     "cext",
 )
 PYPI_DOWNLOAD = "https://pypi.python.org/simple/"
-PIWHEEL_DOWNLOAD = "https://www.piwheels.hostedpi.com/simple/"
+PIWHEEL_DOWNLOAD = "https://www.piwheels.org/simple/"
 
 
 def get_path_with_arch(platform, path, abi, implementation, python_version):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -3,10 +3,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import time
+from datetime import datetime
+from datetime import timedelta
 from functools import partial
 from itertools import groupby
+from uuid import uuid4
 
-from datetime import datetime, timedelta
 from django.contrib.auth import authenticate
 from django.contrib.auth import login
 from django.contrib.auth import logout
@@ -30,7 +32,6 @@ from rest_framework import permissions
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.response import Response
-from uuid import uuid4
 
 from .constants import collection_kinds
 from .constants import role_kinds


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to update the piwheels url to download the cryptography packages for rpi, since the old url has been deprecated.
note that the previous merge commits from 0.12 branch have been squashed for simplicity.
please feel free to let me know if you have any questions. Thank you!


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

please check if the builds have passed.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

0.10.x: #6855
0.11.x: #6857
0.12.x: https://github.com/learningequality/kolibri/pull/6858

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
