### PR TITLE
add option STATIC_USE_SYMLINKS to toggle on/off symlinked static files

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -1,3 +1,56 @@
+"""
+This module is intended to allow customization of Kolibri settings with the
+options.ini file.
+The settings can be changed through environment variables or sections and keys
+in the options.ini file.
+The following options are supported:
+
+[Cache]
+CACHE_BACKEND
+CACHE_TIMEOUT
+CACHE_MAX_ENTRIES
+CACHE_PASSWORD
+CACHE_LOCATION
+CACHE_REDIS_MIN_DB
+
+[Database]
+DATABASE_ENGINE
+DATABASE_NAME
+DATABASE_PASSWORD
+DATABASE_USER
+DATABASE_HOST
+DATABASE_PORT
+
+[Server]
+CHERRYPY_START
+CHERRYPY_THREAD_POOL
+CHERRYPY_SOCKET_TIMEOUT
+CHERRYPY_QUEUE_SIZE
+CHERRYPY_QUEUE_TIMEOUT
+PROFILE
+
+[Paths]
+CONTENT_DIR
+
+[Urls]
+CENTRAL_CONTENT_BASE_URL
+DATA_PORTAL_SYNCING_BASE_URL
+
+[Deployment]
+HTTP_PORT
+RUN_MODE
+URL_PATH_PREFIX
+LANGUAGES
+STATIC_USE_SYMLINKS
+    We currently create symbolic links when collecting static files. The option
+    can be set to False to disable the feature to instead copy files to STATIC_ROOT.
+    This is useful for the cloud infrastructure where Nginx and Kolibri are set
+    up in separate network mounted volumes such that Nginx cannot access symlinked
+    static files in the other volume.
+
+[Python]
+PICKLE_PROTOCOL
+"""
 import logging.config
 import os
 import sys

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -233,6 +233,11 @@ base_option_spec = {
             "default": SUPPORTED_LANGUAGES,
             "envvars": ("KOLIBRI_LANGUAGES",),
         },
+        "STATIC_USE_SYMLINKS": {
+            "type": "boolean",
+            "default": True,
+            "envvars": ("KOLIBRI_STATIC_USE_SYMLINKS",),
+        },
     },
     "Python": {
         "PICKLE_PROTOCOL": {

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -27,6 +27,7 @@ import six
 from django.db import connections
 
 from .conf import KOLIBRI_HOME
+from .conf import OPTIONS
 from kolibri.utils.android import on_android
 
 logger = logging.getLogger(__name__)
@@ -242,6 +243,10 @@ def _symlink_capability_check():
     Function to try to establish a symlink
     return True if it succeeds, return False otherwise.
     """
+    # If STATIC_USE_SYMLINKS has been set to False, return False directly
+    if not OPTIONS["Deployment"]["STATIC_USE_SYMLINKS"]:
+        return False
+
     fd, temp_target = tempfile.mkstemp()
     temp_pathname = temp_target + ".lnk"
     can_do = True


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to add an option `STATIC_USE_SYMLINKS` to toggle on and off symlinked static files to adapt to our cloud deployment infrastructure where Nginx and Kolibri do not have access to each other's local file system.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I've tested this PR locally with the following steps:
1. without any additional settings change, run `kolibri start`
2. check that the static files under kolibri home directory are symlinked 
3. stop kolibri, and set environment variable `KOLIBRI_STATIC_USE_SYMLINKS` to False
4. start kolibri again
5. check that the static files under kolibri home directory are not symlinked

please feel free to let me know if you have any questions. thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6839
#6805 

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
