### PR TITLE
Auto-select newly added network addresses/locations in the SelectAddressModalGroup

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/AddAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/AddAddressForm.vue
@@ -66,7 +66,6 @@
       UiAlert,
     },
     mixins: [commonCoreStrings],
-    props: {},
     data() {
       return {
         address: '',
@@ -113,8 +112,8 @@
           base_url: this.address,
           nickname: this.name,
         })
-          .then(() => {
-            this.$emit('added_address');
+          .then(address => {
+            this.$emit('added_address', address.id);
           })
           .catch(err => {
             const errorsCaught = CatchErrors(err, [

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -147,6 +147,11 @@
         type: Boolean,
         default: false,
       },
+      // If an ID is provided, that address's radio button will be automatically selected
+      selectedId: {
+        type: String,
+        required: false,
+      },
     },
     data() {
       return {
@@ -236,6 +241,9 @@
             this.resetSelectedAddress();
             this.stage = this.Stages.FETCHING_SUCCESSFUL;
             this.savedAddressesInitiallyFetched = true;
+            if (this.savedAddresses.find(({ id }) => this.selectedId === id)) {
+              this.selectedAddressId = this.selectedId;
+            }
           })
           .catch(() => {
             this.stage = this.Stages.FETCHING_FAILED;

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/index.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/index.vue
@@ -4,6 +4,7 @@
     <SelectAddressForm
       v-if="stage === Stages.SELECT_ADDRESS"
       :fetchAddressArgs="fetchAddressArgs"
+      :selectedId="addedAddressId"
       @click_add_address="goToAddAddress"
       @click_search_address="goToSearchAddress"
       @removed_address="handleRemovedAddress"
@@ -45,6 +46,7 @@
     data() {
       return {
         stage: Stages.SELECT_ADDRESS,
+        addedAddressId: '',
         Stages,
       };
     },
@@ -53,6 +55,7 @@
         this.$store.dispatch('createSnackbar', args);
       },
       goToAddAddress() {
+        this.addedAddressId = '';
         this.stage = Stages.ADD_ADDRESS;
       },
       goToSearchAddress() {
@@ -61,7 +64,8 @@
       goToSelectAddress() {
         this.stage = Stages.SELECT_ADDRESS;
       },
-      handleAddedAddress() {
+      handleAddedAddress(addressId) {
+        this.addedAddressId = addressId;
         this.createSnackbar(this.$tr('addAddressSnackbarText'));
         this.goToSelectAddress();
       },


### PR DESCRIPTION

### Summary

This adds a link (via events, data, and props) between the Add + Select steps in the `SelectNetworkAddressModalGroup` so that addresses created in the "Add" step are automatically selected when the user is returned to the "Select" step.

Screengrab: note that, after creating "d", the radio button for "d" is selected, despite "a" being selected initially.

![CleanShot 2020-07-14 at 15 28 21](https://user-images.githubusercontent.com/10248067/87482943-5b69d080-c5e7-11ea-80bb-9623967d6f13.gif)

### Reviewer guidance

Does it work like the screen shot? Is there so possible interaction that I'm not accounting for? (Weird navigation between states or something like that).

### References

Fixes #7252

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
