### PR TITLE
Fix bugs in Permissions pages caused by "unique username" assumption

### DIFF
--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -266,7 +266,8 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                     track_progress=True,
                     cancellable=False,
                 ),
-            ]
+            ],
+            any_order=True,
         )
 
     @patch("kolibri.core.tasks.api.validate_and_prepare_peer_sync_job")

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -38,7 +38,7 @@
           <td class="btn-col">
             <KButton
               appearance="flat-button"
-              :text="permissionsButtonText(user.username)"
+              :text="permissionsButtonText(user)"
               style="margin-top: 6px;"
               @click="goToUserPermissionsPage(user.id)"
             />
@@ -54,7 +54,7 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
@@ -79,10 +79,7 @@
       },
     },
     computed: {
-      ...mapGetters(['facilities']),
-      ...mapState({
-        isCurrentUser: state => username => state.core.session.username === username,
-      }),
+      ...mapGetters(['facilities', 'currentUserId']),
       emptyMessage() {
         return this.$tr('noUsersMatching', { searchFilter: this.filterText });
       },
@@ -91,17 +88,20 @@
       },
     },
     methods: {
+      isCurrentUser(user) {
+        return this.currentUserId === user.id;
+      },
       userFacility(facId) {
         return this.facilities.find(fac => fac.id === facId).name || '';
       },
-      fullNameLabel({ username, full_name }) {
-        if (this.isCurrentUser(username)) {
-          return this.$tr('selfUsernameLabel', { full_name });
+      fullNameLabel(user) {
+        if (this.isCurrentUser(user)) {
+          return this.$tr('selfUsernameLabel', { full_name: user.full_name });
         }
-        return full_name;
+        return user.full_name;
       },
-      permissionsButtonText(username) {
-        if (this.isCurrentUser(username)) {
+      permissionsButtonText(user) {
+        if (this.isCurrentUser(user)) {
           return this.$tr('viewPermissions');
         }
         return this.$tr('editPermissions');

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -32,7 +32,7 @@
           </td>
           <td v-if="hasMultipleFacilities">
             <span dir="auto" class="maxwidth">
-              {{ userFacility(user.facility) }}
+              {{ memoizedFacilityName(user.facility) }}
             </span>
           </td>
           <td class="btn-col">
@@ -56,6 +56,7 @@
 
   import { mapGetters } from 'vuex';
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
+  import memoize from 'lodash/memoize';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -86,13 +87,18 @@
       hasMultipleFacilities() {
         return this.facilities.length > 1;
       },
+      // Use a memoized version of the facilityName function to avoid
+      // doing extra traversals of 'facilities' array
+      memoizedFacilityName() {
+        return memoize(this.facilityName);
+      },
     },
     methods: {
+      facilityName(facilityId) {
+        return this.facilities.find(facility => facility.id === facilityId).name || '';
+      },
       isCurrentUser(user) {
         return this.currentUserId === user.id;
-      },
-      userFacility(facId) {
-        return this.facilities.find(fac => fac.id === facId).name || '';
       },
       fullNameLabel(user) {
         if (this.isCurrentUser(user)) {

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -128,17 +128,14 @@
       };
     },
     computed: {
-      ...mapGetters(['facilities']),
+      ...mapGetters(['facilities', 'currentUserId']),
       ...mapState('userPermissions', ['user', 'permissions']),
-      ...mapState({
-        currentUsername: state => state.core.session.username,
-      }),
       // IDEA Make this a core getter? Need audit
       facilityName() {
         return this.facilities.find(facility => facility.id === this.user.facility).name;
       },
       isCurrentUser() {
-        return this.currentUsername === this.user.username;
+        return this.currentUserId === this.user.id;
       },
       superuserDisabled() {
         return this.uiBlocked || this.isCurrentUser;

--- a/kolibri/plugins/facility/assets/src/views/FacilityIndex.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityIndex.vue
@@ -44,8 +44,11 @@
       pageName() {
         return this.$route.name;
       },
+      inAllFacilitiesPage() {
+        return this.pageName === PageNames.ALL_FACILITIES_PAGE;
+      },
       showSubNav() {
-        if (this.pageName === PageNames.ALL_FACILITIES_PAGE) {
+        if (this.inAllFacilitiesPage) {
           return false;
         }
         return this.userIsAuthorized && !this.immersivePageProps.immersivePage;
@@ -83,7 +86,7 @@
             appBarTitle,
           };
         }
-        if (this.userIsMultiFacilityAdmin) {
+        if (this.userIsMultiFacilityAdmin && !this.inAllFacilitiesPage) {
           appBarTitle = this.$tr('facilityLabelWithName', {
             facilityName: this.currentFacilityName,
           });
@@ -100,7 +103,7 @@
           // Superusers can view any facility
           return true;
         } else if (this.isAdmin) {
-          if (this.pageName === PageNames.ALL_FACILITIES_PAGE) {
+          if (this.inAllFacilitiesPage) {
             return false;
           }
           // Admins can only see the facility they belong to


### PR DESCRIPTION
### Summary

1. Fixes bug where two users (w/ same username and different ID) would be marked as "You" and displayed incorrectly on the ManagePermissionsPage (Fixes #7130 )
1. Fixes bug where buttons and checkboxes would be disabled on the UserPermissionsPage if the user being viewed has the same username (but different user ID). Fixes #7159 
1. Adds optimization to ManagePermissionsPage to use a memoized function to display the Facility name on the table, which will reduce computations for large lists of users.
1. Fix bug where the wrong AppBarTitle would appear on Facility > All Facilities Page

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
