### PR TITLE
Add yet another swagger generator (remove the old one)

### DIFF
--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -278,7 +278,7 @@ class Command(AsyncCommand):
         with self.start_progress(total=total_rows) as progress_update:
             try:
                 for row in csv_file_generator(
-                    facility, filepath, overwrite=options["overwrite"],
+                    facility, filepath, overwrite=options["overwrite"]
                 ):
                     progress_update(1)
             except (ValueError, IOError) as e:

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -274,9 +274,7 @@ class Validator(object):
                         classroom_real_name = class_list_normalized[classroom.lower()]
                         class_list[classroom_real_name].append(username)
                     else:
-                        class_list[classroom] = [
-                            username,
-                        ]
+                        class_list[classroom] = [username]
                         class_list_normalized[classroom.lower()] = classroom
             except AttributeError:
                 # there are not members of 'key'
@@ -400,9 +398,7 @@ class Command(AsyncCommand):
         validator.add_check(
             "USERNAME", value_length(125), MESSAGES[TOO_LONG].format("USERNAME")
         )
-        validator.add_check(
-            "USERNAME", valid_name(), MESSAGES[INVALID_USERNAME],
-        )
+        validator.add_check("USERNAME", valid_name(), MESSAGES[INVALID_USERNAME])
         validator.add_check(
             "USERNAME", not_empty(), MESSAGES[REQUIRED_COLUMN].format("USERNAME")
         )

--- a/kolibri/core/auth/test/test_bulk_export.py
+++ b/kolibri/core/auth/test/test_bulk_export.py
@@ -64,7 +64,7 @@ class UserExportTestCase(TestCase):
         _, self.filepath = tempfile.mkstemp(suffix=".csv")
 
         self.csv_rows = []
-        for row in b.csv_file_generator(self.facility, self.filepath, True,):
+        for row in b.csv_file_generator(self.facility, self.filepath, True):
             self.csv_rows.append(row)
 
     def test_exported_rows(self):

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -139,9 +139,7 @@ class ImportTestCase(TestCase):
         self.create_csv(new_filepath, rows[1:])  # remove header
         self.filepath = new_filepath
         # import exported csv
-        call_command(
-            "bulkimportusers", self.filepath, facility=self.facility.id,
-        )
+        call_command("bulkimportusers", self.filepath, facility=self.facility.id)
         current_classes = Classroom.objects.filter(parent_id=self.facility).all()
         for classroom in current_classes:
             assert len(classroom.get_members()) == CLASSROOMS
@@ -277,9 +275,7 @@ class ImportTestCase(TestCase):
             ],
         ]
         self.create_csv(first_filepath, rows)
-        call_command(
-            "bulkimportusers", first_filepath, facility=self.facility.id,
-        )
+        call_command("bulkimportusers", first_filepath, facility=self.facility.id)
         user1 = FacilityUser.objects.get(username="new_learner")
         passwd1 = user1.password
         uid1 = user1.id
@@ -354,7 +350,7 @@ class ImportTestCase(TestCase):
         ]
         self.create_csv(new_filepath, rows)
         call_command(
-            "bulkimportusers", new_filepath, "--delete", facility=self.facility.id,
+            "bulkimportusers", new_filepath, "--delete", facility=self.facility.id
         )
 
         # Previous users have been deleted, excepting the existing admin:
@@ -417,9 +413,7 @@ class ImportTestCase(TestCase):
             ],
         ]
         self.create_csv(new_filepath, rows)
-        call_command(
-            "bulkimportusers", new_filepath, facility=self.facility.id,
-        )
+        call_command("bulkimportusers", new_filepath, facility=self.facility.id)
         assert FacilityUser.objects.count() == old_users + 2
         current_classes = Classroom.objects.filter(parent_id=self.facility).all()
         for classroom in current_classes:
@@ -468,9 +462,7 @@ class ImportTestCase(TestCase):
             ],
         ]
         self.create_csv(new_filepath, rows)
-        call_command(
-            "bulkimportusers", new_filepath, facility=self.facility.id,
-        )
+        call_command("bulkimportusers", new_filepath, facility=self.facility.id)
         classrooms = Classroom.objects.all()
         assert len(classrooms) == 3
 
@@ -487,12 +479,10 @@ class ImportTestCase(TestCase):
                 "FEMALE",
                 " My CLASS, Just another class ",
                 "Another CLASS ",
-            ],
+            ]
         ]
         self.create_csv(new_filepath, rows)
-        call_command(
-            "bulkimportusers", new_filepath, facility=self.facility.id,
-        )
+        call_command("bulkimportusers", new_filepath, facility=self.facility.id)
         classrooms = Classroom.objects.all()
         assert len(classrooms) == 4
 

--- a/kolibri/core/device/migrations/0007_deviceappkey.py
+++ b/kolibri/core/device/migrations/0007_deviceappkey.py
@@ -11,9 +11,7 @@ from django.db import models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("device", "0006_migrate_guest_access"),
-    ]
+    dependencies = [("device", "0006_migrate_guest_access")]
 
     operations = [
         migrations.CreateModel(
@@ -30,5 +28,5 @@ class Migration(migrations.Migration):
                 ),
                 ("key", morango.models.fields.uuids.UUIDField(default=uuid.uuid4)),
             ],
-        ),
+        )
     ]

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -146,9 +146,7 @@ class DiskCacheRLock(object):
         while True:
             value, count = self._cache.get(self._key, (None, 0))
             if pid_tid == value or count == 0:
-                self._cache.set(
-                    self._key, (pid_tid, count + 1), self._expire,
-                )
+                self._cache.set(self._key, (pid_tid, count + 1), self._expire)
                 return
             time.sleep(0.001)
 

--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -2,9 +2,9 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls import url
 from django.http.response import HttpResponseRedirect
-from rest_framework import permissions
-from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
 
 from kolibri.deployment.default.urls import urlpatterns
 
@@ -18,21 +18,31 @@ def webpack_redirect_view(request):
 
 
 schema_view = get_schema_view(
-   openapi.Info(
-      title="Kolibri API",
-      default_version='v0',
-      description="Kolibri Swagger API",
-      license=openapi.License(name="MIT"),
-   ),
-   public=True,
-   permission_classes=(permissions.AllowAny,),
+    openapi.Info(
+        title="Kolibri API",
+        default_version="v0",
+        description="Kolibri Swagger API",
+        license=openapi.License(name="MIT"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
 )
 
 urlpatterns = urlpatterns + [
     url(r"^__open-in-editor/", webpack_redirect_view),
-    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-    url(r'^api_explorer/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc')
+    url(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    url(
+        r"^api_explorer/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    url(
+        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"
+    ),
 ]
 
 if getattr(settings, "DEBUG_PANEL_ACTIVE", False):

--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -2,7 +2,9 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls import url
 from django.http.response import HttpResponseRedirect
-from rest_framework_swagger.views import get_swagger_view
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from kolibri.deployment.default.urls import urlpatterns
 
@@ -15,11 +17,22 @@ def webpack_redirect_view(request):
     )
 
 
-schema_view = get_swagger_view(title="Kolibri API")
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Kolibri API",
+      default_version='v0',
+      description="Kolibri Swagger API",
+      license=openapi.License(name="MIT"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = urlpatterns + [
     url(r"^__open-in-editor/", webpack_redirect_view),
-    url(r"^api_explorer/", schema_view),
+    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^api_explorer/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc')
 ]
 
 if getattr(settings, "DEBUG_PANEL_ACTIVE", False):

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -318,7 +318,7 @@ AUTHENTICATION_BACKENDS = ["kolibri.core.auth.backends.FacilityUserBackend"]
 REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": "kolibri.core.auth.models.KolibriAnonymousUser",
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.SessionAuthentication"
     ],
     "DEFAULT_CONTENT_NEGOTIATION_CLASS": "kolibri.core.negotiation.LimitContentNegotiation",
     "EXCEPTION_HANDLER": "kolibri.core.utils.exception_handler.custom_exception_handler",

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -7,7 +7,7 @@ from .base import *  # noqa isort:skip @UnusedWildImport
 DEBUG = True
 
 # Settings might be tuples, so switch to lists
-INSTALLED_APPS = list(INSTALLED_APPS) + ["rest_framework_swagger"]  # noqa F405
+INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg"]  # noqa F405
 webpack_middleware = "kolibri.core.webpack.middleware.WebpackErrorHandler"
 MIDDLEWARE = list(MIDDLEWARE) + [webpack_middleware]  # noqa F405
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ tox==3.1.3
 django-debug-panel==0.8.3
 django-debug-toolbar==1.9.1
 sphinx-autobuild
-django-rest-swagger==2.2.0
+drf-yasg
 coreapi==2.3.3
 tabulate==0.8.2
 fonttools==3.29.0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds drf-yasg - a Swagger generator.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to /api_explorer and see all of the API endpoints.

Test some out while logged in and while not logged in (should get API errors depending on the endpoint permissions and what kind of user you're logged in as).

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
