### PR TITLE
Gestures on PDFs

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -10,6 +10,7 @@
     "date-fns": "^1.28.2",
     "fontfaceobserver": "^2.0.13",
     "frame-throttle": "^3.0.0",
+    "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "js-cookie": "^2.1.2",
     "keen-ui": "https://github.com/learningequality/Keen-UI/",

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -126,7 +126,7 @@
       // Returns whether or not the current device is iOS.
       // Probably not perfect, but worked in testing.
       iOS() {
-        var iDevices = [
+        const iDevices = [
           'iPad Simulator',
           'iPhone Simulator',
           'iPod Simulator',
@@ -134,16 +134,7 @@
           'iPhone',
           'iPod',
         ];
-
-        if (navigator.platform) {
-          while (iDevices.length) {
-            if (navigator.platform === iDevices.pop()) {
-              return true;
-            }
-          }
-        }
-
-        return false;
+        return iDevices.includes(navigator.platform);
       },
       targetTime() {
         return this.totalPages * 30;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,6 +5614,11 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds [hammerjs](http://hammerjs.github.io/) and in PDF Renderer make use of it to handle pinch-zoom gestures on mobile.

Does not work on iOS because Apple's pinch zooming always zooms the whole window without regard for any kind of meta viewport settings (ie, `maximum-scale` or `user-scalable`). 

However, it works on Android.

Basically, a pinch will call the same `zoomIn` or `zoomOut` function as tapping the + and - buttons do. They're throttled to 1 second to avoid accidentally zooming all the way in with one pinch.

NOTE: Not tested in a real life proper "app context" running the Android app - but still a valuable addition for non-app users who do use android devices anyway.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Open a PDF using an Android device and pinch zoom in and out.

Testing this without an actual device is a pain - but if you use Genymotion [read this](https://docs.genymotion.com/desktop/3.0/03_Virtual_devices/035_Generating_virtual_device_logs.html) (it wasn't perfect for me, but good enough early on) 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/3710

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
