### PR TITLE
Fixes a bug in aggregation for foreign key field type coercion

### DIFF
--- a/kolibri/core/query.py
+++ b/kolibri/core/query.py
@@ -71,7 +71,10 @@ def get_source_field(model, field_path):
     paths = field_path.split("__")
     while len(paths) > 1:
         model = model._meta.get_field(paths.pop(0)).related_model
-    return model._meta.get_field(paths[0])
+    field = model._meta.get_field(paths[0])
+    if field.is_relation and field.foreign_related_fields:
+        field = field.foreign_related_fields[0]
+    return field
 
 
 def annotate_array_aggregate(queryset, **kwargs):


### PR DESCRIPTION
### Summary
When we are aggregating over a foreign key and not the target key of the foreign key traversal, e.g.:
`lesson_assignments__collection` rather than `lesson_assignments__collection__id` our type inference for aggregation type casting would previously just get the `ForeignKey` field which would then do a `to_python` call appropriate to the underlying data type in Postgres (UUID) and return a UUID.

This PR updates this logic so that we look at the related field of the foreign key in order to get the `to_python` method for that, and then use that for type coercion inside our aggregation logic.

### Reviewer guidance
Does it fix #7271? Does anything in the changes seem risky?

### References
Fixes #7271

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
