### PR TITLE
modify string for quiz completion into score

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AssignedExamsCards.vue
@@ -124,7 +124,7 @@
       questionsLeft:
         '{questionsLeft, number, integer} {questionsLeft, plural, one {question} other {questions}} left',
       completedPercentLabel: {
-        message: 'Completed: {score}%',
+        message: 'Score: {score}%',
         context: 'A label shown to learners on a quiz card when the quiz is completed',
       },
     },


### PR DESCRIPTION
## Summary
Fixes #6944 Modified user string from 'Completed' to 'Score' to avoid user confusion.

## Screenshots 
![pr](https://user-images.githubusercontent.com/33183263/83361353-fdba5580-a3a5-11ea-8cc3-cf5b2661fb06.png)


### Reviewer guidance
Complete a quiz and navigate back to the quiz in the classes tab.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
