### PR TITLE
Fix h5p loading for Python3.

### DIFF
--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -75,7 +75,7 @@ def get_path_or_404(zipped_filename):
 
 def load_json_from_zipfile(zf, filepath):
     with zf.open(filepath, "r") as f:
-        return json.loads(f)
+        return json.load(f)
 
 
 def recursive_h5p_dependencies(zf, data, prefix=""):


### PR DESCRIPTION
### Summary
In Python2, reading from a zipfile returns a string, in Python 3 it returns bytes.
This caused an error for h5p loading.
This fixes that by using `json.load` instead of `json.loads` which behaves consistently across Python2 and 3 when reading from `zf.open(<path>)`.

### Reviewer guidance
Can you access h5p on Python 3 and up?

### References
Fixes #6813

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
