### PR TITLE
 Rollback upload virtualenv to 3.5 | 0.13 <- 0.12

### DIFF
--- a/.buildkite/setup_and_upload_artifact.sh
+++ b/.buildkite/setup_and_upload_artifact.sh
@@ -7,7 +7,7 @@ PIP_PATH="$SCRIPTPATH/env/bin/pip"
 PYTHON_PATH="$SCRIPTPATH/env/bin/python"
 
 echo "Now creating virtualenv..."
-virtualenv -p python3.7 env
+virtualenv -p python3.5 env
 if [ $? -ne 0 ]; then
     echo ".. Abort!  Can't create virtualenv."
     exit 1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Received reports of a failing upload step. Believe the python version in the virtualenv to have been mistakenly updated, rolling back to 3.5.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check git tag to come up after merge to see if fix went through

### References
- #7167 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
