### PR TITLE
add prop to AuthBase to hide the normal create account button

### DIFF
--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -68,7 +68,7 @@
 
             <slot></slot>
 
-            <p class="create">
+            <p v-if="!hideCreateAccount" class="create">
               <KRouterLink
                 v-if="canSignUp"
                 :text="$tr('createAccountAction')"
@@ -160,6 +160,13 @@
     name: 'AuthBase',
     components: { CoreLogo, LanguageSwitcherFooter, PrivacyInfoModal },
     mixins: [commonCoreStrings],
+    props: {
+      hideCreateAccount: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+    },
     data() {
       return {
         privacyModalVisible: false,

--- a/kolibri/plugins/user/assets/src/views/AuthSelect.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthSelect.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <AuthBase>
+  <AuthBase :hideCreateAccount="true">
     <div class="auth-select">
       <div class="sign-up-prompt" style="margin-bottom: 24px;">
         <div>{{ $tr("newUserPrompt") }}</div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes: https://github.com/learningequality/kolibri/issues/7174

Adds prop to AuthBase to allow hiding of the "Create Account" button

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check out that issue and you should see the "Expected" part of the issue.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/7174

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
