### PR TITLE
Add inline tracking code to pf plugin.

### DIFF
--- a/kolibri/plugins/profuturo_mvp/buildConfig.js
+++ b/kolibri/plugins/profuturo_mvp/buildConfig.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    bundle_id: 'track',
+    webpack_config: {
+      entry: './frontend/tracking.js',
+    },
+  },
+];

--- a/kolibri/plugins/profuturo_mvp/frontend/tracking.js
+++ b/kolibri/plugins/profuturo_mvp/frontend/tracking.js
@@ -1,0 +1,13 @@
+(function(h, o, t, j, a, r) {
+  h.hj =
+    h.hj ||
+    function() {
+      (h.hj.q = h.hj.q || []).push(arguments);
+    };
+  h._hjSettings = { hjid: 1828417, hjsv: 6 };
+  a = o.getElementsByTagName('head')[0];
+  r = o.createElement('script');
+  r.async = 1;
+  r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+  a.appendChild(r);
+})(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');

--- a/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
+++ b/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
 from kolibri.core import theme_hook
+from kolibri.core.hooks import FrontEndBaseSyncHook
+from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
 
@@ -75,3 +77,14 @@ class ProfuturoThemeHook(theme_hook.ThemeHook):
                 theme_hook.SHOW_K_FOOTER_LOGO: True,
             },
         }
+
+
+@register_hook
+class TrackingAsset(webpack_hooks.WebpackBundleHook):
+    bundle_id = "track"
+    inline = True
+
+
+@register_hook
+class TrackingInclusionHook(FrontEndBaseSyncHook):
+    bundle_class = TrackingAsset


### PR DESCRIPTION
### Summary
Adds an inline frontend asset to inject tracking code into Kolibri
Registers it to load in the base html.

### Reviewer guidance
Does the tracking code appear in every page?

### References
![Screenshot from 2020-05-29 08-44-14](https://user-images.githubusercontent.com/1680573/83279360-dbe48700-a189-11ea-8c4b-4723f3e1d25c.png)


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
