### PR TITLE
Fix exercise rendering

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -2,6 +2,7 @@
  * Module for REST API client
  */
 
+import axios from 'axios';
 import qs from 'qs';
 import heartbeat from 'kolibri.heartbeat';
 import logger from 'kolibri.lib.logging';
@@ -14,14 +15,16 @@ export const logging = logger.getLogger(__filename);
 const baseClient = clientFactory();
 
 // Disconnection handler interceptor
-baseClient.interceptors.request.use(function(request) {
+baseClient.interceptors.request.use(function(config) {
   if (!store.getters.connected) {
     // If the vuex state records that we are not currently connected then cancel all
     // outgoing requests.
-    request.abort();
-    return Promise.reject(request);
+    const CancelToken = axios.CancelToken;
+    const source = CancelToken.source();
+    config.cancelToken = source.token;
+    source.cancel('Request cancelled as currently disconnected from Kolibri');
   }
-  return request;
+  return config;
 });
 
 // Login timeout detection interceptor and disconnection monitoring

--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -83,14 +83,33 @@ const client = options => {
       logging.warn('option path is deprecated, please use url option instead');
     }
   }
+  if (typeof options === 'string') {
+    options = { url: options };
+    logging.warn(
+      'passing the URL as the only argument is deprecated, please use url option instead'
+    );
+  }
+
   const headers = { ...(options.headers || {}) };
   if (options.multipart) {
     headers['Content-Type'] = 'multipart/form-data';
   }
-  return baseClient.request({
-    ...options,
-    headers,
-  });
+  return baseClient
+    .request({
+      ...options,
+      headers,
+    })
+    .then(response => {
+      return {
+        get entity() {
+          logging.warn(
+            'entity is deprecated for accessing response data, please use the data key instead'
+          );
+          return response.data;
+        },
+        ...response,
+      };
+    });
 };
 
 export default client;


### PR DESCRIPTION
### Summary
More cleanup from #6969 

* Properly handle cancelling requests when disconnected
* Maintain full support for old client API
* Add deprecation warnings

### Reviewer guidance
To test the cancelling:
* set your Network status to 'offline' so that your browser is not connected to Kolibri.
* In the developer console type execute: `kolibriCoreAppGlobal.client.default({url: "http://127.0.0.1:8000/bleg"})`
* It shoudl fail because there is no network connection and the disconnection snackbar appears
* Again execute `kolibriCoreAppGlobal.client.default({url: "http://127.0.0.1:8000/bleg"})`
* The returned promise should be immediately rejected and shown as cancelled.

To test exercises:
* Load an exercise
* Make sure it renders
* See the console for deprecation warnings

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
