### PR TITLE
Change the name for Simplified Chinese in the language modal

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -233,7 +233,7 @@ EXTRA_LANG_INFO = {
         "bidi": False,
         "code": "zh-hans",
         "name": "Simplified Chinese",
-        "name_local": "简化字",
+        "name_local": "简体中文",
     },
     "yo": {"bidi": False, "code": "yo", "name": "Yoruba", "name_local": "Yorùbá"},
     "zu": {"bidi": False, "code": "zu", "name": "Zulu", "name_local": "isiZulu"},

--- a/kolibri/locale/language_info.json
+++ b/kolibri/locale/language_info.json
@@ -156,7 +156,7 @@
   {
     "crowdin_code": "zh-CN",
     "intl_code": "zh-hans",
-    "language_name": "简化字",
+    "language_name": "简体中文",
     "english_name": "Simplified Chinese",
     "default_font": "NotoSans"
   }


### PR DESCRIPTION

### Summary
Use the more appropriate name `简体中文` for Chinese Simplified in the *Change language* modal.

![image](https://user-images.githubusercontent.com/1457929/83177784-f5e97f80-a11f-11ea-803d-f2112fee0267.png)
 
### Reviewer guidance
…

### References
…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
