### PR TITLE
Redirect logout hook

### DIFF
--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -61,3 +61,14 @@ class FrontEndBaseASyncHook(WebpackInclusionASyncMixin):
     Inherit a hook defining assets to be loaded in kolibri/base.html, that means
     ALL pages. Use with care.
     """
+
+
+@define_hook(only_one_registered=True)
+class LogoutRedirectHook(KolibriHook):
+    """
+    A hook to enable the OIDC client
+    """
+
+    @classmethod
+    def is_enabled(cls):
+        return len(list(cls.registered_hooks)) == 1

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -72,3 +72,10 @@ class LogoutRedirectHook(KolibriHook):
     @classmethod
     def is_enabled(cls):
         return len(list(cls.registered_hooks)) == 1
+
+    @abstractproperty
+    def url(self):
+        """
+        A property to be overriden by the class using this hook to provide the needed url to redirect
+        """
+        pass

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -27,6 +27,7 @@ from kolibri.core.device.translation import get_device_language
 from kolibri.core.device.translation import get_settings_language
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import device_provisioned
+from kolibri.core.hooks import LogoutRedirectHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 
 
@@ -84,7 +85,12 @@ def set_language(request):
 
 def logout_view(request):
     logout(request)
-    return HttpResponseRedirect(reverse("kolibri:core:redirect_user"))
+    if LogoutRedirectHook.registered_hooks:
+        return HttpResponseRedirect(
+            next(obj.url for obj in LogoutRedirectHook.registered_hooks)
+        )
+    else:
+        return HttpResponseRedirect(reverse("kolibri:core:redirect_user"))
 
 
 def get_urls_by_role(role):

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -85,7 +85,7 @@ def set_language(request):
 
 def logout_view(request):
     logout(request)
-    if LogoutRedirectHook.registered_hooks:
+    if LogoutRedirectHook.is_enabled():
         return HttpResponseRedirect(
             next(obj.url for obj in LogoutRedirectHook.registered_hooks)
         )


### PR DESCRIPTION


### Summary

Some plugins might require (OIDC client, as an example) to redirect the user to an external url after logging out.
This PR adds the scalfolding needed for it

### Reviewer guidance

Any suggestion to improve it?

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
