### PR TITLE
For User Permissions and Profiles, adds exit-on-success behavior from #6705 

### DIFF
--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -88,10 +88,7 @@
           @click="goBack()"
         />
       </div>
-      <div v-show="uiBlocked">
-        {{ progressNotification }}
-      </div>
-      <div v-show="saveProgress==='FAILURE'">
+      <div v-if="saveFailed">
         {{ $tr('saveFailureNotification') }}
       </div>
     </template>
@@ -109,10 +106,6 @@
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
 
-  const SUCCESS = 'SUCCESS';
-  const IN_PROGRESS = 'IN_PROGRESS';
-  const FAILURE = 'FAILURE';
-
   export default {
     name: 'UserPermissionsPage',
     metaInfo() {
@@ -128,7 +121,7 @@
     data() {
       return {
         devicePermissionsChecked: undefined,
-        saveProgress: undefined,
+        saveFailed: false,
         superuserChecked: undefined,
         uiBlocked: false,
       };
@@ -154,16 +147,6 @@
       },
       devicePermissionsDisabled() {
         return this.uiBlocked || this.superuserChecked;
-      },
-      progressNotification() {
-        switch (this.saveProgress) {
-          case IN_PROGRESS:
-            return this.$tr('saveInProgressNotification');
-          case SUCCESS:
-            return this.$tr('saveSuccessfulNotification');
-          default:
-            return '';
-        }
       },
       // "dirty check" of permissions
       permissionsAreUnchanged() {
@@ -193,7 +176,6 @@
       ...mapActions(['createSnackbar']),
       save() {
         this.uiBlocked = true;
-        this.saveProgress = IN_PROGRESS;
         this.addOrUpdateUserPermissions({
           userId: this.user.id,
           is_superuser: this.superuserChecked,
@@ -201,13 +183,12 @@
         })
           .then(() => {
             this.createSnackbar(this.$tr('permissionChangeConfirmation'));
-            this.saveProgress = SUCCESS;
             this.uiBlocked = false;
             this.goBack();
           })
           .catch(() => {
             this.uiBlocked = false;
-            this.saveProgress = FAILURE;
+            this.saveFailed = true;
           });
       },
       goBack() {
@@ -226,8 +207,6 @@
       permissionChangeConfirmation: 'Changes saved',
       saveButton: 'Save Changes',
       saveFailureNotification: 'There was a problem saving these changes.',
-      saveInProgressNotification: 'Saving...',
-      saveSuccessfulNotification: 'Changes saved!',
       userDoesNotExist: 'User does not exist',
       superAdminExplanation1:
         'Has all device permissions and can manage device permissions of other users',

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -203,6 +203,7 @@
             this.createSnackbar(this.$tr('permissionChangeConfirmation'));
             this.saveProgress = SUCCESS;
             this.uiBlocked = false;
+            this.goBack();
           })
           .catch(() => {
             this.uiBlocked = false;

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -173,9 +173,7 @@
         return this.status === 'BUSY';
       },
       cancelButtonText() {
-        return this.status === 'SUCCESS'
-          ? this.coreString('closeAction')
-          : this.coreString('cancelAction');
+        return this.coreString('cancelAction');
       },
       coachIsSelected() {
         return this.typeSelected && this.typeSelected.value === UserKinds.COACH;
@@ -332,7 +330,6 @@
           });
       },
       handleSubmitSuccess() {
-        this.status = 'SUCCESS';
         // newUserKind is falsey if Super Admin, since that's not a facility role
         if (this.willBeLoggedOut) {
           // Log out of Facility Page if and Admin demotes themselves to non-Admin

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -339,6 +339,7 @@
           this.$store.dispatch('kolibriLogout');
         } else {
           this.$store.dispatch('createSnackbar', this.$tr('userUpdateNotification'));
+          this.goToUserManagementPage();
         }
       },
       handleSubmitFailure(error) {

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -163,6 +163,7 @@
             .then(() => {
               this.status = 'SUCCESS';
               this.$store.dispatch('createSnackbar', this.$tr('updateSuccessNotification'));
+              this.$router.push(this.$router.getRoute('PROFILE'));
             })
             .catch(error => {
               this.status = 'FAILURE';

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -117,9 +117,7 @@
         return true;
       },
       cancelButtonText() {
-        return this.status === 'SUCCESS'
-          ? this.coreString('closeAction')
-          : this.coreString('cancelAction');
+        return this.coreString('cancelAction');
       },
       formIsValid() {
         return every([this.fullNameValid, this.usernameValid]);
@@ -161,7 +159,6 @@
               updates: this.getUpdates(),
             })
             .then(() => {
-              this.status = 'SUCCESS';
               this.$store.dispatch('createSnackbar', this.$tr('updateSuccessNotification'));
               this.$router.push(this.$router.getRoute('PROFILE'));
             })


### PR DESCRIPTION
### Summary

This cherry picks the changes in #6705 to 0.13.x branch.

Since it removes the ability to click "Save" again after a successful save on the UserEditPage, it resolves #6400 and #6824 

Also removes some extra code in UserPermissionsPage

### Reviewer guidance

Confirm that the problem in the two issues above is resolved by this.

Check in UserPermissionsPage and ProfileEditPage, that there are no problems.

### References
Fixes #6400
Fixes #6824

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
