### PR TITLE
Catch error when kolibri runs in linux non-debian distros

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -27,6 +27,11 @@ except NotImplementedError:
     # This module can't work on this OS
     psutil = None
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 logger = logging.getLogger(__name__)
 
 # Status codes for kolibri

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -489,7 +489,10 @@ def installation_type(cmd_line=None):  # noqa:C901
             apt_repo = str(check_output(["apt-cache", "madison", "kolibri"]))
             if apt_repo:
                 install_type = "apt"
-        except CalledProcessError:  # kolibri package not installed!
+        except (
+            CalledProcessError,
+            FileNotFoundError,
+        ):  # kolibri package not installed!
             install_type = "whl"
         return install_type
 


### PR DESCRIPTION

### Summary
It catches an error happening when Kolibri is installed in a non-Debian based Linux distribution using pip.

### Reviewer guidance
It's a very simple fix, not much to say.
We should cherry-pick this fix to the develop branch.

### References
Fixes #6882



### Contributor Checklist


PR process:

- [x PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
