### PR TITLE
handle numpad enter on Sign in page form

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -466,6 +466,7 @@
           case 'Escape':
             this.showDropdown = false;
             break;
+          case 'NumpadEnter':
           case 'Enter':
             if (this.highlightedIndex < 0) {
               this.showDropdown = false;


### PR DESCRIPTION

### Summary

On an extended keyboard, pressing the numpad 'enter' key wasn't working during sign-in


| before | after |
|--|--|
| ![2020-06-18 15 57 46](https://user-images.githubusercontent.com/2367265/85080274-9cec9480-b17d-11ea-812e-f71b0cdd3f9e.gif) | ![2020-06-18 16 06 23](https://user-images.githubusercontent.com/2367265/85080391-e6d57a80-b17d-11ea-8aa2-7ba93819e4db.gif) |


### Reviewer guidance

make sense?



----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
