### PR TITLE
parameters to device provisioning command for arbitrary settings

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -1,15 +1,11 @@
 import logging
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
-from django.core.management.base import CommandError
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import six
-
-from kolibri.core.auth.constants.facility_presets import mappings
-from kolibri.core.auth.constants.facility_presets import presets
-from kolibri.core.auth.models import Facility
-from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.constants.facility_presets import mappings, presets
+from kolibri.core.auth.models import Facility, FacilityUser
 from kolibri.core.device.utils import provision_device
 
 logger = logging.getLogger(__name__)

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -27,7 +27,7 @@ def check_setting(name):
 
     if name not in AVAILABLE_SETTINGS:
         raise Exception(
-            "'{}' is not a setting that can be changed by this command".format(key)
+            "'{}' is not a setting that can be changed by this command".format(name)
         )
 
 

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -237,6 +237,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+
+        logger.warn(
+            "The 'provisiondevice' command is experimental, and the API and behavior will change in a future release"
+        )
+
         with transaction.atomic():
             facility = create_facility(
                 facility_name=options["facility"],

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -3,11 +3,15 @@ import logging
 import os
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils import six
-from kolibri.core.auth.constants.facility_presets import mappings, presets
-from kolibri.core.auth.models import Facility, FacilityUser
+
+from kolibri.core.auth.constants.facility_presets import mappings
+from kolibri.core.auth.constants.facility_presets import presets
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.utils import provision_device
 
 logger = logging.getLogger(__name__)

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -157,11 +157,12 @@ def create_device_settings(
     for key in new_settings:
         check_device_setting(key)
 
-    new_settings["language_id"] = language_id
-    new_settings["default_facility"] = facility
+    settings_to_set = dict(new_settings)
+    settings_to_set["language_id"] = language_id
+    settings_to_set["default_facility"] = facility
 
-    provision_device(**new_settings)
-    logger.info("Device settings updated with {}".format(new_settings))
+    provision_device(**settings_to_set)
+    logger.info("Device settings updated with {}".format(settings_to_set))
 
 
 def json_file_contents(parser, arg):

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -427,9 +427,9 @@ def update(old_version, new_version):
         # If there are, then we need to stop users from starting kolibri again.
         server.get_status()
         logger.error(
-            "There is a Kolibri server running."
-            "Running updates now could cause a database error."
-            "Please use `kolibri stop` and try again."
+            "There is a Kolibri server running. "
+            "Running updates now could cause a database error. "
+            "Please use `kolibri stop` and try again. "
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Summary

* allow arbitrary settings to be passed in as JSON files
* added warning that the API for this command is liable to change in the future

### Reviewer guidance

You can specify JSON files that will take precedence over other settings.

For example:

```bash
kolibri manage provisiondevice --skip-update --device_settings ./ds.json --facility_settings ./fs.json
```

where _ds.json_ is:

```json
{
  "allow_guest_access": false
}
```

and _fs.json_ is:

```json
{
  "learner_can_login_with_no_password": false
}
```


### References


fixes https://github.com/learningequality/kolibri/issues/6613

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
