### PR TITLE
Communicate that 404 is an expected response when requesting /device_channel

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -163,7 +163,16 @@ export function showSelectContentPage(store, params) {
       store.commit('manageContent/REMOVE_FROM_CHANNEL_LIST', channel.id);
       store.commit('manageContent/ADD_TO_CHANNEL_LIST', channel);
     })
-    .catch(() => {});
+    .catch(error => {
+      // This is an expected scenario because it's possible that there
+      // are no data for this channel on a device yet (download channel
+      // metadata task will be triggered later for this situation)
+      if (error.response && error.response.status === 404) {
+        console.log(
+          `^^^ 404 (Not Found) error returned while requesting "${error.response.config.url}..." is an expected response.`
+        );
+      }
+    });
 
   if (transferType === TransferTypes.LOCALIMPORT) {
     selectedDrivePromise = getSelectedDrive(store, drive_id);


### PR DESCRIPTION
### Summary

`/device/api/device_channel/<channel_id>/` request can return `404` when channel is not on device yet and there's no need to be concerned about it. Though it's confusing and people repeatedly debug and report it. @indirectlylit proposed to add some message to logging to clarify it so here it is:

![Selection_001](https://user-images.githubusercontent.com/13509191/85871576-e3ba3a00-b7ce-11ea-8bab-adf444dc01e9.png)

### Reviewer guidance

1. Remove _~/.kolibri_
2. Navigate to [import resources selection](http://127.0.0.1:8000/en/device/#/content/channels)
3. Open your browser console
4. Choose a channel and click _SELECT RESOURCES_ button
5. Check the message in the console

### References

#5343
#7046

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
