### PR TITLE
Update CoreBanner layout: improves appearance on small screens and locales with long "More Information" translations

### DIFF
--- a/kolibri/core/assets/src/views/CoreBanner.vue
+++ b/kolibri/core/assets/src/views/CoreBanner.vue
@@ -8,8 +8,8 @@
       <KGrid>
         <!-- Grid Content -->
         <KGridItem
-          :layout8="{ span: bannerClosed ? 6 : 8 }"
-          :layout12="{ span: bannerClosed ? 10 : 12 }"
+          :layout8="{ span: bannerClosed ? 5 : 8 }"
+          :layout12="{ span: bannerClosed ? 9 : 12 }"
         >
           <slot :bannerClosed="bannerClosed"></slot>
         </KGridItem>
@@ -17,9 +17,9 @@
         <!-- Grid Buttons -->
         <KGridItem
           v-if="bannerClosed"
-          :layout="{ alignment: 'right' }"
-          :layout8="{ span: 2 }"
-          :layout12="{ span: 2 }"
+          class="button-grid-item"
+          :layout8="{ span: 3 }"
+          :layout12="{ span: 3 }"
         >
           <KButton
             class="open-button"
@@ -29,7 +29,7 @@
             @click="toggleBanner"
           />
         </KGridItem>
-        <KGridItem v-else :layout="{ alignment: 'right' }">
+        <KGridItem v-else class="button-grid-item">
           <KButton
             class="close-button"
             :text="coreString('closeAction')"
@@ -94,12 +94,11 @@
     }
   }
 
-  .close-button {
-    margin-bottom: 24px;
-  }
-
-  .open-button {
-    margin-top: 14px;
+  .button-grid-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    min-height: 60px;
   }
 
 </style>


### PR DESCRIPTION

### Summary

Updates layout of Demo Banner to properly fit the longer messages used for "More Information" button (e.g. in Italian), as well as layout on smaller screen sizes.

![screenshots 001](https://user-images.githubusercontent.com/10248067/86852828-48e11b80-c06a-11ea-8631-d85b0ca73954.jpeg)
![screenshots 002](https://user-images.githubusercontent.com/10248067/86852836-4b437580-c06a-11ea-8c27-06843420389a.jpeg)

Screenshots are on Chrome with Italian locale. The screens basically look the same in my testing on Ie11, Firefox and Safari. Confirmed that layout fits localized messages for most of the languages.

Fixes #6799 

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
