### PR TITLE
attempt to exclude .po files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-added-large-files
     -   id: debug-statements
     -   id: end-of-file-fixer
-        exclude: '^.+?\.json$'
+        exclude: '^.+?(\.json|\.po)$'
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.3.3
     hooks:


### PR DESCRIPTION


### Summary

recently seeing many failure in 0.14 like this:

```
node-sass@4.14.1 /home/travis/build/learningequality/kolibri/node_modules/node-sass
lint run-test: commands[2] | pre-commit install -f --install-hooks
pre-commit installed at .git/hooks/pre-commit
lint run-test: commands[3] | pre-commit run --all-files
Trim Trailing Whitespace.................................................Passed
Flake8...................................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook
Fixing kolibri/locale/ach_UG/LC_MESSAGES/django.po
Fixing kolibri/locale/fr_FR/LC_MESSAGES/django.po
Fixing kolibri/locale/fa/LC_MESSAGES/django.po
Fixing kolibri/locale/ur_PK/LC_MESSAGES/django.po
Fixing kolibri/locale/vi/LC_MESSAGES/django.po
Fixing kolibri/locale/es_ES/LC_MESSAGES/django.po
Fixing kolibri/locale/sw_TZ/LC_MESSAGES/django.po
Fixing kolibri/locale/te/LC_MESSAGES/django.po
Fixing kolibri/locale/hi_IN/LC_MESSAGES/django.po
Fixing kolibri/locale/it/LC_MESSAGES/django.po
Fixing kolibri/locale/yo/LC_MESSAGES/django.po
Fixing kolibri/locale/zh_Hans/LC_MESSAGES/django.po
Fixing kolibri/locale/bn_BD/LC_MESSAGES/django.po
Fixing kolibri/locale/es_419/LC_MESSAGES/django.po
Fixing kolibri/locale/ff_CM/LC_MESSAGES/django.po
Fixing kolibri/locale/ko/LC_MESSAGES/django.po
Fixing kolibri/locale/gu_IN/LC_MESSAGES/django.po
Fixing kolibri/locale/ar/LC_MESSAGES/django.po
Fixing kolibri/locale/my/LC_MESSAGES/django.po
Fixing kolibri/locale/bg_BG/LC_MESSAGES/django.po
Fixing kolibri/locale/pt_BR/LC_MESSAGES/django.po
Fixing kolibri/locale/nyn/LC_MESSAGES/django.po
Fixing kolibri/locale/mr/LC_MESSAGES/django.po
```

unsure why I cannot reproduce locally

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
