### PR TITLE
Limit permissions to learners

### DIFF
--- a/integration_testing/features/coach/coach-change-profile-information.feature
+++ b/integration_testing/features/coach/coach-change-profile-information.feature
@@ -4,7 +4,6 @@ Feature: Coach changes profile information
   Background:
     Given I am signed in to Kolibri as a coach user
       And I am on my <username> *Profile > Details* page
-      And facility is set up to allow learners and coaches to edit full names, usernames, and change their passwords
 
   Scenario: Coach changes username and full name
     When I click the *Edit* button

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -157,9 +157,9 @@
       // These are not going to be picked up by the linter because snake cased versions
       // are used to get the keys to these strings.
       /* eslint-disable kolibri/vue-no-unused-translations */
-      learnerCanEditName: 'Allow learners and coaches to edit their full name',
-      learnerCanEditPassword: 'Allow learners and coaches to change their password when signed in',
-      learnerCanEditUsername: 'Allow learners and coaches to edit their username',
+      learnerCanEditName: 'Allow learners to edit their full name',
+      learnerCanEditPassword: 'Allow learners to change their password when signed in',
+      learnerCanEditUsername: 'Allow learners to edit their username',
       learnerCanSignUp: 'Allow learners to create accounts',
       learnerCanLoginWithNoPassword: 'Allow learners to sign in with no password',
       showDownloadButtonInLearn: "Show 'download' button with resources",

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -40,9 +40,9 @@ describe('facility config page view', () => {
     const checkboxes = wrapper.findAll({ name: 'KCheckbox' });
     expect(checkboxes.length).toEqual(6);
     const labels = [
-      'Allow learners and coaches to edit their username',
-      'Allow learners and coaches to change their password when signed in',
-      'Allow learners and coaches to edit their full name',
+      'Allow learners to edit their username',
+      'Allow learners to change their password when signed in',
+      'Allow learners to edit their full name',
       'Allow learners to create accounts',
       'Allow learners to sign in with no password',
       "Show 'download' button with resources",

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -100,18 +100,18 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig', 'isCoach', 'isLearner']),
+      ...mapGetters(['facilityConfig', 'isLearner']),
       formDisabled() {
         return this.status === 'BUSY';
       },
       canEditName() {
-        if (this.isLearner || this.isCoach) {
+        if (this.isLearner) {
           return this.facilityConfig.learner_can_edit_name;
         }
         return true;
       },
       canEditUsername() {
-        if (this.isLearner || this.isCoach) {
+        if (this.isLearner) {
           return this.facilityConfig.learner_can_edit_username;
         }
         return true;

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -159,6 +159,7 @@
         'facilityConfig',
         'getUserKind',
         'getUserPermissions',
+        'isCoach',
         'isSuperuser',
         'totalPoints',
         'userHasPermissions',
@@ -192,7 +193,7 @@
         return '';
       },
       canEditPassword() {
-        return this.isSuperuser || this.facilityConfig.learner_can_edit_password;
+        return this.isSuperuser || this.isCoach || this.facilityConfig.learner_can_edit_password;
       },
     },
     created() {


### PR DESCRIPTION
### Summary
Permissions to change password, edit username and fullname are only configurable for learners.
Admins and coaches have always them


### Reviewer guidance
Check learners are affected by these facility permissions while coaches are not.
Check tests pass and gherking scenarios are correctly updated

### References
Fixes #6878 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
