### PR TITLE
Add Gherkin scenarios for Android app context

### DIFF
--- a/integration_testing/features/app-context/app-context-disable-device-network-access.feature
+++ b/integration_testing/features/app-context/app-context-disable-device-network-access.feature
@@ -1,0 +1,16 @@
+Feature: Disabled network access to Kolibri app server
+	If the network access to Kolibri server app is disabled, users who navigate to its URL need to see the notification message
+
+Background:
+	Given that the device setting *Allow others in the network to access Kolibri on this device using a browser* is unchecked
+		And I use an external device to connect to the Kolibri app server and access Kolibri
+
+Scenario: Attempt to connect to the Kolibri app server from an external devices
+  When I type the Kolibri app server URL address on my external device browser
+  Then I see this message on the Kolibri sign in page: *Access to Kolibri has been restricted for external devices. To change this, sign in as a super admin and enable 'Allow others in the network to access Kolibri on this device using a browser', located in Device settings*
+
+Scenario: Security alert when network access setting is enabled
+	When I enable the device setting *Allow others in the network to access Kolibri on this device using a browser*
+	Then I see a security alert below the setting *If learners are allowed to sign in with no password on this device, enabling this may allow external devices to view the user data, which could be a potential security concern.*
+	When I disable the same setting
+	Then I don't see the security alert anymore

--- a/integration_testing/features/app-context/app-context-disable-device-network-access.feature
+++ b/integration_testing/features/app-context/app-context-disable-device-network-access.feature
@@ -5,6 +5,8 @@ Background:
 	Given that the device setting *Allow others in the network to access Kolibri on this device using a browser* is unchecked
 		And I use an external device to connect to the Kolibri app server and access Kolibri
 
+		# You don't need to be in an external device: use an incongnito window, or any other browser where the cookie for the App user is not set
+
 Scenario: Attempt to connect to the Kolibri app server from an external devices
   When I type the Kolibri app server URL address on my external device browser
   Then I see this message on the Kolibri sign in page: *Access to Kolibri has been restricted for external devices. To change this, sign in as a super admin and enable 'Allow others in the network to access Kolibri on this device using a browser', located in Device settings*

--- a/integration_testing/features/app-context/app-context-manage-password-requirements.feature
+++ b/integration_testing/features/app-context/app-context-manage-password-requirements.feature
@@ -1,0 +1,76 @@
+Feature: Manage password requirements in app context
+	In app context password may not be required to sign in or create accounts.
+
+	Background:
+		Given that I am signed in as superadmin or facility admin
+			And I am on the *Facility > Settings* page
+
+	Scenario: Learners cannot change password when it is not required to sign in
+		When I see that the facility setting *Require password for learners* is unchecked
+		Then I see that the nested setting *Allow learners to change their password when signed in* is disabled (grayed out)
+
+	Scenario: Users are not required to input password when creating accounts
+		Given that the facility setting *Require password for learners* is unchecked
+			And I am signed out
+		When I open Kolibri app
+			And I tap *Create account*
+		Then I only see the input fields for *Username* and *Fullname*
+			But I don't see the *Password* and *Re-enter password* fields
+
+	Scenario: Password is not required when admins create user accounts
+		Given that the facility setting *Require password for learners* is unchecked
+			And I am signed in as superadmin or facility admin
+			And I am on the *Facility > Users* page
+		When I tap *New user*
+		Then I am on *Create new user* modal
+			And I see see the input fields for *Username* and *Fullname*
+			But I don't see the *Password* and *Re-enter password* fields
+
+	Scenario: Learners do not see option to change password
+		Given that the facility setting *Require password for learners* is unchecked
+			And I am signed in as a learner
+		When I tap on my username on the top right corner
+			And I tap *Profile*
+		Then I see the details of my profile
+			But I don't see the option *Change password*
+
+	Scenario: Learners can change password when it is required to sign in
+		Given that the facility setting *Require password for learners* is unchecked
+			And *Allow learners to change their password when signed in* is disabled (grayed out)
+			And I am signed in as superadmin or facility admin
+		When I check the setting *Require password for learners*
+		Then see that the nested setting *Allow learners to change their password when signed in* is enabled
+
+	Scenario: Users are required to input password when creating accounts
+		Given that the facility setting *Require password for learners* is checked
+			And I am signed out
+		When I open Kolibri app
+			And I tap *Create account*
+		Then I see the input fields for *Username*, *Fullname*, *Password* and *Re-enter password*
+
+	Scenario: Password is required when admins create user accounts
+		Given that the facility setting *Require password for learners* is checked
+			And I am signed in as superadmin or facility admin
+			And I am on the *Facility > Users* page
+		When I tap *New user*
+		Then I am on *Create new user* modal
+			And I see see the input fields for *Username*, *Fullname*, *Password* and *Re-enter password*
+
+	Scenario: Learners can see the option to change password
+		Given that the facility setting *Require password for learners* is checked
+			And I am signed in as a learner
+		When I tap on my username on the top right corner
+			And I tap *Profile*
+		Then I see the details of my profile
+			And I see the option *Change password*
+
+	Scenario: Password creation for learners who did not set one when their account was created
+		Given that the facility setting *Require password for learners* is checked
+			And I have a learner account
+			And my account was created without the password
+		When I open Kolibri app
+			And I tap/type my username
+		Then I see and input fields to type a new password and retype the same
+		When I type my password
+			And I click or tap *Continue*
+		Then I see my Kolibri account

--- a/integration_testing/features/app-context/app-context-manage-sign-in-options.feature
+++ b/integration_testing/features/app-context/app-context-manage-sign-in-options.feature
@@ -1,0 +1,60 @@
+Feature: Manage sign in options within app context
+	In Kolibri running as an app, users need to be able to sign in by tapping their username on the sign in page.
+
+	Background:
+	  Given Kolibri is running in app context
+	  	And I am signed in to Kolibri as a super admin or a facility admin user
+	    And there are 16 or less users on the facility
+	    And that signing in without password is enabled in the *Facility Settings*
+
+	Scenario: Sign in page displays the list of usernames
+		When I sign out and close Kolibri app
+			And I tap the icon to open the Kolibri app again
+		Then I see a list of all the usernames on the sign in page
+
+	Scenario: Learner signs in directly by taping their username
+		When I tap learner <learner> username
+		Then I see learner <learner> *Learn* page
+
+	Scenario: Require password for learner sign in
+		Given I am signed in to Kolibri as a super admin or a facility admin user
+			And I am on *Facility > Settings* page
+		When I uncheck the *Allow learners to sign in with no password* checkbox
+			And I tap *Save changes*
+			And I sign out
+		Then I see a list of all the usernames on the sign in page
+		When I tap learner <learner> username <username>
+		Then I see another screen with a password input field
+		When I type learner <learner> password <password>
+			And I tap *Continue*
+		Then I see learner <learner> *Learn* page
+
+	Scenario: Sign in when password is required and more than 16 users in the facility
+		# create additional users for this scenario
+		Given there are more than 16 users on the facility
+			And I am signed out
+		When I tap the Kolibri app icon
+		Then I see the sign in page with a username input field
+		When I type learner <learner> username <username>
+			And I tap *Sign in*
+		Then I see another screen with a password input field
+		When I type learner <learner> password <password>
+			And I tap *Continue*
+		Then I see learner <learner> *Learn* page
+
+	Scenario: Enable learners to sign in without password
+		Given I am signed in to Kolibri as a super admin or a facility admin user
+			And there are more than 16 users on the facility
+			And I am on *Facility > Settings* page
+		When I check the *Allow learners to sign in with no password* checkbox
+			And I tap *Save changes*
+			And I sign out and close Kolibri app
+		When I tap the Kolibri app icon
+		Then I see the sign in page with a username input feild
+		When I type learner <learner> username
+			And I tap *Sign in*
+		Then I see learner <learner> *Learn* page
+
+	Examples:
+	| learner | username | password |
+	| John C. | johnc    | johnc    |

--- a/integration_testing/features/app-context/app-context-remote-network-access.feature
+++ b/integration_testing/features/app-context/app-context-remote-network-access.feature
@@ -7,6 +7,9 @@ Feature: Access Kolibri app server remotely
 	Scenario: Sign in directly after entering the username
 		Given that the signing in without password is enabled in *Facility > Settings*
 		When I try to access the Kolibri server app from a browser on an external device
+
+		# You don't need to be in an external device: use an incongnito window, or any other browser where the cookie for the App user is not set
+		
 		Then I see the sign in page with just the username input feild
 			And I type my username
 			And I click or tap *Sign in*

--- a/integration_testing/features/app-context/app-context-remote-network-access.feature
+++ b/integration_testing/features/app-context/app-context-remote-network-access.feature
@@ -9,7 +9,7 @@ Feature: Access Kolibri app server remotely
 		When I try to access the Kolibri server app from a browser on an external device
 
 		# You don't need to be in an external device: use an incongnito window, or any other browser where the cookie for the App user is not set
-		
+
 		Then I see the sign in page with just the username input feild
 			And I type my username
 			And I click or tap *Sign in*

--- a/integration_testing/features/app-context/app-context-remote-network-access.feature
+++ b/integration_testing/features/app-context/app-context-remote-network-access.feature
@@ -1,0 +1,24 @@
+Feature: Access Kolibri app server remotely
+	Users accessing Kolibri app server remotely need to have the same sign in experience
+
+	Background:
+		Given that the remote access to Kolibri is enabled
+
+	Scenario: Sign in directly after entering the username
+		Given that the signing in without password is enabled in *Facility > Settings*
+		When I try to access the Kolibri server app from a browser on an external device
+		Then I see the sign in page with just the username input feild
+			And I type my username
+			And I click or tap *Sign in*
+		Then I see my Kolibri account
+
+	Scenario: Sign in after entering the username and the password
+	 	Given that the signing in without password is disabled in *Facility > Settings*
+		When I try to access the Kolibri server app from a browser on an external device
+		Then I see the sign in page with only the username input field
+		When I type my username
+			And I click or tap *Sign in*
+		Then I see an input field to type my password
+		When I type my password
+			And I click or tap *Continue*
+		Then I see my Kolibri account


### PR DESCRIPTION
### Summary
Added Gherkin scenarios for signing in, facility and device settings relative to app context.
Run `pre-commit run --all-files`, green across the board.
Replaces #7023

### Reviewer guidance
Do the steps describe user flows as designed?
Is there anything missing?

### References
[Notion doc](https://www.notion.so/learningequality/Gherkin-stories-7b46e739971b4b92b2407dca8a7252ec)

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
