### PR TITLE
Fix +- buttons wrap behavior in quiz creation for small resolutions

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -528,21 +528,4 @@
     vertical-align: middle;
   }
 
-  .buttons-container {
-    text-align: right;
-    button {
-      margin: 0 0 0 16px;
-    }
-  }
-
-  .items {
-    display: inline-block;
-  }
-
-  .numItems {
-    display: inline-block;
-    margin: 8px;
-    list-style: none;
-  }
-
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -37,36 +37,48 @@
           />
         </KGridItem>
         <KGridItem :layout12="{ span: 6 }">
-          <KTextbox
-            ref="questionsInput"
-            v-model.trim.number="numQuestions"
-            type="number"
-            :min="1"
-            :max="maxQs"
-            :invalid="Boolean(showError && numQuestIsInvalidText)"
-            :invalidText="numQuestIsInvalidText"
-            :label="$tr('numQuestions')"
-            class="number-field"
-            @blur="numQuestionsBlurred = true"
-          />
-          <UiIconButton
-            type="flat"
-            aria-hidden="true"
-            class="number-btn"
-            :disabled="numQuestions === 1"
-            @click="numQuestions -= 1"
-          >
-            <mat-svg name="remove" category="content" />
-          </UiIconButton>
-          <UiIconButton
-            type="flat"
-            aria-hidden="true"
-            class="number-btn"
-            :disabled="numQuestions === maxQs"
-            @click="numQuestions += 1"
-          >
-            <mat-svg name="add" category="content" />
-          </UiIconButton>
+          <KGrid>
+            <KGridItem
+              :layout4="{ span: 2 }"
+              :layout8="{ span: 5 }"
+              :layout12="{ span: 8 }"
+            >
+              <KTextbox
+                ref="questionsInput"
+                v-model.trim.number="numQuestions"
+                type="number"
+                :min="1"
+                :max="maxQs"
+                :invalid="Boolean(showError && numQuestIsInvalidText)"
+                :invalidText="numQuestIsInvalidText"
+                :label="$tr('numQuestions')"
+                @blur="numQuestionsBlurred = true"
+              />
+            </KGridItem>
+            <KGridItem
+              :layout4="{ span: 2 }"
+              :layout8="{ span: 3 }"
+              :layout12="{ span: 4 }"
+              :style="{ marginTop: '16px' }"
+            >
+              <UiIconButton
+                type="flat"
+                aria-hidden="true"
+                :disabled="numQuestions === 1"
+                @click="numQuestions -= 1"
+              >
+                <mat-svg name="remove" category="content" />
+              </UiIconButton>
+              <UiIconButton
+                type="flat"
+                aria-hidden="true"
+                :disabled="numQuestions === maxQs"
+                @click="numQuestions += 1"
+              >
+                <mat-svg name="add" category="content" />
+              </UiIconButton>
+            </KGridItem>
+          </KGrid>
         </KGridItem>
       </KGrid>
 
@@ -531,19 +543,6 @@
     display: inline-block;
     margin: 8px;
     list-style: none;
-  }
-
-  .number-field {
-    display: inline-block;
-    max-width: 250px;
-    margin-right: 8px;
-  }
-
-  .number-btn {
-    position: relative;
-    top: 16px;
-    display: inline-block;
-    vertical-align: top;
   }
 
 </style>


### PR DESCRIPTION
### Summary

- do not break questions number buttons (+-) in quiz creation
- add grid to ensure that +- buttons are always on the same line as input
- remove obsolete styles from _CreateExamPage/index.vue_

#### Small

| Before | After |
| --------- | ------ |
|![Selection_011](https://user-images.githubusercontent.com/13509191/83630164-a8e03000-a59b-11ea-875b-4406d6bba820.png) | ![Selection_010](https://user-images.githubusercontent.com/13509191/83630249-cdd4a300-a59b-11ea-998e-c3087455c73d.png) |

#### Medium

![medium](https://user-images.githubusercontent.com/13509191/83631437-d1692980-a59d-11ea-9684-4c8247dac7f2.png)


#### Large

![large](https://user-images.githubusercontent.com/13509191/83631450-d5954700-a59d-11ea-8f19-6fd868b014c5.png)


### Reviewer guidance

Check "Number of questions" input together with +- buttons for various resolutions on quiz creation page.

### References

#6893 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
