### PR TITLE
Make tracking code injection optional.

### DIFF
--- a/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
+++ b/kolibri/plugins/profuturo_mvp/kolibri_plugin.py
@@ -9,10 +9,12 @@ from kolibri.core.hooks import FrontEndBaseSyncHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils.conf import OPTIONS
 
 
 class ProfuturoPlugin(KolibriPluginBase):
     kolibri_option_defaults = "option_defaults"
+    kolibri_options = "options"
 
 
 @register_hook
@@ -88,3 +90,9 @@ class TrackingAsset(webpack_hooks.WebpackBundleHook):
 @register_hook
 class TrackingInclusionHook(FrontEndBaseSyncHook):
     bundle_class = TrackingAsset
+
+    @property
+    def bundle_html(self):
+        if OPTIONS["ProFuturo"]["HOTJAR"]:
+            return super(TrackingInclusionHook, self).bundle_html
+        return ""

--- a/kolibri/plugins/profuturo_mvp/options.py
+++ b/kolibri/plugins/profuturo_mvp/options.py
@@ -1,0 +1,9 @@
+option_spec = {
+    "ProFuturo": {
+        "HOTJAR": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_PROFUTURO_HOTJAR",),
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Adds a profuturo plugin specific option to make tracking code optional
Defaults to False

### Reviewer guidance
Run the server without the env var.

Tracking code should be absent from the HTML.

Run the server with the env var: `KOLIBRI_PROFUTURO_HOTJAR=True` and see the tracking code injected in the HTML:
```
!function(modules){var installedModules={};function __webpack_require__(moduleId){if(installedModules[moduleId])return installedModules[moduleId].exports;var module=installedModules[moduleId]={i:moduleId,l:!1,exports:{}};return modules[moduleId].call(module.exports,module,module.exports,__webpack_require__),module.l=!0,module.exports}__webpack_require__.m=modules,__webpack_require__.c=installedModules,__webpack_require__.d=function(exports,name,getter){__webpack_require__.o(exports,name)||Object.defineProperty(exports,name,{enumerable:!0,get:getter})},__webpack_require__.r=function(exports){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(exports,"__esModule",{value:!0})},__webpack_require__.t=function(value,mode){if(1&mode&&(value=__webpack_require__(value)),8&mode)return value;if(4&mode&&"object"==typeof value&&value&&value.__esModule)return value;var ns=Object.create(null);if(__webpack_require__.r(ns),Object.defineProperty(ns,"default",{enumerable:!0,value:value}),2&mode&&"string"!=typeof value)for(var key in value)__webpack_require__.d(ns,key,function(key){return value[key]}.bind(null,key));return ns},__webpack_require__.n=function(module){var getter=module&&module.__esModule?function(){return module.default}:function(){return module};return __webpack_require__.d(getter,"a",getter),getter},__webpack_require__.o=function(object,property){return Object.prototype.hasOwnProperty.call(object,property)},__webpack_require__.p="",__webpack_require__(__webpack_require__.s=0)}([function(module,exports){var h,o,a,r;h=window,o=document,h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)},h._hjSettings={hjid:1828417,hjsv:6},a=o.getElementsByTagName("head")[0],(r=o.createElement("script")).async=1,r.src="https://static.hotjar.com/c/hotjar-"+h._hjSettings.hjid+".js?sv="+h._hjSettings.hjsv,a.appendChild(r)}]);
//# sourceMappingURL=kolibri.plugins.profuturo_mvp.track-0.13.3b1.dev0+git.254.g6a96f92a.js.map
```

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
