### PR TITLE
arrow buttons on very small screens

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -44,8 +44,24 @@
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
+            <UiIconButton
+              v-if="windowBreakpoint === 0"
+              :aria-label="$tr('nextQuestion')"
+              size="large"
+              type="secondary"
+              class="footer-button"
+              :disabled="questionNumber === exam.question_count - 1"
+              @click="goToQuestion(questionNumber + 1)"
+            >
+              <mat-svg
+                name="arrow_forward"
+                category="navigation"
+                :style="{fill: $themeTokens.primary}"
+              />
+            </UiIconButton>
             <KButton
-              :disabled="questionNumber===exam.question_count-1"
+              v-else
+              :disabled="questionNumber === exam.question_count - 1"
               :primary="true"
               class="footer-button"
               :dir="layoutDirReset"
@@ -54,8 +70,24 @@
               {{ $tr('nextQuestion') }}
               <KIcon icon="forward" color="white" class="forward-icon" />
             </KButton>
+            <UiIconButton
+              v-if="windowBreakpoint === 0"
+              :aria-label="$tr('previousQuestion')"
+              size="large"
+              type="secondary"
+              class="footer-button left-align"
+              :disabled="questionNumber === 0"
+              @click="goToQuestion(questionNumber - 1)"
+            >
+              <mat-svg
+                name="arrow_back"
+                category="navigation"
+                :style="{fill: $themeTokens.primary}"
+              />
+            </UiIconButton>
             <KButton
-              :disabled="questionNumber===0"
+              v-else
+              :disabled="questionNumber === 0"
               :primary="true"
               class="footer-button"
               :dir="layoutDirReset"
@@ -135,6 +167,7 @@
   import debounce from 'lodash/debounce';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import UiAlert from 'kolibri.coreVue.components.UiAlert';
+  import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { ClassesPageNames } from '../../constants';
@@ -150,6 +183,7 @@
     components: {
       AnswerHistory,
       UiAlert,
+      UiIconButton,
       BottomAppBar,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],


### PR DESCRIPTION


### Summary

show arrow buttons without text on very small screens in quiz view

| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/2367265/82608491-a7f8d880-9b6f-11ea-8ba6-89eefd05ffca.png) |![image](https://user-images.githubusercontent.com/2367265/82608511-b3e49a80-9b6f-11ea-98a6-ae7e9e7abd93.png)|

### Reviewer guidance

* take a quiz on a tiny screen
* make sure tabbing works as expected


### References

fixes https://github.com/learningequality/kolibri/issues/6358

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
