### PR TITLE
Prevent the overly persistent welcome modal

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -495,11 +495,6 @@ class SessionViewSet(viewsets.ViewSet):
             # Correct password, and the user is marked "active"
             login(request, user)
             # Success!
-            # Is this the first time this user has logged in?
-            # If so, they will not have any UserSessionLogs until we call get_session.
-            request.session["first_login"] = not UserSessionLog.objects.filter(
-                user=user
-            ).exists()
             return self.get_session_response(request)
         elif (
             not password

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -43,10 +43,6 @@ class RoleBasedRedirectHook(KolibriHook):
     def url(self):
         pass
 
-    # Special flag to only redirect on first login
-    # Default to False
-    first_login = False
-
     def plugin_url(self, plugin_class, url_name):
         return plugin_url(plugin_class, url_name)
 

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -36,9 +36,20 @@ class KolibriTagNavigationTestCase(APITestCase):
             response.get("location"), reverse("kolibri:kolibri.plugins.user:user")
         )
 
-    def test_redirect_root_to_learn_if_logged_in(self):
+    def test_redirect_root_to_device_if_superuser_logged_in(self):
         facility = FacilityFactory.create()
         do = create_superuser(facility)
+        provision_device()
+        self.client.login(username=do.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse("kolibri:core:root_redirect"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"),
+            reverse("kolibri:kolibri.plugins.device:device_management"),
+        )
+
+    def test_redirect_root_to_learn_if_logged_in(self):
+        do = FacilityUserFactory.create()
         provision_device()
         self.client.login(username=do.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse("kolibri:core:root_redirect"))

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -31,13 +31,6 @@ const routes = [
     redirect: '/content',
   },
   {
-    path: '/welcome',
-    redirect: () => {
-      store.commit('SET_WELCOME_MODAL_VISIBLE', true);
-      return '/content';
-    },
-  },
-  {
     name: PageNames.MANAGE_CONTENT_PAGE,
     component: withAuthMessage(ManageContentPage, 'contentManager'),
     path: '/content',

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -35,6 +35,8 @@
   import DeviceTopNav from './DeviceTopNav';
   import WelcomeModal from './WelcomeModal';
 
+  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+
   export default {
     name: 'DeviceIndex',
     components: {
@@ -44,8 +46,11 @@
     },
     computed: {
       ...mapGetters(['canManageContent', 'isSuperuser']),
-      ...mapState(['welcomeModalVisible']),
+      ...mapState({ welcomeModalVisibleState: 'welcomeModalVisible' }),
       ...mapState('coreBase', ['appBarTitle']),
+      welcomeModalVisible() {
+        return this.welcomeModalVisibleState && !window.sessionStorage.getItem(welcomeDimissalKey);
+      },
       pageName() {
         return this.$route.name;
       },
@@ -164,6 +169,7 @@
     methods: {
       ...mapActions('manageContent', ['refreshTaskList']),
       hideWelcomeModal() {
+        window.sessionStorage.setItem(welcomeDimissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
       startTaskPolling() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -166,6 +166,11 @@
         }
       },
     },
+    created() {
+      if (!this.channelsAreInstalled) {
+        this.$store.commit('SET_WELCOME_MODAL_VISIBLE', true);
+      }
+    },
     methods: {
       ...mapActions('manageContent', ['refreshChannelList', 'startImportWorkflow']),
       handleSelect({ value }) {

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -21,15 +21,12 @@ class DeviceManagementAsset(WebpackBundleHook):
 
 
 @register_hook
-class DeviceFirstTimeRedirect(RoleBasedRedirectHook):
+class DeviceRedirect(RoleBasedRedirectHook):
     roles = (SUPERUSER,)
-    first_login = True
 
     @property
     def url(self):
-        return (
-            self.plugin_url(DeviceManagementPlugin, "device_management") + "#/welcome"
-        )
+        return self.plugin_url(DeviceManagementPlugin, "device_management")
 
 
 @register_hook


### PR DESCRIPTION
### Summary
Remove first_login checking.
Use lack of installed content to prompt welcome modal.
Always redirect super users to Device.

### Reviewer guidance
On first setup, does the welcome modal appear?
Once you have installed content, does the welcome modal no longer appear on refresh?
Every time you login as a superuser, does it redirect you to device?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
