### PR TITLE
Don't use diskcache when we are using Redis

### DIFF
--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -16,6 +16,7 @@ from kolibri.core.content.utils.file_availability import (
     get_available_checksums_from_remote,
 )
 from kolibri.core.discovery.models import NetworkLocation
+from kolibri.core.utils.cache import process_cache
 
 
 def get_engine(connection_string):
@@ -34,6 +35,7 @@ class LocalFileByDisk(TransactionTestCase):
 
     def setUp(self):
         super(LocalFileByDisk, self).setUp()
+        process_cache.clear()
         self.mock_home_dir = tempfile.mkdtemp()
         self.mock_storage_dir = os.path.join(self.mock_home_dir, "content", "storage")
         os.makedirs(self.mock_storage_dir)
@@ -133,6 +135,7 @@ class LocalFileRemote(TransactionTestCase):
 
     def setUp(self):
         super(LocalFileRemote, self).setUp()
+        process_cache.clear()
         self.location = NetworkLocation.objects.create(base_url="test")
 
     @patch("kolibri.core.content.utils.file_availability.requests")

--- a/kolibri/core/content/utils/file_availability.py
+++ b/kolibri/core/content/utils/file_availability.py
@@ -11,7 +11,7 @@ from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.paths import get_content_storage_dir_path
 from kolibri.core.content.utils.paths import get_file_checksums_url
 from kolibri.core.discovery.models import NetworkLocation
-from kolibri.core.utils.cache import CrossProcessCache
+from kolibri.core.utils.cache import get_process_cache
 
 checksum_regex = re.compile("^([a-f0-9]{32})$")
 
@@ -37,7 +37,7 @@ def _generate_mask_from_integer(integer_mask):
         integer_mask //= 2
 
 
-cache = CrossProcessCache(3600)
+cache = get_process_cache
 
 
 def get_available_checksums_from_remote(channel_id, peer_id):

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -22,7 +22,7 @@ from kolibri.core.content.utils.file_availability import (
 from kolibri.core.content.utils.file_availability import (
     get_available_checksums_from_remote,
 )
-from kolibri.core.utils.cache import CrossProcessCache
+from kolibri.core.utils.cache import get_process_cache
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +248,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):
     return stats
 
 
-cache = CrossProcessCache(3600)
+cache = get_process_cache()
 
 
 CHANNEL_STATS_CACHED_KEYS = "CHANNEL_STATS_CACHED_KEYS_{channel_id}"

--- a/kolibri/core/discovery/test/test_connection_check.py
+++ b/kolibri/core/discovery/test/test_connection_check.py
@@ -2,9 +2,12 @@ from django.test import TestCase
 from mock import patch
 
 from ..utils.network.connections import check_connection_info
+from ..utils.network.connections import DEVICE_INFO_CACHE_KEY
+from ..utils.network.connections import DEVICE_PORT_CACHE_KEY
 from ..utils.network.connections import FAILED_TO_CONNECT
 from ..utils.network.connections import INVALID_DEVICE_INFO
 from .helpers import info as VALID_DEVICE_INFO
+from kolibri.core.utils.cache import process_cache
 
 FAKE_KOLIBRI_ONLINE = "http://fake_kolibri_online:80/"
 FAKE_KOLIBRI_OFFLINE = "http://fake_kolibri_offline:80/"
@@ -53,17 +56,19 @@ mock_check_if_port_open = (
     "kolibri.core.discovery.utils.network.connections.check_if_port_open"
 )
 
-mock_device_info_cache = (
-    "kolibri.core.discovery.utils.network.connections.device_info_cache"
-)
-mock_device_port_open_cache = (
-    "kolibri.core.discovery.utils.network.connections.device_port_open_cache"
-)
+
+def set_device_info_cache(url, info):
+    process_cache.set(DEVICE_INFO_CACHE_KEY.format(url=url), info)
+
+
+def set_device_port_cache(url, is_open):
+    process_cache.set(DEVICE_PORT_CACHE_KEY.format(url=url), is_open)
 
 
 class TestCheckConnection(TestCase):
-    @patch(mock_device_info_cache, MockCache(None))
-    @patch(mock_device_port_open_cache, MockCache(None))
+    def setUp(self):
+        process_cache.clear()
+
     @patch(mock_check_device_info, mock_check_device_info_function)
     @patch(mock_check_if_port_open, mock_check_if_port_open_function)
     def test_check_with_no_previous_information(self):
@@ -72,55 +77,53 @@ class TestCheckConnection(TestCase):
         self.assertEqual(check_connection_info(REAL_KOLIBRI_ONLINE), VALID_DEVICE_INFO)
         self.assertFalse(check_connection_info(REAL_KOLIBRI_OFFLINE))
 
-    @patch(mock_device_info_cache, MockCache(VALID_DEVICE_INFO))
-    @patch(mock_device_port_open_cache, MockCache(True))
     @patch(mock_check_device_info)
     @patch(mock_check_if_port_open)
     def test_real_kolibri_again_after_recently_checking(
         self, mock_check_if_port_open, mock_check_device_info
     ):
+        set_device_info_cache(REAL_KOLIBRI_ONLINE, VALID_DEVICE_INFO)
+        set_device_port_cache(REAL_KOLIBRI_ONLINE, True)
         self.assertEqual(check_connection_info(REAL_KOLIBRI_ONLINE), VALID_DEVICE_INFO)
         mock_check_if_port_open.assert_not_called()
         mock_check_device_info.assert_not_called()
 
-    @patch(mock_device_info_cache, MockCache(INVALID_DEVICE_INFO))
-    @patch(mock_device_port_open_cache, MockCache(True))
     @patch(mock_check_device_info)
     @patch(mock_check_if_port_open)
     def test_fake_kolibri_online(self, mock_check_if_port_open, mock_check_device_info):
+        set_device_info_cache(FAKE_KOLIBRI_ONLINE, INVALID_DEVICE_INFO)
+        set_device_port_cache(FAKE_KOLIBRI_ONLINE, True)
         self.assertFalse(check_connection_info(FAKE_KOLIBRI_ONLINE))
         mock_check_if_port_open.assert_not_called()
         mock_check_device_info.assert_not_called()
 
-    @patch(mock_device_info_cache, MockCache(VALID_DEVICE_INFO))
-    @patch(mock_device_port_open_cache, MockCache(None))
     @patch(mock_check_device_info, return_value=VALID_DEVICE_INFO)
-    @patch(mock_check_if_port_open)
+    @patch(mock_check_if_port_open, return_value=True)
     def test_real_kolibri_online_but_its_been_a_little_while(
         self, mock_check_if_port_open, mock_check_device_info
     ):
+        set_device_info_cache(REAL_KOLIBRI_ONLINE, VALID_DEVICE_INFO)
         self.assertEqual(check_connection_info(REAL_KOLIBRI_ONLINE), VALID_DEVICE_INFO)
         mock_check_if_port_open.assert_called_once()
         mock_check_device_info.assert_not_called()
 
-    @patch(mock_device_info_cache, MockCache(VALID_DEVICE_INFO))
-    @patch(mock_device_port_open_cache, MockCache(False))
     @patch(mock_check_device_info)
     @patch(mock_check_if_port_open, return_value=False)
     def test_real_kolibri_recently_went_offline(
         self, mock_check_if_port_open, mock_check_device_info
     ):
+        set_device_info_cache(REAL_KOLIBRI_OFFLINE, VALID_DEVICE_INFO)
+        set_device_port_cache(REAL_KOLIBRI_OFFLINE, False)
         self.assertFalse(check_connection_info(REAL_KOLIBRI_OFFLINE))
         mock_check_if_port_open.assert_called()
         mock_check_device_info.assert_not_called()
 
-    @patch(mock_device_info_cache, MockCache(FAILED_TO_CONNECT))
-    @patch(mock_device_port_open_cache, MockCache(None))
     @patch(mock_check_device_info, return_value=VALID_DEVICE_INFO)
     @patch(mock_check_if_port_open, return_value=True)
     def test_previously_checked_offline_kolibri_instance_just_came_online(
         self, mock_check_if_port_open, mock_check_device_info
     ):
+        set_device_info_cache(REAL_KOLIBRI_ONLINE, FAILED_TO_CONNECT)
         self.assertEqual(check_connection_info(REAL_KOLIBRI_ONLINE), VALID_DEVICE_INFO)
         mock_check_if_port_open.assert_called_once()
         mock_check_device_info.assert_called()

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -4,7 +4,7 @@ from contextlib import closing
 from . import errors
 from .client import NetworkClient
 from .urls import parse_address_into_components
-from kolibri.core.utils.cache import CrossProcessCache
+from kolibri.core.utils.cache import get_process_cache
 from kolibri.core.utils.nothing import Nothing
 
 
@@ -37,8 +37,11 @@ def check_device_info(base_url):
         return INVALID_DEVICE_INFO
 
 
-device_info_cache = CrossProcessCache(3)
-device_port_open_cache = CrossProcessCache(60)
+cache = get_process_cache()
+
+DEVICE_INFO_TIMEOUT = 3
+
+DEVICE_PORT_TIMEOUT = 60
 
 
 class CachedDeviceConnectionChecker(object):
@@ -49,13 +52,13 @@ class CachedDeviceConnectionChecker(object):
         info = check_device_info(self.base_url)
 
         if info:
-            device_info_cache.set(self.base_url, info)
+            cache.set(self.base_url, info, DEVICE_INFO_TIMEOUT)
 
         return info
 
     @property
     def device_info(self):
-        return device_info_cache.get(self.base_url)
+        return cache.get(self.base_url)
 
     @property
     def valid_device_info(self):
@@ -76,13 +79,13 @@ class CachedDeviceConnectionChecker(object):
     def device_port_open(self):
         """ check to see if a port is open at a given `base_url` """
 
-        cached = device_port_open_cache.get(self.base_url)
+        cached = cache.get(self.base_url)
 
         if cached:
             return cached
 
         result = check_if_port_open(self.base_url)
-        device_port_open_cache.set(self.base_url, result)
+        cache.set(self.base_url, result, DEVICE_PORT_TIMEOUT)
 
         return result
 

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -4,7 +4,7 @@ from contextlib import closing
 from . import errors
 from .client import NetworkClient
 from .urls import parse_address_into_components
-from kolibri.core.utils.cache import get_process_cache
+from kolibri.core.utils.cache import process_cache
 from kolibri.core.utils.nothing import Nothing
 
 
@@ -37,8 +37,6 @@ def check_device_info(base_url):
         return INVALID_DEVICE_INFO
 
 
-cache = get_process_cache()
-
 DEVICE_INFO_TIMEOUT = 3
 
 DEVICE_PORT_TIMEOUT = 60
@@ -52,13 +50,13 @@ class CachedDeviceConnectionChecker(object):
         info = check_device_info(self.base_url)
 
         if info:
-            cache.set(self.base_url, info, DEVICE_INFO_TIMEOUT)
+            process_cache.set(self.base_url, info, DEVICE_INFO_TIMEOUT)
 
         return info
 
     @property
     def device_info(self):
-        return cache.get(self.base_url)
+        return process_cache.get(self.base_url)
 
     @property
     def valid_device_info(self):
@@ -79,13 +77,13 @@ class CachedDeviceConnectionChecker(object):
     def device_port_open(self):
         """ check to see if a port is open at a given `base_url` """
 
-        cached = cache.get(self.base_url)
+        cached = process_cache.get(self.base_url)
 
         if cached:
             return cached
 
         result = check_if_port_open(self.base_url)
-        cache.set(self.base_url, result, DEVICE_PORT_TIMEOUT)
+        process_cache.set(self.base_url, result, DEVICE_PORT_TIMEOUT)
 
         return result
 

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -41,6 +41,10 @@ DEVICE_INFO_TIMEOUT = 3
 
 DEVICE_PORT_TIMEOUT = 60
 
+DEVICE_INFO_CACHE_KEY = "device_info_cache_{url}"
+
+DEVICE_PORT_CACHE_KEY = "device_port_cache_{url}"
+
 
 class CachedDeviceConnectionChecker(object):
     def __init__(self, base_url):
@@ -50,13 +54,17 @@ class CachedDeviceConnectionChecker(object):
         info = check_device_info(self.base_url)
 
         if info:
-            process_cache.set(self.base_url, info, DEVICE_INFO_TIMEOUT)
+            process_cache.set(
+                DEVICE_INFO_CACHE_KEY.format(url=self.base_url),
+                info,
+                DEVICE_INFO_TIMEOUT,
+            )
 
         return info
 
     @property
     def device_info(self):
-        return process_cache.get(self.base_url)
+        return process_cache.get(DEVICE_INFO_CACHE_KEY.format(url=self.base_url))
 
     @property
     def valid_device_info(self):
@@ -77,13 +85,15 @@ class CachedDeviceConnectionChecker(object):
     def device_port_open(self):
         """ check to see if a port is open at a given `base_url` """
 
-        cached = process_cache.get(self.base_url)
+        cached = process_cache.get(DEVICE_PORT_CACHE_KEY.format(url=self.base_url))
 
         if cached:
             return cached
 
         result = check_if_port_open(self.base_url)
-        process_cache.set(self.base_url, result, DEVICE_PORT_TIMEOUT)
+        process_cache.set(
+            DEVICE_PORT_CACHE_KEY.format(url=self.base_url), result, DEVICE_PORT_TIMEOUT
+        )
 
         return result
 

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -1,12 +1,16 @@
 import importlib
 import logging
+import os
 import time
 import uuid
 
-from diskcache import RLock
+try:
+    from thread import get_ident
+except ImportError:
+    from threading import get_ident
 
 from kolibri.core.tasks import compat
-from kolibri.deployment.default.cache import diskcache_cache
+from kolibri.core.utils.cache import get_process_cache
 
 
 # An object on which to store data about the current job
@@ -122,12 +126,52 @@ class InfiniteLoopThread(compat.Thread):
         self.stop()
 
 
-class DiskCacheRLock(RLock):
+class DiskCacheRLock(object):
+    """
+    Vendored from
+    https://github.com/grantjenks/python-diskcache/blob/2d1f43ea2be4c82a430d245de6260c3e18059ba1/diskcache/recipes.py
+    """
+
+    def __init__(self, cache, key, expire=None):
+        self._cache = cache
+        self._key = key
+        self._expire = expire
+
+    def acquire(self):
+        "Acquire lock by incrementing count using spin-lock algorithm."
+        pid = os.getpid()
+        tid = get_ident()
+        pid_tid = "{}-{}".format(pid, tid)
+
+        while True:
+            value, count = self._cache.get(self._key, (None, 0))
+            if pid_tid == value or count == 0:
+                self._cache.set(
+                    self._key, (pid_tid, count + 1), self._expire,
+                )
+                return
+            time.sleep(0.001)
+
     def release(self):
-        super(DiskCacheRLock, self).release()
+        "Release lock by decrementing count."
+        pid = os.getpid()
+        tid = get_ident()
+        pid_tid = "{}-{}".format(pid, tid)
+
+        value, count = self._cache.get(self._key, default=(None, 0))
+        is_owned = pid_tid == value and count > 0
+        assert is_owned, "cannot release un-acquired lock"
+        self._cache.set(self._key, (value, count - 1), self._expire)
+
         # RLOCK leaves the db connection open after releasing the lock
         # Let's ensure it's correctly closed
         self._cache.close()
 
+    def __enter__(self):
+        self.acquire()
 
-db_task_write_lock = DiskCacheRLock(diskcache_cache, "db_task_write_lock")
+    def __exit__(self, *exc_info):
+        self.release()
+
+
+db_task_write_lock = DiskCacheRLock(get_process_cache(), "db_task_write_lock")

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -10,7 +10,7 @@ except ImportError:
     from threading import get_ident
 
 from kolibri.core.tasks import compat
-from kolibri.core.utils.cache import get_process_cache
+from kolibri.core.utils.cache import process_cache
 
 
 # An object on which to store data about the current job
@@ -174,4 +174,4 @@ class DiskCacheRLock(object):
         self.release()
 
 
-db_task_write_lock = DiskCacheRLock(get_process_cache(), "db_task_write_lock")
+db_task_write_lock = DiskCacheRLock(process_cache, "db_task_write_lock")

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -1,8 +1,12 @@
 from django.core.cache import caches
+from django.utils.functional import SimpleLazyObject
 
 
-def get_process_cache():
+def __get_process_cache():
     try:
         return caches["process_cache"]
     except KeyError:
         return caches["default"]
+
+
+process_cache = SimpleLazyObject(__get_process_cache)

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -1,43 +1,8 @@
 from django.core.cache import caches
 
-from kolibri.utils.conf import OPTIONS
 
-
-cache_options = OPTIONS["Cache"]
-
-NOTHING = object()
-
-
-class CrossProcessCache(object):
-    def __init__(self, default_timeout=cache_options["CACHE_TIMEOUT"]):
-        self.default_timeout = default_timeout
-
-    def __contains__(self, key):
-        if key in caches["default"]:
-            return True
-        if cache_options["CACHE_BACKEND"] != "redis" and key in caches["process_cache"]:
-            return True
-        return False
-
-    def get(self, key, default=None, version=None):
-        if key in caches["default"] or cache_options["CACHE_BACKEND"] == "redis":
-            return caches["default"].get(key, default=default, version=version)
-        if key in caches["process_cache"]:
-            item = caches["process_cache"].get(key, default=None, version=None)
-            caches["default"].set(
-                key, item, timeout=self.default_timeout, version=version
-            )
-            return item
-        return default
-
-    def set(self, key, value, timeout=NOTHING, version=None):
-        if timeout == NOTHING:
-            timeout = self.default_timeout
-        caches["default"].set(key, value, timeout=timeout, version=version)
-        if cache_options["CACHE_BACKEND"] != "redis":
-            caches["process_cache"].set(key, value, timeout=timeout, version=version)
-
-    def delete(self, key, version=None):
-        caches["default"].delete(key, version=version)
-        if cache_options["CACHE_BACKEND"] != "redis":
-            caches["process_cache"].delete(key, version=version)
+def get_process_cache():
+    try:
+        return caches["process_cache"]
+    except KeyError:
+        return caches["default"]

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -1,11 +1,12 @@
 from django.core.cache import caches
+from django.core.cache import InvalidCacheBackendError
 from django.utils.functional import SimpleLazyObject
 
 
 def __get_process_cache():
     try:
         return caches["process_cache"]
-    except KeyError:
+    except InvalidCacheBackendError:
         return caches["default"]
 
 

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -16,19 +16,21 @@ pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
 
 
-def recreate_cache():
-    shutil.rmtree(diskcache_location, ignore_errors=True)
-    os.mkdir(diskcache_location)
-    diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
-    diskcache_cache.close()
-    return diskcache_cache
+def recreate_diskcache():
+    if cache_options["CACHE_BACKEND"] != "redis":
+        try:
+            diskcache_cache = Cache(
+                diskcache_location, disk_pickle_protocol=pickle_protocol
+            )
+        except DatabaseError:
+            shutil.rmtree(diskcache_location, ignore_errors=True)
+            os.mkdir(diskcache_location)
+            diskcache_cache = Cache(
+                diskcache_location, disk_pickle_protocol=pickle_protocol
+            )
+        diskcache_cache.clear()
+        diskcache_cache.close()
 
-
-try:
-    diskcache_cache = Cache(diskcache_location, disk_pickle_protocol=pickle_protocol)
-    diskcache_cache.close()
-except DatabaseError:
-    diskcache_cache = recreate_cache()
 
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -12,11 +12,19 @@ ROOT_URLCONF = "kolibri.deployment.default.dev_urls"
 
 DEVELOPER_MODE = True
 
+try:
+    process_cache = CACHES["process_cache"]  # noqa F405
+except KeyError:
+    process_cache = None
+
 # Create a memcache for each cache
 CACHES = {
     key: {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
     for key in CACHES.keys()  # noqa F405
 }
+
+if process_cache:
+    CACHES["process_cache"] = process_cache
 
 
 REST_FRAMEWORK = {

--- a/kolibri/deployment/default/settings/test.py
+++ b/kolibri/deployment/default/settings/test.py
@@ -13,8 +13,16 @@ if "KOLIBRI_HOME" not in os.environ:
 
 from .base import *  # noqa isort:skip @UnusedWildImport
 
+try:
+    process_cache = CACHES["process_cache"]  # noqa F405
+except KeyError:
+    process_cache = None
+
 # Create a dummy cache for each cache
 CACHES = {
     key: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}
     for key in CACHES.keys()  # noqa F405
 }
+
+if process_cache:
+    CACHES["process_cache"] = process_cache

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -36,7 +36,7 @@ from .system import become_daemon
 from kolibri.core.deviceadmin.utils import IncompatibleDatabase
 from kolibri.core.upgrade import matches_version
 from kolibri.core.upgrade import run_upgrades
-from kolibri.deployment.default.cache import recreate_cache
+from kolibri.deployment.default.cache import recreate_diskcache
 from kolibri.plugins import config
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins.utils import autoremove_unavailable_plugins
@@ -448,7 +448,7 @@ def start(port, background):
 
     # Clear old sessions up
     call_command("clearsessions")
-    recreate_cache()
+    recreate_diskcache()
 
     # On Mac, Python crashes when forking the process, so prevent daemonization until we can figure out
     # a better fix. See https://github.com/learningequality/kolibri/issues/4821
@@ -602,7 +602,7 @@ def services(port, background):
     """
 
     create_startup_lock(None)
-    recreate_cache()
+    recreate_diskcache()
 
     logger.info("Starting Kolibri background services")
 


### PR DESCRIPTION
### Summary
* Vendor diskcache RLock to use django cache transparently.
* Don't recreate diskcache at import.
* Only recreate diskcache when completely necessary.

### Reviewer guidance
Does kolibri still start?
Does importing a channel database still work?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
