### PR TITLE
Add method to get initialize url.

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -149,7 +149,7 @@ class DeviceAppKey(models.Model):
     @classmethod
     def update_app_key(cls):
         app_key, created = cls.objects.get_or_create()
-        app_key.key = uuid4()
+        app_key.key = uuid4().hex
         app_key.save()
         cache.set(APP_KEY_CACHE_KEY, app_key.key, 5000)
         return app_key

--- a/kolibri/plugins/app/utils.py
+++ b/kolibri/plugins/app/utils.py
@@ -1,3 +1,5 @@
+from django.core.urlresolvers import reverse
+
 from kolibri.plugins.app.kolibri_plugin import App
 from kolibri.plugins.registry import registered_plugins
 
@@ -20,6 +22,19 @@ class AppInterface(object):
         for capability in CAPABILITES:
             if capability in kwargs:
                 self._capabilities[capability] = kwargs[capability]
+
+    def get_initialize_url(self, next_url=None):
+        if not self.enabled:
+            raise RuntimeError("App plugin is not enabled")
+        # Import here to prevent a circular import
+        from kolibri.core.device.models import DeviceAppKey
+
+        url = reverse(
+            "kolibri:kolibri.plugins.app:initialize", args=(DeviceAppKey.get_app_key(),)
+        )
+        if next_url is None:
+            return url
+        return url + "?next={}".format(next_url)
 
     @property
     def enabled(self):


### PR DESCRIPTION
### Summary
* Adds get_initialize_url method to app interface API
* Has optional argument for next url
* Returns the URL relative to the host (protocol, host name and port must be supplied)

### Reviewer guidance
Can you generate the URL?

Note that I did not add the protocol hostname, and port, because the port can be dynamically changed by the `--port` argument, so it is best left to the invoker.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
