### PR TITLE
Suppress login popup on unauthenticated xhr requests in development

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -90,7 +90,7 @@ const client = options => {
     );
   }
 
-  const headers = { ...(options.headers || {}) };
+  const headers = { ...(options.headers || {}), 'X-Requested-With': 'XMLHttpRequest' };
   if (options.multipart) {
     headers['Content-Type'] = 'multipart/form-data';
     options.transformRequest = function(data) {

--- a/kolibri/core/auth/middleware.py
+++ b/kolibri/core/auth/middleware.py
@@ -64,3 +64,14 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
             "'kolibri.core.auth.middleware.CustomAuthenticationMiddleware'."
         )
         request.user = SimpleLazyObject(lambda: _get_user(request))
+
+
+class XhrPreventLoginPromptMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if response and response.status_code == 401 and request.is_ajax():
+            del response["WWW-Authenticate"]
+        return response

--- a/kolibri/core/auth/middleware.py
+++ b/kolibri/core/auth/middleware.py
@@ -67,6 +67,16 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
 
 
 class XhrPreventLoginPromptMiddleware(object):
+    """
+    By default, HTTP 401 responses are sent with a ``WWW-Authenticate``
+    header. Web browsers react to this header by displaying a login prompt
+    dialog.  By removing the header, the login prompt can be avoided.  While
+    this isn't recommended in general, there's a convention of removing it
+    for XHR requests, so that unauthenticated XHR requests don't trigger a
+    popup.
+    
+    See `here <https://stackoverflow.com/a/20221330>`_ for reference.
+    """
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -101,6 +101,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
+    "kolibri.core.auth.middleware.XhrPreventLoginPromptMiddleware",
 ]
 
 # By default don't cache anything unless it explicitly requests it to!

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -101,7 +101,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
-    "kolibri.core.auth.middleware.XhrPreventLoginPromptMiddleware",
 ]
 
 # By default don't cache anything unless it explicitly requests it to!

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -9,7 +9,13 @@ DEBUG = True
 # Settings might be tuples, so switch to lists
 INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg"]  # noqa F405
 webpack_middleware = "kolibri.core.webpack.middleware.WebpackErrorHandler"
-MIDDLEWARE = list(MIDDLEWARE) + [webpack_middleware]  # noqa F405
+no_login_popup_middleware = (
+    "kolibri.core.auth.middleware.XhrPreventLoginPromptMiddleware"
+)
+MIDDLEWARE = list(MIDDLEWARE) + [  # noqa F405
+    webpack_middleware,
+    no_login_popup_middleware,
+]
 
 INTERNAL_IPS = ["127.0.0.1"]
 


### PR DESCRIPTION
### Summary
`BasicAuthentication` is used as a default authentication class in development.  Because it returns HTTP code 401 with a `www-authenticate` header, this causes the browser to show a login popup any time an unauthenticated request is made, even if that request is made in the background.

However, in production deployments, `BasicAuthentication` is not used, so the popups don't happen.

This caused some confusion in debugging #7147.

This change implements a middleware for the behavior described [here](https://stackoverflow.com/a/20221330), where `www-authenticate` headers are removed for all requests with the header `X-Requested-With: XMLHttpRequest`.

Additionally, the `X-Requested-With: XMLHttpRequest` header is set on all requests from Kolibri's default HTTP client. 

Currently the middleware is only enabled for development settings, but it could also be enabled in production if we wanted to use the 401 response code more intentionally.

### Reviewer guidance
Steps to test:
1. Start Kolibri with development settings
2. Open an incognito window
3. Navigate to `http://localhost:8000/en/learn/#/classes`
4. Make sure there's no login popup!

### References
- https://github.com/learningequality/kolibri/issues/7147
- https://stackoverflow.com/a/20221330

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
