### PR TITLE
Delay setting default "NOT_SPECIFIED" password for learners and other Facility page bug fixes

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -6,7 +6,7 @@ import { filterAndSortUsers } from '../../userSearchUtils';
 
 export function showClassEditPage(store, classId) {
   store.dispatch('preparePage');
-  const facilityId = store.getters.currentFacilityId;
+  const facilityId = store.getters.activeFacilityId;
   const promises = [
     FacilityUserResource.fetchCollection({ getParams: { member_of: classId }, force: true }),
     ClassroomResource.fetchModel({ id: classId, force: true }),

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <KPageContainer class="narrow-container">
+  <KPageContainer v-if="!loading" class="narrow-container">
 
     <form class="form" @submit.prevent="submitForm">
       <h1>
@@ -146,6 +146,7 @@
         gender: NOT_SPECIFIED,
         birthYear: NOT_SPECIFIED,
         idNumber: '',
+        loading: true,
         kind: {
           label: this.coreString('learnerLabel'),
           value: UserKinds.LEARNER,
@@ -154,12 +155,17 @@
         busy: false,
         formSubmitted: false,
         caughtErrors: [],
-        showPasswordInput: true,
       };
     },
     computed: {
       ...mapGetters(['currentFacilityId', 'facilityConfig']),
       ...mapState('userManagement', ['facilityUsers']),
+      showPasswordInput() {
+        if (this.facilityConfig.learner_can_login_with_no_password) {
+          return this.kind.value !== UserKinds.LEARNER;
+        }
+        return true;
+      },
       newUserRole() {
         if (this.coachIsSelected) {
           return this.classCoachIsSelected ? UserKinds.ASSIGNABLE_COACH : UserKinds.COACH;
@@ -190,29 +196,14 @@
         ];
       },
     },
-    watch: {
-      kind(val) {
-        this.showPasswordInput =
-          val.value !== UserKinds.LEARNER ||
-          !this.facilityConfig.learner_can_login_with_no_password;
-        this.updatePasswordValues();
-      },
-    },
-    mounted() {
-      this.$store.dispatch('notLoading');
+    beforeMount() {
       this.getFacilityConfig(this.currentFacilityId).then(() => {
-        this.showPasswordInput = !this.facilityConfig.learner_can_login_with_no_password;
-        this.updatePasswordValues();
+        this.$store.dispatch('notLoading');
+        this.loading = false;
       });
     },
     methods: {
       ...mapActions(['getFacilityConfig']),
-      updatePasswordValues() {
-        if (!this.showPasswordInput) {
-          this.passwordValid = true;
-          if (this.password === '') this.password = 'NOT_SPECIFIED';
-        }
-      },
       goToUserManagementPage(onComplete) {
         this.$router.push(this.$store.getters.facilityPageLinks.UserPage, onComplete);
       },
@@ -223,8 +214,12 @@
       },
       submitForm() {
         this.formSubmitted = true;
+        let password = this.password;
         if (!this.formIsValid) {
           return this.focusOnInvalidField();
+        }
+        if (!this.showPasswordInput) {
+          password = 'NOT_SPECIFIED';
         }
         this.busy = true;
         this.$store
@@ -238,7 +233,7 @@
               kind: this.newUserRole,
               collection: this.currentFacilityId,
             },
-            password: this.password,
+            password,
           })
           .then(() => {
             this.handleSubmitSuccess();

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -158,7 +158,7 @@
       };
     },
     computed: {
-      ...mapGetters(['currentFacilityId', 'facilityConfig']),
+      ...mapGetters(['activeFacilityId', 'facilityConfig']),
       ...mapState('userManagement', ['facilityUsers']),
       showPasswordInput() {
         if (this.facilityConfig.learner_can_login_with_no_password) {
@@ -197,7 +197,7 @@
       },
     },
     beforeMount() {
-      this.getFacilityConfig(this.currentFacilityId).then(() => {
+      this.getFacilityConfig(this.activeFacilityId).then(() => {
         this.$store.dispatch('notLoading');
         this.loading = false;
       });
@@ -231,7 +231,6 @@
             birth_year: this.birthYear,
             role: {
               kind: this.newUserRole,
-              collection: this.currentFacilityId,
             },
             password,
           })

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -171,7 +171,7 @@
       };
     },
     computed: {
-      ...mapGetters(['currentFacilityId', 'currentUserId']),
+      ...mapGetters(['currentUserId']),
       ...mapState('userManagement', ['facilityUsers']),
       formDisabled() {
         return this.status === 'BUSY';
@@ -303,7 +303,6 @@
         // their update separately
         if (!this.editingSuperAdmin && this.newUserKind !== this.userCopy.kind) {
           roleUpdates = {
-            collection: this.currentFacilityId,
             kind: this.newUserKind,
           };
         }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Refactors the `UserCreatePage` to defer setting a Learners password to "NOT_SPECIFIED" to the "submit" event handler. Fixes #7135 
1. Fixes the `beforeMount` handler to pull the FacilityConfig for the correct facility in a multi-facility device
1. Fixes issue where the password field would appear, then disappear after the usercreatepage mounts 
1. Removes the `role.collection` param from payloads to `userManagement` vuex module's actions, since they aren't used.
1. Fixes bug in ClassEditPage, where the wrong facility_id was being sent to FacilityUser API

### Reviewer guidance
Verify that:

1. In the UserCreatePage, the visibility of the password field should reflect the Facility setting for the current facility
1. If you switch between roles, the first "password" field should stay blank or with whatever password you entered
1. Editing users still works


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
