### PR TITLE
Assessment data is correctly added to the fetch request

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -358,7 +358,7 @@ class ContentNodeViewset(ValuesViewset):
         output = []
 
         for item in items:
-            item["assessmentmetadata"] = assessmentmetadata.get("id")
+            item["assessmentmetadata"] = assessmentmetadata.get(item["id"])
             item["files"] = list(
                 map(lambda x: map_file(x, item), files.get(item["id"], []))
             )


### PR DESCRIPTION
### Summary
api contentnode was not including the assessment metadata in the response object.

### Reviewer guidance
http://localhost:8000/api/content/contentnode/?ids=b5092f8637e64d24a54ad82913ff6409 (replacing the id by any resource existing in your kolibri server) should provide objects including assessement metadata (previously this property returned null)

### References
Fixes #7097 , #7101 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
