### PR TITLE
Move disconnection checking into accessible code branch.

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -47,9 +47,10 @@ baseClient.interceptors.response.use(
       }
       // On every error, check to see if the status code is one of our designated
       // disconnection status codes.
-    } else if (errorCodes.includes(error.response.status)) {
-      // If so, set our heartbeat module to start monitoring the disconnection state
-      heartbeat.monitorDisconnect(error.response.status);
+      if (errorCodes.includes(error.response.status)) {
+        // If so, set our heartbeat module to start monitoring the disconnection state
+        heartbeat.monitorDisconnect(error.response.status);
+      }
     }
     return Promise.reject(error);
   }

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -33,6 +33,7 @@ import {
   UPDATE_MODAL_DISMISSED,
 } from '../../../constants';
 import samePageCheckGenerator from '../../../utils/samePageCheckGenerator';
+import errorCodes from './../../../disconnectionErrorCodes.js';
 
 const logging = logger.getLogger(__filename);
 const intervalTime = 5000; // Frequency at which time logging is updated
@@ -180,6 +181,11 @@ export function handleApiError(store, errorObject) {
   if (typeof errorObject === 'object' && !(errorObject instanceof Error)) {
     error = JSON.stringify(errorObject, null, 2);
   } else if (errorObject.response) {
+    if (errorCodes.includes(errorObject.response.status)) {
+      // Do not log errors for disconnections, as it disrupts the user experience
+      // and should already be being handled by our disconnection overlay.
+      return;
+    }
     // Reassign object properties here as Axios error objects have built in
     // pretty printing support which messes with this.
     error = JSON.stringify(errorObject.response, null, 2);


### PR DESCRIPTION
### Summary
Fixes a regression induced by #6969 that moved the disconnection handling code to an inaccessible code branch (because `error.response` always existed when it mattered for disconnection checking).

### Reviewer guidance
* Run server
* Load login page
* Turn off server
* Try to login
* See disconnect overlay

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
