### PR TITLE
Channel dropdown reset fix

### DIFF
--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -90,11 +90,15 @@ def create_superuser(user_data, facility):
     ).exists():
         raise ValidationError("An account with that username already exists")
 
+    # gender and birth_year are set to "DEFERRED", since superusers do not
+    # need to provide this and are not nudged to update profile on Learn page
     superuser = FacilityUser.objects.create(
         full_name=full_name or username,
         username=username,
         password=password,
         facility=facility,
+        gender="DEFERRED",
+        birth_year="DEFERRED",
     )
 
     superuser.full_clean()

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -219,6 +219,9 @@
   }
 
   .no-match {
+    // Add extra height to empty state message
+    // so opening language dropdown doesn't cause an overflow
+    height: 250px;
     padding: 32px 0;
   }
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -87,6 +87,8 @@
       return {
         languageFilter: {},
         titleFilter: '',
+        // Use a copy of channels from Vuex to avoid #6989 when it gets mutated
+        channelsCopy: [...this.channels],
       };
     },
     computed: {
@@ -110,7 +112,7 @@
         };
       },
       languageFilterOptions() {
-        const codes = uniqBy(this.channels, 'lang_code')
+        const codes = uniqBy(this.channelsCopy, 'lang_code')
           .map(({ lang_name, lang_code }) => ({
             value: lang_code,
             label: lang_name,
@@ -122,7 +124,7 @@
         return this.$tr('numChannelsAvailable', { count: this.filteredItems.length });
       },
       filteredItems() {
-        return this.channels.filter(this.channelPassesFilters);
+        return this.channelsCopy.filter(this.channelPassesFilters);
       },
       noMatchMsg() {
         if (

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -1,7 +1,6 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import { currentLanguage, createTranslator } from 'kolibri.utils.i18n';
-import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
 import { Presets, permissionPresets } from '../constants';
 import { FacilityImportResource } from '../api';
 
@@ -11,8 +10,6 @@ const SetupStrings = createTranslator('SetupStrings', {
     context: 'Template for a facility name for personal setups',
   },
 });
-
-const { DEFERRED } = DemographicConstants;
 
 export default {
   state: {
@@ -44,10 +41,6 @@ export default {
         full_name: '',
         username: '',
         password: '',
-        // Superusers are not required to provide this info and are not
-        // nudged to update the profile when on Learn page
-        gender: DEFERRED,
-        birth_year: DEFERRED,
       },
     },
     loading: false,

--- a/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
@@ -47,17 +47,11 @@
         // that the non-superuser-related payload is valid for the 'deviceprovision' endpoint
         this.$store.dispatch('setPersonalUsageDefaults');
 
-        const {
-          full_name,
-          username,
-          password,
-          gender,
-          birth_year,
-        } = this.$store.state.onboardingData.superuser;
+        const { full_name, username, password } = this.$store.state.onboardingData.superuser;
 
         // Validate the superuser info in case user ended up in a bad state here via history
         // and redirect to credentials page
-        if (every([full_name, username, password, gender, birth_year])) {
+        if (every([full_name, username, password])) {
           this.$store.dispatch('provisionDevice');
         } else {
           return this.$refs.credentials.focusOnInvalidField();

--- a/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/SuperuserCredentialsForm.spec.js
@@ -33,8 +33,6 @@ describe('SuperuserCredentialsForm', () => {
       full_name: 'Schoolhouse Rock',
       username: 'schoolhouse_rock',
       password: 'password',
-      birth_year: 'DEFERRED',
-      gender: 'DEFERRED',
     });
     expect(wrapper.vm.$emit).toHaveBeenCalledWith('click_next', {
       full_name: 'Schoolhouse Rock',


### PR DESCRIPTION
### Summary

1. Fixes #6989 by decoupling the Filter widget from Vuex, where updates to the `channel` state can cause rerenders.
1. Adds extra height to the "No channels match filter" paragraph to avoid overflow when opening the channel filter (see screenshots)
1. Also adds a fix to a bug in the setup wizard #7204 by moving the "defer superuser demographic data" logic from the client to the server.

Without extra height
<img width="1044" alt="CleanShot 2020-07-08 at 13 02 21@2x" src="https://user-images.githubusercontent.com/10248067/86965510-8d2cf400-c11c-11ea-9830-9c126143c6c6.png">



With extra height

<img width="1042" alt="CleanShot 2020-07-08 at 13 02 47@2x" src="https://user-images.githubusercontent.com/10248067/86965514-8ef6b780-c11c-11ea-986d-5b0ad3713b71.png">

### Reviewer guidance

In #6989, I found that the reason the bug (the language dropdown in the Available Channels Page would always jump to the top) was happening because of Tasks inside the vuex state. So, to test this,

1. reset your local copy to before this patch
1. Start some kind of task (import/ export/delete channel) and _don't clear it_
1. Go to the Available Channels Page for any workflow (import from studio/local/p2p, or export)
1. Confirm that the problem in #6989 happens
1. Checkout the patch here and confirm the problem doesn't happen anymore

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
