### PR TITLE
Explanation text visible on option checked

### DIFF
--- a/kolibri/locale/ach_UG/LC_MESSAGES/django.po
+++ b/kolibri/locale/ach_UG/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "crwdns276368:0crwdne276368:0"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "crwdns276370:0crwdne276370:0"
-

--- a/kolibri/locale/ar/LC_MESSAGES/django.po
+++ b/kolibri/locale/ar/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "ترخيص مزود معرف الدخول"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "طلب تصريح"
-

--- a/kolibri/locale/bg_BG/LC_MESSAGES/django.po
+++ b/kolibri/locale/bg_BG/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Разрешение от доставчик на OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Заявка за разрешение"
-

--- a/kolibri/locale/bn_BD/LC_MESSAGES/django.po
+++ b/kolibri/locale/bn_BD/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "ওপেনআইডি প্রোভাইডারের অনু�
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "অনুমতির জন্য অনুরোধ"
-

--- a/kolibri/locale/es_419/LC_MESSAGES/django.po
+++ b/kolibri/locale/es_419/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Autorización del proveedor de OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Petición de permiso"
-

--- a/kolibri/locale/es_ES/LC_MESSAGES/django.po
+++ b/kolibri/locale/es_ES/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Autorización del proveedor de OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Petición de permiso"
-

--- a/kolibri/locale/fa/LC_MESSAGES/django.po
+++ b/kolibri/locale/fa/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "مجوز ارائه‌دهنده‌ی شناسه‌ی باز"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "درخواست مجوز"
-

--- a/kolibri/locale/ff_CM/LC_MESSAGES/django.po
+++ b/kolibri/locale/ff_CM/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr ""
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr ""
-

--- a/kolibri/locale/fr_FR/LC_MESSAGES/django.po
+++ b/kolibri/locale/fr_FR/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Autorisation du fournisseur de OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Demande de Permission"
-

--- a/kolibri/locale/gu_IN/LC_MESSAGES/django.po
+++ b/kolibri/locale/gu_IN/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "ઓપન આઈડી પ્રોવાઇડર અધિકૃતત
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "પરવાનગી માટે વિનંતી"
-

--- a/kolibri/locale/hi_IN/LC_MESSAGES/django.po
+++ b/kolibri/locale/hi_IN/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "ओपन आईडी प्रदाता प्राधिकरण
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "अनुमति का अनुरोध करें"
-

--- a/kolibri/locale/it/LC_MESSAGES/django.po
+++ b/kolibri/locale/it/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Autorizzazione provider OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Richiesta di autorizzazione"
-

--- a/kolibri/locale/ko/LC_MESSAGES/django.po
+++ b/kolibri/locale/ko/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Open Id 제공자 권한"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "권한 요청"
-

--- a/kolibri/locale/mr/LC_MESSAGES/django.po
+++ b/kolibri/locale/mr/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "ओपनआयडी प्रदाता अधिकार"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "परवानगीसाठी विनंती"
-

--- a/kolibri/locale/my/LC_MESSAGES/django.po
+++ b/kolibri/locale/my/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "OpenID Provider ခွင့်ပြုခြင်း"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "ခွင့်ပြုချက်အတွက် တောင်းခံခြင်း"
-

--- a/kolibri/locale/nyn/LC_MESSAGES/django.po
+++ b/kolibri/locale/nyn/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Kuvomereza kuti musakatule masamba a webusayiti"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Request for Permission"
-

--- a/kolibri/locale/pt_BR/LC_MESSAGES/django.po
+++ b/kolibri/locale/pt_BR/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Autorização do Provedor OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Pedido de permissão"
-

--- a/kolibri/locale/sw_TZ/LC_MESSAGES/django.po
+++ b/kolibri/locale/sw_TZ/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Idini ya Mtu mwingine wa Kutoa OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Omba Idhini"
-

--- a/kolibri/locale/te/LC_MESSAGES/django.po
+++ b/kolibri/locale/te/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "OpenID ప్రదాత అధికారికం"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "అనుమతి కోసం అభ్యర్థించు"
-

--- a/kolibri/locale/ur_PK/LC_MESSAGES/django.po
+++ b/kolibri/locale/ur_PK/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "اوپن آیڈی فراہم کنندہ کی اجازت"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "اجازت کی درخواست"
-

--- a/kolibri/locale/vi/LC_MESSAGES/django.po
+++ b/kolibri/locale/vi/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Ủy quyền Nhà cung cấp OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Yêu cầu quyền truy cập"
-

--- a/kolibri/locale/yo/LC_MESSAGES/django.po
+++ b/kolibri/locale/yo/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "Ìfúnláṣẹ Olùpèsè OpenID"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "Bèèrè fún Àyè"
-

--- a/kolibri/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/kolibri/locale/zh_Hans/LC_MESSAGES/django.po
@@ -263,4 +263,3 @@ msgstr "OpenID提供方授权"
 #: kolibri/plugins/oidc_provider_plugin/templates/oidc_provider/authorize.html:15
 msgid "Request for Permission"
 msgstr "请求许可"
-

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -51,7 +51,11 @@
         @change="allowOtherBrowsersToConnect = $event"
       >
         <span> {{ $tr('allowExternalConnectionsApp') }}
-          <p v-if="allowOtherBrowsersToConnect">
+          <p
+            v-if="allowOtherBrowsersToConnect"
+            class="description"
+            :style="{ color: $themeTokens.annotation }"
+          >
             {{ $tr('allowExternalConnectionsAppDescription') }}
           </p>
         </span>
@@ -291,6 +295,11 @@
 
   .save-button {
     margin-left: 0;
+  }
+  .description {
+    width: 100%;
+    font-size: 12px;
+    line-height: normal;
   }
 
   .ul-reset {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -51,8 +51,9 @@
         @change="allowOtherBrowsersToConnect = $event"
       >
         <span> {{ $tr('allowExternalConnectionsApp') }}
-          <p>{{ $tr('allowExternalConnectionsAppDescription') }}</p>
-
+          <p v-if="allowOtherBrowsersToConnect">
+            {{ $tr('allowExternalConnectionsAppDescription') }}
+          </p>
         </span>
       </KCheckbox>
       <p>


### PR DESCRIPTION
### Summary
According to final design, the text explaining the consequences of allowing other browsers to connect should appear only when the option is checked. Currently it's always showed.
This PR produces these two different screens:

![image](https://user-images.githubusercontent.com/1008178/84528773-91621f00-ace0-11ea-86c3-bf421a72ad11.png)
and 

![image](https://user-images.githubusercontent.com/1008178/84598728-2134d400-ae6d-11ea-9b0d-ed5afea1ea01.png)


### Reviewer guidance
Do tests pass?
is this correctly aligned to the design?
https://www.figma.com/file/LI2L6gUncmCDDtaDECcbY6/Log-in-updates?node-id=43%3A3

### References
Relates #6955


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
