### PR TITLE
Cache etags 

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -345,7 +345,7 @@ def cache_no_user_data(view_func):
         setattr(_response, "response", None)
 
         request = args[0]
-        etag = cache.get(request.path)
+        etag = cache.get(CACHE_KEY_TEMPLATE.format(request.path))
 
         # Doing this here - will also be the same in inner_func
         # required to delete the session for this to work as expected

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -329,6 +329,7 @@ def cache_no_user_data(view_func):
     """
 
     CACHE_TIMEOUT = 15
+    CACHE_KEY_TEMPLATE = "SPA_ETAG_CACHE_{}"
     _response = local()
 
     def render_and_cache(response, cache_key):
@@ -353,7 +354,7 @@ def cache_no_user_data(view_func):
         if not etag:
             response = view_func(*args, **kwargs)
             setattr(_response, "response", response)
-            etag = render_and_cache(response, request.path)
+            etag = render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
         return etag
 
     @etag(calculate_spa_etag)
@@ -364,7 +365,7 @@ def cache_no_user_data(view_func):
         if not response:
             response = view_func(*args, **kwargs)
 
-        render_and_cache(response, request.path)
+        render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
         patch_response_headers(response, cache_timeout=CACHE_TIMEOUT)
         response["Vary"] = "accept-encoding, accept"
         return response


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

After further discussion with @rtibbles this PR has changed to be removing the etag decorator we were looking at altogether.

-- below this is the original comment --

Updated the etag generation decorator function so that it also uses the rendered HTML which includes everything in `plugin_data`.

Is there a better or easier way to get `plugin_data` only?

I hate that I call the view_func twice and feel like that could be a problem - I'll come back to it.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Load a page and check the root request URL in your devtools network tab.
- Check its etag 
- Go to the `kolibri_plugin.py` file for the plugin associated with the URL you're testing. Add a key to the `plugin_data`
- Reload the page and see that the same resource's etag has changed
- Reload again and see that it has not changed

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/6785

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
