### PR TITLE
make staticdeps run on systems where python is 3, and 2.7 is availabl…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,6 +22,7 @@ Please feel free to add your name to this list if you make a PR
 * Chao-Wen Tan (chaowentan)
 * Christian Memije (christianmemije)
 * Cyril Pauya (cpauya)
+* Jigish Gohil (cyberorg)
 * David Hu (divad12)
 * Derek Lobo (dlobo)
 * David Cañas (DXCanas)

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ clean-staticdeps:
 	git checkout -- kolibri/dist # restore __init__.py
 
 staticdeps: clean-staticdeps
-	test "${SKIP_PY_CHECK}" = "1" || python --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
+	test "${SKIP_PY_CHECK}" = "1" || python2 --version 2>&1 | grep -q 2.7 || ( echo "Only intended to run on Python 2.7" && exit 1 )
 	pip2 install -t kolibri/dist -r "requirements.txt"
 	rm -rf kolibri/dist/*.dist-info  # pip installs from PyPI will complain if we have more than one dist-info directory.
 	rm -rf kolibri/dist/*.egg-info
@@ -142,7 +142,7 @@ staticdeps: clean-staticdeps
 	# Remove unnecessary python2-syntax'ed file
 	# https://github.com/learningequality/kolibri/issues/3152
 	rm -f kolibri/dist/kolibri_exercise_perseus_plugin/static/mathjax/kathjax.py
-	python build_tools/py2only.py # move `future` and `futures` packages to `kolibri/dist/py2only`
+	python2 build_tools/py2only.py # move `future` and `futures` packages to `kolibri/dist/py2only`
 	make test-namespaced-packages
 
 staticdeps-cext:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
python is available as python2

make dist fails as it fails to run staticdeps on Ubuntu 20.04.
python build_tools/py2only.py puts just the concurrent folder in py2only, running python2 build_tools/py2only.py completes the step successfully.
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
On Ubuntu 20.04 or any distro where python 2.7 is available as /usr/bin/python2 
git pull the kolibri repository
Follow https://kolibri-dev.readthedocs.io/en/develop/getting_started.html to set up the build environment
Run make dist

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
