### PR TITLE
Facility deletion management command

### DIFF
--- a/kolibri/core/assets/src/api-resources/facilityTask.js
+++ b/kolibri/core/assets/src/api-resources/facilityTask.js
@@ -18,7 +18,18 @@ export default new Resource({
     return this.postListEndpoint('startdataportalbulksync');
   },
 
+  /**
+   * @return {Promise}
+   */
   deleteFinishedTasks() {
     return this.postListEndpoint('deletefinishedtasks');
+  },
+
+  /**
+   * @param {string} facility
+   * @return {Promise}
+   */
+  deleteFacility(facility) {
+    return this.postListEndpoint('deletefacility', { facility });
   },
 });

--- a/kolibri/core/auth/constants/morango_sync.py
+++ b/kolibri/core/auth/constants/morango_sync.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
 
+PROFILE_FACILITY_DATA = "facilitydata"
+
+
 class ScopeDefinitions(object):
     """
     Class contains morango scope definition constants for certificates.

--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -1,0 +1,341 @@
+import logging
+from contextlib import contextmanager
+
+from django.contrib.admin.models import LogEntry
+from django.core.exceptions import FieldError
+from django.core.management.base import CommandError
+from django.db import transaction
+from django.db.models import Q
+from morango.models import Buffer
+from morango.models import Certificate
+from morango.models import RecordMaxCounter
+from morango.models import RecordMaxCounterBuffer
+from morango.models import Store
+from morango.models import SyncSession
+from morango.models import TransferSession
+from morango.registry import syncable_models
+
+from kolibri.core.analytics.models import PingbackNotificationDismissed
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
+from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.management.utils import get_facility
+from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import FacilityDataset
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.models import Membership
+from kolibri.core.auth.models import Role
+from kolibri.core.auth.utils import confirm_or_exit
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import ExamAttemptLog
+from kolibri.core.logger.models import ExamLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.models import UserSessionLog
+from kolibri.core.tasks.management.commands.base import AsyncCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class GroupDeletion(object):
+    """
+    Helper to manage deleting many models, or groups of models
+    """
+
+    def __init__(self, name, groups=None, querysets=None):
+        """
+        :type groups: GroupDeletion[]
+        :type querysets: QuerySet[]
+        """
+        self.name = name
+        groups = [] if groups is None else groups
+        if querysets is not None:
+            groups.extend(querysets)
+        self.groups = groups
+
+    def count(self, progress_updater):
+        """
+        :type progress_updater: function
+        :rtype: int
+        """
+        sum = 0
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count = qs.count(progress_updater)
+                logger.debug("Counted {} in group `{}`".format(count, qs.name))
+            else:
+                count = qs.count()
+                progress_updater(increment=1)
+                logger.debug(
+                    "Counted {} of `{}`".format(count, qs.model._meta.model_name)
+                )
+
+            sum += count
+
+        return sum
+
+    def group_count(self):
+        """
+        :rtype: int
+        """
+        return sum(
+            [
+                qs.group_count() if isinstance(qs, GroupDeletion) else 1
+                for qs in self.groups
+            ]
+        )
+
+    def delete(self, progress_updater):
+        """
+        :type progress_updater: function
+        :rtype: tuple(int, dict)
+        """
+        total_count = 0
+        all_deletions = dict()
+
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count, deletions = qs.delete(progress_updater)
+                debug_msg = "Deleted {} of `{}` in group `{}`"
+                name = qs.name
+            else:
+                count, deletions = qs.delete()
+                debug_msg = "Deleted {} of `{}` with model `{}`"
+                name = qs.model._meta.model_name
+
+            total_count += count
+            progress_updater(increment=count)
+
+            for obj_name, count in deletions.items():
+                if not isinstance(qs, GroupDeletion):
+                    logger.debug(debug_msg.format(count, obj_name, name))
+                all_deletions.update({obj_name: all_deletions.get(obj_name, 0) + count})
+
+        return total_count, all_deletions
+
+
+def chunk(things, size):
+    """
+    Chunk generator
+
+    :type things: list
+    :type size: int
+    """
+    for i in range(0, len(things), size):
+        yield things[i : i + size]
+
+
+class Command(AsyncCommand):
+    help = "This command initiates the deletion process for a facility and all of it's related data."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--facility",
+            action="store",
+            type=str,
+            help="The ID of the facility to delete",
+        )
+        parser.add_argument(
+            "--strict",
+            action="store_true",
+            help="Enforce that deletion count matches expected count",
+        )
+        parser.add_argument("--noninteractive", action="store_true")
+
+    def handle_async(self, *args, **options):
+        noninteractive = options["noninteractive"]
+        strict = options["strict"]
+        facility = get_facility(
+            facility_id=options["facility"], noninteractive=noninteractive
+        )
+        dataset_id = facility.dataset_id
+
+        logger.info(
+            "Found facility {} <{}> for deletion".format(facility.id, dataset_id)
+        )
+
+        if not noninteractive:
+            # ensure the user REALLY wants to do this!
+            confirm_or_exit(
+                "Are you sure you wish to permanently delete this facility? This will DELETE ALL DATA FOR THE FACILITY."
+            )
+            confirm_or_exit(
+                "ARE YOU SURE? If you do this, there is no way to recover the facility data on this device."
+            )
+
+        # everything should get cascade deleted from the facility, but we'll check anyway
+        delete_group = GroupDeletion(
+            "Main",
+            groups=[
+                self._get_morango_models(dataset_id),
+                self._get_log_models(dataset_id),
+                self._get_class_models(dataset_id),
+                self._get_users(dataset_id),
+                self._get_facility_dataset(dataset_id),
+            ],
+        )
+
+        logger.info(
+            "Proceeding with facility deletion. Deleting all data for facility <{}>".format(
+                dataset_id
+            )
+        )
+
+        with self._delete_context():
+            total_deleted = 0
+
+            # run the counting step
+            with self.start_progress(
+                total=delete_group.group_count()
+            ) as update_progress:
+                update_progress(increment=0, message="Counting database objects")
+                total_count = delete_group.count(update_progress)
+
+            # no the deleting step
+            with self.start_progress(total=total_count) as update_progress:
+                update_progress(increment=0, message="Deleting database objects")
+                count, stats = delete_group.delete(update_progress)
+                total_deleted += count
+
+            # if count doesn't match, something doesn't seem right
+            if total_count != total_deleted:
+                msg = "Deleted count does not match total ({} != {})".format(
+                    total_count, total_deleted
+                )
+                if strict:
+                    raise CommandError("{}, aborting!".format(msg))
+                else:
+                    logger.warning(msg)
+
+        logger.info("Deletion complete.")
+
+    @contextmanager
+    def _delete_context(self):
+        with DisablePostDeleteSignal(), transaction.atomic():
+            yield
+
+    def _get_facility_dataset(self, dataset_id):
+        return FacilityDataset.objects.filter(id=dataset_id)
+
+    def _get_certificates(self, dataset_id):
+        return (
+            Certificate.objects.filter(id=dataset_id)
+            .get_descendants(include_self=True)
+            .exclude(_private_key=None)
+        )
+
+    def _get_users(self, dataset_id):
+        user_id_filter = Q(
+            user_id__in=FacilityUser.objects.filter(dataset_id=dataset_id).values_list(
+                "pk", flat=True
+            )
+        )
+        dataset_id_filter = Q(dataset_id=dataset_id)
+
+        return GroupDeletion(
+            "User models",
+            querysets=[
+                LogEntry.objects.filter(user_id_filter),
+                DevicePermissions.objects.filter(user_id_filter),
+                PingbackNotificationDismissed.objects.filter(user_id_filter),
+                Collection.objects.filter(
+                    Q(parent_id__isnull=True) & dataset_id_filter
+                ),
+                Role.objects.filter(dataset_id_filter),
+                Membership.objects.filter(dataset_id_filter),
+                FacilityUser.objects.filter(dataset_id_filter),
+            ],
+        )
+
+    def _get_class_models(self, dataset_id):
+        dataset_id_filter = Q(dataset_id=dataset_id)
+        return GroupDeletion(
+            "Class models",
+            querysets=[
+                ExamAssignment.objects.filter(dataset_id_filter),
+                Exam.objects.filter(dataset_id_filter),
+                LessonAssignment.objects.filter(dataset_id_filter),
+                Lesson.objects.filter(dataset_id_filter),
+                AdHocGroup.objects.filter(dataset_id_filter),
+                LearnerGroup.objects.filter(dataset_id_filter),
+                Classroom.objects.filter(dataset_id_filter),
+            ],
+        )
+
+    def _get_log_models(self, dataset_id):
+        dataset_id_filter = Q(dataset_id=dataset_id)
+        return GroupDeletion(
+            "Log models",
+            querysets=[
+                ContentSessionLog.objects.filter(dataset_id_filter),
+                ContentSummaryLog.objects.filter(dataset_id_filter),
+                AttemptLog.objects.filter(dataset_id_filter),
+                ExamAttemptLog.objects.filter(dataset_id_filter),
+                ExamLog.objects.filter(dataset_id_filter),
+                MasteryLog.objects.filter(dataset_id_filter),
+                UserSessionLog.objects.filter(dataset_id_filter),
+            ],
+        )
+
+    def _get_morango_models(self, dataset_id):
+        models = syncable_models.get_models(PROFILE_FACILITY_DATA)
+        querysets = []
+
+        for model in models:
+            try:
+                model_source_ids = set(
+                    model.objects.filter(dataset_id=dataset_id).values_list(
+                        "_morango_source_id", flat=True
+                    )
+                )
+            except FieldError:
+                continue
+
+            for source_id_chunk in chunk(list(model_source_ids), 300):
+                stores = Store.objects.filter(
+                    profile=PROFILE_FACILITY_DATA,
+                    model_name=model.morango_model_name,
+                    source_id__in=source_id_chunk,
+                )
+                store_ids = stores.values_list("pk", flat=True)
+                querysets.append(
+                    RecordMaxCounter.objects.filter(store_model_id__in=store_ids)
+                )
+                querysets.append(stores)
+
+        certificates = self._get_certificates(dataset_id)
+        certificate_ids = certificates.distinct().values_list("pk", flat=True)
+
+        for certificate_id_chunk in chunk(certificate_ids, 300):
+            sync_sessions = SyncSession.objects.filter(
+                Q(client_certificate_id__in=certificate_id_chunk)
+                | Q(server_certificate_id__in=certificate_id_chunk)
+            )
+            sync_session_ids = sync_sessions.distinct().values_list("pk", flat=True)
+            transfer_sessions = TransferSession.objects.filter(
+                sync_session_id__in=sync_session_ids
+            )
+            transfer_session_filter = Q(
+                transfer_session_id__in=transfer_sessions.values_list("pk", flat=True)
+            )
+
+            querysets.extend(
+                [
+                    RecordMaxCounterBuffer.objects.filter(transfer_session_filter),
+                    Buffer.objects.filter(transfer_session_filter),
+                    transfer_sessions,
+                    sync_sessions,
+                    certificates,
+                ]
+            )
+
+        return GroupDeletion("Morango models", groups=querysets)

--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -1,13 +1,13 @@
 import logging
 import sys
 
-from django.db.models.signals import post_delete
 from morango.models import Buffer
 from morango.models import Certificate
 from morango.models import DatabaseIDModel
 from morango.models import DeletedModels
 from morango.models import Store
 
+from kolibri.core.auth.management.utils import DisablePostDeleteSignal
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.utils import confirm_or_exit
@@ -35,18 +35,6 @@ MODELS_TO_DELETE = [
     DeletedModels,
     DeviceSettings,
 ]
-
-# we want to disable the post_delete signal temporarily when deleting, so morango doesn't create DeletedModels objects
-
-
-class DisablePostDeleteSignal(object):
-    def __enter__(self):
-        self.receivers = post_delete.receivers
-        post_delete.receivers = []
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        post_delete.receivers = self.receivers
-        self.receivers = None
 
 
 class Command(AsyncCommand):

--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -15,6 +15,7 @@ from morango.sync.controller import MorangoProfileController
 from requests.exceptions import ConnectionError
 from six.moves.urllib.parse import urljoin
 
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import DevicePermissions
@@ -134,7 +135,7 @@ class Command(AsyncCommand):
         if not ScopeDefinition.objects.filter():
             call_command("loaddata", "scopedefinitions")
 
-        controller = MorangoProfileController("facilitydata")
+        controller = MorangoProfileController(PROFILE_FACILITY_DATA)
         with self.start_progress(total=7) as progress_update:
             try:
                 network_connection = controller.create_network_connection(

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -14,6 +14,7 @@ from ..utils import create_superuser_and_provision_device
 from ..utils import get_baseurl
 from ..utils import get_client_and_server_certs
 from ..utils import get_dataset_id
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.constants.morango_sync import State
 from kolibri.core.auth.management.utils import get_facility
@@ -96,7 +97,7 @@ class Command(AsyncCommand):
             call_command("loaddata", "scopedefinitions")
 
         # try to connect to server
-        controller = MorangoProfileController("facilitydata")
+        controller = MorangoProfileController(PROFILE_FACILITY_DATA)
         network_connection = controller.create_network_connection(baseurl)
 
         # if instance_ids are equal, this means device is trying to sync with itself, which we don't allow

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 import requests
 from django.core.management.base import CommandError
+from django.db.models.signals import post_delete
 from django.urls import reverse
 from django.utils.six.moves import input
 from morango.models import Certificate
@@ -20,6 +21,21 @@ from kolibri.core.device.utils import provision_device
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import URLParseError
+
+
+class DisablePostDeleteSignal(object):
+    """
+    Helper that disables the post_delete signal temporarily when deleting, so Morango doesn't
+    create DeletedModels objects for what we're deleting
+    """
+
+    def __enter__(self):
+        self.receivers = post_delete.receivers
+        post_delete.receivers = []
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        post_delete.receivers = self.receivers
+        self.receivers = None
 
 
 def _interactive_client_facility_selection():

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -45,6 +45,7 @@ from mptt.models import TreeForeignKey
 
 from .constants import collection_kinds
 from .constants import facility_presets
+from .constants import morango_sync
 from .constants import role_kinds
 from .constants import user_kinds
 from .errors import InvalidRoleKind
@@ -85,7 +86,7 @@ def _has_permissions_class(obj):
 
 class FacilityDataSyncableModel(SyncableModel):
 
-    morango_profile = "facilitydata"
+    morango_profile = morango_sync.PROFILE_FACILITY_DATA
 
     class Meta:
         abstract = True
@@ -169,7 +170,7 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
     such as ``FacilityUsers``, ``Collections``, and other data associated with those users and collections.
     """
 
-    dataset = models.ForeignKey(FacilityDataset)
+    dataset = models.ForeignKey(FacilityDataset, on_delete=models.CASCADE)
 
     class Meta:
         abstract = True
@@ -662,7 +663,7 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
 
     objects = FacilityUserModelManager()
 
-    facility = models.ForeignKey("Facility")
+    facility = models.ForeignKey("Facility", on_delete=models.CASCADE)
 
     is_facility_user = True
 
@@ -1205,7 +1206,11 @@ class Role(AbstractFacilityDataModel):
     permissions = own | role
 
     user = models.ForeignKey(
-        "FacilityUser", related_name="roles", blank=False, null=False
+        "FacilityUser",
+        related_name="roles",
+        blank=False,
+        null=False,
+        on_delete=models.CASCADE,
     )
     # Note: "It's recommended you use mptt.fields.TreeForeignKey wherever you have a foreign key to an MPTT model.
     # https://django-mptt.github.io/django-mptt/models.html#treeforeignkey-treeonetoonefield-treemanytomanyfield

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -15,6 +15,7 @@ from morango.sync.controller import MorangoProfileController
 from rest_framework import status
 from six.moves.urllib.parse import urljoin
 
+from ..constants.morango_sync import PROFILE_FACILITY_DATA
 from ..models import Classroom
 from ..models import Facility
 from ..models import FacilityDataset
@@ -47,7 +48,7 @@ class FacilityDatasetCertificateTestCase(TestCase):
 
 class DateTimeTZFieldTestCase(TestCase):
     def setUp(self):
-        self.controller = MorangoProfileController("facilitydata")
+        self.controller = MorangoProfileController(PROFILE_FACILITY_DATA)
         InstanceIDModel.get_or_create_current_instance()
 
     def test_deserializing_field(self):
@@ -127,7 +128,7 @@ class EcosystemTestCase(TestCase):
         return resp
 
     def assertServerQuerysetEqual(self, s1, s2, dataset_id):
-        models = syncable_models.get_models("facilitydata")
+        models = syncable_models.get_models(PROFILE_FACILITY_DATA)
         models.pop(
             0
         )  # remove FacilityDataset because __str__() does not point to correct db alias

--- a/kolibri/core/device/permissions.py
+++ b/kolibri/core/device/permissions.py
@@ -42,3 +42,8 @@ class UserHasAnyDevicePermissions(DenyAll):
         from .models import device_permissions_fields
 
         return any(getattr(request.user, field) for field in device_permissions_fields)
+
+
+class IsSuperuser(DenyAll):
+    def has_permission(self, request, view):
+        return request.user.is_superuser

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -27,6 +27,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from six import string_types
 
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import State as FacilitySyncState
 from kolibri.core.auth.management.utils import get_client_and_server_certs
 from kolibri.core.auth.models import Facility
@@ -951,7 +952,7 @@ def validate_and_prepare_peer_sync_job(request, **kwargs):
     username = request.data.get("username", None)
     password = request.data.get("password", None)
 
-    controller = MorangoProfileController("facilitydata")
+    controller = MorangoProfileController(PROFILE_FACILITY_DATA)
     network_connection = controller.create_network_connection(baseurl)
 
     # try to get the certificate, which will save it if successful

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -16,14 +16,15 @@ from django.http.response import HttpResponseBadRequest
 from django.utils.translation import get_language_from_request
 from django.utils.translation import gettext_lazy as _
 from morango.sync.controller import MorangoProfileController
+from rest_framework import decorators
 from rest_framework import serializers
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.decorators import action
 from rest_framework.exceptions import APIException
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from six import string_types
 
@@ -41,6 +42,7 @@ from kolibri.core.content.utils.channels import read_channel_metadata_from_db_fi
 from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.content.utils.upgrade import diff_stats
+from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.permissions import NotProvisionedCanGet
 from kolibri.core.device.permissions import NotProvisionedCanPost
 from kolibri.core.discovery.models import NetworkLocation
@@ -215,7 +217,7 @@ class BaseViewSet(viewsets.ViewSet):
         # unimplemented for now.
         pass
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def canceltask(self, request):
         """
         Cancel a task with its task id given in the task_id parameter.
@@ -235,7 +237,7 @@ class BaseViewSet(viewsets.ViewSet):
 
         return Response({})
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def cleartasks(self, request):
         """
         Cancels all running tasks.
@@ -246,7 +248,7 @@ class BaseViewSet(viewsets.ViewSet):
 
         return Response({})
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def cleartask(self, request):
         # Given a single task ID, clear it from the queue
         task_id = request.data.get("task_id")
@@ -258,7 +260,7 @@ class BaseViewSet(viewsets.ViewSet):
 
         return Response({"task_id": task_id})
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def deletefinishedtasks(self, request):
         """
         Delete all tasks that have succeeded, failed, or been cancelled.
@@ -284,7 +286,7 @@ class TasksViewSet(BaseViewSet):
 
         return super(TasksViewSet, self).permission_classes
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startchannelupdate(self, request):
 
         sourcetype = request.data.get("sourcetype", None)
@@ -325,7 +327,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startremotebulkimport(self, request):
         if not isinstance(request.data, list):
             raise serializers.ValidationError(
@@ -353,7 +355,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startremotechannelimport(self, request):
 
         task = validate_remote_import_task(request, request.data)
@@ -374,7 +376,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startremotecontentimport(self, request):
 
         task = validate_remote_import_task(request, request.data)
@@ -398,7 +400,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdiskbulkimport(self, request):
         if not isinstance(request.data, list):
             raise serializers.ValidationError(
@@ -426,7 +428,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdiskchannelimport(self, request):
         task = validate_local_import_task(request, request.data)
 
@@ -446,7 +448,7 @@ class TasksViewSet(BaseViewSet):
         resp = _job_to_response(priority_queue.fetch_job(job_id))
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdiskcontentimport(self, request):
         task = validate_local_import_task(request, request.data)
 
@@ -470,7 +472,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startbulkdelete(self, request):
         if not isinstance(request.data, list):
             raise serializers.ValidationError(
@@ -499,7 +501,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdeletechannel(self, request):
         """
         Delete a channel and all its associated content from the server
@@ -528,7 +530,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdiskbulkexport(self, request):
         if not isinstance(request.data, list):
             raise serializers.ValidationError(
@@ -555,7 +557,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdiskexport(self, request):
         """
         Export a channel to a local drive, and copy content to the drive.
@@ -581,7 +583,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["get"], detail=False)
+    @decorators.action(methods=["get"], detail=False)
     def localdrive(self, request):
         drives = get_mounted_drives_with_channel_info()
 
@@ -591,7 +593,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(out)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def importusersfromcsv(self, request):
         """
         Import users, classes, roles and roles assignemnts from a csv file.
@@ -667,7 +669,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def exportuserstocsv(self, request):
         """
         Export users, classes, roles and roles assignemnts to a csv file.
@@ -697,7 +699,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startexportlogcsv(self, request):
         """
         Dumps in csv format the required logs.
@@ -752,7 +754,7 @@ class TasksViewSet(BaseViewSet):
 
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def channeldiffstats(self, request):
         job_metadata = {}
         channel_id = request.data.get("channel_id")
@@ -827,7 +829,7 @@ class FacilityTasksViewSet(BaseViewSet):
 
         return [p | NotProvisionedCanPost for p in permission_classes]
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdataportalsync(self, request):
         """
         Initiate a PUSH sync with Kolibri Data Portal.
@@ -840,7 +842,7 @@ class FacilityTasksViewSet(BaseViewSet):
         resp = _job_to_response(facility_queue.fetch_job(job_id))
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startdataportalbulksync(self, request):
         """
         Initiate a PUSH sync with Kolibri Data Portal for ALL registered facilities.
@@ -856,7 +858,7 @@ class FacilityTasksViewSet(BaseViewSet):
 
         return Response(responses)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startpeerfacilityimport(self, request):
         """
         Initiate a PULL of a specific facility from another device.
@@ -872,7 +874,7 @@ class FacilityTasksViewSet(BaseViewSet):
         resp = _job_to_response(facility_queue.fetch_job(job_id))
         return Response(resp)
 
-    @action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False)
     def startpeerfacilitysync(self, request):
         """
         Initiate a SYNC (PULL + PUSH) of a specific facility from another device.
@@ -881,6 +883,54 @@ class FacilityTasksViewSet(BaseViewSet):
             request, extra_metadata=prepare_sync_task(request, type="SYNCPEER/FULL"),
         )
         job_id = facility_queue.enqueue(call_command, "sync", **job_data)
+
+        resp = _job_to_response(facility_queue.fetch_job(job_id))
+        return Response(resp)
+
+    @decorators.permission_classes([IsSuperuser])
+    @decorators.action(methods=["post"], detail=False)
+    def startdeletefacility(self, request):
+        """
+        Initiate a task to delete a facility
+        """
+        try:
+            facility_id = request.data.get("facility")
+            if not facility_id:
+                raise KeyError()
+        except KeyError:
+            raise ParseError(
+                dict(code="INVALID_FACILITY", message="Missing `facility` parameter",)
+            )
+
+        if not Facility.objects.filter(id=facility_id).exists():
+            raise ValidationError(
+                dict(code="INVALID_FACILITY", message="Facility doesn't exist",)
+            )
+
+        if not Facility.objects.exclude(id=facility_id).exists():
+            raise ValidationError(
+                dict(
+                    code="SOLE_FACILITY",
+                    message="Cannot delete the sole facility on the device",
+                )
+            )
+
+        if request.user.is_facility_user and request.user.facility_id == facility_id:
+            raise ValidationError(
+                dict(code="FACILITY_MEMBER", message="User is member of facility",)
+            )
+
+        job_id = facility_queue.enqueue(
+            call_command,
+            "deletefacility",
+            facility=facility_id,
+            track_progress=True,
+            noninteractive=True,
+            cancellable=False,
+            extra_metadata=dict(
+                facility=facility_id, started_by=request.user.pk, type="DELETEFACILITY"
+            ),
+        )
 
         resp = _job_to_response(facility_queue.fetch_job(job_id))
         return Response(resp)

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.test import APITestCase
 
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
@@ -459,7 +460,7 @@ class FacilityTaskHelperTestCase(TestCase):
         )
         self.assertEqual(expected, actual)
 
-        MorangoProfileController.assert_called_with("facilitydata")
+        MorangoProfileController.assert_called_with(PROFILE_FACILITY_DATA)
         controller.create_network_connection.assert_called_with(
             "https://some.server.test/"
         )

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -379,6 +379,83 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         )
         facility_queue.enqueue.assert_called_with(call_command, "sync", **prepared_data)
 
+    def test_startdeletefacility(self, facility_queue):
+        user = self._setup_device()
+        facility2 = Facility.objects.create(name="facility2")
+
+        extra_metadata = dict(
+            facility=facility2.id, started_by=user.pk, type="DELETEFACILITY",
+        )
+        prepared_data = dict(
+            facility=facility2.id,
+            noninteractive=True,
+            extra_metadata=extra_metadata,
+            track_progress=True,
+            cancellable=False,
+        )
+
+        facility_queue.enqueue.return_value = 123
+        fake_job_data = dict(
+            job_id=123,
+            state="testing",
+            cancellable=False,
+            extra_metadata=dict(this_is_extra=True),
+        )
+        fake_job_data["extra_metadata"].update(extra_metadata)
+        facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
+
+        response = self.client.post(
+            reverse("kolibri:core:facilitytask-startdeletefacility"),
+            dict(facility=facility2.id),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertJobResponse(fake_job_data, response)
+
+        facility_queue.enqueue.assert_called_with(
+            call_command, "deletefacility", **prepared_data
+        )
+
+    def test_startdeletefacility__sole_facility(self, facility_queue):
+        self._setup_device()
+
+        response = self.client.post(
+            reverse("kolibri:core:facilitytask-startdeletefacility"),
+            dict(facility=self.facility.id),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual("SOLE_FACILITY", response.data.get("code"))
+
+    def test_startdeletefacility__not_superuser(self, facility_queue):
+        DeviceSettings.objects.create(is_provisioned=True)
+        facility1 = Facility.objects.create(name="facility1")
+        Facility.objects.create(name="facility2")
+
+        user = FacilityUser.objects.create(username="superuser", facility=facility1)
+        user.set_password(DUMMY_PASSWORD)
+        user.save()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse("kolibri:core:facilitytask-startdeletefacility"),
+            dict(facility=facility1.id),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_startdeletefacility__facility_member(self, facility_queue):
+        self._setup_device()
+        Facility.objects.create(name="facility2")
+
+        response = self.client.post(
+            reverse("kolibri:core:facilitytask-startdeletefacility"),
+            dict(facility=self.facility.id),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual("FACILITY_MEMBER", response.data.get("code"))
+
 
 class FacilityTaskHelperTestCase(TestCase):
     def test_prepare_sync_task(self):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds a management command for facility deletion to remove a facility entirely from the device
- Adds a `facilitytask` endpoint for initiating a facility deletion task
- Explicitly added the `on_delete=CASCADE` to the models since it in future versions of Django, it requires an explicit action it instead of assuming cascade
- Updated `@action` decorators with preferred alternative since it is deprecated

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
A nice to have feature was to have the command report progress. Relying on CASCADE deletions works just fine for most of the models, but also doesn't give much insight into that progress, as far as I know. This currently goes through all the models, counts them, and then deletes them; through this procedure it can report progress since it's handling the models individually.

Some feedback on whether we care about any of that would be great. It was a nice to have that didn't seem too difficult, but could get stale in the future if adding more related models, although still completely deleting the facility because of the cascade.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
[Notion page](https://www.notion.so/learningequality/Backend-Admins-can-delete-a-Facility-and-all-its-data-from-a-Device-13-pts-0-14-dev-fac-UC6-2277c6a5cf3940ecaf822f3e0d25bb38)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
