### PR TITLE
allowRemoteAccess `undefined` from state - was a getter

### DIFF
--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -39,8 +39,8 @@ export default {
     canManageContent(state) {
       return state.can_manage_content;
     },
-    canAccessUnassignedContent(state) {
-      return state.can_access_unassigned_content && state.allowRemoteAccess;
+    canAccessUnassignedContent(state, getters) {
+      return state.can_access_unassigned_content && getters.allowRemoteAccess;
     },
     isSuperuser(state) {
       return state.kind.includes(UserKinds.SUPERUSER);

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -62,7 +62,7 @@ describe('learn plugin index page', () => {
   };
   const setCanAccessUnassignedContent = canAccess => {
     store.state.core.session.can_access_unassigned_content = canAccess;
-    store.state.core.session.allowRemoteAccess = canAccess;
+    store.state.core.allowRemoteAccess = canAccess;
   };
 
   beforeEach(() => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I couldn't see my channels in Learn despite the settings saying that I should.

I found that one piece of the state in the boolean deciding whether to render the Channels and Recommended tabs was trying to get `allowRemoteAccess` from state but it was a getter.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Pull regular `app-support` as it is now - try to view channels in Learn as any user.

Check this branch out then see your content appear in Learn.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Me. 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
