### PR TITLE
Fix copy paste error and catch programming errors.

### DIFF
--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -6,6 +6,7 @@ import sys
 import portend
 from django.apps import apps
 from django.db.utils import OperationalError
+from django.db.utils import ProgrammingError
 
 from .conf import KOLIBRI_HOME
 from .conf import OPTIONS
@@ -36,7 +37,7 @@ class DatabaseNotMigrated(SanityException):
 class DatabaseInaccessible(SanityException):
     def __init__(self, *args, **kwargs):
         self.db_exception = kwargs.get("db_exception")
-        super(DatabaseNotMigrated, self).__init__(
+        super(DatabaseInaccessible, self).__init__(
             "Not able to access the database while checking it.\n\n"
             "Exception: {}".format(str(self.db_exception))
         )
@@ -154,7 +155,7 @@ def check_database_is_migrated():
         InstanceIDModel.get_or_create_current_instance()[0]
         connection.close()
         return
-    except OperationalError as e:
+    except (OperationalError, ProgrammingError) as e:
         raise DatabaseNotMigrated(db_exception=e)
     except Exception as e:
         raise DatabaseInaccessible(db_exception=e)


### PR DESCRIPTION
### Summary
Cleanup after refactor of the database sanity check in #6580 
Fixes copy paste issue that had incorrect class name for super
Catches ProgrammingError so that an unmigrated PostgreSQL instance can be migrated with `kolibri manage migrate`

### Reviewer guidance
Run Kolibri once with SQLite
Run Kolibri from the same Kolibri home with PostgreSQL with an empty database
Check that migration happens properly

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
