### PR TITLE
Responsively make room for info icon in demographic fields

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -2,7 +2,7 @@
 
   <div class="pos-rel">
     <KSelect
-      class="select"
+      class="birthyear-select"
       :value="selected"
       :label="coreString('birthYearLabel')"
       :placeholder="$tr('placeholder')"
@@ -97,10 +97,14 @@
     position: relative;
   }
 
+  .birthyear-select {
+    width: calc(100% - 32px);
+  }
+
   .info-icon {
     position: absolute;
     top: 27px;
-    right: -34px;
+    right: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
+++ b/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
@@ -2,6 +2,7 @@
 
   <div class="pos-rel">
     <KTextbox
+      class="identifier-textbox"
       :value="value"
       :label="$tr('label')"
       :maxlength="64"
@@ -49,10 +50,14 @@
     position: relative;
   }
 
+  .identifier-textbox {
+    width: calc(100% - 32px);
+  }
+
   .info-icon {
     position: absolute;
     top: 27px;
-    right: -34px;
+    right: 0;
   }
 
   /deep/ .k-tooltip {


### PR DESCRIPTION
Same change as in #6915 which might have gotten auto-closed via a merge, but didn't make it to release-v0.14