### PR TITLE
Add and update snackbar notifications for different coach + admin workflows

### DIFF
--- a/integration_testing/features/admin/admin-change-profile-information.feature
+++ b/integration_testing/features/admin/admin-change-profile-information.feature
@@ -12,7 +12,7 @@ Feature: Admin changes profile information
       And I change my username
       And if my changes are valid (I did not leave the fields empty)
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
     When I go back to my *Profile > Details* page
     Then I see the new full name and username on the profile page
 
@@ -22,7 +22,7 @@ Feature: Admin changes profile information
     When I select my gender
       And I select my birth year
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
       And I see my selected gender and birth year on the profile page
 
   Scenario: Admin changes password

--- a/integration_testing/features/coach/coach-change-profile-information.feature
+++ b/integration_testing/features/coach/coach-change-profile-information.feature
@@ -13,7 +13,7 @@ Feature: Coach changes profile information
       And I change my username
       And if my changes are valid (I did not leave the fields empty)
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
     When I go back to my *Profile > Details* page
     Then I see the new full name and username on the profile page
       And I see the new username in the user menu
@@ -24,7 +24,7 @@ Feature: Coach changes profile information
     When I select my gender
       And I select my birth year
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
     When I go back to my *Profile > Details* page
     Then I see my selected gender and birth year on the profile page
 

--- a/integration_testing/features/learner/learner-change-profile-information.feature
+++ b/integration_testing/features/learner/learner-change-profile-information.feature
@@ -13,7 +13,7 @@ Feature: Learner changes profile information
   	  And I change my username
   	  And if my changes are valid (I did not leave the fields empty)
   	  And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
     When I go back to my *Profile > Details* page
     Then I see the new full name and username on the profile page
       And I see the new username in the user menu
@@ -24,7 +24,7 @@ Feature: Learner changes profile information
     When I select my gender
       And I select my birth year
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
       And I see my selected gender and birth year on the profile page
 
   Scenario: Learner changes password

--- a/integration_testing/features/super-admin/super-admin-change-profile-information.feature
+++ b/integration_testing/features/super-admin/super-admin-change-profile-information.feature
@@ -12,7 +12,7 @@ Feature: Super admin changes their own profile information
       And I change my username
       And if my changes are valid (I did not leave the fields empty)
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
     When I go back to my *Profile > Details* page
     Then I see the new full name and username on the profile page
       And I see the new username in the user menu
@@ -23,7 +23,7 @@ Feature: Super admin changes their own profile information
     When I select my gender
       And I select my birth year
       And I click the “Save” button
-    Then I see the *Profile details updated* snackbar notification
+    Then I see the *Changes saved* snackbar notification
       And I see my selected gender and birth year on the profile page
 
 

--- a/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
+++ b/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
@@ -3,20 +3,36 @@ import NotificationStrings from '../notificationStrings';
 describe('Coach Notification Strings', () => {
   const pluralTestCases = [
     // [key, args, expected plural, expected singular]
-    ['learnersEnrolledNoCount', { count: 10 }, 'Learners enrolled', 'Learner enrolled'],
-    ['learnersRemovedNoCount', { count: 10 }, 'Learners removed', 'Learner removed'],
-    ['learnersEnrolledWithCount', { count: 10 }, '10 learners enrolled', '1 learner enrolled'],
-    ['learnersRemovedWithCount', { count: 10 }, '10 learners removed', '1 learner removed'],
-    ['resourcesAddedWithCount', { count: 10 }, '10 resources added', '1 resource added'],
-    ['resourcesRemovedWithCount', { count: 10 }, '10 resources removed', '1 resources removed'],
-    ['coachesAssignedNoCount', { count: 10 }, 'Coaches assigned', 'Coach assigned'],
-    ['coachesRemovedNoCount', { count: 10 }, 'Coaches removed', 'Coach removed'],
+    ['learnersEnrolledNoCount', 'Learners enrolled', 'Learner enrolled'],
+    ['learnersRemovedNoCount', 'Learners removed', 'Learner removed'],
+    ['learnersEnrolledWithCount', '10 learners enrolled', '1 learner enrolled'],
+    ['learnersRemovedWithCount', '10 learners removed', '1 learner removed'],
+    ['resourcesAddedWithCount', '10 resources added', '1 resource added'],
+    ['resourcesRemovedWithCount', '10 resources removed', '1 resource removed'],
+    ['coachesAssignedNoCount', 'Coaches assigned', 'Coach assigned'],
+    ['coachesRemovedNoCount', 'Coaches removed', 'Coach removed'],
   ];
   test.each(pluralTestCases)(
     'Plural and singular versions of %s are displayed correctly',
-    (key, args, expectedPlural, expectedSingular) => {
+    (key, expectedPlural, expectedSingular) => {
       expect(NotificationStrings.$tr(key, { count: 10 })).toEqual(expectedPlural);
       expect(NotificationStrings.$tr(key, { count: 1 })).toEqual(expectedSingular);
     }
   );
+
+  // Test that the rest of the messages don't need paramaters
+  it('The other notification strings do not require params', () => {
+    const paramMsgs = pluralTestCases.map(([key]) => key);
+    Object.keys(NotificationStrings.defaultMessages).forEach(key => {
+      if (paramMsgs.includes(key)) {
+        expect(() => {
+          NotificationStrings.$tr(key);
+        }).toThrow();
+      } else {
+        expect(() => {
+          NotificationStrings.$tr(key);
+        }).not.toThrow();
+      }
+    });
+  });
 });

--- a/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
+++ b/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
@@ -9,6 +9,8 @@ describe('Coach Notification Strings', () => {
     ['learnersRemovedWithCount', '10 learners removed', '1 learner removed'],
     ['resourcesAddedWithCount', '10 resources added', '1 resource added'],
     ['resourcesRemovedWithCount', '10 resources removed', '1 resource removed'],
+    ['resourcesAddedNoCount', 'Resources added', 'Resource added'],
+    ['resourcesRemovedNoCount', 'Resources removed', 'Resource removed'],
     ['coachesAssignedNoCount', 'Coaches assigned', 'Coach assigned'],
     ['coachesRemovedNoCount', 'Coaches removed', 'Coach removed'],
   ];

--- a/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
+++ b/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
@@ -1,24 +1,22 @@
 import NotificationStrings from '../notificationStrings';
 
 describe('Coach Notification Strings', () => {
-  const testCases = [
-    // [key, args, expected]
-    // plural
-    ['learnersEnrolledNoCount', { count: 10 }, 'Learners enrolled'],
-    ['learnersRemovedNoCount', { count: 10 }, 'Learners removed'],
-    ['learnersEnrolledWithCount', { count: 10 }, '10 learners enrolled'],
-    ['learnersRemovedWithCount', { count: 10 }, '10 learners removed'],
-    ['resourcesAddedWithCount', { count: 10 }, '10 resources added'],
-    ['resourcesRemovedWithCount', { count: 10 }, '10 resources removed'],
-    // singular
-    ['learnersEnrolledNoCount', { count: 1 }, 'Learner enrolled'],
-    ['learnersRemovedNoCount', { count: 1 }, 'Learner removed'],
-    ['learnersEnrolledWithCount', { count: 1 }, '1 learner enrolled'],
-    ['learnersRemovedWithCount', { count: 1 }, '1 learner removed'],
-    ['resourcesAddedWithCount', { count: 1 }, '1 resource added'],
-    ['resourcesRemovedWithCount', { count: 1 }, '1 resource removed'],
+  const pluralTestCases = [
+    // [key, args, expected plural, expected singular]
+    ['learnersEnrolledNoCount', { count: 10 }, 'Learners enrolled', 'Learner enrolled'],
+    ['learnersRemovedNoCount', { count: 10 }, 'Learners removed', 'Learner removed'],
+    ['learnersEnrolledWithCount', { count: 10 }, '10 learners enrolled', '1 learner enrolled'],
+    ['learnersRemovedWithCount', { count: 10 }, '10 learners removed', '1 learner removed'],
+    ['resourcesAddedWithCount', { count: 10 }, '10 resources added', '1 resource added'],
+    ['resourcesRemovedWithCount', { count: 10 }, '10 resources removed', '1 resources removed'],
+    ['coachesAssignedNoCount', { count: 10 }, 'Coaches assigned', 'Coach assigned'],
+    ['coachesRemovedNoCount', { count: 10 }, 'Coaches removed', 'Coach removed'],
   ];
-  test.each(testCases)('%s is displayed correctly', (key, args, expected) => {
-    expect(NotificationStrings.$tr(key, args)).toEqual(expected);
-  });
+  test.each(pluralTestCases)(
+    'Plural and singular versions of %s are displayed correctly',
+    (key, args, expectedPlural, expectedSingular) => {
+      expect(NotificationStrings.$tr(key, { count: 10 })).toEqual(expectedPlural);
+      expect(NotificationStrings.$tr(key, { count: 1 })).toEqual(expectedSingular);
+    }
+  );
 });

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -123,7 +123,7 @@ export default {
       return coreStrings.$tr(key, args);
     },
     showSnackbarNotification(key, args, coreCreateSnackbarArgs) {
-      let text = notificationStrings.$tr(key, args);
+      let text = notificationStrings.$tr(key, args || {});
       if (coreCreateSnackbarArgs) {
         this.$store.commit('CORE_CREATE_SNACKBAR', {
           ...coreCreateSnackbarArgs,

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -95,6 +95,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   quotedPhrase: `'{phrase}'`,
   dashSeparatedPair: '{item1} - {item2}',
   dashSeparatedTriple: '{item1} - {item2} - {item3}',
+  labelColonThenDetails: '{label}: {details}',
 
   // Demographic-specific strings
   genderOptionMale: 'Male',

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -122,8 +122,16 @@ export default {
     coreString(key, args) {
       return coreStrings.$tr(key, args);
     },
-    showSnackbarNotification(key, args) {
-      this.$store.dispatch('createSnackbar', notificationStrings.$tr(key, args));
+    showSnackbarNotification(key, args, coreCreateSnackbarArgs) {
+      let text = notificationStrings.$tr(key, args);
+      if (coreCreateSnackbarArgs) {
+        this.$store.commit('CORE_CREATE_SNACKBAR', {
+          ...coreCreateSnackbarArgs,
+          text,
+        });
+      } else {
+        this.$store.dispatch('createSnackbar', text);
+      }
     },
   },
 };

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -12,27 +12,27 @@ export default createTranslator('NotificationStrings', {
   },
   coachesAssignedNoCount: {
     message: '{count, plural, one {Coach assigned} other {Coaches assigned}}',
-    context: 'Assigning coaches to a class',
+    context: 'Assigning an unspecified number of coaches to a class',
   },
   coachesRemovedNoCount: {
     message: '{count, plural, one {Coach removed} other {Coaches removed}}',
-    context: 'Removing coaches from a class',
+    context: 'Removing an unspecified number of coaches from a class',
   },
   learnersEnrolledNoCount: {
     message: '{count, plural, one {Learner enrolled} other {Learners enrolled}}',
-    context: 'Enrolling learners into group or class',
+    context: 'Enrolling an unspecified number of learners into group or class',
   },
   learnersRemovedNoCount: {
     message: '{count, plural, one {Learner removed} other {Learners removed}}',
-    context: 'Removing (unenrolling) learners from a group or class',
+    context: 'Removing (unenrolling) an unspecified number of learners from a group or class',
   },
   learnersEnrolledWithCount: {
     message: '{count, number} {count, plural, one {learner enrolled} other {learners enrolled}}',
-    context: 'Enrolling learners into group or class',
+    context: 'Enrolling a specified number of learners into group or class',
   },
   learnersRemovedWithCount: {
     message: '{count, number} {count, plural, one {learner removed} other {learners removed}}',
-    context: 'Removing (unenrolling) learners from a group or class',
+    context: 'Removing (unenrolling) a specified number of learners from a group or class',
   },
   userCreated: {
     message: 'User created',
@@ -62,25 +62,21 @@ export default createTranslator('NotificationStrings', {
     message: 'Lesson deleted',
     context: 'Deleting a lesson',
   },
-  resourceAdded: {
-    message: 'Resource added',
-    context: 'Adding a single resource to a lesson',
-  },
   resourcesAddedWithCount: {
     message: '{count, number} {count, plural, one {resource added} other {resources added}}',
-    context: 'Adding resources to a lesson',
+    context: 'Adding a specified number of resources to a lesson',
   },
   resourcesRemovedWithCount: {
     message: '{count, number} {count, plural, one {resource removed} other {resources removed}}',
-    context: 'Removing resources from a lesson',
+    context: 'Removing a specified number of resources from a lesson',
   },
   resourcesAddedNoCount: {
     message: '{count, plural, one {Resource added} other {Resources added}}',
-    context: 'Adding resources to a lesson',
+    context: 'Adding an unspecified number of resources to a lesson',
   },
   resourcesRemovedNoCount: {
     message: '{count, plural, one {Resource removed} other {Resources removed}}',
-    context: 'Removing resources from a lesson',
+    context: 'Removing an unspecified number of resources from a lesson',
   },
   resourceOrderChanged: {
     message: 'Resource order changed',
@@ -106,4 +102,12 @@ export default createTranslator('NotificationStrings', {
     message: 'Group deleted',
     context: 'Deleting a learner group',
   },
+  // TODO move more messages into this namespace:
+  // - "Quiz started"
+  // - "Quiz Ended"
+  // - "Quiz report is not visible to learners"
+  // - "Quiz report is visible to learners
+  // - "Lesson is visible to learners"
+  // - "Lesson is not visible to learners"
+  // - "Profile details updated"
 });

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -22,13 +22,13 @@ export default createTranslator('NotificationStrings', {
     message: '{count, plural, one {Learner enrolled} other {Learners enrolled}}',
     context: 'Enrolling learners into group or class',
   },
-  learnersEnrolledWithCount: {
-    message: '{count, number} {count, plural, one {learner enrolled} other {learners enrolled}}',
-    context: 'Enrolling learners into group or class',
-  },
   learnersRemovedNoCount: {
     message: '{count, plural, one {Learner removed} other {Learners removed}}',
     context: 'Removing (unenrolling) learners from a group or class',
+  },
+  learnersEnrolledWithCount: {
+    message: '{count, number} {count, plural, one {learner enrolled} other {learners enrolled}}',
+    context: 'Enrolling learners into group or class',
   },
   learnersRemovedWithCount: {
     message: '{count, number} {count, plural, one {learner removed} other {learners removed}}',

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -109,5 +109,4 @@ export default createTranslator('NotificationStrings', {
   // - "Quiz report is visible to learners
   // - "Lesson is visible to learners"
   // - "Lesson is not visible to learners"
-  // - "Profile details updated"
 });

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -78,9 +78,9 @@ export default createTranslator('NotificationStrings', {
     message: '{count, plural, one {Resource removed} other {Resources removed}}',
     context: 'Removing an unspecified number of resources from a lesson',
   },
-  resourceOrderChanged: {
-    message: 'Resource order changed',
-    context: 'Changing the order of resources in a lesson',
+  resourceOrderSaved: {
+    message: 'Resource order saved',
+    context: 'Saving the new order of resources in a lesson',
   },
   quizCopied: {
     message: 'Quiz copied',

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -10,21 +10,13 @@ export default createTranslator('NotificationStrings', {
     message: 'Class deleted',
     context: 'Deleting a class',
   },
-  coachAssigned: {
-    message: 'Coach assigned',
-    context: 'Assigning one coach to a class',
+  coachesAssignedNoCount: {
+    message: '{count, plural, one {Coach assigned} other {Coaches assigned}}',
+    context: 'Assigning coaches to a class',
   },
-  coachesAssigned: {
-    message: 'Coaches assigned',
-    context: 'Assigning multiple coaches to a class',
-  },
-  coachRemoved: {
-    message: 'Coach removed',
-    context: 'Removing (unassigning) one coach from a class',
-  },
-  coachesRemoved: {
-    message: 'Coach removed',
-    context: 'Removing (unassigning) multiple coaches from a class',
+  coachesRemovedNoCount: {
+    message: '{count, plural, one {Coach removed} other {Coaches removed}}',
+    context: 'Removing coaches from a class',
   },
   learnersEnrolledNoCount: {
     message: '{count, plural, one {Learner enrolled} other {Learners enrolled}}',

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -1,5 +1,6 @@
 import { createTranslator } from 'kolibri.utils.i18n';
 
+// TODO add error messages
 export default createTranslator('NotificationStrings', {
   classCreated: {
     message: 'Class created',

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -54,6 +54,10 @@ export default createTranslator('NotificationStrings', {
     message: 'Lesson created',
     context: 'Creating a new lesson',
   },
+  lessonCopied: {
+    message: 'Lesson copied',
+    context: 'Copying a lesson to a classroom',
+  },
   lessonDeleted: {
     message: 'Lesson deleted',
     context: 'Deleting a lesson',
@@ -69,6 +73,22 @@ export default createTranslator('NotificationStrings', {
   resourcesRemovedWithCount: {
     message: '{count, number} {count, plural, one {resource removed} other {resources removed}}',
     context: 'Removing resources from a lesson',
+  },
+  resourcesAddedNoCount: {
+    message: '{count, plural, one {Resource added} other {Resources added}}',
+    context: 'Adding resources to a lesson',
+  },
+  resourcesRemovedNoCount: {
+    message: '{count, plural, one {Resource removed} other {Resources removed}}',
+    context: 'Removing resources from a lesson',
+  },
+  resourceOrderChanged: {
+    message: 'Resource order changed',
+    context: 'Changing the order of resources in a lesson',
+  },
+  quizCopied: {
+    message: 'Quiz copied',
+    context: 'Copying a quiz to a classroom',
   },
   quizCreated: {
     message: 'Quiz created',

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
@@ -5,7 +5,6 @@ import union from 'lodash/union';
 import shuffled from 'kolibri.utils.shuffled';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
-import { createTranslator } from 'kolibri.utils.i18n';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import router from 'kolibri.coreVue.router';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -13,10 +12,6 @@ import { PageNames } from '../../constants';
 import { MAX_QUESTIONS } from '../../constants/examConstants';
 import { createExam } from '../examShared/exams';
 import selectQuestions from './selectQuestions';
-
-const snackbarTranslator = createTranslator('ExamCreateSnackbarTexts', {
-  newExamCreated: 'New quiz created',
-});
 
 export function resetExamCreationState(store) {
   store.commit('RESET_STATE');
@@ -105,8 +100,7 @@ export function createExamAndRoute(store, { classId, adHocGroupId }) {
   };
 
   return createExam(store, exam).then(() => {
-    router.push({ name: PageNames.EXAMS });
-    store.dispatch('createSnackbar', snackbarTranslator.$tr('newExamCreated'), { root: true });
+    return router.push({ name: PageNames.EXAMS });
   });
 }
 

--- a/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examReport/actions.js
@@ -1,43 +1,12 @@
-import { ExamResource } from 'kolibri.resources';
-import { createTranslator } from 'kolibri.utils.i18n';
 import { createExam } from '../examShared/exams';
 
-const snackbarTranslator = createTranslator('ExamReportSnackbarTexts', {
-  changesToExamSaved: 'Changes to quiz saved',
-  copiedExamToClass: 'Copied quiz to { className }',
-});
-
-function showSnackbar(store, string) {
-  return store.dispatch('createSnackbar', string, { root: true });
-}
-
-export function copyExam(store, { exam, className }) {
+export function copyExam(store, { exam }) {
   store.commit('CORE_SET_PAGE_LOADING', true, { root: true });
   return new Promise((resolve, reject) => {
     createExam(store, exam).then(newExam => {
       store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
-      showSnackbar(store, snackbarTranslator.$tr('copiedExamToClass', { className }));
       store.commit('examsRoot/ADD_EXAM', newExam, { root: true });
       resolve(newExam);
     }, reject);
-  });
-}
-
-export function updateExamDetails(store, { examId, payload }) {
-  return new Promise((resolve, reject) => {
-    ExamResource.saveModel({
-      id: examId,
-      data: payload,
-    }).then(
-      () => {
-        // Update state.exam if it was just saved.
-        // Is this necessary? Where is state.exams used?
-        showSnackbar(store, snackbarTranslator.$tr('changesToExamSaved'));
-        resolve();
-      },
-      error => {
-        reject(error);
-      }
-    );
   });
 }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -246,16 +246,21 @@
                 classId: this.classId,
                 adHocGroupId: this.$store.state.adHocLearners.id,
               };
-              this.$store.dispatch('examCreation/createExamAndRoute', params).catch(error => {
-                const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
-                if (errors) {
-                  this.showError = true;
-                  this.showTitleError = true;
-                  this.$refs.title.focus();
-                } else {
-                  this.$store.dispatch('handleApiError', error);
-                }
-              });
+              this.$store
+                .dispatch('examCreation/createExamAndRoute', params)
+                .then(() => {
+                  this.showSnackbarNotification('quizCreated');
+                })
+                .catch(error => {
+                  const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
+                  if (errors) {
+                    this.showError = true;
+                    this.showTitleError = true;
+                    this.$refs.title.focus();
+                  } else {
+                    this.$store.dispatch('handleApiError', error);
+                  }
+                });
             });
         }
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -331,7 +331,6 @@
       },
     },
     methods: {
-      ...mapActions(['createSnackbar']),
       ...mapActions('examCreation', [
         'addToSelectedExercises',
         'removeFromSelectedExercises',
@@ -398,45 +397,44 @@
         return '';
       },
       toggleTopicInWorkingResources(isChecked) {
-        let snackbarString;
         if (isChecked) {
           this.showError = false;
+          // NOTE must call snackbar first before mutating the exercise list
+          this.showSnackbarNotification('resourcesAddedWithCount', {
+            count: this.addableExercises.length,
+          });
           this.addToSelectedExercises(this.addableExercises);
-          snackbarString = 'added';
         } else {
+          this.showSnackbarNotification('resourcesRemovedWithCount', {
+            count: this.allExercises.length,
+          });
           this.removeFromSelectedExercises(this.allExercises);
-          snackbarString = 'removed';
         }
-        this.createSnackbar(this.$tr(snackbarString, { item: this.topicTitle }));
       },
       toggleSelected({ checked, contentId }) {
         let exercises;
-        let snackbarString;
         const contentNode = this.contentList.find(item => item.id === contentId);
         const isTopic = contentNode.kind === ContentNodeKinds.TOPIC;
         if (checked && isTopic) {
           this.showError = false;
           exercises = contentNode.exercises;
           this.addToSelectedExercises(exercises);
-          snackbarString = 'added';
         } else if (checked && !isTopic) {
           this.showError = false;
           exercises = [contentNode];
           this.addToSelectedExercises(exercises);
-          snackbarString = 'added';
         } else if (!checked && isTopic) {
           exercises = contentNode.exercises;
           this.removeFromSelectedExercises(exercises);
-          snackbarString = 'removed';
         } else if (!checked && !isTopic) {
           exercises = [contentNode];
           this.removeFromSelectedExercises(exercises);
-          snackbarString = 'removed';
         }
 
-        if (snackbarString) {
-          this.createSnackbar(this.$tr(snackbarString, { item: contentNode.title }));
-        }
+        this.showSnackbarNotification(
+          checked ? 'resourcesAddedWithCount' : 'resourcesRemovedWithCount',
+          { count: exercises.length }
+        );
       },
       handleMoreResults() {
         this.moreResultsState = 'waiting';
@@ -494,15 +492,8 @@
         'The max number of questions based on the exercises you selected is {maxQuestionsFromSelection}. Select more exercises to reach {inputNumQuestions} questions, or lower the number of questions to {maxQuestionsFromSelection}.',
       noneSelected: 'No exercises are selected',
       exitSearchButtonLabel: 'Exit search',
-      // TODO: Handle singular/plural
       selectionInformation:
-        '{count, number, integer} of {total, number, integer} resources selected',
-      // TODO: Interpolate strings correctly
-      /* eslint-disable kolibri/vue-no-unused-translations */
-      /* The items below are referred to dynamically */
-      added: "Added '{item}'",
-      removed: "Removed '{item}'",
-      /* eslint-enable kolibri/vue-no-unused-translations */
+        '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -198,7 +198,7 @@
           userIds: this.selectedUsers,
         }).then(() => {
           this.$router.push(this.$router.getRoute('GroupMembersPage'), () => {
-            this.showSnackbarNotification('learnersEnrolledWithCount', {
+            this.showSnackbarNotification('learnersEnrolledNoCount', {
               count: this.selectedUsers.length,
             });
           });

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -181,7 +181,10 @@
         }
         if (this.sortedFilteredUsers.length === 0 && this.filterInput !== '') {
           // TODO internationalize this
-          return `${this.$tr('noUsersMatch')}: '${this.filterInput}'`;
+          return this.coreString('labelColonThenDetails', {
+            label: this.$tr('noUsersMatch'),
+            details: this.filterInput,
+          });
         }
 
         return '';
@@ -189,14 +192,15 @@
     },
     methods: {
       ...mapActions('groups', ['addUsersToGroup']),
-      ...mapActions(['createSnackbar']),
       addSelectedUsersToGroup() {
         this.addUsersToGroup({
           groupId: this.currentGroup.id,
           userIds: this.selectedUsers,
         }).then(() => {
           this.$router.push(this.$router.getRoute('GroupMembersPage'), () => {
-            this.createSnackbar(this.coachString('updatedNotification'));
+            this.showSnackbarNotification('learnersEnrolledWithCount', {
+              count: this.selectedUsers.length,
+            });
           });
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -132,14 +132,13 @@
     },
     methods: {
       ...mapActions('groups', ['removeUsersFromGroup']),
-      ...mapActions(['createSnackbar']),
       removeSelectedUserFromGroup() {
         if (this.userForRemoval) {
           this.removeUsersFromGroup({
             userIds: [this.userForRemoval.id],
             groupId: this.currentGroup.id,
           }).then(() => {
-            this.createSnackbar(this.coachString('updatedNotification'));
+            this.showSnackbarNotification('learnersRemovedNoCount', { count: 1 });
             this.userForRemoval = null;
           });
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/RenameGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/RenameGroupModal.vue
@@ -97,6 +97,8 @@
           this.renameGroup({
             groupId: this.groupId,
             newGroupName: this.name,
+          }).then(() => {
+            this.showSnackbarNotification('changesSaved');
           });
         } else {
           this.$refs.name.focus();

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -126,7 +126,6 @@
     },
     methods: {
       ...mapActions('groups', ['displayModal']),
-      ...mapActions(['createSnackbar']),
       closeModal() {
         this.displayModal(false);
       },
@@ -148,11 +147,11 @@
         this.displayModal(GroupModals.DELETE_GROUP);
       },
       handleSuccessCreateGroup() {
-        this.createSnackbar(this.coachString('createdNotification'));
+        this.showSnackbarNotification('groupCreated');
         this.displayModal(false);
       },
       handleSuccessDeleteGroup() {
-        this.createSnackbar(this.coachString('deletedNotification'));
+        this.showSnackbarNotification('groupDeleted');
         this.displayModal(false);
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
@@ -36,6 +36,7 @@
 <script>
 
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AssignmentDetailsModal from '../assignments/AssignmentDetailsModal';
   import LessonRootPage from '../LessonsRootPage';
   import commonCoach from '../../common';
@@ -43,7 +44,7 @@
   export default {
     name: 'LessonCreationPage',
     components: { AssignmentDetailsModal },
-    mixins: [commonCoach],
+    mixins: [commonCoach, commonCoreStrings],
     computed: {
       classId() {
         return this.$route.params.classId;
@@ -66,10 +67,14 @@
           }
           return assignment;
         });
-        this.$store.dispatch('lessonsRoot/createLesson', {
-          classId: this.classId,
-          payload: formData,
-        });
+        this.$store
+          .dispatch('lessonsRoot/createLesson', {
+            classId: this.classId,
+            payload: formData,
+          })
+          .then(() => {
+            this.showSnackbarNotification('lessonCreated');
+          });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
@@ -180,7 +180,7 @@
         this.$store.dispatch('notLoading');
       },
       goBackToSummaryPage() {
-        this.$router.push(this.previousPageRoute);
+        return this.$router.push(this.previousPageRoute);
       },
       saveLessonModel(data) {
         if (isEmpty(data)) {
@@ -208,7 +208,11 @@
         }
 
         return this.saveLessonModel(data)
-          .then(this.goBackToSummaryPage)
+          .then(() => {
+            this.goBackToSummaryPage().then(() => {
+              this.showSnackbarNotification('changesSaved');
+            });
+          })
           .catch(() => {
             this.disabled = false;
             this.$store.dispatch('createSnackbar', this.$tr('submitErrorMessage'));

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -270,9 +270,9 @@
           return;
         }
         if (difference > 0) {
-          this.showSnackbarNotification('resourcesAddedWithCount', { count: difference });
+          this.showSnackbarNotification('resourcesAddedNoCount', { count: difference });
         } else {
-          this.showSnackbarNotification('resourcesRemovedWithCount', { count: -difference });
+          this.showSnackbarNotification('resourcesRemovedNoCount', { count: -difference });
         }
       },
       showResourcesChangedError() {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -266,16 +266,14 @@
         removeFromSelectedResources: 'REMOVE_FROM_WORKING_RESOURCES',
       }),
       showResourcesDifferenceMessage(difference) {
-        let text;
         if (difference === 0) {
           return;
         }
         if (difference > 0) {
-          text = this.$tr('resourcesAddedSnackbarText', { count: difference });
+          this.showSnackbarNotification('resourcesAddedWithCount', { count: difference });
         } else {
-          text = this.$tr('resourcesRemovedSnackbarText', { count: -difference });
+          this.showSnackbarNotification('resourcesRemovedWithCount', { count: -difference });
         }
-        this.createSnackbar(text);
       },
       showResourcesChangedError() {
         this.createSnackbar(this.$tr('resourcesChangedErrorSnackbarText'));
@@ -396,10 +394,6 @@
       totalResourcesSelected:
         '{total, number, integer} {total, plural, one {resource} other {resources}} in this lesson',
       documentTitle: `Manage resources in '{lessonName}'`,
-      resourcesAddedSnackbarText:
-        'Added {count, number, integer} {count, plural, one {resource} other {resources}} to lesson',
-      resourcesRemovedSnackbarText:
-        'Removed {count, number, integer} {count, plural, one {resource} other {resources}} from lesson',
       resourcesChangedErrorSnackbarText: 'There was a problem updating this lesson',
       saveBeforeExitSnackbarText: 'Saving your changes…',
       // only shown on search page

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -106,10 +106,7 @@
                   this.$store.dispatch('classSummary/refreshClassSummary');
                 }
                 this.closeModal();
-                this.$store.dispatch(
-                  'createSnackbar',
-                  this.$tr('copiedLessonTo', { classroomName })
-                );
+                this.showSnackbarNotification('lessonCopied');
               })
               .catch(error => {
                 const caughtErrors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
@@ -149,7 +146,6 @@
       deleteLessonTitle: 'Delete lesson',
       deleteLessonConfirmation: "Are you sure you want to delete '{ title }'?",
       copyOfLesson: 'Copy of { lessonTitle }',
-      copiedLessonTo: `Copied lesson to '{classroomName}'`,
       uniqueTitleError: `A lesson titled '{title}' already exists in '{className}'`,
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -131,11 +131,11 @@
           });
       },
       handleSubmitDelete() {
-        const { title, id } = this.currentLesson;
+        const { id } = this.currentLesson;
         return LessonResource.deleteModel({ id })
           .then(() => {
             this.$router.replace(this.$router.getRoute('PLAN_LESSONS_ROOT'), () => {
-              this.$store.dispatch('createSnackbar', this.$tr('lessonDeleted', { title }));
+              this.showSnackbarNotification('lessonDeleted');
             });
           })
           .catch(error => {
@@ -151,7 +151,6 @@
       copyOfLesson: 'Copy of { lessonTitle }',
       copiedLessonTo: `Copied lesson to '{classroomName}'`,
       uniqueTitleError: `A lesson titled '{title}' already exists in '{className}'`,
-      lessonDeleted: `Lesson '{title}' was deleted`,
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -116,20 +116,8 @@
       workingResources() {
         return this.workingResourcesIds.filter(resourceId => this.resourceContentNodes[resourceId]);
       },
-      removalMessage() {
-        const numberOfRemovals = this.workingResourcesBackup.length - this.workingResources.length;
-
-        if (!numberOfRemovals) {
-          return '';
-        } else if (numberOfRemovals === 1) {
-          return this.$tr('singleResourceRemovalConfirmationMessage', {
-            resourceTitle: this.firstRemovalTitle,
-          });
-        }
-
-        return this.$tr('multipleResourceRemovalsConfirmationMessage', {
-          numberOfRemovals,
-        });
+      numberOfRemovals() {
+        return this.workingResourcesBackup.length - this.workingResources.length;
       },
     },
     mounted() {
@@ -161,23 +149,28 @@
 
         this.autoSave(this.lessonId, this.workingResources);
 
-        this.$store.commit('CORE_CREATE_SNACKBAR', {
-          text: this.removalMessage,
-          autoDismiss: true,
-          duration: removalSnackbarTime,
-          actionText: this.$tr('undoActionPrompt'),
-          actionCallback: () => {
-            this.setWorkingResources(this.workingResourcesBackup);
-            this.autoSave(this.lessonId, this.workingResources);
-            this.clearSnackbar();
-          },
-          hideCallback: () => {
-            if (this.workingResourcesBackup) {
-              // snackbar might carryover to another page (like select)
-              this.workingResourcesBackup = this.workingResources;
+        if (this.numberOfRemovals > 0) {
+          this.showSnackbarNotification(
+            'resourcesRemovedWithCount',
+            { count: this.numberOfRemovals },
+            {
+              autoDismiss: true,
+              duration: removalSnackbarTime,
+              actionText: this.$tr('undoActionPrompt'),
+              actionCallback: () => {
+                this.setWorkingResources(this.workingResourcesBackup);
+                this.autoSave(this.lessonId, this.workingResources);
+                this.clearSnackbar();
+              },
+              hideCallback: () => {
+                if (this.workingResourcesBackup) {
+                  // snackbar might carryover to another page (like select)
+                  this.workingResourcesBackup = this.workingResources;
+                }
+              },
             }
-          },
-        });
+          );
+        }
       },
       moveUpOne(oldIndex) {
         this.shiftOne(oldIndex, oldIndex - 1);
@@ -214,8 +207,6 @@
     $trs: {
       resourceReorderConfirmationMessage: 'New lesson order saved',
       undoActionPrompt: 'Undo',
-      singleResourceRemovalConfirmationMessage: 'Removed { resourceTitle }',
-      multipleResourceRemovalsConfirmationMessage: 'Removed { numberOfRemovals } resources',
       moveResourceUpButtonDescription: 'Move this resource one position up in this lesson',
       moveResourceDownButtonDescription: 'Move this resource one position down in this lesson',
       parentChannelLabel: 'Parent channel:',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -187,12 +187,12 @@
         this.setWorkingResources(resources);
         this.autoSave(this.lessonId, resources);
 
-        this.showSnackbarNotification('resourceOrderChanged');
+        this.showSnackbarNotification('resourceOrderSaved');
       },
       handleDrag({ newArray }) {
         this.setWorkingResources(newArray);
         this.autoSave(this.lessonId, newArray);
-        this.showSnackbarNotification('resourceOrderChanged');
+        this.showSnackbarNotification('resourceOrderSaved');
       },
       autoSave(id, resources) {
         this.saveLessonResources({ lessonId: id, resourceIds: resources }).catch(() => {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -128,7 +128,7 @@
       }
     },
     methods: {
-      ...mapActions(['createSnackbar', 'clearSnackbar']),
+      ...mapActions(['clearSnackbar']),
       ...mapActions('lessonSummary', ['saveLessonResources', 'updateCurrentLesson']),
       ...mapMutations('lessonSummary', {
         removeFromWorkingResources: 'REMOVE_FROM_WORKING_RESOURCES',
@@ -187,12 +187,12 @@
         this.setWorkingResources(resources);
         this.autoSave(this.lessonId, resources);
 
-        this.createSnackbar(this.$tr('resourceReorderConfirmationMessage'));
+        this.showSnackbarNotification('resourceOrderChanged');
       },
       handleDrag({ newArray }) {
         this.setWorkingResources(newArray);
         this.autoSave(this.lessonId, newArray);
-        this.createSnackbar(this.$tr('resourceReorderConfirmationMessage'));
+        this.showSnackbarNotification('resourceOrderChanged');
       },
       autoSave(id, resources) {
         this.saveLessonResources({ lessonId: id, resourceIds: resources }).catch(() => {
@@ -205,7 +205,6 @@
       },
     },
     $trs: {
-      resourceReorderConfirmationMessage: 'New lesson order saved',
       undoActionPrompt: 'Undo',
       moveResourceUpButtonDescription: 'Move this resource one position up in this lesson',
       moveResourceDownButtonDescription: 'Move this resource one position down in this lesson',

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizEditDetailsPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizEditDetailsPage.vue
@@ -31,6 +31,7 @@
 
   import { mapGetters } from 'vuex';
   import { ExamResource } from 'kolibri.resources';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { CollectionKinds } from 'kolibri.coreVue.vuex.constants';
   import { CoachCoreBase } from '../common';
   import { coachStringsMixin } from '../common/commonCoachStrings';
@@ -42,8 +43,7 @@
       AssignmentDetailsForm: AssignmentDetailsModal,
       CoreBase: CoachCoreBase,
     },
-    mixins: [coachStringsMixin],
-    props: {},
+    mixins: [coachStringsMixin, commonCoreStrings],
     data() {
       return {
         quiz: {
@@ -153,7 +153,7 @@
         this.$store.dispatch('notLoading');
       },
       goBackToSummaryPage() {
-        this.$router.push(this.previousPageRoute);
+        return this.$router.push(this.previousPageRoute);
       },
       handleSaveChanges(changes) {
         let promise;
@@ -169,7 +169,9 @@
         }
         return promise
           .then(() => {
-            this.goBackToSummaryPage();
+            this.goBackToSummaryPage().then(() => {
+              this.showSnackbarNotification('changesSaved');
+            });
           })
           .catch(() => {
             this.disabled = false;

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -222,6 +222,7 @@
                 className,
               })
               .then(result => {
+                this.showSnackbarNotification('quizCopied');
                 // If exam was copied to the current classroom, add it to the classSummary module
                 if (classroomId === this.classId) {
                   const object = {

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -263,10 +263,7 @@
           .then(() => {
             this.$store.commit('classSummary/DELETE_ITEM', { map: 'examMap', id: this.quiz.id });
             this.$router.replace(this.$router.getRoute('EXAMS'), () => {
-              this.$store.dispatch(
-                'createSnackbar',
-                this.$tr('quizDeletedNotification', { title: this.quiz.title })
-              );
+              this.showSnackbarNotification('quizDeleted');
             });
           })
           .catch(error => {
@@ -275,7 +272,6 @@
       },
     },
     $trs: {
-      quizDeletedNotification: `'{title}' was deleted`,
       uniqueTitleError: `A quiz titled '{title}' already exists in '{className}'`,
     },
   };

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -190,7 +190,6 @@
     },
     methods: {
       ...mapActions('userPermissions', ['addOrUpdateUserPermissions']),
-      ...mapActions(['createSnackbar']),
       save() {
         this.uiBlocked = true;
         this.saveProgress = IN_PROGRESS;
@@ -200,7 +199,7 @@
           can_manage_content: this.devicePermissionsChecked,
         })
           .then(() => {
-            this.createSnackbar(this.$tr('permissionChangeConfirmation'));
+            this.showSnackbarNotification('changesSaved');
             this.saveProgress = SUCCESS;
             this.uiBlocked = false;
             this.goBack();
@@ -223,7 +222,6 @@
       },
       documentTitle: "{ name }'s Device Permissions",
       makeSuperAdmin: 'Make super admin',
-      permissionChangeConfirmation: 'Changes saved',
       saveButton: 'Save Changes',
       saveFailureNotification: 'There was a problem saving these changes.',
       saveInProgressNotification: 'Saving...',

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
@@ -170,11 +170,7 @@
       },
     },
     methods: {
-      ...mapActions('classEditManagement', [
-        'displayModal',
-        'removeClassLearner',
-        'removeClassCoach',
-      ]),
+      ...mapActions('classEditManagement', ['displayModal']),
       closeModal() {
         this.displayModal(false);
       },
@@ -182,6 +178,16 @@
         this.userToBeRemoved = user;
         this.removalAction = removalAction;
         this.displayModal(Modals.REMOVE_USER);
+      },
+      removeClassCoach(args) {
+        this.$store.dispatch('classEditManagement/removeClassCoach', args).then(() => {
+          this.showSnackbarNotification('coachesRemovedNoCount', { count: 1 });
+        });
+      },
+      removeClassLearner(args) {
+        this.$store.dispatch('classEditManagement/removeClassLearner', args).then(() => {
+          this.showSnackbarNotification('learnersRemovedNoCount', { count: 1 });
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -16,6 +16,7 @@
 <script>
 
   import { mapState, mapActions } from 'vuex';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames } from '../constants';
   import ClassEnrollForm from './ClassEnrollForm';
 
@@ -29,6 +30,7 @@
     components: {
       ClassEnrollForm,
     },
+    mixins: [commonCoreStrings],
     computed: {
       ...mapState('classAssignMembers', ['class', 'classUsers', 'facilityUsers']),
       className() {
@@ -40,7 +42,9 @@
       assignCoaches(coaches) {
         this.assignCoachesToClass({ classId: this.class.id, coaches }).then(() => {
           // do this in action?
-          this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE });
+          this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE }).then(() => {
+            this.showSnackbarNotification('coachesAssignedNoCount', { count: coaches.length });
+          });
         });
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -16,6 +16,7 @@
 <script>
 
   import { mapState, mapActions } from 'vuex';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames } from '../constants';
   import ClassEnrollForm from './ClassEnrollForm';
 
@@ -29,6 +30,7 @@
     components: {
       ClassEnrollForm,
     },
+    mixins: [commonCoreStrings],
     computed: {
       ...mapState('classAssignMembers', ['class', 'facilityUsers', 'classUsers']),
       className() {
@@ -40,7 +42,11 @@
       enrollLearners(selectedUsers) {
         // do this in action?
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers }).then(() => {
-          this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE });
+          this.$router.push({ name: PageNames.CLASS_EDIT_MGMT_PAGE }).then(() => {
+            this.showSnackbarNotification('learnersEnrolledNoCount', {
+              count: selectedUsers.length,
+            });
+          });
         });
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassCreateModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassCreateModal.vue
@@ -82,10 +82,7 @@
         if (this.formIsValid) {
           this.submitting = true;
           this.createClass(this.name).then(() => {
-            this.$store.dispatch(
-              'createSnackbar',
-              this.$tr('classroomCreated', { name: this.name })
-            );
+            this.showSnackbarNotification('classCreated');
           });
         } else {
           this.$refs.name.focus();
@@ -94,7 +91,6 @@
     },
     $trs: {
       createNewClassHeader: 'Create new class',
-      classroomCreated: `Class '{name}' was created`,
       duplicateName: 'A class with that name already exists',
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -36,17 +36,13 @@
       ...mapActions('classManagement', ['deleteClass']),
       classDelete() {
         this.deleteClass(this.classid).then(() => {
-          this.$store.dispatch(
-            'createSnackbar',
-            this.$tr('classroomDeleted', { name: this.classname })
-          );
+          this.showSnackbarNotification('classDeleted');
         });
       },
     },
     $trs: {
       modalTitle: 'Delete class',
       confirmation: "Are you sure you want to delete '{ classname }'?",
-      classroomDeleted: `Class '{name}' was deleted`,
       description:
         "Enrolled users will be removed from the class but remain accessible from the 'Users' tab.",
     },

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -225,10 +225,7 @@
       },
       handleSubmitSuccess() {
         this.goToUserManagementPage(() => {
-          this.$store.dispatch(
-            'createSnackbar',
-            this.$tr('userCreatedNotification', { username: this.username })
-          );
+          this.showSnackbarNotification('userCreated');
         });
       },
       handleSubmitFailure(error) {
@@ -256,7 +253,6 @@
       createNewUserHeader: 'Create new user',
       classCoachDescription: "Can only instruct classes that they're assigned to",
       facilityCoachDescription: 'Can instruct all classes in your facility',
-      userCreatedNotification: "User account for '{username}' was created",
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
@@ -45,10 +45,7 @@
           .then(() => {
             this.$store.commit('userManagement/DELETE_USER', this.id);
             this.$emit('cancel');
-            this.$store.dispatch(
-              'createSnackbar',
-              this.$tr('userDeletedNotification', { username: this.username })
-            );
+            this.showSnackbarNotification('userDeleted');
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);
@@ -59,7 +56,6 @@
       deleteUser: 'Delete user',
       confirmation: "Are you sure you want to delete the user '{ username }'?",
       warning: 'All data and logs for this user will be lost.',
-      userDeletedNotification: "User account for '{username}' was deleted",
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/UserPage/ResetUserPasswordModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/ResetUserPasswordModal.vue
@@ -70,10 +70,7 @@
           .then(() => {
             this.busy = false;
             this.$emit('cancel');
-            this.$store.dispatch(
-              'createSnackbar',
-              this.$tr('passwordChangedNotification', { username: this.username })
-            );
+            this.showSnackbarNotification('passwordReset');
           })
           .catch(error => this.$store.dispatch('handleApiError', error));
       },
@@ -88,7 +85,6 @@
     $trs: {
       resetPassword: 'Reset user password',
       username: 'Username: ',
-      passwordChangedNotification: "Password changed for '{username}'",
     },
   };
 

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -159,7 +159,7 @@
               updates: this.getUpdates(),
             })
             .then(() => {
-              this.$store.dispatch('createSnackbar', this.$tr('updateSuccessNotification'));
+              this.showSnackbarNotification('changesSaved');
               this.$router.push(this.$router.getRoute('PROFILE'));
             })
             .catch(error => {
@@ -187,7 +187,6 @@
     },
     $trs: {
       editProfileHeader: 'Edit profile',
-      updateSuccessNotification: 'Profile details updated',
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Updates existing snackbars to use new messages in #5281 
1. NOTE: This does not implement the "Undo" logic if the issue specced it out as a new feature (will need to be done as separate work)
1. When a notification intentionally enumerates the number of items involved, we keep the number in all versions of the notification (e.g. "5 learners enrolled", "1 learner removed"). Similarly, if we omit the count, we are consistent about it: "learner removed" , "learners removed"

### Reviewer guidance

Use this checklist to go through each of the workflows

Columns: `| context | message | `

## Facility > Classes

- [ ]  Adding a class | Class created |
- [ ]  Deleting a class | Class deleted |
- [ ]  Assigning a coach | Coach assigned | Undo
- [ ]  Assigning multiple coaches | Coaches assigned |
- [ ]  Removing a coach | Coach removed | Undo
- [ ]  Enrolling a learner | Learner enrolled | Undo
- [ ]  Enrolling multiple learners | Learners enrolled |
- [ ]  Removing a learner | Learner removed | Undo

## Facility > Users

- [ ]  Creating a new user | User created |
- [ ]  Deleting a user | User deleted |
- [ ]  Updating user password | Password reset |

## Device > permissions

- [ ]  Updating permission | Changes saved |

## Coach > Plan lesson

- [ ]  Creating a new lesson | Lesson created |
- [ ]  Editing lesson details | Changes saved |
- [ ]  Deleting a lesson | Lesson deleted |
- [ ]  Adding a resource | Resource added |
- [ ]  Adding multiple resources | N resources added |
- [ ]  Removing a resource | Resource removed |
- [ ]  Removing multiple resources | N resources removed |
- [ ]  Removing a resource from the lesson page | Resource removed | Undo
- [ ]  Removing multiple resources quickly from the lesson page | 2 resources removed | Undo

## Coach > Plan quiz

- [ ]  Creating a new quiz | Lesson created |
- [ ]  Deleting a lesson | Lesson deleted |
- [ ]  Adding a resource to a quiz | 1 Resource added |
- [ ]   Adding multiple resources | N resources added |
- [ ]  Removing a resource | 1 Resource removed |
- [ ]  Removing multiple resources | N resources removed |
- [ ]  Finishing creating a new quiz | Quiz created
- [ ]  Editing quiz details | Changes saved |
- [ ]  Deleting a quiz | Quiz deleted

## Coach > Plan groups

- [ ]  Creating a new group | Group created |
- [ ]  Deleting a group | Group deleted |
- [ ]   Editing group name | Changes saved |
- [ ]   Enrolling learner into the group |1 Learner enrolled |
- [ ]  Enrolling multiple learners | N learners enrolled |
- [ ]  Removing learner from group | Learner removed |

### References

Fixes #5281 
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
