### PR TITLE
Responsively make room for info icon in demographic fields

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -2,7 +2,7 @@
 
   <div class="pos-rel">
     <KSelect
-      class="select"
+      class="birthyear-select"
       :value="selected"
       :label="coreString('birthYearLabel')"
       :placeholder="$tr('placeholder')"
@@ -97,10 +97,14 @@
     position: relative;
   }
 
+  .birthyear-select {
+    width: calc(100% - 32px);
+  }
+
   .info-icon {
     position: absolute;
     top: 27px;
-    right: -34px;
+    right: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
+++ b/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
@@ -2,6 +2,7 @@
 
   <div class="pos-rel">
     <KTextbox
+      class="identifier-textbox"
       :value="value"
       :label="$tr('label')"
       :maxlength="64"
@@ -49,10 +50,14 @@
     position: relative;
   }
 
+  .identifier-textbox {
+    width: calc(100% - 32px);
+  }
+
   .info-icon {
     position: absolute;
     top: 27px;
-    right: -34px;
+    right: 0;
   }
 
   /deep/ .k-tooltip {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Responsively applies different widths to controls when `windowIsSmall` computed prop is true.

When window is larger, the icons are unchanged relative to original positioning.

![CleanShot 2020-05-21 at 14 34 00](https://user-images.githubusercontent.com/10248067/82608812-35d4c380-9b70-11ea-9cee-5f1a35526673.gif)

### Reviewer guidance

1. Check out the fix on the other pages: Sign UP, Edit User, Profile Edit, etc.

### References

Fixes #6359
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
