### PR TITLE
Facility command and task improvements

### DIFF
--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -18,9 +18,9 @@ from kolibri.core.analytics.models import PingbackNotificationDismissed
 from kolibri.core.auth.management.utils import DisablePostDeleteSignal
 from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.models import AdHocGroup
-from kolibri.core.auth.models import cache
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import dataset_cache
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
@@ -205,7 +205,7 @@ class Command(AsyncCommand):
                 count, stats = delete_group.delete(update_progress)
                 total_deleted += count
                 # clear related cache
-                cache.clear()
+                dataset_cache.clear()
 
             # if count doesn't match, something doesn't seem right
             if total_count != total_deleted:

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -19,6 +19,7 @@ from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.constants.morango_sync import State
 from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.management.utils import run_once
+from kolibri.core.auth.models import dataset_cache
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import db_task_write_lock
 from kolibri.utils import conf
@@ -102,6 +103,8 @@ class Command(AsyncCommand):
         # call this in case user directly syncs without migrating database
         if not ScopeDefinition.objects.filter():
             call_command("loaddata", "scopedefinitions")
+
+        dataset_cache.clear()
 
         # try to connect to server
         controller = MorangoProfileController(PROFILE_FACILITY_DATA)
@@ -386,5 +389,6 @@ class Command(AsyncCommand):
         if noninteractive or tracker.progressbar is None:
             signal_group.started.connect(started)
 
+        signal_group.started.connect(dataset_cache.clear)
         signal_group.started.connect(handler)
         signal_group.completed.connect(handler)

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -377,7 +377,10 @@ class Command(AsyncCommand):
         tracker = self.start_progress(total=2)
 
         def started(transfer_session):
-            if transfer_session.push == is_push:
+            dataset_cache.clear()
+            if transfer_session.push == is_push and (
+                noninteractive or tracker.progressbar is None
+            ):
                 logger.info(message)
 
         def handler(transfer_session):
@@ -389,6 +392,6 @@ class Command(AsyncCommand):
         if noninteractive or tracker.progressbar is None:
             signal_group.started.connect(started)
 
-        signal_group.started.connect(dataset_cache.clear)
+        signal_group.started.connect(started)
         signal_group.started.connect(handler)
         signal_group.completed.connect(handler)

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -40,7 +40,7 @@ class DisablePostDeleteSignal(object):
 
 def _interactive_client_facility_selection():
     facilities = Facility.objects.all().order_by("name")
-    message = "Please choose a facility to sync:\n"
+    message = "Please choose a facility:\n"
     for idx, facility in enumerate(facilities):
         message += "{}. {}\n".format(idx + 1, facility.name)
     idx = input(message)

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -75,9 +75,11 @@ from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import set_device_settings
 from kolibri.core.errors import KolibriValidationError
 from kolibri.core.fields import DateTimeTzField
+from kolibri.core.utils.cache import NamespacedCacheProxy
 from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
+dataset_cache = NamespacedCacheProxy(cache, "dataset")
 
 
 def _has_permissions_class(obj):
@@ -186,13 +188,13 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         key = "{id}_{db_table}_dataset".format(
             id=getattr(self, field.attname), db_table=field.related_model._meta.db_table
         )
-        dataset_id = cache.get(key)
+        dataset_id = dataset_cache.get(key)
         if dataset_id is None:
             try:
                 dataset_id = getattr(self, related_obj_name).dataset_id
             except ObjectDoesNotExist as e:
                 raise ValidationError(e)
-            cache.set(key, dataset_id, 60 * 10)
+            dataset_cache.set(key, dataset_id, 60 * 10)
         return dataset_id
 
     def calculate_source_id(self):

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -989,7 +989,7 @@ def validate_prepare_sync_job(request, **kwargs):
 
     job_data = dict(
         facility=facility_id,
-        chunk_size=50,
+        chunk_size=100,
         noninteractive=True,
         extra_metadata=dict(),
         track_progress=True,

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -989,11 +989,11 @@ def validate_prepare_sync_job(request, **kwargs):
 
     job_data = dict(
         facility=facility_id,
-        chunk_size=100,
+        chunk_size=200,
         noninteractive=True,
         extra_metadata=dict(),
         track_progress=True,
-        cancellable=True,
+        cancellable=False,
     )
 
     job_data.update(kwargs)

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -173,7 +173,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(this_is_extra=True,),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
@@ -190,7 +190,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             call_command,
             "sync",
             facility=self.facility.id,
-            chunk_size=100,
+            chunk_size=200,
             noninteractive=True,
             extra_metadata=dict(
                 facility=self.facility.id,
@@ -202,7 +202,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                 type="SYNCDATAPORTAL",
             ),
             track_progress=True,
-            cancellable=True,
+            cancellable=False,
         )
 
     def test_startdataportalbulksync(self, facility_queue):
@@ -217,7 +217,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(this_is_extra=True,),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
@@ -234,7 +234,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                     call_command,
                     "sync",
                     facility=facility2.id,
-                    chunk_size=100,
+                    chunk_size=200,
                     noninteractive=True,
                     extra_metadata=dict(
                         facility=facility2.id,
@@ -246,13 +246,13 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                         type="SYNCDATAPORTAL",
                     ),
                     track_progress=True,
-                    cancellable=True,
+                    cancellable=False,
                 ),
                 call(
                     call_command,
                     "sync",
                     facility=facility3.id,
-                    chunk_size=100,
+                    chunk_size=200,
                     noninteractive=True,
                     extra_metadata=dict(
                         facility=facility3.id,
@@ -264,7 +264,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                         type="SYNCDATAPORTAL",
                     ),
                     track_progress=True,
-                    cancellable=True,
+                    cancellable=False,
                 ),
             ]
         )
@@ -296,11 +296,11 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             baseurl="https://some.server.test/",
             facility=self.facility.id,
             no_push=True,
-            chunk_size=100,
+            chunk_size=200,
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
-            cancellable=True,
+            cancellable=False,
         )
         validate_and_prepare_peer_sync_job.return_value = prepared_data.copy()
 
@@ -309,7 +309,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(this_is_extra=True,),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
@@ -354,11 +354,11 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         prepared_data = dict(
             baseurl="https://some.server.test/",
             facility=self.facility.id,
-            chunk_size=100,
+            chunk_size=200,
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
-            cancellable=True,
+            cancellable=False,
         )
         validate_and_prepare_peer_sync_job.return_value = prepared_data.copy()
 
@@ -367,7 +367,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(this_is_extra=True,),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
@@ -494,10 +494,10 @@ class FacilityTaskHelperTestCase(TestCase):
 
         expected = dict(
             facility=123,
-            chunk_size=100,
+            chunk_size=200,
             noninteractive=True,
             track_progress=True,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(type="test"),
         )
         actual = validate_prepare_sync_job(req, extra_metadata=dict(type="test"))
@@ -550,10 +550,10 @@ class FacilityTaskHelperTestCase(TestCase):
         expected = dict(
             baseurl="https://some.server.test/",
             facility=123,
-            chunk_size=100,
+            chunk_size=200,
             noninteractive=True,
             track_progress=True,
-            cancellable=True,
+            cancellable=False,
             extra_metadata=dict(type="test"),
         )
         actual = validate_and_prepare_peer_sync_job(

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -190,7 +190,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             call_command,
             "sync",
             facility=self.facility.id,
-            chunk_size=50,
+            chunk_size=100,
             noninteractive=True,
             extra_metadata=dict(
                 facility=self.facility.id,
@@ -234,7 +234,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                     call_command,
                     "sync",
                     facility=facility2.id,
-                    chunk_size=50,
+                    chunk_size=100,
                     noninteractive=True,
                     extra_metadata=dict(
                         facility=facility2.id,
@@ -252,7 +252,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                     call_command,
                     "sync",
                     facility=facility3.id,
-                    chunk_size=50,
+                    chunk_size=100,
                     noninteractive=True,
                     extra_metadata=dict(
                         facility=facility3.id,
@@ -296,7 +296,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             baseurl="https://some.server.test/",
             facility=self.facility.id,
             no_push=True,
-            chunk_size=50,
+            chunk_size=100,
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
@@ -354,7 +354,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         prepared_data = dict(
             baseurl="https://some.server.test/",
             facility=self.facility.id,
-            chunk_size=50,
+            chunk_size=100,
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
@@ -494,7 +494,7 @@ class FacilityTaskHelperTestCase(TestCase):
 
         expected = dict(
             facility=123,
-            chunk_size=50,
+            chunk_size=100,
             noninteractive=True,
             track_progress=True,
             cancellable=True,
@@ -550,7 +550,7 @@ class FacilityTaskHelperTestCase(TestCase):
         expected = dict(
             baseurl="https://some.server.test/",
             facility=123,
-            chunk_size=50,
+            chunk_size=100,
             noninteractive=True,
             track_progress=True,
             cancellable=True,

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -5,7 +5,6 @@ import uuid
 
 from kolibri.core.tasks import compat
 from kolibri.core.utils.cache import DiskCacheRLock
-from kolibri.core.utils.cache import process_cache
 
 
 # An object on which to store data about the current job
@@ -121,4 +120,4 @@ class InfiniteLoopThread(compat.Thread):
         self.stop()
 
 
-db_task_write_lock = DiskCacheRLock(process_cache, "db_task_write_lock")
+db_task_write_lock = DiskCacheRLock("db_task_write_lock")

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -1,15 +1,10 @@
 import importlib
 import logging
-import os
 import time
 import uuid
 
-try:
-    from thread import get_ident
-except ImportError:
-    from threading import get_ident
-
 from kolibri.core.tasks import compat
+from kolibri.core.utils.cache import DiskCacheRLock
 from kolibri.core.utils.cache import process_cache
 
 
@@ -124,52 +119,6 @@ class InfiniteLoopThread(compat.Thread):
 
     def shutdown(self):
         self.stop()
-
-
-class DiskCacheRLock(object):
-    """
-    Vendored from
-    https://github.com/grantjenks/python-diskcache/blob/2d1f43ea2be4c82a430d245de6260c3e18059ba1/diskcache/recipes.py
-    """
-
-    def __init__(self, cache, key, expire=None):
-        self._cache = cache
-        self._key = key
-        self._expire = expire
-
-    def acquire(self):
-        "Acquire lock by incrementing count using spin-lock algorithm."
-        pid = os.getpid()
-        tid = get_ident()
-        pid_tid = "{}-{}".format(pid, tid)
-
-        while True:
-            value, count = self._cache.get(self._key, (None, 0))
-            if pid_tid == value or count == 0:
-                self._cache.set(self._key, (pid_tid, count + 1), self._expire)
-                return
-            time.sleep(0.001)
-
-    def release(self):
-        "Release lock by decrementing count."
-        pid = os.getpid()
-        tid = get_ident()
-        pid_tid = "{}-{}".format(pid, tid)
-
-        value, count = self._cache.get(self._key, default=(None, 0))
-        is_owned = pid_tid == value and count > 0
-        assert is_owned, "cannot release un-acquired lock"
-        self._cache.set(self._key, (value, count - 1), self._expire)
-
-        # RLOCK leaves the db connection open after releasing the lock
-        # Let's ensure it's correctly closed
-        self._cache.close()
-
-    def __enter__(self):
-        self.acquire()
-
-    def __exit__(self, *exc_info):
-        self.release()
 
 
 db_task_write_lock = DiskCacheRLock(process_cache, "db_task_write_lock")

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -1,0 +1,66 @@
+import mock
+from django.core.cache.backends.base import BaseCache
+from django.test import TestCase
+
+from kolibri.core.utils.cache import NamespacedCacheProxy
+
+
+class NamespacedCacheProxyTestCase(TestCase):
+    def setUp(self):
+        self.cache = mock.Mock(spec=BaseCache)
+        self.proxy = NamespacedCacheProxy(self.cache, "")
+
+    def test_get_keys(self):
+        self.cache.get.return_value = ["abc"]
+        self.assertEqual(["abc"], self.proxy._get_keys())
+        self.cache.get.assert_called_with("__KEYS__", default=[])
+
+    def test_set_keys(self):
+        self.proxy._set_keys(["abc"])
+        self.cache.set.assert_called_with("__KEYS__", ["abc"])
+
+    def test_add(self):
+        self.cache.add.return_value = True
+        self.cache.get.return_value = []
+
+        result = self.proxy.add("abc", 123, "normal arg", timeout=456)
+        self.assertTrue(result)
+
+        self.cache.add.assert_called_with("abc", 123, "normal arg", timeout=456)
+        self.cache.set.assert_called_with("__KEYS__", ["abc"])
+
+    def test_add__failed(self):
+        self.cache.add.return_value = False
+        self.cache.get.return_value = []
+
+        result = self.proxy.add("abc", 123)
+        self.assertFalse(result)
+
+        self.cache.add.assert_called_with("abc", 123)
+        self.cache.set.assert_not_called()
+
+    def test_set(self):
+        self.cache.get.return_value = []
+
+        self.proxy.set("abc", 123, "normal arg", timeout=456)
+
+        self.cache.set.assert_any_call("__KEYS__", ["abc"])
+        self.cache.set.assert_any_call("abc", 123, "normal arg", timeout=456)
+
+    def test_delete(self):
+        self.cache.get.return_value = ["abc"]
+
+        self.proxy.delete("abc", 123, "normal arg", extra=456)
+
+        self.cache.set.assert_called_with("__KEYS__", [])
+        self.cache.delete.assert_called_with("abc", 123, "normal arg", extra=456)
+
+    def test_clear(self):
+        self.cache.get.return_value = ["abc", "def", "ghi"]
+
+        self.proxy.clear()
+
+        self.cache.set.assert_called_with("__KEYS__", [])
+        self.cache.delete.assert_any_call("abc")
+        self.cache.delete.assert_any_call("def")
+        self.cache.delete.assert_any_call("ghi")

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -8,16 +8,16 @@ from kolibri.core.utils.cache import NamespacedCacheProxy
 class NamespacedCacheProxyTestCase(TestCase):
     def setUp(self):
         self.cache = mock.Mock(spec=BaseCache)
-        self.proxy = NamespacedCacheProxy(self.cache, "")
+        self.proxy = NamespacedCacheProxy(self.cache, "test")
 
     def test_get_keys(self):
         self.cache.get.return_value = ["abc"]
         self.assertEqual(["abc"], self.proxy._get_keys())
-        self.cache.get.assert_called_with("__KEYS__", default=[])
+        self.cache.get.assert_called_with("test:1:__KEYS__", default=[])
 
     def test_set_keys(self):
         self.proxy._set_keys(["abc"])
-        self.cache.set.assert_called_with("__KEYS__", ["abc"])
+        self.cache.set.assert_called_with("test:1:__KEYS__", ["abc"])
 
     def test_add(self):
         self.cache.add.return_value = True
@@ -26,8 +26,8 @@ class NamespacedCacheProxyTestCase(TestCase):
         result = self.proxy.add("abc", 123, "normal arg", timeout=456)
         self.assertTrue(result)
 
-        self.cache.add.assert_called_with("abc", 123, "normal arg", timeout=456)
-        self.cache.set.assert_called_with("__KEYS__", ["abc"])
+        self.cache.add.assert_called_with("test:1:abc", 123, "normal arg", timeout=456)
+        self.cache.set.assert_called_with("test:1:__KEYS__", ["abc"])
 
     def test_add__failed(self):
         self.cache.add.return_value = False
@@ -36,7 +36,7 @@ class NamespacedCacheProxyTestCase(TestCase):
         result = self.proxy.add("abc", 123)
         self.assertFalse(result)
 
-        self.cache.add.assert_called_with("abc", 123)
+        self.cache.add.assert_called_with("test:1:abc", 123)
         self.cache.set.assert_not_called()
 
     def test_set(self):
@@ -44,23 +44,23 @@ class NamespacedCacheProxyTestCase(TestCase):
 
         self.proxy.set("abc", 123, "normal arg", timeout=456)
 
-        self.cache.set.assert_any_call("__KEYS__", ["abc"])
-        self.cache.set.assert_any_call("abc", 123, "normal arg", timeout=456)
+        self.cache.set.assert_any_call("test:1:__KEYS__", ["abc"])
+        self.cache.set.assert_any_call("test:1:abc", 123, "normal arg", timeout=456)
 
     def test_delete(self):
         self.cache.get.return_value = ["abc"]
 
         self.proxy.delete("abc", 123, "normal arg", extra=456)
 
-        self.cache.set.assert_called_with("__KEYS__", [])
-        self.cache.delete.assert_called_with("abc", 123, "normal arg", extra=456)
+        self.cache.set.assert_called_with("test:1:__KEYS__", [])
+        self.cache.delete.assert_called_with("test:1:abc", 123, "normal arg", extra=456)
 
     def test_clear(self):
         self.cache.get.return_value = ["abc", "def", "ghi"]
 
         self.proxy.clear()
 
-        self.cache.set.assert_called_with("__KEYS__", [])
-        self.cache.delete.assert_any_call("abc")
-        self.cache.delete.assert_any_call("def")
-        self.cache.delete.assert_any_call("ghi")
+        self.cache.set.assert_called_with("test:1:__KEYS__", [])
+        self.cache.delete.assert_any_call("test:1:abc")
+        self.cache.delete.assert_any_call("test:1:def")
+        self.cache.delete.assert_any_call("test:1:ghi")

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -28,8 +28,8 @@ class DiskCacheRLock(object):
     https://github.com/grantjenks/python-diskcache/blob/2d1f43ea2be4c82a430d245de6260c3e18059ba1/diskcache/recipes.py
     """
 
-    def __init__(self, cache, key, expire=None):
-        self._cache = cache
+    def __init__(self, key, expire=None):
+        self._cache = process_cache
         self._key = key
         self._expire = expire
 
@@ -82,9 +82,7 @@ class NamespacedCacheProxy(BaseCache):
         params.update(KEY_PREFIX=namespace)
         super(NamespacedCacheProxy, self).__init__(params)
         self.cache = cache
-        self._lock = DiskCacheRLock(
-            process_cache, "namespaced_cache_{}".format(namespace)
-        )
+        self._lock = DiskCacheRLock("namespaced_cache_{}".format(namespace))
 
     def _get_keys(self):
         """

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -1,6 +1,8 @@
 from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
+from django.core.cache.backends.base import BaseCache
 from django.utils.functional import SimpleLazyObject
+from django.utils.synch import RWLock
 
 
 def __get_process_cache():
@@ -11,3 +13,85 @@ def __get_process_cache():
 
 
 process_cache = SimpleLazyObject(__get_process_cache)
+_namespace_locks = {}
+
+
+class NamespacedCacheProxy(BaseCache):
+    """
+    Namespaces keys and retains a record of inserted keys for easy clearing of
+    all namespaced keys in the cache
+    """
+
+    def __init__(self, cache, namespace, **params):
+        """
+        :type cache: BaseCache
+        :type namespace: str
+        """
+        params.update(KEY_PREFIX=namespace)
+        super(NamespacedCacheProxy, self).__init__(params)
+        self.cache = cache
+        self._lock = _namespace_locks.setdefault(namespace, RWLock())
+
+    def _get_keys(self):
+        """
+        :rtype: list
+        """
+        return self.cache.get("__KEYS__", default=[])
+
+    def _set_keys(self, keys):
+        """
+        :type keys: list
+        """
+        self.cache.set("__KEYS__", keys)
+
+    def add(self, key, *args, **kwargs):
+        """
+        :type key: str
+        :rtype: bool
+        """
+        with self._lock.writer():
+            keys = self._get_keys()
+            if key not in keys:
+                keys.append(key)
+            result = self.cache.add(key, *args, **kwargs)
+            if result:
+                self._set_keys(keys)
+
+        return result
+
+    def get(self, key, *args, **kwargs):
+        """
+        :type key: str
+        :rtype: any
+        """
+        with self._lock.reader():
+            return self.cache.get(key, *args, **kwargs)
+
+    def set(self, key, *args, **kwargs):
+        """
+        :type key: str
+        """
+        with self._lock.writer():
+            keys = self._get_keys()
+            if key not in keys:
+                keys.append(key)
+            self.cache.set(key, *args, **kwargs)
+            self._set_keys(keys)
+
+    def delete(self, key, *args, **kwargs):
+        """
+        :type key: str
+        """
+        with self._lock.writer():
+            keys = self._get_keys()
+            self.cache.delete(key, *args, **kwargs)
+            self._set_keys([cached_key for cached_key in keys if cached_key != key])
+
+    def clear(self):
+        """
+        Clears only the cached keys in this namespace
+        """
+        with self._lock.writer():
+            for key in self._get_keys():
+                self.cache.delete(key)
+            self._set_keys([])

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -36,13 +36,15 @@ class NamespacedCacheProxy(BaseCache):
         """
         :rtype: list
         """
-        return self.cache.get("__KEYS__", default=[])
+        key = self.make_key("__KEYS__")
+        return self.cache.get(key, default=[])
 
     def _set_keys(self, keys):
         """
         :type keys: list
         """
-        self.cache.set("__KEYS__", keys)
+        key = self.make_key("__KEYS__")
+        self.cache.set(key, keys)
 
     def add(self, key, *args, **kwargs):
         """
@@ -53,7 +55,7 @@ class NamespacedCacheProxy(BaseCache):
             keys = self._get_keys()
             if key not in keys:
                 keys.append(key)
-            result = self.cache.add(key, *args, **kwargs)
+            result = self.cache.add(self.make_key(key), *args, **kwargs)
             if result:
                 self._set_keys(keys)
 
@@ -65,7 +67,7 @@ class NamespacedCacheProxy(BaseCache):
         :rtype: any
         """
         with self._lock.reader():
-            return self.cache.get(key, *args, **kwargs)
+            return self.cache.get(self.make_key(key), *args, **kwargs)
 
     def set(self, key, *args, **kwargs):
         """
@@ -75,7 +77,7 @@ class NamespacedCacheProxy(BaseCache):
             keys = self._get_keys()
             if key not in keys:
                 keys.append(key)
-            self.cache.set(key, *args, **kwargs)
+            self.cache.set(self.make_key(key), *args, **kwargs)
             self._set_keys(keys)
 
     def delete(self, key, *args, **kwargs):
@@ -84,7 +86,7 @@ class NamespacedCacheProxy(BaseCache):
         """
         with self._lock.writer():
             keys = self._get_keys()
-            self.cache.delete(key, *args, **kwargs)
+            self.cache.delete(self.make_key(key), *args, **kwargs)
             self._set_keys([cached_key for cached_key in keys if cached_key != key])
 
     def clear(self):
@@ -93,5 +95,5 @@ class NamespacedCacheProxy(BaseCache):
         """
         with self._lock.writer():
             for key in self._get_keys():
-                self.cache.delete(key)
+                self.cache.delete(self.make_key(key))
             self._set_keys([])

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue
@@ -21,11 +21,20 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import {
+    SyncTaskStatuses,
     syncFacilityTaskDisplayInfo,
     removeFacilityTaskDisplayInfo,
     importFacilityTaskDisplayInfo,
   } from '../syncTaskUtils';
   import TaskPanel from './TaskPanel';
+
+  const indeterminateSyncStatuses = [
+    SyncTaskStatuses.SESSION_CREATION,
+    SyncTaskStatuses.LOCAL_QUEUING,
+    SyncTaskStatuses.LOCAL_DEQUEUING,
+    SyncTaskStatuses.REMOTE_QUEUING,
+    SyncTaskStatuses.REMOTE_DEQUEUING,
+  ];
 
   export default {
     name: 'FacilityTaskPanel',
@@ -69,6 +78,11 @@
         return {};
       },
       loaderType() {
+        const { sync_state = '' } = this.task;
+        if (indeterminateSyncStatuses.find(s => s === sync_state)) {
+          return 'indeterminate';
+        }
+
         return 'determinate';
       },
       statusMsg() {

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -3,7 +3,7 @@ import taskStrings from 'kolibri.coreVue.mixins.commonTaskStrings';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
 import { taskIsClearable, TaskStatuses } from '../constants';
 
-const SyncTaskStatuses = {
+export const SyncTaskStatuses = {
   SESSION_CREATION: 'SESSION_CREATION',
   REMOTE_QUEUING: 'REMOTE_QUEUING',
   PULLING: 'PULLING',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.0
+morango==0.5.1
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Adds new `NamespacedCacheProxy` to enable efficient clearing of cache keys related to Facility dataset data
- Clears namespaced dataset cache after deleting a facility and before syncing
- Updates the default chunk size for facility tasks to be `200` and makes them not cancellable
- Updates `sync` command to not aggregate progress tracking total
- Updates frontend to make progress indeterminate for certain facility task stages
- Updates `morango` to `0.5.1` which has [deserialization improvements](https://github.com/learningequality/morango/pull/84)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- From the CLI:
  1) Set up another Kolibri with some _real_ facility data
  2) On a second Kolibri instance, with fresh database, issue the `kolibri manage sync` command pulling from the first
  3) Verify facility data in Kolibri
  4) On the second instance, issue the `kolibri manage deletefacility` command deleting the facility
  5) On a second instance, issue the `kolibri manage sync` command pulling again to pull the same facility
  6) No warnings or errors should occur
- From the frontend:
  1) Initiate a sync with the Kolibri bet server
  2) Verify all facility import/sync tasks show indeterminate progress when not sending or receiving data

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/morango/pull/84
https://github.com/learningequality/kolibri/issues/7127

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
