### PR TITLE
Do not bootstrap every user into sign in page

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -372,7 +372,7 @@ export function getFacilityConfig(store, facilityId) {
     return Promise.resolve(redirectBrowser());
   }
   let datasetPromise;
-  if (selectedFacility && typeof selectedFacility.dataset === 'object') {
+  if (selectedFacility && typeof selectedFacility.dataset !== 'object') {
     datasetPromise = Promise.resolve([selectedFacility.dataset]);
   } else {
     datasetPromise = FacilityDatasetResource.fetchCollection({

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -152,7 +152,6 @@ class FacilityDatasetViewSet(ValuesViewset):
         "location",
         "registered",
         "preset",
-        "num_users_in_facility",
     )
 
     field_map = {"allow_guest_access": lambda x: allow_guest_access()}
@@ -334,14 +333,55 @@ class FacilityViewSet(ValuesViewset):
     values = (
         "id",
         "name",
-        "dataset",
         "num_classrooms",
         "num_users",
         "last_synced",
+        # dataset keys
+        "dataset__id",
+        "dataset__learner_can_edit_username",
+        "dataset__learner_can_edit_name",
+        "dataset__learner_can_edit_password",
+        "dataset__learner_can_sign_up",
+        "dataset__learner_can_delete_account",
+        "dataset__learner_can_login_with_no_password",
+        "dataset__show_download_button_in_learn",
+        "dataset__description",
+        "dataset__location",
+        "dataset__registered",
+        "dataset__preset",
     )
+
+    def _map_dataset(facility):
+        dataset = {}
+        dataset["id"] = facility.pop("dataset__id")
+        dataset["learner_can_edit_username"] = facility.pop(
+            "dataset__learner_can_edit_username"
+        )
+        dataset["learner_can_edit_name"] = facility.pop(
+            "dataset__learner_can_edit_name"
+        )
+        dataset["learner_can_edit_password"] = facility.pop(
+            "dataset__learner_can_edit_password"
+        )
+        dataset["learner_can_sign_up"] = facility.pop("dataset__learner_can_sign_up")
+        dataset["learner_can_delete_account"] = facility.pop(
+            "dataset__learner_can_delete_account"
+        )
+        dataset["learner_can_login_with_no_password"] = facility.pop(
+            "dataset__learner_can_login_with_no_password"
+        )
+        dataset["show_download_button_in_learn"] = facility.pop(
+            "dataset__show_download_button_in_learn"
+        )
+        dataset["description"] = facility.pop("dataset__description")
+        dataset["location"] = facility.pop("dataset__location")
+        dataset["registered"] = facility.pop("dataset__registered")
+        dataset["preset"] = facility.pop("dataset__preset")
+        return dataset
 
     field_map = {
         "default": lambda x: Facility.get_default_facility().id == x["id"],
+        "dataset": _map_dataset,
     }
 
     def get_queryset(self, prefetch=True):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -185,7 +185,7 @@ class FacilityUserViewSet(ValuesViewset):
         "is_superuser": lambda x: bool(x.pop("devicepermissions__is_superuser"))
     }
 
-    @list_route(methods=["get"],)
+    @list_route(methods=["get"])
     def users_for_facilities(self, request):
         facility_ids = dict(request.GET)["member_of"]
 

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -330,13 +330,9 @@ class FacilityViewSet(ValuesViewset):
     queryset = Facility.objects.all()
     serializer_class = FacilitySerializer
 
-    values = (
-        "id",
-        "name",
-        "num_classrooms",
-        "num_users",
-        "last_synced",
-        # dataset keys
+    facility_values = ["id", "name", "num_classrooms", "num_users", "last_synced"]
+
+    dataset_keys = [
         "dataset__id",
         "dataset__learner_can_edit_username",
         "dataset__learner_can_edit_name",
@@ -349,34 +345,17 @@ class FacilityViewSet(ValuesViewset):
         "dataset__location",
         "dataset__registered",
         "dataset__preset",
-    )
+    ]
 
-    def _map_dataset(facility):
+    values = tuple(facility_values + dataset_keys)
+
+    # map function to pop() all of the dataset__ items into an dict
+    # then assign that new dict to the `dataset` key of the facility
+    def _map_dataset(facility, dataset_keys=dataset_keys):
         dataset = {}
-        dataset["id"] = facility.pop("dataset__id")
-        dataset["learner_can_edit_username"] = facility.pop(
-            "dataset__learner_can_edit_username"
-        )
-        dataset["learner_can_edit_name"] = facility.pop(
-            "dataset__learner_can_edit_name"
-        )
-        dataset["learner_can_edit_password"] = facility.pop(
-            "dataset__learner_can_edit_password"
-        )
-        dataset["learner_can_sign_up"] = facility.pop("dataset__learner_can_sign_up")
-        dataset["learner_can_delete_account"] = facility.pop(
-            "dataset__learner_can_delete_account"
-        )
-        dataset["learner_can_login_with_no_password"] = facility.pop(
-            "dataset__learner_can_login_with_no_password"
-        )
-        dataset["show_download_button_in_learn"] = facility.pop(
-            "dataset__show_download_button_in_learn"
-        )
-        dataset["description"] = facility.pop("dataset__description")
-        dataset["location"] = facility.pop("dataset__location")
-        dataset["registered"] = facility.pop("dataset__registered")
-        dataset["preset"] = facility.pop("dataset__preset")
+        for dataset_key in dataset_keys:
+            stripped_key = dataset_key.replace("dataset__", "")
+            dataset[stripped_key] = facility.pop(dataset_key)
         return dataset
 
     field_map = {

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -373,10 +373,6 @@ class FacilityViewSet(ValuesViewset):
         return queryset
 
     def annotate_queryset(self, queryset):
-        # Fixes issue using OuterRef within Cast() that is patched in later Django version
-        # Patch from https://github.com/django/django/commit/c412926a2e359afb40738d8177c9f3bef80ee04e
-        # https://code.djangoproject.com/ticket/29142
-        F.relabeled_clone = lambda self, relabels: self
         return (
             queryset.annotate(
                 num_users=SQCount(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -19,6 +19,7 @@ from django.db.models import Exists
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
+from django.db.models.functions import Cast
 from django.db.models.query import F
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
@@ -28,6 +29,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from django_filters.rest_framework import ModelChoiceFilter
 from morango.models import TransferSession
+from morango.models import UUIDField
 from rest_framework import filters
 from rest_framework import permissions
 from rest_framework import status
@@ -384,7 +386,9 @@ class FacilityViewSet(ValuesViewset):
             )
             .annotate(
                 last_synced=Subquery(
-                    TransferSession.objects.filter(filter=OuterRef("dataset"))
+                    TransferSession.objects.filter(
+                        filter=Cast(OuterRef("dataset"), UUIDField)
+                    )
                     .order_by("-last_activity_timestamp")
                     .values("last_activity_timestamp")
                 )

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -373,6 +373,7 @@ class FacilityViewSet(ValuesViewset):
         return queryset
 
     def annotate_queryset(self, queryset):
+        # Fixes issue using OuterRef within Cast() that is patched in later Django version
         # Patch from https://github.com/django/django/commit/c412926a2e359afb40738d8177c9f3bef80ee04e
         # https://code.djangoproject.com/ticket/29142
         F.relabeled_clone = lambda self, relabels: self

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -227,7 +227,6 @@ class FacilityUserViewSet(ValuesViewset):
 
         return Response(list(map(sanitize_users, users)))
 
-    
     def consolidate(self, items, queryset):
         output = []
         items = sorted(items, key=lambda x: x["id"])

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -19,7 +19,6 @@ from .models import LearnerGroup
 from .models import Membership
 from .models import Role
 from kolibri.core import error_constants
-from kolibri.core.device.utils import allow_guest_access
 
 
 class RoleSerializer(serializers.ModelSerializer):
@@ -74,9 +73,6 @@ class MembershipSerializer(serializers.ModelSerializer):
 
 
 class FacilityDatasetSerializer(serializers.ModelSerializer):
-    allow_guest_access = serializers.SerializerMethodField()
-    num_users_in_facility = serializers.SerializerMethodField()
-
     class Meta:
         model = FacilityDataset
         fields = (
@@ -90,39 +86,9 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
             "show_download_button_in_learn",
             "description",
             "location",
-            "allow_guest_access",
             "registered",
             "preset",
-            "num_users_in_facility",
         )
-
-    def get_allow_guest_access(self, instance):
-        return allow_guest_access()
-
-    def get_num_users_in_facility(self, instance):
-        facility = Facility.objects.get(dataset_id=instance.id)
-        return FacilityUser.objects.filter(facility=facility).count()
-
-
-class FacilityUsersForFacilitiesSerializer(serializers.Serializer):
-    users = serializers.SerializerMethodField()
-
-    class Meta:
-        fields = "users"
-
-    def get_users(self, users):
-        def sanitize_users(user):
-            return {
-                "id": user.id,
-                "username": user.username,
-                "facility_id": user.facility_id,
-                "is_learner": len(user.get_roles_for_user(user)) == 0,
-                "needs_password": (
-                    user.password == "NOT_SPECIFIED" or not user.password
-                ),
-            }
-
-        return list(map(sanitize_users, users))
 
 
 class FacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -75,6 +75,7 @@ class MembershipSerializer(serializers.ModelSerializer):
 
 class FacilityDatasetSerializer(serializers.ModelSerializer):
     allow_guest_access = serializers.SerializerMethodField()
+    num_users_in_facility = serializers.SerializerMethodField()
 
     class Meta:
         model = FacilityDataset
@@ -92,10 +93,36 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
             "allow_guest_access",
             "registered",
             "preset",
+            "num_users_in_facility",
         )
 
     def get_allow_guest_access(self, instance):
         return allow_guest_access()
+
+    def get_num_users_in_facility(self, instance):
+        facility = Facility.objects.get(dataset_id=instance.id)
+        return FacilityUser.objects.filter(facility=facility).count()
+
+
+class FacilityUsersForFacilitiesSerializer(serializers.Serializer):
+    users = serializers.SerializerMethodField()
+
+    class Meta:
+        fields = "users"
+
+    def get_users(self, users):
+        def sanitize_users(user):
+            return {
+                "id": user.id,
+                "username": user.username,
+                "facility_id": user.facility_id,
+                "is_learner": len(user.get_roles_for_user(user)) == 0,
+                "needs_password": (
+                    user.password == "NOT_SPECIFIED" or not user.password
+                ),
+            }
+
+        return list(map(sanitize_users, users))
 
 
 class FacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -87,16 +87,10 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
 
 
 class FacilitySerializer(serializers.ModelSerializer):
-    dataset = FacilityDatasetSerializer(read_only=True)
-
     class Meta:
         model = Facility
-        extra_kwargs = {"id": {"read_only": True}, "dataset": {"read_only": True}}
-        fields = (
-            "id",
-            "name",
-            "dataset",
-        )
+        extra_kwargs = {"id": {"read_only": True}}
+        fields = ("id", "name")
 
 
 class PublicFacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/core/models.py
+++ b/kolibri/core/models.py
@@ -3,9 +3,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.conf import settings
+from django.db.models.query import F
 
 from kolibri.plugins.registry import registered_plugins
 
 # Register any django apps that may have kolibri plugin
 # modules inside them
 registered_plugins.register_non_plugins(settings.INSTALLED_APPS)
+
+# Fixes issue using OuterRef within Cast() that is patched in later Django version
+# Patch from https://github.com/django/django/commit/c412926a2e359afb40738d8177c9f3bef80ee04e
+# https://code.djangoproject.com/ticket/29142
+F.relabeled_clone = lambda self, relabels: self

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -25,7 +25,7 @@ export default {
 
       FacilityUserResource.getListEndpoint('users_for_facilities', getParams)
         .then(response => {
-          store.commit('SET_SELECTED_FACILITY_USERS', JSON.parse(response.data));
+          store.commit('SET_SELECTED_FACILITY_USERS', response.data);
         })
         .catch(e => {
           console.error(e);

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -15,7 +15,6 @@ export default {
       state.hasMultipleFacilities = null;
     },
     SET_SELECTED_FACILITY_USERS(state, payload) {
-      console.log(payload);
       state.usersForSelectedFacilities = payload;
     },
   },

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -1,7 +1,11 @@
+import { FacilityUserResource } from 'kolibri.resources';
+
 export default {
   namespaced: true,
   state: {
     hasMultipleFacilities: null,
+    // These users are retrieved for specified facilities
+    usersForSelectedFacilities: [],
   },
   mutations: {
     SET_STATE(state, payload) {
@@ -9,6 +13,23 @@ export default {
     },
     RESET_STATE(state) {
       state.hasMultipleFacilities = null;
+    },
+    SET_SELECTED_FACILITY_USERS(state, payload) {
+      console.log(payload);
+      state.usersForSelectedFacilities = payload;
+    },
+  },
+  actions: {
+    fetchUsersForFacilities(store, payload) {
+      const getParams = { member_of: payload };
+
+      FacilityUserResource.getListEndpoint('users_for_facilities', getParams)
+        .then(response => {
+          store.commit('SET_SELECTED_FACILITY_USERS', JSON.parse(response.data)['users']);
+        })
+        .catch(e => {
+          console.error(e);
+        });
     },
   },
 };

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -21,10 +21,11 @@ export default {
   actions: {
     fetchUsersForFacilities(store, payload) {
       const getParams = { member_of: payload };
+      console.log(payload);
 
       FacilityUserResource.getListEndpoint('users_for_facilities', getParams)
         .then(response => {
-          store.commit('SET_SELECTED_FACILITY_USERS', JSON.parse(response.data)['users']);
+          store.commit('SET_SELECTED_FACILITY_USERS', JSON.parse(response.data));
         })
         .catch(e => {
           console.error(e);

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -21,14 +21,13 @@ export default {
   actions: {
     fetchUsersForFacilities(store, payload) {
       const getParams = { member_of: payload };
-      console.log(payload);
 
       FacilityUserResource.getListEndpoint('users_for_facilities', getParams)
         .then(response => {
           store.commit('SET_SELECTED_FACILITY_USERS', response.data);
         })
         .catch(e => {
-          console.error(e);
+          store.dispatch('handleApiError', e);
         });
     },
   },

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -365,7 +365,11 @@
       const facilityIdsToFetch = this.facilities
         .filter(f => f.num_users <= MAX_USERS_FOR_LISTING_VIEW)
         .map(f => f.id);
-      this.$store.dispatch('signIn/fetchUsersForFacilities', facilityIdsToFetch);
+
+      // Only fetch if there are facilities to fetch for
+      if (facilityIdsToFetch.length) {
+        this.$store.dispatch('signIn/fetchUsersForFacilities', facilityIdsToFetch);
+      }
     },
     mounted() {
       /*

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -289,7 +289,7 @@
       },
       shouldShowUsersList() {
         return (
-          this.facilityConfig.num_users_in_facility <= MAX_USERS_FOR_LISTING_VIEW &&
+          this.selectedFacility.num_users <= MAX_USERS_FOR_LISTING_VIEW &&
           this.isAppContext &&
           !this.selectedListUser
         );
@@ -363,7 +363,7 @@
     created() {
       // Only get facilities that meet our criteria for listing the users
       const facilityIdsToFetch = this.facilities
-        .filter(f => f.dataset.num_users_in_facility <= MAX_USERS_FOR_LISTING_VIEW)
+        .filter(f => f.num_users <= MAX_USERS_FOR_LISTING_VIEW)
         .map(f => f.id);
       this.$store.dispatch('signIn/fetchUsersForFacilities', facilityIdsToFetch);
     },

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -371,27 +371,6 @@
         this.$store.dispatch('signIn/fetchUsersForFacilities', facilityIdsToFetch);
       }
     },
-    mounted() {
-      /*
-        Chrome has non-standard behavior with auto-filled text fields where
-        the value shows up as an empty string even though there is text in
-        the field:
-          https://bugs.chromium.org/p/chromium/issues/detail?id=669724
-        As super-brittle hack to detect the presence of auto-filled text and
-        work-around it, we look for a change in background color as described
-        here:
-          https://stackoverflow.com/a/35783761
-      */
-      setTimeout(() => {
-        const bgColor = window.getComputedStyle(this.$refs.username.$el.querySelector('input'))
-          .backgroundColor;
-
-        if (bgColor === 'rgb(250, 255, 189)') {
-        }
-      }, 250);
-    },
-          this.autoFilledByChromeAndNotEdited = true;
-        }
     methods: {
       ...mapActions(['kolibriLogin', 'kolibriLoginWithNewPassword', 'clearLoginError']),
       unselectListUser() {

--- a/kolibri/plugins/user/kolibri_plugin.py
+++ b/kolibri/plugins/user/kolibri_plugin.py
@@ -24,23 +24,9 @@ class UserAsset(webpack_hooks.WebpackBundleHook):
 
     @property
     def plugin_data(self):
-        from kolibri.core.auth.models import FacilityUser
-
-        def sanitize_users(user):
-            return {
-                "id": user.id,
-                "username": user.username,
-                "facility_id": user.facility_id,
-                "is_learner": len(user.get_roles_for_user(user)) == 0,
-                "needs_password": (
-                    user.password == "NOT_SPECIFIED" or not user.password
-                ),
-            }
-
         return {
             "oidcProviderEnabled": OIDCProviderHook.is_enabled(),
             "allowGuestAccess": get_device_setting("allow_guest_access"),
-            "deviceUsers": list(map(sanitize_users, FacilityUser.objects.all())),
         }
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

@rtibbles pointed out that my initial solution to get all facility users needed for the user listing flow on the Sign In page was a performance liability. What if a Facility had 10000+ users?!

So now - the facility config receives a new value `num_users_in_facility`

And there is a new `facilityusers` endpoint that gets all FacilityUsers in a given Facility.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Does sign in work?
- When you are in app context and have a facility with <= 16 users do you see them listed?
- When you are in app context and have a facility > 16 users do you see the normal "Username" field?

Also:
- How about that Python code?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Discussed on Slack

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
