### PR TITLE
0.14.0-beta7 bug fixes

### DIFF
--- a/kolibri/core/assets/src/views/BottomAppBar.vue
+++ b/kolibri/core/assets/src/views/BottomAppBar.vue
@@ -65,6 +65,8 @@
   }
 
   .inner-bottom {
+    height: 100%;
+    padding: 10px 0;
     margin: auto;
   }
 

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -123,7 +123,7 @@ def get_channels_for_data_folder(datafolder):
             "id": channel.id,
             "name": channel.name,
             "description": channel.description,
-            "tagline": channel.tagline,
+            "tagline": getattr(channel, "tagline", ""),
             "thumbnail": channel.thumbnail,
             "version": channel.version,
             "root": channel.root_id,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -100,7 +100,7 @@
       />
 
       <BottomAppBar style="z-index: 1062;">
-        <KButtonGroup style="margin-top: 8px;">
+        <KButtonGroup>
           <KRouterLink
             appearance="flat-button"
             :text="coreString('goBackAction')"

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -128,7 +128,7 @@
         />
       </BottomAppBar>
       <BottomAppBar v-else>
-        <KButtonGroup style="margin-top: 8px;">
+        <KButtonGroup>
           <KRouterLink
             appearance="flat-button"
             :text="coreString('goBackAction')"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -53,7 +53,7 @@
     </form>
 
     <BottomAppBar>
-      <KButtonGroup style="margin-top: 8px;">
+      <KButtonGroup>
         <KButton
           :text="coreString('cancelAction')"
           appearance="flat-button"

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -17,7 +17,7 @@ class DeviceManagementModule extends KolibriApp {
   ready() {
     // reset module states after leaving their respective page
     router.beforeEach((to, from, next) => {
-      if (this.store.getters.isSuperuser && this.store.state.core.facilities.length === 0) {
+      if (this.store.state.core.facilities.length === 0) {
         this.store.dispatch('getFacilities').then(next, next);
       }
       next();

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectionBottomBar.vue
@@ -1,9 +1,9 @@
 <template>
 
   <BottomAppBar>
-    <span class="message">{{ selectedMessage }}</span>
     <template v-if="actionType === 'manage'">
-      <KButtonGroup style="margin-top: 8px;">
+      <KButtonGroup>
+        <span class="message">{{ selectedMessage }}</span>
         <KButton
           :disabled="$attrs.disabled || buttonsDisabled"
           :text="coreString('deleteAction')"
@@ -19,13 +19,15 @@
       </KButtonGroup>
     </template>
 
-    <KButton
-      v-else
-      :disabled="$attrs.disabled || buttonsDisabled"
-      :text="confirmButtonLabel"
-      :primary="true"
-      @click="$emit('clickconfirm')"
-    />
+    <template v-else>
+      <span class="message">{{ selectedMessage }}</span>
+      <KButton
+        :disabled="$attrs.disabled || buttonsDisabled"
+        :text="confirmButtonLabel"
+        :primary="true"
+        @click="$emit('clickconfirm')"
+      />
+    </template>
   </BottomAppBar>
 
 </template>

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -68,7 +68,7 @@
       // This used to determine Select Source workflow to enter into
       importedFacility() {
         const [facility] = this.$store.state.core.facilities;
-        if (facility.last_synced !== null) {
+        if (facility && facility.last_synced !== null) {
           return facility;
         }
         return null;

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -3,7 +3,6 @@
   <KPageContainer>
 
     <h1>{{ $tr('syncData') }}</h1>
-    <p>{{ $tr('access') }}</p>
     <p>
       <KButton
         appearance="basic-link"
@@ -131,8 +130,6 @@
     },
     $trs: {
       syncData: 'Sync facility data',
-      access:
-        'This is an experimental feature. You can use it if you have access to the Kolibri Data Portal.',
       learnMore: 'Usage and privacy',
       facility: 'Facility',
       register: 'Register',

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -215,11 +215,14 @@
       submitForm() {
         this.formSubmitted = true;
         let password = this.password;
-        if (!this.formIsValid) {
-          return this.focusOnInvalidField();
-        }
+
         if (!this.showPasswordInput) {
           password = 'NOT_SPECIFIED';
+          this.passwordValid = true;
+        }
+
+        if (!this.formIsValid) {
+          return this.focusOnInvalidField();
         }
         this.busy = true;
         this.$store

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -50,7 +50,6 @@ oriented data synchronization.
         <KIcon
           icon="mastered"
           :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
-          style="margin-bottom: -6px;"
         />
         <div class="overall-status-text">
           <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -12,7 +12,7 @@ const SetupStrings = createTranslator('SetupStrings', {
   },
 });
 
-const { NOT_SPECIFIED } = DemographicConstants;
+const { DEFERRED } = DemographicConstants;
 
 export default {
   state: {
@@ -44,8 +44,10 @@ export default {
         full_name: '',
         username: '',
         password: '',
-        gender: NOT_SPECIFIED,
-        birth_year: NOT_SPECIFIED,
+        // Superusers are not required to provide this info and are not
+        // nudged to update the profile when on Learn page
+        gender: DEFERRED,
+        birth_year: DEFERRED,
       },
     },
     loading: false,

--- a/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
@@ -33,8 +33,8 @@ describe('SuperuserCredentialsForm', () => {
       full_name: 'Schoolhouse Rock',
       username: 'schoolhouse_rock',
       password: 'password',
-      birth_year: 'NOT_SPECIFIED',
-      gender: 'NOT_SPECIFIED',
+      birth_year: 'DEFERRED',
+      gender: 'DEFERRED',
     });
     expect(wrapper.vm.$emit).toHaveBeenCalledWith('click_next', {
       full_name: 'Schoolhouse Rock',

--- a/kolibri/plugins/user/assets/src/views/SignInPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage.vue
@@ -179,7 +179,7 @@
             ref="username"
             v-model="username"
             autocomplete="username"
-            :autofocus="!hasMultipleFacilities"
+            :autofocus="true"
             :label="coreString('usernameLabel')"
             :invalid="usernameIsInvalid"
             :invalidText="usernameIsInvalidText"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

* Fix bottombar spacing (Fixes #7091). Note that this was accomplished by selecting specific values that were meant to give the appearance of vertical alignment for KButtons and KButtongroups, and not for general types of elements.
* Default channel tagline to “” if it’s not there (Fixes #7194)
* Default superuser demographic info to DEFERRED at setup (Fixes #7204)
* Add guard in PostSetupModalGroup if `core.state.facilities` is empty (Fixes #7222)
* Remove “access” paragraph from SyncInterface (Fixes #7211)
* Always autofocus on web-version of SignInPage (Fixes #7172)
* Manually set passwordValid = true if there is no password field (Fixes #7227)

### Reviewer guidance

1. Give special attention to the fixes for 7172, 7204, 7091, and 7227. The others should be easy to review just from the changes

Some before-after pictures of before the #7091 fix

Place | Before | After
-- | -- | --
Exercises | <img width="417" alt="Exercise 1" src="https://user-images.githubusercontent.com/10248067/86297429-2a81a880-bbb0-11ea-9259-e1f81ceccc9e.png">   |  <img width="520" alt="Exercise 2" src="https://user-images.githubusercontent.com/10248067/86297435-2d7c9900-bbb0-11ea-9be9-ad79098efb1d.png">
Manage Channel |  <img width="522" alt="MC 1" src="https://user-images.githubusercontent.com/10248067/86297484-52710c00-bbb0-11ea-82ab-39187158b8ea.png">  | <img width="530" alt="MC 2" src="https://user-images.githubusercontent.com/10248067/86297490-569d2980-bbb0-11ea-8c18-52a54610c702.png">
Import From Channel |  <img width="474" alt="CleanShot 2020-07-01 at 15 25 46@2x" src="https://user-images.githubusercontent.com/10248067/86297514-674d9f80-bbb0-11ea-8aba-bcfeb6b1e906.png">  |  <img width="448" alt="CleanShot 2020-07-01 at 15 26 02@2x" src="https://user-images.githubusercontent.com/10248067/86297522-6c125380-bbb0-11ea-8186-edf695aaf276.png">



### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
