### PR TITLE
Scorm hashi bugs

### DIFF
--- a/kolibri/plugins/html5_viewer/options.py
+++ b/kolibri/plugins/html5_viewer/options.py
@@ -15,7 +15,7 @@ allowable_sandbox_tokens = set(
         "allow-presentation",
         "allow-same-origin",
         "allow-scripts",
-        "allow-storage-access-by-user-activation ",
+        "allow-storage-access-by-user-activation",
         "allow-top-navigation",
         "allow-top-navigation-by-user-activation",
     ]

--- a/packages/hashi/src/SCORM.js
+++ b/packages/hashi/src/SCORM.js
@@ -613,7 +613,7 @@ export default class SCORM extends BaseShim {
   }
 
   __calculateProgress() {
-    const score = this.data.cmi.core.score;
+    const score = getByKeyPath(this.data, 'cmi.core.score', SCHEMA, self.userData);
     if (score) {
       // If min and max are not set, raw will be a value in the range 0-100. Source:
       // https://support.scorm.com/hc/en-us/articles/206166466-cmi-score-raw-whole-numbers-
@@ -622,8 +622,8 @@ export default class SCORM extends BaseShim {
       const raw = Number(isNaN(score.raw) ? min : score.raw);
       return Math.max(Math.min((raw - min) / (max - min), 1), 0);
     }
-    const lessonStatus = this.data.cmi.core.lesson_status;
-    if (statusProgressMap.hasOwnProperty(lessonStatus)) {
+    const lessonStatus = getByKeyPath(this.data, 'cmi.core.lesson_status', SCHEMA, self.userData);
+    if (Object.prototype.hasOwnProperty.call(statusProgressMap, lessonStatus)) {
       return statusProgressMap[lessonStatus];
     }
     // Return null if we have no progress information to report.


### PR DESCRIPTION
### Summary
Fixes two small issues that I noticed while using hashi after the SCORM updates:
* When SCORM data is undefined, the SCORM shim will error because it is trying to access an undefined key path
* An option had an extra space inside it, meaning it would not pass validation

### Reviewer guidance
* Check that non-SCORM html5 apps do not give an error trying to access a property on undefined as currently happens

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
