### PR TITLE
PDF Renderer: Add border to content, move controls to top

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -411,6 +411,11 @@
   }
 
   .fullscreen-header {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 24;
     height: $controls-height;
     text-align: end;
   }
@@ -429,7 +434,7 @@
 
   .slide-enter,
   .slide-leave-to {
-    height: 0;
+    transform: translateY(-40px);
   }
 
 </style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -365,7 +365,7 @@
 
 <style lang="scss" scoped>
 
-  @import '~kolibri-design-system/lib/styles/definitions';
+  @import '~kolibri.styles.definitions';
   $controls-height: 40px;
 
   .pdf-renderer {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -188,6 +188,7 @@
     },
     created() {
       this.currentLocation = this.savedLocation;
+      this.showControls = true; // Ensures it shows on load even if we're scrolled
       const loadPdfPromise = PDFJSLib.getDocument(this.defaultFile.storage_url);
 
       // pass callback to update loading bar
@@ -415,11 +416,15 @@
   }
 
   .slide-enter-active {
-    transition: all 0.3s ease;
+    @extend %md-accelerate-func;
+
+    transition: all 0.3s;
   }
 
   .slide-leave-active {
-    transition: all 0.3s ease;
+    @extend %md-decelerate-func;
+
+    transition: all 0.3s;
   }
 
   .slide-enter,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

**RE: https://github.com/learningequality/kolibri/issues/6901**

- Full screen toggle, zoom in and out are all move to a top bar on PDFs.
- Bar hides when you scroll down, shows when you scroll up.

![hide-show-on-scroll](https://user-images.githubusercontent.com/6356129/84085439-7454e580-a99a-11ea-920b-aa7c671ab6e7.gif)


**RE: https://github.com/learningequality/kolibri/issues/6909**

- Adds 2dp drop shadow to container of renderer.
- Honestly I have no idea exactly what is best here but I felt like a solid border kind of looked odd. But some shadow seemed nice and to have the expected effect.

_Solid Black 1px_

![border-1px-mobile](https://user-images.githubusercontent.com/6356129/84085526-a0706680-a99a-11ea-93a2-bd2847afb939.png)

_2dp Drop Shadow_

![shadow-2dp-mobile](https://user-images.githubusercontent.com/6356129/84085540-a8300b00-a99a-11ea-8655-985a174e7816.png)


Related to the above:

- CSS to ensure hiding & showing of top control bar doesn't effect a covering of information beneath the PDF (ie, author's name, download button).


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Test this:

- Full screen & not fullscreen & mobile & not mobile & zoom.

What do you think about this:

- Solid border vs shadow? 
- Does the hiding controls violate any kind of a11y concerns?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6909
https://github.com/learningequality/kolibri/issues/6901

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
