### PR TITLE
exclude status endpoint from the logs

### DIFF
--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -80,7 +80,7 @@ def cherrypy_access_log_middleware(get_response):
         # https://github.com/learningequality/kolibri/issues/6459
         log_as_debug = (
             "/api/tasks/tasks/" in request.path_info
-            or "/status/" in request.path_info
+            or "/status/" == request.path_info
             or request.method == "PATCH"
         )
         if log_as_debug:

--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -79,7 +79,9 @@ def cherrypy_access_log_middleware(get_response):
         # Silence busy polling API endpoints and PATCH requests:
         # https://github.com/learningequality/kolibri/issues/6459
         log_as_debug = (
-            "/api/tasks/tasks/" in request.path_info or request.method == "PATCH"
+            "/api/tasks/tasks/" in request.path_info
+            or "/status/" in request.path_info
+            or request.method == "PATCH"
         )
         if log_as_debug:
             cp_logger.debug(log_message)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to exclude `/status/` endpoint from the logs, similar to `/api/tasks/tasks/`. In our Kolibri demo servers, we use `/status/` endpoint to check the health of the servers in Kubernetes by sending a get request to the endpoint every second. To reduce the noisiness in the log files, I think it would be best to remove it in the code.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Will the requests to `/status/` endpoint still be logged to kolibri.txt?
Please feel free to let me know if you have any questions. Thank you!

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
