### PR TITLE
spacing when windowIsSmall for mobile buttons on channel import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/HeaderWithOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/HeaderWithOptions.vue
@@ -12,6 +12,7 @@
     <KGridItem
       :layout8="{ span: 4, alignment: 'right' }"
       :layout12="{ span: 6, alignment: 'right' }"
+      :style="{ padding: windowIsSmall ? '0 8px 16px' : '0' }"
       class="buttons"
     >
       <slot name="options"></slot>
@@ -23,8 +24,11 @@
 
 <script>
 
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
   export default {
     name: 'HeaderWithOptions',
+    mixins: [responsiveWindowMixin],
     props: {
       headerText: {
         type: String,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes https://github.com/learningequality/kolibri/issues/7113 by adding conditional padding when `windowIsSmall`

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See the issue and then login as super admin and see that it is fixed. Check all screen sizes.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/7113

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
