### PR TITLE
Convert keys from UUIDs to strings when channel stats are created, not accessed.

### DIFF
--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -11,7 +11,6 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.fields import create_timezonestamp
-from uuid import UUID
 
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
@@ -438,18 +437,7 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
 
     @property
     def channel_stats(self):
-        channel_stats = self.context["channel_stats"]
-        if channel_stats is not None:
-            # Convert ContentNode IDs to hex strings if they are UUID
-            # objects
-            stats_convert_id = {}
-            for key in channel_stats.keys():
-                if not isinstance(key, UUID):
-                    return channel_stats
-                contentnode_id = key.hex
-                stats_convert_id[contentnode_id] = channel_stats[key]
-            channel_stats = stats_convert_id
-        return channel_stats
+        return self.context["channel_stats"]
 
     def get_total_resources(self, instance):
         # channel_stats is None for export

--- a/kolibri/core/content/utils/importability_annotation.py
+++ b/kolibri/core/content/utils/importability_annotation.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import UUID
 
 from le_utils.constants import content_kinds
 from sqlalchemy import and_
@@ -27,6 +28,12 @@ from kolibri.core.utils.cache import process_cache
 logger = logging.getLogger(__name__)
 
 CONTENT_APP_NAME = KolibriContentConfig.label
+
+
+def coerce_key(key):
+    if isinstance(key, UUID):
+        return key.hex
+    return key
 
 
 def get_channel_annotation_stats(channel_id, checksums=None):
@@ -212,7 +219,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):
         )
 
         for stat in level_stats:
-            stats[stat[0]] = {
+            stats[coerce_key(stat[0])] = {
                 "coach_content": bool(stat[1]),
                 "num_coach_contents": stat[2] or 0,
                 "total_resources": stat[3] or 0,
@@ -234,7 +241,7 @@ def get_channel_annotation_stats(channel_id, checksums=None):
         )
     ).fetchone()
 
-    stats[root_node_stats[0]] = {
+    stats[coerce_key(root_node_stats[0])] = {
         "coach_content": root_node_stats[1],
         "num_coach_contents": root_node_stats[2],
         "total_resources": root_node_stats[3],


### PR DESCRIPTION
### Summary
Importing content on postgresql can lead to timeouts because we are coercing all the keys of the channel_stats dict from a UUID to a string for each content node in a request.

This PR solves this by instead coercing the id of each individual content node when the channel stats are created.

### Reviewer guidance
Question - should this be rebased and targeted to 0.13.x instead?

### References
Follow up from #6544

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
