### PR TITLE
Validation fixes for bulkimport

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -776,18 +776,23 @@ class Command(AsyncCommand):
         for user in users:
             # enrolled:
             to_remove = user.memberships.filter(collection__kind=CLASSROOM)
-            if user.username in users_enrolled.keys():
+            username = (
+                user.username
+                if sys.version_info[0] >= 3
+                else user.username.encode("utf-8")
+            )
+            if username in users_enrolled.keys():
                 to_remove.exclude(
-                    collection__name__in=users_enrolled[user.username]
+                    collection__name__in=users_enrolled[username]
                 ).delete()
             else:
                 to_remove.delete()
 
             # assigned:
             to_remove = user.roles.filter(collection__kind=CLASSROOM)
-            if user.username in users_assigned.keys():
+            if username in users_assigned.keys():
                 to_remove.exclude(
-                    collection__name__in=users_assigned[user.username]
+                    collection__name__in=users_assigned[username]
                 ).delete()
             else:
                 to_remove.delete()

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -142,21 +142,29 @@ def not_empty():
     return checker
 
 
-def value_length(length, allow_null=False):
+def value_length(length, allow_null=False, multiple=False):
     """
     Return a value check function which raises a ValueError if the supplied
     value has a length greater than 'length'
     If null is not True raises a ValueError if the supplied value is None.
+    If multiple is True it checks the length of each of the separated by commas value
     """
 
     def checker(v):
+        def check_single_value(v):
+            if v is None or len(v) > length:
+                raise ValueError(v)
+
         if v == DEFERRED:
             return checker
         if allow_null and v is None:
             return None
-
-        if v is None or len(v) > length:
-            raise ValueError(v)
+        if multiple:
+            values = v.split(",")
+            for value in values:
+                check_single_value(value)
+        else:
+            check_single_value(v)
 
     return checker
 
@@ -426,12 +434,12 @@ class Command(AsyncCommand):
         )
         validator.add_check(
             "ENROLLED_IN",
-            value_length(100, allow_null=True),
+            value_length(100, allow_null=True, multiple=True),
             MESSAGES[TOO_LONG].format("Class name"),
         )
         validator.add_check(
             "ASSIGNED_TO",
-            value_length(100, allow_null=True),
+            value_length(100, allow_null=True, multiple=True),
             MESSAGES[TOO_LONG].format("Class name"),
         )
 

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -434,12 +434,12 @@ class Command(AsyncCommand):
         )
         validator.add_check(
             "ENROLLED_IN",
-            value_length(100, allow_null=True, multiple=True),
+            value_length(50, allow_null=True, multiple=True),
             MESSAGES[TOO_LONG].format("Class name"),
         )
         validator.add_check(
             "ASSIGNED_TO",
-            value_length(100, allow_null=True, multiple=True),
+            value_length(50, allow_null=True, multiple=True),
             MESSAGES[TOO_LONG].format("Class name"),
         )
 

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -54,6 +54,13 @@ def test_value_length_validator():
     assert check("ok") is None
     assert check("") is None
 
+    with pytest.raises(ValueError):
+        check("a,b,c,d,e,f")
+    check = b.value_length(4, allow_null=False, multiple=True)
+    with pytest.raises(ValueError):
+        check("a,bbbbb,c,d")
+    assert check("a,b,c,d,e,f,") is None
+
 
 def test_enumeration_validator():
     check = b.enumeration("LEARNER", "ADMIN", "COACH")


### PR DESCRIPTION
### Summary
Fixes a couple of problems when doing a bulk import of the users:
1. Max length validation in the class names is done on each class name, not in the list of classes. New tests are added to check this behaviour.
2. When running the server on Python 2, the returned unicode values for obj.username can not be used as a dictionary key. This pr converts it into a string value


### Reviewer guidance
Tests pass
Exporting and importing the users works correctly

### References
Closes: #7235 
These two commits should be cherry-picked in the server running the ProFuturo server

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
