### PR TITLE
ensure that HTML5 content displays with the correct height

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -106,7 +106,7 @@
         if (this.isInFullscreen) {
           return {
             position: 'absolute',
-            top: '50px',
+            top: '37px',
             bottom: 0,
           };
         }

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -58,6 +58,8 @@
   const iOSTest = /ip[honead]{2,4}(?:.*os\s([\w]+)\slike\smac|;\sopera)/i;
   const IE11Test = /(trident).+rv[:\s]([\w.]+).+like\sgecko/i;
 
+  const defaultHeight = '560px';
+
   export default {
     name: 'Html5AppRendererIndex',
     components: {
@@ -79,7 +81,7 @@
         return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
       },
       iframeHeight() {
-        return (this.options && this.options.height) || '500px';
+        return (this.options && this.options.height) || defaultHeight;
       },
       iframeWidth() {
         return (this.options && this.options.width) || 'auto';
@@ -108,7 +110,7 @@
             bottom: 0,
           };
         }
-        return { height: '560px' };
+        return { height: this.iframeHeight };
       },
     },
     watch: {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -58,7 +58,7 @@
   const iOSTest = /ip[honead]{2,4}(?:.*os\s([\w]+)\slike\smac|;\sopera)/i;
   const IE11Test = /(trident).+rv[:\s]([\w.]+).+like\sgecko/i;
 
-  const defaultContentHeight = '560px';
+  const defaultContentHeight = '500px';
   const frameTopbarHeight = '37px';
   const pxStringAdd = (x, y) => parseInt(x, 10) + parseInt(y, 10) + 'px';
 

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -3,7 +3,7 @@
   <CoreFullscreen
     ref="html5Renderer"
     class="html5-renderer"
-    :style="{ height: iframeHeight, width: iframeWidth }"
+    :style="{ height: contentRendererHeight, width: iframeWidth }"
     @changeFullscreen="isInFullscreen = $event"
   >
 
@@ -58,7 +58,9 @@
   const iOSTest = /ip[honead]{2,4}(?:.*os\s([\w]+)\slike\smac|;\sopera)/i;
   const IE11Test = /(trident).+rv[:\s]([\w.]+).+like\sgecko/i;
 
-  const defaultHeight = '560px';
+  const defaultContentHeight = '560px';
+  const frameTopbarHeight = '37px';
+  const pxStringAdd = (x, y) => parseInt(x, 10) + parseInt(y, 10) + 'px';
 
   export default {
     name: 'Html5AppRendererIndex',
@@ -81,10 +83,13 @@
         return this.defaultFile.storage_url + (iOSorIE11 ? '?SKIP_HASHI=true' : '');
       },
       iframeHeight() {
-        return (this.options && this.options.height) || defaultHeight;
+        return (this.options && this.options.height) || defaultContentHeight;
       },
       iframeWidth() {
         return (this.options && this.options.width) || 'auto';
+      },
+      contentRendererHeight() {
+        return pxStringAdd(this.iframeHeight, frameTopbarHeight);
       },
       sandbox() {
         return plugin_data.html5_sandbox_tokens;
@@ -106,7 +111,7 @@
         if (this.isInFullscreen) {
           return {
             position: 'absolute',
-            top: '37px',
+            top: frameTopbarHeight,
             bottom: 0,
           };
         }


### PR DESCRIPTION
### Summary
This makes sure the correct height is used in the `Html5AppRendererIndex` component, fixing #7143.

Before:
![image](https://user-images.githubusercontent.com/389782/86071745-a3182600-ba45-11ea-91a9-da10ef9f36e0.png)

After:
![image](https://user-images.githubusercontent.com/389782/86071726-9a275480-ba45-11ea-9003-6ee4f59a0850.png)


### Reviewer guidance
Open some HTML5 content and make sure that there's no overlap between the content and the license info below it.

### References
See #7143 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
