### PR TITLE
Obtain dataset ID from server before checking for certs

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -29,6 +29,7 @@ from six import string_types
 
 from kolibri.core.auth.constants.morango_sync import State as FacilitySyncState
 from kolibri.core.auth.management.utils import get_client_and_server_certs
+from kolibri.core.auth.management.utils import get_dataset_id
 from kolibri.core.auth.models import Facility
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.permissions import CanExportLogs
@@ -956,9 +957,14 @@ def validate_and_prepare_peer_sync_job(request, **kwargs):
 
     # try to get the certificate, which will save it if successful
     try:
+        # make sure we get the dataset ID
+        dataset_id = get_dataset_id(
+            baseurl, identifier=facility_id, noninteractive=True
+        )
+
         # username and password are not required for this to succeed unless there is no cert
         get_client_and_server_certs(
-            username, password, facility_id, network_connection, noninteractive=True
+            username, password, dataset_id, network_connection, noninteractive=True
         )
     except CommandError as e:
         if not username and not password:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
I missed a step in the API endpoint to queue a P2P import/sync. It should obtain the dataset ID for the facility first, then check to ensure we have permission to access the facility data, through the server certs


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Original PR https://github.com/learningequality/kolibri/pull/6881

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
