### PR TITLE
Fix for mount point detection on Android with latest toolchain.

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -76,14 +76,16 @@ def get_drive_list():
 
     if sys.platform == "darwin":
         MOUNT_PARSER = OSX_MOUNT_PARSER
-    elif on_android():
-        MOUNT_PARSER = RAW_MOUNT_PARSER
     else:
         MOUNT_PARSER = LINUX_MOUNT_PARSER
 
     try:
         drivelist = subprocess.Popen("mount", shell=True, stdout=subprocess.PIPE)
         drivelisto, err = drivelist.communicate()
+        # Some Android devices at least now use the LINUX_MOUNT_PARSER format.
+        # Try it and revert to RAW_MOUNT_PARSER if we can't find any matches with it.
+        if on_android() and not MOUNT_PARSER.match(drivelisto.decode()):
+            MOUNT_PARSER = RAW_MOUNT_PARSER
     except OSError:  # couldn't run `mount`, let's try reading the /etc/mounts listing directly
         with open("/proc/mounts") as f:
             drivelisto = f.read()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

On the Android devices I'm testing on, mount works and returns output in the format defined for the Linux parser. This modifies the detection logic to try that first, then fall back to the RAW_MOUNT_PARSER syntax if it fails.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test, you need an Android device with external storage, like an SD Card or possibly a USB device. You also need to go into the app settings and enable storage permissions manually until the app support branch has the ability to prompt for permissions.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
