### PR TITLE
Remove inline style for channel filter when window is small

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -104,6 +104,7 @@
   import { mapGetters, mapState } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import { PageNames } from '../constants';
 
   const ALL_FILTER = null;
@@ -119,7 +120,7 @@
 
   export default {
     name: 'SearchBox',
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveElementMixin],
     props: {
       icon: {
         type: String,
@@ -152,13 +153,20 @@
         'channelFilter',
       ]),
       channelFilterStyle() {
+        const maxWidth = 375;
+        // If window is small, just let it have its default width
+        if (this.elementWidth < maxWidth + 32) {
+          return {};
+        }
+        // Otherwise, adjust the width based on the longest channel name,
+        // capped at 375px, or approx 50 characters
         const longestChannelName = maxBy(
           this.channelFilterOptions,
           channel => channel.label.length
         );
-        // Adjust the width based on the longest channel name
+        const maxPx = Math.min(longestChannelName.label.length * 8, maxWidth);
         return {
-          width: `${longestChannelName.label.length * 10}px`,
+          width: `${maxPx}px`,
         };
       },
       allFilter() {


### PR DESCRIPTION
### Summary

Tries to fix #6891 by letting the Channel filter be its default width of around 150px when the window starts to get very small, while also trying to stay at a moderate width that allows the channel names to be readable at a wide variety of screen sizes.

![CleanShot 2020-07-07 at 16 57 09](https://user-images.githubusercontent.com/10248067/86857411-4fc05c00-c073-11ea-957c-792a39669057.gif)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
