### PR TITLE
Forcing GH upload step to use Vader | 0.11 <- 0.10

### DIFF
--- a/.buildkite/build_whl.sh
+++ b/.buildkite/build_whl.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+echo '--- Building environment'
+make dockerenvbuild
+
+echo '--- Building installers'
 make dockerenvdist
 buildkite-agent artifact upload 'dist/*.whl'
 buildkite-agent artifact upload 'dist/*.zip'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,4 @@
 steps:
-  - label: Build the docker environment
-    command: make dockerenvbuild
-
-  - wait
-
   - label: Build the python packages
     command: mkdir -p dist && .buildkite/build_whl.sh && docker container prune -f
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,4 +11,6 @@ steps:
 
   - label: Upload Release Artifacts
     command: .buildkite/setup_and_upload_artifact.sh && docker image prune -f -a
+    agents:
+        vader=true
     if: build.tag != null


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

There are some python compatibility issues between Vader and everyone else. Vader has many versions of the python binaries installed, because it's needed it for cheffing. In the context of a build pipeline, this _should_ be dockerized (to make for easier portability across different builders), but that's not currently the case, rather than adding another dependency to agent builders (the list is already pretty long and scattered).

Doing this as a half step.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

After this is merged, keep an eye on the dummy alpha release I'm going to make as a test.

### References

#7119

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
