### PR TITLE
Fix h5p content data bootstrapping

### DIFF
--- a/kolibri/core/content/templates/content/h5p.html
+++ b/kolibri/core/content/templates/content/h5p.html
@@ -29,7 +29,7 @@
                 contents: {
                     "cid-1": {
                         library: "{{ library }}",
-                        jsonContent: JSON.stringify({{ content|safe }}),
+                        jsonContent: {{ content|safe }},
                         displayOptions: {
                             copyright: false,
                             download: false,


### PR DESCRIPTION
### Summary
Small tweak to template which was still trying to stringify data that was being passed into the template already stringified.

Note: this means that H5P is currently broken on 0.13.x due to the PR #6928, targeting this to 0.14.x as I think we are unlikely to do a patch release, and H5P is not yet officially supported.

### Reviewer guidance
Test that the H5P content in this channel: `effbdfe850dd56d4a595037a090e9225` renders properly.

### References
Follow up from #6928 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
