### PR TITLE
User id is used to create or update users for bulk import/export

### DIFF
--- a/integration_testing/features/super-admin/super-admin-bulk-import-users.feature
+++ b/integration_testing/features/super-admin/super-admin-bulk-import-users.feature
@@ -30,7 +30,7 @@ Feature: Super Admin bulk import users into a facility
       And the facility contains just classes and users listed in the CSV file
 
 # CSV file content example (for the first row, texts not inside parenthesis may be translated). For the UUID column, it will be empty to create the user, otherwise it will contain an uuid4 :
-User Unique ID (UUID),Username (USERNAME),Password (PASSWORD),Full name (FULL_NAME),User type (USER_TYPE),Identifier (IDENTIFIER),Birth year (BIRTH_YEAR),Gender (GENDER),Learner enrollment (ENROLLED_IN),Coach assignment (ASSIGNED_TO)
+Database ID (UUID),Username (USERNAME),Password (PASSWORD),Full name (FULL_NAME),User type (USER_TYPE),Identifier (IDENTIFIER),Birth year (BIRTH_YEAR),Gender (GENDER),Learner enrollment (ENROLLED_IN),Coach assignment (ASSIGNED_TO)
 ,jkrowling,passwd1,Too bad to be here,STUDENT,Potter1,1899,FEMALE,Literature 0,
 ,ignored_data,passwd2,You are not a coach,LEARNER,,,,,Ignored class
 ,new_coach,passwd3,Miguel de Cervantes,CLASS_COACH,Sancho1,1969,MALE,,Literature 1

--- a/integration_testing/features/super-admin/super-admin-bulk-import-users.feature
+++ b/integration_testing/features/super-admin/super-admin-bulk-import-users.feature
@@ -29,10 +29,10 @@ Feature: Super Admin bulk import users into a facility
       And I see that old classes not listed in the CSV file have been deleted
       And the facility contains just classes and users listed in the CSV file
 
-# CSV file content example (for the first row, texts not inside parenthesis may be translated) :
-Username (USERNAME),Password (PASSWORD),Full name (FULL_NAME),User type (USER_TYPE),Identifier (IDENTIFIER),Birth year (BIRTH_YEAR),Gender (GENDER),Learner enrollment (ENROLLED_IN),Coach assignment (ASSIGNED_TO)
-jkrowling,passwd1,Too bad to be here,STUDENT,Potter1,1899,FEMALE,Literature 0,
-ignored_data,passwd2,You are not a coach,LEARNER,,,,,Ignored class
-new_coach,passwd3,Miguel de Cervantes,CLASS_COACH,Sancho1,1969,MALE,,Literature 1
-student1,passwd4,William Shakespeare,LEARNER,Otelo1,2001,MALE,Literature 1,
-student2,passwd5,Agatha Christie,LEARNER,Poirot1,1999,FEMALE,"Literature 1,Chemistry2",
+# CSV file content example (for the first row, texts not inside parenthesis may be translated). For the UUID column, it will be empty to create the user, otherwise it will contain an uuid4 :
+User Unique ID (UUID),Username (USERNAME),Password (PASSWORD),Full name (FULL_NAME),User type (USER_TYPE),Identifier (IDENTIFIER),Birth year (BIRTH_YEAR),Gender (GENDER),Learner enrollment (ENROLLED_IN),Coach assignment (ASSIGNED_TO)
+,jkrowling,passwd1,Too bad to be here,STUDENT,Potter1,1899,FEMALE,Literature 0,
+,ignored_data,passwd2,You are not a coach,LEARNER,,,,,Ignored class
+,new_coach,passwd3,Miguel de Cervantes,CLASS_COACH,Sancho1,1969,MALE,,Literature 1
+,student1,passwd4,William Shakespeare,LEARNER,Otelo1,2001,MALE,Literature 1,
+,student2,passwd5,Agatha Christie,LEARNER,Poirot1,1999,FEMALE,"Literature 1,Chemistry2",

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # TODO: decide whether these should be internationalized
 labels = OrderedDict(
     (
-        ("id", _("User Unique ID ({})".format("UUID"))),
+        ("id", _("Database ID ({})".format("UUID"))),
         ("username", _("Username ({})".format("USERNAME"))),
         ("password", _("Password ({})".format("PASSWORD"))),
         ("full_name", _("Full name ({})".format("FULL_NAME"))),

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 # TODO: decide whether these should be internationalized
 labels = OrderedDict(
     (
+        ("id", _("User Unique ID ({})".format("UUID"))),
         ("username", _("Username ({})".format("USERNAME"))),
         ("password", _("Password ({})".format("PASSWORD"))),
         ("full_name", _("Full name ({})".format("FULL_NAME"))),

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -87,9 +87,9 @@ MESSAGES = {
         "The password field is required. To leave the password unchanged in existing users, insert an asterisk (*)"
     ),
     NON_EXISTENT_UUID: _(
-        "Imposible to update {} because the provided Unique ID does not exist in this facility"
+        "Cannot update update '{}' because no user with that database ID exists in this facility"
     ),
-    INVALID_UUID: _("Provided User Unique Identifier is not valid"),
+    INVALID_UUID: _("Database ID is not valid"),
 }
 
 # Validators ###

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -304,6 +304,7 @@ class Validator(object):
             # if there aren't any errors, let's add the user and classes
             if not error_flag:
                 self.check_classroom(row, username)
+                row["position"] = index + 1
                 self.users[username] = row
 
 
@@ -512,9 +513,10 @@ class Command(AsyncCommand):
             else:
                 if not values["password"]:
                     error = {
-                        "row": "USERNAME:{}".format(user),
+                        "row": users[user]["position"],
+                        "username": user,
                         "message": MESSAGES[REQUIRED_PASSWORD],
-                        "field": "password",
+                        "field": "PASSWORD",
                         "value": "*",
                     }
                     per_line_errors.append(error)

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -3,6 +3,7 @@ import logging
 import ntpath
 import re
 import sys
+from uuid import UUID
 
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
@@ -65,6 +66,7 @@ FILE_READ_ERROR = 8
 FILE_WRITE_ERROR = 9
 REQUIRED_PASSWORD = 10
 NON_EXISTENT_UUID = 11
+INVALID_UUID = 12
 
 MESSAGES = {
     UNEXPECTED_EXCEPTION: _("Unexpected exception [{}]: {}"),
@@ -84,7 +86,10 @@ MESSAGES = {
     REQUIRED_PASSWORD: _(
         "The password field is required. To leave the password unchanged in existing users, insert an asterisk (*)"
     ),
-    NON_EXISTENT_UUID: _("Imposible to update {} because the provided Unique ID does not exist in this facility")
+    NON_EXISTENT_UUID: _(
+        "Imposible to update {} because the provided Unique ID does not exist in this facility"
+    ),
+    INVALID_UUID: _("Provided User Unique Identifier is not valid"),
 }
 
 # Validators ###
@@ -137,6 +142,23 @@ def value_length(length, allow_null=False):
             return None
 
         if v is None or len(v) > length:
+            raise ValueError(v)
+
+    return checker
+
+
+def valid_uuid(allow_null=True):
+    """
+    Return a value check function which raises a ValueError if the supplied
+    value is ot a valid uuid
+    """
+
+    def checker(v):
+        if allow_null and (v is None or v == ""):
+            return None
+        try:
+            UUID(v).version
+        except (ValueError, TypeError):
             raise ValueError(v)
 
     return checker
@@ -356,6 +378,7 @@ class Command(AsyncCommand):
     def csv_values_validation(self, reader, header_translation):
         per_line_errors = []
         validator = Validator(header_translation)
+        validator.add_check("UUID", valid_uuid(), MESSAGES[INVALID_UUID])
         validator.add_check(
             "FULL_NAME", value_length(125), MESSAGES[TOO_LONG].format("FULL_NAME")
         )
@@ -416,7 +439,6 @@ class Command(AsyncCommand):
                     validator.coach_classrooms[
                         real_name
                     ] = validator.coach_classrooms.pop(classroom)
-
         return (
             per_line_errors,
             (validator.classrooms, validator.coach_classrooms),
@@ -467,6 +489,8 @@ class Command(AsyncCommand):
         full_name = user_row.get(self.header_translation["FULL_NAME"], None)
 
         return {
+            "uuid": user_row.get(self.header_translation["UUID"], ""),
+            "username": user_row.get(self.header_translation["USERNAME"], ""),
             "password": password,
             "gender": gender,
             "birth_year": birth_year,
@@ -477,12 +501,12 @@ class Command(AsyncCommand):
     def compare_fields(self, user_obj, values):
         changed = False
         for field in values:
-            if getattr(user_obj, field) != values[field]:
-                changed = True
-            if field == "password" and values["password"] is None:
-                changed = False
-            if changed:
-                setattr(user_obj, field, values[field])
+            if field == "uuid":
+                continue  # uuid can't be updated
+            if field != "password" or values["password"] is not None:
+                if getattr(user_obj, field) != values[field]:
+                    changed = True
+                    setattr(user_obj, field, values[field])
         return changed
 
     def build_users_objects(self, users):
@@ -490,28 +514,56 @@ class Command(AsyncCommand):
         update_users = list()
         keeping_users = list()
         per_line_errors = list()
+        users_uuid = [
+            u[self.header_translation["UUID"]]
+            for u in users.values()
+            if u[self.header_translation["UUID"]] != ""
+        ]
         existing_users = (
             FacilityUser.objects.filter(facility=self.default_facility)
-            .filter(username__in=users.keys())
+            .filter(id__in=users_uuid)
             .values_list("id", flat=True)
         )
 
         # creating the users takes half of the time
         progress = (100 / self.number_lines) * 0.5
-
         for user in users:
             self.progress_update(progress)
             user_row = users[user]
             values = self.get_field_values(user_row)
-            if user_row["UUID"] in existing_users:
+            if values["uuid"] in existing_users:
                 user_obj = FacilityUser.objects.get(
-                    id=user_row["UUID"], facility=self.default_facility
+                    id=values["uuid"], facility=self.default_facility
                 )
                 keeping_users.append(user_obj)
+                if user_obj.username != user:
+                    # check for duplicated username in the facility
+                    existing_user = FacilityUser.objects.get(
+                        username=user, facility=self.default_facility
+                    )
+                    if existing_user:
+                        error = {
+                            "row": users[user]["position"],
+                            "username": user,
+                            "message": MESSAGES[DUPLICATED_USERNAME],
+                            "field": "USERNAME",
+                            "value": user,
+                        }
+                        per_line_errors.append(error)
+                        continue
                 if self.compare_fields(user_obj, values):
                     update_users.append(user_obj)
             else:
-                if not values["password"]:
+                if values["uuid"] != "":
+                    error = {
+                        "row": users[user]["position"],
+                        "username": user,
+                        "message": MESSAGES[NON_EXISTENT_UUID].format(user),
+                        "field": "PASSWORD",
+                        "value": "*",
+                    }
+                    per_line_errors.append(error)
+                elif not values["password"]:
                     error = {
                         "row": users[user]["position"],
                         "username": user,

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -496,12 +496,6 @@ class ImportTestCase(TestCase):
         classrooms = Classroom.objects.all()
         assert len(classrooms) == 4
 
-    def test_update_username(self):
-        self.import_exported_csv()
-        user_to_update = FacilityUser.objects.get(username="learnerag")
-        print(user_to_update.id)
-        print("ola")
-
     def test_non_existing_uuid(self):
         self.import_exported_csv()
         _, new_filepath = tempfile.mkstemp(suffix=".csv")

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -246,6 +246,7 @@ class ImportTestCase(TestCase):
         # validation when checking db content should trigger an error for '*'  password for a non-existing user:
         assert "'value': '*'" in result[1]
         assert "new_coach" in result[1]
+        assert "'row': 2" in result[1]
 
     def test_asterisk_in_password(self):
         _, first_filepath = tempfile.mkstemp(suffix=".csv")

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -2,6 +2,7 @@ import csv
 import io
 import sys
 import tempfile
+from uuid import uuid4
 
 import pytest
 from django.core.management import call_command
@@ -107,7 +108,7 @@ class ImportTestCase(TestCase):
         FacilityUser.objects.all().delete()
         Classroom.objects.all().delete()
 
-    def create_csv(self, filepath, rows):
+    def create_csv(self, filepath, rows, remove_uuid=False):
         header_labels = list(labels.values())
 
         if sys.version_info[0] < 3:
@@ -119,17 +120,21 @@ class ImportTestCase(TestCase):
             writer = csv.writer(f)
             writer.writerow(header_labels)
             for item in rows:
+                if remove_uuid:
+                    rows[0] = None
                 writer.writerow(item)
 
     def import_exported_csv(self):
         # Replace asterisk in passwords to be able to import it
+        # Remove UUID so new users are created
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = list()
         with open(self.filepath) as source:
             reader = csv.reader(source, strict=True)
             for row in reader:
-                if row[1] == "*":
-                    row[1] = "temp_password"
+                row[0] = None
+                if row[2] == "*":
+                    row[2] = "temp_password"
                 rows.append(row)
         self.create_csv(new_filepath, rows[1:])  # remove header
         self.filepath = new_filepath
@@ -175,6 +180,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
+                "uuid1",
                 "new_learner",
                 None,
                 None,
@@ -186,6 +192,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
+                "uuid2",
                 "new_coach",
                 "*",
                 None,
@@ -197,6 +204,7 @@ class ImportTestCase(TestCase):
                 "new_class",
             ],
             [
+                "uuid3",
                 "another_new_coach",
                 "passwd1",
                 None,
@@ -243,6 +251,7 @@ class ImportTestCase(TestCase):
         _, first_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
+                "uuid4",
                 "new_learner",
                 "passwd1",
                 None,
@@ -254,6 +263,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
+                "uuid5",
                 "new_coach",
                 "passwd2",
                 None,
@@ -276,6 +286,7 @@ class ImportTestCase(TestCase):
         _, second_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
+                "uuid6",
                 "new_learner",
                 "passwd3",
                 None,
@@ -287,6 +298,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
+                "uuid7",
                 "new_coach",
                 "*",
                 None,
@@ -311,6 +323,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
+                "uuid8",
                 "new_learner",
                 "passwd1",
                 None,
@@ -322,6 +335,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
+                "uuid9",
                 "new_coach",
                 "passwd2",
                 None,
@@ -374,6 +388,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
+                "uuid10",
                 "new_learner",
                 "passwd1",
                 None,
@@ -384,6 +399,7 @@ class ImportTestCase(TestCase):
                 "classroom1,classroom0",
             ],
             [
+                "uuid11",
                 "new_coach",
                 "passwd2",
                 None,
@@ -423,6 +439,7 @@ class ImportTestCase(TestCase):
         # first inside the same csv file
         rows = [
             [
+                "uuid12",
                 "learner1",
                 "passwd1",
                 None,
@@ -433,6 +450,7 @@ class ImportTestCase(TestCase):
                 " My class,another class ",
             ],
             [
+                "uuid13",
                 "coach1",
                 "passwd2",
                 None,
@@ -454,6 +472,7 @@ class ImportTestCase(TestCase):
         # now, testing it's insensitive with database names:
         rows = [
             [
+                "uuid14",
                 "learner2",
                 "passwd2",
                 None,
@@ -471,3 +490,33 @@ class ImportTestCase(TestCase):
         )
         classrooms = Classroom.objects.all()
         assert len(classrooms) == 4
+
+    def test_update_username(self):
+        self.import_exported_csv()
+        user_to_update = FacilityUser.objects.get(username="learnerag")
+        print(user_to_update.id)
+        print("ola")
+
+    def test_non_existing_uuid(self):
+        self.import_exported_csv()
+        _, new_filepath = tempfile.mkstemp(suffix=".csv")
+        rows = list()
+        with open(self.filepath) as source:
+            reader = csv.reader(source, strict=True)
+            for row in reader:
+                row[0] = uuid4()
+                row[2] = "*"
+                rows.append(row)
+        self.create_csv(new_filepath, rows[1:])  # remove header
+        number_of_rows = len(rows)
+        # import exported csv
+        out_log = StringIO()
+        call_command(
+            "bulkimportusers",
+            new_filepath,
+            facility=self.facility.id,
+            errorlines=out_log,
+        )
+        result = out_log.getvalue().split("\n")
+
+        assert len(result) == number_of_rows - 1  # exclude header

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -180,7 +180,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
-                "uuid1",
+                None,
                 "new_learner",
                 None,
                 None,
@@ -192,7 +192,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
-                "uuid2",
+                None,
                 "new_coach",
                 "*",
                 None,
@@ -204,7 +204,7 @@ class ImportTestCase(TestCase):
                 "new_class",
             ],
             [
-                "uuid3",
+                None,
                 "another_new_coach",
                 "passwd1",
                 None,
@@ -252,7 +252,7 @@ class ImportTestCase(TestCase):
         _, first_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
-                "uuid4",
+                None,
                 "new_learner",
                 "passwd1",
                 None,
@@ -264,7 +264,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
-                "uuid5",
+                None,
                 "new_coach",
                 "passwd2",
                 None,
@@ -280,14 +280,18 @@ class ImportTestCase(TestCase):
         call_command(
             "bulkimportusers", first_filepath, facility=self.facility.id,
         )
-        passwd1 = FacilityUser.objects.get(username="new_learner").password
-        passwd2 = FacilityUser.objects.get(username="new_coach").password
+        user1 = FacilityUser.objects.get(username="new_learner")
+        passwd1 = user1.password
+        uid1 = user1.id
+        user2 = FacilityUser.objects.get(username="new_coach")
+        passwd2 = user2.password
+        uid2 = user2.id
 
         # let's edit the users with a new import
         _, second_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
-                "uuid6",
+                uid1,
                 "new_learner",
                 "passwd3",
                 None,
@@ -299,7 +303,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
-                "uuid7",
+                uid2,
                 "new_coach",
                 "*",
                 None,
@@ -324,7 +328,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
-                "uuid8",
+                None,
                 "new_learner",
                 "passwd1",
                 None,
@@ -336,7 +340,7 @@ class ImportTestCase(TestCase):
                 None,
             ],
             [
-                "uuid9",
+                None,
                 "new_coach",
                 "passwd2",
                 None,
@@ -389,7 +393,7 @@ class ImportTestCase(TestCase):
         _, new_filepath = tempfile.mkstemp(suffix=".csv")
         rows = [
             [
-                "uuid10",
+                None,
                 "new_learner",
                 "passwd1",
                 None,
@@ -400,7 +404,7 @@ class ImportTestCase(TestCase):
                 "classroom1,classroom0",
             ],
             [
-                "uuid11",
+                None,
                 "new_coach",
                 "passwd2",
                 None,
@@ -440,7 +444,7 @@ class ImportTestCase(TestCase):
         # first inside the same csv file
         rows = [
             [
-                "uuid12",
+                None,
                 "learner1",
                 "passwd1",
                 None,
@@ -451,7 +455,7 @@ class ImportTestCase(TestCase):
                 " My class,another class ",
             ],
             [
-                "uuid13",
+                None,
                 "coach1",
                 "passwd2",
                 None,
@@ -473,7 +477,7 @@ class ImportTestCase(TestCase):
         # now, testing it's insensitive with database names:
         rows = [
             [
-                "uuid14",
+                None,
                 "learner2",
                 "passwd2",
                 None,
@@ -509,7 +513,7 @@ class ImportTestCase(TestCase):
                 row[2] = "*"
                 rows.append(row)
         self.create_csv(new_filepath, rows[1:])  # remove header
-        number_of_rows = len(rows)
+        number_of_rows = len(rows) - 1  # exclude header
         # import exported csv
         out_log = StringIO()
         call_command(
@@ -518,6 +522,6 @@ class ImportTestCase(TestCase):
             facility=self.facility.id,
             errorlines=out_log,
         )
-        result = out_log.getvalue().split("\n")
+        result = out_log.getvalue().strip().split("\n")
 
-        assert len(result) == number_of_rows - 1  # exclude header
+        assert len(result) == number_of_rows

--- a/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
@@ -21,6 +21,15 @@
       <tbody>
         <tr>
           <td>
+            {{ $tr('uuid') }}<br>
+            <span class="label" :style="label">{{ $tr('required') }}</span>
+          </td>
+          <td><code>UUID</code></td>
+
+          <td>{{ $tr('uuidInfo') }}</td>
+        </tr>
+        <tr>
+          <td>
             {{ $tr('username') }}<br>
             <span class="label" :style="label">{{ $tr('required') }}</span>
           </td>
@@ -151,6 +160,8 @@
       close: 'Close',
       required: 'Required',
       optional: 'Optional',
+      uuidInfo:
+        'Empty to create a new user. To update the user it has to be the User Unique Identifier from the Kolibri database',
       usernameInfo: 'Maximum 125 characters. Can contain letters, numbers and underscores',
       passwordInfo: 'Maximum 125 characters. To leave unchanged, use an asterisk:',
       fullNameInfo: 'Maximum 125 characters',
@@ -169,6 +180,7 @@
       columnNameHeader: 'Column',
       columnIDHeader: 'Identifier',
       columnInfoHeader: 'Information',
+      uuid: 'User Unique Identifier',
       username: 'Username',
       password: 'Password',
       fullName: 'Full name',

--- a/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
@@ -22,10 +22,9 @@
         <tr>
           <td>
             {{ $tr('uuid') }}<br>
-            <span class="label" :style="label">{{ $tr('required') }}</span>
+            <span class="label" :style="label">{{ $tr('optional') }}</span>
           </td>
           <td><code>UUID</code></td>
-
           <td>{{ $tr('uuidInfo') }}</td>
         </tr>
         <tr>
@@ -34,7 +33,6 @@
             <span class="label" :style="label">{{ $tr('required') }}</span>
           </td>
           <td><code>USERNAME</code></td>
-
           <td>{{ $tr('usernameInfo') }}</td>
         </tr>
         <tr>
@@ -161,7 +159,7 @@
       required: 'Required',
       optional: 'Optional',
       uuidInfo:
-        'Empty to create a new user. To update the user it has to be the User Unique Identifier from the Kolibri database',
+        'An ID used by Kolibri to uniquely identify a user. Leave it blank to create a new user',
       usernameInfo: 'Maximum 125 characters. Can contain letters, numbers and underscores',
       passwordInfo: 'Maximum 125 characters. To leave unchanged, use an asterisk:',
       fullNameInfo: 'Maximum 125 characters',
@@ -180,7 +178,7 @@
       columnNameHeader: 'Column',
       columnIDHeader: 'Identifier',
       columnInfoHeader: 'Information',
-      uuid: 'User Unique Identifier',
+      uuid: 'Database ID',
       username: 'Username',
       password: 'Password',
       fullName: 'Full name',


### PR DESCRIPTION
### Summary

- Bulk exports include the user id in the exported csv
- User id column is now mandatory to import
- If user id value is empty, the user will be created
- If user id value is a valid value, existing in the database, the user will be updated (usernames includes)


### Reviewer guidance
Check everything works fine and tests pass

### References
Fixes #6823


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
