### PR TITLE
[WIP] Login frontend tests

### DIFF
--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -77,6 +77,7 @@
                 :to="signUpPage"
                 :primary="true"
                 appearance="flat-button"
+                data-test="createUser"
               />
             </p>
 

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -25,7 +25,9 @@
             >
               {{ logoText }}
             </h1>
-            <p>{{ $tr('restrictedAccess') }}</p>
+            <p data-test="restrictedAccess">
+              {{ $tr('restrictedAccess') }}
+            </p>
             <p>{{ $tr('restrictedAccessDescription') }}</p>
           </div>
           <!-- remote access enabled -->

--- a/kolibri/plugins/user/assets/src/views/AuthSelect.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthSelect.vue
@@ -9,6 +9,7 @@
           :to="facilitySelectPage(PageNames.SIGN_UP)"
           appearance="flat-button"
           class="auth-button"
+          data-test="createUser"
         />
       </div>
       <div>
@@ -18,6 +19,7 @@
           :to="facilitySelectPage(PageNames.SIGN_IN)"
           appearance="flat-button"
           class="auth-button"
+          data-test="signIn"
         />
       </div>
     </div>

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -44,7 +44,7 @@
             <h2>
               {{ coreString('facilityLabel') }}
             </h2>
-            <p>
+            <p data-test="facilityLabel">
               {{ selectedFacility.name }}
             </p>
           </template>

--- a/kolibri/plugins/user/assets/test/views/auth-base.spec.js
+++ b/kolibri/plugins/user/assets/test/views/auth-base.spec.js
@@ -1,0 +1,43 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import AuthBase from '../../src/views/AuthBase';
+import makeStore from '../makeStore';
+
+jest.mock('kolibri.urls');
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+const router = new VueRouter({
+  routes: [{ name: 'SIGN_UP', path: '/signup' }],
+});
+
+const store = makeStore();
+store.state.core.facilityConfig = { learner_can_sign_up: true };
+
+function makeWrapper(allowAccess = true) {
+  store.getters = { ...store.getters, allowAccess: allowAccess };
+
+  return mount(AuthBase, {
+    store: store,
+    localVue,
+    router,
+  });
+}
+
+describe('auth base component', () => {
+  it('access_disallowed', () => {
+    const wrapper = makeWrapper(false);
+    const restrictedParagraph = wrapper.find('[data-test="restrictedAccess"]');
+    expect(restrictedParagraph.exists()).toBeTruthy();
+  });
+
+  it('access_allowed', () => {
+    const wrapper = makeWrapper();
+    const restrictedParagraph = wrapper.find('[data-test="restrictedAccess"]');
+    expect(restrictedParagraph.exists()).toBeFalsy();
+  });
+  it('create_session_link', () => {
+    const wrapper = makeWrapper();
+    const createLink = wrapper.find('a');
+    expect(createLink.attributes().href).toBe('#/signup');
+  });
+});

--- a/kolibri/plugins/user/assets/test/views/auth-base.spec.js
+++ b/kolibri/plugins/user/assets/test/views/auth-base.spec.js
@@ -37,7 +37,7 @@ describe('auth base component', () => {
   });
   it('create_session_link', () => {
     const wrapper = makeWrapper();
-    const createLink = wrapper.find('a');
+    const createLink = wrapper.find('[data-test="createUser"]');
     expect(createLink.attributes().href).toBe('#/signup');
   });
 });

--- a/kolibri/plugins/user/assets/test/views/auth-select-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/auth-select-page.spec.js
@@ -1,0 +1,35 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import AuthSelect from '../../src/views/AuthSelect';
+import makeStore from '../makeStore';
+
+jest.mock('kolibri.urls');
+const localVue = createLocalVue();
+const router = new VueRouter({
+  routes: [
+    { name: 'SIGN_IN', path: '/signin' },
+    { name: 'SIGN_UP', path: '/signup' },
+    { name: 'FACILITY_SELECT', path: '/facilities' },
+  ],
+});
+
+function makeWrapper() {
+  const store = makeStore();
+  store.getters = { ...store.getters, allowAccess: true };
+
+  return mount(AuthSelect, {
+    store,
+    localVue,
+    router,
+  });
+}
+
+describe('user index page component', () => {
+  it('auth select facility', () => {
+    const wrapper = makeWrapper();
+    const createLink = wrapper.find('[data-test="createUser"]');
+    expect(createLink.attributes().href).toBe('#/facilities?next=SIGN_UP&backTo=AUTH_SELECT');
+    const signIn = wrapper.find('[data-test="signIn"]');
+    expect(signIn.attributes().href).toBe('#/facilities?next=SIGN_IN&backTo=AUTH_SELECT');
+  });
+});

--- a/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/sign-up-page.spec.js
@@ -15,7 +15,10 @@ router.getRoute = () => {
 
 function makeWrapper() {
   const store = makeStore();
-  store.state.core.facilities = [{ id: 1, name: 'facility' }];
+  store.state.core.facilities = [
+    { id: 1, name: 'Facility 1' },
+    { id: 2, name: 'Facility 2' },
+  ];
   store.state.facilityId = 1;
   return mount(SignUpPage, {
     store,
@@ -32,6 +35,16 @@ function makeWrapper() {
 describe('signUpPage component', () => {
   it('smoke test', () => {
     const wrapper = makeWrapper();
-    expect(wrapper.exists()).toEqual(true);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+});
+
+describe('multiFacility signUpPage component', () => {
+  it('right facility', async () => {
+    const wrapper = makeWrapper();
+    const facilityLabel = wrapper.find('[data-test="facilityLabel"]').element;
+    expect(facilityLabel.textContent).toMatch(/Facility 1/);
+    await wrapper.vm.$store.commit('SET_FACILITY_ID', 2);
+    expect(facilityLabel.textContent).toMatch(/Facility 2/);
   });
 });


### PR DESCRIPTION
### Summary
This is a battery of tests trying to cover parts of the current Kolibri sign in/sign up logic


### Reviewer guidance
do tests pass?

### References
 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
