### PR TITLE
Fix missing info on Device Info Page

### DIFF
--- a/docs/backend_architecture/uap/implementation.rst
+++ b/docs/backend_architecture/uap/implementation.rst
@@ -13,7 +13,7 @@ and ``LearnerGroup`` -- are implemented as _proxy models of the main
 us to distinguish between these types, and the ``ModelManager`` for the proxy
 models returns only instances of the matching kind.
 
-.. _proxy: https://docs.djangoproject.com/en/1.9/topics/db/models/#proxy-models
+.. _proxy: https://docs.djangoproject.com/en/1.11/topics/db/models/#proxy-models
 
 From a ``Collection`` instance, you can traverse upwards in the tree with the
 ``parent`` field, and downwards via the ``children`` field (which is a reverse
@@ -153,7 +153,7 @@ strings, of role kinds), these parameters accept either:
   from the base model in the ``F`` function, but you can also indirectly reference
   fields of related models, e.g. ``F("collection__parent")``)
 
-.. _F expression: https://docs.djangoproject.com/en/1.9/ref/models/expressions/#f-expressions
+.. _F expression: https://docs.djangoproject.com/en/1.11/ref/models/expressions/#f-expressions
 
 For example, the ``ContentLog`` query described above ("give me all
 ``ContentLogs`` associated with ``FacilityUsers`` for which Source User has an

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -109,7 +109,7 @@ Dynamic values are passed into translation strings as named arguments in an obje
 .py files
 ~~~~~~~~~
 
-For any user-facing strings in python files, we are using standard Django tools (``gettext`` and associated functions). See the `Django i18n documentation <https://docs.djangoproject.com/en/1.10/topics/i18n/>`__ for more information.
+For any user-facing strings in python files, we are using standard Django tools (``gettext`` and associated functions). See the `Django i18n documentation <https://docs.djangoproject.com/en/1.11/topics/i18n/>`__ for more information.
 
 
 RTL language support

--- a/docs/stack.rst
+++ b/docs/stack.rst
@@ -67,7 +67,7 @@ We use a number of mechanisms to help encourage code quality and consistency. Mo
 - We use `EditorConfig <http://editorconfig.org/>`__ to help developers set their editor preferences
 - `tox <https://tox.readthedocs.io/en/latest/>`__ is used to run our test suites under a range of Python and Node environment versions
 - ``sphinx-build -b linkcheck`` checks the validity of documentation links
-- `pytest <http://pytest.org/latest/>`__ runs our Python unit tests. We also leverage the `Django test framework <https://docs.djangoproject.com/en/1.9/topics/testing/>`__.
+- `pytest <http://pytest.org/latest/>`__ runs our Python unit tests. We also leverage the `Django test framework <https://docs.djangoproject.com/en/1.11/topics/testing/>`__.
 - In addition to building client assets, `webpack <https://webpack.github.io/>`__ runs linters on client-side code: `ESLint <http://eslint.org/>`__ for ES6 JavaScript, `Stylelint <https://stylelint.io/>`__ for SCSS, and `HTMLHint <http://htmlhint.com/>`__ for HTML and Vue.js components.
 - Client-side code is tested using `Jest <https://facebook.github.io/jest/>`__
 - `codecov <https://codecov.io/>`__ reports on the test coverage

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -94,7 +94,7 @@ class DeviceInfoView(views.APIView):
         elif db_engine.endswith("postgresql"):
             info["database_path"] = "postgresql"
         else:
-            info["database_path"] = ""
+            info["database_path"] = "unknown"
 
         instance_model = InstanceIDModel.get_or_create_current_instance()[0]
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -89,7 +89,7 @@ class DeviceInfoView(views.APIView):
         db_engine = settings.DATABASES["default"]["ENGINE"]
 
         if db_engine.endswith("sqlite3"):
-            # If any other database backend, will not be file backed, so no database path to return
+            # Return path to .sqlite file (usually in KOLIBRI_HOME folder)
             info["database_path"] = settings.DATABASES["default"]["NAME"]
         elif db_engine.endswith("postgresql"):
             info["database_path"] = "postgresql"

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -86,9 +86,15 @@ class DeviceInfoView(views.APIView):
 
         info["urls"] = urls
 
-        if settings.DATABASES["default"]["ENGINE"].endswith("sqlite3"):
+        db_engine = settings.DATABASES["default"]["ENGINE"]
+
+        if db_engine.endswith("sqlite3"):
             # If any other database backend, will not be file backed, so no database path to return
             info["database_path"] = settings.DATABASES["default"]["NAME"]
+        elif db_engine.endswith("postgresql"):
+            info["database_path"] = "postgresql"
+        else:
+            info["database_path"] = ""
 
         instance_model = InstanceIDModel.get_or_create_current_instance()[0]
 

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -340,12 +340,14 @@ class DeviceInfoTestCase(APITestCase):
 
     def test_database_path(self):
         response = self.client.get(reverse("kolibri:core:deviceinfo"), format="json")
-        if settings.DATABASES["default"]["ENGINE"].endswith("sqlite3"):
-            self.assertEqual(
-                response.data["database_path"], settings.DATABASES["default"]["NAME"]
-            )
+        db_engine = settings.DATABASES["default"]["ENGINE"]
+        db_path = response.data["database_path"]
+        if db_engine.endswith("sqlite3"):
+            self.assertEqual(db_path, settings.DATABASES["default"]["NAME"])
+        elif db_engine.endswith("postgresql"):
+            self.assertEqual(db_path, "postgresql")
         else:
-            self.assertTrue("database_path" not in response.data)
+            self.assertEqual(db_path, "unknown")
 
     def test_os(self):
         response = self.client.get(reverse("kolibri:core:deviceinfo"), format="json")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -3,10 +3,10 @@
 Django settings for kolibri project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.9/topics/settings/
+https://docs.djangoproject.com/en/1.11/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.9/ref/settings/
+https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 from __future__ import absolute_import
 from __future__ import print_function
@@ -48,7 +48,7 @@ BASE_DIR = os.path.abspath(os.path.dirname(__name__))
 LOCALE_PATHS = [os.path.join(KOLIBRI_MODULE_PATH, "locale")]
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "f@ey3)y^03r9^@mou97apom*+c1m#b1!cwbm50^s4yk72xce27"
@@ -133,7 +133,7 @@ WSGI_APPLICATION = "kolibri.deployment.default.wsgi.application"
 
 
 # Database
-# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
     DATABASES = {
@@ -176,7 +176,7 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.9/topics/i18n/
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
 
 # For language names, see:
 # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
@@ -268,7 +268,7 @@ USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.9/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 path_prefix = conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
 
@@ -291,8 +291,8 @@ CSRF_COOKIE_NAME = "kolibri_csrftoken"
 # set by other Django apps served from the same domain.
 SESSION_COOKIE_PATH = path_prefix
 
-# https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-LOGGING
-# https://docs.djangoproject.com/en/1.9/topics/logging/
+# https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-LOGGING
+# https://docs.djangoproject.com/en/1.11/topics/logging/
 
 LOGGING = get_logging_config(
     conf.LOG_ROOT,
@@ -302,7 +302,7 @@ LOGGING = get_logging_config(
 
 
 # Customizing Django auth system
-# https://docs.djangoproject.com/en/1.9/topics/auth/customizing/
+# https://docs.djangoproject.com/en/1.11/topics/auth/customizing/
 
 AUTH_USER_MODEL = "kolibriauth.FacilityUser"
 
@@ -326,7 +326,7 @@ REST_FRAMEWORK = {
 }
 
 # System warnings to disable
-# see https://docs.djangoproject.com/en/1.9/ref/settings/#silenced-system-checks
+# see https://docs.djangoproject.com/en/1.11/ref/settings/#silenced-system-checks
 SILENCED_SYSTEM_CHECKS = ["auth.W004"]
 
 # Configuration for Django JS Reverse

--- a/kolibri/deployment/default/urls.py
+++ b/kolibri/deployment/default/urls.py
@@ -2,7 +2,7 @@
 """kolibri URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
+    https://docs.djangoproject.com/en/1.11/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for kolibri project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 import os
 import time

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -20,13 +20,15 @@ export function getDeviceInfo() {
     data.content_storage_free_space = bytesForHumans(data.content_storage_free_space);
     data.device_name = nameResponse.data.name;
 
-    if (infoResponse.headers.server.includes('0.0.0.0')) {
+    const { server } = infoResponse.headers;
+
+    if (server.includes('0.0.0.0')) {
       if (isEmbeddedWebView) {
         data.server_type = 'Kolibri app server';
       } else {
         data.server_type = 'Kolibri internal server';
       }
-    } else data.server_type = infoResponse.headers.Server;
+    } else data.server_type = server;
 
     return data;
   });


### PR DESCRIPTION

### Summary
Fixes some bugs on the Device Info Page's "Advanced" section

1. Fixes the `Server: undefined` bug
1. Fixes the `Database: undefined` bug for installations using PostgreSQL
1. Updates links to Django docs to point to the 1.11 version, since the older links have been taken down

### Reviewer guidance

1. Does the code look like it will display the correct info under `Database` and `Server`


### References


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
