### PR TITLE
Fix the generateuserdata errors in Command Prompt on Windows.

### DIFF
--- a/docs/manual_testing/general_notes/index.rst
+++ b/docs/manual_testing/general_notes/index.rst
@@ -133,24 +133,27 @@ Create 2 facilities, with 2 classes per facility, with 20 learners per class, 2 
 Examples for a fresh Kolibri install (no imported channels)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For a fresh Kolibri installation, use this to automatically create superusers and skip on-boarding.  The super user username is ``superuser`` and password is ``password``.
+For a fresh Kolibri installation, use this to automatically create superusers and skip on-boarding (setup wizard).  The superuser username is ``superuser`` and password is ``password``.
 
 .. code-block:: bash
 
     kolibri manage generateuserdata --no-onboarding
 
-Create 2 facilities, with 2 classes per facility, with 20 learners per class, 2 interactions per learner.
+Create 2 facilities, with 2 classes per facility, with 20 learners per class.
 
 .. code-block:: bash
 
-    kolibri manage generateuserdata --facilities 2 --classes 2 --users 20 --num-content-items 2
+    kolibri manage generateuserdata --facilities 2 --classes 2 --users 20 --no-onboarding
+
 
 Notes
 ~~~~~
 
 1. If there are existing facilities, it will only create the remaining ones.  So if you already have one facility, specifying ``--facilities 2`` will create one more facility and its subsequent sample data.
-1. Use the `--max-channels` option to limit the number of channels for learners to interact with.  This saves a lot of time specially on large data samples.
-1. The ``--no-onboarding`` argument creates a super user for each facility with username ``superuser`` and password ``password``.
+
+2. Use the `--max-channels` option to limit the number of channels for learners to interact with.  This saves a lot of time specially on large data samples.
+
+3. The ``--no-onboarding`` argument creates a super user for each facility with username ``superuser`` and password ``password``.
 
 
 Collecting client and server errors using Sentry


### PR DESCRIPTION
### Summary
This fixes #7077 - it now just uses `print()` when the `--verbosity` argument is greater than zero.  This arg defaults to 1 so it follows [Django's convention](https://docs.djangoproject.com/en/1.11/ref/django-admin/#cmdoption-verbosity).

I have also updated the documentation to fix formatting and correct a wrong example.

Examples:

* `kolibri manage generateuserdata` == shows output
* `kolibri manage generateuserdata --verbosity 0` == will suppress output


### Reviewer guidance

1. Install the Windows installer artifact produced in BuildKite for this PR in a Windows 7 or 10 VM.
1. Run the following commands in Command Prompt
    * `kolibri manage generateuserdata` == shows output
    * `kolibri manage generateuserdata --verbosity 0` == will suppress output


### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
