### PR TITLE
Using the right data payload with axios and multipart content type

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -93,6 +93,9 @@ const client = options => {
   const headers = { ...(options.headers || {}) };
   if (options.multipart) {
     headers['Content-Type'] = 'multipart/form-data';
+    const fd = new FormData();
+    Object.assign(fd, options.data);
+    options.data = fd;
   }
   return baseClient
     .request({

--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -96,7 +96,6 @@ const client = options => {
     options.transformRequest = function(data) {
       const fd = new FormData();
       Object.keys(data).forEach(item => {
-        console.log(item);
         fd.append(item, data[item]);
       });
       return fd;

--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -93,9 +93,14 @@ const client = options => {
   const headers = { ...(options.headers || {}) };
   if (options.multipart) {
     headers['Content-Type'] = 'multipart/form-data';
-    const fd = new FormData();
-    Object.assign(fd, options.data);
-    options.data = fd;
+    options.transformRequest = function(data) {
+      const fd = new FormData();
+      Object.keys(data).forEach(item => {
+        console.log(item);
+        fd.append(item, data[item]);
+      });
+      return fd;
+    };
   }
   return baseClient
     .request({


### PR DESCRIPTION
### Summary
After the frontend changed Rest by Axios in #6969 , sending multiform content type has stopped working.

This PR creates the right FormData object to use it.


### Reviewer guidance
Test if post works properly when posting binary objects 

### References
Fixes #7156 
Relates #6969 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
