### PR TITLE
pin to tagged design system

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -15,7 +15,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.0-beta1",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.0-beta2",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -15,7 +15,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#develop",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.0-beta1",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8466,9 +8466,9 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#develop":
+"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.0-beta1":
   version "0.2.0"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/7d9829c7456819e6aa1e31f9ba939d1a5634d3d9"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/1698dc2178875dd552f42b5f374a6767f9d96b36"
   dependencies:
     "@babel/core" "^7.9.6"
     "@babel/preset-env" "^7.9.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8466,9 +8466,9 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.0-beta1":
+"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.0-beta2":
   version "0.2.0"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/1698dc2178875dd552f42b5f374a6767f9d96b36"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/6e2fb9898a63a0c37199faf37bf5a33c856ce474"
   dependencies:
     "@babel/core" "^7.9.6"
     "@babel/preset-env" "^7.9.6"


### PR DESCRIPTION
### Summary

based on investigation from @MisRob in https://github.com/learningequality/kolibri-design-system/pull/38 I believe that it's a bit problematic pointing at the `develop` branch of design system and expecting updates to be made.

Instead, I've moved forward with updating our design system branching:

* removed the `master` branch
* pointed the default netlify deployment at `develop` (https://kolibri-design-system.netlify.app/)
* created a new release branch, [`v0.2.x`](https://github.com/learningequality/kolibri-design-system/tree/v0.2.x)
* created a new pre-release, [`v0.2.0-beta2`](https://github.com/learningequality/kolibri-design-system/releases/tag/v0.2.0-beta2)

This PR points Kolibri at `v0.2.0-beta2`

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
