### PR TITLE
Channel Upgrade Fixes and Enhancements

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -898,6 +898,8 @@ class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericView
         child_serializer = self.get_serializer(children, many=True)
         parent_data["children"] = child_serializer.data
 
+        parent_data["ancestors"] = instance.get_ancestors().values("id", "title")
+
         return Response(parent_data)
 
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -898,7 +898,7 @@ class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericView
         child_serializer = self.get_serializer(children, many=True)
         parent_data["children"] = child_serializer.data
 
-        parent_data["ancestors"] = instance.get_ancestors().values("id", "title")
+        parent_data["ancestors"] = list(instance.get_ancestors().values("id", "title"))
 
         return Response(parent_data)
 

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -102,30 +102,6 @@ class ContentNodeManager(
         """
         vendored from:
         https://github.com/django-mptt/django-mptt/blob/fe2b9cc8cfd8f4b764d294747dba2758147712eb/mptt/managers.py#L614
-
-        Load a tree from a nested dictionary for bulk insert, returning an
-        array of records. Use to efficiently insert many nodes within a tree
-        without an expensive `rebuild`.
-        ::
-            records = MyModel.objects.build_tree_nodes({
-                'id': 7,
-                'name': 'parent',
-                'children': [
-                    {
-                        'id': 8,
-                        'parent_id': 7,
-                        'name': 'child',
-                        'children': [
-                            {
-                                'id': 9,
-                                'parent_id': 8,
-                                'name': 'grandchild',
-                            }
-                        ]
-                    }
-                ]
-            })
-            MyModel.objects.bulk_create(records)
         """
         opts = self.model._mptt_meta
         if target:

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -98,6 +98,78 @@ class ContentNodeManager(
             .order_by(self.tree_id_attr, self.left_attr)
         )
 
+    def build_tree_nodes(self, data, target=None, position="last-child"):
+        """
+        vendored from:
+        https://github.com/django-mptt/django-mptt/blob/fe2b9cc8cfd8f4b764d294747dba2758147712eb/mptt/managers.py#L614
+
+        Load a tree from a nested dictionary for bulk insert, returning an
+        array of records. Use to efficiently insert many nodes within a tree
+        without an expensive `rebuild`.
+        ::
+            records = MyModel.objects.build_tree_nodes({
+                'id': 7,
+                'name': 'parent',
+                'children': [
+                    {
+                        'id': 8,
+                        'parent_id': 7,
+                        'name': 'child',
+                        'children': [
+                            {
+                                'id': 9,
+                                'parent_id': 8,
+                                'name': 'grandchild',
+                            }
+                        ]
+                    }
+                ]
+            })
+            MyModel.objects.bulk_create(records)
+        """
+        opts = self.model._mptt_meta
+        if target:
+            tree_id = target.tree_id
+            if position in ("left", "right"):
+                level = getattr(target, opts.level_attr)
+                if position == "left":
+                    cursor = getattr(target, opts.left_attr)
+                else:
+                    cursor = getattr(target, opts.right_attr) + 1
+            else:
+                level = getattr(target, opts.level_attr) + 1
+                if position == "first-child":
+                    cursor = getattr(target, opts.left_attr) + 1
+                else:
+                    cursor = getattr(target, opts.right_attr)
+        else:
+            tree_id = self._get_next_tree_id()
+            cursor = 1
+            level = 0
+
+        stack = []
+
+        def treeify(data, cursor=1, level=0):
+            data = dict(data)
+            children = data.pop("children", [])
+            node = self.model(**data)
+            stack.append(node)
+            setattr(node, opts.tree_id_attr, tree_id)
+            setattr(node, opts.level_attr, level)
+            setattr(node, opts.left_attr, cursor)
+            for child in children:
+                cursor = treeify(child, cursor=cursor + 1, level=level + 1)
+            cursor += 1
+            setattr(node, opts.right_attr, cursor)
+            return cursor
+
+        treeify(data, cursor=cursor, level=level)
+
+        if target:
+            self._create_space(2 * len(stack), cursor - 1, tree_id)
+
+        return stack
+
 
 @python_2_unicode_compatible
 class ContentNode(base_models.ContentNode):

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -280,6 +280,9 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
     coach_content = serializers.SerializerMethodField()
     total_resources = serializers.SerializerMethodField()
     importable = serializers.SerializerMethodField()
+    new_resource = serializers.SerializerMethodField()
+    num_new_resources = serializers.SerializerMethodField()
+    updated_resource = serializers.SerializerMethodField()
 
     class Meta:
         model = ContentNode
@@ -293,6 +296,9 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
             "on_device_resources",
             "title",
             "total_resources",
+            "new_resource",
+            "num_new_resources",
+            "updated_resource",
         )
 
     @property
@@ -330,6 +336,24 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
         if self.channel_stats is None:
             return None
         return instance.id in self.channel_stats
+
+    def get_new_resource(self, instance):
+        # If for export, just return None
+        if self.channel_stats is None:
+            return None
+        return self.channel_stats.get(instance.id, {}).get("new_resource", False)
+
+    def get_num_new_resources(self, instance):
+        # If for export, just return None
+        if self.channel_stats is None:
+            return None
+        return self.channel_stats.get(instance.id, {}).get("num_new_resources", 0)
+
+    def get_updated_resource(self, instance):
+        # If for export, just return None
+        if self.channel_stats is None:
+            return None
+        return self.channel_stats.get(instance.id, {}).get("updated_resource", False)
 
 
 class ContentNodeProgressListSerializer(serializers.ListSerializer):

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -72,6 +72,7 @@ class ChannelBuilder(object):
         self.localfile_to_files_map = {}
 
         self.root_node = self.generate_topic()
+        self.channel["root_id"] = self.root_node["id"]
 
         if self.levels:
             self.root_node["children"] = self.recurse_and_generate(
@@ -318,7 +319,7 @@ class ChannelBuilder(object):
 
     def channel_data(self, channel_id=None, version=1):
         return {
-            "root_id": uuid4_hex(),
+            "root_id": None,
             "last_updated": None,
             "version": 1,
             "author": "Outis",

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -1,0 +1,732 @@
+import copy
+import random
+import tempfile
+import uuid
+from itertools import chain
+
+from django.test import TestCase
+from le_utils.constants import content_kinds
+from le_utils.constants import format_presets
+from mock import patch
+from sqlalchemy import create_engine
+
+from kolibri.core.content.constants.schema_versions import CURRENT_SCHEMA_VERSION
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import File
+from kolibri.core.content.models import LocalFile
+from kolibri.core.content.utils.annotation import mark_local_files_as_available
+from kolibri.core.content.utils.content_types_tools import renderable_files_presets
+from kolibri.core.content.utils.sqlalchemybridge import load_metadata
+from kolibri.core.content.utils.upgrade import count_removed_resources
+from kolibri.core.content.utils.upgrade import get_automatically_updated_resources
+from kolibri.core.content.utils.upgrade import get_new_resources_available_for_import
+
+
+def to_dict(instance):
+    opts = instance._meta
+    data = {}
+    for f in chain(opts.concrete_fields, opts.private_fields):
+        data[f.name] = f.value_from_object(instance)
+    return data
+
+
+def uuid4_hex():
+    return uuid.uuid4().hex
+
+
+class ChannelBuilder(object):
+    """
+    This class is purely to generate all the relevant data for a single
+    channel for use during testing.
+    """
+
+    __TREE_CACHE = {}
+
+    tree_keys = (
+        "channel",
+        "files",
+        "localfiles",
+        "node_to_files_map",
+        "localfile_to_files_map",
+        "root_node",
+    )
+
+    def __init__(self, levels=3):
+        self.levels = levels
+
+        try:
+            self.load_data()
+        except KeyError:
+            print("key error {}".format(self.levels))
+            self.generate_new_tree()
+            self.save_data()
+
+        self.generate_nodes_from_root_node()
+
+    def generate_new_tree(self):
+        self.channel = self.channel_data()
+        self.files = {}
+        self.localfiles = {}
+        self.node_to_files_map = {}
+        self.localfile_to_files_map = {}
+
+        self.root_node = self.generate_topic()
+
+        if self.levels:
+            self.root_node["children"] = self.recurse_and_generate(
+                self.root_node["id"], self.levels
+            )
+
+    def load_data(self):
+        data = copy.deepcopy(self.__TREE_CACHE[self.levels])
+
+        for key in self.tree_keys:
+            setattr(self, key, data[key])
+
+    def save_data(self):
+        data = {}
+
+        for key in self.tree_keys:
+            data[key] = getattr(self, key)
+
+        self.__TREE_CACHE[self.levels] = copy.deepcopy(data)
+
+    def generate_nodes_from_root_node(self):
+        self._django_nodes = ContentNode.objects.build_tree_nodes(self.root_node)
+
+        self.nodes = {n["id"]: n for n in map(to_dict, self._django_nodes)}
+
+    def insert_into_default_db(self):
+        ContentNode.objects.bulk_create(self._django_nodes)
+        ChannelMetadata.objects.create(**self.channel)
+        LocalFile.objects.bulk_create(
+            (LocalFile(**l) for l in self.localfiles.values())
+        )
+        File.objects.bulk_create((File(**f) for f in self.files.values()))
+
+    def recurse_tree_until_leaf_container(self, parent):
+        if not parent.get("children"):
+            parent["children"] = []
+            return parent
+        child = random.choice(parent["children"])
+        if child["kind"] != content_kinds.TOPIC:
+            return parent
+        return self.recurse_tree_until_leaf_container(child)
+
+    def delete_file(self, file):
+        try:
+            index = self.localfile_to_files_map[file["local_file_id"]].index(file["id"])
+            self.localfile_to_files_map[file["local_file_id"]].pop(index)
+        except ValueError:
+            pass
+        if not self.localfile_to_files_map[file["local_file_id"]]:
+            del self.localfiles[file["local_file_id"]]
+        del self.files[file["id"]]
+
+    def update_resource(self, resource):
+        """
+        Update any main files for the resource
+        """
+        new_localfiles = []
+        keys_to_remove = set()
+        # Make a copy of the node to file map
+        # as it will otherwise change during iteration
+        node_to_files_map = list(self.node_to_files_map[resource["id"]])
+        for f_id in node_to_files_map:
+            file = self.files[f_id]
+            if not file["supplementary"]:
+                self.delete_file(file)
+                # Create a new file in its place
+                localfile = self.localfile_data()
+                self.file_data(
+                    resource["id"], localfile["id"], preset=format_presets.VIDEO_LOW_RES
+                )
+                keys_to_remove.add(f_id)
+                new_localfiles.append(localfile)
+        self.node_to_files_map[resource["id"]] = list(
+            filter(
+                lambda x: x not in keys_to_remove,
+                self.node_to_files_map[resource["id"]],
+            )
+        )
+        return new_localfiles
+
+    def update_thumbnail(self, node):
+        """
+        Update the thumbnail for a node
+        """
+        new_localfiles = []
+        keys_to_remove = set()
+        # Make a copy of the node to file map
+        # as it will otherwise change during iteration
+        node_to_files_map = list(self.node_to_files_map[node["id"]])
+        for f_id in node_to_files_map:
+            file = self.files[f_id]
+            if file["thumbnail"]:
+                self.delete_file(file)
+                # Create a new file in its place
+                thumbnail = self.localfile_data(extension="png")
+                self.file_data(
+                    node["id"],
+                    thumbnail["id"],
+                    thumbnail=True,
+                    preset=format_presets.TOPIC_THUMBNAIL,
+                )
+                keys_to_remove.add(f_id)
+                new_localfiles.append(thumbnail)
+        self.node_to_files_map[node["id"]] = list(
+            filter(
+                lambda x: x not in keys_to_remove, self.node_to_files_map[node["id"]],
+            )
+        )
+        return new_localfiles
+
+    def delete_resource_files(self, resource):
+        for f_id in self.node_to_files_map[resource["id"]]:
+            file = self.files[f_id]
+            self.delete_file(file)
+        del self.node_to_files_map[resource["id"]]
+
+    def duplicate_resource(self, resource):
+        node = self.contentnode_data(
+            parent_id=resource["parent_id"],
+            content_id=resource["content_id"],
+            kind=resource["kind"],
+        )
+        for f_id in self.node_to_files_map[resource["id"]]:
+            file = self.files[f_id]
+            self.file_data(
+                node["id"],
+                file["local_file_id"],
+                thumbnail=file["thumbnail"],
+                preset=file["preset"],
+            )
+        return node
+
+    def duplicate_resources(self, num_resources):
+        self.duplicated_resources = []
+        for i in range(0, num_resources):
+            parent = self.recurse_tree_until_leaf_container(self.root_node)
+            child = random.choice(parent["children"])
+            duplicate = self.duplicate_resource(child)
+            self.duplicated_resources.append(duplicate)
+            parent["children"].append(duplicate)
+        self.generate_nodes_from_root_node()
+
+    def move_resources(self, num_resources):
+        self.moved_resources = []
+        self.deleted_resources = []
+        for i in range(0, num_resources):
+            parent = self.recurse_tree_until_leaf_container(self.root_node)
+            child = random.choice(parent["children"])
+            moved = self.duplicate_resource(child)
+            self.moved_resources.append(moved)
+            self.deleted_resources.append(child)
+            parent["children"].pop(parent["children"].index(child))
+            parent["children"].append(moved)
+        self.generate_nodes_from_root_node()
+
+    def upgrade(self, new_resources=0, updated_resources=0, deleted_resources=0):
+        self.new_resources = []
+        self.updated_thumbnails = []
+        for i in range(0, new_resources):
+            parent = self.recurse_tree_until_leaf_container(self.root_node)
+            child = self.generate_leaf(parent["id"])
+            parent["children"].append(child)
+            self.new_resources.append(child)
+            # To emulate a common occurrence that produces edge cases
+            # we also update the parent's thumbnail here
+            self.updated_thumbnails.extend(self.update_thumbnail(parent))
+
+        self.updated_resources = []
+        self.updated_resource_localfiles = []
+        for i in range(0, updated_resources):
+            parent = self.recurse_tree_until_leaf_container(self.root_node)
+            child = random.choice(parent["children"])
+            self.updated_resource_localfiles.extend(self.update_resource(child))
+            self.updated_resources.append(child)
+
+        self.deleted_resources = []
+        for i in range(0, deleted_resources):
+            parent = self.recurse_tree_until_leaf_container(self.root_node)
+            child_index = random.randint(0, len(parent["children"]) - 1)
+            child = parent["children"].pop(child_index)
+            self.delete_resource_files(child)
+            self.deleted_resources.append(child)
+
+        self.generate_nodes_from_root_node()
+
+    @property
+    def resources(self):
+        return filter(lambda x: x["kind"] != content_kinds.TOPIC, self.nodes.values())
+
+    def get_resource_localfiles(self, ids):
+        localfiles = {}
+        for r in ids:
+            for f in self.node_to_files_map.get(r, []):
+                file = self.files[f]
+                localfile = self.localfiles[file["local_file_id"]]
+                localfiles[localfile["id"]] = localfile
+        return list(localfiles.values())
+
+    @property
+    def data(self):
+        return {
+            "content_channel": [self.channel],
+            "content_contentnode": list(self.nodes.values()),
+            "content_file": list(self.files.values()),
+            "content_localfile": list(self.localfiles.values()),
+        }
+
+    def recurse_and_generate(self, parent_id, levels):
+        children = []
+        for i in range(0, 5):
+            if levels == 0:
+                node = self.generate_leaf(parent_id)
+            else:
+                node = self.generate_topic(parent_id=parent_id)
+                node["children"] = self.recurse_and_generate(parent_id, levels - 1)
+            children.append(node)
+        return children
+
+    def generate_topic(self, parent_id=None):
+        data = self.contentnode_data(
+            kind=content_kinds.TOPIC, root=parent_id is None, parent_id=parent_id,
+        )
+        thumbnail = self.localfile_data(extension="png")
+        self.file_data(
+            data["id"],
+            thumbnail["id"],
+            thumbnail=True,
+            preset=format_presets.TOPIC_THUMBNAIL,
+        )
+        return data
+
+    def generate_leaf(self, parent_id):
+        node = self.contentnode_data(parent_id=parent_id, kind=content_kinds.VIDEO)
+        localfile = self.localfile_data()
+        thumbnail = self.localfile_data(extension="png")
+        self.file_data(node["id"], localfile["id"], preset=format_presets.VIDEO_LOW_RES)
+        self.file_data(
+            node["id"],
+            thumbnail["id"],
+            thumbnail=True,
+            preset=format_presets.VIDEO_THUMBNAIL,
+        )
+        return node
+
+    def channel_data(self, channel_id=None, version=1):
+        return {
+            "root_id": uuid4_hex(),
+            "last_updated": None,
+            "version": 1,
+            "author": "Outis",
+            "description": "Test channel",
+            "tagline": None,
+            "min_schema_version": "1",
+            "thumbnail": "",
+            "name": "testing",
+            "id": channel_id or uuid4_hex(),
+        }
+
+    def localfile_data(self, extension="mp4"):
+        data = {
+            "file_size": random.randint(1, 1000),
+            "extension": extension,
+            "available": False,
+            "id": uuid4_hex(),
+        }
+
+        self.localfiles[data["id"]] = data
+
+        return data
+
+    def file_data(
+        self,
+        contentnode_id,
+        local_file_id,
+        thumbnail=False,
+        preset=None,
+        supplementary=False,
+    ):
+        data = {
+            "priority": None,
+            "supplementary": supplementary or thumbnail,
+            "id": uuid4_hex(),
+            "local_file_id": local_file_id or uuid4_hex(),
+            "contentnode_id": contentnode_id,
+            "thumbnail": thumbnail,
+            "preset": preset or random.choice(list(renderable_files_presets)),
+            "lang_id": None,
+        }
+        self.files[data["id"]] = data
+        if contentnode_id not in self.node_to_files_map:
+            self.node_to_files_map[contentnode_id] = []
+        self.node_to_files_map[contentnode_id].append(data["id"])
+        if local_file_id not in self.localfile_to_files_map:
+            self.localfile_to_files_map[local_file_id] = []
+        self.localfile_to_files_map[local_file_id].append(data["id"])
+        return data
+
+    def contentnode_data(
+        self, node_id=None, content_id=None, parent_id=None, kind=None, root=False,
+    ):
+        return {
+            "options": "{}",
+            "content_id": content_id or uuid4_hex(),
+            "channel_id": self.channel["id"],
+            "description": "Blah blah blah",
+            "id": node_id or uuid4_hex(),
+            "license_name": "GNU",
+            "license_owner": "",
+            "license_description": None,
+            "lang_id": None,
+            "author": "",
+            "title": "Test",
+            "parent_id": None if root else parent_id or uuid4_hex(),
+            # First kind in choices is Topic, so exclude it here.
+            "kind": kind or random.choice(content_kinds.choices[1:])[0],
+            "coach_content": False,
+            "available": False,
+        }
+
+
+class ChannelUpdateTestBase(TestCase):
+    def setUp(self):
+        patcher = patch(
+            "kolibri.core.content.utils.upgrade.get_annotated_content_database_file_path",
+            return_value=self.content_db_path,
+        )
+        # Do this as tearDown doesn't get called if there is an error in the test.
+        self.addCleanup(patcher.stop)
+        self.db_path_mock = patcher.start()
+        super(ChannelUpdateTestBase, self).setUp()
+
+    @classmethod
+    def set_content_fixture(cls):
+        _, cls.content_db_path = tempfile.mkstemp(suffix=".sqlite3")
+
+        cls.content_engine = create_engine(
+            "sqlite:///" + cls.content_db_path, convert_unicode=True
+        )
+
+        metadata = load_metadata(CURRENT_SCHEMA_VERSION)
+
+        metadata.bind = cls.content_engine
+
+        metadata.create_all()
+
+        conn = cls.content_engine.connect()
+
+        # Write data for each fixture into the table
+        for table in metadata.sorted_tables:
+            if table.name in cls.upgraded_channel.data:
+                conn.execute(table.insert(), cls.upgraded_channel.data[table.name])
+
+        conn.close()
+
+        cls.channel_id = cls.upgraded_channel.channel["id"]
+
+
+class ChannelUpdateAllNewTestCase(ChannelUpdateTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.upgraded_channel = ChannelBuilder()
+        cls.set_content_fixture()
+        ContentNode.objects.all().update(available=True)
+        LocalFile.objects.all().update(available=True)
+
+    def test_new_resources(self):
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            set(new_resource_ids),
+            set(map(lambda x: x["id"], self.upgraded_channel.resources)),
+        )
+        self.assertEqual(
+            set(new_resource_content_ids),
+            set(map(lambda x: x["content_id"], self.upgraded_channel.resources)),
+        )
+        self.assertEqual(
+            new_resource_total_size,
+            sum(
+                map(
+                    lambda x: x["file_size"],
+                    self.upgraded_channel.get_resource_localfiles(
+                        map(lambda x: x["id"], self.upgraded_channel.resources)
+                    ),
+                )
+            ),
+        )
+
+    def test_deleted_resources(self):
+        resources_to_be_deleted_count = count_removed_resources(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(resources_to_be_deleted_count, 0)
+
+    def test_update_resources(self):
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
+
+        self.assertEqual(updated_resource_ids, [])
+        self.assertEqual(updated_resource_content_ids, [])
+        self.assertEqual(updated_resource_total_size, 0)
+
+
+class ChannelDeleteAllTestCase(ChannelUpdateTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.upgraded_channel = ChannelBuilder(0)
+        cls.set_content_fixture()
+        cls.already_imported_channel = ChannelBuilder()
+        cls.already_imported_channel.insert_into_default_db()
+        cls.channel_id = cls.already_imported_channel.channel["id"]
+        ContentNode.objects.all().update(available=True)
+        LocalFile.objects.all().update(available=True)
+
+    def test_new_resources(self):
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(new_resource_ids, [])
+        self.assertEqual(
+            new_resource_content_ids, [],
+        )
+        self.assertEqual(
+            new_resource_total_size, 0,
+        )
+
+    def test_deleted_resources(self):
+        resources_to_be_deleted_count = count_removed_resources(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            resources_to_be_deleted_count,
+            ContentNode.objects.exclude(kind=content_kinds.TOPIC)
+            .filter(channel_id=self.channel_id, available=True)
+            .values("content_id")
+            .distinct()
+            .count(),
+        )
+
+    def test_update_resources(self):
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
+
+        self.assertEqual(updated_resource_ids, [])
+        self.assertEqual(updated_resource_content_ids, [])
+        self.assertEqual(updated_resource_total_size, 0)
+
+
+class ChannelMixedTestCase(ChannelUpdateTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.upgraded_channel = ChannelBuilder()
+        cls.upgraded_channel.insert_into_default_db()
+        cls.upgraded_channel.upgrade(
+            new_resources=3, updated_resources=4, deleted_resources=5
+        )
+        cls.set_content_fixture()
+        mark_local_files_as_available(
+            LocalFile.objects.all().values_list("id", flat=True),
+            destination=cls.content_db_path,
+        )
+        ContentNode.objects.all().update(available=True)
+        LocalFile.objects.all().update(available=True)
+
+    def test_new_resources(self):
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            set(new_resource_ids),
+            set(map(lambda x: x["id"], self.upgraded_channel.new_resources)),
+        )
+        self.assertEqual(
+            set(new_resource_content_ids),
+            set(map(lambda x: x["content_id"], self.upgraded_channel.new_resources)),
+        )
+
+        new_resource_local_files = self.upgraded_channel.get_resource_localfiles(
+            map(lambda x: x["id"], self.upgraded_channel.new_resources)
+        )
+
+        self.assertEqual(
+            new_resource_total_size,
+            sum(map(lambda x: x["file_size"], new_resource_local_files,)),
+        )
+
+    def test_deleted_resources(self):
+        resources_to_be_deleted_count = count_removed_resources(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(resources_to_be_deleted_count, 5)
+
+    def test_update_resources(self):
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
+
+        self.assertEqual(
+            set(updated_resource_ids),
+            set(map(lambda x: x["id"], self.upgraded_channel.updated_resources)),
+        )
+        self.assertEqual(
+            set(updated_resource_content_ids),
+            set(
+                map(lambda x: x["content_id"], self.upgraded_channel.updated_resources)
+            ),
+        )
+        self.assertEqual(
+            updated_resource_total_size,
+            sum(
+                map(
+                    lambda x: x["file_size"],
+                    self.upgraded_channel.updated_resource_localfiles,
+                )
+            ),
+        )
+
+
+class ChannelDuplicateTestCase(ChannelUpdateTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.upgraded_channel = ChannelBuilder()
+        cls.upgraded_channel.insert_into_default_db()
+        cls.upgraded_channel.duplicate_resources(10)
+        cls.set_content_fixture()
+        mark_local_files_as_available(
+            LocalFile.objects.all().values_list("id", flat=True),
+            destination=cls.content_db_path,
+        )
+        ContentNode.objects.all().update(available=True)
+        LocalFile.objects.all().update(available=True)
+
+    def test_new_resources(self):
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            set(new_resource_ids),
+            set(map(lambda x: x["id"], self.upgraded_channel.duplicated_resources)),
+        )
+        self.assertEqual(
+            set(new_resource_content_ids), set(),
+        )
+
+        self.assertEqual(new_resource_total_size, 0)
+
+    def test_deleted_resources(self):
+        resources_to_be_deleted_count = count_removed_resources(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(resources_to_be_deleted_count, 0)
+
+    def test_update_resources(self):
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
+
+        self.assertEqual(
+            set(updated_resource_ids), set(),
+        )
+        self.assertEqual(
+            set(updated_resource_content_ids), set(),
+        )
+        self.assertEqual(updated_resource_total_size, 0)
+
+
+class ChannelNodesMovedTestCase(ChannelUpdateTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.upgraded_channel = ChannelBuilder()
+        cls.upgraded_channel.insert_into_default_db()
+        cls.upgraded_channel.move_resources(10)
+        cls.set_content_fixture()
+        mark_local_files_as_available(
+            LocalFile.objects.all().values_list("id", flat=True),
+            destination=cls.content_db_path,
+        )
+        ContentNode.objects.all().update(available=True)
+        LocalFile.objects.all().update(available=True)
+
+    def test_new_resources(self):
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            set(new_resource_ids),
+            set(map(lambda x: x["id"], self.upgraded_channel.moved_resources)),
+        )
+
+        self.assertEqual(
+            set(new_resource_content_ids), set(),
+        )
+
+        self.assertEqual(new_resource_total_size, 0)
+
+    def test_deleted_resources(self):
+        resources_to_be_deleted_count = count_removed_resources(
+            self.content_db_path, self.channel_id
+        )
+
+        self.assertEqual(
+            resources_to_be_deleted_count, len(self.upgraded_channel.deleted_resources)
+        )
+
+    def test_update_resources(self):
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
+
+        self.assertEqual(
+            set(updated_resource_ids), set(),
+        )
+        self.assertEqual(
+            set(updated_resource_content_ids), set(),
+        )
+        self.assertEqual(updated_resource_total_size, 0)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -246,7 +246,8 @@ class ContentNodeAPITestCase(APITestCase):
 
     @mock.patch("kolibri.core.content.api.get_channel_stats_from_studio")
     def test_contentnode_granular_network_import(self, stats_mock):
-        c1_id = content.ContentNode.objects.get(title="root").id
+        c1 = content.ContentNode.objects.get(title="root")
+        c1_id = c1.id
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
         content.ContentNode.objects.all().update(available=False)
@@ -271,6 +272,7 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(
             reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1_id})
         )
+
         self.assertEqual(
             response.data,
             {
@@ -283,6 +285,10 @@ class ContentNodeAPITestCase(APITestCase):
                 "coach_content": False,
                 "importable": True,
                 "num_coach_contents": 0,
+                "new_resource": False,
+                "num_new_resources": 0,
+                "updated_resource": False,
+                "ancestors": list(c1.get_ancestors().values("id", "title")),
                 "children": [
                     {
                         "id": c2_id,
@@ -294,6 +300,9 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": True,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                     {
                         "id": c3_id,
@@ -305,6 +314,9 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": True,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                 ],
             },
@@ -315,7 +327,8 @@ class ContentNodeAPITestCase(APITestCase):
         content.LocalFile.objects.update(available=False)
         content.ContentNode.objects.update(available=False)
 
-        c1_id = content.ContentNode.objects.get(title="root").id
+        c1 = content.ContentNode.objects.get(title="root")
+        c1_id = c1.id
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
 
@@ -349,6 +362,10 @@ class ContentNodeAPITestCase(APITestCase):
                 "importable": True,
                 "coach_content": False,
                 "num_coach_contents": 0,
+                "new_resource": False,
+                "num_new_resources": 0,
+                "updated_resource": False,
+                "ancestors": list(c1.get_ancestors().values("id", "title")),
                 "children": [
                     {
                         "id": c2_id,
@@ -360,6 +377,9 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": False,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                     {
                         "id": c3_id,
@@ -371,6 +391,9 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": True,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                 ],
             },
@@ -381,7 +404,8 @@ class ContentNodeAPITestCase(APITestCase):
         content.LocalFile.objects.update(available=False)
         content.ContentNode.objects.update(available=False)
 
-        c1_id = content.ContentNode.objects.get(title="root").id
+        c1 = content.ContentNode.objects.get(title="root")
+        c1_id = c1.id
         c2_id = content.ContentNode.objects.get(title="c1").id
         c3_id = content.ContentNode.objects.get(title="c2").id
         stats = {
@@ -414,6 +438,10 @@ class ContentNodeAPITestCase(APITestCase):
                 "importable": True,
                 "coach_content": False,
                 "num_coach_contents": 0,
+                "new_resource": False,
+                "num_new_resources": 0,
+                "updated_resource": False,
+                "ancestors": list(c1.get_ancestors().values("id", "title")),
                 "children": [
                     {
                         "id": c2_id,
@@ -425,6 +453,9 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": False,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                     {
                         "id": c3_id,
@@ -436,13 +467,17 @@ class ContentNodeAPITestCase(APITestCase):
                         "importable": True,
                         "coach_content": False,
                         "num_coach_contents": 0,
+                        "new_resource": False,
+                        "num_new_resources": 0,
+                        "updated_resource": False,
                     },
                 ],
             },
         )
 
     def test_contentnode_granular_export_available(self):
-        c1_id = content.ContentNode.objects.get(title="c1").id
+        c1 = content.ContentNode.objects.get(title="c1")
+        c1_id = c1.id
         content.ContentNode.objects.filter(title="c1").update(on_device_resources=1)
         response = self.client.get(
             reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1_id}),
@@ -461,11 +496,16 @@ class ContentNodeAPITestCase(APITestCase):
                 "children": [],
                 "coach_content": False,
                 "num_coach_contents": 0,
+                "new_resource": None,
+                "num_new_resources": None,
+                "updated_resource": None,
+                "ancestors": list(c1.get_ancestors().values("id", "title")),
             },
         )
 
     def test_contentnode_granular_export_unavailable(self):
-        c1_id = content.ContentNode.objects.get(title="c1").id
+        c1 = content.ContentNode.objects.get(title="c1")
+        c1_id = c1.id
         content.ContentNode.objects.filter(title="c1").update(available=False)
         response = self.client.get(
             reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1_id}),
@@ -484,6 +524,10 @@ class ContentNodeAPITestCase(APITestCase):
                 "children": [],
                 "coach_content": False,
                 "num_coach_contents": 0,
+                "new_resource": None,
+                "num_new_resources": None,
+                "updated_resource": None,
+                "ancestors": list(c1.get_ancestors().values("id", "title")),
             },
         )
 

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -409,7 +409,7 @@ def mark_local_files_availability(checksums, availability, destination=None):
             connection.execute(
                 LocalFileTable.update()
                 .where(LocalFileTable.c.id.in_(checksums[i : i + CHUNKSIZE]))
-                .values(available=True)
+                .values(available=availability)
             )
 
         trans.commit()

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -393,7 +393,7 @@ def mark_local_files_availability(checksums, availability, destination=None):
     if checksums:
         bridge = Bridge(app_name=CONTENT_APP_NAME, sqlite_file_path=destination)
 
-        LocalFileClass = bridge.get_class(LocalFile)
+        LocalFileTable = bridge.get_table(LocalFile)
 
         logger.info(
             "Setting availability to {availability} of {number} LocalFile objects based on passed in checksums".format(
@@ -401,17 +401,18 @@ def mark_local_files_availability(checksums, availability, destination=None):
             )
         )
 
-        for i in range(0, len(checksums), CHUNKSIZE):
-            bridge.session.bulk_update_mappings(
-                LocalFileClass,
-                (
-                    {"id": checksum, "available": availability}
-                    for checksum in checksums[i : i + CHUNKSIZE]
-                ),
-            )
-            bridge.session.flush()
+        connection = bridge.get_connection()
 
-        bridge.session.commit()
+        trans = connection.begin()
+
+        for i in range(0, len(checksums), CHUNKSIZE):
+            connection.execute(
+                LocalFileTable.update()
+                .where(LocalFileTable.c.id.in_(checksums[i : i + CHUNKSIZE]))
+                .values(available=True)
+            )
+
+        trans.commit()
 
         bridge.end()
 

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -12,6 +12,8 @@ from kolibri.utils.uuids import is_valid_uuid
 
 logger = logging.getLogger(__name__)
 
+CHANNEL_UPDATE_STATS_CACHE_KEY = "CHANNEL_UPDATE_STATS_{}"
+
 
 def get_channel_ids_for_content_dirs(content_dirs):
     database_dir_paths = [

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -209,7 +209,9 @@ def get_new_resources_available_for_import(destination, channel_id):
             ContentNodeTable.update()
             .where(
                 and_(
-                    filter_by_uuids(ContentNodeTable.c.id, node_ids),
+                    filter_by_uuids(
+                        ContentNodeTable.c.id, node_ids, vendor=bridge.engine.name
+                    ),
                     ContentNodeTable.c.channel_id == channel_id,
                 ),
             )
@@ -310,7 +312,11 @@ def get_new_resources_available_for_import(destination, channel_id):
             ContentNodeTable.update()
             .where(
                 and_(
-                    filter_by_uuids(ContentNodeTable.c.content_id, content_ids),
+                    filter_by_uuids(
+                        ContentNodeTable.c.content_id,
+                        content_ids,
+                        vendor=bridge.engine.name,
+                    ),
                     ContentNodeTable.c.channel_id == channel_id,
                 ),
             )
@@ -495,7 +501,7 @@ def get_automatically_updated_resources(destination, channel_id):
     while ids_batch:
 
         contentnode_filter_expression = filter_by_uuids(
-            ContentNodeTable.c.id, ids_batch
+            ContentNodeTable.c.id, ids_batch, vendor=bridge.engine.name
         )
 
         # This does the first step in the many to many lookup for File

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -176,5 +176,7 @@ def automatically_updated_resource_ids(destination, channel_id):
     return (
         ContentNode.objects.filter_by_uuids(contentnode_ids, validate=False)
         .filter(available=True, channel_id=channel_id)
+        # Exclude topics from here to prevent erroneous imports of their children
+        .exclude(kind=content_kinds.TOPIC)
         .values_list("id", flat=True)
     )

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -3,23 +3,45 @@ import os
 
 from django.core.management import call_command
 from le_utils.constants import content_kinds
+from sqlalchemy import and_
+from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy import select
 
-from .annotation import CONTENT_APP_NAME
-from .sqlalchemybridge import Bridge
 from kolibri.core.content.constants.schema_versions import CURRENT_SCHEMA_VERSION
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils import annotation
 from kolibri.core.content.utils import channel_import
-from kolibri.core.content.utils import paths
+from kolibri.core.content.utils.annotation import CONTENT_APP_NAME
+from kolibri.core.content.utils.channels import CHANNEL_UPDATE_STATS_CACHE_KEY
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
+from kolibri.core.content.utils.content_types_tools import (
+    renderable_contentnodes_q_filter,
+)
+from kolibri.core.content.utils.content_types_tools import renderable_files_presets
+from kolibri.core.content.utils.importability_annotation import (
+    get_channel_stats_from_disk,
+)
+from kolibri.core.content.utils.importability_annotation import (
+    get_channel_stats_from_peer,
+)
+from kolibri.core.content.utils.paths import get_annotated_content_database_file_path
+from kolibri.core.content.utils.paths import get_upgrade_content_database_file_path
+from kolibri.core.content.utils.sqlalchemybridge import Bridge
+from kolibri.core.content.utils.sqlalchemybridge import coerce_key
+from kolibri.core.content.utils.sqlalchemybridge import filter_by_uuids
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.utils import get_current_job
+from kolibri.core.utils.cache import process_cache
 
 
 logger = logging.getLogger(__name__)
+
+
+def clear_diff_stats(channel_id):
+    process_cache.delete(CHANNEL_UPDATE_STATS_CACHE_KEY.format(channel_id))
 
 
 def diff_stats(channel_id, method, drive_id=None, baseurl=None):
@@ -29,9 +51,9 @@ def diff_stats(channel_id, method, drive_id=None, baseurl=None):
     Calculate diff stats comparing default db and annotated channel db.
     """
     # upgraded content database path
-    source_path = paths.get_upgrade_content_database_file_path(channel_id)
+    source_path = get_upgrade_content_database_file_path(channel_id)
     # annotated db to be used for calculating diff stats
-    destination_path = paths.get_annotated_content_database_file_path(channel_id)
+    destination_path = get_annotated_content_database_file_path(channel_id)
     try:
         if method == "network":
             call_command(
@@ -64,17 +86,21 @@ def diff_stats(channel_id, method, drive_id=None, baseurl=None):
         # annotate file availability on destination db
         annotation.set_local_file_availability_from_disk(destination=destination_path)
         # get the diff count between whats on the default db and the annotated db
-        new_resources_count = count_new_resources_available_for_import(
-            destination_path, channel_id
-        )
+        (
+            new_resource_ids,
+            new_resource_content_ids,
+            new_resource_total_size,
+        ) = get_new_resources_available_for_import(destination_path, channel_id)
         # get the count for leaf nodes which are in the default db, but not in the annotated db
         resources_to_be_deleted_count = count_removed_resources(
             destination_path, channel_id
         )
         # get the ids of leaf nodes which are now incomplete due to missing local files
-        updated_resources_ids = automatically_updated_resource_ids(
-            destination_path, channel_id
-        )
+        (
+            updated_resource_ids,
+            updated_resource_content_ids,
+            updated_resource_total_size,
+        ) = get_automatically_updated_resources(destination_path, channel_id)
         # remove the annotated database
         try:
             os.remove(destination_path)
@@ -87,12 +113,31 @@ def diff_stats(channel_id, method, drive_id=None, baseurl=None):
         # annotate job metadata with diff stats
         job = get_current_job()
         if job:
-            job.extra_metadata["new_resources_count"] = new_resources_count
+            job.extra_metadata["new_resources_count"] = len(new_resource_content_ids)
             job.extra_metadata[
                 "deleted_resources_count"
             ] = resources_to_be_deleted_count
-            job.extra_metadata["updated_node_ids"] = updated_resources_ids
+            job.extra_metadata["updated_resources_count"] = len(
+                updated_resource_content_ids
+            )
             job.save_meta()
+
+        CACHE_KEY = CHANNEL_UPDATE_STATS_CACHE_KEY.format(channel_id)
+
+        process_cache.set(
+            CACHE_KEY,
+            {
+                "new_resource_ids": new_resource_ids,
+                "new_resource_content_ids": new_resource_content_ids,
+                "new_resource_total_size": new_resource_total_size,
+                "updated_resource_ids": updated_resource_ids,
+                "updated_resource_content_ids": updated_resource_content_ids,
+                "updated_resource_total_size": updated_resource_total_size,
+            },
+            # Should persist until explicitly cleared (at content import)
+            # or until server restart.
+            None,
+        )
 
     except UserCancelledError:
         # remove the annotated database
@@ -103,80 +148,478 @@ def diff_stats(channel_id, method, drive_id=None, baseurl=None):
         raise
 
 
-def count_new_resources_available_for_import(destination, channel_id):
+batch_size = 1000
+
+
+def get_new_resources_available_for_import(destination, channel_id):
     """
     Queries the destination db to get leaf nodes.
     Subtract total number of leaf nodes by the count of leaf nodes on default db to get the number of new resources.
     """
     bridge = Bridge(app_name=CONTENT_APP_NAME, sqlite_file_path=destination)
-    ContentNodeClass = bridge.get_class(ContentNode)
-    leaf_node_ids = [
-        i
-        for i, in bridge.session.query(ContentNodeClass.id)
-        .filter(
-            ContentNodeClass.channel_id == channel_id,
-            ContentNodeClass.kind != content_kinds.TOPIC,
+    # SQL Alchemy reference to the content node table
+    ContentNodeTable = bridge.get_table(ContentNode)
+    # SQL Alchemy reference to the file table - a mapping from
+    # contentnodes to the files that they use
+    FileTable = bridge.get_table(File)
+    # SQL Alchemy reference to the localfile table which tracks
+    # information about the files on disk, such as availability
+    LocalFileTable = bridge.get_table(LocalFile)
+    connection = bridge.get_connection()
+
+    # To efficiently get the node ids of all new nodes in the channel
+    # we are going to iterate over the currently existing nodes for the
+    # channel in the default database, and cache their existence in the
+    # temporary upgrade database by flagging them as 'available' in there
+    # We can then read out all of the unavailable ContentNodes in order
+    # to get a complete list of the newly available ids.
+    # We wrap this all in a transaction so that we can roll it back afterwards
+    # but this is mostly just not to leave the upgrade DB in a messy state
+    # and could be removed if it becomes a performance concern
+
+    # Create a queryset for the node ids of resources currently in this channel
+    # we will slice this later in a while loop in order to efficiently process this
+    # this is necessary otherwise we would end up querying tens of thousands of node ids
+    # for a large channel, which would then be impossible to pass into an update query
+    # for the temporary upgrade DB without causing an excessively large query
+    # greater than 1MB, which is the default max for SQLite
+    current_resource_node_id_queryset = (
+        ContentNode.objects.filter(channel_id=channel_id)
+        .exclude(kind=content_kinds.TOPIC)
+        .values_list("id", flat=True)
+    )
+
+    i = 0
+
+    # start a transaction
+
+    trans = connection.begin()
+
+    # Set everything to False to start with
+    connection.execute(
+        ContentNodeTable.update()
+        .where(ContentNodeTable.c.channel_id == channel_id,)
+        .values(available=False)
+    )
+
+    node_ids = current_resource_node_id_queryset[i : i + batch_size]
+    while node_ids:
+        # Set everything to False to start with
+        connection.execute(
+            ContentNodeTable.update()
+            .where(
+                and_(
+                    filter_by_uuids(ContentNodeTable.c.id, node_ids),
+                    ContentNodeTable.c.channel_id == channel_id,
+                ),
+            )
+            .values(available=True)
         )
-        .all()
-    ]
+        i += batch_size
+        node_ids = current_resource_node_id_queryset[i : i + batch_size]
+
+    renderable_contentnodes = (
+        select([FileTable.c.contentnode_id])
+        .where(FileTable.c.supplementary == False)  # noqa
+        .where(
+            or_(*(FileTable.c.preset == preset for preset in renderable_files_presets))
+        )
+    )
+
+    contentnode_filter_expression = and_(
+        ContentNodeTable.c.channel_id == channel_id,
+        ContentNodeTable.c.kind != content_kinds.TOPIC,
+        ContentNodeTable.c.available == False,  # noqa
+        ContentNodeTable.c.id.in_(renderable_contentnodes),
+    )
+
+    new_resource_nodes_total_size = (
+        connection.execute(
+            # This does the first step in the many to many lookup for File
+            select([func.sum(LocalFileTable.c.file_size)]).where(
+                LocalFileTable.c.id.in_(
+                    select([LocalFileTable.c.id])
+                    .select_from(
+                        # and LocalFile.
+                        LocalFileTable.join(
+                            FileTable.join(
+                                ContentNodeTable,
+                                FileTable.c.contentnode_id == ContentNodeTable.c.id,
+                            ),  # This does the actual correlation between file and local file
+                            FileTable.c.local_file_id == LocalFileTable.c.id,
+                        )
+                    )
+                    .where(
+                        and_(
+                            # Filter only for files that are unavailable so we show
+                            # the import size
+                            LocalFileTable.c.available == False,  # noqa
+                            contentnode_filter_expression,
+                        )
+                    )
+                )
+            )
+        ).fetchone()[0]
+        or 0
+    )
+
+    new_resource_node_ids_statement = select([ContentNodeTable.c.id]).where(
+        and_(
+            ContentNodeTable.c.channel_id == channel_id,
+            ContentNodeTable.c.kind != content_kinds.TOPIC,
+            ContentNodeTable.c.available == False,  # noqa
+        )
+    )
+
+    new_resource_node_ids = list(
+        coerce_key(c[0])
+        for c in connection.execute(new_resource_node_ids_statement).fetchall()
+    )
+
+    trans.rollback()
+
+    # Create a queryset for the content_ids of resources currently in this channel
+    # we will slice this later in a while loop in order to efficiently process this
+    # this is necessary otherwise we would end up querying tens of thousands of node ids
+    # for a large channel, which would then be impossible to pass into an update query
+    # for the temporary upgrade DB without causing an excessively large query
+    # greater than 1MB, which is the default max for SQLite
+    current_resource_content_id_queryset = (
+        ContentNode.objects.filter(channel_id=channel_id)
+        .exclude(kind=content_kinds.TOPIC)
+        .values_list("content_id", flat=True)
+    )
+
+    i = 0
+
+    # start a transaction
+
+    trans = connection.begin()
+
+    # Set everything to False to start with
+    connection.execute(
+        ContentNodeTable.update()
+        .where(ContentNodeTable.c.channel_id == channel_id)
+        .values(available=False)
+    )
+
+    content_ids = current_resource_content_id_queryset[i : i + batch_size]
+    while content_ids:
+        # Set everything to False to start with
+        connection.execute(
+            ContentNodeTable.update()
+            .where(
+                and_(
+                    filter_by_uuids(ContentNodeTable.c.content_id, content_ids),
+                    ContentNodeTable.c.channel_id == channel_id,
+                ),
+            )
+            .values(available=True)
+        )
+        i += batch_size
+        content_ids = current_resource_content_id_queryset[i : i + batch_size]
+
+    new_resource_content_ids_statement = (
+        select([ContentNodeTable.c.content_id])
+        .where(
+            and_(
+                ContentNodeTable.c.channel_id == channel_id,
+                ContentNodeTable.c.kind != content_kinds.TOPIC,
+                ContentNodeTable.c.available == False,  # noqa
+            )
+        )
+        .distinct()
+    )
+
+    new_resource_content_ids = list(
+        coerce_key(c[0])
+        for c in connection.execute(new_resource_content_ids_statement).fetchall()
+    )
+
+    trans.rollback()
+
     return (
-        len(leaf_node_ids)
-        - ContentNode.objects.filter_by_uuids(leaf_node_ids, validate=False)
-        .filter(channel_id=channel_id)
-        .count()
+        new_resource_node_ids,
+        new_resource_content_ids,
+        new_resource_nodes_total_size,
     )
 
 
 def count_removed_resources(destination, channel_id):
     """
-    Queries the destination db to get the leaf node ids.
-    Subtract available leaf nodes count on default db by available leaf nodes based on destination db leaf node ids.
+    Queries the destination db to get the leaf node content_ids.
+    Subtract available leaf nodes count on default db by available
+    leaf nodes based on destination db leaf node content_ids.
     """
     bridge = Bridge(app_name=CONTENT_APP_NAME, sqlite_file_path=destination)
-    ContentNodeClass = bridge.get_class(ContentNode)
-    leaf_node_ids = [
-        i
-        for i, in bridge.session.query(ContentNodeClass.id)
-        .filter(
-            ContentNodeClass.channel_id == channel_id,
-            ContentNodeClass.kind != content_kinds.TOPIC,
+    connection = bridge.get_connection()
+    ContentNodeTable = bridge.get_table(ContentNode)
+    resource_node_ids_statement = (
+        select([ContentNodeTable.c.id])
+        .where(
+            and_(
+                ContentNodeTable.c.channel_id == channel_id,
+                ContentNodeTable.c.kind != content_kinds.TOPIC,
+            )
         )
-        .all()
+        .limit(batch_size)
+    )
+
+    i = 0
+
+    resource_node_ids = [
+        coerce_key(cid[0])
+        for cid in connection.execute(resource_node_ids_statement.offset(i)).fetchall()
     ]
+
+    content_ids_after_upgrade = set()
+
+    # Batch the query here, as passing too many uuids into Django could cause
+    # the a SQL query too large error. This will happen around about 30000+ uuids.
+    # Could probably batch at 10000 rather than 1000 - but using 1000 to be defensive.
+
+    while resource_node_ids:
+        content_ids_after_upgrade.update(
+            (
+                ContentNode.objects.filter_by_uuids(resource_node_ids, validate=False)
+                .exclude(kind=content_kinds.TOPIC)
+                .filter(available=True, channel_id=channel_id)
+                .values_list("content_id", flat=True)
+                .distinct()
+            )
+        )
+
+        i += batch_size
+        resource_node_ids = [
+            coerce_key(cid[0])
+            for cid in connection.execute(
+                resource_node_ids_statement.offset(i)
+            ).fetchall()
+        ]
+
+    total_resources_after_upgrade = len(content_ids_after_upgrade)
+
     return (
         ContentNode.objects.filter(channel_id=channel_id, available=True)
         .exclude(kind=content_kinds.TOPIC)
+        .values("content_id")
+        .distinct()
         .count()
-        - ContentNode.objects.filter_by_uuids(leaf_node_ids, validate=False)
-        .filter(available=True, channel_id=channel_id)
-        .count()
+        - total_resources_after_upgrade
     )
 
 
-def automatically_updated_resource_ids(destination, channel_id):
+def get_automatically_updated_resources(destination, channel_id):
     """
     Queries the destination db to get the leaf node ids, where local file objects are unavailable.
     Get the available node ids related to those missing file objects.
     """
     bridge = Bridge(app_name=CONTENT_APP_NAME, sqlite_file_path=destination)
-    FileClass = bridge.get_class(File)
-    LocalFileClass = bridge.get_class(LocalFile)
+    connection = bridge.get_connection()
+    ContentNodeTable = bridge.get_table(ContentNode)
+    # SQL Alchemy reference to the file table - a mapping from
+    # contentnodes to the files that they use
+    FileTable = bridge.get_table(File)
+    # SQL Alchemy reference to the localfile table which tracks
+    # information about the files on disk, such as availability
+    LocalFileTable = bridge.get_table(LocalFile)
     # get unavailable local file ids on the destination db
-    unavailable_local_file_ids_statement = select([LocalFileClass.id]).where(
-        LocalFileClass.available == False  # noqa
+    unavailable_local_file_ids_statement = select([LocalFileTable.c.id]).where(
+        LocalFileTable.c.available == False  # noqa
     )
     # get the Contentnode ids where File objects are missing in the destination db
-    contentnode_ids = [
-        i
-        for i, in bridge.session.query(FileClass.contentnode_id)
-        .filter(FileClass.local_file_id.in_(unavailable_local_file_ids_statement))
-        .distinct()
-        .all()
-    ]
-    return (
-        ContentNode.objects.filter_by_uuids(contentnode_ids, validate=False)
-        .filter(available=True, channel_id=channel_id)
-        # Exclude topics from here to prevent erroneous imports of their children
-        .exclude(kind=content_kinds.TOPIC)
-        .values_list("id", flat=True)
+    contentnode_ids_statement = (
+        select([FileTable.c.contentnode_id])
+        .where(
+            and_(
+                FileTable.c.local_file_id.in_(unavailable_local_file_ids_statement),
+                FileTable.c.supplementary == False,  # noqa
+                or_(
+                    *(
+                        FileTable.c.preset == preset
+                        for preset in renderable_files_presets
+                    )
+                ),
+            )
+        )
+        .limit(batch_size)
     )
+
+    i = 0
+
+    updated_resource_ids = set()
+
+    updated_resource_content_ids = set()
+
+    contentnode_ids = [
+        coerce_key(cid[0])
+        for cid in connection.execute(contentnode_ids_statement.offset(i)).fetchall()
+    ]
+
+    while contentnode_ids:
+        # Exclude topics from here to prevent erroneous imports of their children
+        # This should already be excluded as we are filtering to renderable files
+        # so this is more of a sanity check
+        for c in (
+            ContentNode.objects.filter_by_uuids(contentnode_ids, validate=False)
+            .filter(available=True, channel_id=channel_id)
+            .exclude(kind=content_kinds.TOPIC)
+            .values_list("id", "content_id")
+        ):
+            updated_resource_ids.add(c[0])
+            updated_resource_content_ids.add(c[1])
+
+        i += batch_size
+
+        contentnode_ids = [
+            coerce_key(cid[0])
+            for cid in connection.execute(
+                contentnode_ids_statement.offset(i)
+            ).fetchall()
+        ]
+
+    # Do this after we have fetched all the ids and made them unique
+    # otherwise, because we are getting our ids from the File table, we could
+    # end up with a duplicate count of file sizes
+
+    updated_resources_total_size = 0
+
+    i = 0
+
+    # Coerce to lists
+    updated_resource_ids = list(updated_resource_ids)
+    updated_resource_content_ids = list(updated_resource_content_ids)
+
+    ids_batch = updated_resource_ids[i : i + batch_size]
+
+    while ids_batch:
+
+        contentnode_filter_expression = filter_by_uuids(
+            ContentNodeTable.c.id, ids_batch
+        )
+
+        # This does the first step in the many to many lookup for File
+        updated_resources_total_size += connection.execute(
+            select([func.sum(LocalFileTable.c.file_size)]).where(
+                LocalFileTable.c.id.in_(
+                    select([LocalFileTable.c.id])
+                    .select_from(
+                        # and LocalFile.
+                        LocalFileTable.join(
+                            FileTable.join(
+                                ContentNodeTable,
+                                FileTable.c.contentnode_id == ContentNodeTable.c.id,
+                            ),  # This does the actual correlation between file and local file
+                            FileTable.c.local_file_id == LocalFileTable.c.id,
+                        )
+                    )
+                    .where(
+                        and_(
+                            # Filter only for files that are unavailable so we show
+                            # the import size
+                            LocalFileTable.c.available == False,  # noqa
+                            contentnode_filter_expression,
+                        )
+                    )
+                )
+            )
+        ).fetchone()[0]
+
+        i += batch_size
+
+        ids_batch = updated_resource_ids[i : i + batch_size]
+
+    return (
+        updated_resource_ids,
+        updated_resource_content_ids,
+        updated_resources_total_size,
+    )
+
+
+def get_import_data_for_update(
+    channel_id, drive_id=None, peer_id=None, renderable_only=True
+):
+    update_stats = process_cache.get(CHANNEL_UPDATE_STATS_CACHE_KEY.format(channel_id))
+    if not update_stats:
+        raise ValueError(
+            "Tried to get update content nodes for channel {} that has no precalculated update stats".format(
+                channel_id
+            )
+        )
+
+    # By default don't filter node ids by their underlying file importability
+    file_based_node_id_dict = None
+    if drive_id:
+        file_based_node_id_dict = get_channel_stats_from_disk(channel_id, drive_id)
+
+    if peer_id:
+        file_based_node_id_dict = get_channel_stats_from_peer(channel_id, peer_id)
+
+    updated_resource_ids = update_stats.get("updated_resource_ids", [])
+
+    i = 0
+
+    updated_ids_slice = updated_resource_ids[i : i + batch_size]
+
+    nodes_to_include = ContentNode.objects.filter(channel_id=channel_id)
+
+    # if requested, filter out nodes we're not able to render
+    if renderable_only:
+        nodes_to_include = nodes_to_include.filter(renderable_contentnodes_q_filter)
+
+    queried_file_objects = []
+
+    content_ids = set()
+
+    while updated_ids_slice:
+        if file_based_node_id_dict is not None:
+            # If we have a list of limited node id availability limit our slice here
+            updated_ids_slice = list(
+                filter(lambda x: x in file_based_node_id_dict, updated_ids_slice)
+            )
+
+        # Possible that the above filtering rendered our list empty, so skip queries
+        # in that case
+
+        if updated_ids_slice:
+
+            batch_nodes = nodes_to_include.filter_by_uuids(updated_ids_slice)
+
+            content_ids.update(
+                batch_nodes.values_list("content_id", flat=True).distinct()
+            )
+
+            files_to_transfer = LocalFile.objects.filter(
+                available=False, files__contentnode__in=batch_nodes
+            )
+
+            queried_file_objects.extend(files_to_transfer)
+
+        i += batch_size
+        updated_ids_slice = updated_resource_ids[i : i + batch_size]
+
+    # Get all nodes that are marked as available but have missing supplementary files.
+    # This will ensure that we update thumbnails, and other files.
+    queried_file_objects.extend(
+        LocalFile.objects.filter(
+            available=False,
+            files__supplementary=True,
+            files__contentnode__in=ContentNode.objects.filter(
+                available=True, channel_id=channel_id
+            ),
+        )
+    )
+
+    checksums = set()
+
+    total_bytes_to_transfer = 0
+
+    files_to_download = []
+
+    for file in queried_file_objects:
+        if file.id not in checksums:
+            checksums.add(file.id)
+            total_bytes_to_transfer += file.file_size
+            files_to_download.append(file)
+
+    return len(content_ids), files_to_download, total_bytes_to_transfer

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -1,6 +1,7 @@
 """
-Mixins for Django REST Framework ViewSets
+Mixins for Django REST Framework ViewSets and Django Querysets
 """
+import logging
 from uuid import UUID
 
 from django.core.exceptions import EmptyResultSet
@@ -11,6 +12,8 @@ from django.db.models.lookups import In
 from morango.models import UUIDField
 from rest_framework import status
 from rest_framework.response import Response
+
+logger = logging.getLogger(__name__)
 
 
 class BulkCreateMixin(object):
@@ -158,6 +161,13 @@ class FilterByUUIDQuerysetMixin(object):
             # on the queryset itself.
             lookup = "in"
         else:
+            if len(ids) > 10000:
+                logger.warn(
+                    """
+                    More than 10000 UUIDs passed to filter by uuids method,
+                    these should be batched into separate querysets to avoid SQL Query too large errors in SQLite
+                """
+                )
             if validate:
                 try:
                     validate_uuids(ids)

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1079,21 +1079,18 @@ def _remoteimport(
 
     job.save_meta()
 
-    # Skip importcontent step if updating and no nodes have changed
-    if is_updating and (node_ids is not None) and len(node_ids) == 0:
-        pass
-    else:
-        call_command(
-            "importcontent",
-            "network",
-            channel_id,
-            baseurl=baseurl,
-            peer_id=peer_id,
-            node_ids=node_ids,
-            exclude_node_ids=exclude_node_ids,
-            update_progress=update_progress,
-            check_for_cancel=check_for_cancel,
-        )
+    call_command(
+        "importcontent",
+        "network",
+        channel_id,
+        baseurl=baseurl,
+        peer_id=peer_id,
+        node_ids=node_ids,
+        exclude_node_ids=exclude_node_ids,
+        import_updates=is_updating,
+        update_progress=update_progress,
+        check_for_cancel=check_for_cancel,
+    )
 
 
 def _diskimport(

--- a/kolibri/plugins/device/assets/src/modules/wizard/apiChannelMetadata.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/apiChannelMetadata.js
@@ -12,6 +12,8 @@ export function getChannelWithContentSizes(channelId) {
           'total_file_size',
           'on_device_resources',
           'on_device_file_size',
+          'new_resource_count',
+          'new_resource_total_size',
         ],
       },
       force: true,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
@@ -1,6 +1,5 @@
 import {
   ContentNodeGranularResource,
-  ContentNodeResource,
   RemoteChannelResource,
   TaskResource,
 } from 'kolibri.resources';
@@ -30,18 +29,13 @@ export function fetchPageData(channelId) {
 }
 
 export function fetchNodeWithAncestors(nodeId) {
-  return Promise.all([
-    ContentNodeGranularResource.fetchModel({
-      id: nodeId,
-      getParams: {
-        // Set this param to only show resources that are 'available'
-        for_export: true,
-      },
-      force: true,
-    }),
-    ContentNodeResource.fetchAncestors(nodeId),
-  ]).then(([node, ancestors]) => {
-    return { ...node, ancestors: [...ancestors] };
+  return ContentNodeGranularResource.fetchModel({
+    id: nodeId,
+    getParams: {
+      // Set this param to only show resources that are 'available'
+      for_export: true,
+    },
+    force: true,
   });
 }
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -262,6 +262,9 @@
       handleClickViewNewVersion() {
         this.$router.push({
           name: PageNames.NEW_CHANNEL_VERSION_PAGE,
+          query: {
+            last: PageNames.MANAGE_CHANNEL,
+          },
         });
       },
       handleSelectImportMoreSource(params) {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -120,7 +120,7 @@
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { taskIsClearable, TaskStatuses } from '../../constants';
+  import { taskIsClearable, PageNames, TaskStatuses } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
 
   export default {
@@ -142,7 +142,7 @@
         currentVersion: null,
         deletedResources: null,
         newResources: null,
-        updatedNodeIds: [],
+        updatedResources: null,
         versionNotes: {},
         showModal: false,
         disableModal: false,
@@ -163,9 +163,6 @@
           });
         }
         return '';
-      },
-      updatedResources() {
-        return this.updatedNodeIds.length;
       },
       params() {
         return pickBy({
@@ -216,7 +213,6 @@
         const updateParams = {
           sourcetype: 'remote',
           channel_id: this.params.channelId,
-          node_ids: this.updatedNodeIds,
           new_version: this.nextVersion,
         };
 
@@ -229,8 +225,24 @@
 
         // Create the import channel task
         return TaskResource.postListEndpoint('startchannelupdate', updateParams)
-          .then(() => {
-            this.$router.push(this.$router.getRoute('MANAGE_TASKS'));
+          .then(taskResponse => {
+            if (this.newResources) {
+              this.loadingTask = true;
+              const taskId = taskResponse.data.id;
+              const taskList = state => state.manageContent.taskList;
+              const stopWatching = this.$store.watch(taskList, tasks => {
+                const match = tasks.find(task => task.id === taskId) || {};
+                if (match && match.database_ready) {
+                  stopWatching();
+                  this.$router.push(this.$router.getRoute(PageNames.MANAGE_CHANNEL));
+                } else if (match.status === TaskStatuses.FAILED) {
+                  stopWatching();
+                  this.$router.push(this.$router.getRoute('MANAGE_TASKS'));
+                }
+              });
+            } else {
+              this.$router.push(this.$router.getRoute('MANAGE_TASKS'));
+            }
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);
@@ -280,7 +292,7 @@
         this.loadingTask = false;
         this.newResources = task.new_resources_count;
         this.deletedResources = task.deleted_resources_count;
-        this.updatedNodeIds = task.updated_node_ids || [];
+        this.updatedResources = task.updated_resources_count;
 
         return TaskResource.deleteFinishedTask(task.id);
       },

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -45,8 +45,10 @@
         <td>{{ $tr('resourceCount', { count: channel.on_device_resources || 0 }) }}</td>
         <td>{{ bytesForHumans(channel.on_device_file_size || 0) }}</td>
       </tr>
-      <tr v-if="false">
+      <tr v-if="channel.new_resource_count !== null">
         <th>{{ $tr('newOrUpdatedLabel') }}</th>
+        <td>{{ $tr('resourceCount', { count: channel.new_resource_count || 0 }) }}</td>
+        <td>{{ bytesForHumans(channel.new_resource_total_size || 0) }}</td>
       </tr>
     </table>
   </section>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelUpdateAnnotations.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelUpdateAnnotations.vue
@@ -1,16 +1,8 @@
 <template>
 
-  <div>
-    <p v-if="false">
-      {{ $tr('newResource') }}
-    </p>
-    <p v-if="false">
-      {{ $tr('newResourcesInTopic') }}
-    </p>
-    <p v-if="false">
-      {{ $tr('inQueueForImport') }}
-    </p>
-  </div>
+  <span :class="styleClass" :style="style">
+    {{ label }}
+  </span>
 
 </template>
 
@@ -19,14 +11,52 @@
 
   export default {
     name: 'ChannelUpdateAnnotations',
-    components: {},
-    mixins: [],
-    props: {},
-    data() {
-      return {};
+    props: {
+      newResources: {
+        type: Number,
+        default: 0,
+      },
+      isTopic: {
+        type: Boolean,
+        default: false,
+      },
+      importing: {
+        type: Boolean,
+        default: false,
+      },
     },
-    computed: {},
-    methods: {},
+    computed: {
+      new() {
+        return this.newResources > 0;
+      },
+      styleClass() {
+        if (this.new) {
+          // Doing this separately from the dynamic styling below
+          // to ensure things get properly RTL transpiled in CSS
+          return ['new-label'];
+        }
+        return [];
+      },
+      style() {
+        if (this.new) {
+          return {
+            color: this.$themeTokens.textInverted,
+            backgroundColor: this.$themeTokens.success,
+          };
+        }
+        return {};
+      },
+      label() {
+        if (this.new && this.isTopic === false) {
+          return this.$tr('newResource');
+        } else if (this.new && this.isTopic === true) {
+          return this.$tr('newResourcesInTopic', { count: this.newResources });
+        } else if (this.importing) {
+          return this.$tr('inQueueForImport');
+        }
+        return '';
+      },
+    },
     $trs: {
       newResource: {
         message: 'New',
@@ -48,4 +78,16 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .new-label {
+    top: 2px;
+    display: inline-block;
+    padding: 2px 8px;
+    margin-left: 8px;
+    font-size: 14px;
+    font-weight: bold;
+    border-radius: 2px;
+  }
+
+</style>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentNodeRow.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentNodeRow.vue
@@ -37,9 +37,17 @@
     </td>
 
     <td class="message">
-      {{ message }}
+      <template v-if="message && !importing">
+        {{ message }}
+      </template>
+      <ChannelUpdateAnnotations
+        v-if="node.num_new_resources || importing"
+        class="update-label"
+        :isTopic="isTopic"
+        :newResources="node.num_new_resources"
+        :importing="importing"
+      />
     </td>
-    <ChannelUpdateAnnotations v-if="false" />
   </tr>
 
 </template>
@@ -89,6 +97,9 @@
       isTopic() {
         return this.node.kind === ContentNodeKinds.TOPIC;
       },
+      importing() {
+        return this.node.updated_resource && !this.node.available;
+      },
     },
   };
 
@@ -110,6 +121,10 @@
   .message {
     width: 40%;
     text-align: right;
+  }
+
+  .update-label {
+    margin-left: 24px;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -32,7 +32,8 @@
             v-for="cNode in showableAnnotatedChildNodes"
             :key="cNode.id"
             :checked="nodeIsChecked(cNode)"
-            :disabled="disabled || disableAll || cNode.disabled"
+            :disabled="disabled || disableAll || cNode.disabled ||
+              (cNode.updated_resource && !cNode.available)"
             :indeterminate="nodeIsIndeterminate(cNode)"
             :message="cNode.message"
             :node="cNode"


### PR DESCRIPTION
### Summary
* Fixes calculations for channel upgrade diff stats and adds tests
* Passes ancestor data back with contentnodegranular to avoid a second request that might have been inappropriately cached
* Adds upgrade stats to channel importability annotation stats
* Leverages these upgrade stats on the frontend to display 'new' and 'import queued' data for new nodes after an upgrade and nodes that are being automatically updated
* Modifies the importcontent management command to add a specific 'update' workflow, that downloads all updated content node files, and any updated thumbnails, and supplementary files.
* When the content metadata update has taken place, a user is redirected to the channel page if new resources are available for import
* Fixes back behaviour from the channel update page to properly return to the channel page

### Reviewer guidance
Do the following upgrade scenarios, in each case, publishing and testing the upgrade:

* Change a file for a content node
* Add a new content node
* Move a content node within a channel
* Remove a content node from a channel
* Update a thumbnail for an imported topic

### References
Fixes #6751
Fixes #6712
Fixes #6576
Fixes #6227

N.B.
Does not fix #6230
Does not fix #6351 - due to a deliberate decision to leave this unfixed until we can clarify duplicate vs unique resources in interface strings
I did not see this issue: #6712 while testing this, but would be good to see if this replicates during testing of this PR
Also did not see this issue: #4752

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
