### PR TITLE
Fix Export-Users-To-CSV functionality in multi-facility devices.

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -675,9 +675,22 @@ class TasksViewSet(BaseViewSet):
         """
         Export users, classes, roles and roles assignemnts to a csv file.
 
+        :param: facility_id
         :returns: An object with the job information
+
         """
-        facility = request.user.facility.id
+        facility_id = request.data.get("facility_id", None)
+
+        try:
+            if facility_id:
+                facility = Facility.objects.get(pk=facility_id).id
+            else:
+                facility = request.user.facility
+        except Facility.DoesNotExist:
+            raise serializers.ValidationError(
+                "Facility with ID {} does not exist".format(facility_id)
+            )
+
         job_type = "EXPORTUSERSTOCSV"
         job_metadata = {
             "type": job_type,
@@ -707,6 +720,7 @@ class TasksViewSet(BaseViewSet):
         By default it will be dump contentsummarylog.
 
         :param: logtype: Kind of log to dump, summary or session
+        :param: facility
         :returns: An object with the job information
 
         """

--- a/kolibri/plugins/facility/api_urls.py
+++ b/kolibri/plugins/facility/api_urls.py
@@ -4,7 +4,7 @@ from .views import download_csv_file
 
 urlpatterns = [
     url(
-        r"^downloadcsvfile/(?P<filename>.*)/$",
+        r"^downloadcsvfile/(?P<filename>.*)/(?P<facility_id>.*)$",
         download_csv_file,
         name="download_csv_file",
     )

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -68,8 +68,11 @@ function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitF
     const task = myNewTasks.find(task => task.id === taskId);
 
     if (task && task.status === TaskStatuses.COMPLETED) {
-      if (task.type === TaskTypes.EXPORTUSERSTOCSV) store.commit(commitFinish, task.filename);
-      else store.commit(commitFinish, new Date());
+      if (task.type === TaskTypes.EXPORTUSERSTOCSV) {
+        store.commit(commitFinish, task.filename);
+      } else {
+        store.commit(commitFinish, new Date());
+      }
       TaskResource.deleteFinishedTask(taskId);
     }
   } else {
@@ -86,7 +89,9 @@ function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitF
 
 function startExportUsers(store) {
   if (!store.getters.exportingUsers) {
-    let promise = TaskResource.export_users_to_csv({});
+    let promise = TaskResource.export_users_to_csv({
+      facility_id: store.rootGetters.activeFacilityId,
+    });
     return promise.then(task => {
       store.commit('START_EXPORT_USERS', task.data);
       return task.data.id;

--- a/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
@@ -77,7 +77,10 @@
       exportUsersStatus(val) {
         if (val == UsersExportStatuses.FINISHED) {
           window.open(
-            urls['kolibri:kolibri.plugins.facility:download_csv_file'](this.exportUsersFilename),
+            urls['kolibri:kolibri.plugins.facility:download_csv_file'](
+              this.exportUsersFilename,
+              this.$store.getters.activeFacilityId
+            ),
             '_blank'
           );
         }


### PR DESCRIPTION

### Summary

Makes some changes that Fix #7233, which is caused by using the CSV export functionality in a multi-facility device

1. From `ImportInterface`, we pass the `facility_id` to the  `exportuserstocsv` endpoint. This makes sure that the correct `facility` (ID) field is on the `Task` object, especially if we are trying to get users from a facility other than the Super Admin's own.
1. Updates the `facility/downloadcsvfile` endpoint to accept a `facility_id` URL param so we can append the facility name to the exported CSV file, like we do for the content log CSV files. This was done in a somewhat hacky way, by pre-pending the facility-name to the localized filename, since we can't update messages at this point.

### Reviewer guidance

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
