### PR TITLE
Separate morango pull/push clients with better write locking and better cancellation handling

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -319,7 +319,7 @@ class Command(AsyncCommand):
             noninteractive,
         )
         self._transfer_tracker_adapter(
-            sync_client.signals.pushing,
+            sync_client.signals.transferring,
             "Sending data ({})".format(TRANSFER_MESSAGE),
             State.PUSHING,
             noninteractive,

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -345,7 +345,10 @@ class Command(AsyncCommand):
         # we can't cancel remotely integrating data
         if self.job:
             self.job.cancellable = False
-        sync_client.finalize()
+
+        # allow server timeout since remotely integrating data can take a while and the request
+        # could timeout. In that case, we'll assume everything is good.
+        sync_client.finalize(allow_server_timeout=True)
 
     def _update_all_progress(self, progress_fraction, progress):
         """

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -682,6 +682,15 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
 
     id_number = models.CharField(max_length=64, default="", blank=True)
 
+    @classmethod
+    def deserialize(cls, dict_model):
+        # be defensive against blank passwords, set to `NOT_SPECIFIED` if blank
+        password = dict_model.get("password", "") or ""
+        if len(password) == 0:
+            dict_model.update(password="NOT_SPECIFIED")
+
+        return super(FacilityUser, cls).deserialize(dict_model)
+
     def calculate_partition(self):
         return "{dataset_id}:user-ro:{user_id}".format(
             dataset_id=self.dataset_id, user_id=self.ID_PLACEHOLDER

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -603,3 +603,11 @@ class FacilityUserTestCase(TestCase):
             FacilityUser.objects.create(username="bob", facility=self.facility)
         except IntegrityError:
             self.fail("Can't create user with same username.")
+
+    def test_deserialize_empty_password(self):
+        self.facility = Facility.objects.create()
+        self.device_settings = DeviceSettings.objects.create()
+
+        user = FacilityUser.deserialize(dict(username="bob", password=""))
+        self.assertEqual("bob", user.username)
+        self.assertEqual("NOT_SPECIFIED", user.password)

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -16,6 +16,7 @@ from django.http.response import HttpResponseBadRequest
 from django.utils.translation import get_language_from_request
 from django.utils.translation import gettext_lazy as _
 from morango.sync.controller import MorangoProfileController
+from requests.exceptions import HTTPError
 from rest_framework import decorators
 from rest_framework import serializers
 from rest_framework import status
@@ -1049,7 +1050,7 @@ def validate_and_prepare_peer_sync_job(request, **kwargs):
         get_client_and_server_certs(
             username, password, dataset_id, network_connection, noninteractive=True
         )
-    except CommandError as e:
+    except (CommandError, HTTPError) as e:
         if not username and not password:
             raise PermissionDenied()
         else:

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1007,7 +1007,7 @@ def validate_prepare_sync_job(request, **kwargs):
         noninteractive=True,
         extra_metadata=dict(),
         track_progress=True,
-        cancellable=False,
+        cancellable=True,
     )
 
     job_data.update(kwargs)

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -102,6 +102,7 @@ class Job(object):
         self.save_meta_method = None
         self.update_progress_method = None
         self.check_for_cancel_method = None
+        self.save_as_cancellable_method = None
 
         if callable(func):
             funcstring = stringify_func(func)
@@ -138,6 +139,14 @@ class Job(object):
                 )
             self.check_for_cancel_method(self.job_id)
 
+    def save_as_cancellable(self, cancellable=True):
+        # if we're not changing cancellability then ignore
+        if self.cancellable == cancellable:
+            return
+        if self.save_as_cancellable_method is None:
+            raise ReferenceError("Missing method to save job as cancellable")
+        self.save_as_cancellable_method(self.job_id, cancellable=self.cancellable)
+
     def get_lambda_to_execute(self):
         """
         return a function that executes the function assigned to this job.
@@ -150,20 +159,27 @@ class Job(object):
         :return: a function that executes the original function assigned to this job.
         """
 
-        def y(update_progress_func, cancel_job_func, save_job_meta_func):
+        def y(
+            update_progress_func,
+            cancel_job_func,
+            save_job_meta_func,
+            save_as_cancellable_func,
+        ):
             """
             Call the function stored in self.func, and passing in update_progress_func
             or cancel_job_func depending if self.track_progress or self.cancellable is defined,
             respectively.
             :param update_progress_func: The callback for when the job updates its progress.
-            :param cancel_job_func: The function that the function has to call occasionally to see
-            if the user wants to cancel the currently running job.
+            :param cancel_job_func: The callback to see if the user wants to cancel the job.
+            :param save_job_meta_func: The callback to save any changes to meta data
+            :param save_as_cancellable_func: The callback to save any changes to meta data
             :return: Any
             """
 
             setattr(current_state_tracker, "job", self)
 
             self.save_meta_method = save_job_meta_func
+            self.save_as_cancellable_method = save_as_cancellable_func
             if self.track_progress:
                 self.update_progress_method = update_progress_func
 

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -145,7 +145,7 @@ class Job(object):
             return
         if self.save_as_cancellable_method is None:
             raise ReferenceError("Missing method to save job as cancellable")
-        self.save_as_cancellable_method(self.job_id, cancellable=self.cancellable)
+        self.save_as_cancellable_method(self.job_id, cancellable=cancellable)
 
     def get_lambda_to_execute(self):
         """

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -245,6 +245,9 @@ class Storage(StorageMixin):
     def save_job_meta(self, job):
         self._update_job(job.job_id, extra_metadata=job.extra_metadata)
 
+    def save_job_as_cancellable(self, job_id, cancellable=True):
+        self._update_job(job_id, cancellable=cancellable)
+
     def _update_job(self, job_id, state=None, **kwargs):
         with self.session_scope() as session:
             try:

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -173,7 +173,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(this_is_extra=True,),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
@@ -202,7 +202,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                 type="SYNCDATAPORTAL",
             ),
             track_progress=True,
-            cancellable=False,
+            cancellable=True,
         )
 
     def test_startdataportalbulksync(self, facility_queue):
@@ -217,7 +217,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(this_is_extra=True,),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
@@ -246,7 +246,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                         type="SYNCDATAPORTAL",
                     ),
                     track_progress=True,
-                    cancellable=False,
+                    cancellable=True,
                 ),
                 call(
                     call_command,
@@ -264,7 +264,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
                         type="SYNCDATAPORTAL",
                     ),
                     track_progress=True,
-                    cancellable=False,
+                    cancellable=True,
                 ),
             ],
             any_order=True,
@@ -301,7 +301,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
-            cancellable=False,
+            cancellable=True,
         )
         validate_and_prepare_peer_sync_job.return_value = prepared_data.copy()
 
@@ -310,7 +310,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(this_is_extra=True,),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
@@ -359,7 +359,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             noninteractive=True,
             extra_metadata=extra_metadata,
             track_progress=True,
-            cancellable=False,
+            cancellable=True,
         )
         validate_and_prepare_peer_sync_job.return_value = prepared_data.copy()
 
@@ -368,7 +368,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             job_id=123,
             state="testing",
             percentage_progress=42,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(this_is_extra=True,),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
@@ -498,7 +498,7 @@ class FacilityTaskHelperTestCase(TestCase):
             chunk_size=200,
             noninteractive=True,
             track_progress=True,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(type="test"),
         )
         actual = validate_prepare_sync_job(req, extra_metadata=dict(type="test"))
@@ -554,7 +554,7 @@ class FacilityTaskHelperTestCase(TestCase):
             chunk_size=200,
             noninteractive=True,
             track_progress=True,
-            cancellable=False,
+            cancellable=True,
             extra_metadata=dict(type="test"),
         )
         actual = validate_and_prepare_peer_sync_job(

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -1,0 +1,26 @@
+import mock
+from django.test.testcases import TestCase
+
+from kolibri.core.tasks.job import Job
+
+
+class JobTest(TestCase):
+    def setUp(self):
+        self.job = Job(id)
+
+    def test_job_save_as_cancellable(self):
+        callback = mock.Mock()
+        self.job.save_as_cancellable_method = callback
+        cancellable = not self.job.cancellable
+
+        self.job.save_as_cancellable(cancellable=cancellable)
+        callback.assert_called_once_with(self.job.job_id, cancellable=cancellable)
+
+    def test_job_save_as_cancellable__skip(self):
+        cancellable = self.job.cancellable
+        self.job.save_as_cancellable(cancellable=cancellable)
+
+    def test_job_save_as_cancellable__no_callback(self):
+        cancellable = not self.job.cancellable
+        with self.assertRaises(ReferenceError):
+            self.job.save_as_cancellable(cancellable=cancellable)

--- a/kolibri/core/tasks/test/test_storage.py
+++ b/kolibri/core/tasks/test/test_storage.py
@@ -92,3 +92,19 @@ class TestBackend:
         requeued_job = defaultbackend.get_job(job_id)
 
         assert requeued_job.state == State.QUEUED
+
+    def test_save_job_as_cancellable(self, defaultbackend, simplejob):
+        simplejob.cancellable = True
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        job = defaultbackend.get_job(job_id)
+        assert job.cancellable, "Job is not cancellable"
+
+        defaultbackend.save_job_as_cancellable(job_id, cancellable=False)
+        job = defaultbackend.get_job(job_id)
+        assert not job.cancellable, "Job is still cancellable"
+
+        # default should be back to True
+        defaultbackend.save_job_as_cancellable(job_id)
+        job = defaultbackend.get_job(job_id)
+        assert job.cancellable, "Job is not cancellable default"

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -150,6 +150,7 @@ class Worker(object):
             update_progress_func=self.update_progress,
             cancel_job_func=self._check_for_cancel,
             save_job_meta_func=self.storage.save_job_meta,
+            save_as_cancellable_func=self.storage.save_job_as_cancellable,
         )
 
         # assign the futures to a dict, mapping them to a job
@@ -191,8 +192,6 @@ class Worker(object):
         was before it was cancelled.
 
         :param job_id: The job_id to check
-        :param current_stage: Where the job currently is
-
         :return: raises a UserCancelledError if we find out that we were cancelled.
         """
 

--- a/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
@@ -101,7 +101,7 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
 
   const controlAndStatusTests = [
     // [status, canClear/hideCancel, isRunning, canCancel]
-    ['PENDING', false, false, true],
+    ['PENDING', false, false, false],
     ['CANCELED', true, false, false],
     ['CANCELING', false, false, false],
     ['FAILED', true, false, false],
@@ -112,7 +112,7 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
     ['LOCAL_QUEUING', false, true, false],
     ['PUSHING', false, true, true],
     ['REMOTE_DEQUEUING', false, true, false],
-    ['COMPLETED', true, false],
+    ['COMPLETED', true, false, false],
   ];
 
   test.each(controlAndStatusTests)(

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -100,7 +100,7 @@ export function syncFacilityTaskDisplayInfo(task) {
     deviceNameMsg,
     isRunning: Boolean(syncStep) && !canClear,
     canClear,
-    canCancel: !canClear,
+    canCancel: !canClear && task.cancellable,
     canRetry: task.status === TaskStatuses.FAILED,
   };
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.1
+morango==0.5.2
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR integrates the latest morango changes in [this PR](https://github.com/learningequality/morango/pull/85), and only uses the `db_write_task_lock` when data is queuing or dequeuing locally. This also attempts to address cancellation during the stages of a sync task, since we should only allow cancellation when we can expect that the cancellation will occur as expected. For instance, attempting to cancel during a remote dequeuing shouldn't be allowed, as we don't have that control over the remote's processing.

Also addresses the issues with blank passwords as shown in https://github.com/learningequality/kolibri/issues/7127 by setting any blank passwords to `NOT_SPECIFIED` when deserializing.

No cancel button shown when locally integrating received data, or aka local dequeuing. Also progress is indeterminate.
![Screenshot from 2020-07-07 14-17-57](https://user-images.githubusercontent.com/819838/86844336-c7cf5780-c05c-11ea-81d5-cc83b47cb9da.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Utilize the UI to schedule a sync
- Use the management command to sync a facility
- Ensure cancelling during transfer works as expected
- Cancel button shouldn't appear when the task is in a uncancellable stage

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Depends on: https://github.com/learningequality/morango/pull/85
Related: https://github.com/learningequality/kolibri/issues/7125
Resolves: https://github.com/learningequality/kolibri/issues/7127

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
