### PR TITLE
Remove chrome autofilling detection

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -199,9 +199,8 @@
                     :autofocus="true"
                     :invalid="passwordIsInvalid"
                     :invalidText="passwordIsInvalidText"
-                    :floatingLabel="!autoFilledByChromeAndNotEdited"
+                    :floatingLabel="false"
                     @blur="passwordBlurred = true"
-                    @input="handlePasswordChanged"
                   />
                 </transition>
                 <div>
@@ -403,7 +402,6 @@
         usernameBlurred: false,
         passwordBlurred: false,
         formSubmitted: false,
-        autoFilledByChromeAndNotEdited: false,
         privacyModalVisible: false,
         whatsThisModalVisible: false,
         selectedListUser: null,
@@ -471,10 +469,6 @@
         return '';
       },
       passwordIsInvalid() {
-        // prevent validation from showing when we only think that the password is empty
-        if (this.autoFilledByChromeAndNotEdited) {
-          return false;
-        }
         return Boolean(this.passwordIsInvalidText);
       },
       formIsValid() {
@@ -542,26 +536,6 @@
     },
     created() {
       this.$kolibriBranding = branding;
-    },
-    mounted() {
-      /*
-        Chrome has non-standard behavior with auto-filled text fields where
-        the value shows up as an empty string even though there is text in
-        the field:
-          https://bugs.chromium.org/p/chromium/issues/detail?id=669724
-        As super-brittle hack to detect the presence of auto-filled text and
-        work-around it, we look for a change in background color as described
-        here:
-          https://stackoverflow.com/a/35783761
-      */
-      setTimeout(() => {
-        const bgColor = window.getComputedStyle(this.$refs.username.$el.querySelector('input'))
-          .backgroundColor;
-
-        if (bgColor === 'rgb(250, 255, 189)') {
-          this.autoFilledByChromeAndNotEdited = true;
-        }
-      }, 250);
     },
     methods: {
       ...mapActions(['kolibriLogin', 'kolibriLoginWithNewPassword', 'clearLoginError']),
@@ -725,9 +699,7 @@
           this.$refs.password.focus();
         }
       },
-      handlePasswordChanged() {
-        this.autoFilledByChromeAndNotEdited = false;
-      },
+
       suggestionStyle(i) {
         return {
           backgroundColor: this.highlightedIndex === i ? this.$themePalette.grey.v_200 : '',


### PR DESCRIPTION
### Summary
After the latest changes in the Sign In page, an ugly message appears in the browser console:
TypeError: this$1.$refs.username is undefined
![image](https://user-images.githubusercontent.com/1008178/84527837-eac94e80-acde-11ea-8596-4c26fa7f4a03.png)

It was caused by a logic executed after the component is mounted to detect if Chrome had autofilled the password.
However:
1. This was not working if you  have a Chrome theme applied in the browser
2. This is not working anymore as the username input that was used to detect the bg color has been removed from the component

This PR removes all the associated logic to this brittle detection.

### Reviewer guidance
Can we assume removing this detection?

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
