### PR TITLE
Remove docker-clean recipe.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,6 @@
 steps:
   - label: Build Python packages
     command:
-     - make docker-clean
      - mkdir -p dist
      - .buildkite/build_whl.sh
 
@@ -22,9 +21,6 @@ steps:
     if: build.tag != null
 
   - wait
-
-  - label: Cleaning up
-    command: make docker-clean
 
   - block: "Test .debs?"
   - label: Test on Trusty, Xenial, Bionic

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # List most target names as 'PHONY' to prevent Make from thinking it will be creating a file of the same name
-.PHONY: help clean clean-assets clean-build clean-pyc clean-docs lint test test-all assets coverage docs release test-namespaced-packages staticdeps staticdeps-cext writeversion buildconfig pex i18n-extract-frontend i18n-extract-backend i18n-extract i18n-django-compilemessages i18n-upload i18n-download i18n-regenerate-fonts i18n-stats i18n-install-font docker-clean docker-whl docker-deb docker-deb-test docker-windows docker-demoserver docker-devserver
+.PHONY: help clean clean-assets clean-build clean-pyc clean-docs lint test test-all assets coverage docs release test-namespaced-packages staticdeps staticdeps-cext writeversion buildconfig pex i18n-extract-frontend i18n-extract-backend i18n-extract i18n-django-compilemessages i18n-upload i18n-download i18n-regenerate-fonts i18n-stats i18n-install-font docker-whl docker-deb docker-deb-test docker-windows docker-demoserver docker-devserver
 
 help:
 	@echo "Usage:"
@@ -203,10 +203,6 @@ i18n-stats:
 
 i18n-install-font:
 	python build_tools/i18n/fonts.py add-source-font ${name}
-
-docker-clean:
-	docker container prune -f
-	docker image prune -f
 
 docker-whl: writeversion
 	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
*These changes are intended to be propagated all the way up into current develop*.

With the introduction of a share-nothing multi-machine "cluster" of build agents, we can no longer assume that the cleanup step will run on the same machine that built the prior steps - the jobs regularly alternate between builders.

Further, a job (buildkite step) isn't really meant for that kind of cleanup anyway. It assumes that the source code is necessary, and pulls the entire repo. This is actually a pretty time consuming step when the network is bogged down due to our use of `git-lfs`.

For now, I've enabled an system-level hook to run some docker cleanup commands (look for the step in buildkite logs. Punctuated by a docker emoji) on every single job, on both our current agents. Even for the jobs that don't use Docker. This is heavy handed, but doesn't take very long. 

Conditionalizing the cleanup to only run when necessary is  possible, and I've locally drafted some ways to do that, but will require many commits/PR's across several repos. Most likely, the cleanup will become part of the pipelines' codebase so that cleanup can be customized per-build. This will probably happen eventually, but I don't think it's a priority right now.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Make sure the cleanup job is running in logs. I've verified that it's doing what's expected, but there are some pretty bad consequences down the road if it's not running.

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
