### PR TITLE
Use correct link according to figma design 

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -89,19 +89,11 @@
             type="submit"
           />
         </p>
-
-        <p
-          v-if="showGuestAccess"
-          class="guest"
-        >
-          <KExternalLink
-            :text="$tr('accessAsGuest')"
-            :href="guestURL"
-            :primary="true"
-            appearance="basic-link"
-          />
-        </p>
-
+        <KRouterLink
+          :text="$tr('signInPrompt')"
+          :to="this.$router.getRoute(PageNames.SIGN_IN)"
+          appearance="basic-link"
+        />
       </form>
     </KPageContainer>
 
@@ -130,7 +122,7 @@
   import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import urls from 'kolibri.urls';
+  import { PageNames } from '../constants';
   import { SignUpResource } from '../apiResource';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
   import getUrlParameter from './getUrlParameter';
@@ -178,8 +170,8 @@
       firstStepIsValid() {
         return every([this.nameValid, this.usernameValid, this.passwordValid]);
       },
-      guestURL() {
-        return urls['kolibri:core:guest']();
+      PageNames() {
+        return PageNames;
       },
       nextParam() {
         // query is after hash
@@ -188,9 +180,6 @@
         }
         // query is before hash
         return getUrlParameter('next');
-      },
-      showGuestAccess() {
-        return plugin_data.allowGuestAccess;
       },
       showPasswordInput() {
         return !this.facilityConfig.learner_can_login_with_no_password;
@@ -235,7 +224,7 @@
         }
       },
       goToFirstStep() {
-        this.$router.replace({ query: {} });
+        if (this.$router.query != undefined) this.$router.replace({ query: {} });
       },
       goToSecondStep() {
         if (this.firstStepIsValid) {
@@ -322,7 +311,11 @@
           'It will be visible to administrators. It will also be used to help improve the software and resources for different learner types and needs.',
         context: '\nDetails on how the demographic information requested in the form will be used.',
       },
-      accessAsGuest: 'Explore without account',
+      signInPrompt: {
+        message: 'Sign in if you have an existing account',
+        context:
+          'When a device has multiple facilities, this message is above a button which leads the user to the rest of the sign in process.',
+      },
       privacyLinkText: {
         message: 'Learn more about usage and privacy',
         context:

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -91,7 +91,7 @@
         </p>
         <KRouterLink
           :text="signUpStrings.$tr('signInPrompt')"
-          :to="this.$router.getRoute(PageNames.SIGN_IN)"
+          :to="$router.getRoute(PageNames.SIGN_IN)"
           appearance="basic-link"
         />
       </form>

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -90,7 +90,7 @@
           />
         </p>
         <KRouterLink
-          :text="$tr('signInPrompt')"
+          :text="signUpStrings.$tr('signInPrompt')"
           :to="this.$router.getRoute(PageNames.SIGN_IN)"
           appearance="basic-link"
         />
@@ -122,8 +122,10 @@
   import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { PageNames } from '../constants';
   import { SignUpResource } from '../apiResource';
+  import AuthSelect from './AuthSelect';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
   import getUrlParameter from './getUrlParameter';
   import plugin_data from 'plugin_data';
@@ -183,6 +185,9 @@
       },
       showPasswordInput() {
         return !this.facilityConfig.learner_can_login_with_no_password;
+      },
+      signUpStrings() {
+        return crossComponentTranslator(AuthSelect);
       },
     },
     beforeMount() {
@@ -310,11 +315,6 @@
         message:
           'It will be visible to administrators. It will also be used to help improve the software and resources for different learner types and needs.',
         context: '\nDetails on how the demographic information requested in the form will be used.',
-      },
-      signInPrompt: {
-        message: 'Sign in if you have an existing account',
-        context:
-          'When a device has multiple facilities, this message is above a button which leads the user to the rest of the sign in process.',
       },
       privacyLinkText: {
         message: 'Learn more about usage and privacy',

--- a/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
@@ -6,15 +6,20 @@ import makeStore from '../makeStore';
 const localVue = createLocalVue();
 localVue.use(VueRouter);
 
+const router = new VueRouter({
+  routes: [{ name: 'SIGN_IN', path: '/signin' }],
+});
+router.getRoute = () => {
+  return { name: 'SIGN_IN', path: '/signin' };
+};
+
 function makeWrapper() {
   const store = makeStore();
   store.state.core.facilities = [{ id: 1, name: 'facility' }];
   store.state.facilityId = 1;
   return mount(SignUpPage, {
     store,
-    router: new VueRouter({
-      routes: [{ name: 'SIGN_IN', path: '/signin' }],
-    }),
+    router,
     methods: {
       // To silence router error
       goToFirstStep() {
@@ -27,6 +32,6 @@ function makeWrapper() {
 describe('signUpPage component', () => {
   it('smoke test', () => {
     const wrapper = makeWrapper();
-    expect(wrapper.isVueInstance()).toEqual(true);
+    expect(wrapper.exists()).toEqual(true);
   });
 });


### PR DESCRIPTION


### Summary
Change the "Explore without account" link at the botton of the page by a "Sign in if you have an existing account" link

![image](https://user-images.githubusercontent.com/1008178/86587920-e5cc8780-bf8a-11ea-8215-88630c7618c4.png)

It also fixes an ugly console error happening while mounting the component due to a recursive call to the first step.

### Reviewer guidance
- No new strings are added
- The design is according to https://www.figma.com/file/LI2L6gUncmCDDtaDECcbY6/Log-in-updates?node-id=574%3A2
- Everything works fine

### References
Closes: #7206 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
