### PR TITLE
Add context to python strings

### DIFF
--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -14,6 +14,7 @@ from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy
 
 from .bulkimportusers import FILE_WRITE_ERROR
 from .bulkimportusers import MESSAGES
@@ -42,12 +43,30 @@ labels = OrderedDict(
         ("username", _("Username ({})").format("USERNAME")),
         ("password", _("Password ({})").format("PASSWORD")),
         ("full_name", _("Full name ({})").format("FULL_NAME")),
-        ("kind", _("User type ({})").format("USER_TYPE")),
+        (
+            "kind",
+            pgettext_lazy(
+                "CSV header for the type of user: ADMIN, LEARNER, COACH...",
+                "User type ({})",
+            ).format("USER_TYPE"),
+        ),
         ("id_number", _("Identifier ({})").format("IDENTIFIER")),
         ("birth_year", _("Birth year ({})").format("BIRTH_YEAR")),
         ("gender", _("Gender ({})").format("GENDER")),
-        ("enrolled", _("Learner enrollment ({})").format("ENROLLED_IN")),
-        ("assigned", _("Coach assignment ({})").format("ASSIGNED_TO")),
+        (
+            "enrolled",
+            pgettext_lazy(
+                "CSV file header for the list of classrooms names where the learner is going to be enrolled",
+                "Learner enrollment ({})",
+            ).format("ENROLLED_IN"),
+        ),
+        (
+            "assigned",
+            pgettext_lazy(
+                "CSV file header for the list of classrooms names where the tutor is going to be a coach",
+                "Coach assignment ({})",
+            ).format("ASSIGNED_TO"),
+        ),
     )
 )
 
@@ -105,12 +124,30 @@ def translate_labels():
             ("username", _("Username ({})").format("USERNAME")),
             ("password", _("Password ({})").format("PASSWORD")),
             ("full_name", _("Full name ({})").format("FULL_NAME")),
-            ("kind", _("User type ({})").format("USER_TYPE")),
+            (
+                "kind",
+                pgettext_lazy(
+                    "CSV header for the type of user: ADMIN, LEARNER, COACH...",
+                    "User type ({})",
+                ).format("USER_TYPE"),
+            ),
             ("id_number", _("Identifier ({})").format("IDENTIFIER")),
             ("birth_year", _("Birth year ({})").format("BIRTH_YEAR")),
             ("gender", _("Gender ({})").format("GENDER")),
-            ("enrolled", _("Learner enrollment ({})").format("ENROLLED_IN")),
-            ("assigned", _("Coach assignment ({})").format("ASSIGNED_TO")),
+            (
+                "enrolled",
+                pgettext_lazy(
+                    "CSV file header for the list of classrooms names where the learner is going to be enrolled",
+                    "Learner enrollment ({})",
+                ).format("ENROLLED_IN"),
+            ),
+            (
+                "assigned",
+                pgettext_lazy(
+                    "CSV file header for the list of classrooms names where the tutor is going to be a coach",
+                    "Coach assignment ({})",
+                ).format("ASSIGNED_TO"),
+            ),
         )
     )
 

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -47,7 +47,7 @@ labels = OrderedDict(
         (
             "kind",
             pgettext_lazy(
-                "CSV header for the type of user: ADMIN, LEARNER, COACH...",
+                "CSV column header for the type of user: ADMIN, LEARNER, COACH...",
                 "User type ({})",
             ).format("USER_TYPE"),
         ),
@@ -57,14 +57,14 @@ labels = OrderedDict(
         (
             "enrolled",
             pgettext_lazy(
-                "CSV file header for the list of classrooms names where the learner is going to be enrolled",
+                "CSV column header for the list of classrooms names where the learner is going to be enrolled",
                 "Learner enrollment ({})",
             ).format("ENROLLED_IN"),
         ),
         (
             "assigned",
             pgettext_lazy(
-                "CSV file header for the list of classrooms names where the tutor is going to be a coach",
+                "CSV column header for the list of classrooms names where the tutor is going to be a coach",
                 "Coach assignment ({})",
             ).format("ASSIGNED_TO"),
         ),

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -81,11 +81,11 @@ MESSAGES = {
         "Username only can contain characters, numbers and underscores"
     ),
     REQUIRED_COLUMN: pgettext_lazy(
-        "Importing a CSV file, there's a column that has not been added to the file",
+        "Error message indicating that the CSV file selected for import is missing a required column",
         "The column '{}' is required",
     ),
     INVALID_HEADER: pgettext_lazy(
-        "Importing a CSV file, the name of a column in the header is not correct (or is missed)",
+        "Error message indicating that one column header in the CSV file selected for import is missing or incorrect",
         "Invalid header label found in the first row",
     ),
     NO_FACILITY: _(

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy
 
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.constants.collection_kinds import CLASSROOM
@@ -65,15 +66,24 @@ FILE_WRITE_ERROR = 9
 REQUIRED_PASSWORD = 10
 
 MESSAGES = {
-    UNEXPECTED_EXCEPTION: _("Unexpected error [{}]: {}"),
+    UNEXPECTED_EXCEPTION: pgettext_lazy(
+        "Error message that might appear when there's a programming error importing a CSV file",
+        "Unexpected error [{}]: {}",
+    ),
     TOO_LONG: _("Value in column '{}' is too many characters"),
     INVALID: _("Invalid value in column '{}'"),
     DUPLICATED_USERNAME: _("Username is duplicated"),
     INVALID_USERNAME: _(
         "Username only can contain characters, numbers and underscores"
     ),
-    REQUIRED_COLUMN: _("The column '{}' is required"),
-    INVALID_HEADER: _("Invalid header label found in the first row"),
+    REQUIRED_COLUMN: pgettext_lazy(
+        "Importing a CSV file, there's a column that has not been added to the file",
+        "The column '{}' is required",
+    ),
+    INVALID_HEADER: pgettext_lazy(
+        "Importing a CSV file, the name of a column in the header is not correct (or is missed)",
+        "Invalid header label found in the first row",
+    ),
     NO_FACILITY: _(
         "No default facility exists. Make sure to provision this device before importing"
     ),

--- a/kolibri/locale/es_419/LC_MESSAGES/django.po
+++ b/kolibri/locale/es_419/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kolibri\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-30 16:30-0700\n"
+"POT-Creation-Date: 2020-05-11 18:23+0200\n"
 "PO-Revision-Date: 2020-05-05 22:47\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish, Latin America\n"
@@ -32,80 +32,127 @@ msgid "Ad hoc learners group"
 msgstr "Ad hoc grupo de estudiantes"
 
 #: kolibri/core/auth/management/commands/bulkexportusers.py:42
+#: kolibri/core/auth/management/commands/bulkexportusers.py:123
 msgid "Username ({})"
 msgstr "Nombre de usuario ({})"
 
 #: kolibri/core/auth/management/commands/bulkexportusers.py:43
+#: kolibri/core/auth/management/commands/bulkexportusers.py:124
 msgid "Password ({})"
 msgstr "Contraseña ({})"
 
 #: kolibri/core/auth/management/commands/bulkexportusers.py:44
+#: kolibri/core/auth/management/commands/bulkexportusers.py:125
 msgid "Full name ({})"
 msgstr "Nombre completo ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:45
+#: kolibri/core/auth/management/commands/bulkexportusers.py:49
+#: kolibri/core/auth/management/commands/bulkexportusers.py:130
+#, fuzzy
+#| msgid "User type ({})"
+msgctxt "CSV header for the type of user: ADMIN, LEARNER, COACH..."
 msgid "User type ({})"
 msgstr "Tipo de usuario ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:46
+#: kolibri/core/auth/management/commands/bulkexportusers.py:52
+#: kolibri/core/auth/management/commands/bulkexportusers.py:133
 msgid "Identifier ({})"
 msgstr "Identificador ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:47
+#: kolibri/core/auth/management/commands/bulkexportusers.py:53
+#: kolibri/core/auth/management/commands/bulkexportusers.py:134
 msgid "Birth year ({})"
 msgstr "Año de nacimiento ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:48
+#: kolibri/core/auth/management/commands/bulkexportusers.py:54
+#: kolibri/core/auth/management/commands/bulkexportusers.py:135
 msgid "Gender ({})"
 msgstr "Género ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:49
+#: kolibri/core/auth/management/commands/bulkexportusers.py:59
+#: kolibri/core/auth/management/commands/bulkexportusers.py:140
+#, fuzzy
+#| msgid "Learner enrollment ({})"
+msgctxt ""
+"CSV file header for the list of classrooms names where the learner is going "
+"to be enrolled"
 msgid "Learner enrollment ({})"
 msgstr "Inscrito como estudiante ({})"
 
-#: kolibri/core/auth/management/commands/bulkexportusers.py:50
+#: kolibri/core/auth/management/commands/bulkexportusers.py:66
+#: kolibri/core/auth/management/commands/bulkexportusers.py:147
+#, fuzzy
+#| msgid "Coach assignment ({})"
+msgctxt ""
+"CSV file header for the list of classrooms names where the tutor is going to "
+"be a coach"
 msgid "Coach assignment ({})"
 msgstr "Asignado como tutor ({})"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:68
+#: kolibri/core/auth/management/commands/bulkimportusers.py:71
+#, fuzzy
+#| msgid "Unexpected error [{}]: {}"
+msgctxt ""
+"Error message that might appear when there's a programming error importing a "
+"CSV file"
 msgid "Unexpected error [{}]: {}"
 msgstr "Error inesperado [{}]: {}"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:69
+#: kolibri/core/auth/management/commands/bulkimportusers.py:73
 msgid "Value in column '{}' is too many characters"
 msgstr "El valor en la columna '{}' tiene más caracteres de los permitidos"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:70
+#: kolibri/core/auth/management/commands/bulkimportusers.py:74
 msgid "Invalid value in column '{}'"
 msgstr "Valor incorrecto en la columna '{}'"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:71
+#: kolibri/core/auth/management/commands/bulkimportusers.py:75
 msgid "Username is duplicated"
 msgstr "Nombre de usuario duplicado"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:73
+#: kolibri/core/auth/management/commands/bulkimportusers.py:77
 msgid "Username only can contain characters, numbers and underscores"
-msgstr "Los nombres de usuario solo pueden contener letras, números y guiones bajos"
+msgstr ""
+"Los nombres de usuario solo pueden contener letras, números y guiones bajos"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:75
+#: kolibri/core/auth/management/commands/bulkimportusers.py:81
+#, fuzzy
+#| msgid "The column '{}' is required"
+msgctxt ""
+"Importing a CSV file, there's a column that has not been added to the file"
 msgid "The column '{}' is required"
 msgstr "La columna '{}' es obligatoria"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:76
+#: kolibri/core/auth/management/commands/bulkimportusers.py:85
+#, fuzzy
+#| msgid "Invalid header label found in the first row"
+msgctxt ""
+"Importing a CSV file, the name of a column in the header is not correct (or "
+"is missed)"
 msgid "Invalid header label found in the first row"
 msgstr "Etiqueta de encabezado incorrecta en la primera fila"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:78
-msgid "No default facility exists. Make sure to provision this device before importing"
-msgstr "El dispositivo no tiene configurado ningún centro educativo. Asegúrese que exista un centro antes de importar usuarios."
+#: kolibri/core/auth/management/commands/bulkimportusers.py:88
+msgid ""
+"No default facility exists. Make sure to provision this device before "
+"importing"
+msgstr ""
+"El dispositivo no tiene configurado ningún centro educativo. Asegúrese que "
+"exista un centro antes de importar usuarios."
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:80
+#: kolibri/core/auth/management/commands/bulkimportusers.py:90
 msgid "Error trying to read csv file: {}"
 msgstr "Error al intentar leer el archivo CSV: {}"
 
-#: kolibri/core/auth/management/commands/bulkimportusers.py:81
+#: kolibri/core/auth/management/commands/bulkimportusers.py:91
 msgid "Error trying to write csv file: {}"
 msgstr "Error al intentar guardar el archivo CSV: {}"
+
+#: kolibri/core/auth/management/commands/bulkimportusers.py:93
+msgid ""
+"The password field is required. To leave the password unchanged in existing "
+"users, insert an asterisk (*)"
+msgstr ""
 
 #: kolibri/core/content/api.py:149
 msgid "Content"
@@ -157,8 +204,12 @@ msgid "You can also try updating your current browser."
 msgstr "También puedes actualizar tu navegador actual."
 
 #: kolibri/core/views.py:174
-msgid "No appropriate redirect pages found. It is likely that Kolibri is badly configured"
-msgstr "Fue imposible redirigir página correctamente. Es probable que Kolibri está mal configurado"
+msgid ""
+"No appropriate redirect pages found. It is likely that Kolibri is badly "
+"configured"
+msgstr ""
+"Fue imposible redirigir página correctamente. Es probable que Kolibri está "
+"mal configurado"
 
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:7
 msgid "OpenID Provider Authorization"


### PR DESCRIPTION
### Summary
We are adding new strings to be translated that are done through gettext because they're not in the frontend, but in the backend.
This PR uses the tools Django provided to add the context translators might need on some of these strings.

### Reviewer guidance
- is more context required in other strings?
- is the wording of the context meaningfull and gramatically correct?

### References

This PR branch is branched off #6854 , so don't merge this PR until #6854 is merged into `pf-mvp`.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
