### PR TITLE
Fix invalid JSON during morango sync

### DIFF
--- a/kolibri/core/negotiation.py
+++ b/kolibri/core/negotiation.py
@@ -1,21 +1,29 @@
-from rest_framework.negotiation import BaseContentNegotiation
+from rest_framework.negotiation import DefaultContentNegotiation
 from rest_framework.parsers import JSONParser
 from rest_framework.parsers import MultiPartParser
 from rest_framework.renderers import JSONRenderer
 
 
-class LimitContentNegotiation(BaseContentNegotiation):
+class LimitContentNegotiation(DefaultContentNegotiation):
     def select_parser(self, request, parsers):
         """
         Always return JSONParser unless a 'multipart/form-data' content type is sent
+        or this is for morango
         """
+
+        if request.path.startswith("/api/morango"):
+            return super(LimitContentNegotiation, self).select_parser(request, parsers)
         if "multipart" in request.content_type:
             return MultiPartParser()
         return JSONParser()
 
-    def select_renderer(self, request, renderers, format_suffix):
+    def select_renderer(self, request, renderers, format_suffix=None):
         """
-        Always return JSONRenderer
+        Always return JSONRenderer unless for morango
         """
+        if request.path.startswith("/api/morango"):
+            return super(LimitContentNegotiation, self).select_renderer(
+                request, renderers, format_suffix=None
+            )
         renderer = JSONRenderer()
         return (renderer, renderer.media_type)

--- a/kolibri/core/negotiation.py
+++ b/kolibri/core/negotiation.py
@@ -1,22 +1,8 @@
 from rest_framework.negotiation import DefaultContentNegotiation
-from rest_framework.parsers import JSONParser
-from rest_framework.parsers import MultiPartParser
 from rest_framework.renderers import JSONRenderer
 
 
 class LimitContentNegotiation(DefaultContentNegotiation):
-    def select_parser(self, request, parsers):
-        """
-        Always return JSONParser unless a 'multipart/form-data' content type is sent
-        or this is for morango
-        """
-
-        if request.path.startswith("/api/morango"):
-            return super(LimitContentNegotiation, self).select_parser(request, parsers)
-        if "multipart" in request.content_type:
-            return MultiPartParser()
-        return JSONParser()
-
     def select_renderer(self, request, renderers, format_suffix=None):
         """
         Always return JSONRenderer unless for morango

--- a/kolibri/core/negotiation.py
+++ b/kolibri/core/negotiation.py
@@ -7,9 +7,5 @@ class LimitContentNegotiation(DefaultContentNegotiation):
         """
         Always return JSONRenderer unless for morango
         """
-        if request.path.startswith("/api/morango"):
-            return super(LimitContentNegotiation, self).select_renderer(
-                request, renderers, format_suffix=None
-            )
         renderer = JSONRenderer()
         return (renderer, renderer.media_type)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Updates the content negotiation class to use default behavior for morango.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Needs a GZIP enabled peer
- Pull a facility first, make changes, then try to sync with the peer you pulled from (it should push)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
