### PR TITLE
Don't show the password input if the username is not correctly validated

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -296,7 +296,7 @@
         );
       },
       shouldShowPasswordForm() {
-        return Boolean(this.selectedListUser);
+        return Boolean(this.selectedListUser) && !this.usernameIsInvalid;
       },
       suggestions() {
         // Filter suggestions on the client side so we don't hammer the server

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -390,13 +390,15 @@
         // have a username in our data()
         if (user) {
           this.username = user.username;
-        } else {
+        } else if (this.username !== '') {
           user = this.usersForCurrentFacility.find(u => u.username === this.username) || {
             needs_password: false,
             username: this.username,
             facility: '',
           };
         }
+        if (!user) return;
+
         // If the user is a learner and we don't require passwords sign them in
         if (this.simpleSignIn && user.is_learner) {
           this.signIn();

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -388,16 +388,20 @@
       setSelectedListUser(user) {
         // If we get a user - then use it's username, otherwise, we should already
         // have a username in our data()
+        if (this.usernameIsInvalid) {
+          this.$refs.username.updateText();
+          this.$refs.username.focus();
+          return;
+        }
         if (user) {
           this.username = user.username;
-        } else if (this.username !== '') {
+        } else {
           user = this.usersForCurrentFacility.find(u => u.username === this.username) || {
             needs_password: false,
             username: this.username,
             facility: '',
           };
         }
-        if (!user) return;
 
         // If the user is a learner and we don't require passwords sign them in
         if (this.simpleSignIn && user.is_learner) {


### PR DESCRIPTION
### Summary
Password input text is not shown until the username is validated

### Reviewer guidance
Pressing next without adding an username (or using an invalid username) does not show the password input screen

### References
Closes #7093 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
