### PR TITLE
Include additional pre-aggregated stats in pingback

### DIFF
--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -200,6 +200,7 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
                 "learner_can_login_with_no_password": False,
                 "show_download_button_in_learn": True,
                 "allow_guest_access": True,
+                "registered": False,
             },
             "lc": 20,  # learners_count
             "llc": 20,  # learner_login_count
@@ -232,9 +233,15 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
                     for (gender, _) in demographics.choices
                     if FacilityUser.objects.filter(gender=gender).exists()
                 },
-            },
-            "dsnl": {},
+            },  # demographic_stats_learner
+            "dsnl": {},  # demographic_stats_non_learner
+            "crc": 1,  # class_count
+            "grc": 0,  # group_count
+            "sacnv": 20,  # sess_anon_count_no_visitor_id
+            "uwl": 20,  # users_with_logs
+            "vwl": 0,  # anon_visitors_with_logs
         }
+
         assert actual == expected
 
     def test_regression_4606_no_usersessions(self):
@@ -302,8 +309,11 @@ class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
                     for (gender, _) in demographics.choices
                     if FacilityUser.objects.filter(gender=gender).exists()
                 },
-            },
-            "dsnl": {},
+            },  # demographic_stats_learner
+            "dsnl": {},  # demographic_stats_non_learner
+            "sacnv": 20,  # sess_anon_count_no_visitor_id
+            "uwl": 20,  # users_with_logs
+            "vwl": 0,  # anon_visitors_with_logs
         }
         assert actual == expected
 


### PR DESCRIPTION
### Summary

Include additional statistics requested for the 0.14 telemetry pingback.


### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
