### PR TITLE
Handle backend provisioning errors.

### DIFF
--- a/kolibri/core/device/hooks.py
+++ b/kolibri/core/device/hooks.py
@@ -15,3 +15,7 @@ class SetupHook(KolibriHook):
 
     def plugin_url(self, plugin_class, url_name):
         return plugin_url(plugin_class, url_name)
+
+    @classmethod
+    def provision_url(cls):
+        return next(hook.url for hook in cls.registered_hooks)

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -129,10 +129,8 @@ class RootURLRedirectView(View):
         Redirects user based on the highest role they have for which a redirect is defined.
         """
         # If it has not been provisioned and we have something that can handle setup, redirect there.
-        if not is_provisioned():
-            SETUP_WIZARD_URLS = [hook.url for hook in SetupHook.registered_hooks]
-            if SETUP_WIZARD_URLS:
-                return redirect(SETUP_WIZARD_URLS[0])
+        if not is_provisioned() and SetupHook.provision_url:
+            return redirect(SetupHook.provision_url())
 
         if request.user.is_authenticated():
             url = None

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "kolibri.core.analytics.middleware.cherrypy_access_log_middleware",
+    "kolibri.core.device.middleware.ProvisioningErrorHandler",
     "django.middleware.cache.UpdateCacheMiddleware",
     "kolibri.core.analytics.middleware.MetricsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
### Summary
* At some point we added device settings data into the bootstrapped data in the user plugin page, this caused the page to error when unprovisioned
* This broke our client side redirect behaviour when a device is unprovisioned
* This PR adds a middleware to handle DeviceNotProvisioned exceptions and redirect to a setup url when available

### Reviewer guidance
Does the code make sense?
Visit `/user/` on an unprovisioned Kolibri, does it redirect you to setup_wizard? (note there will be two redirects, first for language, and then for setup).

### References
Fixes #7020

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
