### PR TITLE
Dev Webpack - Find your local IP and use that as `address` instead of `localhost`

### DIFF
--- a/packages/kolibri-tools/lib/webpackdevserver.js
+++ b/packages/kolibri-tools/lib/webpackdevserver.js
@@ -8,6 +8,7 @@
 
 process.env.DEV_SERVER = true;
 
+const os = require('os');
 const path = require('path');
 const WebpackDevServer = require('webpack-dev-server');
 const webpack = require('webpack');
@@ -15,6 +16,21 @@ const openInEditor = require('launch-editor-middleware');
 const webpackBaseConfig = require('./webpack.config.base');
 const logger = require('./logging');
 const { getEnvVars } = require('./build');
+
+// Serve webpack files over local network
+const ifaces = os.networkInterfaces();
+// address defaults to localhost
+let address = 'localhost';
+// Find the IP of your machine on your local network and make that the address
+Object.keys(ifaces).forEach(dev => {
+  ifaces[dev].filter(details => {
+    // Check to see if we're still at default `localhost` value otherwise we'll go through
+    // all of the interfaces - the local IP that we want should be early in this list
+    if (address === 'localhost' && details.family === 'IPv4' && details.internal === false) {
+      address = details.address;
+    }
+  });
+});
 
 const buildLogging = logger.getLogger('Kolibri Webpack Dev Server');
 
@@ -27,7 +43,7 @@ function genPublicPath(address, port, basePath) {
 }
 
 const CONFIG = {
-  address: 'localhost',
+  address,
   host: '0.0.0.0',
   basePath: 'js-dist',
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I always forget that I can change this file so that `address` is my local network so that webpack serves my files in a way that a mobile device on my network can use them.

So I found some of this code and tweaked it a bit to find my local network address and use that instead of `localhost`.

Works on my machine and I'm curious if it works on yours too!

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Start the full devserver `yarn devserver` or `yarn devserver-hot` on your computer.
- Get your local IP address - should be something like `192.168.1.x` (I think - typically - idk maybe other routers generate the last two numbers differently?). In any case - find that for your machine that is running your server. 
- Access that `http://192.168.1.x:8000` from a different device on your network.
- Assets and JS and CSS and so on should be loaded without issue!

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
