### PR TITLE
Fix KIcon size and positioning in AttemptLogList

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -193,11 +193,9 @@
   }
 
   .svg-item {
-    width: 24px;
-    height: auto;
-    margin-top: -4px;
     margin-right: 12px;
-    vertical-align: middle;
+    margin-bottom: -4px;
+    font-size: 24px;
   }
 
   .attempt-item {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Remove `height; auto` rule and replaces height/width with font-size rule and margins (Fixes #7230)

Screenshots are IE11 on Windows 10 in Browserstack 

Before

<img width="721" alt="CleanShot 2020-07-02 at 14 58 56@2x" src="https://user-images.githubusercontent.com/10248067/86414477-d7bff380-bc78-11ea-857a-1d25a9f38164.png">

After

<img width="794" alt="CleanShot 2020-07-02 at 14 55 42@2x" src="https://user-images.githubusercontent.com/10248067/86414479-dbec1100-bc78-11ea-87ce-834ae95cea24.png">

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
