### PR TITLE
Allow configuration of Redis through Kolibri options

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -10,8 +10,11 @@ from django.db.utils import DatabaseError
 from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
 from kolibri.core.sqlite.pragmas import START_PRAGMAS
 from kolibri.core.sqlite.utils import repair_sqlite_db
+from kolibri.core.utils.cache import RedisSettingsHelper
+from kolibri.utils.conf import OPTIONS
 
 logger = logging.getLogger(__name__)
+CACHE_OPTIONS = OPTIONS["Cache"]
 
 
 class KolibriCoreConfig(AppConfig):
@@ -31,6 +34,9 @@ class KolibriCoreConfig(AppConfig):
                 settings=os.environ["DJANGO_SETTINGS_MODULE"]
             )
         )
+        # When configured to use Redis, make sure we have sensible Redis settings
+        if CACHE_OPTIONS["CACHE_BACKEND"] == "redis":
+            self.check_redis_settings()
 
     @staticmethod
     def activate_pragmas_per_connection(sender, connection, **kwargs):
@@ -84,3 +90,54 @@ class KolibriCoreConfig(AppConfig):
             # at the cost of a slight penalty to all reads.
             cursor.execute(START_PRAGMAS)
             connection.close()
+
+    @staticmethod
+    def check_redis_settings():
+        """
+        Check that Redis settings are sensible, and use the lower level Redis client to make updates
+        if we are configured to do so, and if we should, otherwise make some logging noise.
+        """
+        from kolibri.core.utils.cache import process_cache
+
+        config_use_conf = CACHE_OPTIONS["CACHE_REDIS_USE_CONF"]
+        config_maxmemory = CACHE_OPTIONS["CACHE_REDIS_MAXMEMORY"]
+        config_maxmemory_policy = CACHE_OPTIONS["CACHE_REDIS_MAXMEMORY_POLICY"]
+
+        try:
+            # see redis_cache.backends.single.RedisCache
+            client = process_cache.get_master_client()
+            helper = RedisSettingsHelper(client)
+            config_warn = False
+
+            # default setting is "0", or no limit
+            maxmemory = helper.get_maxmemory()
+            if config_use_conf:
+                if maxmemory == 0:
+                    logger.warning("Redis is configured without a maximum memory size.")
+                    config_warn = True
+            elif maxmemory != config_maxmemory:
+                helper.set_maxmemory(config_maxmemory)
+
+            # default setting is "noeviction"
+            maxmemory_policy = helper.get_maxmemory_policy()
+            if config_use_conf:
+                if maxmemory_policy == "noeviction":
+                    logger.warning(
+                        "Redis is configured without a maximum memory policy. Using Redis with "
+                        "Kolibri, the following is suggested: maxmemory-policy allkeys-lru"
+                    )
+                    config_warn = True
+            elif maxmemory_policy != config_maxmemory_policy:
+                helper.set_maxmemory_policy(config_maxmemory_policy)
+
+            # should only change something when `config_use_conf` is also `False`
+            helper.save()
+
+            if config_warn:
+                logger.warning(
+                    "Please see Redis configuration documentation for details: "
+                    "https://redis.io/topics/config"
+                )
+        except Exception as e:
+            logger.warning("Unable to check Redis settings")
+            logger.warning(e)

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -89,7 +89,6 @@ class KolibriCoreConfig(AppConfig):
             cursor.execute(START_PRAGMAS)
             connection.close()
 
-    # flake8: noqa: C901
     @staticmethod
     def check_redis_settings():
         """
@@ -115,7 +114,7 @@ class KolibriCoreConfig(AppConfig):
             # default setting is "noeviction"
             maxmemory_policy = helper.get_maxmemory_policy()
             if (
-                config_maxmemory_policy is not None
+                config_maxmemory_policy != ""
                 and maxmemory_policy != config_maxmemory_policy
             ):
                 helper.set_maxmemory_policy(config_maxmemory_policy)

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -4,9 +4,7 @@ import time
 import uuid
 
 from kolibri.core.tasks import compat
-from kolibri.core.utils.cache import DiskCacheRLock
-from kolibri.core.utils.cache import process_cache
-from kolibri.utils.conf import OPTIONS
+from kolibri.core.utils.cache import get_process_lock
 
 
 # An object on which to store data about the current job
@@ -122,16 +120,4 @@ class InfiniteLoopThread(compat.Thread):
         self.stop()
 
 
-DB_TASK_WRITE_LOCK = "db_task_write_lock"
-if OPTIONS["Cache"]["CACHE_BACKEND"] == "redis":
-    # if we're using Redis, be sure we use Redis' locking mechanism which uses
-    # `SET NX` under the hood. See redis.lock.Lock
-    db_task_write_lock = process_cache.lock(
-        DB_TASK_WRITE_LOCK,
-        timeout=None,  # milliseconds
-        sleep=DiskCacheRLock.sleep_time,  # seconds
-        blocking_timeout=100,  # seconds
-        thread_local=True,
-    )
-else:
-    db_task_write_lock = DiskCacheRLock(DB_TASK_WRITE_LOCK)
+db_task_write_lock = get_process_lock("db_task_write_lock")

--- a/kolibri/core/test/test_apps.py
+++ b/kolibri/core/test/test_apps.py
@@ -8,6 +8,7 @@ from kolibri.core.apps import KolibriCoreConfig
 from kolibri.core.apps import RedisSettingsHelper
 
 DEFAULT_CACHE_OPTS = dict(
+    CACHE_BACKEND="redis",
     CACHE_REDIS_USE_CONF=False,
     CACHE_REDIS_MAXMEMORY=123,
     CACHE_REDIS_MAXMEMORY_POLICY="allkeys-lru",
@@ -17,17 +18,18 @@ DEFAULT_CACHE_OPTS = dict(
 def do_setup(**cache_opts):
     defaults = DEFAULT_CACHE_OPTS.copy()
     defaults.update(cache_opts)
-    cache_opts = defaults
+    all_opts = dict(Cache=defaults)
 
     def outer_decorator(func):
         @functools.wraps(func)
         def wrapped(self, mock_cache, mock_options, mock_helper_cls, mock_logger):
             mock_cache.get_master_client.return_value = self.client
-            mock_options.__getitem__.side_effect = cache_opts.__getitem__
+            mock_options.__getitem__.side_effect = all_opts.__getitem__
             mock_helper_cls.return_value = self.helper
-            func(self, mock_logger)
-            mock_cache.get_master_client.assert_called_once()
-            mock_helper_cls.assert_called_once_with(self.client)
+            result = func(self, mock_logger)
+            if not result:
+                mock_cache.get_master_client.assert_called_once()
+                mock_helper_cls.assert_called_once_with(self.client)
 
         return wrapped
 
@@ -36,8 +38,8 @@ def do_setup(**cache_opts):
 
 @mock.patch("kolibri.core.apps.logger")
 @mock.patch("kolibri.core.apps.RedisSettingsHelper")
-@mock.patch("kolibri.core.apps.CACHE_OPTIONS")
-@mock.patch("kolibri.core.utils.cache.process_cache")
+@mock.patch("kolibri.core.apps.OPTIONS")
+@mock.patch("kolibri.core.apps.process_cache")
 class KolibriCoreConfigTestCase(TestCase):
     def setUp(self):
         super(KolibriCoreConfigTestCase, self).setUp()
@@ -59,15 +61,30 @@ class KolibriCoreConfigTestCase(TestCase):
 
         logger.assert_not_called()
 
+    @do_setup(CACHE_BACKEND="magic")
+    def test_check_redis_settings__not_redis(self, logger):
+        KolibriCoreConfig.check_redis_settings()
+        self.helper.get_maxmemory.assert_not_called()
+        self.helper.set_maxmemory.assert_not_called()
+
+        self.helper.get_maxmemory_policy.assert_not_called()
+        self.helper.set_maxmemory_policy.assert_not_called()
+
+        self.helper.save.assert_not_called()
+        logger.assert_not_called()
+        return True
+
     @do_setup()
     def test_check_redis_settings(self, logger):
         self.setUp_okay()
         self.assertOkay(logger)
+        self.helper.save.assert_called()
 
     @do_setup(CACHE_REDIS_USE_CONF=True)
     def test_check_redis_settings__use_conf(self, logger):
         self.setUp_okay()
         self.assertOkay(logger)
+        self.helper.save.assert_not_called()
 
     @do_setup(CACHE_REDIS_USE_CONF=True)
     def test_check_redis_settings__use_conf__not_okay__maxmemory(self, logger):
@@ -81,6 +98,7 @@ class KolibriCoreConfigTestCase(TestCase):
         self.helper.get_maxmemory_policy.assert_called_once()
         self.helper.set_maxmemory_policy.assert_not_called()
 
+        self.helper.save.assert_not_called()
         logger.warning.assert_called()
 
     @do_setup(CACHE_REDIS_USE_CONF=True)
@@ -95,6 +113,7 @@ class KolibriCoreConfigTestCase(TestCase):
         self.helper.get_maxmemory_policy.assert_called_once()
         self.helper.set_maxmemory_policy.assert_not_called()
 
+        self.helper.save.assert_not_called()
         logger.warning.assert_called()
 
     @do_setup(CACHE_REDIS_MAXMEMORY=456)
@@ -109,6 +128,7 @@ class KolibriCoreConfigTestCase(TestCase):
         self.helper.get_maxmemory_policy.assert_called_once()
         self.helper.set_maxmemory_policy.assert_not_called()
 
+        self.helper.save.assert_called_once()
         logger.warning.assert_not_called()
 
     @do_setup(CACHE_REDIS_MAXMEMORY_POLICY="volatile-lru")
@@ -123,8 +143,5 @@ class KolibriCoreConfigTestCase(TestCase):
         self.helper.get_maxmemory_policy.assert_called_once()
         self.helper.set_maxmemory_policy.assert_called_once_with("volatile-lru")
 
-        logger.warning.assert_not_called()
-
-    def tearDown(self):
-        super(KolibriCoreConfigTestCase, self).tearDown()
         self.helper.save.assert_called_once()
+        logger.warning.assert_not_called()

--- a/kolibri/core/test/test_apps.py
+++ b/kolibri/core/test/test_apps.py
@@ -94,7 +94,7 @@ class KolibriCoreConfigTestCase(TestCase):
         self.helper.save.assert_not_called()
         logger.warning.assert_called()
 
-    @do_setup(CACHE_REDIS_MAXMEMORY_POLICY="noeviction")
+    @do_setup(CACHE_REDIS_MAXMEMORY_POLICY="")
     def test_check_redis_settings__not_okay__maxmemory_policy(self, logger):
         self.helper.get_maxmemory.return_value = 123
         self.helper.get_maxmemory_policy.return_value = "noeviction"

--- a/kolibri/core/test/test_apps.py
+++ b/kolibri/core/test/test_apps.py
@@ -1,0 +1,130 @@
+import functools
+
+import mock
+from django.test.testcases import TestCase
+from redis import Redis
+
+from kolibri.core.apps import KolibriCoreConfig
+from kolibri.core.apps import RedisSettingsHelper
+
+DEFAULT_CACHE_OPTS = dict(
+    CACHE_REDIS_USE_CONF=False,
+    CACHE_REDIS_MAXMEMORY=123,
+    CACHE_REDIS_MAXMEMORY_POLICY="allkeys-lru",
+)
+
+
+def do_setup(**cache_opts):
+    defaults = DEFAULT_CACHE_OPTS.copy()
+    defaults.update(cache_opts)
+    cache_opts = defaults
+
+    def outer_decorator(func):
+        @functools.wraps(func)
+        def wrapped(self, mock_cache, mock_options, mock_helper_cls, mock_logger):
+            mock_cache.get_master_client.return_value = self.client
+            mock_options.__getitem__.side_effect = cache_opts.__getitem__
+            mock_helper_cls.return_value = self.helper
+            func(self, mock_logger)
+            mock_cache.get_master_client.assert_called_once()
+            mock_helper_cls.assert_called_once_with(self.client)
+
+        return wrapped
+
+    return outer_decorator
+
+
+@mock.patch("kolibri.core.apps.logger")
+@mock.patch("kolibri.core.apps.RedisSettingsHelper")
+@mock.patch("kolibri.core.apps.CACHE_OPTIONS")
+@mock.patch("kolibri.core.utils.cache.process_cache")
+class KolibriCoreConfigTestCase(TestCase):
+    def setUp(self):
+        super(KolibriCoreConfigTestCase, self).setUp()
+        self.client = mock.MagicMock(spec=Redis)
+        self.helper = mock.MagicMock(spec=RedisSettingsHelper)
+
+    def setUp_okay(self):
+        self.helper.get_maxmemory.return_value = 123
+        self.helper.get_maxmemory_policy.return_value = "allkeys-lru"
+
+    def assertOkay(self, logger):
+        KolibriCoreConfig.check_redis_settings()
+
+        self.helper.get_maxmemory.assert_called_once()
+        self.helper.set_maxmemory.assert_not_called()
+
+        self.helper.get_maxmemory_policy.assert_called_once()
+        self.helper.set_maxmemory_policy.assert_not_called()
+
+        logger.assert_not_called()
+
+    @do_setup()
+    def test_check_redis_settings(self, logger):
+        self.setUp_okay()
+        self.assertOkay(logger)
+
+    @do_setup(CACHE_REDIS_USE_CONF=True)
+    def test_check_redis_settings__use_conf(self, logger):
+        self.setUp_okay()
+        self.assertOkay(logger)
+
+    @do_setup(CACHE_REDIS_USE_CONF=True)
+    def test_check_redis_settings__use_conf__not_okay__maxmemory(self, logger):
+        self.helper.get_maxmemory.return_value = 0
+        self.helper.get_maxmemory_policy.return_value = "allkeys-lru"
+        KolibriCoreConfig.check_redis_settings()
+
+        self.helper.get_maxmemory.assert_called_once()
+        self.helper.set_maxmemory.assert_not_called()
+
+        self.helper.get_maxmemory_policy.assert_called_once()
+        self.helper.set_maxmemory_policy.assert_not_called()
+
+        logger.warning.assert_called()
+
+    @do_setup(CACHE_REDIS_USE_CONF=True)
+    def test_check_redis_settings__use_conf__not_okay__maxmemory_policy(self, logger):
+        self.helper.get_maxmemory.return_value = 123
+        self.helper.get_maxmemory_policy.return_value = "noeviction"
+        KolibriCoreConfig.check_redis_settings()
+
+        self.helper.get_maxmemory.assert_called_once()
+        self.helper.set_maxmemory.assert_not_called()
+
+        self.helper.get_maxmemory_policy.assert_called_once()
+        self.helper.set_maxmemory_policy.assert_not_called()
+
+        logger.warning.assert_called()
+
+    @do_setup(CACHE_REDIS_MAXMEMORY=456)
+    def test_check_redis_settings__update__maxmemory(self, logger):
+        self.helper.get_maxmemory.return_value = 0
+        self.helper.get_maxmemory_policy.return_value = "allkeys-lru"
+        KolibriCoreConfig.check_redis_settings()
+
+        self.helper.get_maxmemory.assert_called_once()
+        self.helper.set_maxmemory.assert_called_once_with(456)
+
+        self.helper.get_maxmemory_policy.assert_called_once()
+        self.helper.set_maxmemory_policy.assert_not_called()
+
+        logger.warning.assert_not_called()
+
+    @do_setup(CACHE_REDIS_MAXMEMORY_POLICY="volatile-lru")
+    def test_check_redis_settings__update__maxmemory_policy(self, logger):
+        self.helper.get_maxmemory.return_value = 123
+        self.helper.get_maxmemory_policy.return_value = "noeviction"
+        KolibriCoreConfig.check_redis_settings()
+
+        self.helper.get_maxmemory.assert_called_once()
+        self.helper.set_maxmemory.assert_not_called()
+
+        self.helper.get_maxmemory_policy.assert_called_once()
+        self.helper.set_maxmemory_policy.assert_called_once_with("volatile-lru")
+
+        logger.warning.assert_not_called()
+
+    def tearDown(self):
+        super(KolibriCoreConfigTestCase, self).tearDown()
+        self.helper.save.assert_called_once()

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -1,25 +1,31 @@
 import mock
+from diskcache.recipes import RLock
 from django.core.cache.backends.base import BaseCache
 from django.test import TestCase
+from redis import Redis
 
 from kolibri.core.utils.cache import NamespacedCacheProxy
+from kolibri.core.utils.cache import RedisSettingsHelper
 
 
+@mock.patch("kolibri.core.utils.cache.get_process_lock")
 class NamespacedCacheProxyTestCase(TestCase):
     def setUp(self):
+        self.lock = mock.MagicMock(spec=RLock)
         self.cache = mock.Mock(spec=BaseCache)
         self.proxy = NamespacedCacheProxy(self.cache, "test")
+        self.proxy._lock = self.lock
 
-    def test_get_keys(self):
+    def test_get_keys(self, mock_lock):
         self.cache.get.return_value = ["abc"]
         self.assertEqual(["abc"], self.proxy._get_keys())
         self.cache.get.assert_called_with("test:1:__KEYS__", default=[])
 
-    def test_set_keys(self):
+    def test_set_keys(self, mock_lock):
         self.proxy._set_keys(["abc"])
         self.cache.set.assert_called_with("test:1:__KEYS__", ["abc"])
 
-    def test_add(self):
+    def test_add(self, mock_lock):
         self.cache.add.return_value = True
         self.cache.get.return_value = []
 
@@ -29,7 +35,7 @@ class NamespacedCacheProxyTestCase(TestCase):
         self.cache.add.assert_called_with("test:1:abc", 123, "normal arg", timeout=456)
         self.cache.set.assert_called_with("test:1:__KEYS__", ["abc"])
 
-    def test_add__failed(self):
+    def test_add__failed(self, mock_lock):
         self.cache.add.return_value = False
         self.cache.get.return_value = []
 
@@ -39,7 +45,7 @@ class NamespacedCacheProxyTestCase(TestCase):
         self.cache.add.assert_called_with("test:1:abc", 123)
         self.cache.set.assert_not_called()
 
-    def test_set(self):
+    def test_set(self, mock_lock):
         self.cache.get.return_value = []
 
         self.proxy.set("abc", 123, "normal arg", timeout=456)
@@ -47,7 +53,7 @@ class NamespacedCacheProxyTestCase(TestCase):
         self.cache.set.assert_any_call("test:1:__KEYS__", ["abc"])
         self.cache.set.assert_any_call("test:1:abc", 123, "normal arg", timeout=456)
 
-    def test_delete(self):
+    def test_delete(self, mock_lock):
         self.cache.get.return_value = ["abc"]
 
         self.proxy.delete("abc", 123, "normal arg", extra=456)
@@ -55,7 +61,7 @@ class NamespacedCacheProxyTestCase(TestCase):
         self.cache.set.assert_called_with("test:1:__KEYS__", [])
         self.cache.delete.assert_called_with("test:1:abc", 123, "normal arg", extra=456)
 
-    def test_clear(self):
+    def test_clear(self, mock_lock):
         self.cache.get.return_value = ["abc", "def", "ghi"]
 
         self.proxy.clear()
@@ -64,3 +70,33 @@ class NamespacedCacheProxyTestCase(TestCase):
         self.cache.delete.assert_any_call("test:1:abc")
         self.cache.delete.assert_any_call("test:1:def")
         self.cache.delete.assert_any_call("test:1:ghi")
+
+
+class RedisSettingsHelperTestCase(TestCase):
+    def setUp(self):
+        self.client = mock.MagicMock(spec=Redis)
+        self.helper = RedisSettingsHelper(self.client)
+
+    def test_getters(self):
+        self.client.config_get.side_effect = [
+            {"maxmemory": 123},
+            {"maxmemory-policy": "allkeys-lru"},
+        ]
+        self.assertEqual(123, self.helper.get_maxmemory())
+        self.client.config_get.assert_called_with("maxmemory")
+        self.assertEqual("allkeys-lru", self.helper.get_maxmemory_policy())
+        self.client.config_get.assert_called_with("maxmemory-policy")
+
+    @mock.patch("kolibri.core.utils.cache.logger")
+    def test_setters(self, mock_logger):
+        self.client.config_get.side_effect = [
+            {"maxmemory": 123},
+            {"maxmemory-policy": "allkeys-lru"},
+        ]
+        self.helper.set_maxmemory(123)
+        self.client.config_set.assert_called_with("maxmemory", 123)
+        self.assertTrue(self.helper.changed)
+
+        self.helper.set_maxmemory_policy("allkeys-lru")
+        self.client.config_set.assert_called_with("maxmemory-policy", "allkeys-lru")
+        self.assertTrue(self.helper.changed)

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -100,3 +100,13 @@ class RedisSettingsHelperTestCase(TestCase):
         self.helper.set_maxmemory_policy("allkeys-lru")
         self.client.config_set.assert_called_with("maxmemory-policy", "allkeys-lru")
         self.assertTrue(self.helper.changed)
+
+    @mock.patch("kolibri.core.utils.cache.logger")
+    def test_save(self, mock_logger):
+        self.helper.save()
+        self.client.config_rewrite.assert_not_called()
+
+        self.helper.changed = True
+        self.helper.save()
+        self.client.config_rewrite.assert_called()
+        self.assertFalse(self.helper.changed)

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -44,7 +44,10 @@ def get_process_lock(key, expire=None):
             thread_local=True,
         )
     else:
-        return RLock(process_cache, key, expire=expire)
+        # we can't pass in the `process_cache` because it's an instance of DjangoCache
+        # and we need a Cache instance
+        cache = process_cache.cache("locks")
+        return RLock(cache, key, expire=expire)
 
 
 class NamespacedCacheProxy(BaseCache):

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -78,6 +78,11 @@ if cache_options["CACHE_BACKEND"] == "redis":
             "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
             # Pin pickle protocol for Python 2 compatibility
             "PICKLE_VERSION": pickle_protocol,
+            "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
+            "CONNECTION_POOL_CLASS_KWARGS": {
+                "max_connections": cache_options["CACHE_REDIS_MAX_POOL_SIZE"],
+                "timeout": cache_options["CACHE_REDIS_POOL_TIMEOUT"],
+            },
         },
     }
     default_cache = copy.deepcopy(base_cache)

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -12,6 +12,9 @@ CACHE_MAX_ENTRIES
 CACHE_PASSWORD
 CACHE_LOCATION
 CACHE_REDIS_MIN_DB
+CACHE_REDIS_USE_CONF
+CACHE_REDIS_MAXMEMORY
+CACHE_REDIS_MAXMEMORY_POLICY
 
 [Database]
 DATABASE_ENGINE
@@ -215,6 +218,29 @@ base_option_spec = {
             "type": "integer",
             "default": 0,
             "envvars": ("KOLIBRI_CACHE_REDIS_MIN_DB",),
+        },
+        "CACHE_REDIS_USE_CONF": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_CACHE_REDIS_USE_CONF",),
+        },
+        "CACHE_REDIS_MAXMEMORY": {
+            "type": "integer",
+            "default": 100 * 1024 * 1024,  # ~100MB
+            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY",),
+        },
+        "CACHE_REDIS_MAXMEMORY_POLICY": {
+            "type": "option",
+            "options": (
+                "allkeys-lru",
+                "volatile-lru",
+                "allkeys-random",
+                "volatile-random",
+                "volatile-ttl",
+                "noeviction",
+            ),
+            "default": "allkeys-lru",
+            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
         },
     },
     "Database": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -15,6 +15,8 @@ CACHE_REDIS_MIN_DB
 CACHE_REDIS_USE_CONF
 CACHE_REDIS_MAXMEMORY
 CACHE_REDIS_MAXMEMORY_POLICY
+CACHE_REDIS_MAX_POOL_SIZE
+CACHE_REDIS_POOL_TIMEOUT
 
 [Database]
 DATABASE_ENGINE
@@ -241,6 +243,16 @@ base_option_spec = {
             ),
             "default": "allkeys-lru",
             "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
+        },
+        "CACHE_REDIS_MAX_POOL_SIZE": {
+            "type": "integer",
+            "default": 50,  # use redis-benchmark to determine better value
+            "envvars": ("KOLIBRI_CACHE_REDIS_MAX_POOL_SIZE",),
+        },
+        "CACHE_REDIS_POOL_TIMEOUT": {
+            "type": "integer",
+            "default": 30,  # seconds
+            "envvars": ("KOLIBRI_CACHE_REDIS_POOL_TIMEOUT",),
         },
     },
     "Database": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -239,7 +239,7 @@ base_option_spec = {
         "CACHE_REDIS_MAXMEMORY_POLICY": {
             "type": "option",
             "options": (
-                None,
+                "",
                 "allkeys-lru",
                 "volatile-lru",
                 "allkeys-random",
@@ -247,7 +247,7 @@ base_option_spec = {
                 "volatile-ttl",
                 "noeviction",
             ),
-            "default": None,
+            "default": "",
             "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
         },
     },

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -12,11 +12,10 @@ CACHE_MAX_ENTRIES
 CACHE_PASSWORD
 CACHE_LOCATION
 CACHE_REDIS_MIN_DB
-CACHE_REDIS_USE_CONF
-CACHE_REDIS_MAXMEMORY
-CACHE_REDIS_MAXMEMORY_POLICY
 CACHE_REDIS_MAX_POOL_SIZE
 CACHE_REDIS_POOL_TIMEOUT
+CACHE_REDIS_MAXMEMORY
+CACHE_REDIS_MAXMEMORY_POLICY
 
 [Database]
 DATABASE_ENGINE
@@ -221,29 +220,6 @@ base_option_spec = {
             "default": 0,
             "envvars": ("KOLIBRI_CACHE_REDIS_MIN_DB",),
         },
-        "CACHE_REDIS_USE_CONF": {
-            "type": "boolean",
-            "default": False,
-            "envvars": ("KOLIBRI_CACHE_REDIS_USE_CONF",),
-        },
-        "CACHE_REDIS_MAXMEMORY": {
-            "type": "integer",
-            "default": 100 * 1024 * 1024,  # ~100MB
-            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY",),
-        },
-        "CACHE_REDIS_MAXMEMORY_POLICY": {
-            "type": "option",
-            "options": (
-                "allkeys-lru",
-                "volatile-lru",
-                "allkeys-random",
-                "volatile-random",
-                "volatile-ttl",
-                "noeviction",
-            ),
-            "default": "allkeys-lru",
-            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
-        },
         "CACHE_REDIS_MAX_POOL_SIZE": {
             "type": "integer",
             "default": 50,  # use redis-benchmark to determine better value
@@ -253,6 +229,26 @@ base_option_spec = {
             "type": "integer",
             "default": 30,  # seconds
             "envvars": ("KOLIBRI_CACHE_REDIS_POOL_TIMEOUT",),
+        },
+        # Optional redis settings to overwrite redis.conf
+        "CACHE_REDIS_MAXMEMORY": {
+            "type": "integer",
+            "default": 0,
+            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY",),
+        },
+        "CACHE_REDIS_MAXMEMORY_POLICY": {
+            "type": "option",
+            "options": (
+                None,
+                "allkeys-lru",
+                "volatile-lru",
+                "allkeys-random",
+                "volatile-random",
+                "volatile-ttl",
+                "noeviction",
+            ),
+            "default": None,
+            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
         },
     },
     "Database": {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds options to configure Redis through Kolibri's `options.ini`
- Adds startup check that determines if Redis is sensibly configured
- Use's the Redis Lock implementation when Redis is the cache backend, which uses the `SET NX` command
- Removes vendored version of `RLock` class
- Adds [connection pooling](https://django-redis-cache.readthedocs.io/en/latest/advanced_configuration.html#connection-pool) and options to adjust pooling settings

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Ensure Kolibri works as expected without Redis backend
- Update `options.ini` to use Redis and ensure:
  1. Kolibri runs as expected
  2. Messages are shown during startup indicating the Redis configuration is being overwritten
  3. Verify changes will are written to the `redis.conf` when `CACHE_REDIS_USE_CONF` is `False`
  4. Verify warning messages appear when maxmemory settings in `redis.conf` are defaults and when `CACHE_REDIS_USE_CONF` is `True`


----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
