### PR TITLE
Bump zeroconf-py2compat to 0.19.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,6 +29,6 @@ semver==2.8.1
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-zeroconf-py2compat==0.19.6
+zeroconf-py2compat==0.19.7
 django-oidc-provider==0.7.0
 Click==7.0


### PR DESCRIPTION
Reverts the switch from ifcfg to ifaddr, through https://github.com/learningequality/python-zeroconf-py2compat/pull/4/files