### PR TITLE
Add explicit post method to device provision call.

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -68,7 +68,11 @@ export default {
 
       store.commit('SET_LOADING', true);
 
-      return client({ url: urls['kolibri:core:deviceprovision'](), data: onboardingData }).then(
+      return client({
+        url: urls['kolibri:core:deviceprovision'](),
+        data: onboardingData,
+        method: 'post',
+      }).then(
         response => {
           superuser.facility = response.data.facility.id;
           store.dispatch('kolibriLogin', superuser);


### PR DESCRIPTION
### Summary
Cleanup from #6969 - the device provision call was relying on rest JS' implicit POST behaviour when data is submitted, this adds the explicit POST method to fix device provisioning.

### Reviewer guidance
Can you provision the device?

Fixes #7030 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
