### PR TITLE
add title and description for manage lesson resources

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -43,6 +43,9 @@
         :topicsLink="topicsLink"
       />
 
+      <h2>{{ topicTitle }}</h2>
+      <p>{{ topicDescription }}</p>
+
       <ContentCardList
         v-if="!isExiting"
         :contentList="filteredContentList"
@@ -201,6 +204,18 @@
       },
       channelsLink() {
         return this.selectionRootLink();
+      },
+      topicTitle() {
+        if (!this.ancestors.length) {
+          return '';
+        }
+        return this.ancestors[this.ancestors.length - 1].title;
+      },
+      topicDescription() {
+        if (!this.ancestors.length) {
+          return '';
+        }
+        return this.ancestors[this.ancestors.length - 1].description;
       },
       exitButtonRoute() {
         const lastId = this.$route.query.last_id;


### PR DESCRIPTION
### Summary 
Fixes #6957 Added title and description for manage lesson resources page.

## Screenshots 
Before 

![Screenshot from 2020-06-01 01-51-52](https://user-images.githubusercontent.com/33183263/83362055-f138fb80-a3ab-11ea-9083-c0c7c648c112.png)

After  

![Screenshot from 2020-06-01 01-57-57](https://user-images.githubusercontent.com/33183263/83362061-f5fdaf80-a3ab-11ea-9ce9-0af06a3ac5e1.png)

### Reviewer guidance
Open lesson resource management on a lesson

### Contributor Checklist
PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
