### PR TITLE
Close language modal when language not changed

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -4,7 +4,7 @@
     :title="$tr('changeLanguageModalHeader')"
     :submitText="coreString('confirmAction')"
     :cancelText="coreString('cancelAction')"
-    @cancel="$emit('cancel')"
+    @cancel="cancel"
     @submit="setLang"
   >
     <KGrid>
@@ -57,7 +57,15 @@
     },
     methods: {
       setLang() {
+        if (currentLanguage === this.selectedLanguage) {
+          this.cancel();
+          return;
+        }
+
         this.switchLanguage(this.selectedLanguage);
+      },
+      cancel() {
+        this.$emit('cancel');
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary

Close language dialog and do not send a request when a language not changed.

### Reviewer guidance

1. Open _Change language_ modal (can be opened from app bar menu, signin page footer or during setup wizard)
2. Do not change language selection
3. Click _Confirm_

### References

Closes #7067

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
