### PR TITLE
Coerce generators to lists in annotations

### DIFF
--- a/kolibri/core/query.py
+++ b/kolibri/core/query.py
@@ -11,7 +11,7 @@ try:
         def convert_value(self, value, expression, connection, context):
             if not value:
                 return []
-            return filter(lambda x: x is not None, value)
+            return list(filter(lambda x: x is not None, value))
 
 
 except ImportError:
@@ -54,7 +54,7 @@ class GroupConcat(Aggregate):
             return []
         results = value.split(",")
         if self.result_field is not None:
-            return map(self.result_field.to_python, results)
+            return list(map(self.result_field.to_python, results))
         return results
 
 

--- a/kolibri/core/query.py
+++ b/kolibri/core/query.py
@@ -8,10 +8,17 @@ try:
     from django.contrib.postgres.aggregates import ArrayAgg
 
     class NotNullArrayAgg(ArrayAgg):
+        def __init__(self, *args, **kwargs):
+            self.result_field = kwargs.pop("result_field", None)
+            super(NotNullArrayAgg, self).__init__(*args, **kwargs)
+
         def convert_value(self, value, expression, connection, context):
             if not value:
                 return []
-            return list(filter(lambda x: x is not None, value))
+            results = list(filter(lambda x: x is not None, value))
+            if self.result_field is not None:
+                return list(map(self.result_field.to_python, results))
+            return results
 
 
 except ImportError:
@@ -68,11 +75,16 @@ def get_source_field(model, field_path):
 
 
 def annotate_array_aggregate(queryset, **kwargs):
+    model = queryset.model
     if connection.vendor == "postgresql" and NotNullArrayAgg is not None:
         return queryset.annotate(
-            **{target: NotNullArrayAgg(source) for target, source in kwargs.items()}
+            **{
+                target: NotNullArrayAgg(
+                    source, result_field=get_source_field(model, source)
+                )
+                for target, source in kwargs.items()
+            }
         )
-    model = queryset.model
     # Call values on "pk" to insert a GROUP BY to ensure the GROUP CONCAT
     # is called by row and not across the entire queryset.
     return queryset.values("pk").annotate(


### PR DESCRIPTION
### Summary
Two of our annotation helpers were using Python built ins that behave differently in Python 2 to 3 - returning lists in the former, and generators in the latter. This meant that in Python 3 repeated iteration of the results of these annotations would return an empty iterator after the first complete run through.

This coerces those two instances to lists so that the behaviour is consistent.

### Reviewer guidance
Step through the scenario outlined in #7200 and ensure that user data is properly shown on the coach report.

### References
Fixes #7200
Fixes #7145

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
