### PR TITLE
bump kds to 0.2.0-beta4

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -15,7 +15,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.0-beta2",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.0-beta4",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",


### PR DESCRIPTION
Bumping `kolibri-design-system` package to `v0.2.0-beta4` to make sure we have the latest from KDS.